### PR TITLE
Stop print-syslog.inc.php from shortening hostnames

### DIFF
--- a/html/includes/print-syslog.inc.php
+++ b/html/includes/print-syslog.inc.php
@@ -5,7 +5,8 @@ if (device_permitted($entry['device_id']))
   echo("<tr class=\"syslog\">
     <td width=0></td>");
 
-  $entry['hostname'] = shorthost($entry['hostname'], 20);
+  // Stop shortening hostname. Issue #61
+  //$entry['hostname'] = shorthost($entry['hostname'], 20);
 
   if ($vars['page'] != "device")
   {


### PR DESCRIPTION
This is for issue #61 in librenms/librenms to stop print-syslog.inc.php shortening hostnames.
