### PR TITLE
Fixed the placement of overlib popup images

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -186,7 +186,7 @@ function overlib_link($url, $text, $contents, $class)
 
   $contents = str_replace("\"", "\'", $contents);
   $output = '<a class="'.$class.'" href="'.$url.'"';
-  $output .= " onmouseover=\"return overlib('".$contents."'".$config['overlib_defaults'].");\" onmouseout=\"return nd();\">";
+  $output .= " onmouseover=\"return overlib('".$contents."'".$config['overlib_defaults'].", WRAP,HAUTO,VAUTO);\" onmouseout=\"return nd();\">";
   $output .= $text."</a>";
 
   return $output;


### PR DESCRIPTION
Taken from: http://www.macridesweb.com/oltest/commandRef.html

Those commands are from an improved version of overlib but a lot (including what I've used here) are still relevant.
