### PR TITLE
Added a preg_replace to get rid of snmp errors for bgp graphs

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -149,6 +149,7 @@ if ($config['enable_bgp'])
 
           if ($debug) { echo("$cbgp_cmd\n"); }
           $cbgp_data = preg_replace("/^OID.*$/", "", trim(`$cbgp_cmd`));
+          $cbgp_data = preg_replace("/No Such Instance currently exists at this OID/", "0", $cbgp_data);
           if ($debug) { echo("$cbgp_data\n"); }
           list($cbgpPeerAcceptedPrefixes,$cbgpPeerDeniedPrefixes,$cbgpPeerPrefixAdminLimit,$cbgpPeerPrefixThreshold,$cbgpPeerPrefixClearThreshold,$cbgpPeerAdvertisedPrefixes,$cbgpPeerSuppressedPrefixes,$cbgpPeerWithdrawnPrefixes) = explode("\n", $cbgp_data);
         }


### PR DESCRIPTION
This is a bit of a work around but without refactoring how snmp is called then this is the best I can do. It's currently a bug and stops bgp graphs working for devices that don't support all currently used snmp calls:

This is currently what is happening:

RRD[update /opt/librenms/rrd/router/cbgp-1.1.1.1.ipv4.unicast.rrd N:0:No Such Instance currently exists at this OID:0:No Such Instance currently exists at this OID:No Such Instance currently exists at this OID]

This patch replaces No Such Instance currently exists at this OID with 0 so that an RRD update can happen and in turn generate the graphs.
