### PR TITLE
Added arp discovered device name and ip to eventlog

### DIFF
--- a/includes/discovery/discovery-arp.inc.php
+++ b/includes/discovery/discovery-arp.inc.php
@@ -87,7 +87,7 @@ echo("\n");
 foreach ($names as $name) {
 	$remote_device_id = discover_new_device($name);
 	if ($remote_device_id) {
-		log_event("Device autodiscovered through ARP on $hostname", $remote_device_id, 'interface', $if);
+		log_event("Device $name (" . $ips[$name] .") autodiscovered through ARP on $hostname", $remote_device_id, 'interface', $if);
 	}
 	else {
 		log_event("ARP discovery of $name (" . $ips[$name] . ") failed - check ping and SNMP access", $deviceid, 'interface', $if);


### PR DESCRIPTION
This is to add the name and IP to eventlog as requested in issue #20 on librenms/librenms
