### PR TITLE
Autodiscovery $config['mydomain'] variable check

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -16,7 +16,7 @@ function discover_new_device($hostname)
   global $config, $debug;
 
   if ($config['autodiscovery']['xdp']) {
-    if ( isDomainResolves($hostname . "." . $config['mydomain']) ) {
+    if (!empty($config['mydomain']) && isDomainResolves($hostname . "." . $config['mydomain']) ) {
       $dst_host = $hostname . "." . $config['mydomain'];
     } else {
       $dst_host = $hostname;


### PR DESCRIPTION
When host is added via autodiscovery and $config['mydomain'] variable is empty, an additional '.' is added to the end of hostname. This can cause host to be added multiple times via autodiscovery: with and without trailing '.'