### PR TITLE
Shorthost should return full IP addresses

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -32,7 +32,7 @@ function external_exec($command)
 
 function shorthost($hostname, $len=12)
 {
-  # IP addresses should not be shortened
+  // IP addresses should not be shortened
   if (filter_var($hostname, FILTER_VALIDATE_IP))
     return $hostname;
   


### PR DESCRIPTION
Using filter_var to simply return the hostname if it is an IP address.
