### PR TITLE
Urgent: Ports set to be ignored will now be ignored for threshold alerts

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -354,7 +354,7 @@ foreach ($ports as $port)
     }
 
     // Port utilisation % threshold alerting. // FIXME allow setting threshold per-port. probably 90% of ports we don't care about.
-    if ($config['alerts']['port_util_alert'])
+    if ($config['alerts']['port_util_alert'] && $port['ignore'] == '0')
     {
       // Check for port saturation of $config['alerts']['port_util_perc'] or higher.  Alert if we see this.
       // Check both inbound and outbound rates


### PR DESCRIPTION
Ports set to be ignored still generate threshold breaches as they do not check the database if they should or not.

Added an extra check to ensure the port is set to ignored = 0.
