### PR TITLE
[URGENT] Unset variables which were leaking into other polling runs

### DIFF
--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -96,6 +96,6 @@ foreach ($ipsec_array as $index => $tunnel)
 
 }
 
-unset($oids, $data, $data_array, $oid, $tunnel);
+unset($rrd_file,$rrd_create,$rrdupdate,$oids, $data, $data_array, $oid, $tunnel);
 
 ?>


### PR DESCRIPTION
Some variables haven't been unset, when another include file after this runs it uses those variables.
