### PR TITLE
Added options for fping to retry and timeout

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -39,24 +39,26 @@ $config['own_hostname'] = "localhost";
 
 // Location of executables
 
-$config['rrdtool']        = "/usr/bin/rrdtool";
-$config['fping']          = "/usr/bin/fping";
-$config['fping6']         = "/usr/bin/fping6";
-$config['snmpwalk']       = "/usr/bin/snmpwalk";
-$config['snmpget']        = "/usr/bin/snmpget";
-$config['snmpbulkwalk']   = "/usr/bin/snmpbulkwalk";
-$config['whois']          = "/usr/bin/whois";
-$config['ping']           = "/bin/ping";
-$config['mtr']            = "/usr/bin/mtr";
-$config['nmap']           = "/usr/bin/nmap";
-$config['nagios_plugins'] = "/usr/lib/nagios/plugins";
-$config['ipmitool']       = "/usr/bin/ipmitool";
-$config['virsh']          = "/usr/bin/virsh";
-$config['dot']            = "/usr/bin/dot";
-$config['unflatten']      = "/usr/bin/unflatten";
-$config['neato']          = "/usr/bin/neato";
-$config['sfdp']           = "/usr/bin/sfdp";
-$config['svn']                  = "/usr/bin/svn";
+$config['rrdtool']          = "/usr/bin/rrdtool";
+$config['fping']            = "/usr/bin/fping";
+$config['fping_options']['retries'] = 3;
+$config['fping_options']['timeout'] = 500;
+$config['fping6']           = "/usr/bin/fping6";
+$config['snmpwalk']         = "/usr/bin/snmpwalk";
+$config['snmpget']          = "/usr/bin/snmpget";
+$config['snmpbulkwalk']     = "/usr/bin/snmpbulkwalk";
+$config['whois']            = "/usr/bin/whois";
+$config['ping']             = "/bin/ping";
+$config['mtr']              = "/usr/bin/mtr";
+$config['nmap']             = "/usr/bin/nmap";
+$config['nagios_plugins']   = "/usr/lib/nagios/plugins";
+$config['ipmitool']         = "/usr/bin/ipmitool";
+$config['virsh']            = "/usr/bin/virsh";
+$config['dot']              = "/usr/bin/dot";
+$config['unflatten']        = "/usr/bin/unflatten";
+$config['neato']            = "/usr/bin/neato";
+$config['sfdp']             = "/usr/bin/sfdp";
+$config['svn']              = "/usr/bin/svn";
 
 // Memcached - Keep immediate statistics
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -463,13 +463,20 @@ function isPingable($hostname,$device_id = FALSE)
 {
    global $config;
 
-   $status = shell_exec($config['fping'] . " -e $hostname 2>/dev/null");
+   $fping_params = '';
+   if(is_numeric($config['fping_options']['retries']) || $config['fping_options']['retries'] > 1) {
+       $fping_params .= ' -r ' . $config['fping_options']['retries'];
+   }
+   if(is_numeric($config['fping_options']['timeout']) || $config['fping_options']['timeout'] > 1) {
+       $fping_params .= ' -t ' . $config['fping_options']['timeout'];
+   }
+   $status = shell_exec($config['fping'] . "$fping_params -e $hostname 2>/dev/null");
    $response = array();
    if (strstr($status, "alive"))
    {
      $response['result'] = TRUE;
    } else {
-     $status = shell_exec($config['fping6'] . " -e $hostname 2>/dev/null");
+     $status = shell_exec($config['fping6'] . "$fping_params -e $hostname 2>/dev/null");
      if (strstr($status, "alive"))
      {
        $response['result'] = TRUE;


### PR DESCRIPTION
On lightly loaded systems fping can lead to devices being marked as up / down as the call times out. These options will allow people to increase the defaults.

Feel free to edit the config variable names if you like.
