### PR TITLE
if ifInOctets/ifOutOctets not available, fall back to ifHCInOctets/ifHCOutOctets

### DIFF
--- a/html/data.php
+++ b/html/data.php
@@ -36,6 +36,14 @@ if (is_numeric($_GET['id']) && ($config['allow_unauth_graphs'] || port_permitted
 
 $in  = snmp_get($device, "ifInOctets.".$port['ifIndex'], "-OUqnv", "IF-MIB");
 $out = snmp_get($device, "ifOutOctets.".$port['ifIndex'], "-OUqnv", "IF-MIB");
+if(empty($in))
+{
+  $in  = snmp_get($device, "ifHCInOctets.".$port['ifIndex'], "-OUqnv", "IF-MIB");
+}
+if(empty($out))
+{
+  $out = snmp_get($device, "ifHCOutOctets.".$port['ifIndex'], "-OUqnv", "IF-MIB");
+}
 
 $time = time();
 


### PR DESCRIPTION
Dlink doesn't support ifInOctets/ifOutOctets on it's mgmt ports, if we don't see data back on ifInOctets/ifOutOctets then we fall back to the HC version.
