### PR TITLE
[URGENT] Changed incorrect MAX CF to MIN for rrd creation

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -75,7 +75,7 @@ $config['slow_statistics']      = TRUE; // THIS WILL CHANGE TO FALSE IN FUTURE
 // Or if one had a very fast I/O subsystem with no performance worries.
 
 $config['rrd_rra']  = " RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1440 RRA:AVERAGE:0.5:24:1440 RRA:AVERAGE:0.5:288:1440 ";
-$config['rrd_rra'] .= " RRA:MAX:0.5:1:720 RRA:MIN:0.5:6:1440     RRA:MIN:0.5:24:775     RRA:MIN:0.5:288:797 ";
+$config['rrd_rra'] .= " RRA:MIN:0.5:1:720 RRA:MIN:0.5:6:1440     RRA:MIN:0.5:24:775     RRA:MIN:0.5:288:797 ";
 $config['rrd_rra'] .= " RRA:MAX:0.5:1:720 RRA:MAX:0.5:6:1440     RRA:MAX:0.5:24:775     RRA:MAX:0.5:288:797 ";
 $config['rrd_rra'] .= " RRA:LAST:0.5:1:1440 ";
 


### PR DESCRIPTION
New rrd files that are created are done so with an incorrect RRA definition. MAX is defined twice (for short term data), the first should be MIN.
