### PR TITLE
Get rid of ugly status box overlap

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -488,6 +488,7 @@ a.list-device-disabled, a.list-device-disabled:visited {
   padding: 3px;
   width: 117px;
   height: 85px;
+  overflow: hidden;
 
   /* Rounded corners */
   -moz-border-radius: 2pt 2pt 2pt 2pt;


### PR DESCRIPTION
Ideally it'd fully be displayed, but that would require a size change or alt-text. Hiding overflow is good enough
