### PR TITLE
Removed --no-edit for git pull, not a valid command

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $(php daily.php -f update) -eq 1 ]; then 
-  git pull --no-edit --quiet
+  git pull --quiet
   php includes/sql-schema/update.php
 fi
 


### PR DESCRIPTION
--no-edit doesn't appear to be a valid command for git pull. Checked on two versions of git 1.7.1 and 1.7.9.
