### PR TITLE
Add VRF-Lite logic and adapt all VRF-Lite discovery and polling modules ...

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -302,6 +302,15 @@ function device_by_id_cache($device_id, $refresh = '0')
     $device = $cache['devices']['id'][$device_id];
   } else {
     $device = dbFetchRow("SELECT * FROM `devices` WHERE `device_id` = ?", array($device_id));
+        //order vrf_lite_cisco with context, this will help to get the vrf_name and instance_name all the time
+    $vrfs_lite_cisco=dbFetchRows("SELECT * FROM `vrf_lite_cisco` WHERE `device_id` = ?", array($device_id));
+    $device['vrf_lite_cisco']=array();
+    if(!empty($vrfs_lite_cisco)){
+        foreach ($vrfs_lite_cisco as $vrf){
+            $device['vrf_lite_cisco'][$vrf['context_name']]=$vrf;
+        }
+    }
+    
     if (get_dev_attrib($device,'override_sysLocation_bool'))
     {
       $device['real_location'] = $device['location'];

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -273,6 +273,7 @@ $config['enable_syslog']                = 0; # Enable Syslog
 $config['enable_inventory']             = 1; # Enable Inventory
 $config['enable_pseudowires']           = 1; # Enable Pseudowires
 $config['enable_vrfs']                  = 1; # Enable VRFs
+$config['enable_vrf_lite_cisco']        = 1; # Enable VRF lite cisco  
 $config['enable_printers']              = 0; # Enable Printer support
 $config['enable_sla']                   = 0; # Enable Cisco SLA collection and display
 
@@ -542,6 +543,9 @@ $config['discovery_modules']['ports-stack']               = 1;
 $config['discovery_modules']['entity-physical']           = 1;
 $config['discovery_modules']['processors']                = 1;
 $config['discovery_modules']['mempools']                  = 1;
+//this module is preferred to be charge before bgp-peers, ipv4-addresses,
+// ipv6-addresses, arp-table and all other module-context-related 
+$config['discovery_modules']['cisco-vrf-lite']            = 1;
 $config['discovery_modules']['ipv4-addresses']            = 1;
 $config['discovery_modules']['ipv6-addresses']            = 1;
 $config['discovery_modules']['sensors']                   = 1;

--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -3,6 +3,19 @@
 unset ($mac_table);
 
 echo("ARP Table : ");
+//WHAT HAPPEN IF THE CONTEXT_NAME CHANGE AND THE VALUE IS ALREADY IN THE DATBABASE?????!!!!!
+
+if(key_exists('vrf_lite_cisco', $device)&&(count($device['vrf_lite_cisco'])!=0)){
+    $vrfs_lite_cisco=$device['vrf_lite_cisco'];
+}else{
+    $vrfs_lite_cisco=array(array('context_name'=>null));
+}
+
+
+foreach ($vrfs_lite_cisco as $vrf) {
+    
+//this will not used if snmp v1, v2c, but i dont use IF{} because is not necessary
+$device['context_name']=$vrf['context_name'];
 
 $ipNetToMedia_data = snmp_walk($device, 'ipNetToMediaPhysAddress', '-Oq', 'IP-MIB');
 $ipNetToMedia_data = str_replace("ipNetToMediaPhysAddress.", "", trim($ipNetToMedia_data));
@@ -29,37 +42,37 @@ foreach (explode("\n", $ipNetToMedia_data) as $data)
     $port_id = $interface['port_id'];
     $mac_table[$port_id][$clean_mac] = 1;
 
-    if (dbFetchCell("SELECT COUNT(*) from ipv4_mac WHERE port_id = ? AND ipv4_address = ?",array($interface['port_id'], $ip)))
-    {
+    if (dbFetchCell("SELECT COUNT(*) from `ipv4_mac` WHERE `port_id` = ? AND `ipv4_address` = ? AND `context_name`= ?",array($interface['port_id'], $ip,$device['context_name'])))
+      {
       // Commented below, no longer needed but leaving for reference.
       //$sql = "UPDATE `ipv4_mac` SET `mac_address` = '$clean_mac' WHERE port_id = '".$interface['port_id']."' AND ipv4_address = '$ip'";
-      $old_mac = dbFetchCell("SELECT mac_address from ipv4_mac WHERE ipv4_address=? AND port_id=?",array($ip,$interface['port_id']));
+      $old_mac = dbFetchCell("SELECT mac_address from ipv4_mac WHERE ipv4_address=? AND port_id= ? AND `context_name`= ?",array($ip,$interface['port_id'],$device['context_name']));
 
       if ($clean_mac != $old_mac && $clean_mac != '' && $old_mac != '')
       {
         if ($debug) { echo("Changed mac address for $ip from $old_mac to $clean_mac\n"); }
         log_event("MAC change: $ip : " . mac_clean_to_readable($old_mac) . " -> " . mac_clean_to_readable($clean_mac), $device, "interface", $interface['port_id']);
       }
-      dbUpdate(array('mac_address' => $clean_mac), 'ipv4_mac', 'port_id=? AND ipv4_address=?',array($interface['port_id'],$ip));
+      dbUpdate(array('mac_address' => $clean_mac), 'ipv4_mac', ' `port_id`=? AND `ipv4_address`=? AND `context_name`= ?',array($interface['port_id'],$ip,$device['context_name']));
       echo(".");
     }
     else
     {
       echo("+");
     #echo("Add MAC $mac\n");
-      dbInsert(array('port_id' => $interface['port_id'], 'mac_address' => $clean_mac, 'ipv4_address' => $ip), 'ipv4_mac');
+      dbInsert(array('port_id' => $interface['port_id'], 'mac_address' => $clean_mac, 'ipv4_address' => $ip, 'context_name'=>$device['context_name']), 'ipv4_mac');
     }
   }
 }
 
-$sql = "SELECT * from ipv4_mac AS M, ports as I WHERE M.port_id = I.port_id and I.device_id = '".$device['device_id']."'";
+$sql = "SELECT * from ipv4_mac AS M, ports as I WHERE M.port_id = I.port_id and I.device_id = '".$device['device_id']." AND M.context_name='".$device['context_name']."'";
 foreach (dbFetchRows($sql) as $entry)
 {
   $entry_mac = $entry['mac_address'];
   $entry_if  = $entry['port_id'];
   if (!$mac_table[$entry_if][$entry_mac])
   {
-    dbDelete('ipv4_mac', '`port_id` = ? AND `mac_address` = ?', array($entry_if,$entry_mac));
+    dbDelete('ipv4_mac', '`port_id` = ? AND `mac_address` = ? AND `context_name`', array($entry_if,$entry_mac,$device['context_name']));
     if ($debug) { echo("Removing MAC $entry_mac from interface ".$interface['ifName']); }
     echo("-");
   }
@@ -67,5 +80,7 @@ foreach (dbFetchRows($sql) as $entry)
 
 echo("\n");
 unset($mac);
-
+unset($device['context_name']);
+}
+unset($vrfs_c);
 ?>

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -2,214 +2,225 @@
 
 global $debug;
 
-if ($config['enable_bgp'])
-{
-  // Discover BGP peers
 
-  echo("BGP Sessions : ");
+if ($config['enable_bgp']) {
+    // Discover BGP peers
 
-  $bgpLocalAs = trim(snmp_walk($device, ".1.3.6.1.2.1.15.2", "-Oqvn", "BGP4-MIB", $config['mibdir']));
+    echo("BGP Sessions : ");
 
-  if (is_numeric($bgpLocalAs))
-  {
-    echo("AS$bgpLocalAs ");
 
-    if ($bgpLocalAs != $device['bgpLocalAs'])
-    {
-      dbUpdate(array('bgpLocalAs' => $bgpLocalAs), 'devices', 'device_id=?',array($device['device_id']));
-      echo("Updated AS ");
+    //WHAT HAPPEN IF THE CONTEXT_NAME CHANGE AND THE VALUE IS ALREADY IN THE DATBABASE?????!!!!!
+
+    if (key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco']) != 0)) {
+        $vrfs_lite_cisco = $device['vrf_lite_cisco'];
+    } else {
+        $vrfs_lite_cisco = array(array('context_name' => null));
     }
 
-    $peers_data = snmp_walk($device, "BGP4-MIB::bgpPeerRemoteAs", "-Oq", "BGP4-MIB", $config['mibdir']);
-    if ($debug) { echo("Peers : $peers_data \n"); }
-    $peers = trim(str_replace("BGP4-MIB::bgpPeerRemoteAs.", "", $peers_data));
+    $bgpLocalAs = trim(snmp_walk($device, ".1.3.6.1.2.1.15.2", "-Oqvn", "BGP4-MIB", $config['mibdir']));
 
-    foreach (explode("\n", $peers) as $peer)
-    {
-      list($peer_ip, $peer_as) = explode(" ",  $peer);
+    if (is_numeric($bgpLocalAs)) {
+        echo("AS$bgpLocalAs ");
 
-      if ($peer && $peer_ip != "0.0.0.0")
-      {
-        if ($debug) { echo("Found peer $peer_ip (AS$peer_as)\n"); }
-        $peerlist[] = array('ip' => $peer_ip, 'as' => $peer_as);
-      }
-    } # Foreach
-
-    if ($device['os'] == "junos")
-    {
-      // Juniper BGP4-V2 MIB
-
-      // FIXME: needs a big cleanup! also see below.
-
-      // FIXME: is .0.ipv6 the only possible value here?
-      $result = snmp_walk($device, "jnxBgpM2PeerRemoteAs.0.ipv6", "-Onq", "BGP4-V2-MIB-JUNIPER", $config['install_dir']."/mibs/junos");
-      $peers = trim(str_replace(".1.3.6.1.4.1.2636.5.1.1.2.1.1.1.13.0.","", $result));
-      foreach (explode("\n", $peers) as $peer)
-      {
-        list($peer_ip_snmp, $peer_as) = explode(" ",  $peer);
-
-        # Magic! Basically, takes SNMP form and finds peer IPs from the walk OIDs.
-        $peer_ip = Net_IPv6::compress(snmp2ipv6(implode('.',array_slice(explode('.',$peer_ip_snmp),count(explode('.',$peer_ip_snmp))-16))));
-
-        if ($peer)
-        {
-          if ($debug) echo("Found peer $peer_ip (AS$peer_as)\n");
-          $peerlist[] = array('ip' => $peer_ip, 'as' => $peer_as);
+        if ($bgpLocalAs != $device['bgpLocalAs']) {
+            dbUpdate(array('bgpLocalAs' => $bgpLocalAs), 'devices', 'device_id=?', array($device['device_id']));
+            echo("Updated AS ");
         }
-      } # Foreach
-    } # OS junos
-  } else {
-    echo("No BGP on host");
-    if ($device['bgpLocalAs'])
-    {
-     dbUpdate(array('bgpLocalAs' => 'NULL'), 'devices', 'device_id=?',array($device['device_id']));
-     echo(" (Removed ASN) ");
-    } # End if
-  } # End if
-
-  // Process disovered peers
-
-  if (isset($peerlist))
-  {
-    foreach ($peerlist as $peer)
-    {
-      $astext = get_astext($peer['as']);
-
-      if (dbFetchCell("SELECT COUNT(*) from `bgpPeers` WHERE device_id = ? AND bgpPeerIdentifier = ?",array($device['device_id'], $peer['ip'])) < '1')
-      {
-        $add = dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'bgpPeerRemoteAs' => $peer['as']), 'bgpPeers');
-        echo("+");
-      } else {
-        $update = dbUpdate(array('bgpPeerRemoteAs' => $peer['as'], 'astext' => mres($astext)), 'bgpPeers', 'device_id=? AND bgpPeerIdentifier=?',array($device['device_id'],$peer['ip']));
-        echo(".");
-      }
-
-      if ($device['os_group'] == "cisco" || $device['os'] == "junos")
-      {
-
-        if ($device['os_group'] == "cisco")
-        {
-          // Get afi/safi and populate cbgp on cisco ios (xe/xr)
-          unset($af_list);
-
-          $af_data = snmp_walk($device, "cbgpPeerAddrFamilyName." . $peer['ip'], "-OsQ", "CISCO-BGP4-MIB", $config['mibdir']);
-          if ($debug) { echo("afi data :: $af_data \n"); }
-
-          $afs = trim(str_replace("cbgpPeerAddrFamilyName.".$peer['ip'].".", "", $af_data));
-          foreach (explode("\n", $afs) as $af)
-          {
-            if ($debug) { echo("AFISAFI = $af\n"); }
-            list($afisafi, $text) = explode(" = ", $af);
-            list($afi, $safi) = explode(".", $afisafi);
-            if ($afi && $safi)
-            {
-              $af_list[$afi][$safi] = 1;
-              if (dbFetchCell("SELECT COUNT(*) from `bgpPeers_cbgp` WHERE device_id = ? AND bgpPeerIdentifier = ?, AND afi=? AND safi=?",array($device['device_id'], $peer['ip'],$afi,$safi)) == 0)
-              {
-                dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'afi' => $afi, 'safi' => $safi), 'bgpPeers_cbgp');
-              }
-            }
-          }
-        } # os_group=cisco
-
-        if ($device['os'] == "junos")
-        {
-          $safis[1] = "unicast";
-          $safis[2] = "multicast";
-
-          if (!isset($j_peerIndexes))
-          {
-            $j_bgp = snmpwalk_cache_multi_oid($device, "jnxBgpM2PeerTable", $jbgp, "BGP4-V2-MIB-JUNIPER", $config['install_dir']."/mibs/junos");
-
-            foreach ($j_bgp as $index => $entry)
-            {
-              switch ($entry['jnxBgpM2PeerRemoteAddrType'])
-              {
-                case 'ipv4':
-                  $ip = long2ip(hexdec($entry['jnxBgpM2PeerRemoteAddr']));
-                  if ($debug) { echo("peerindex for ipv4 $ip is " . $entry['jnxBgpM2PeerIndex'] . "\n"); }
-                  $j_peerIndexes[$ip] = $entry['jnxBgpM2PeerIndex'];
-                  break;
-                case 'ipv6':
-                  $ip6 = trim(str_replace(' ','',$entry['jnxBgpM2PeerRemoteAddr']),'"');
-                  $ip6 = substr($ip6,0,4) . ':' . substr($ip6,4,4) . ':' . substr($ip6,8,4) . ':' . substr($ip6,12,4) . ':' . substr($ip6,16,4) . ':' . substr($ip6,20,4) . ':' . substr($ip6,24,4) . ':' . substr($ip6,28,4);
-                  $ip6 = Net_IPv6::compress($ip6);
-                  if ($debug) { echo("peerindex for ipv6 $ip6 is " . $entry['jnxBgpM2PeerIndex'] . "\n"); }
-                  $j_peerIndexes[$ip6] = $entry['jnxBgpM2PeerIndex'];
-                  break;
-                default:
-                  echo("HALP? Don't know RemoteAddrType " . $entry['jnxBgpM2PeerRemoteAddrType'] . "!\n");
-                  break;
-              }
-            }
-          }
-
-          if (!isset($j_afisafi))
-          {
-            $j_prefixes = snmpwalk_cache_multi_oid($device, "jnxBgpM2PrefixCountersTable", $jbgp, "BGP4-V2-MIB-JUNIPER", $config['install_dir']."/mibs/junos");
-            foreach (array_keys($j_prefixes) as $key)
-            {
-              list($index,$afisafi) = explode('.',$key,2);
-              $j_afisafi[$index][] = $afisafi;
-            }
-          }
-
-          foreach ($j_afisafi[$j_peerIndexes[$peer['ip']]] as $afisafi)
-          {
-            list ($afi,$safi) = explode('.',$afisafi); $safi = $safis[$safi];
-            $af_list[$afi][$safi] = 1;
-            if (dbFetchCell("SELECT COUNT(*) from `bgpPeers_cbgp` WHERE device_id = ? AND bgpPeerIdentifier = ?, AND afi=? AND safi=?",array($device['device_id'], $peer['ip'],$afi,$safi)) == 0)
-            {
-              dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'afi' => $afi, 'safi' => $safi), 'bgpPeers_cbgp');
-            }
-          }
-        } # os=junos
-
-        $af_query = "SELECT * FROM bgpPeers_cbgp WHERE `device_id` = '".$device['device_id']."' AND bgpPeerIdentifier = '".$peer['ip']."'";
-        foreach (dbFetchRows($af_query) as $entry)
-        {
-          $afi = $entry['afi'];
-          $safi = $entry['safi'];
-          if (!$af_list[$afi][$safi])
-          {
-            dbDelete('bgpPeers_cbgp', '`device_id` = ? AND `bgpPeerIdentifier` = ?, afi=?, safi=?', array($device['device_id'],$peer['ip'],$afi,$safi));
-          }
-        } # AF list
-      } # os=cisco|junos
-    } # Foreach
-
-    unset($j_afisafi);
-    unset($j_prefixes);
-    unset($j_bgp);
-    unset($j_peerIndexes);
-  } # isset
-
-  // Delete removed peers
-
-  $sql = "SELECT * FROM bgpPeers AS B, devices AS D WHERE B.device_id = D.device_id AND D.device_id = '".$device['device_id']."'";
-
-  foreach (dbFetchRows($sql) as $entry)
-  {
-    unset($exists);
-    $i = 0;
-
-    while ($i < count($peerlist) && !isset($exists))
-    {
-      if ($peerlist[$i]['ip'] == $entry['bgpPeerIdentifier']) { $exists = 1; }
-      $i++;
+    } else {
+        echo("No BGP on host");
+        if ($device['bgpLocalAs']) {
+            dbUpdate(array('bgpLocalAs' => 'NULL'), 'devices', 'device_id=?', array($device['device_id']));
+            echo(" (Removed ASN) ");
+        }
     }
 
-    if (!isset($exists))
-    {
-      dbDelete('bgpPeers', '`bgpPeer_id` = ?', array($entry['bgpPeer_id']));
-      dbDelete('bgpPeers_cbgp', '`bgpPeer_id` = ?', array($entry['bgpPeer_id']));
-      echo("-");
+
+    foreach ($vrfs_lite_cisco as $vrf) {
+        
+        $device['context_name']=$vrf['context_name'];
+
+        if (is_numeric($bgpLocalAs)) {
+
+
+            $peers_data = snmp_walk($device, "BGP4-MIB::bgpPeerRemoteAs", "-Oq", "BGP4-MIB", $config['mibdir']);
+            if ($debug) {
+                echo("Peers : $peers_data \n");
+            }
+            $peers = trim(str_replace("BGP4-MIB::bgpPeerRemoteAs.", "", $peers_data));
+
+            foreach (explode("\n", $peers) as $peer) {
+                list($peer_ip, $peer_as) = explode(" ", $peer);
+
+                if ($peer && $peer_ip != "0.0.0.0") {
+                    if ($debug) {
+                        echo("Found peer $peer_ip (AS$peer_as)\n");
+                    }
+                    $peerlist[] = array('ip' => $peer_ip, 'as' => $peer_as);
+                }
+            } # Foreach
+
+            
+            //TODO: see what happen with CONTEXT in OS JUNOS
+            if ($device['os'] == "junos") {
+                // Juniper BGP4-V2 MIB
+                // FIXME: needs a big cleanup! also see below.
+                // FIXME: is .0.ipv6 the only possible value here?
+                $result = snmp_walk($device, "jnxBgpM2PeerRemoteAs.0.ipv6", "-Onq", "BGP4-V2-MIB-JUNIPER", $config['install_dir'] . "/mibs/junos");
+                $peers = trim(str_replace(".1.3.6.1.4.1.2636.5.1.1.2.1.1.1.13.0.", "", $result));
+                foreach (explode("\n", $peers) as $peer) {
+                    list($peer_ip_snmp, $peer_as) = explode(" ", $peer);
+
+                    # Magic! Basically, takes SNMP form and finds peer IPs from the walk OIDs.
+                    $peer_ip = Net_IPv6::compress(snmp2ipv6(implode('.', array_slice(explode('.', $peer_ip_snmp), count(explode('.', $peer_ip_snmp)) - 16))));
+
+                    if ($peer) {
+                        if ($debug)
+                            echo("Found peer $peer_ip (AS$peer_as)\n");
+                        $peerlist[] = array('ip' => $peer_ip, 'as' => $peer_as);
+                    }
+                } # Foreach
+            } # OS junos
+        }
+        // Process disovered peers
+
+        if (isset($peerlist)) {
+            foreach ($peerlist as $peer) {
+                $astext = get_astext($peer['as']);
+
+                if (dbFetchCell("SELECT COUNT(*) from `bgpPeers` WHERE device_id = ? AND `bgpPeerIdentifier` = ? AND `context_name` = ?", array($device['device_id'], $peer['ip'],$device['context_name'])) < '1') {
+                    $add = dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'bgpPeerRemoteAs' => $peer['as'],'context_name'=>$device['context_name']), 'bgpPeers');
+                    echo("+");
+                } else {
+                    $update = dbUpdate(array('bgpPeerRemoteAs' => $peer['as'], 'astext' => mres($astext)), 'bgpPeers', 'device_id=? AND bgpPeerIdentifier=?', array($device['device_id'], $peer['ip']));
+                    echo(".");
+                }
+
+                if ($device['os_group'] == "cisco" || $device['os'] == "junos") {
+
+                    if ($device['os_group'] == "cisco") {
+                        // Get afi/safi and populate cbgp on cisco ios (xe/xr)
+                        unset($af_list);
+
+                        $af_data = snmp_walk($device, "cbgpPeerAddrFamilyName." . $peer['ip'], "-OsQ", "CISCO-BGP4-MIB", $config['mibdir']);
+                        if ($debug) {
+                            echo("afi data :: $af_data \n");
+                        }
+
+                        $afs = trim(str_replace("cbgpPeerAddrFamilyName." . $peer['ip'] . ".", "", $af_data));
+                        foreach (explode("\n", $afs) as $af) {
+                            if ($debug) {
+                                echo("AFISAFI = $af\n");
+                            }
+                            list($afisafi, $text) = explode(" = ", $af);
+                            list($afi, $safi) = explode(".", $afisafi);
+                            if ($afi && $safi) {
+                                $af_list[$afi][$safi] = 1;
+                                if (dbFetchCell("SELECT COUNT(*) from `bgpPeers_cbgp` WHERE `device_id` = ? AND `bgpPeerIdentifier` = ?, AND `afi`=? AND `safi`=? and `context_name`=?", array($device['device_id'], $peer['ip'], $afi, $safi,$device['context_name'])) == 0) {
+                                    dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'afi' => $afi, 'safi' => $safi,'context_name'=>$device['context_name']), 'bgpPeers_cbgp');
+                                }
+                            }
+                        }
+                    } # os_group=cisco
+
+                    
+                    
+                    //TODO: See what happen with CONTEXT for the OS JUNOS 
+                    if ($device['os'] == "junos") {
+                        $safis[1] = "unicast";
+                        $safis[2] = "multicast";
+
+                        if (!isset($j_peerIndexes)) {
+                            $j_bgp = snmpwalk_cache_multi_oid($device, "jnxBgpM2PeerTable", $jbgp, "BGP4-V2-MIB-JUNIPER", $config['install_dir'] . "/mibs/junos");
+
+                            foreach ($j_bgp as $index => $entry) {
+                                switch ($entry['jnxBgpM2PeerRemoteAddrType']) {
+                                    case 'ipv4':
+                                        $ip = long2ip(hexdec($entry['jnxBgpM2PeerRemoteAddr']));
+                                        if ($debug) {
+                                            echo("peerindex for ipv4 $ip is " . $entry['jnxBgpM2PeerIndex'] . "\n");
+                                        }
+                                        $j_peerIndexes[$ip] = $entry['jnxBgpM2PeerIndex'];
+                                        break;
+                                    case 'ipv6':
+                                        $ip6 = trim(str_replace(' ', '', $entry['jnxBgpM2PeerRemoteAddr']), '"');
+                                        $ip6 = substr($ip6, 0, 4) . ':' . substr($ip6, 4, 4) . ':' . substr($ip6, 8, 4) . ':' . substr($ip6, 12, 4) . ':' . substr($ip6, 16, 4) . ':' . substr($ip6, 20, 4) . ':' . substr($ip6, 24, 4) . ':' . substr($ip6, 28, 4);
+                                        $ip6 = Net_IPv6::compress($ip6);
+                                        if ($debug) {
+                                            echo("peerindex for ipv6 $ip6 is " . $entry['jnxBgpM2PeerIndex'] . "\n");
+                                        }
+                                        $j_peerIndexes[$ip6] = $entry['jnxBgpM2PeerIndex'];
+                                        break;
+                                    default:
+                                        echo("HALP? Don't know RemoteAddrType " . $entry['jnxBgpM2PeerRemoteAddrType'] . "!\n");
+                                        break;
+                                }
+                            }
+                        }
+
+                        if (!isset($j_afisafi)) {
+                            $j_prefixes = snmpwalk_cache_multi_oid($device, "jnxBgpM2PrefixCountersTable", $jbgp, "BGP4-V2-MIB-JUNIPER", $config['install_dir'] . "/mibs/junos");
+                            foreach (array_keys($j_prefixes) as $key) {
+                                list($index, $afisafi) = explode('.', $key, 2);
+                                $j_afisafi[$index][] = $afisafi;
+                            }
+                        }
+
+                        foreach ($j_afisafi[$j_peerIndexes[$peer['ip']]] as $afisafi) {
+                            list ($afi, $safi) = explode('.', $afisafi);
+                            $safi = $safis[$safi];
+                            $af_list[$afi][$safi] = 1;
+                            if (dbFetchCell("SELECT COUNT(*) from `bgpPeers_cbgp` WHERE device_id = ? AND bgpPeerIdentifier = ?, AND afi=? AND safi=?", array($device['device_id'], $peer['ip'], $afi, $safi)) == 0) {
+                                dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'afi' => $afi, 'safi' => $safi), 'bgpPeers_cbgp');
+                            }
+                        }
+                    } # os=junos
+
+                    $af_query = "SELECT * FROM bgpPeers_cbgp WHERE `device_id` = '" . $device['device_id'] . "' AND `bgpPeerIdentifier` = '" . $peer['ip'] . "' AND  `context_name` = '" . $device['context_name'] . "'";
+                    foreach (dbFetchRows($af_query) as $entry) {
+                        $afi = $entry['afi'];
+                        $safi = $entry['safi'];
+                        if (!$af_list[$afi][$safi]) {
+                            dbDelete('bgpPeers_cbgp', '`device_id` = ? AND `bgpPeerIdentifier` = ? AND afi=? AND safi=? AND `context_name`=?', array($device['device_id'], $peer['ip'], $afi, $safi, $device['context_name']));
+                        }
+                    } # AF list
+                } # os=cisco|junos
+            } # Foreach
+
+            unset($j_afisafi);
+            unset($j_prefixes);
+            unset($j_bgp);
+            unset($j_peerIndexes);
+        } # isset
+        // Delete removed peers
+
+        $sql = "SELECT * FROM bgpPeers AS B, devices AS D WHERE B.device_id = D.device_id AND D.device_id = '" . $device['device_id'] . "' AND  `context_name` = '" . $device['context_name'] . "'";
+
+        foreach (dbFetchRows($sql) as $entry) {
+            unset($exists);
+            $i = 0;
+
+            while ($i < count($peerlist) && !isset($exists)) {
+                if ($peerlist[$i]['ip'] == $entry['bgpPeerIdentifier']) {
+                    $exists = 1;
+                }
+                $i++;
+            }
+
+            if (!isset($exists)) {
+                dbDelete('bgpPeers', '`bgpPeer_id` = ?', array($entry['bgpPeer_id']));
+                dbDelete('bgpPeers_cbgp', '`bgpPeer_id` = ?', array($entry['bgpPeer_id']));
+                echo("-");
+            }
+        }
+
+        unset($peerlist);
+
+        echo("\n");
+        unset($device['context_name']);
     }
