### PR TITLE
Change <title> to use page_title_suffix as the fall back to

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -110,7 +110,7 @@ if ($config['page_title']) { $config['page_title_prefix'] = $config['page_title'
 <!DOCTYPE HTML>
 <html>
 <head>
-  <title><?php echo($config['page_title_prefix']); ?></title>
+  <title><?php echo($config['page_title_suffix']); ?></title>
   <base href="<?php echo($config['base_url']); ?>" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />


### PR DESCRIPTION
The html tag <title> gets set to blank currently on a default install (it's updated via Javascript later on), however the title should at least have a value just in case. This change falls back to using page_title_suffix from includes/defaults.inc.php which is currently set to project_name.
