### PR TITLE
Fixes the fact daily.sh does not run outside of the install directory

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+dir=`dirname $0`
+cd $dir;
+
 if [ $(php daily.php -f update) -eq 1 ]; then 
   git pull --no-edit --quiet
   php includes/sql-schema/update.php


### PR DESCRIPTION
/bin/sh /opt/librenms/daily.sh
# !/bin/bash

Could not open input file: daily.php
# !/bin/bash

Could not open input file: daily.php
Could not open input file: daily.php
# !/bin/bash

Could not open input file: daily.php

The script now changes into the directory that daily.sh is in to run.