-  }
-
-  unset($peerlist);
-
-  echo("\n");
+    unset($device['context_name']);
+    unset($vrfs_c);
+    
+    
 }
-
 ?>

--- a/includes/discovery/cisco-vrf-lite.inc.php
+++ b/includes/discovery/cisco-vrf-lite.inc.php
@@ -1,0 +1,142 @@
+<?php
+
+/* Copyright (C) 2014 Nicolas Armando <nicearma@yahoo.com> and Mathieu Millet <htam-net@github.net>
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>. */
+
+
+global $debug;
+
+// This one only will work with the CISCO-CONTEXT-MAPPING-MIB V2 of cisco
+if ($config['enable_vrf_lite_cisco']) {
+
+    $ids = array();
+
+    // For the moment only will be cisco and the version 3
+    if ($device['os_group'] == "cisco" && $device['snmpver'] == 'v3') {
+
+        echo ("VRF lite cisco : ");
+        $mib = "SNMP-COMMUNITY-MIB";
+
+        $mib = "CISCO-CONTEXT-MAPPING-MIB";
+        //-Osq because if i put the n the oid from the first command is not the same of this one
+        $listVrf = snmp_walk($device, "cContextMappingVrfName", "-Osq -Ln", $mib, NULL);
+        $listVrf = str_replace("cContextMappingVrfName.", "", $listVrf);
+        $listVrf = str_replace('"', "", $listVrf);
+        $listVrf = trim($listVrf);
+
+        if ($debug) {
+            echo ("\n[DEBUG]\nUsing $mib\n[/DEBUG]\n");
+            echo ("\n[DEBUG List Vrf only name]\n$listVrf\n[/DEBUG]\n");
+        }
+
+        $tableVrf;
+        foreach (explode("\n", $listVrf) as $lineVrf) {
+            $tmpVrf = explode(" ", $lineVrf, 2);
+            //the $tmpVrf[0] will be the context
+            if (count($tmpVrf) == 2 && !empty($tmpVrf[1])) {
+                $tableVrf[$tmpVrf[0]]['vrf_name'] = $tmpVrf[1];
+            }
+        }
+
+        unset($listVrf);
+
+        $listIntance = snmp_walk($device, "cContextMappingProtoInstName", "-Osq -Ln", $mib, NULL);
+        $listIntance = str_replace("cContextMappingProtoInstName.", "", $listIntance);
+        $listIntance = str_replace('"', "", $listIntance);
+        $listIntance = trim($listIntance);
+
+        if ($debug) {
+            echo ("\n[DEBUG]\nUsing $mib\n[/DEBUG]\n");
+            echo ("\n[DEBUG]\n List Intance only names\n$listIntance\n[/DEBUG]\n");
+        }
+
+
+        foreach (explode("\n", $listIntance) as $lineIntance) {
+            $tmpIntance = explode(" ", $lineIntance, 2);
+            //the $tmpIntance[0] will be the context and $tmpIntance[1] the intance
+            if (count($tmpIntance) == 2 && !empty($tmpIntance[1])) {
+                $tableVrf[$tmpIntance[0]]['intance_name'] = $tmpIntance[1];
+            }
+        }
+        unset($listIntance);
+     
+
+        foreach ($tableVrf as $context => $vrf) {
+
+
+
+            if ($debug) {
+
+                echo ("\n[DEBUG]\nRelation:t" . $context . "t" . $vrf['intance'] . "t" . $vrf['vrf'] . "\n[/DEBUG]\n");
+            }
+
+            $tmpVrf = dbFetchRow("SELECT * FROM vrf_lite_cisco WHERE device_id = ? and context_name=?", array(
+                $device ['device_id'],
+                $context
+            ));
+            if (!empty($tmpVrf)) {
+
+                $ids[$tmpVrf['vrf_lite_cisco_id']] = $tmpVrf['vrf_lite_cisco_id'];
+                
+                $vrfUpdate=array();
+                
+                foreach ($vrfUpdate as $key => $value) {
+                    if($vrf[$key]!=$value){
+                        $vrfUpdate[$key]=$value;
+                    }
+                }
+                if (!empty($vrfUpdate)) {
+               dbUpdate($vrfUpdate, 'vrf_lite_cisco', 'vrf_lite_cisco_id=?', array(
+                        $tmp['vrf_lite_cisco_id']
+                    ));
+                }
+            } else {
+
+                $id = dbInsert(array(
+                    'device_id' => $device ['device_id'],
+                    'context_name' => $context,
+                    'intance_name' => $vrf['intance_name'],
+                    'vrf_name' => $vrf['vrf_name']
+                        ), 'vrf_lite_cisco');
+
+                $ids[$id] = $id;
+            }
+        }
+        
+        unset($tableVrf);
+    }
+
+    //get all vrf_lite_cisco, this will used where the value depend of the context, be careful with the order that you call this module, if the module is disabled the context search will not work 
+    $tmpVrfC = dbFetchRows("SELECT * FROM vrf_lite_cisco WHERE device_id = ? ", array(
+        $device ['device_id']));
+
+    $device['vrf_lite_cisco'] = $tmpVrfC;
+
+    //Delete all vrf that chaged
+    foreach ($tmpVrfC as $vrfC) {
+        unset($ids[$vrfC['vrf_lite_cisco_id']]);
+    }
+    if (!empty($ids)) {
+        foreach ($ids as $id) {
+
+            dbDelete('vrf_lite_cisco', 'vrf_lite_cisco_id = ? ', array(
+                $id));
+        }
+    }
+
+
+    unset($ids);
+    unset($tmpVrfC);
+} // enable_vrf_lite_cisco
+?>

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -500,7 +500,7 @@ function discover_toner(&$valid, $device, $oid, $index, $type, $descr, $capacity
   $valid[$type][$index] = 1;
 }
 
