### PR TITLE
Removed check for image/png content-type

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -380,13 +380,6 @@ function list_bgp() {
 function get_graph_by_portgroup() {
   global $config;
   $app = \Slim\Slim::getInstance();
-  if ($app->request->getMediaType() != "image/png") {
-      // we only support PNG graphs at the moment
-      $app->response->setStatus(406);	// Not Acceptable
-      echo("<h3>Not Acceptable</h3>\n");
-      echo("<p>Only media type 'image/png' is provided at present</p>\n");
-      return;
-  }
   $router = $app->router()->getCurrentRoute()->getParams();
   $group = $router['group'];
   $vars = array();


### PR DESCRIPTION
14:08 <lafwood> blahdeblah: Quick question about the portgroups api route, you added a check for image/png
14:09 <lafwood> I'm not sure that's what that function is meant for. Event sending -H "Accept: image/png" on a curl request fails. I think this is for checking if you send an image to the api rather than what's to be output
14:27 <lafwood> Sending -H "Content-type: image/png" works but this for defining what content-type the request will send.
14:29 <lafwood> I think the curl request needs to send an Accept and then the API check for this, I'll put a PR through to remove the current code until it can be looked at in more detail.
