### PR TITLE
Updated adduser to check for existing user and use password hashing

### DIFF
--- a/html/includes/authentication/http-auth.inc.php
+++ b/html/includes/authentication/http-auth.inc.php
@@ -49,7 +49,13 @@ function auth_usermanagement()
 
 function adduser($username, $password, $level, $email = "", $realname = "", $can_modify_passwd = '1')
 {
-  return dbInsert(array('username' => $username, 'password' => $password, 'level' => $level, 'email' => $email, 'realname' => $realname), 'users');
+    if (!user_exists($username)) {
+        $hasher = new PasswordHash(8, FALSE);
+        $encrypted = $hasher->HashPassword($password);
+        return dbInsert(array('username' => $username, 'password' => $encrypted, 'level' => $level, 'email' => $email, 'realname' => $realname), 'users');
+    } else {
+        return FALSE;
+    }
 }
 
 function user_exists($username)


### PR DESCRIPTION
Adding users when using http-auth did so with plaintext password, updated so this now hashes the password even thought it's never used.
