### PR TITLE
Urgent: build-base.php now calls includes/sql-schema/update.php

### DIFF
--- a/build-base.php
+++ b/build-base.php
@@ -20,4 +20,6 @@ while( !feof( $sql_fh ) ) {
 
 fclose($sql_fh);
 
+include("includes/sql-schema/update.php");
+
 ?>


### PR DESCRIPTION
On new installs running php build-base.php creates the skeleton files for the mysql data structure but doesn't run any of the sql updates until a discovery is run which is too late for the new password format + potentially any other key changes we make to sql files.

This resolves this so running build-base.php will now call the updates as well.