-function discover_process_ipv6(&$valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$ipv6_origin)
+function discover_process_ipv6(&$valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$ipv6_origin,$context_name='')
 {
   global $device,$config;
 
@@ -516,24 +516,24 @@ function discover_process_ipv6(&$valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$
   if (dbFetchCell("SELECT COUNT(*) FROM `ports` WHERE device_id = ? AND `ifIndex` = ?",array($device['device_id'], $ifIndex)) != '0' && $ipv6_prefixlen > '0' && $ipv6_prefixlen < '129' && $ipv6_compressed != '::1')
   {
     $port_id = dbFetchCell("SELECT port_id FROM `ports` WHERE device_id = ? AND ifIndex = ?",array($device['device_id'], $ifIndex));
-    if (dbFetchCell("SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ?",array($ipv6_network)) < '1')
+    if (dbFetchCell("SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name`=?",array($ipv6_network),$context_name) < '1')
     {
-      dbInsert(array('ipv6_network' => $ipv6_network), 'ipv6_networks');
+      dbInsert(array('ipv6_network' => $ipv6_network,'context_name'=>$context_name), 'ipv6_networks');
       echo("N");
     }
 
     // Below looks like a duplicate of the above FIXME
-    if (dbFetchCell("SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ?",array($ipv6_network)) < '1')
+    if (dbFetchCell("SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name`=? ",array($ipv6_network,$context_name)) < '1')
     {
-      dbInsert(array('ipv6_network' => $ipv6_network), 'ipv6_networks');
+      dbInsert(array('ipv6_network' => $ipv6_network,'context_name'=>$context_name), 'ipv6_networks');
       echo("N");
     }
 
-    $ipv6_network_id = dbFetchCell("SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ?",array($ipv6_network));
+    $ipv6_network_id = dbFetchCell("SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` =?  AND `context_name`=? ",array($ipv6_network,$context_name));
 
-    if (dbFetchCell("SELECT COUNT(*) FROM `ipv6_addresses` WHERE `ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?",array($ipv6_address, $ipv6_prefixlen, $port_id)) == '0')
+    if (dbFetchCell("SELECT COUNT(*) FROM `ipv6_addresses` WHERE `ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ? AND `context_name`=? ",array($ipv6_address, $ipv6_prefixlen, $port_id,$context_name)) == '0')
     {
-     dbInsert(array('ipv6_address' => $ipv6_address, 'ipv6_compressed' => $ipv6_compressed, 'ipv6_prefixlen' => $ipv6_prefixlen,'ipv6_origin' => $ipv6_origin, 'ipv6_network_id' => $ipv6_network_id, 'port_id' => $port_id), 'ipv6_addresses');
+     dbInsert(array('ipv6_address' => $ipv6_address, 'ipv6_compressed' => $ipv6_compressed, 'ipv6_prefixlen' => $ipv6_prefixlen,'ipv6_origin' => $ipv6_origin, 'ipv6_network_id' => $ipv6_network_id, 'port_id' => $port_id, 'context_name'=>$context_name), 'ipv6_addresses');
      echo("+");
     }
     else

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -2,6 +2,19 @@
 
 echo("IPv4 Addresses : ");
 
+if(key_exists('vrf_lite_cisco', $device)&&(count($device['vrf_lite_cisco'])!=0)){
+    $vrfs_lite_cisco=$device['vrf_lite_cisco'];
+}else{
+    $vrfs_lite_cisco=array(array('context_name'=>null));
+}
+
+
+foreach ($vrfs_lite_cisco as $vrf_lite) {
+
+//this will not used if snmp v1, v2c, but i dont use IF{} because is not necessary
+$device['context_name']=$vrf_lite['context_name'];
+
+
 $oids = trim(snmp_walk($device,"ipAdEntIfIndex","-Osq","IP-MIB"));
 $oids = str_replace("ipAdEntIfIndex.", "", $oids);
 foreach (explode("\n", $oids) as $data)
@@ -17,18 +30,18 @@ foreach (explode("\n", $oids) as $data)
   {
     $port_id = dbFetchCell("SELECT `port_id` FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?",array($device['device_id'], $ifIndex));
 
-    if (dbFetchCell("SELECT COUNT(*) FROM `ipv4_networks` WHERE `ipv4_network` = ?",array($network)) < '1')
+    if (dbFetchCell("SELECT COUNT(*) FROM `ipv4_networks` WHERE `ipv4_network` = ? and `context_name` = ?",array($network,$device['context_name'])) < '1')
     {
-      dbInsert(array('ipv4_network' => $network), 'ipv4_networks');
+      dbInsert(array('ipv4_network' => $network,'context_name'=>$device['context_name']), 'ipv4_networks');
       #echo("Create Subnet $network\n");
       echo("S");
     }
 
-    $ipv4_network_id = dbFetchCell("SELECT `ipv4_network_id` FROM `ipv4_networks` WHERE `ipv4_network` = ?",array($network));
+        $ipv4_network_id = dbFetchCell("SELECT `ipv4_network_id` FROM `ipv4_networks` WHERE `ipv4_network` = ? and `context_name`= ?",array($network,$device['context_name']));
 
-    if (dbFetchCell("SELECT COUNT(*) FROM `ipv4_addresses` WHERE `ipv4_address` = ? AND `ipv4_prefixlen` = ? AND `port_id` = ?",array($oid,$cidr,$port_id)) == '0')
+    if (dbFetchCell("SELECT COUNT(*) FROM `ipv4_addresses` WHERE `ipv4_address` = ? AND `ipv4_prefixlen` = ? AND `port_id` = ? and `context_name`=?",array($oid,$cidr,$port_id,$device['context_name'])) == '0')
     {
-      dbInsert(array('ipv4_address' => $oid, 'ipv4_prefixlen' => $cidr, 'ipv4_network_id' => $ipv4_network_id,'port_id' => $port_id), 'ipv4_addresses');
+      dbInsert(array('ipv4_address' => $oid, 'ipv4_prefixlen' => $cidr, 'ipv4_network_id' => $ipv4_network_id,'port_id' => $port_id,'context_name'=>$device['context_name']), 'ipv4_addresses'); 
       #echo("Added $oid/$cidr to $port_id ( $hostname $ifIndex )\n $i_query\n");
       echo("+");
     } else { echo("."); }
@@ -38,7 +51,7 @@ foreach (explode("\n", $oids) as $data)
   } else { echo("!"); }
 }
 
-$sql   = "SELECT * FROM ipv4_addresses AS A, ports AS I WHERE I.device_id = '".$device['device_id']."' AND  A.port_id = I.port_id";
+$sql   = "SELECT * FROM ipv4_addresses AS A, ports AS I WHERE I.device_id = '".$device['device_id']."' AND  A.port_id = I.port_id AND a.context_name= '".$device['context_name']."'";
 foreach (dbFetchRows($sql) as $row)
 {
   $full_address = $row['ipv4_address'] . "/" . $row['ipv4_prefixlen'] . "|" . $row['ifIndex'];
@@ -55,7 +68,11 @@ foreach (dbFetchRows($sql) as $row)
 }
 
 echo("\n");
-
+unset($device['context_name']);
 unset($valid_v4);
+
+}
+unset($vrfs_c);
+
 
 ?>

--- a/includes/discovery/ipv6-addresses.inc.php
+++ b/includes/discovery/ipv6-addresses.inc.php
@@ -2,6 +2,21 @@
 
 echo("IPv6 Addresses : ");
 
+//WHAT HAPPEN IF THE CONTEXT_NAME CHANGE AND THE VALUE IS ALREADY IN THE DATBABASE?????!!!!!
+
+if(key_exists('vrf_lite_cisco', $device)&&(count($device['vrf_lite_cisco'])!=0)){
+    $vrfs_lite_cisco=$device['vrf_lite_cisco'];
+}else{
+    $vrfs_lite_cisco=array(array('context_name'=>null));
+}
+
+
+foreach ($vrfs_lite_cisco as $vrf_lite) {
+
+//this will not used if snmp v1, v2c, but i dont use IF{} because is not necessary
+$device['context_name']=$vrf_lite['context_name'];
+
+
 $oids = snmp_walk($device, "ipAddressIfIndex.ipv6", "-Ln -Osq", "IP-MIB");
 $oids = str_replace("ipAddressIfIndex.ipv6.", "", $oids);
 $oids = str_replace("\"", "", $oids);
@@ -34,7 +49,7 @@ foreach (explode("\n", $oids) as $data)
 
     $ipv6_origin = snmp_get($device, ".1.3.6.1.2.1.4.34.1.6.2.16.$oid", "-Ovq", "IP-MIB");
 
-    discover_process_ipv6($valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$ipv6_origin);
+    discover_process_ipv6($valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$ipv6_origin,$device['context_name']);
   } // if $data
 } // foreach
 
@@ -53,12 +68,12 @@ if (!$oids)
       list($ifIndex,$ipv6addr) = explode(".",$if_ipv6addr,2);
       $ipv6_address = snmp2ipv6($ipv6addr);
       $ipv6_origin = snmp_get($device, "IPV6-MIB::ipv6AddrType.$if_ipv6addr", "-Ovq", "IPV6-MIB");
-      discover_process_ipv6($valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$ipv6_origin);
+      discover_process_ipv6($valid, $ifIndex,$ipv6_address,$ipv6_prefixlen,$ipv6_origin,$device['context_name']);
     } // if $data
   } // foreach
 } // if $oids
 
-$sql   = "SELECT * FROM ipv6_addresses AS A, ports AS I WHERE I.device_id = '".$device['device_id']."' AND  A.port_id = I.port_id";
+$sql   = "SELECT * FROM ipv6_addresses AS A, ports AS I WHERE I.device_id = '".$device['device_id']."' AND  A.port_id = I.port_id AND A.context_name= '".$device['context_name']."'";
 
 foreach (dbFetchRows($sql) as $row)
 {
@@ -77,5 +92,10 @@ foreach (dbFetchRows($sql) as $row)
 }
 
 echo("\n");
