### PR TITLE
Added none to vtpversion check

### DIFF
--- a/includes/discovery/vlans/cisco-vtp.inc.php
+++ b/includes/discovery/vlans/cisco-vtp.inc.php
@@ -6,7 +6,7 @@ if ($device['os_group'] == "cisco")
 
   // Not sure why we check for VTP, but this data comes from that MIB, so...
   $vtpversion = snmp_get($device, "vtpVersion.0"  , "-OnvQ", "CISCO-VTP-MIB");
-  if ($vtpversion == '1' || $vtpversion == '2' || $vtpversion == '3' || $vtpversion == 'one' ||  $vtpversion == 'two' || $vtpversion == 'three')
+  if ($vtpversion == '1' || $vtpversion == '2' || $vtpversion == '3' || $vtpversion == 'one' ||  $vtpversion == 'two' || $vtpversion == 'three' || $vtpversion == 'none')
   {
 
     // FIXME - can have multiple VTP domains.


### PR DESCRIPTION
This resolves an issue with Cisco switches where they return none for the vtpversion even when vtp is running.

http://gorthx.wordpress.com/2011/12/09/snmp-snarky-network-management-protocol/

reported by gadago on irc, he's also confirmed this fix resolves the issue.

It's not a bug as confirmed by cisco's bug tool and I've put this fix on our install with 80+ devices and vlans discovery has gone through with no issue.
