### PR TITLE
Changed top X boxes to fade rather than scroll

### DIFF
--- a/html/includes/front/boxes.inc.php
+++ b/html/includes/front/boxes.inc.php
@@ -15,7 +15,7 @@
 
 echo('
 <div class="cycle-slideshow"
-    data-cycle-fx="scrollVert"
+    data-cycle-fx="fade"
     data-cycle-timeout="10000"
     data-cycle-slides="> div">
 ');

--- a/html/index.php
+++ b/html/index.php
@@ -129,7 +129,6 @@ if ($config['page_refresh']) { echo('  <meta http-equiv="refresh" content="'.$co
   <script src="js/hogan-2.0.0.js"></script>
 
   <script src="js/jquery.cycle2.min.js"></script>
-  <script src="js/jquery.cycle2.scrollVert.min.js"></script>
 <?php
 if ($config['favicon']) { echo('  <link rel="shortcut icon" href="'.$config['favicon'].'" />' . "\n"); }
 ?>


### PR DESCRIPTION
This changes the the top  X boxes to use the fade plugin rather than vertscroll.

Because of the change, the vertscroll js plugin is no longer needed so files removed and reference removed from html code.
