### PR TITLE
Remove cause of duplicate ports listing

### DIFF
--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -333,21 +333,6 @@ list($format, $subformat) = explode("_", $vars['format']);
 
 $ports = dbFetchRows($query, $param);
 
-// FIXME - only populate what we need to search at this point, because we shouldn't show *all* ports, as it's silly.
-
-foreach ($ports as $port)
-{
-  if ($config['memcached']['enable'])
-  {
-    if ($config['memcached']['enable'])
-    {
-      $state = $memcache->get('port-'.$port['port_id'].'-state');
-      if(is_array($state)) { $ports[$port['port_id']] = array_merge($port, $state); }
-      unset($state);
-    }
-  }
-}
-
 switch ($vars['sort'])
 {
   case 'traffic':


### PR DESCRIPTION
#30 
Removed bogus and buggy Memcached reference from html/pages/ports.inc.php to avoid duplicates.

This code was without function. It didnt relief the SQL from any additional queries and only adds duplications in case memcached is used.