+
+unset($device['context_name']);
+}
+unset($vrfs_c);
+
 
 ?>

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -8,20 +8,43 @@ if ($config['enable_bgp'])
 {
   foreach (dbFetchRows("SELECT * FROM bgpPeers WHERE device_id = ?", array($device['device_id'])) as $peer)
   {
+    //add context if exist  
+    $device['context_name']= $peer['context_name'];
     // Poll BGP Peer
 
     echo("Checking BGP peer ".$peer['bgpPeerIdentifier']." ");
 
     if (!strstr($peer['bgpPeerIdentifier'],':'))
     {
+      //change for work snmp_get_multi
       # v4 BGP4 MIB
       // FIXME - needs moved to function
-      $peer_cmd  = $config['snmpget'] . " -M ".$config['mibdir'] . " -m BGP4-MIB -OUvq " . snmp_gen_auth($device) . " " . $device['hostname'].":".$device['port'] . " ";
-      $peer_cmd .= "bgpPeerState." . $peer['bgpPeerIdentifier'] . " bgpPeerAdminStatus." . $peer['bgpPeerIdentifier'] . " bgpPeerInUpdates." . $peer['bgpPeerIdentifier'] . " bgpPeerOutUpdates." . $peer['bgpPeerIdentifier'] . " bgpPeerInTotalMessages." . $peer['bgpPeerIdentifier'] . " ";
-      $peer_cmd .= "bgpPeerOutTotalMessages." . $peer['bgpPeerIdentifier'] . " bgpPeerFsmEstablishedTime." . $peer['bgpPeerIdentifier'] . " bgpPeerInUpdateElapsedTime." . $peer['bgpPeerIdentifier'] . " ";
-      $peer_cmd .= "bgpPeerLocalAddr." . $peer['bgpPeerIdentifier'] . "";
-      $peer_data = trim(`$peer_cmd`);
-      list($bgpPeerState, $bgpPeerAdminStatus, $bgpPeerInUpdates, $bgpPeerOutUpdates, $bgpPeerInTotalMessages, $bgpPeerOutTotalMessages, $bgpPeerFsmEstablishedTime, $bgpPeerInUpdateElapsedTime, $bgpLocalAddr) = explode("\n", $peer_data);
+     // $peer_cmd  = $config['snmpget'] . " -M ".$config['mibdir'] . " -m BGP4-MIB -OUvq " . snmp_gen_auth($device) . " " . $device['hostname'].":".$device['port'] . " ";
+      $oids = "bgpPeerState." . $peer['bgpPeerIdentifier'] . " bgpPeerAdminStatus." . $peer['bgpPeerIdentifier'] . " bgpPeerInUpdates." . $peer['bgpPeerIdentifier'] . " bgpPeerOutUpdates." . $peer['bgpPeerIdentifier'] . " bgpPeerInTotalMessages." . $peer['bgpPeerIdentifier'] . " ";
+      $oids .= "bgpPeerOutTotalMessages." . $peer['bgpPeerIdentifier'] . " bgpPeerFsmEstablishedTime." . $peer['bgpPeerIdentifier'] . " bgpPeerInUpdateElapsedTime." . $peer['bgpPeerIdentifier'] . " ";
+      $oids .= "bgpPeerLocalAddr." . $peer['bgpPeerIdentifier'] . "";
+      $peer_data=snmp_get_multi($device,$oids,'-OUQs','BGP4-MIB');
+      $peer_data=  array_pop($peer_data);
+      if($debug){
+          var_dump($peer_data);  
+      }
+       $bgpPeerState=  !empty($peer_data['bgpPeerState'])?$peer_data['bgpPeerState']:'';
+       $bgpPeerAdminStatus=  !empty($peer_data['bgpPeerAdminStatus'])?$peer_data['bgpPeerAdminStatus']:'';
+       $bgpPeerInUpdates=  !empty($peer_data['bgpPeerInUpdates'])?$peer_data['bgpPeerInUpdates']:'';
+       $bgpPeerOutUpdates=  !empty($peer_data['bgpPeerOutUpdates'])?$peer_data['bgpPeerOutUpdates']:'';
+       $bgpPeerInTotalMessages=  !empty($peer_data['bgpPeerInTotalMessages'])?$peer_data['bgpPeerInTotalMessages']:'';
+       $bgpPeerOutTotalMessages=  !empty($peer_data['bgpPeerOutTotalMessages'])?$peer_data['bgpPeerOutTotalMessages']:'';
+       $bgpPeerFsmEstablishedTime=  !empty($peer_data['bgpPeerFsmEstablishedTime'])?$peer_data['bgpPeerFsmEstablishedTime']:'';
+       $bgpPeerInUpdateElapsedTime=  !empty($peer_data['bgpPeerInUpdateElapsedTime'])?$peer_data['bgpPeerInUpdateElapsedTime']:'';
+       $bgpLocalAddr=  !empty($peer_data['bgpPeerLocalAddr'])?$peer_data['bgpPeerLocalAddr']:'';
+ 
+      //list($bgpPeerState, $bgpPeerAdminStatus, $bgpPeerInUpdates, $bgpPeerOutUpdates, $bgpPeerInTotalMessages, $bgpPeerOutTotalMessages, $bgpPeerFsmEstablishedTime, $bgpPeerInUpdateElapsedTime, $bgpLocalAddr) = array_values($peer_data) ;
+      
+      
+      
+      
+      unset($peer_data);
+      
     }
     else
     if ($device['os'] == "junos")
@@ -33,9 +56,9 @@ if ($config['enable_bgp'])
       {
         echo("\nCaching Oids...");
         // FIXME - needs moved to function
-        $peer_cmd  = $config['snmpwalk'] . " -M ".$config['mibdir'] . "/junos -m BGP4-V2-MIB-JUNIPER -OUnq -" . $device['snmpver'] . " " . snmp_gen_auth($device) . " " . $device['hostname'].":".$device['port'];
-        $peer_cmd .= " jnxBgpM2PeerStatus.0.ipv6";
-        foreach (explode("\n",trim(`$peer_cmd`)) as $oid)
+        //snmp_get($device,'jnxBgpM2PeerStatus.0.ipv6','-OUnq','BGP4-V2-MIB-JUNIPER',$config['mibdir'] . "/junos");
+        
+        foreach (explode("\n",snmp_get($device,'jnxBgpM2PeerStatus.0.ipv6"','-OUnq','BGP4-V2-MIB-JUNIPER',$config['mibdir'] . "/junos")) as $oid)
         {
           list($peer_oid) = explode(' ',$oid);
           $peer_id = explode('.',$peer_oid);
@@ -44,23 +67,36 @@ if ($config['enable_bgp'])
       }
 
       // FIXME - move to function (and clean up, wtf?)
-      $peer_cmd  = $config['snmpget'] . " -M ".$config['mibdir'] . "/junos -m BGP4-V2-MIB-JUNIPER -OUvq " . snmp_gen_auth($device);
-      $peer_cmd .= ' -M"' . $config['install_dir'] . '/mibs/junos"';
-      $peer_cmd .= " " . $device['hostname'].":".$device['port'];
-      $peer_cmd .= " jnxBgpM2PeerState.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerStatus.0.ipv6." . $junos_v6[$peer_ip]; # Should be jnxBgpM2CfgPeerAdminStatus but doesn't seem to be implemented?
-      $peer_cmd .= " jnxBgpM2PeerInUpdates.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerOutUpdates.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerInTotalMessages.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerOutTotalMessages.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerFsmEstablishedTime.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerInUpdatesElapsedTime.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= " jnxBgpM2PeerLocalAddr.0.ipv6." . $junos_v6[$peer_ip];
-      $peer_cmd .= '|grep -v "No Such Instance"';
-      if ($debug) echo("\n$peer_cmd\n");
-      $peer_data = trim(`$peer_cmd`);
-      list($bgpPeerState, $bgpPeerAdminStatus, $bgpPeerInUpdates, $bgpPeerOutUpdates, $bgpPeerInTotalMessages, $bgpPeerOutTotalMessages, $bgpPeerFsmEstablishedTime, $bgpPeerInUpdateElapsedTime, $bgpLocalAddr) = explode("\n", $peer_data);
-
+      $oids = " jnxBgpM2PeerState.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerStatus.0.ipv6." . $junos_v6[$peer_ip]; # Should be jnxBgpM2CfgPeerAdminStatus but doesn't seem to be implemented?
+      $oids .= " jnxBgpM2PeerInUpdates.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerOutUpdates.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerInTotalMessages.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerOutTotalMessages.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerFsmEstablishedTime.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerInUpdatesElapsedTime.0.ipv6." . $junos_v6[$peer_ip];
+      $oids .= " jnxBgpM2PeerLocalAddr.0.ipv6." . $junos_v6[$peer_ip];
+      //$peer_cmd .= '|grep -v "No Such Instance"'; WHAT TO DO WITH THIS??,USE TO SEE -Ln?? 
+      $peer_data=snmp_get_multi($device,$oids,'-OUQs -Ln','BGP4-V2-MIB-JUNIPER',$config['mibdir'] . "/junos");
+      $peer_data=  array_pop($peer_data);
+      if($debug){
+          var_dump($peer_data);
+      }
+      $bgpPeerState=  !empty($peer_data['bgpPeerState'])?$peer_data['bgpPeerState']:'';
+       $bgpPeerAdminStatus=  !empty($peer_data['bgpPeerAdminStatus'])?$peer_data['bgpPeerAdminStatus']:'';
+       $bgpPeerInUpdates=  !empty($peer_data['bgpPeerInUpdates'])?$peer_data['bgpPeerInUpdates']:'';
+       $bgpPeerOutUpdates=  !empty($peer_data['bgpPeerOutUpdates'])?$peer_data['bgpPeerOutUpdates']:'';
+       $bgpPeerInTotalMessages=  !empty($peer_data['bgpPeerInTotalMessages'])?$peer_data['bgpPeerInTotalMessages']:'';
+       $bgpPeerOutTotalMessages=  !empty($peer_data['bgpPeerOutTotalMessages'])?$peer_data['bgpPeerOutTotalMessages']:'';
+       $bgpPeerFsmEstablishedTime=  !empty($peer_data['bgpPeerFsmEstablishedTime'])?$peer_data['bgpPeerFsmEstablishedTime']:'';
+       $bgpPeerInUpdateElapsedTime=  !empty($peer_data['bgpPeerInUpdateElapsedTime'])?$peer_data['bgpPeerInUpdateElapsedTime']:'';
+       $bgpLocalAddr=  !empty($peer_data['bgpPeerLocalAddr'])?$peer_data['bgpPeerLocalAddr']:'';
+      
+      //list($bgpPeerState, $bgpPeerAdminStatus, $bgpPeerInUpdates, $bgpPeerOutUpdates, $bgpPeerInTotalMessages, $bgpPeerOutTotalMessages, $bgpPeerFsmEstablishedTime, $bgpPeerInUpdateElapsedTime, $bgpLocalAddr) = array_values($peer_data);
+      
+      
+      unset($peer_data);
+      
       if ($debug) { echo("State = $bgpPeerState - AdminStatus: $bgpPeerAdminStatus\n"); }
 
       $bgpLocalAddr = str_replace('"','',str_replace(' ','',$bgpLocalAddr));
@@ -137,22 +173,30 @@ if ($config['enable_bgp'])
         if ($device['os_group'] == "cisco")
         {
           // FIXME - move to function
-          $cbgp_cmd  = $config['snmpget'] . " -M ".$config['mibdir'] . " -m CISCO-BGP4-MIB -Ovq " . snmp_gen_auth($device) . " " . $device['hostname'].":".$device['port'];
-          $cbgp_cmd .= " cbgpPeerAcceptedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerDeniedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerPrefixAdminLimit." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerPrefixThreshold." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerPrefixClearThreshold." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerAdvertisedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerSuppressedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
-          $cbgp_cmd .= " cbgpPeerWithdrawnPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids = " cbgpPeerAcceptedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerDeniedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerPrefixAdminLimit." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerPrefixThreshold." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerPrefixClearThreshold." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerAdvertisedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerSuppressedPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          $oids .= " cbgpPeerWithdrawnPrefixes." . $peer['bgpPeerIdentifier'] . ".$afi.$safi";
+          
+          $cbgp_data=  snmp_get_multi($device,$oids,'-OUQs ','CISCO-BGP4-MIB');
+          $cbgp_data=  array_pop($cbgp_data);
 
-          if ($debug) { echo("$cbgp_cmd\n"); }
-          $cbgp_data = preg_replace("/^OID.*$/", "", trim(`$cbgp_cmd`));
-          $cbgp_data = preg_replace("/No Such Instance currently exists at this OID/", "0", $cbgp_data);
-          if ($debug) { echo("$cbgp_data\n"); }
-          list($cbgpPeerAcceptedPrefixes,$cbgpPeerDeniedPrefixes,$cbgpPeerPrefixAdminLimit,$cbgpPeerPrefixThreshold,$cbgpPeerPrefixClearThreshold,$cbgpPeerAdvertisedPrefixes,$cbgpPeerSuppressedPrefixes,$cbgpPeerWithdrawnPrefixes) = explode("\n", $cbgp_data);
-        }
+          $cbgpPeerAcceptedPrefixes=  !empty($cbgp_data['cbgpPeerAcceptedPrefixes'])?$cbgp_data['cbgpPeerAcceptedPrefixes']:'';
+          $cbgpPeerDeniedPrefixes=  !empty($cbgp_data['cbgpPeerDeniedPrefixes'])?$cbgp_data['cbgpPeerDeniedPrefixes']:'';
+          $cbgpPeerPrefixAdminLimit=  !empty($cbgp_data['cbgpPeerPrefixAdminLimit'])?$cbgp_data['cbgpPeerPrefixAdminLimit']:'';
+          $cbgpPeerPrefixThreshold=  !empty($cbgp_data['cbgpPeerPrefixThreshold'])?$cbgp_data['cbgpPeerPrefixThreshold']:'';
+          $cbgpPeerPrefixClearThreshold=  !empty($cbgp_data['cbgpPeerPrefixClearThreshold'])?$cbgp_data['cbgpPeerPrefixClearThreshold']:'';
+          $cbgpPeerAdvertisedPrefixes=  !empty($cbgp_data['cbgpPeerAdvertisedPrefixes'])?$cbgp_data['cbgpPeerAdvertisedPrefixes']:'';
+          $cbgpPeerSuppressedPrefixes=  !empty($cbgp_data['cbgpPeerSuppressedPrefixes'])?$cbgp_data['cbgpPeerSuppressedPrefixes']:'';
+          $cbgpPeerWithdrawnPrefixes=  !empty($cbgp_data['cbgpPeerWithdrawnPrefixes'])?$cbgp_data['cbgpPeerWithdrawnPrefixes']:'';
+          //list($cbgpPeerAcceptedPrefixes,$cbgpPeerDeniedPrefixes,$cbgpPeerPrefixAdminLimit,$cbgpPeerPrefixThreshold,$cbgpPeerPrefixClearThreshold,$cbgpPeerAdvertisedPrefixes,$cbgpPeerSuppressedPrefixes,$cbgpPeerWithdrawnPrefixes) =array_values( $cbgp_data);
+          unset($cbgp_data);
+          
+          }
 
         if ($device['os'] == "junos")
         {
@@ -224,6 +268,7 @@ if ($config['enable_bgp'])
     } # os_group=cisco | junos
     echo("\n");
 
+    unset($device['context_name']);
   } // End While loop on peers
 } // End check for BGP support
 

--- a/includes/polling/ospf.inc.php
+++ b/includes/polling/ospf.inc.php
@@ -3,224 +3,242 @@
 echo("OSPF: ");
 echo("Processes: ");
 
-$ospf_instance_count  = 0;
-$ospf_port_count      = 0;
-$ospf_area_count      = 0;
+$ospf_instance_count = 0;
+$ospf_port_count = 0;
+$ospf_area_count = 0;
 $ospf_neighbour_count = 0;
 
