### PR TITLE
Revert "Super big important merge"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 config.php
 .index
-junk
 logs
 patches
 rrd


### PR DESCRIPTION
Why was this merge made?
Does a non-existing folder really need to be in the global gitignore?
What purpose will the folder junk serve?

Any info on why the decision has been made?

I personally dont see the point of having this on a global scope unless there are plans on introducing a junk-folder which I'm unaware of.

@paulgear please elaborate so I can sleep well :)
Thanks