### PR TITLE
Urgent: Updated external_exec to use proc_open

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -47,7 +47,7 @@ function external_exec($command)
     fclose($pipes[0]);
     fclose($pipes[1]);
     fclose($pipes[2]);
-    $exec_status['status'] = proc_close($process);
+    $exec_response['status'] = proc_close($process);
   } else {
     fclose($pipes[0]);
     fclose($pipes[1]);
@@ -55,7 +55,7 @@ function external_exec($command)
     proc_terminate($process);
     $output = FALSE;
     $exec_error['error'] = '';
-    $exec_status['status'] = -1;
+    $exec_response['status'] = -1;
   }
 
   print_debug($output);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -47,7 +47,7 @@ function discover_new_device($hostname)
 
 function discover_device($device, $options = NULL)
 {
-  global $config, $valid;
+  global $config, $valid, $exec_response;
 
   $valid = array(); // Reset $valid array
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -89,7 +89,7 @@ function poll_sensor($device, $class, $unit)
 
 function poll_device($device, $options)
 {
-  global $config, $device, $polled_devices, $db_stats, $memcache;
+  global $config, $device, $polled_devices, $db_stats, $memcache, $exec_response;
 
   $attribs = get_dev_attribs($device['device_id']);
 


### PR DESCRIPTION
This changes the function external_exec from a standard shell_exec to using proc_open. Should see some performance gains with this (when using large scale deployment) however the main reason is to get a status response back from the commands so that we can see what things like snmpget are upto.

This is also to enable an update to poller that detects for snmp-config match prefix being on or off so that we can resolve a perfomance issue at work.