+global $debug;
+
+
 $ospf_oids_db = array('ospfRouterId', 'ospfAdminStat', 'ospfVersionNumber', 'ospfAreaBdrRtrStatus', 'ospfASBdrRtrStatus',
-                      'ospfExternLsaCount', 'ospfExternLsaCksumSum', 'ospfTOSSupport', 'ospfOriginateNewLsas', 'ospfRxNewLsas',
-                      'ospfExtLsdbLimit', 'ospfMulticastExtensions', 'ospfExitOverflowInterval', 'ospfDemandExtensions');
+    'ospfExternLsaCount', 'ospfExternLsaCksumSum', 'ospfTOSSupport', 'ospfOriginateNewLsas', 'ospfRxNewLsas',
+    'ospfExtLsdbLimit', 'ospfMulticastExtensions', 'ospfExitOverflowInterval', 'ospfDemandExtensions');
+
+
+$ospf_area_oids = array('ospfAuthType', 'ospfImportAsExtern', 'ospfSpfRuns', 'ospfAreaBdrRtrCount', 'ospfAsBdrRtrCount',
+    'ospfAreaLsaCount', 'ospfAreaLsaCksumSum', 'ospfAreaSummary', 'ospfAreaStatus');
+
+
+$ospf_port_oids = array('ospfIfIpAddress', 'port_id', 'ospfAddressLessIf', 'ospfIfAreaId', 'ospfIfType', 'ospfIfAdminStat',
+    'ospfIfRtrPriority', 'ospfIfTransitDelay', 'ospfIfRetransInterval', 'ospfIfHelloInterval', 'ospfIfRtrDeadInterval',
+    'ospfIfPollInterval', 'ospfIfState', 'ospfIfDesignatedRouter', 'ospfIfBackupDesignatedRouter', 'ospfIfEvents',
+    'ospfIfAuthKey', 'ospfIfStatus', 'ospfIfMulticastForwarding', 'ospfIfDemand', 'ospfIfAuthType');
+
+$ospf_nbr_oids_db = array('ospfNbrIpAddr', 'ospfNbrAddressLessIndex', 'ospfNbrRtrId', 'ospfNbrOptions', 'ospfNbrPriority',
+    'ospfNbrState', 'ospfNbrEvents', 'ospfNbrLsRetransQLen', 'ospfNbmaNbrStatus', 'ospfNbmaNbrPermanence', 'ospfNbrHelloSuppressed');
+$ospf_nbr_oids_rrd = array();
+$ospf_nbr_oids = array_merge($ospf_nbr_oids_db, $ospf_nbr_oids_rrd);
+
+
+
+if (key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco']) != 0)) {
+    $vrfs_lite_cisco = $device['vrf_lite_cisco'];
+} else {
+    $vrfs_lite_cisco = array(array('context_name' => null));
+}
+
+
+foreach ($vrfs_lite_cisco as $vrf_lite) {
+
+    $device['context_name'] = $vrf_lite['context_name'];
 
 // Build array of existing entries
-foreach (dbFetchRows("SELECT * FROM `ospf_instances` WHERE `device_id` = ?", array($device['device_id'])) as $entry)
-{
-  $ospf_instances_db[$entry['ospf_instance_id']] = $entry;
-}
-
-// Pull data from device
-$ospf_instances_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfGeneralGroup", array(), "OSPF-MIB");
-foreach ($ospf_instances_poll as $ospf_instance_id => $ospf_entry)
-{
-  // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
-  if (!isset($ospf_instances_db[$ospf_instance_id]))
-  {
-    dbInsert(array('device_id' => $device['device_id'], 'ospf_instance_id' => $ospf_instance_id), 'ospf_instances');
-    echo("+");
-    $ospf_instances_db[$entry['ospf_instance_id']] = dbFetchRow("SELECT * FROM `ospf_instances` WHERE `device_id` = ? AND `ospf_instance_id` = ?", array($device['device_id'],$ospf_instance_id));
-    $ospf_instances_db[$entry['ospf_instance_id']] = $entry;
-  }
-}
-
-if ($debug)
-{
-  echo("\nPolled: ");
-  print_r($ospf_instances_poll);
-  echo("Database: ");
-  print_r($ospf_instances_db);
-  echo("\n");
-}
-
-// Loop array of entries and update
-if (is_array($ospf_instances_db))
-{
-  foreach ($ospf_instances_db as $ospf_instance_db)
-  {
-    $ospf_instance_poll = $ospf_instances_poll[$ospf_instance_db['ospf_instance_id']];
-    foreach ($ospf_oids_db as $oid)
-    { // Loop the OIDs
-      if ($ospf_instance_db[$oid] != $ospf_instance_poll[$oid])
-      { // If data has changed, build a query
-        $ospf_instance_update[$oid] = $ospf_instance_poll[$oid];
-        #log_event("$oid -> ".$this_port[$oid], $device, 'ospf', $port['port_id']); // FIXME
-      }
-    }
-    if ($ospf_instance_update)
-    {
-      dbUpdate($ospf_instance_update, 'ospf_instances', '`device_id` = ? AND `ospf_instance_id` = ?', array($device['device_id'], $ospf_instance_id));
-      echo("U");
-      unset($ospf_instance_update);
-    } else {
-      echo(".");
+    foreach (dbFetchRows("SELECT * FROM `ospf_instances` WHERE `device_id` = ? AND `context_name` = ?", array($device['device_id'], $device['context_name'])) as $entry) {
+        $ospf_instances_db[$entry['ospf_instance_id']][$entry['context_name']] = $entry;
     }
 
-    unset($ospf_instance_poll);
-    unset($ospf_instance_db);
-    $ospf_instance_count++;
-  }
-}
-
-unset($ospf_instances_poll);
-unset($ospf_instances_db);
-
-echo(" Areas: ");
-
-$ospf_area_oids = array('ospfAuthType','ospfImportAsExtern','ospfSpfRuns','ospfAreaBdrRtrCount','ospfAsBdrRtrCount','ospfAreaLsaCount','ospfAreaLsaCksumSum','ospfAreaSummary','ospfAreaStatus');
-
-// Build array of existing entries
-foreach (dbFetchRows("SELECT * FROM `ospf_areas` WHERE `device_id` = ?", array($device['device_id'])) as $entry)
-{
-  $ospf_areas_db[$entry['ospfAreaId']] = $entry;
-}
-
 // Pull data from device
-$ospf_areas_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfAreaEntry", array(), "OSPF-MIB");
-
-foreach ($ospf_areas_poll as $ospf_area_id => $ospf_area)
-{
-  // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
-  if (!isset($ospf_areas_db[$ospf_area_id]))
-  {
-    dbInsert(array('device_id' => $device['device_id'], 'ospfAreaId' => $ospf_area_id), 'ospf_areas');
-    echo("+");
-    $entry = dbFetchRows("SELECT * FROM `ospf_areas` WHERE `device_id` = ? AND `ospfAreaId` = ?",array($device['device_id'], $ospf_area_id));
-    $ospf_areas_db[$entry['ospf_area_id']] = $entry;
-  }
-}
-
-if ($debug)
-{
-  echo("\nPolled: ");
-  print_r($ospf_areas_poll);
-  echo("Database: ");
-  print_r($ospf_areas_db);
-  echo("\n");
-}
-
-// Loop array of entries and update
-if (is_array($ospf_areas_db))
-{
-  foreach ($ospf_areas_db as $ospf_area_db)
-  {
-    if (is_array($ospf_ports_poll[$ospf_port_db['ospf_port_id']]))
-    {
-      $ospf_area_poll = $ospf_areas_poll[$ospf_area_db['ospfAreaId']];
-      foreach ($ospf_area_oids as $oid)
-      { // Loop the OIDs
-        if ($ospf_area_db[$oid] != $ospf_area_poll[$oid])
-        { // If data has changed, build a query
-          $ospf_area_update[$oid] = $ospf_area_poll[$oid];
-          #log_event("$oid -> ".$this_port[$oid], $device, 'interface', $port['port_id']); // FIXME
+    $ospf_instances_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfGeneralGroup", array(), "OSPF-MIB");
+    foreach ($ospf_instances_poll as $ospf_instance_id => $ospf_entry) {
+        // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
+        if (empty($ospf_instances_db[$ospf_instance_id][$device['context_name']])) {
+            dbInsert(array('device_id' => $device['device_id'], 'ospf_instance_id' => $ospf_instance_id, 'context_name' => $device['context_name']), 'ospf_instances');
+            echo("+");
+            $ospf_instances_db[$ospf_instance_id][$device['context_name']] = dbFetchRow("SELECT * FROM `ospf_instances` WHERE `device_id` = ? AND `ospf_instance_id` = ? and `context_name`=?", array($device['device_id'], $ospf_instance_id, $device['context_name']));
         }
-      }
-      if ($ospf_area_update)
-      {
-        dbUpdate($ospf_area_update, 'ospf_areas', '`device_id` = ? AND `ospfAreaId` = ?', array($device['device_id'], $ospf_area_id));
-        echo("U");
-        unset($ospf_area_update);
-      } else {
-        echo(".");
-      }
-      unset($ospf_area_poll);
-      unset($ospf_area_db);
-      $ospf_area_count++;
-    } else {
-      dbDelete('ospf_ports', '`device_id` = ? AND `ospfAreaId` = ?', array($device['device_id'], $ospf_area_db['ospfAreaId']));
     }
-  }
-}
 
-unset($ospf_areas_db);
-unset($ospf_areas_poll);
+    if ($debug) {
+        echo("\nPolled: ");
+        print_r($ospf_instances_poll);
+        echo("Database: ");
+        print_r($ospf_instances_db);
+        echo("\n");
+    }
+
+// Loop array of entries and update
+    if (is_array($ospf_instances_db)) {
+
+        foreach ($ospf_instances_db as $ospf_instance_id=>$ospf_instance_db) {
+
+            if (is_array($ospf_instances_poll[$ospf_instance_id])) {
+                $ospf_instance_poll = $ospf_instances_poll[$ospf_instance_id];
+                foreach ($ospf_oids_db as $oid) { // Loop the OIDs
+                    if ($ospf_instance_db[$device['context_name']][$oid] != $ospf_instance_poll[$oid]) { // If data has changed, build a query
+                        $ospf_instance_update[$oid] = $ospf_instance_poll[$oid];
+                        #log_event("$oid -> ".$this_port[$oid], $device, 'ospf', $port['port_id']); // FIXME
+                    }
+                }
+                if ($ospf_instance_update) {
+                    dbUpdate($ospf_instance_update, 'ospf_instances', '`device_id` = ? AND `ospf_instance_id` = ? AND `context_name`=? ', array($device['device_id'], $ospf_instance_id, $device['context_name']));
+                    echo("U");
+                    unset($ospf_instance_update);
+                } else {
+                    echo(".");
+                }
+
+                unset($ospf_instance_poll);
+                unset($ospf_instance_db);
+                $ospf_instance_count++;
+            } else {
+                dbDelete('ospf_instances', '`device_id` = ? AND `ospf_instance_id` = ? AND `context_name`=? ', array($device['device_id'], $ospf_area_db['ospfAreaId'], $device['context_name']));
+            }
+        }
+    }
+
+
+    unset($ospf_instances_poll);
+    unset($ospf_instances_db);
+
+
+
+    echo(" Areas: ");
+
+// Build array of existing entries
+    foreach (dbFetchRows("SELECT * FROM `ospf_areas` WHERE `device_id` = ? AND `context_name`=?", array($device['device_id'], $device['context_name'])) as $entry) {
+        $ospf_areas_db[$entry['ospfAreaId']][$entry['context_name']] = $entry;
+    }
+
+// Pull data from device
+    $ospf_areas_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfAreaEntry", array(), "OSPF-MIB");
+
+    foreach ($ospf_areas_poll as $ospf_area_id => $ospf_area) {
+        // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
+        if (empty($ospf_areas_db[$ospf_area_id][$device['context_name']])) {
+            dbInsert(array('device_id' => $device['device_id'], 'ospfAreaId' => $ospf_area_id, 'context_name' => $device['context_name']), 'ospf_areas');
+            echo("+");
+            $ospf_areas_db[$ospf_area_id][$device['context_name']] = dbFetchRows("SELECT * FROM `ospf_areas` WHERE `device_id` = ? AND `ospfAreaId` = ? AND `context_name` = ?", array($device['device_id'], $ospf_area_id, $device['context_name']));
+        }
+    }
+
+    if ($debug) {
+        echo("\nPolled: ");
+        print_r($ospf_areas_poll);
+        echo("Database: ");
+        print_r($ospf_areas_db);
+        echo("\n");
+    }
+
+// Loop array of entries and update
+    if (is_array($ospf_areas_db)) {
+        foreach ($ospf_areas_db as $ospf_area_id=>$ospf_area_db) {
+
+            if (is_array($ospf_areas_poll[$ospf_area_id])) {
+
+                $ospf_area_poll = $ospf_areas_poll[$ospf_area_id];
+
+                foreach ($ospf_area_oids as $oid) { // Loop the OIDs
+                    if ($ospf_area_db[$device['context_name']][$oid] != $ospf_area_poll[$oid]) { // If data has changed, build a query
+                        $ospf_area_update[$oid] = $ospf_area_poll[$oid];
+                        #log_event("$oid -> ".$this_port[$oid], $device, 'interface', $port['port_id']); // FIXME
+                    }
+                }
+
+                if ($ospf_area_update) {
+                    dbUpdate($ospf_area_update, 'ospf_areas', '`device_id` = ? AND `ospfAreaId` = ? AND `context_name` = ?', array($device['device_id'], $ospf_area_id, $device['context_name']));
+                    echo("U");
+                    unset($ospf_area_update);
+                } else {
+                    echo(".");
+                }
+                unset($ospf_area_poll);
+                unset($ospf_area_db);
+                $ospf_area_count++;
+            } else {
+                dbDelete('ospf_ports', '`device_id` = ? AND `ospfAreaId` = ? AND `context_name` = ?', array($device['device_id'], $ospf_area_db['ospfAreaId'], $device['context_name']));
+            }
+        }
+    }
+
+    unset($ospf_areas_db);
+    unset($ospf_areas_poll);
 
 #$ospf_ports = snmpwalk_cache_oid($device, "OSPF-MIB::ospfIfEntry", array(), "OSPF-MIB");
 #print_r($ospf_ports);
 
-echo(" Ports: ");
 
-$ospf_port_oids = array('ospfIfIpAddress','port_id','ospfAddressLessIf','ospfIfAreaId','ospfIfType','ospfIfAdminStat','ospfIfRtrPriority','ospfIfTransitDelay','ospfIfRetransInterval','ospfIfHelloInterval','ospfIfRtrDeadInterval','ospfIfPollInterval','ospfIfState','ospfIfDesignatedRouter','ospfIfBackupDesignatedRouter','ospfIfEvents','ospfIfAuthKey','ospfIfStatus','ospfIfMulticastForwarding','ospfIfDemand','ospfIfAuthType');
+
+    echo(" Ports: ");
 
 // Build array of existing entries
-foreach (dbFetchRows("SELECT * FROM `ospf_ports` WHERE `device_id` = ?", array($device['device_id'])) as $entry)
-{
-  $ospf_ports_db[$entry['ospf_port_id']] = $entry;
-}
+    foreach (dbFetchRows("SELECT * FROM `ospf_ports` WHERE `device_id` = ? AND `context_name` = ?", array($device['device_id'], $device['context_name'])) as $entry) {
+        $ospf_ports_db[$entry['ospf_port_id']][$device['context_name']] = $entry;
+    }
 
 // Pull data from device
-$ospf_ports_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfIfEntry", array(), "OSPF-MIB");
+    $ospf_ports_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfIfEntry", array(), "OSPF-MIB");
 
-foreach ($ospf_ports_poll as $ospf_port_id => $ospf_port)
-{
-  // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
-  if (!isset($ospf_ports_db[$ospf_port_id]))
-  {
-    dbInsert(array('device_id' => $device['device_id'], 'ospf_port_id' => $ospf_port_id), 'ospf_ports');
-    echo("+");
-    $ospf_ports_db[$entry['ospf_port_id']] = dbFetchRow("SELECT * FROM `ospf_ports` WHERE `device_id` = ? AND `ospf_port_id` = ?", array($device['device_id'], $ospf_port_id));
-  }
-}
+    foreach ($ospf_ports_poll as $ospf_port_id => $ospf_port) {
+        // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
+        if (empty($ospf_ports_db[$ospf_port_id][$device['context_name']])) {
+            dbInsert(array('device_id' => $device['device_id'], 'ospf_port_id' => $ospf_port_id, 'context_name' => $device['context_name']), 'ospf_ports');
+            echo("+");
+            $ospf_ports_db[$ospf_port_id][$device['context_name']] = dbFetchRow("SELECT * FROM `ospf_ports` WHERE `device_id` = ? AND `ospf_port_id` = ? AND `context_name` = ?", array($device['device_id'], $ospf_port_id, $device['context_name']));
+        }
+    }
 
-if ($debug)
-{
-  echo("\nPolled: ");
-  print_r($ospf_ports_poll);
-  echo("Database: ");
-  print_r($ospf_ports_db);
-  echo("\n");
-}
+    if ($debug) {
+        echo("\nPolled: ");
+        print_r($ospf_ports_poll);
+        echo("Database: ");
+        print_r($ospf_ports_db);
+        echo("\n");
+    }
 
 // Loop array of entries and update
-if (is_array($ospf_ports_db))
-{
-  foreach ($ospf_ports_db as $ospf_port_id => $ospf_port_db)
-  {
-    if (is_array($ospf_ports_poll[$ospf_port_db['ospf_port_id']]))
-    {
-      $ospf_port_poll = $ospf_ports_poll[$ospf_port_db['ospf_port_id']];
+    if (is_array($ospf_ports_db)) {
 
-      if ($ospf_port_poll['ospfAddressLessIf'])
-      {
-        $ospf_port_poll['port_id'] = @dbFetchCell("SELECT `port_id` FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?", array($device['device_id'], $ospf_port_poll['ospfAddressLessIf']));
-      } else {
-        $ospf_port_poll['port_id'] = @dbFetchCell("SELECT A.`port_id` FROM ipv4_addresses AS A, ports AS I WHERE A.ipv4_address = ? AND I.port_id = A.port_id AND I.device_id = ?", array($ospf_port_poll['ospfIfIpAddress'], $device['device_id']));
-      }
+        foreach ($ospf_ports_db as $ospf_port_id => $ospf_port_db) {
 
-      foreach ($ospf_port_oids as $oid)
-      { // Loop the OIDs
-        if ($ospf_port_db[$oid] != $ospf_port_poll[$oid])
-        { // If data has changed, build a query
-          $ospf_port_update[$oid] = $ospf_port_poll[$oid];
-          #log_event("$oid -> ".$this_port[$oid], $device, 'ospf', $port['port_id']); // FIXME
+            if (is_array($ospf_ports_poll[$ospf_port_id])) {
+                $ospf_port_poll = $ospf_ports_poll[$ospf_port_id];
+
+                if ($ospf_port_poll['ospfAddressLessIf']) {
+                    $ospf_port_poll['port_id'] = @dbFetchCell("SELECT `port_id` FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?", array($device['device_id'], $ospf_port_poll['ospfAddressLessIf']));
+                } else {
+                    $ospf_port_poll['port_id'] = @dbFetchCell("SELECT A.`port_id` FROM ipv4_addresses AS A, ports AS I WHERE A.ipv4_address = ? AND I.port_id = A.port_id AND I.device_id = ? AND A.context_name = ?", array($ospf_port_poll['ospfIfIpAddress'], $device['device_id'], $device['context_name']));
+                }
+
+                foreach ($ospf_port_oids as $oid) { // Loop the OIDs
+                    if ($ospf_port_db[$device['context_name']][$oid] != $ospf_port_poll[$oid]) { // If data has changed, build a query
+                        $ospf_port_update[$oid] = $ospf_port_poll[$oid];
+                        #log_event("$oid -> ".$this_port[$oid], $device, 'ospf', $port['port_id']); // FIXME
+                    }
+                }
+                if ($ospf_port_update) {
+                    dbUpdate($ospf_port_update, 'ospf_ports', '`device_id` = ? AND `ospf_port_id` = ? AND `context_name` = ?', array($device['device_id'], $ospf_port_id, $device['context_name']));
+                    echo("U");
+                    unset($ospf_port_update);
+                } else {
+                    echo(".");
+                }
+                unset($ospf_port_poll);
+                unset($ospf_port_db);
+                $ospf_port_count++;
+            } else {
+                dbDelete('ospf_ports', '`device_id` = ? AND `ospf_port_id` = ? AND `context_name` = ?', array($device['device_id'], $ospf_port_db['ospf_port_id'], $device['context_name']));
+                # "DELETE FROM `ospf_ports` WHERE `device_id` = '".$device['device_id']."' AND `ospf_port_id` = '".$ospf_port_db['ospf_port_id']."'");
+                echo("-");
+            }
         }
-      }
-      if ($ospf_port_update)
-      {
-        dbUpdate($ospf_port_update, 'ospf_ports', '`device_id` = ? AND `ospf_port_id` = ?', array($device['device_id'], $ospf_port_id));
-        echo("U");
-        unset($ospf_port_update);
-      } else {
-        echo(".");
-      }
-      unset($ospf_port_poll);
-      unset($ospf_port_db);
-      $ospf_port_count++;
-    } else {
-      dbDelete('ospf_ports', '`device_id` = ? AND `ospf_port_id` = ?', array($device['device_id'], $ospf_port_db['ospf_port_id']));
-      # "DELETE FROM `ospf_ports` WHERE `device_id` = '".$device['device_id']."' AND `ospf_port_id` = '".$ospf_port_db['ospf_port_id']."'");
-      echo("-");
     }
-  }
-}
+
+
+    
+    unset($ospf_ports_db);
+    unset($ospf_ports_poll);
+  
 
 #OSPF-MIB::ospfNbrIpAddr.172.22.203.98.0 172.22.203.98
 #OSPF-MIB::ospfNbrAddressLessIndex.172.22.203.98.0 0
@@ -234,109 +252,100 @@ if (is_array($ospf_ports_db))
 #OSPF-MIB::ospfNbmaNbrPermanence.172.22.203.98.0 dynamic
 #OSPF-MIB::ospfNbrHelloSuppressed.172.22.203.98.0 false
 
-echo(' Neighbours: ');
+    echo(' Neighbours: ');
 
-$ospf_nbr_oids_db  = array('ospfNbrIpAddr', 'ospfNbrAddressLessIndex', 'ospfNbrRtrId', 'ospfNbrOptions', 'ospfNbrPriority', 'ospfNbrState', 'ospfNbrEvents', 'ospfNbrLsRetransQLen', 'ospfNbmaNbrStatus', 'ospfNbmaNbrPermanence', 'ospfNbrHelloSuppressed');
-$ospf_nbr_oids_rrd = array();
-$ospf_nbr_oids = array_merge($ospf_nbr_oids_db, $ospf_nbr_oids_rrd);
 
 // Build array of existing entries
-foreach (dbFetchRows("SELECT * FROM `ospf_nbrs` WHERE `device_id` = ?", array($device['device_id'])) as $nbr_entry)
-{
-  $ospf_nbrs_db[$nbr_entry['ospf_nbr_id']] = $nbr_entry;
-}
+    foreach (dbFetchRows("SELECT * FROM `ospf_nbrs` WHERE `device_id` = ? AND `context_name` = ?", array($device['device_id'],$device['context_name'])) as $entry) {
+        $ospf_nbrs_db[$entry['ospf_nbr_id']][$device['context_name']] = $entry;
+    }
 
 // Pull data from device
-$ospf_nbrs_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfNbrEntry", array(), "OSPF-MIB");
+    $ospf_nbrs_poll = snmpwalk_cache_oid($device, "OSPF-MIB::ospfNbrEntry", array(), "OSPF-MIB");
 
-foreach ($ospf_nbrs_poll as $ospf_nbr_id => $ospf_nbr)
-{
-  // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
-  if (!isset($ospf_nbrs_db[$ospf_nbr_id]))
-  {
-    dbInsert(array('device_id' => $device['device_id'], 'ospf_nbr_id' => $ospf_nbr_id), 'ospf_nbrs');
-    echo("+");
-    $entry = dbFetchRow("SELECT * FROM `ospf_nbrs` WHERE `device_id` = ? AND `ospf_nbr_id` = ?", array($device['device_id'], $ospf_nbr_id));
-    $ospf_nbrs_db[$entry['ospf_nbr_id']] = $entry;
-  }
-}
+    foreach ($ospf_nbrs_poll as $ospf_nbr_id => $ospf_nbr) {
+        // If the entry doesn't already exist in the prebuilt array, insert into the database and put into the array
+        if (empty($ospf_nbrs_db[$ospf_nbr_id][$device['context_name']])) {
+            dbInsert(array('device_id' => $device['device_id'], 'ospf_nbr_id' => $ospf_nbr_id, 'context_name' => $device['context_name']), 'ospf_nbrs');
+            echo("+");
+            $ospf_nbrs_db[$ospf_nbr_id][$device['context_name']] = dbFetchRow("SELECT * FROM `ospf_nbrs` WHERE `device_id` = ? AND `ospf_nbr_id` = ? AND `context_name` = ?", array($device['device_id'], $ospf_nbr_id,$device['context_name']));
+        }
+    }
 
-if ($debug)
-{
-  echo("\nPolled: ");
-  print_r($ospf_nbrs_poll);
-  echo("Database: ");
-  print_r($ospf_nbrs_db);
-  echo("\n");
-}
+    if ($debug) {
+        echo("\nPolled: ");
+        print_r($ospf_nbrs_poll);
+        echo("Database: ");
+        print_r($ospf_nbrs_db);
+        echo("\n");
+    }
 
 // Loop array of entries and update
-if (is_array($ospf_nbrs_db))
-{
-  foreach ($ospf_nbrs_db as $ospf_nbr_id => $ospf_nbr_db)
-  {
-    if (is_array($ospf_nbrs_poll[$ospf_nbr_db['ospf_nbr_id']]))
-    {
-      $ospf_nbr_poll = $ospf_nbrs_poll[$ospf_nbr_db['ospf_nbr_id']];
+    if (is_array($ospf_nbrs_db)) {
+        foreach ($ospf_nbrs_db as $ospf_nbr_id => $ospf_nbr_db) {
+            if (is_array($ospf_nbrs_poll[$ospf_nbr_id])) {
+                $ospf_nbr_poll = $ospf_nbrs_poll[$ospf_nbr_id];
 
-      $ospf_nbr_poll['port_id'] = @dbFetchCell("SELECT A.`port_id` FROM ipv4_addresses AS A, nbrs AS I WHERE A.ipv4_address = ? AND I.port_id = A.port_id AND I.device_id = ?", array($ospf_nbr_poll['ospfNbrIpAddr'], $device['device_id']));
+                $ospf_nbr_poll['port_id'] = @dbFetchCell("SELECT A.`port_id` FROM ipv4_addresses AS A, ospf_nbrs AS I WHERE A.ipv4_address = ? AND I.port_id = A.port_id AND I.device_id = ? AND A.context_name = ?", array($ospf_nbr_poll['ospfNbrIpAddr'], $device['device_id'], $device['context_name']));
 
-      if ($ospf_nbr_db['port_id'] != $ospf_nbr_poll['port_id'])
-      {
-        if ($ospf_nbr_poll['port_id']) {
-          $ospf_nbr_update = array('port_id' => $ospf_nbr_poll['port_id']);
-        } else {
-          $ospf_nbr_update = array('port_id' => array('NULL'));
+                if ($ospf_nbr_db[$device['context_name']]['port_id'] != $ospf_nbr_poll['port_id']) {
+                    if (!empty($ospf_nbr_poll['port_id'])) {
+                        $ospf_nbr_update = array('port_id' => $ospf_nbr_poll['port_id']);
+                    } else {
+                        $ospf_nbr_update = array('port_id' => array('NULL'));
+                    }
+                }
+
+                foreach ($ospf_nbr_oids as $oid) { // Loop the OIDs
+                    if ($debug) {
+                        echo($ospf_nbr_db[$device['context_name']][$oid] . "|" . $ospf_nbr_poll[$oid] . "\n");
+                    }
+                    if ($ospf_nbr_db[$device['context_name']][$oid] != $ospf_nbr_poll[$oid]) { // If data has changed, build a query
+                        $ospf_nbr_update[$oid] = $ospf_nbr_poll[$oid];
+                        #log_event("$oid -> ".$this_nbr[$oid], $device, 'ospf', $nbr['port_id']); // FIXME
+                    }
+                }
+                if ($ospf_nbr_update) {
+                    dbUpdate($ospf_nbr_update, 'ospf_nbrs', '`device_id` = ? AND `ospf_nbr_id` = ? AND `context_name` = ?', array($device['device_id'], $ospf_nbr_id, $device['context_name']));
+                    echo("U");
+                    unset($ospf_nbr_update);
+                } else {
+                    echo(".");
+                }
+
+                unset($ospf_nbr_poll);
+                unset($ospf_nbr_db);
+                $ospf_nbr_count++;
+            } else {
+                dbDelete('ospf_nbrs', '`device_id` = ? AND `ospf_nbr_id` = ? AND `context_name` = ?', array($device['device_id'], $ospf_nbr_db['ospf_nbr_id'], $device['context_name']));
+                echo("-");
+            }
         }
-      }
-
-      foreach ($ospf_nbr_oids as $oid)
-      { // Loop the OIDs
-        if ($debug) { echo($ospf_nbr_db[$oid]."|".$ospf_nbr_poll[$oid]."\n"); }
-        if ($ospf_nbr_db[$oid] != $ospf_nbr_poll[$oid])
-        { // If data has changed, build a query
-          $ospf_nbr_update[$oid] = $ospf_nbr_poll[$oid];
-          #log_event("$oid -> ".$this_nbr[$oid], $device, 'ospf', $nbr['port_id']); // FIXME
-        }
-      }
-      if ($ospf_nbr_update)
-      {
-        dbUpdate($ospf_nbr_update, 'ospf_nbrs', '`device_id` = ? AND `ospf_nbr_id` = ?', array($device['device_id'], $ospf_nbr_id));
-        echo("U");
-        unset($ospf_nbr_update);
-      } else {
-        echo(".");
-      }
-
-      unset($ospf_nbr_poll);
-      unset($ospf_nbr_db);
-      $ospf_nbr_count++;
-    } else {
-      dbDelete('ospf_nbrs', '`device_id` = ? AND `ospf_nbr_id` = ?', array($device['device_id'], $ospf_nbr_db['ospf_nbr_id']));
-      echo("-");
     }
-  }
+    
+    unset($ospf_nbrs_db);
+    unset($ospf_nbrs_poll);
+    
 }
 
+unset($device['context_name']);
+unset($vrfs_lite_cisco);
 // Create device-wide statistics RRD
 
 $filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename("ospf-statistics.rrd");
 
-if (!is_file($filename))
-{
-  rrdtool_create($filename, "--step 300 \
+if (!is_file($filename)) {
+    rrdtool_create($filename, "--step 300 \
           DS:instances:GAUGE:600:0:1000000 \
           DS:areas:GAUGE:600:0:1000000 \
           DS:ports:GAUGE:600:0:1000000 \
-          DS:neighbours:GAUGE:600:0:1000000 ".$config['rrd_rra']);
- }
+          DS:neighbours:GAUGE:600:0:1000000 " . $config['rrd_rra']);
+}
 
-$rrd_update  = "N:".$ospf_instance_count.":".$ospf_area_count.":".$ospf_port_count.":".$ospf_neighbour_count;
+$rrd_update = "N:" . $ospf_instance_count . ":" . $ospf_area_count . ":" . $ospf_port_count . ":" . $ospf_neighbour_count;
 $ret = rrdtool_update("$filename", $rrd_update);
 
-unset($ospf_ports_db);
-unset($ospf_ports_poll);
+
 
 echo("\n");
-
 ?>

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -57,7 +57,7 @@ function snmp_get_multi($device, $oids, $options = "-OQUs", $mib = NULL, $mibdir
   {
     list($oid,$value) = explode("=", $entry);
     $oid = trim($oid); $value = trim($value);
-    list($oid, $index) = explode(".", $oid);
+    list($oid, $index) = explode(".", $oid,2); //this is more generic
     if (!strstr($value, "at this OID") && isset($oid) && isset($index))
     {
       $array[$index][$oid] = $value;
@@ -770,7 +770,17 @@ function snmp_gen_auth (&$device)
 
   if ($device['snmpver'] === "v3")
   {
-    $cmd = " -v3 -n \"\" -l " . $device['authlevel'];
+        $cmd = ' -v3 ';
+    
+    
+    //add context if exist context
+    if(key_exists('context_name', $device)){
+        $cmd .= ' -n "'.$device['context_name'].'"';
+    }else{
+         $cmd .= ' -n ""';
+    }  
+
+    $cmd .= " -l " . $device['authlevel'];
 
     if ($device['authlevel'] === "noAuthNoPriv")
     {

--- a/mibs/CISCO-BRIDGE-DOMAIN-MIB
+++ b/mibs/CISCO-BRIDGE-DOMAIN-MIB
@@ -1,0 +1,450 @@
+-- *****************************************************************
+-- CISCO-BRIDGE-DOMAIN-MIB.my : Cisco Bridge Domain MIB
+--   
+-- Oct 2007, Madhavi Dokku
+--   
+-- Copyright (c) 2007 by Cisco Systems, Inc.
+--   
+-- All rights reserved.
+-- *****************************************************************
+
+CISCO-BRIDGE-DOMAIN-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE,
+    Unsigned32
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP
+        FROM SNMPv2-CONF
+    TEXTUAL-CONVENTION,
+    TruthValue,
+    RowStatus,
+    StorageType
+        FROM SNMPv2-TC
+    ifIndex
+        FROM IF-MIB
+    ciscoMgmt
+        FROM CISCO-SMI;
+
+
+ciscoBridgeDomainMIB MODULE-IDENTITY
+    LAST-UPDATED    "200712290000Z"
+    ORGANIZATION    "Cisco Systems, Inc."
+    CONTACT-INFO
+            "Cisco Systems
+            Customer Service
+
+            Postal: 170 W Tasman Drive
+            San Jose, CA  95134
+            USA
+            Tel: +1 800 553-NETS
+
+            E-mail: cs-ethermibs@cisco.com"
+    DESCRIPTION
+        "A bridge domain is one of the means by which it is possible
+        to define a broadcast domain on a bridging device. It is an 
+            alternative to 802.1D bridge-groups and to 802.1Q VLAN 
+        bridging.
+
+        Bridge domain is the service specification, and specifies the 
+        broadcast domain number on which this frame of this particular
+        service instance must be made available on. The physical and 
+        virtual interfaces that can comprise a bridge domain are 
+        heterogeneous in nature comprising Ethernet service instances,
+        WAN Virtual Circuit for ATM or Frame Relay and VFIs. However,
+        the frame encapsulations for all interface types are
+        essentially Ethernet. 
+
+        Without bridge-domains, VLANs would have to be globally unique
+        per device and one would only be restricted to the theoretical  
+             maximum of 4095 VLANs for single tagged traffic. However
+        with        the introduction of bridge-domains, one can
+        associate a service        instance with a bridge-domain and all
+        service instances in the        same bridge-domain form a
+        broadcast domain. Bridge-domain ID        determines the
+        broadcast domain and the VLAN id is merely used        to match
+        and map traffic. With bridge domain feature configured       
+        VLAN IDs would be unique per interface only and not globally.   
+            Thus bridge domains make VLAN ids have only local
+        significance        per port
+
+
+        Differences between Bridge Domains and 802.1AD Bridges:
+        =======================================================
+        1. Scope of the VLAN technology which uses 802.1 AD is global to
+        the box.
+        But in case of Bridge domain, the scope of vlan is local to
+        interface
+
+        2. Switchport 802.1AD restricts the number of broadcast domain  
+            on a box to 4095.
+        However, with Bridge domains, we can have up to 16k broadcast   
+               domain.
+
+        3. Under a single Bridge domain service instance, there can be  
+                flexible service mapping criterion.(i.e match based on
+        outer vlan, outer cos, inner vlan, inner cos and payload
+        ethertype).
+        Whereas in case of switch port 802.1AD/dot1q this is not
+        supported.
+
+        Similarities between Bridge Domains and 802.1AD Bridges:
+        =======================================================
+
+        1. Both use the same MAC address lookup for forwarding.
+
+        2. Both work with protocols like STP, DTP etc.
+
+        3. Both of them classify 'ports' in a system into Bridges/Bridge
+                  Domains.
+
+        Ethernet service instance is the instantiation of an Ethernet 
+        virtual circuit on a given port on a given router. In other 
+        words, an Ethernet service instance is an object that holds 
+        information about the layer 2 service that is being offered
+        on a given port of a given router as part of a given Ethernet
+        virtual circuit. Bridge domains feature is currently supported
+        on ethernet service instances only and can be later extented
+        to other interfaces like ATM and Frame Relay.
+
+        This MIB helps the network management personnel to find out the 
+        details of various broadcast domains configured in the network.
+
+        Definition of terms and acronyms:
+
+        ATM: Asynchronous Transfer mode
+
+        BD: Bridge Domain
+
+        C-mac: Customer MAC
+
+        EVC: Ethernet Virtual Circuit
+
+        FR: Frame Relay
+
+        SH: Split Horizon
+
+        VFI: Virtual Forwarding Instance 
+
+        VLAN: Virtual Local Area Network
+
+        WAN: Wide Area Network"
+    REVISION        "200712290000Z"
+    DESCRIPTION
+        "Modified the MIB description with details on similarities and
+        differences between Bridge Domains and 802.1AD Bridges."
+    REVISION        "200712040000Z"
+    DESCRIPTION
+        "Initial version of this MIB module."
+    ::= { ciscoMgmt 642 }
+
+
+ciscoBdMIBNotifications  OBJECT IDENTIFIER
+    ::= { ciscoBridgeDomainMIB 0 }
+
+ciscoBdMIBObjects  OBJECT IDENTIFIER
+    ::= { ciscoBridgeDomainMIB 1 }
+
+ciscoBdMIBConformance  OBJECT IDENTIFIER
+    ::= { ciscoBridgeDomainMIB 2 }
+
+cbdSystemInfo  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBObjects 1 }
+
+cbdMemberInfo  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBObjects 2 }
+
+
+-- Textual Conventions
+
+CbdType ::= TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "Defines the different types of bridge domain members:
+
+        'other': none of the following
+
+            'ether': Ethernet Service Instance
+
+        'atmVc': ATM Virtual connection
+
+        'frVc': Frame Relay Virtual Connection"
+    SYNTAX          INTEGER  {
+                        other(1),
+                        ether(2),
+                        atmVc(3),
+                        frVc(4)
+                    }
+
+cbdMembersConfigured OBJECT-TYPE
+    SYNTAX          Unsigned32
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the number of bridge domain
+        members configured on this bridge domain." 
+    ::= { cbdSystemInfo 1 }
+-- Member Info Table
+
+cbdMemberInfoTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CbdMemberInfoEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table provides the bridge domain member attributes
+        of the members currently configured for each bridge
+        domain."
+    ::= { cbdMemberInfo 1 }
+
+cbdMemberInfoEntry OBJECT-TYPE
+    SYNTAX          CbdMemberInfoEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "A conceptual row in cbdMemberInfoTable. This is indexed
+        by ifIndex and cbdSIIndex. Each row is created when a bridge
+        domain member is configured under a service instance."
+    INDEX           {
+                        ifIndex,
+                        cbdSIIndex
+                    } 
+    ::= { cbdMemberInfoTable 1 }
+
+CbdMemberInfoEntry ::= SEQUENCE {
+        cbdSIIndex               Unsigned32,
+        cbdMemberType            CbdType,
+        cbdMemberOperState       INTEGER ,
+        cbdMemberAdminState      INTEGER ,
+        cbdMemberSplitHorizon    TruthValue,
+        cbdMemberSplitHorizonNum Unsigned32,
+        cbdMemberStorageType     StorageType,
+        cbdMemberStatus          RowStatus,
+        cbdMembercMac            TruthValue
+}
+
+cbdSIIndex OBJECT-TYPE
+    SYNTAX          Unsigned32 (1..4294967295 )
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This object indicates an arbitary index that uniquely
+        identifies the Service Instance to which this bridge domain
+        member belongs to." 
+    ::= { cbdMemberInfoEntry 1 }
+
+cbdMemberType OBJECT-TYPE
+    SYNTAX          CbdType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object identifies the type of the bridge domain member
+        like ATM VC, Frame Relay VC, or Ethernet service."
+    DEFVAL          { other } 
+    ::= { cbdMemberInfoEntry 2 }
+
+cbdMemberOperState OBJECT-TYPE
+    SYNTAX          INTEGER  {
+                        unknown(1),
+                        up(2),
+                        down(3)
+                    }
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the operational state of the bridge
+        domain Member. Operational state of the Bridge domain member
+        is same as the operational state of the underlying service
+        instance. Bridge domain members are configured under service
+        instances and multiple service instances can be attached to a  
+        single physical interface defining various kinds of services.
+        Bridge domain members have many to one relationship with
+        interface
+        Indexes. When ifOperStatus of the underlying interface is down,
+        the state of cbdMemberOperState should be down. When
+        ifOperStatus
+        of the underlying interface is up, cbdMemberOperState can be
+        either up or down based on the state of underlying service
+        instance.
+
+        'unknown': the bridge domain member is an unknown state.
+
+        'up': the bridge domain member is fully operational and 
+        able to bridge the traffic. This means that both the  
+        physical interface and the underlying service instance
+        are administratively up. 
+
+        'down': the Bridge Domain member is down and not
+        capable of bridging. This state means either the underlying 
+        service instance is down or the interface is down." 
+    ::= { cbdMemberInfoEntry 3 }
+
+cbdMemberAdminState OBJECT-TYPE
+    SYNTAX          INTEGER  {
+                        unknown(1),
+                        up(2),
+                        down(3)
+                    }
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the administrative state of the
+        bridge domain Member.  Admin state of the Bridge domain member
+        is same as the admin state of the underlying service instance.
+        Bridge domain members are configured under service instances 
+        and multiple service instances can be attached to a single
+        physical interface defining various kinds of services. Bridge
+        Domain members have many to one relationship with interface
+        Indexes. When ifAdminStatus of the unerlying interface is down
+        the state of cbdMemberAdminState should be down. When ifOperStatus
+        of the underlying interface is up cbdMemberAdminState can be 
+        either up or down based on the state of underlying service
+        instance.
+
+        'unknown': the bridge domain member is in unknown 
+        administrative state.
+
+        'up': the Bridge Domain member is administratively up. This 
+        means that both the physical interface and the underlying service
+        instance are administratively up. 
+
+        'admindown': the Bridge Domain member is down as it is 
+        administratively configured to be down and is not 
+        capable of bridging. This means that either the underlying 
+        service instance is configured as administratively down or
+        the physical interface is configured as administratively
+        down." 
+    ::= { cbdMemberInfoEntry 4 }
+
+cbdMemberSplitHorizon OBJECT-TYPE
+    SYNTAX          TruthValue
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates whether split horizon is
+        configured on this bridge domain member." 
+    ::= { cbdMemberInfoEntry 5 }
+
+cbdMemberSplitHorizonNum OBJECT-TYPE
+    SYNTAX          Unsigned32 (0..65535 )
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the split horizon number if
+        configured on the bridge domain member. Split horizon
+        is used to avoid sending traffic between interfaces. 
+        Frames are not forwarded to the members belonging to the
+        same split horizon group."
+    DEFVAL          { 0 } 
+    ::= { cbdMemberInfoEntry 6 }
+
+cbdMemberStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the storage type of this conceptual
+        row.  This object can only have a value 'nonVolatile'.  Other 
+        values are not applicable for this conceptual row and are 
+        not supported."
+    DEFVAL          { nonVolatile } 
+    ::= { cbdMemberInfoEntry 7 }
+
+cbdMemberStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object enables the SNMP agent to create, modify,
+        and delete rows in the cbdMemberInfoTable."
+    DEFVAL          { active } 
+    ::= { cbdMemberInfoEntry 8 }
+
+cbdMembercMac OBJECT-TYPE
+    SYNTAX          TruthValue
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates if cmac is configured on this
+        bridge domain member. Cmac denotes if this bridge domain is
+        configured as a customer domain." 
+    ::= { cbdMemberInfoEntry 9 }
+ 
+
+-- Notifications
+
+ciscoBdNotificationPrefix  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBNotifications 0 }
+
+-- Conformance
+
+ciscoBdMIBCompliances  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBConformance 1 }
+
+ciscoBdMIBGroups  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBConformance 2 }
+
+
+ciscoBdMIBComplianceRev1 MODULE-COMPLIANCE
+    STATUS          current
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-BRIDGE-DOMAIN-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cbdSystemInfoGroup,
+                        cbdMemberInfoGroup
+                    }
+    ::= { ciscoBdMIBCompliances 1 }
+
+-- Units of Conformance
+
+cbdSystemInfoGroup OBJECT-GROUP
+    OBJECTS         { cbdMembersConfigured }
+    STATUS          current
+    DESCRIPTION
+        "This group contain information about bridge domain."
+    ::= { ciscoBdMIBGroups 1 }
+
+cbdMemberInfoGroup OBJECT-GROUP
+    OBJECTS         {
+                        cbdMemberType,
+                        cbdMemberOperState,
+                        cbdMemberAdminState,
+                        cbdMemberSplitHorizon,
+                        cbdMemberSplitHorizonNum,
+                        cbdMemberStorageType,
+                        cbdMemberStatus,
+                        cbdMembercMac
+                    }
+    STATUS          current
+    DESCRIPTION
+        "This group contain information related to bridge domain
+        members."
+    ::= { ciscoBdMIBGroups 2 }
+
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/mibs/CISCO-CONTEXT-MAPPING-MIB
+++ b/mibs/CISCO-CONTEXT-MAPPING-MIB
@@ -1,0 +1,853 @@
+-- *****************************************************************
+-- CISCO-CONTEXT-MAPPING-MIB.my:  Cisco Context Mapping MIB
+--   
+-- January 2005, Chinna Pellacuru.
+--   
+-- May 2008, Sheethal Gunjal.
+--   
+-- Copyright (c) 2004-2005, 2008 by cisco Systems Inc.
+-- All rights reserved.
+--   
+-- ****************************************************************
+
+CISCO-CONTEXT-MAPPING-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB
+    RowStatus,
+    StorageType
+        FROM SNMPv2-TC
+    CiscoBridgeDomain
+        FROM CISCO-TC
+    ciscoMgmt
+        FROM CISCO-SMI;
+
+
+ciscoContextMappingMIB MODULE-IDENTITY
+    LAST-UPDATED    "200811220000Z"
+    ORGANIZATION    "Cisco Systems, Inc."
+    CONTACT-INFO
+            "Cisco Systems
+            Customer Service
+
+            Postal: 170 W Tasman Drive
+            San Jose, CA  95134
+            USA
+
+            Tel: +1 800 553-NETS
+
+            E-mail: cs-snmp@cisco.com"
+    DESCRIPTION
+        "A single SNMP agent sometimes needs to support multiple
+        instances of the same MIB module, and does so through the
+        use of multiple SNMP contexts.  This typically occurs because
+        the technology has evolved to have extra dimension(s), i.e.,
+        one or more extra data and/or identifier values which are
+        different in the different contexts, but were not defined in
+        INDEX clause(s) of the original MIB module.  In such cases,
+        network management applications need to know the specific
+        data/identifier values in each context, and this MIB module
+        provides mapping tables which contain that information.
+
+        Within a network there can be multiple Virtual Private
+        Networks (VPNs) configured using Virtual Routing and
+        Forwarding Instances (VRFs). Within a VPN there can be
+        multiple topologies when Multi-topology Routing (MTR) is
+        used. Also, Interior Gateway Protocols (IGPs) can have
+        multiple protocol instances running on the device.
+        A network can have multiple broadcast domains configured
+        using Bridge Domain Identifiers.
+
+        With MTR routing, VRFs, and Bridge domains, a router now 
+        needs to support multiple instances of several existing 
+        MIB modules, and this can be achieved if the router's SNMP 
+        agent provides access to each instance of the same MIB module 
+        via a different SNMP context (see Section 3.1.1 of RFC 3411).
+        For MTR routing, VRFs, and Bridge domains, a different SNMP 
+        context is needed depending on one or more of the following: 
+        the VRF, the topology-identifier, the routing protocol instance,
+        and the bridge domain identifier.
+        In other words, the router's management information can be
+        accessed through multiple SNMP contexts where each such
+        context represents a specific VRF, a specific
+        topology-identifier, a specific routing protocol instance 
+        and/or a bridge domain identifier. This MIB module provides 
+        a mapping of each such SNMP context to the corresponding VRF,
+        the corresponding topology, the corresponding routing protocol 
+        instance, and the corresponding bridge domain identifier.
+        Some SNMP contexts are independent of VRFs, independent of
+        a topology, independent of a routing protocol instance, or 
+        independent of a bridge domain and in such a case, the mapping
+        is to the zero length string.
+
+        With the Cisco package licensing strategy, the features 
+        available in the image are grouped into multiple packages 
+        and each packages can be managed to operate at different 
+        feature levels based on the available license. This MIB 
+        module provides option to associate an SNMP context to a 
+        feature package group. This will allow manageability of 
+        license MIB objects specific to a feature package group.
+
+        As technology evolves more we may need additional
+        identifiers to identify the context. Then we would need
+        to add those additional identifiers into the mapping."
+    REVISION        "200811220000Z"
+    DESCRIPTION
+        "Added New Table cContextMappingLicenseGroupTable
+        to provide SNMP Context support for license package groups.
+
+        Added cContextMappingLicenseGroupDataGroup in OBJECT-GROUP
+        Added cContextMappingMIBComplianceRev2 in MODULE-COMPLIANCE
+
+        Updated the MIB description to indicate the use of
+        the above additions"
+    REVISION        "200805300000Z"
+    DESCRIPTION
+        "Add cContextMappingBridgeInstanceTable.
+
+        Added cContextMappingBridgeInstanceDataGroup.
+        Deprecated cContextMappingMIBComplianceRev1 and added
+        cContextMappingMIBComplianceRev2 compliance statement."
+    REVISION        "200802010000Z"
+    DESCRIPTION
+        "Added New Table cContextMappingBridgeDomainTable
+        to provide SNMP context support to the Bridge Domain.
+
+        Added cContextMappingBridgeDomainDataGroup in OBJECT-GROUP
+        Added cContextMappingMIBComplianceRev1 in MODULE-COMPLIANCE"
+    REVISION        "200503170000Z"
+    DESCRIPTION
+        "Initial version of the MIB module."
+    ::= { ciscoMgmt 468 }
+
+
+cContextMappingMIBObjects  OBJECT IDENTIFIER
+    ::= { ciscoContextMappingMIB 1 }
+
+cContextMappingMIBConformance  OBJECT IDENTIFIER
+    ::= { ciscoContextMappingMIB 2 }
+
+
+cContextMappingTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on which
+        cContextMappingVacmContextName is mapped to
+        which VRF, topology, and routing protocol instance.
+
+        This table is indexed by SNMP VACM context.
+
+        Configuring a row in this table for an SNMP context
+        does not require that the context be already defined,
+        i.e., a row can be created in this table for a context
+        before the corresponding row is created in RFC 3415's
+        vacmContextTable.
+
+        To create a row in this table, a manager must set
+        cContextMappingRowStatus to either 'createAndGo' or
+        'createAndWait'.
+
+        To delete a row in this table, a manager must set
+        cContextMappingRowStatus to 'destroy'."
+    ::= { cContextMappingMIBObjects 1 }
+
+cContextMappingEntry OBJECT-TYPE
+    SYNTAX          CContextMappingEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        cContextMappingVacmContextName to the corresponding VRF,
+        the corresponding topology, and the corresponding routing
+        protocol instance."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingTable 1 }
+
+CContextMappingEntry ::= SEQUENCE {
+        cContextMappingVacmContextName SnmpAdminString,
+        cContextMappingVrfName         SnmpAdminString,
+        cContextMappingTopologyName    SnmpAdminString,
+        cContextMappingProtoInstName   SnmpAdminString,
+        cContextMappingStorageType     StorageType,
+        cContextMappingRowStatus       RowStatus
+}
+
+cContextMappingVacmContextName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "The vacmContextName given to the SNMP context.
+
+        This is a human readable name identifying a particular
+        SNMP VACM context at a particular SNMP entity.
+        The empty contextName (zero length) represents the
+        default context." 
+    ::= { cContextMappingEntry 1 }
+
+cContextMappingVrfName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the VRF to which the SNMP context
+        is mapped to.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this VRF.
+
+        When the value of this object is the zero length
+        string it indicates that the SNMP context is independent
+        of any VRF."
+    DEFVAL          { ''H } 
+    ::= { cContextMappingEntry 2 }
+
+cContextMappingTopologyName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the topology to which the SNMP
+        context is mapped to.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this topology.
+
+        When the value of this object is the zero length
+        string it indicates that the SNMP context is independent
+        of any topology."
+    DEFVAL          { ''H } 
+    ::= { cContextMappingEntry 3 }
+
+cContextMappingProtoInstName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the protocol instance to which the
+        SNMP context is mapped to.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this protocol instance.
+
+        When the value of this object is the zero length
+        string it indicates that the SNMP context is independent
+        of any protocol instance."
+    DEFVAL          { ''H } 
+    ::= { cContextMappingEntry 4 }
+
+cContextMappingStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingEntry 5 }
+
+cContextMappingRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingEntry 6 }
+ 
+
+
+cContextMappingBridgeDomainTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingBridgeDomainEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on which
+        cContextMappingVacmContextName is mapped to
+        which bridge domain.
+
+        A Bridge Domain is one of the means by which it is possible 
+        to define an Ethernet broadcast domain on a bridging device. 
+        A network can have multiple broadcast domains configured.
+        This table helps the network management personnel to find 
+        out the  details of various broadcast domains configured 
+        in the network.
+
+        An entry need to exist in cContextMappingTable, to create 
+        an entry in this table."
+    ::= { cContextMappingMIBObjects 2 }
+
+cContextMappingBridgeDomainEntry OBJECT-TYPE
+    SYNTAX          CContextMappingBridgeDomainEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        cContextMappingVacmContextName to the 
+        corresponding bridge domain.
+
+        To create a row in this table, a manager must set
+        cContextMappingBridgeDomainRowStatus to either 
+        'createAndGo' or 'createAndWait'.
+
+        To delete a row in this table, a manager must set
+        cContextMappingBridgeDomainRowStatus to 'destroy'."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingBridgeDomainTable 1 }
+
+CContextMappingBridgeDomainEntry ::= SEQUENCE {
+        cContextMappingBridgeDomainIdentifier  CiscoBridgeDomain,
+        cContextMappingBridgeDomainStorageType StorageType,
+        cContextMappingBridgeDomainRowStatus   RowStatus
+}
+
+cContextMappingBridgeDomainIdentifier OBJECT-TYPE
+    SYNTAX          CiscoBridgeDomain
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the bridge domain to which the SNMP context is 
+        mapped to."
+    REFERENCE       "CISCO-BRIDGE-DOMAIN-MIB" 
+    ::= { cContextMappingBridgeDomainEntry 1 }
+
+cContextMappingBridgeDomainStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingBridgeDomainEntry 2 }
+
+cContextMappingBridgeDomainRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingBridgeDomainEntry 3 }
+ 
+
+
+cContextMappingBridgeInstanceTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingBridgeInstanceEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on mapping between
+        cContextMappingVacmContextName and bridge instance.
+
+        Bridge instance is an instance of a physical or logical 
+        bridge which has unique bridge-id.
+
+        If an entry is deleted from cContextMappingTable, the
+        corresponding entry in this table will also get deleted.
+
+        If an entry needs to be created in this table, the
+        corresponding entry must exist in cContextMappingTable."
+    REFERENCE       "BRIDGE-MIB"
+    ::= { cContextMappingMIBObjects 3 }
+
+cContextMappingBridgeInstanceEntry OBJECT-TYPE
+    SYNTAX          CContextMappingBridgeInstanceEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        cContextMappingVacmContextName to the 
+        corresponding bridge instance.
+
+        To create a row in this table, a manager must set
+        cContextMappingBridgeInstRowStatus to either 
+        'createAndGo' or 'createAndWait'.
+
+        To delete a row in this table, a manager must set
+        cContextMappingBridgeInstRowStatus to 'destroy'."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingBridgeInstanceTable 1 }
+
+CContextMappingBridgeInstanceEntry ::= SEQUENCE {
+        cContextMappingBridgeInstName        SnmpAdminString,
+        cContextMappingBridgeInstStorageType StorageType,
+        cContextMappingBridgeInstRowStatus   RowStatus
+}
+
+cContextMappingBridgeInstName OBJECT-TYPE
+    SYNTAX          SnmpAdminString
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The object identifies the name given to bridge
+        instance to which the SNMP context is mapped to.
+
+        Value of this object cannot be changed when the 
+        RowStatus object in the same row is 'active'.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this bridge instance.
+
+        When the value of this object is a zero length
+        string, it indicates that the SNMP context is
+        independent of any bridge instances." 
+    ::= { cContextMappingBridgeInstanceEntry 1 }
+
+cContextMappingBridgeInstStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Value of this object cannot be changed when the 
+        RowStatus object in the same row is 'active'.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingBridgeInstanceEntry 2 }
+
+cContextMappingBridgeInstRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingBridgeInstanceEntry 3 }
+ 
+
+
+cContextMappingLicenseGroupTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingLicenseGroupEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on which
+        cContextMappingVacmContextName is mapped to
+        which License Group.
+        Group level licensing is used where each
+        Technology Package is enabled via a License."
+    ::= { cContextMappingMIBObjects 4 }
+
+cContextMappingLicenseGroupEntry OBJECT-TYPE
+    SYNTAX          CContextMappingLicenseGroupEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        CContextMappingVacmContextName to the
+        corresponding License Group."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingLicenseGroupTable 1 }
+
+CContextMappingLicenseGroupEntry ::= SEQUENCE {
+        cContextMappingLicenseGroupName        SnmpAdminString,
+        cContextMappingLicenseGroupStorageType StorageType,
+        cContextMappingLicenseGroupRowStatus   RowStatus
+}
+
+cContextMappingLicenseGroupName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the Group to which the SNMP context
+        is mapped.
+
+        Feature sets from all groups will be combined to form 
+        universal image. User can configure multiple groups as needed.
+
+        For example: In Next generation ISRs will use
+        the universal image package level licensing model
+        for its licensing need. Each group has
+        the feature set needed for that specific technology.
+        Feature sets from different groups are combined to 
+        form universal image and each feature set for a group 
+        can be enabled using a valid license key. There will 
+        be a base level ipbase package in which the router 
+        boots with out any license key.
+
+        The following are the different Technology Groups.
+        1.crypto
+        2.data
+        3.ip
+        4.legacy
+        5.novpn-security
+        6.security
+        7.uc" 
+    ::= { cContextMappingLicenseGroupEntry 1 }
+
+cContextMappingLicenseGroupStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingLicenseGroupEntry 2 }
+
+cContextMappingLicenseGroupRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingLicenseGroupEntry 3 }
+ 
+
+-- Conformance
+
+cContextMappingMIBCompliances  OBJECT IDENTIFIER
+    ::= { cContextMappingMIBConformance 1 }
+
+cContextMappingMIBGroups  OBJECT IDENTIFIER
+    ::= { cContextMappingMIBConformance 2 }
+
+
+-- Compliance
+
+cContextMappingMIBCompliance MODULE-COMPLIANCE
+    STATUS          deprecated
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS { cContextMappingDataGroup }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+    ::= { cContextMappingMIBCompliances 1 }
+
+cContextMappingMIBComplianceRev1 MODULE-COMPLIANCE
+    STATUS          deprecated
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB. This compliance statement 
+        is superceded by cContextMappingMIBComplianceRev2."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cContextMappingDataGroup,
+                        cContextMappingBridgeDomainDataGroup
+                    }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+
+    OBJECT          cContextMappingBridgeDomainIdentifier
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+    ::= { cContextMappingMIBCompliances 2 }
+
+cContextMappingMIBComplianceRev2 MODULE-COMPLIANCE
+    STATUS          deprecated
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cContextMappingDataGroup,
+                        cContextMappingBridgeDomainDataGroup,
+                        cContextMappingBridgeInstanceDataGroup
+                    }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+
+    OBJECT          cContextMappingBridgeDomainIdentifier
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeDomainTable is not required."
+
+    OBJECT          cContextMappingBridgeInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeInstanceTable is not required."
+    ::= { cContextMappingMIBCompliances 3 }
+
+cContextMappingMIBComplianceRev3 MODULE-COMPLIANCE
+    STATUS          current
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cContextMappingDataGroup,
+                        cContextMappingBridgeDomainDataGroup,
+                        cContextMappingBridgeInstanceDataGroup,
+                        cContextMappingLicenseGroupDataGroup
+                    }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+
+    OBJECT          cContextMappingBridgeDomainIdentifier
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeDomainTable is not required."
+
+    OBJECT          cContextMappingBridgeInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeInstanceTable is not required."
+
+    OBJECT          cContextMappingLicenseGroupName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingLicenseGroupStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingLicenseGroupRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+    ::= { cContextMappingMIBCompliances 4 }
+
+-- Units of Conformance
+
+cContextMappingDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingVrfName,
+                        cContextMappingTopologyName,
+                        cContextMappingProtoInstName,
+                        cContextMappingStorageType,
+                        cContextMappingRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding VRF, the corresponding topology,
+        and the corresponding routing protocol instance."
+    ::= { cContextMappingMIBGroups 1 }
+
+cContextMappingBridgeDomainDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingBridgeDomainIdentifier,
+                        cContextMappingBridgeDomainStorageType,
+                        cContextMappingBridgeDomainRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding bridge domain."
+    ::= { cContextMappingMIBGroups 2 }
+
+cContextMappingBridgeInstanceDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingBridgeInstName,
+                        cContextMappingBridgeInstStorageType,
+                        cContextMappingBridgeInstRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding bridge instance."
+    ::= { cContextMappingMIBGroups 3 }
+
+cContextMappingLicenseGroupDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingLicenseGroupName,
+                        cContextMappingLicenseGroupStorageType,
+                        cContextMappingLicenseGroupStorageType,
+                        cContextMappingLicenseGroupRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding LicenseGroupName."
+    ::= { cContextMappingMIBGroups 4 }
+
+END
+
+
+
+
+
+
+
+

