### PR TITLE
Updated new_alert_rule modal to not die and instead only return the page for admins

### DIFF
--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -11,9 +11,7 @@
  * the source code distribution for details.
  */
 
-if(is_admin() === false) {
-    die('ERROR: You need to be admin');
-}
+if(is_admin() !== false) {
 
 ?>
 
@@ -229,3 +227,9 @@ $('#rule-submit').click('', function(e) {
 });
 
 </script>
+
+<?php
+
+}
+
+?>


### PR DESCRIPTION
before hand, the /alerts/ page would die for non-admins rather than render the actual alerts and just not allow them to create a new alert rule.