### PR TITLE
Updated Global Search css to remove width style

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1609,7 +1609,6 @@ tr.search:nth-child(odd) {
     font-size: 14px;
     line-height: 1.428571429;
     border: 1px solid transparent;
-    width: 250px;
 }
 
 .ui-autocomplete {

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -465,7 +465,7 @@ if ($_SESSION['authenticated'])
      </ul>
      <form role="search" class="navbar-form navbar-left">
          <div class="form-group">
-             <input class="form-control" type="search" id="gsearch" name="gsearch" placeholder="Global Search" style="width: 250px">
+             <input class="form-control" type="search" id="gsearch" name="gsearch" placeholder="Global Search">
          </div>
      </form>
    </div>


### PR DESCRIPTION
This isn't needed, the result box is set to a good width so this can stay dynamic to ensure responsive design is ok.