### PR TITLE
Fixed resetting tags back to blank

### DIFF
--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -137,7 +137,7 @@ $('#create-alert').on('show.bs.modal', function (event) {
     var modal = $(this)
     $('#device_id').val(device_id);
     $('#alert_id').val(alert_id);
-    $('#response').data('tagmanager').empty();
+    $('#tagmanager').tagmanager();
     $('#response').tagmanager({
            strategy: 'array',
            tagFieldName: 'rules[]'


### PR DESCRIPTION
This actually fixes the duplicated tags when editing multiple alert rules!