### PR TITLE
Removed trailing slash from v0 part of the uri

### DIFF
--- a/html/.htaccess
+++ b/html/.htaccess
@@ -8,7 +8,7 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI} !\.(js|ico|txt|gif|jpg|png|css|php)
-RewriteRule ^api/v0/(.*)$ api_v0.php/$1 [L]
+RewriteRule ^api/v0(.*)$ api_v0.php/$1 [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI} !\.(js|ico|txt|gif|jpg|png|css|php)


### PR DESCRIPTION
I'm doing a PR so that you can hit /api/v0 to get a list of the end points supported. With this / you can't get to it though as it doesn't see it as part of the redirect. Removing this has no ill affects on current functions (tested).
