### PR TITLE
process_syslog: remove debugging statements

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -44,8 +44,6 @@ function process_syslog($entry, $update)
   {
     if (strpos($entry['msg'], $bi) !== FALSE)
     {
-      print_r($entry);
-      echo('D-'.$bi);
       return $entry;
     }
   }


### PR DESCRIPTION
Currently, filtered syslog messages (via syslog_filter) are spewed into
stdout (unlike unfiltered ones), presumably for debugging. When
syslog.php has been invoked from rsyslog, writing to stdout results in
an EPIPE which is unhandled and hence syslog.php dies. Remove them, as
they're completely redundant and of dubious gains to debugging.
