### PR TITLE
Updated daily schedule to remove old syslog and eventlog entries

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -7,9 +7,26 @@
 
 include('includes/defaults.inc.php');
 include('config.php');
+include_once("includes/definitions.inc.php");
+include("includes/functions.php");
 
 $options = getopt("f:");
 
 if ( $options['f'] === 'update') { echo $config['update']; }
+
+if ( $options['f'] === 'syslog') {
+  if ( is_numeric($config['syslog_purge'])) {
+    if ( dbDelete('syslog', "timestamp < DATE_SUB(NOW(), INTERVAL ? DAY)", array($config['syslog_purge'])) ) {
+      echo 'Syslog cleared for entries over ' . $config['syslog_purge'] . " days\n";
+    }
+  }
+}
+if ( $options['f'] === 'eventlog') {
+  if ( is_numeric($config['eventlog_purge'])) {
+    if ( dbDelete('eventlog', "datetime < DATE_SUB(NOW(), INTERVAL ? DAY)", array($config['eventlog_purge'])) ) {
+      echo 'Eventlog cleared for entries over ' . $config['eventlog_purge'] . " days\n";
+    }
+  }
+}
 
 ?>

--- a/daily.sh
+++ b/daily.sh
@@ -3,3 +3,6 @@
 if [ $(php daily.php -f update) -eq 1 ]; then 
   git pull --no-edit --quiet
 fi
+
+php daily.php -f syslog
+php daily.php -f eventlog

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -566,4 +566,8 @@ $config['modules_compat']['rfc1628']['poweralert']        = 1;
 # Enable daily updates
 $config['update'] = 1;
 
+# Purge syslog and eventlog
+$config['syslog_purge']                                   = 30; # Number in days of how long to keep syslog entries for.
+$config['eventlog_purge']                                 = 30; # Number in days of how long to keep eventlog entries for.
+
 ?>


### PR DESCRIPTION
Defaults are:

$config['syslog_purge'] = 30;
$config['eventlog_purge'] = 30;

These values are in days.

Any logs over that set number will be removed when daily.sh runs.
