### PR TITLE
Added fix for <> being used in alert rules

### DIFF
--- a/html/forms/parse-alert-rule.inc.php
+++ b/html/forms/parse-alert-rule.inc.php
@@ -20,7 +20,7 @@ $alert_id = $_POST['alert_id'];
 
 if(is_numeric($alert_id) && $alert_id > 0) {
     $rule = dbFetchRow("SELECT * FROM `alert_rules` WHERE `id` = ? LIMIT 1",array($alert_id));
-    $rule_split = preg_split('/([a-zA-Z0-9_\-\.\=\%\ \"\'\!\~]+[&&||]+)/',$rule['rule'], -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+    $rule_split = preg_split('/([a-zA-Z0-9_\-\.\=\%\<\>\ \"\'\!\~]+[&&||]+)/',$rule['rule'], -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
     $count = count($rule_split) - 1;
     $rule_split[$count] = $rule_split[$count].'&&';
     $output = array('severity'=>$rule['severity'],'extra'=>$rule['extra'],'name'=>$rule['name'],'rules'=>$rule_split);


### PR DESCRIPTION
Any rules which had greater than or less than would have broken up in the parser.