### PR TITLE
Updated authToken response code to be 401

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -176,7 +176,7 @@ function authToken(\Slim\Route $route)
 
   if($authenticated === false)
   {
-    $app->response->setStatus(403);
+    $app->response->setStatus(401);
     $output = array("status" => "error", "message" => "API Token is missing or invalid; please supply a valid token");
     echo _json_encode($output);
     $app->stop();


### PR DESCRIPTION
Looks like 401 is the correct response code for authentication issues:

https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error

It does say the response must include a www-authenticate header which we don't send as it's done via a custom header.

Feel free to comment and close this if you feel 403 is still the correct response.
