### PR TITLE
Clear out tags before adding current ones

### DIFF
--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -137,6 +137,7 @@ $('#create-alert').on('show.bs.modal', function (event) {
     var modal = $(this)
     $('#device_id').val(device_id);
     $('#alert_id').val(alert_id);
+    $('#response').data('tagmanager').empty();
     $('#response').tagmanager({
            strategy: 'array',
            tagFieldName: 'rules[]'


### PR DESCRIPTION
When editing a rule and then going to edit another one, both sets of tags would load. This fixes that.