### PR TITLE
Removed session regeneration

### DIFF
--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -88,9 +88,9 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
       $hasher = new PasswordHash(8, FALSE);
       $token_id = $_SESSION['username'].'|'.$hasher->HashPassword($_SESSION['username'].$token);
       // If we have been asked to remember the user then set the relevant cookies and create a session in the DB.
-      setcookie("sess_id", $sess_id, time()+60*60*24*$config['auth_remember'], "/", null, null, true);
-      setcookie("token", $token_id, time()+60*60*24*$config['auth_remember'], "/", null, null, true);
-      setcookie("auth", $auth, time()+60*60*24*$config['auth_remember'], "/", null, null, true);
+      setcookie("sess_id", $sess_id, time()+60*60*24*$config['auth_remember'], "/", null, false, true);
+      setcookie("token", $token_id, time()+60*60*24*$config['auth_remember'], "/", null, false, true);
+      setcookie("auth", $auth, time()+60*60*24*$config['auth_remember'], "/", null, false, true);
       dbInsert(array('session_username' => $_SESSION['username'], 'session_value' => $sess_id, 'session_token' => $token, 'session_auth' => $auth, 'session_expiry' => time()+60*60*24*$config['auth_remember']), 'session');
     }
     if (isset($_COOKIE['sess_id'],$_COOKIE['token'],$_COOKIE['auth']))
@@ -98,9 +98,9 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
       // If we have the remember me cookies set then update session expiry times to keep us logged in.
       $sess_id = session_id();
       dbUpdate(array('session_value' => $sess_id, 'session_expiry' => time()+60*60*24*$config['auth_remember']), 'session', 'session_auth=?', array($_COOKIE['auth']));
-      setcookie("sess_id", $sess_id, time()+60*60*24*$config['auth_remember'], "/", null, null, true);
-      setcookie("token", $_COOKIE['token'], time()+60*60*24*$config['auth_remember'], "/", null, null, true);
-      setcookie("auth", $_COOKIE['auth'], time()+60*60*24*$config['auth_remember'], "/", null, null, true);
+      setcookie("sess_id", $sess_id, time()+60*60*24*$config['auth_remember'], "/", null, false, true);
+      setcookie("token", $_COOKIE['token'], time()+60*60*24*$config['auth_remember'], "/", null, false, true);
+      setcookie("auth", $_COOKIE['auth'], time()+60*60*24*$config['auth_remember'], "/", null, false, true);
     }
     $permissions = permissions_cache($_SESSION['user_id']);
   }


### PR DESCRIPTION
The session regeneration causes issues with sessions changing too quickly when lots of graphs are on a page or hitting back in the browser.

It was put in as an additional safe guard so shouldn't be an issue removing it. Trying to resolve this is going to take some work due to the number of http calls that some pages make, each one updating the session ID all the time.