--- a/sql-schema/041.sql
+++ b/sql-schema/041.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS `vrf_lite_cisco` ( `vrf_lite_cisco_id` int(11) NOT NULL AUTO_INCREMENT, `device_id` int(11) NOT NULL, `context_name` varchar(128) CHARACTER SET utf8 collate utf8_general_ci not null  ,`intance_name` varchar(128)  DEFAULT '', `vrf_name` varchar(128) DEFAULT 'Default', PRIMARY KEY (`vrf_lite_cisco_id`)  ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+ALTER TABLE `vrf_lite_cisco` ADD INDEX `vrf` (`vrf_name` ASC), ADD INDEX `context` (`context_name` ASC), ADD INDEX `device` (`device_id` ASC), ADD INDEX `mix` (`device_id` ASC, `context_name` ASC, `vrf_name` ASC);
+ALTER TABLE ipv4_addresses  ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv4_networks   ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv4_mac        ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv6_addresses  ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv6_networks   ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE bgpPeers        ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE bgpPeers_cbgp   ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_areas      ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_areas      DROP INDEX device_area, ADD UNIQUE KEY `device_area` (`device_id`,`ospfAreaId`,`context_name`);
+ALTER TABLE ospf_instances  ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_instances  DROP INDEX device_id, ADD UNIQUE KEY `device_id` (`device_id`,`ospf_instance_id`,`context_name`);
+ALTER TABLE ospf_nbrs       ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_nbrs       DROP INDEX device_id, ADD UNIQUE KEY `device_id` (`device_id`,`ospf_nbr_id`,`context_name`);
+ALTER TABLE ospf_ports      ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_ports DROP INDEX device_id, ADD UNIQUE KEY `device_id` (`device_id`,`ospf_port_id`,`context_name`);
+ALTER TABLE `vlans` CHANGE COLUMN `vlan_name` `vlan_name` VARCHAR(64) DEFAULT NULL;


### PR DESCRIPTION
...that depend of context like:

* Discovery: arp-table
* Diccovery: bgp-peers
* Discovery: ipv4-add..
* Discovery: ipv6-add

Fix logic in (i dont really remenber, but  i think the logic was a bit confusing, with some variable used before exist, something like that and not very libreNMS style)
* Poller: bgp-peer
* Poller: ospf

Add two Mibs

And other little change, two important the first line 773 in snmp.inc.php for add SNMPv3 Context to the le logic and one little 2  at line 60 because i had the problem that with context i get the ip in the answer.