### PR TITLE
Added Package Search

### DIFF
--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -378,18 +378,10 @@ if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf
 <?php
 }
 
-$packages = dbFetchCell("SELECT COUNT(pkg_id) from `packages`");
-
-if ($packages)
-{
+if ( dbFetchCell("SELECT 1 from `packages` LIMIT 1") ) {
 ?>
-
-        <li class="dropdown">
-          <a href="<?php echo(generate_url(array('page'=>'packages'))); ?>" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><img src="images/16/box.png" border="0" align="absmiddle" /> Packages<b class="caret"></b></a>
-          <ul class="dropdown-menu">
-            <li><a href="<?php echo(generate_url(array('page'=>'search','search'=>'packages'))); ?>"><img src="images/16/box.png" border="0" align="absmiddle" /> Search Packages</a></li>
-            <li><a href="<?php echo(generate_url(array('page'=>'packages'))); ?>"><img src="images/16/box.png" border="0" align="absmiddle" /> All Packages</a></li>
-          </ul>
+        <li>
+          <a href="<?php echo(generate_url(array('page'=>'search','search'=>'packages'))); ?>"><img src="images/16/box.png" border="0" align="absmiddle" /> Packages</a>
         </li>
 <?php
 } # if ($packages)

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -387,6 +387,7 @@ if ($packages)
         <li class="dropdown">
           <a href="<?php echo(generate_url(array('page'=>'packages'))); ?>" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><img src="images/16/box.png" border="0" align="absmiddle" /> Packages<b class="caret"></b></a>
           <ul class="dropdown-menu">
+            <li><a href="<?php echo(generate_url(array('page'=>'search','search'=>'packages'))); ?>"><img src="images/16/box.png" border="0" align="absmiddle" /> Search Packages</a></li>
             <li><a href="<?php echo(generate_url(array('page'=>'packages'))); ?>"><img src="images/16/box.png" border="0" align="absmiddle" /> All Packages</a></li>
           </ul>
         </li>

--- a/html/pages/search.inc.php
+++ b/html/pages/search.inc.php
@@ -2,7 +2,7 @@
 
 $pagetitle[] = "Search";
 
-$sections = array('ipv4' => 'IPv4 Address', 'ipv6' => 'IPv6 Address', 'mac' => 'MAC Address', 'arp' => 'ARP Table');
+$sections = array('packages' => 'Packages', 'ipv4' => 'IPv4 Address', 'ipv6' => 'IPv6 Address', 'mac' => 'MAC Address', 'arp' => 'ARP Table');
 
 if (!isset($vars['search'])) { $vars['search'] = "ipv4"; }
 
@@ -32,6 +32,7 @@ print_optionbar_end('', '');
 
 switch ($vars['search'])
 {
+  case 'packages':
   case 'ipv4':
   case 'ipv6':
   case 'mac':

--- a/html/pages/search.inc.php
+++ b/html/pages/search.inc.php
@@ -2,7 +2,11 @@
 
 $pagetitle[] = "Search";
 
-$sections = array('packages' => 'Packages', 'ipv4' => 'IPv4 Address', 'ipv6' => 'IPv6 Address', 'mac' => 'MAC Address', 'arp' => 'ARP Table');
+$sections = array('ipv4' => 'IPv4 Address', 'ipv6' => 'IPv6 Address', 'mac' => 'MAC Address', 'arp' => 'ARP Table');
+
+if( dbFetchCell("SELECT 1 from `packages` LIMIT 1") ) {
+  $sections['packages'] = 'Packages';
+}
 
 if (!isset($vars['search'])) { $vars['search'] = "ipv4"; }
 
@@ -30,18 +34,10 @@ unset ($sep);
 
 print_optionbar_end('', '');
 
-switch ($vars['search'])
-{
-  case 'packages':
-  case 'ipv4':
-  case 'ipv6':
-  case 'mac':
-  case 'arp':
-    include('pages/search/'.$vars['search'].'.inc.php');
-    break;
-  default:
-    echo(report_this('Unknown search type '.$vars['search']));
-    break;
+if( file_exists('pages/search/'.$vars['search'].'.inc.php') ) {
+  include('pages/search/'.$vars['search'].'.inc.php');
+} else {
+  echo(report_this('Unknown search type '.$vars['search']));
 }
 
 ?>

--- a/html/pages/search/packages.inc.php
+++ b/html/pages/search/packages.inc.php
@@ -26,7 +26,7 @@ print_optionbar_start(28);
 ?>
 <form method="post" action="" class="form-inline" role="form">
 	<div class="form-group">
-		<label for="package">Name</label>
+		<label for="package">Package</label>
 		<input type="text" name="package" id="package" size=20 value="<?php echo($_POST['package']); ?>" class="form-control input-sm" placeholder="Any" />
 	</div>
 	<div class="form-group">
@@ -130,6 +130,7 @@ foreach( $ordered as $name=>$entry ) {
 	$arch = array();
 	$devs = array();
 	foreach( $entry as $variation ) {
+		$variation['version'] = str_replace(":",".",$variation['version']);
 		if( !in_array($variation['version'], $vers) && (empty($ver) || version_compare($variation['version'],$ver,$opt)) ) {
 			$vers[] = $variation['version'];
 		}

--- a/html/pages/search/packages.inc.php
+++ b/html/pages/search/packages.inc.php
@@ -1,0 +1,180 @@
+<?php
+/* Copyright (C) 2014 Daniel Preussker <f0o@devilcode.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+/**
+ * Package Search
+ * @author Daniel Preussker <f0o@devilcode.org>
+ * @copyright 2014 f0o, LibreNMS
+ * @license GPL
+ * @package LibreNMS
+ * @subpackage Search
+ */
+
+print_optionbar_start(28);
+?>
+<form method="post" action="" class="form-inline" role="form">
+	<div class="form-group">
+		<label for="package">Name</label>
+		<input type="text" name="package" id="package" size=20 value="<?php echo($_POST['package']); ?>" class="form-control input-sm" placeholder="Any" />
+	</div>
+	<div class="form-group">
+		<label for="version">Version</label>
+		<input type="text" name="version" id="version" size=20 value="<?php echo($_POST['version']); ?>" class="form-control input-sm" placeholder="Any" />
+	</div>
+	<div class="form-group">
+		<label for="version">Arch</label>
+		<input type="text" name="arch" id="arch" size=20 value="<?php echo($_POST['arch']); ?>" class="form-control input-sm" placeholder="Any" />
+	</div>
+	<button type="submit" class="btn btn-default input-sm">Search</button>
+</form>
+<?php
+print_optionbar_end();
+
+if(isset($_POST['results_amount']) && $_POST['results_amount'] > 0) {
+	$results = $_POST['results'];
+} else {
+	$results = 50;
+}
+
+?>
+<form method="post" action="search/search=packages/" id="result_form">
+	<table class="table table-hover table-condensed table-striped">
+		<tr>
+			<td colspan="3"><strong>Packages</strong></td>
+			<td><select name="results" id="results" class="form-control input-sm" onChange="updateResults(this);">
+				<?php
+					$result_options = array('10','50','100','250','500','1000','5000');
+					foreach($result_options as $option) {
+						echo "<option value='$option'";
+						if($results == $option) {
+							echo " selected";
+						}
+						echo ">$option</option>";
+					}
+				?>
+			</select></td>
+		</tr>
+<?php
+
+$count_query = "SELECT COUNT(*) FROM ( ";
+$full_query = "";
+$query = 'SELECT packages.name FROM packages,devices WHERE packages.device_id = devices.device_id AND packages.name LIKE "%'.mres($_POST['package']).'%" GROUP BY packages.name';
+$where = '';
+
+if( !empty($_POST['arch']) ) {
+	$where  .= ' AND packages.arch = ?';
+	$param[] = mres($_POST['arch']);
+}
+
+if( is_numeric($_REQUEST['device_id']) ) {
+	$where  .= " AND packages.device_id = ?";
+	$param[] = $_REQUEST['device_id'];
+}
+
+
+$count_query .= $query." ) sub";
+$query .= $where." ORDER BY packages.name, packages.arch, packages.version";
+$count = dbFetchCell($count_query,$param);
+
+if( !isset($_POST['page_number']) && $_POST['page_number'] < 1 ) {
+	$page_number = 1;
+} else {
+	$page_number = $_POST['page_number'];
+}
+
+$start = ($page_number - 1) * $results;
+$full_query = $full_query . $query . " LIMIT $start,$results";
+
+?>
+		<tr>
+			<th>Package</th>
+			<th>Version</th>
+			<th>Arch</th>
+			<th>Device</th>
+		</tr>
+<?php
+
+$ordered = array();
+foreach( dbFetchRows($full_query, $param) as $entry ) {
+	$tmp = dbFetchRows("SELECT packages.*,devices.hostname FROM packages,devices WHERE packages.device_id=devices.device_id AND packages.name = ?",array($entry['name']));
+	foreach( $tmp as $entry ) {
+		if( !is_array($ordered[$entry['name']]) ) {
+			$ordered[$entry['name']] = array( $entry );
+		} else {
+			$ordered[$entry['name']][] = $entry;
+		}
+	}
+}
+
+if( !empty($_POST['version']) ) {
+	list($opt, $ver) = explode(" ",$_POST['version']);
+}
+
+foreach( $ordered as $name=>$entry ) {
+	$vers = array();
+	$arch = array();
+	$devs = array();
+	foreach( $entry as $variation ) {
+		if( !in_array($variation['version'], $vers) && (empty($ver) || version_compare($variation['version'],$ver,$opt)) ) {
+			$vers[] = $variation['version'];
+		}
+		if( !in_array($variation['arch'], $arch) ) {
+			$arch[] = $variation['arch'];
+		}
+		if( !in_array($variation['hostname'], $devs) ) {
+			unset($variation['version']);
+			$devs[] = generate_device_link($variation);
+		}
+	}
+	if( sizeof($arch) > 0 && sizeof($vers) > 0 ) {
+		?>
+		<tr>
+			<td><a href="/packages/name=<?php echo $name; ?>/"><?php echo $name; ?></a></td>
+			<td><?php echo implode('<br/>',$vers); ?></td>
+			<td><?php echo implode('<br/>',$arch); ?></td>
+			<td><?php echo implode('<br/>',$devs); ?></td>
+		</tr>
+		<?php
+	}
+}
+if( (int) ($count / $results) > 0 && $count != $results ) {
+	?>
+		<tr>
+			<td colspan="6" align="center"><?php echo generate_pagination($count,$results,$page_number); ?></td>
+		</tr>
+	<?php
+}
+
+?>
+	</table>
+	<input type="hidden" name="page_number" id="page_number" value="<?php echo $page_number; ?>">
+	<input type="hidden" name="results_amount" id="results_amount" value="<?php echo $results; ?>">
+	<input type="hidden" name="package" id="results_packages" value="<?php echo $_POST['package']; ?>">
+	<input type="hidden" name="version" id="results_version" value="<?php echo $_POST['version']; ?>">
+	<input type="hidden" name="arch" id="results_arch" value="<?php echo $_POST['arch']; ?>">
+</form>
+<script type="text/javascript">
+    function updateResults(results) {
+       $('#results_amount').val(results.value);
+       $('#page_number').val(1);
+       $('#result_form').submit();
+    }
+
+    function changePage(page,e) {
+        e.preventDefault();
+        $('#page_number').val(page);
+        $('#result_form').submit();
+    }
+</script>

--- a/html/pages/search/packages.inc.php
+++ b/html/pages/search/packages.inc.php
@@ -72,6 +72,9 @@ $count_query = "SELECT COUNT(*) FROM ( ";
 $full_query = "";
 $query = 'SELECT packages.name FROM packages,devices WHERE packages.device_id = devices.device_id AND packages.name LIKE "%'.mres($_POST['package']).'%" GROUP BY packages.name';
 $where = '';
+$param = array();
+$ver = "";
+$opt = "";
 
 if( !empty($_POST['arch']) ) {
 	$where  .= ' AND packages.arch = ?';


### PR DESCRIPTION
#387

Search for Packages with version comparison (`<`, `<=`, `=`, `>=`, `>`) and architecture filter.

The search-term is expanded to the left and right to match package names. Example: `apt` will match `aptitude` as well as `libapt`.

I would prefer replacing the current `/packages/` page with this file because it's more user-friendly and adds pagination and filters which is handy on a install with many packages. Please comment on this prior merge so I can change the links in case we agree on this