### PR TITLE
Updated CISCO-PRODUCTS-MIB

### DIFF
--- a/mibs/CISCO-PRODUCTS-MIB
+++ b/mibs/CISCO-PRODUCTS-MIB
@@ -1,6071 +1,1913 @@
 -- *****************************************************************
 -- CISCO-PRODUCTS-MIB.my:  Cisco Product Object Identifier Assignments
---   
+--
 -- January 1995, Jeffrey T. Johnson
---   
--- Copyright (c) 1995-2010 by cisco Systems, Inc.
+--
+-- Copyright (c) 1995-2014 by cisco Systems, Inc.
 -- All rights reserved.
---   
+-- 
 -- *****************************************************************
---   
 
 CISCO-PRODUCTS-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
-    MODULE-IDENTITY
-        FROM SNMPv2-SMI
-    ciscoModules,
-    ciscoProducts
-        FROM CISCO-SMI;
+	MODULE-IDENTITY
+		FROM SNMPv2-SMI
+	ciscoModules,
+	ciscoProducts
+		FROM CISCO-SMI;
 
 ciscoProductsMIB MODULE-IDENTITY
-    LAST-UPDATED    "201012020000Z"
-    ORGANIZATION    "Cisco Systems, Inc."
-    CONTACT-INFO
-            "Cisco Systems
-            Customer Service
+	LAST-UPDATED	"201411060000Z"
+	ORGANIZATION	"Cisco Systems, Inc."
+	CONTACT-INFO
+		"       Cisco Systems
+			Customer Service
 
-            Postal: 170 W Tasman Drive
-            San Jose, CA  95134
-            USA
+		Postal: 170 W Tasman Drive
+			San Jose, CA  95134
+			USA
 
-            Tel: +1 800 553-NETS
+		   Tel: +1 800 553-NETS
 
-            E-mail: cs-snmp@cisco.com"
-    DESCRIPTION
-        "This module defines the object identifiers that are
-        assigned to various hardware platforms, and hence are
-        returned as values for sysObjectID"
-    REVISION        "201012020000Z"
-    DESCRIPTION
-        "Removed DNP for 2960s, 3560x and 3750x"
-    REVISION        "201009030000Z"
-    DESCRIPTION
-        "Added new product oids"
-    REVISION        "200505051930Z"
-    DESCRIPTION
-        "Added following OIDs:
-        ciscoMPX, ciscoNMCUEEC, ciscoWLSE1132, 
-        ciscoME6340ACA, ciscoME6340DCA,
-        ciscoME6340DCA, catalyst296024TT,
-        catalyst296048TT"
-    REVISION        "200504201930Z"
-    DESCRIPTION
-        "Removed DNP of catalyst6kGateway"
-    REVISION        "200504181930Z"
-    DESCRIPTION
-        "Added following OIDs:
-        ciscoNme16Es1GeNoPwr, ciscoNmeX24Es1GeNoPwr,
-        ciscoNmeXd24Es2StNoPwr, ciscoNmeXd48Es2GeNoPwr,
-        catalyst6kMsfc2a, ciscoEDI, ciscoCe611K9,
-        ciscoWLSEs20."
-    REVISION        "200204051400Z"
-    DESCRIPTION
-        "CANA Assignments."
-    REVISION        "9505310000Z"
-    DESCRIPTION
-        "Miscellaneous updates."
-    ::= { ciscoModules 2 }
+		E-mail: cs-snmp@cisco.com"
+	DESCRIPTION
+		"This module defines the object identifiers that are
+		assigned to various hardware platforms, and hence are
+		returned as values for sysObjectID"
+        REVISION "201305280000Z"
+        DESCRIPTION
+                 "Added following OIDs:
+                 ciscoMPX, ciscoNMCUEEC, ciscoWLSE1132, 
+                 ciscoME6340ACA, ciscoME6340DCA,
+                 ciscoME6340DCA, catalyst296024TT,
+                 catalyst296048TT" 
+        REVISION "200504201930Z"
+        DESCRIPTION
+		"Removed DNP of catalyst6kGateway"
+        REVISION "200504181930Z"
+        DESCRIPTION
+                "Added following OIDs:
+		ciscoNme16Es1GeNoPwr, ciscoNmeX24Es1GeNoPwr,
+		ciscoNmeXd24Es2StNoPwr, ciscoNmeXd48Es2GeNoPwr,
+		catalyst6kMsfc2a, ciscoEDI, ciscoCe611K9,
+		ciscoWLSEs20."
+        REVISION "200204051400Z"
+        DESCRIPTION
+                "CANA Assignments."
+ 	REVISION	"9505310000Z"
+  	DESCRIPTION
+		"Miscellaneous updates."
+	::= { ciscoModules 2 }
+
 -- older cisco routers (i.e. CGS, MGS, AGS) do not have the ability
 -- to determine what kind of router they are.  these devices return
 -- a sysObjectID value that indicates their configured functionality
-
-ciscoGatewayServer  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1 }
-
-ciscoTerminalServer  OBJECT IDENTIFIER
-    ::= { ciscoProducts 2 }
-
-ciscoTrouter  OBJECT IDENTIFIER
-    ::= { ciscoProducts 3 }
-
-ciscoProtocolTranslator  OBJECT IDENTIFIER
-    ::= { ciscoProducts 4 }
+ciscoGatewayServer OBJECT IDENTIFIER ::= { ciscoProducts 1 }
+ciscoTerminalServer OBJECT IDENTIFIER ::= { ciscoProducts 2 }
+ciscoTrouter OBJECT IDENTIFIER ::= { ciscoProducts 3 }
+ciscoProtocolTranslator OBJECT IDENTIFIER ::= { ciscoProducts 4 }
 
 -- newer devices return a sysObjectID value that corresponds to the
 -- device model number
-
-ciscoIGS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 5 }
-
-cisco3000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 6 }
-
-cisco4000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 7 }
-
-cisco7000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 8 }
-
-ciscoCS500  OBJECT IDENTIFIER
-    ::= { ciscoProducts 9 }
-
-cisco2000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 10 }
+ciscoIGS OBJECT IDENTIFIER ::= { ciscoProducts 5 }
+cisco3000 OBJECT IDENTIFIER ::= { ciscoProducts 6 }
+cisco4000 OBJECT IDENTIFIER ::= { ciscoProducts 7 }
+cisco7000 OBJECT IDENTIFIER ::= { ciscoProducts 8 }
+ciscoCS500 OBJECT IDENTIFIER ::= { ciscoProducts 9 }
+cisco2000 OBJECT IDENTIFIER ::= { ciscoProducts 10 }
 
 -- note well that an AGS+ must contain a cBus controller in order to
 -- know that it is an AGS+, otherwise it is unable to determine what
 -- kind of device it is, and returns one of the functionality-based
 -- sysObjectID values from above
-
-ciscoAGSplus  OBJECT IDENTIFIER
-    ::= { ciscoProducts 11 }
-
-cisco7010  OBJECT IDENTIFIER
-    ::= { ciscoProducts 12 }
-
-cisco2500  OBJECT IDENTIFIER
-    ::= { ciscoProducts 13 }
-
-cisco4500  OBJECT IDENTIFIER
-    ::= { ciscoProducts 14 }
-
-cisco2102  OBJECT IDENTIFIER
-    ::= { ciscoProducts 15 }
-
-cisco2202  OBJECT IDENTIFIER
-    ::= { ciscoProducts 16 }
-
-cisco2501  OBJECT IDENTIFIER
-    ::= { ciscoProducts 17 }
-
-cisco2502  OBJECT IDENTIFIER
-    ::= { ciscoProducts 18 }
-
-cisco2503  OBJECT IDENTIFIER
-    ::= { ciscoProducts 19 }
-
-cisco2504  OBJECT IDENTIFIER
-    ::= { ciscoProducts 20 }
-
-cisco2505  OBJECT IDENTIFIER
-    ::= { ciscoProducts 21 }
-
-cisco2506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 22 }
-
-cisco2507  OBJECT IDENTIFIER
-    ::= { ciscoProducts 23 }
-
-cisco2508  OBJECT IDENTIFIER
-    ::= { ciscoProducts 24 }
-
-cisco2509  OBJECT IDENTIFIER
-    ::= { ciscoProducts 25 }
-
-cisco2510  OBJECT IDENTIFIER
-    ::= { ciscoProducts 26 }
-
-cisco2511  OBJECT IDENTIFIER
-    ::= { ciscoProducts 27 }
-
-cisco2512  OBJECT IDENTIFIER
-    ::= { ciscoProducts 28 }
-
-cisco2513  OBJECT IDENTIFIER
-    ::= { ciscoProducts 29 }
-
-cisco2514  OBJECT IDENTIFIER
-    ::= { ciscoProducts 30 }
-
-cisco2515  OBJECT IDENTIFIER
-    ::= { ciscoProducts 31 }
-
-cisco3101  OBJECT IDENTIFIER
-    ::= { ciscoProducts 32 }
-
-cisco3102  OBJECT IDENTIFIER
-    ::= { ciscoProducts 33 }
-
-cisco3103  OBJECT IDENTIFIER
-    ::= { ciscoProducts 34 }
-
-cisco3104  OBJECT IDENTIFIER
-    ::= { ciscoProducts 35 }
-
-cisco3202  OBJECT IDENTIFIER
-    ::= { ciscoProducts 36 }
-
-cisco3204  OBJECT IDENTIFIER
-    ::= { ciscoProducts 37 }
-
-ciscoAccessProRC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 38 }
-
-ciscoAccessProEC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 39 }
-
-cisco1000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 40 }
-
-cisco1003  OBJECT IDENTIFIER
-    ::= { ciscoProducts 41 }
-
-cisco2516  OBJECT IDENTIFIER
-    ::= { ciscoProducts 42 }
-
-cisco1020  OBJECT IDENTIFIER
-    ::= { ciscoProducts 43 }
-
-cisco1004  OBJECT IDENTIFIER
-    ::= { ciscoProducts 44 }
-
-cisco7507  OBJECT IDENTIFIER
-    ::= { ciscoProducts 45 }
-
-cisco7513  OBJECT IDENTIFIER
-    ::= { ciscoProducts 46 }
-
-cisco7506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 47 }
-
-cisco7505  OBJECT IDENTIFIER
-    ::= { ciscoProducts 48 }
-
-cisco1005  OBJECT IDENTIFIER
-    ::= { ciscoProducts 49 }
-
-cisco4700  OBJECT IDENTIFIER
-    ::= { ciscoProducts 50 }
-
-ciscoPro1003  OBJECT IDENTIFIER
-    ::= { ciscoProducts 51 }
-
-ciscoPro1004  OBJECT IDENTIFIER
-    ::= { ciscoProducts 52 }
-
-ciscoPro1005  OBJECT IDENTIFIER
-    ::= { ciscoProducts 53 }
-
-ciscoPro1020  OBJECT IDENTIFIER
-    ::= { ciscoProducts 54 }
-
-ciscoPro2500PCE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 55 }
-
-ciscoPro2501  OBJECT IDENTIFIER
-    ::= { ciscoProducts 56 }
-
-ciscoPro2503  OBJECT IDENTIFIER
-    ::= { ciscoProducts 57 }
-
-ciscoPro2505  OBJECT IDENTIFIER
-    ::= { ciscoProducts 58 }
-
-ciscoPro2507  OBJECT IDENTIFIER
-    ::= { ciscoProducts 59 }
-
-ciscoPro2509  OBJECT IDENTIFIER
-    ::= { ciscoProducts 60 }
-
-ciscoPro2511  OBJECT IDENTIFIER
-    ::= { ciscoProducts 61 }
-
-ciscoPro2514  OBJECT IDENTIFIER
-    ::= { ciscoProducts 62 }
-
-ciscoPro2516  OBJECT IDENTIFIER
-    ::= { ciscoProducts 63 }
-
-ciscoPro2519  OBJECT IDENTIFIER
-    ::= { ciscoProducts 64 }
-
-ciscoPro2521  OBJECT IDENTIFIER
-    ::= { ciscoProducts 65 }
-
-ciscoPro4500  OBJECT IDENTIFIER
-    ::= { ciscoProducts 66 }
-
-cisco2517  OBJECT IDENTIFIER
-    ::= { ciscoProducts 67 }
-
-cisco2518  OBJECT IDENTIFIER
-    ::= { ciscoProducts 68 }
-
-cisco2519  OBJECT IDENTIFIER
-    ::= { ciscoProducts 69 }
-
-cisco2520  OBJECT IDENTIFIER
-    ::= { ciscoProducts 70 }
-
-cisco2521  OBJECT IDENTIFIER
-    ::= { ciscoProducts 71 }
-
-cisco2522  OBJECT IDENTIFIER
-    ::= { ciscoProducts 72 }
-
-cisco2523  OBJECT IDENTIFIER
-    ::= { ciscoProducts 73 }
-
-cisco2524  OBJECT IDENTIFIER
-    ::= { ciscoProducts 74 }
-
-cisco2525  OBJECT IDENTIFIER
-    ::= { ciscoProducts 75 }
-
-ciscoPro751  OBJECT IDENTIFIER
-    ::= { ciscoProducts 76 }
-
-ciscoPro752  OBJECT IDENTIFIER
-    ::= { ciscoProducts 77 }
-
-ciscoPro753  OBJECT IDENTIFIER
-    ::= { ciscoProducts 78 }
-
-ciscoPro901  OBJECT IDENTIFIER
-    ::= { ciscoProducts 79 }
-
-
-ciscoPro902  OBJECT IDENTIFIER
-    ::= { ciscoProducts 80 }
-
-
-cisco751  OBJECT IDENTIFIER
-    ::= { ciscoProducts 81 }
-
-cisco752  OBJECT IDENTIFIER
-    ::= { ciscoProducts 82 }
-
-cisco753  OBJECT IDENTIFIER
-    ::= { ciscoProducts 83 }
-
-ciscoPro741  OBJECT IDENTIFIER
-    ::= { ciscoProducts 84 }
-
-ciscoPro742  OBJECT IDENTIFIER
-    ::= { ciscoProducts 85 }
-
-ciscoPro743  OBJECT IDENTIFIER
-    ::= { ciscoProducts 86 }
-
-ciscoPro744  OBJECT IDENTIFIER
-    ::= { ciscoProducts 87 }
-
-ciscoPro761  OBJECT IDENTIFIER
-    ::= { ciscoProducts 88 }
-
-ciscoPro762  OBJECT IDENTIFIER
-    ::= { ciscoProducts 89 }
-
-ciscoPro763  OBJECT IDENTIFIER
-    ::= { ciscoProducts 90 }
-
-
-ciscoPro764  OBJECT IDENTIFIER
-    ::= { ciscoProducts 91 }
-
-
-ciscoPro765  OBJECT IDENTIFIER
-    ::= { ciscoProducts 92 }
-
-ciscoPro766  OBJECT IDENTIFIER
-    ::= { ciscoProducts 93 }
-
-cisco741  OBJECT IDENTIFIER
-    ::= { ciscoProducts 94 }
-
-cisco742  OBJECT IDENTIFIER
-    ::= { ciscoProducts 95 }
-
-cisco743  OBJECT IDENTIFIER
-    ::= { ciscoProducts 96 }
-
-cisco744  OBJECT IDENTIFIER
-    ::= { ciscoProducts 97 }
-
-cisco761  OBJECT IDENTIFIER
-    ::= { ciscoProducts 98 }
-
-cisco762  OBJECT IDENTIFIER
-    ::= { ciscoProducts 99 }
-
-cisco763  OBJECT IDENTIFIER
-    ::= { ciscoProducts 100 }
-
-
-cisco764  OBJECT IDENTIFIER
-    ::= { ciscoProducts 101 }
-
-
-cisco765  OBJECT IDENTIFIER
-    ::= { ciscoProducts 102 }
-
-cisco766  OBJECT IDENTIFIER
-    ::= { ciscoProducts 103 }
-
-ciscoPro2520  OBJECT IDENTIFIER
-    ::= { ciscoProducts 104 }
-
-ciscoPro2522  OBJECT IDENTIFIER
-    ::= { ciscoProducts 105 }
-
-ciscoPro2524  OBJECT IDENTIFIER
-    ::= { ciscoProducts 106 }
-
-ciscoLS1010  OBJECT IDENTIFIER
-    ::= { ciscoProducts 107 }
-
-cisco7206  OBJECT IDENTIFIER
-    ::= { ciscoProducts 108 }
-
-ciscoAS5200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 109 }
-
-cisco3640  OBJECT IDENTIFIER
-    ::= { ciscoProducts 110 }
-
-ciscoCatalyst3500  OBJECT IDENTIFIER
-    ::= { ciscoProducts 111 }
-
-ciscoWSX3011  OBJECT IDENTIFIER
-    ::= { ciscoProducts 112 }
-
-cisco1601  OBJECT IDENTIFIER
-    ::= { ciscoProducts 113 }
-
-cisco1602  OBJECT IDENTIFIER
-    ::= { ciscoProducts 114 }
-
-cisco1603  OBJECT IDENTIFIER
-    ::= { ciscoProducts 115 }
-
-cisco1604  OBJECT IDENTIFIER
-    ::= { ciscoProducts 116 }
-
-ciscoPro1601  OBJECT IDENTIFIER
-    ::= { ciscoProducts 117 }
-
-ciscoPro1602  OBJECT IDENTIFIER
-    ::= { ciscoProducts 118 }
-
-ciscoPro1603  OBJECT IDENTIFIER
-    ::= { ciscoProducts 119 }
-
-ciscoPro1604  OBJECT IDENTIFIER
-    ::= { ciscoProducts 120 }
-
-ciscoWSX5301  OBJECT IDENTIFIER
-    ::= { ciscoProducts 121 }
-
-
-cisco3620  OBJECT IDENTIFIER
-    ::= { ciscoProducts 122 }
-
-ciscoPro3620  OBJECT IDENTIFIER
-    ::= { ciscoProducts 123 }
-
-ciscoPro3640  OBJECT IDENTIFIER
-    ::= { ciscoProducts 124 }
-
-cisco7204  OBJECT IDENTIFIER
-    ::= { ciscoProducts 125 }
-
-cisco771  OBJECT IDENTIFIER
-    ::= { ciscoProducts 126 }
-
-cisco772  OBJECT IDENTIFIER
-    ::= { ciscoProducts 127 }
-
-cisco775  OBJECT IDENTIFIER
-    ::= { ciscoProducts 128 }
-
-cisco776  OBJECT IDENTIFIER
-    ::= { ciscoProducts 129 }
-
-ciscoPro2502  OBJECT IDENTIFIER
-    ::= { ciscoProducts 130 }
-
-ciscoPro2504  OBJECT IDENTIFIER
-    ::= { ciscoProducts 131 }
-
-ciscoPro2506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 132 }
-
-ciscoPro2508  OBJECT IDENTIFIER
-    ::= { ciscoProducts 133 }
-
-ciscoPro2510  OBJECT IDENTIFIER
-    ::= { ciscoProducts 134 }
-
-ciscoPro2512  OBJECT IDENTIFIER
-    ::= { ciscoProducts 135 }
-
-ciscoPro2513  OBJECT IDENTIFIER
-    ::= { ciscoProducts 136 }
-
-ciscoPro2515  OBJECT IDENTIFIER
-    ::= { ciscoProducts 137 }
-
-ciscoPro2517  OBJECT IDENTIFIER
-    ::= { ciscoProducts 138 }
-
-ciscoPro2518  OBJECT IDENTIFIER
-    ::= { ciscoProducts 139 }
-
-ciscoPro2523  OBJECT IDENTIFIER
-    ::= { ciscoProducts 140 }
-
-ciscoPro2525  OBJECT IDENTIFIER
-    ::= { ciscoProducts 141 }
-
-ciscoPro4700  OBJECT IDENTIFIER
-    ::= { ciscoProducts 142 }
-
-
-ciscoPro316T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 147 }
-
-ciscoPro316C  OBJECT IDENTIFIER
-    ::= { ciscoProducts 148 }
-
-ciscoPro3116  OBJECT IDENTIFIER
-    ::= { ciscoProducts 149 }
-
-catalyst116T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 150 }
-
-catalyst116C  OBJECT IDENTIFIER
-    ::= { ciscoProducts 151 }
-
-catalyst1116  OBJECT IDENTIFIER
-    ::= { ciscoProducts 152 }
-
-ciscoAS2509RJ  OBJECT IDENTIFIER
-    ::= { ciscoProducts 153 }
-
-ciscoAS2511RJ  OBJECT IDENTIFIER
-    ::= { ciscoProducts 154 }
-
-
-ciscoMC3810  OBJECT IDENTIFIER
-    ::= { ciscoProducts 157 }
-
-
-cisco1503  OBJECT IDENTIFIER
-    ::= { ciscoProducts 160 }
-
-cisco1502  OBJECT IDENTIFIER
-    ::= { ciscoProducts 161 }
-
-ciscoAS5300  OBJECT IDENTIFIER
-    ::= { ciscoProducts 162 }
-
-
-ciscoLS1015  OBJECT IDENTIFIER
-    ::= { ciscoProducts 164 }
-
-cisco2501FRADFX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 165 }
-
-cisco2501LANFRADFX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 166 }
-
-cisco2502LANFRADFX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 167 }
-
-ciscoWSX5302  OBJECT IDENTIFIER
-    ::= { ciscoProducts 168 }
-
-ciscoFastHub216T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 169 }
-
-catalyst2908xl  OBJECT IDENTIFIER
-    ::= { ciscoProducts 170 }
-
--- Catalyst 2908XL switch with 8 10/100BaseTX ports
-
-catalyst2916m-xl  OBJECT IDENTIFIER
-    ::= { ciscoProducts 171 }
-
--- Catalyst 2916M-XL switch with 16 10/100BaseTX ports and 2 uplink slots
-
-cisco1605  OBJECT IDENTIFIER
-    ::= { ciscoProducts 172 }
-
-cisco12012  OBJECT IDENTIFIER
-    ::= { ciscoProducts 173 }
-
-
-catalyst1912C  OBJECT IDENTIFIER
-    ::= { ciscoProducts 175 }
-
-ciscoMicroWebServer2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 176 }
-
-ciscoFastHubBMMTX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 177 }
-
-ciscoFastHubBMMFX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 178 }
-
-ciscoUBR7246  OBJECT IDENTIFIER
-    ::= { ciscoProducts 179 }
-
--- Universal Broadband Router
-
-cisco6400  OBJECT IDENTIFIER
-    ::= { ciscoProducts 180 }
-
-cisco12004  OBJECT IDENTIFIER
-    ::= { ciscoProducts 181 }
-
-cisco12008  OBJECT IDENTIFIER
-    ::= { ciscoProducts 182 }
-
-catalyst2924XL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 183 }
-
--- Catalyst 2924XL switch with 24 10/100BaseTX ports; doesn't support port-based VLANs.
-
-catalyst2924CXL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 184 }
-
--- Catalyst 2924C-XL switch; doesn't support port-based VLANs.
-
-cisco2610  OBJECT IDENTIFIER
-    ::= { ciscoProducts 185 }
-
--- Cisco 2600 platform with 1 integrated ethernet interface
-
-cisco2611  OBJECT IDENTIFIER
-    ::= { ciscoProducts 186 }
-
--- Cisco 2600 platform with 2 integrated ethernet interfaces
-
-cisco2612  OBJECT IDENTIFIER
-    ::= { ciscoProducts 187 }
-
--- Cisco 2600 platform with an integrated ethernet and token ring
-
-ciscoAS5800  OBJECT IDENTIFIER
-    ::= { ciscoProducts 188 }
-
-ciscoSC3640  OBJECT IDENTIFIER
-    ::= { ciscoProducts 189 }
-
-cisco8510  OBJECT IDENTIFIER
-    ::= { ciscoProducts 190 }
-
--- Cisco Catalyst 8510CSR (Campus Switching Router)
-
-ciscoUBR904  OBJECT IDENTIFIER
-    ::= { ciscoProducts 191 }
-
--- Cisco Cable Modem (UBR - Universal Broadband Router)
-
-cisco6200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 192 }
-
-
-cisco7202  OBJECT IDENTIFIER
-    ::= { ciscoProducts 194 }
-
--- Modular two slot router in the cisco7200 family
-
-cisco2613  OBJECT IDENTIFIER
-    ::= { ciscoProducts 195 }
-
--- Cisco 2600 platform with 1 integrated token ring interface
-
-cisco8515  OBJECT IDENTIFIER
-    ::= { ciscoProducts 196 }
-
--- Cisco Catalyst 8515CSR (Campus Switching Router)
-
-catalyst9006  OBJECT IDENTIFIER
-    ::= { ciscoProducts 197 }
-
-catalyst9009  OBJECT IDENTIFIER
-    ::= { ciscoProducts 198 }
-
-ciscoRPM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 199 }
-
--- Router Processor Module
-
-cisco1710  OBJECT IDENTIFIER
-    ::= { ciscoProducts 200 }
-
--- VPN(Virtual Private Network) Security Router with 1 FastEthernet and 1 Ethernet interface onboard
-
-cisco1720  OBJECT IDENTIFIER
-    ::= { ciscoProducts 201 }
-
-catalyst8540msr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 202 }
-
--- Catalyst 8540 Multiservice Switching Router
-
-catalyst8540csr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 203 }
-
--- Catalyst 8540 Campus Switching Router
-
-cisco7576  OBJECT IDENTIFIER
-    ::= { ciscoProducts 204 }
-
--- Dual Independent RSP platform, 13 slots
-
-cisco3660  OBJECT IDENTIFIER
-    ::= { ciscoProducts 205 }
-
--- Six slot MARs router
-
-cisco1401  OBJECT IDENTIFIER
-    ::= { ciscoProducts 206 }
-
--- Router product with 1 ethernet and 1 ATM25 interface
-
-cisco2620  OBJECT IDENTIFIER
-    ::= { ciscoProducts 208 }
-
--- Cisco 2600 chassis with 1 onboard FE
-
-cisco2621  OBJECT IDENTIFIER
-    ::= { ciscoProducts 209 }
-
--- Cisco 2600 chassis with 2 onboard 10/100 FE ports
-
-ciscoUBR7223  OBJECT IDENTIFIER
-    ::= { ciscoProducts 210 }
-
--- Universal Broadband Router
-
-cisco6400Nrp  OBJECT IDENTIFIER
-    ::= { ciscoProducts 211 }
-
--- Cisco 6400 Network Routing Processor
-
-cisco801  OBJECT IDENTIFIER
-    ::= { ciscoProducts 212 }
-
--- Cisco 800 platform with 1 ethernet and 1 BRI S/T
-
-cisco802  OBJECT IDENTIFIER
-    ::= { ciscoProducts 213 }
-
--- Cisco 800 platform with 1 ethernet and 1 BRI U
-
-cisco803  OBJECT IDENTIFIER
-    ::= { ciscoProducts 214 }
-
--- Cisco 800 platform with 1 ethernet 4-port HUB, 1 BRI S/T, and 2 POTs
-
-cisco804  OBJECT IDENTIFIER
-    ::= { ciscoProducts 215 }
-
--- Cisco 800 platform with 1 ethernet 4-port HUB, 1 BRI U, and 2 POTs
-
-cisco1750  OBJECT IDENTIFIER
-    ::= { ciscoProducts 216 }
-
--- VoIP (Voice over IP) capable Cisco 1700 platform with 2 WIC/VIC slots and 1 VIC-only slot
-
-catalyst2924XLv  OBJECT IDENTIFIER
-    ::= { ciscoProducts 217 }
-
--- Catalyst 2924XL switch with 24 10BaseT/100BaseTX autosensing switch ports; supports port-based VLANs; can run Standard or Enterprise edition software.
-
-catalyst2924CXLv  OBJECT IDENTIFIER
-    ::= { ciscoProducts 218 }
-
--- Catalyst 2924C-XL switch with 22 10BaseT/100BaseTX and 2 100BaseFX autosensing switch ports; supports port-based VLANs; can run Standard or Enterprise edition software.
-
-catalyst2912XL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 219 }
-
--- Catalyst 2912XL switch with 12 autosensing 10/100BaseTX ports, can run Standard or Enterprise edition software.
-
-catalyst2924MXL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 220 }
-
--- Catalyst 2924M-XL switch with 24 autosensing 10/100BaseTX ports and 2 uplink slots, can run Standard or Enterprise edition software.
-
-catalyst2912MfXL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 221 }
-
--- Catalyst 2912MF-XL switch with 12 100BaseFX ports and 2 uplink slots; can only run Enterprise edition software.
-
-cisco7206VXR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 222 }
-
--- Cisco 7200 platform, VXR series chassis with 6 slots
-
-cisco7204VXR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 223 }
-
--- Cisco 7200 platform, VXR series chassis with 4 slots
-
-cisco1538M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 224 }
-
--- Cisco Network Office 8-port 10/100 Repeater
-
-cisco1548M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 225 }
-
--- Cisco Network Office 10/100 Switch
-
-ciscoFasthub100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 226 }
-
--- Cisco Fast Hub 100 Series 10/100 Repeater
-
-ciscoPIXFirewall  OBJECT IDENTIFIER
-    ::= { ciscoProducts 227 }
-
--- Cisco PIX Firewall
-
-ciscoMGX8850  OBJECT IDENTIFIER
-    ::= { ciscoProducts 228 }
-
--- Cisco Multiservice Gigabit Switch with 32 half height slots
-
-ciscoMGX8830  OBJECT IDENTIFIER
-    ::= { ciscoProducts 229 }
-
--- Cisco Multiservice Switch with 16 half-height slots
+ciscoAGSplus OBJECT IDENTIFIER ::= { ciscoProducts 11 }
+
+cisco7010 OBJECT IDENTIFIER ::= { ciscoProducts 12 }
+cisco2500 OBJECT IDENTIFIER ::= { ciscoProducts 13 }
+cisco4500 OBJECT IDENTIFIER ::= { ciscoProducts 14 }
+cisco2102 OBJECT IDENTIFIER ::= { ciscoProducts 15 }
+cisco2202 OBJECT IDENTIFIER ::= { ciscoProducts 16 }
+cisco2501 OBJECT IDENTIFIER ::= { ciscoProducts 17 }
+cisco2502 OBJECT IDENTIFIER ::= { ciscoProducts 18 }
+cisco2503 OBJECT IDENTIFIER ::= { ciscoProducts 19 }
+cisco2504 OBJECT IDENTIFIER ::= { ciscoProducts 20 }
+cisco2505 OBJECT IDENTIFIER ::= { ciscoProducts 21 }
+cisco2506 OBJECT IDENTIFIER ::= { ciscoProducts 22 }
+cisco2507 OBJECT IDENTIFIER ::= { ciscoProducts 23 }
+cisco2508 OBJECT IDENTIFIER ::= { ciscoProducts 24 }
+cisco2509 OBJECT IDENTIFIER ::= { ciscoProducts 25 }
+cisco2510 OBJECT IDENTIFIER ::= { ciscoProducts 26 }
+cisco2511 OBJECT IDENTIFIER ::= { ciscoProducts 27 }
+cisco2512 OBJECT IDENTIFIER ::= { ciscoProducts 28 }
+cisco2513 OBJECT IDENTIFIER ::= { ciscoProducts 29 }
+cisco2514 OBJECT IDENTIFIER ::= { ciscoProducts 30 }
+cisco2515 OBJECT IDENTIFIER ::= { ciscoProducts 31 }
+cisco3101 OBJECT IDENTIFIER ::= { ciscoProducts 32 }
+cisco3102 OBJECT IDENTIFIER ::= { ciscoProducts 33 }
+cisco3103 OBJECT IDENTIFIER ::= { ciscoProducts 34 }
+cisco3104 OBJECT IDENTIFIER ::= { ciscoProducts 35 }
+cisco3202 OBJECT IDENTIFIER ::= { ciscoProducts 36 }
+cisco3204 OBJECT IDENTIFIER ::= { ciscoProducts 37 }
+ciscoAccessProRC OBJECT IDENTIFIER ::= { ciscoProducts 38 }
+ciscoAccessProEC OBJECT IDENTIFIER ::= { ciscoProducts 39 }
+cisco1000 OBJECT IDENTIFIER ::= { ciscoProducts 40 }
+cisco1003 OBJECT IDENTIFIER ::= { ciscoProducts 41 }
+cisco2516 OBJECT IDENTIFIER ::= { ciscoProducts 42 }
+cisco1020 OBJECT IDENTIFIER ::= { ciscoProducts 43 }
+cisco1004 OBJECT IDENTIFIER ::= { ciscoProducts 44 }
+cisco7507 OBJECT IDENTIFIER ::= { ciscoProducts 45 }
+cisco7513 OBJECT IDENTIFIER ::= { ciscoProducts 46 }
+cisco7506 OBJECT IDENTIFIER ::= { ciscoProducts 47 }	
+cisco7505 OBJECT IDENTIFIER ::= { ciscoProducts 48 }
+cisco1005 OBJECT IDENTIFIER ::= { ciscoProducts 49 }
+cisco4700 OBJECT IDENTIFIER ::= { ciscoProducts 50 }
+ciscoPro1003 OBJECT IDENTIFIER ::= { ciscoProducts 51 }
+ciscoPro1004 OBJECT IDENTIFIER ::= { ciscoProducts 52 }
+ciscoPro1005 OBJECT IDENTIFIER ::= { ciscoProducts 53 }
+ciscoPro1020 OBJECT IDENTIFIER ::= { ciscoProducts 54 }	
+ciscoPro2500PCE OBJECT IDENTIFIER ::= { ciscoProducts 55 }
+ciscoPro2501 OBJECT IDENTIFIER ::= { ciscoProducts 56 }
+ciscoPro2503 OBJECT IDENTIFIER ::= { ciscoProducts 57 }
+ciscoPro2505 OBJECT IDENTIFIER ::= { ciscoProducts 58 }
+ciscoPro2507 OBJECT IDENTIFIER ::= { ciscoProducts 59 }
+ciscoPro2509 OBJECT IDENTIFIER ::= { ciscoProducts 60 }
+ciscoPro2511 OBJECT IDENTIFIER ::= { ciscoProducts 61 }
+ciscoPro2514 OBJECT IDENTIFIER ::= { ciscoProducts 62 }
+ciscoPro2516 OBJECT IDENTIFIER ::= { ciscoProducts 63 }
+ciscoPro2519 OBJECT IDENTIFIER ::= { ciscoProducts 64 }
+ciscoPro2521 OBJECT IDENTIFIER ::= { ciscoProducts 65 }	
+ciscoPro4500 OBJECT IDENTIFIER ::= { ciscoProducts 66 }
+cisco2517 OBJECT IDENTIFIER ::= { ciscoProducts 67 }
+cisco2518 OBJECT IDENTIFIER ::= { ciscoProducts 68 }
+cisco2519 OBJECT IDENTIFIER ::= { ciscoProducts 69 }
+cisco2520 OBJECT IDENTIFIER ::= { ciscoProducts 70 }
+cisco2521 OBJECT IDENTIFIER ::= { ciscoProducts 71 }
+cisco2522 OBJECT IDENTIFIER ::= { ciscoProducts 72 }
+cisco2523 OBJECT IDENTIFIER ::= { ciscoProducts 73 }
+cisco2524 OBJECT IDENTIFIER ::= { ciscoProducts 74 }
+cisco2525 OBJECT IDENTIFIER ::= { ciscoProducts 75 }
+ciscoPro751 OBJECT IDENTIFIER ::= { ciscoProducts 76 }
+ciscoPro752 OBJECT IDENTIFIER ::= { ciscoProducts 77 }
+ciscoPro753 OBJECT IDENTIFIER ::= { ciscoProducts 78 }
+ciscoPro901 OBJECT IDENTIFIER ::= { ciscoProducts 79 }
+ciscoPro902 OBJECT IDENTIFIER ::= { ciscoProducts 80 }
+cisco751 OBJECT IDENTIFIER ::= { ciscoProducts 81 }
+cisco752 OBJECT IDENTIFIER ::= { ciscoProducts 82 }
+cisco753 OBJECT IDENTIFIER ::= { ciscoProducts 83 }
+ciscoPro741 OBJECT IDENTIFIER ::= { ciscoProducts 84 }
+ciscoPro742 OBJECT IDENTIFIER ::= { ciscoProducts 85 }	
+ciscoPro743 OBJECT IDENTIFIER ::= { ciscoProducts 86 }	
+ciscoPro744 OBJECT IDENTIFIER ::= { ciscoProducts 87 }	
+ciscoPro761 OBJECT IDENTIFIER ::= { ciscoProducts 88 }	
+ciscoPro762 OBJECT IDENTIFIER ::= { ciscoProducts 89 }	
+ciscoPro763 OBJECT IDENTIFIER ::= { ciscoProducts 90 }
+ciscoPro764 OBJECT IDENTIFIER ::= { ciscoProducts 91 }
+ciscoPro765 OBJECT IDENTIFIER ::= { ciscoProducts 92 }
+ciscoPro766 OBJECT IDENTIFIER ::= { ciscoProducts 93 }
+cisco741 OBJECT IDENTIFIER ::= { ciscoProducts 94 }	
+cisco742 OBJECT IDENTIFIER ::= { ciscoProducts 95 }
+cisco743 OBJECT IDENTIFIER ::= { ciscoProducts 96 }	
+cisco744 OBJECT IDENTIFIER ::= { ciscoProducts 97 }	
+cisco761 OBJECT IDENTIFIER ::= { ciscoProducts 98 }
+cisco762 OBJECT IDENTIFIER ::= { ciscoProducts 99 }
+cisco763 OBJECT IDENTIFIER ::= { ciscoProducts 100 }
+cisco764 OBJECT IDENTIFIER ::= { ciscoProducts 101 }
+cisco765 OBJECT IDENTIFIER ::= { ciscoProducts 102 }
+cisco766 OBJECT IDENTIFIER ::= { ciscoProducts 103 }
+ciscoPro2520 OBJECT IDENTIFIER ::= { ciscoProducts 104 }
+ciscoPro2522 OBJECT IDENTIFIER ::= { ciscoProducts 105 }
+ciscoPro2524 OBJECT IDENTIFIER ::= { ciscoProducts 106 }
+ciscoLS1010 OBJECT IDENTIFIER ::= { ciscoProducts 107 }
+cisco7206 OBJECT IDENTIFIER ::= { ciscoProducts 108 }
+ciscoAS5200 OBJECT IDENTIFIER ::= { ciscoProducts 109 }
+cisco3640 OBJECT IDENTIFIER ::= { ciscoProducts 110 }
+ciscoCatalyst3500 OBJECT IDENTIFIER ::= { ciscoProducts 111 }	
+ciscoWSX3011 OBJECT IDENTIFIER ::= { ciscoProducts 112 }	
+cisco1601 OBJECT IDENTIFIER ::= { ciscoProducts 113 }
+cisco1602 OBJECT IDENTIFIER ::= { ciscoProducts 114 }
+cisco1603 OBJECT IDENTIFIER ::= { ciscoProducts 115 }
+cisco1604 OBJECT IDENTIFIER ::= { ciscoProducts 116 }
+ciscoPro1601 OBJECT IDENTIFIER ::= { ciscoProducts 117 }
+ciscoPro1602 OBJECT IDENTIFIER ::= { ciscoProducts 118 }
+ciscoPro1603 OBJECT IDENTIFIER ::= { ciscoProducts 119 }
+ciscoPro1604 OBJECT IDENTIFIER ::= { ciscoProducts 120 }
+ciscoWSX5301 OBJECT IDENTIFIER ::= { ciscoProducts 121 }
+cisco3620 OBJECT IDENTIFIER ::= { ciscoProducts 122 }
+ciscoPro3620 OBJECT IDENTIFIER ::= { ciscoProducts 123 }	
+ciscoPro3640 OBJECT IDENTIFIER ::= { ciscoProducts 124 }
+cisco7204 OBJECT IDENTIFIER ::= { ciscoProducts 125 }
+cisco771 OBJECT IDENTIFIER ::= { ciscoProducts 126 }	
+cisco772 OBJECT IDENTIFIER ::= { ciscoProducts 127 }
+cisco775 OBJECT IDENTIFIER ::= { ciscoProducts 128 }
+cisco776 OBJECT IDENTIFIER ::= { ciscoProducts 129 }
+ciscoPro2502 OBJECT IDENTIFIER ::= { ciscoProducts 130 }
+ciscoPro2504 OBJECT IDENTIFIER ::= { ciscoProducts 131 }
+ciscoPro2506 OBJECT IDENTIFIER ::= { ciscoProducts 132 }
+ciscoPro2508 OBJECT IDENTIFIER ::= { ciscoProducts 133 }
+ciscoPro2510 OBJECT IDENTIFIER ::= { ciscoProducts 134 }
+ciscoPro2512 OBJECT IDENTIFIER ::= { ciscoProducts 135 }
+ciscoPro2513 OBJECT IDENTIFIER ::= { ciscoProducts 136 }
+ciscoPro2515 OBJECT IDENTIFIER ::= { ciscoProducts 137 }
+ciscoPro2517 OBJECT IDENTIFIER ::= { ciscoProducts 138 }
+ciscoPro2518 OBJECT IDENTIFIER ::= { ciscoProducts 139 }
+ciscoPro2523 OBJECT IDENTIFIER ::= { ciscoProducts 140 }
+ciscoPro2525 OBJECT IDENTIFIER ::= { ciscoProducts 141 }
+ciscoPro4700 OBJECT IDENTIFIER ::= { ciscoProducts 142 }
+ciscoPro316T OBJECT IDENTIFIER ::= { ciscoProducts 147 }
+ciscoPro316C OBJECT IDENTIFIER ::= { ciscoProducts 148 }
+ciscoPro3116 OBJECT IDENTIFIER ::= { ciscoProducts 149 }
+catalyst116T OBJECT IDENTIFIER ::= { ciscoProducts 150 }
+catalyst116C OBJECT IDENTIFIER ::= { ciscoProducts 151 }
+catalyst1116 OBJECT IDENTIFIER ::= { ciscoProducts 152 }
+ciscoAS2509RJ OBJECT IDENTIFIER ::= { ciscoProducts 153 }
+ciscoAS2511RJ OBJECT IDENTIFIER ::= { ciscoProducts 154 }
+ciscoMC3810 OBJECT IDENTIFIER ::= { ciscoProducts 157 }
+cisco1503 OBJECT IDENTIFIER ::= { ciscoProducts 160 }
+cisco1502 OBJECT IDENTIFIER ::= { ciscoProducts 161 }
+ciscoAS5300 OBJECT IDENTIFIER ::= { ciscoProducts 162 }
+ciscoLS1015 OBJECT IDENTIFIER ::= { ciscoProducts 164 }	
+cisco2501FRADFX OBJECT IDENTIFIER ::= { ciscoProducts 165 }
+cisco2501LANFRADFX OBJECT IDENTIFIER ::= { ciscoProducts 166 }
+cisco2502LANFRADFX OBJECT IDENTIFIER ::= { ciscoProducts 167 }
+ciscoWSX5302 OBJECT IDENTIFIER ::= { ciscoProducts 168 }
+ciscoFastHub216T OBJECT IDENTIFIER ::= { ciscoProducts 169 }
+catalyst2908xl OBJECT IDENTIFIER ::= { ciscoProducts 170 }		-- Catalyst 2908XL switch with 8 10/100BaseTX ports 
+catalyst2916mxl OBJECT IDENTIFIER ::= { ciscoProducts 171 }		-- Catalyst 2916M-XL switch with 16 10/100BaseTX ports and 2 uplink slots
+cisco1605 OBJECT IDENTIFIER ::= { ciscoProducts 172 }
+cisco12012 OBJECT IDENTIFIER ::= { ciscoProducts 173 }
+catalyst1912C OBJECT IDENTIFIER ::= { ciscoProducts 175 }
+ciscoMicroWebServer2 OBJECT IDENTIFIER ::= { ciscoProducts 176 }
+ciscoFastHubBMMTX OBJECT IDENTIFIER ::= { ciscoProducts 177 }
+ciscoFastHubBMMFX OBJECT IDENTIFIER ::= { ciscoProducts 178 }
+ciscoUBR7246 OBJECT IDENTIFIER ::= { ciscoProducts 179 }		-- Universal Broadband Router
+cisco6400 OBJECT IDENTIFIER ::= { ciscoProducts 180 }
+cisco12004 OBJECT IDENTIFIER ::= { ciscoProducts 181 }
+cisco12008 OBJECT IDENTIFIER ::= { ciscoProducts 182 }
+catalyst2924XL OBJECT IDENTIFIER ::= { ciscoProducts 183 }		-- Catalyst 2924XL switch with 24 10/100BaseTX ports; doesn't support port-based VLANs.
+catalyst2924CXL OBJECT IDENTIFIER ::= { ciscoProducts 184 } 		-- Catalyst 2924C-XL switch; doesn't support port-based VLANs. 
+cisco2610 OBJECT IDENTIFIER ::= { ciscoProducts 185 }			-- Cisco 2600 platform with 1 integrated ethernet interface
+cisco2611 OBJECT IDENTIFIER ::= { ciscoProducts 186 }			-- Cisco 2600 platform with 2 integrated ethernet interfaces 
+cisco2612 OBJECT IDENTIFIER ::= { ciscoProducts 187 }			-- Cisco 2600 platform with an integrated ethernet and token ring
+ciscoAS5800 OBJECT IDENTIFIER ::= { ciscoProducts 188 }
+ciscoSC3640 OBJECT IDENTIFIER ::= { ciscoProducts 189 }
+cisco8510 OBJECT IDENTIFIER ::= { ciscoProducts 190 }			-- Cisco Catalyst 8510CSR (Campus Switching Router)
+ciscoUBR904 OBJECT IDENTIFIER ::= { ciscoProducts 191 }			-- Cisco Cable Modem (UBR - Universal Broadband Router)
+cisco6200 OBJECT IDENTIFIER ::= { ciscoProducts 192 }
+cisco7202 OBJECT IDENTIFIER ::= { ciscoProducts 194 } 			-- Modular two slot router in the cisco7200 family 
+cisco2613 OBJECT IDENTIFIER ::= { ciscoProducts 195 }			-- Cisco 2600 platform with 1 integrated token ring interface
+cisco8515 OBJECT IDENTIFIER ::= { ciscoProducts 196 }			-- Cisco Catalyst 8515CSR (Campus Switching Router)
+catalyst9006 OBJECT IDENTIFIER ::= { ciscoProducts 197 } 
+catalyst9009 OBJECT IDENTIFIER ::= { ciscoProducts 198 }
+ciscoRPM OBJECT IDENTIFIER ::= { ciscoProducts 199 }			-- Router Processor Module
+cisco1710	OBJECT IDENTIFIER ::= { ciscoProducts 200 }		-- VPN(Virtual Private Network) Security Router with 1 FastEthernet and 1 Ethernet interface onboard
+cisco1720 OBJECT IDENTIFIER ::= { ciscoProducts 201 }		
+catalyst8540msr OBJECT IDENTIFIER ::= { ciscoProducts 202 }		-- Catalyst 8540 Multiservice Switching Router
+catalyst8540csr OBJECT IDENTIFIER ::= { ciscoProducts 203 }		-- Catalyst 8540 Campus Switching Router
+cisco7576 OBJECT IDENTIFIER ::= { ciscoProducts 204 }			-- Dual Independent RSP platform, 13 slots 
+cisco3660 OBJECT IDENTIFIER ::= { ciscoProducts 205 }			-- Six slot MARs router 
+cisco1401 OBJECT IDENTIFIER ::= { ciscoProducts 206 }			-- Router product with 1 ethernet and 1 ATM25 interface 
+cisco2620 OBJECT IDENTIFIER ::= { ciscoProducts 208 }			-- Cisco 2600 chassis with 1 onboard FE
+cisco2621 OBJECT IDENTIFIER ::= { ciscoProducts 209 }			-- Cisco 2600 chassis with 2 onboard 10/100 FE ports 
+ciscoUBR7223 OBJECT IDENTIFIER ::= { ciscoProducts 210 }		-- Universal Broadband Router
+cisco6400Nrp OBJECT IDENTIFIER ::= { ciscoProducts 211 }		-- Cisco 6400 Network Routing Processor 
+cisco801 OBJECT IDENTIFIER ::= { ciscoProducts 212 }			-- Cisco 800 platform with 1 ethernet and 1 BRI S/T
+cisco802 OBJECT IDENTIFIER ::= { ciscoProducts 213 }			-- Cisco 800 platform with 1 ethernet and 1 BRI U 
+cisco803 OBJECT IDENTIFIER ::= { ciscoProducts 214 }			-- Cisco 800 platform with 1 ethernet 4-port HUB, 1 BRI S/T, and 2 POTs 
+cisco804 OBJECT IDENTIFIER ::= { ciscoProducts 215 }			-- Cisco 800 platform with 1 ethernet 4-port HUB, 1 BRI U, and 2 POTs 
+cisco1750 OBJECT IDENTIFIER ::= { ciscoProducts 216 }			-- VoIP (Voice over IP) capable Cisco 1700 platform with 2 WIC/VIC slots and 1 VIC-only slot
+catalyst2924XLv OBJECT IDENTIFIER ::= { ciscoProducts 217 }		-- Catalyst 2924XL switch with 24 10BaseT/100BaseTX autosensing switch ports; supports port-based VLANs; can run Standard or Enterprise edition software.
+catalyst2924CXLv OBJECT IDENTIFIER ::= { ciscoProducts 218 }		-- Catalyst 2924C-XL switch with 22 10BaseT/100BaseTX and 2 100BaseFX autosensing switch ports; supports port-based VLANs; can run Standard or Enterprise edition software.
+catalyst2912XL OBJECT IDENTIFIER ::= { ciscoProducts 219 }		-- Catalyst 2912XL switch with 12 autosensing 10/100BaseTX ports, can run Standard or Enterprise edition software. 
+catalyst2924MXL OBJECT IDENTIFIER ::= { ciscoProducts 220 }		-- Catalyst 2924M-XL switch with 24 autosensing 10/100BaseTX ports and 2 uplink slots, can run Standard or Enterprise edition software.
+catalyst2912MfXL OBJECT IDENTIFIER ::= { ciscoProducts 221 }		-- Catalyst 2912MF-XL switch with 12 100BaseFX ports and 2 uplink slots; can only run Enterprise edition software.
+cisco7206VXR OBJECT IDENTIFIER ::= { ciscoProducts 222 }		-- Cisco 7200 platform, VXR series chassis with 6 slots 
+cisco7204VXR OBJECT IDENTIFIER ::= { ciscoProducts 223 }		-- Cisco 7200 platform, VXR series chassis with 4 slots
+cisco1538M OBJECT IDENTIFIER ::= { ciscoProducts 224 }		-- Cisco Network Office 8-port 10/100 Repeater
+cisco1548M OBJECT IDENTIFIER ::= { ciscoProducts 225 }		-- Cisco Network Office 10/100 Switch
+ciscoFasthub100 OBJECT IDENTIFIER ::= { ciscoProducts 226 }		-- Cisco Fast Hub 100 Series 10/100 Repeater
+ciscoPIXFirewall OBJECT IDENTIFIER ::= { ciscoProducts 227 }		-- Cisco PIX Firewall
+ciscoMGX8850 OBJECT IDENTIFIER ::= { ciscoProducts 228 }		-- Cisco Multiservice Gigabit Switch with 32 half height slots 
+ciscoMGX8830 OBJECT IDENTIFIER ::= { ciscoProducts 229 }		-- Cisco Multiservice Switch with 16 half-height slots
 -- ciscoMGX8820 OBJECT IDENTIFIER ::= { ciscoProducts 229 }
-
-catalyst8510msr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 230 }
-
--- Catalyst ATM 8510 Multiservice Switching Router
-
-catalyst8515msr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 231 }
-
--- Catalyst ATM 8515 Multiservice Switching Router
-
-ciscoIGX8410  OBJECT IDENTIFIER
-    ::= { ciscoProducts 232 }
-
--- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with 8 slots
-
-ciscoIGX8420  OBJECT IDENTIFIER
-    ::= { ciscoProducts 233 }
-
--- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with 16 slots
-
-ciscoIGX8430  OBJECT IDENTIFIER
-    ::= { ciscoProducts 234 }
-
--- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with 32 slots
-
-ciscoIGX8450  OBJECT IDENTIFIER
-    ::= { ciscoProducts 235 }
-
--- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with integrated MGX feeder
-
-ciscoBPX8620  OBJECT IDENTIFIER
-    ::= { ciscoProducts 237 }
-
--- Cisco BPX8600 (Broadband Packet eXchange) series basic wide-area switch with 15 slots
-
-ciscoBPX8650  OBJECT IDENTIFIER
-    ::= { ciscoProducts 238 }
-
--- Cisco BPX8600 (Broadband Packet eXchange) series wide-area switch with integrated tag switching controller and 15 slots
-
-ciscoBPX8680  OBJECT IDENTIFIER
-    ::= { ciscoProducts 239 }
-
--- Cisco BPX8600 (Broadband Packet eXchange) series wide-area switch with integrated MGX feeder and 15 slots
-
-ciscoCacheEngine  OBJECT IDENTIFIER
-    ::= { ciscoProducts 240 }
-
--- Cisco Cache Engine
-
-ciscoCat6000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 241 }
-
--- Cisco Catalyst 6000
-
-ciscoBPXSes  OBJECT IDENTIFIER
-    ::= { ciscoProducts 242 }
-
--- Cisco BPX (Broadband Packet eXchange) Service Expansion Slot controller
-
-ciscoIGXSes  OBJECT IDENTIFIER
-    ::= { ciscoProducts 243 }
-
--- Cisco IGX (Integrated Gigabit eXchange) Service Expansion Slot controller/feeder, used in IGX8410/IGX8420/IGX8430 switches.
-
-ciscoLocalDirector  OBJECT IDENTIFIER
-    ::= { ciscoProducts 244 }
-
--- Cisco Local Director
-
-cisco805  OBJECT IDENTIFIER
-    ::= { ciscoProducts 245 }
-
--- Cisco 800 platform with 1 ethernet and 1 serial WIC
-
-catalyst3508GXL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 246 }
-
--- Cisco Catalyst 3508G-XL switch with 8 GBIC Gigabit ports, can run Standard or Enterprise edition software.
-
-catalyst3512XL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 247 }
-
--- Cisco Catalyst 3512XL switch with 12 10/100BaseTX ports and 2 GBIC Gigabit ports, can run Standard or Enterprise edition software.
-
-catalyst3524XL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 248 }
-
--- Cisco Catalyst 3524XL switch with 24 10/100BaseTX ports and 2 GBIC Gigabit ports, can run Standard or Enterprise edition software.
-
-cisco1407  OBJECT IDENTIFIER
-    ::= { ciscoProducts 249 }
-
--- Cisco 1400 series router with 1 Ethernet and 1 ADSL interface, with 1407 chipset
-
-cisco1417  OBJECT IDENTIFIER
-    ::= { ciscoProducts 250 }
-
--- Cisco 1400 series router with 1 Ethernet and 1 ADSL interface, with 1417 chipset
-
-cisco6100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 251 }
-
--- Cisco 6100 DSLAM Chassis
-
-cisco6130  OBJECT IDENTIFIER
-    ::= { ciscoProducts 252 }
-
--- Cisco 6130 DSLAM Chassis
-
-cisco6260  OBJECT IDENTIFIER
-    ::= { ciscoProducts 253 }
-
--- Cisco 6260 DSLAM Chassis
-
-ciscoOpticalRegenerator  OBJECT IDENTIFIER
-    ::= { ciscoProducts 254 }
-
--- Cisco Optical Regenerator
-
-ciscoUBR924  OBJECT IDENTIFIER
-    ::= { ciscoProducts 255 }
-
--- Cisco UBR Cable Modem which is a UBR904 with 2 FXS Voice ports
-
-ciscoWSX6302Msm  OBJECT IDENTIFIER
-    ::= { ciscoProducts 256 }
-
--- Catalyst 6000 or 6500 Series Multilayer Switch Module WS-X6302-MSM that directly interfaces to the switch's backplane to provide layer 3 switching.
-
-catalyst5kRsfc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 257 }
-
--- Router Switching Feature Card for the Catalyst 5000 that is treated as a standalone system by the NMS
-
-catalyst6kMsfc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 258 }
-
--- Multilevel Switching Feature Card for Catalyst 6000 that is treated as a standalone system by the NMS
-
-cisco7120Quadt1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 259 }
-
--- 7120 Series chassis with 2 10/100 FE interfaces, 4 T1/E1 interfaces
-
-cisco7120T3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 260 }
-
--- 7120 Series chassis with 2 10/100 FE interfaces, 1 T3 interface
-
-cisco7120E3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 261 }
-
--- 7120 Series chassis with 2 10/100 FE interfaces, 1 E3 interface
-
-cisco7120At3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 262 }
-
--- 7120 Series chassis with 2 10/100 FE interfaces, 1 T3 ATM interface
-
-cisco7120Ae3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 263 }
-
--- 7120 Series chassis with 2 10/100 FE interfaces, 1 E3 ATM interface
-
-cisco7120Smi3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 264 }
-
--- 7120 Series chassis with 2 10/100 FE interfaces, 1 OC3SMI ATM interface
-
-cisco7140Dualt3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 265 }
-
--- 7140 Series chassis with 2 10/100 FE interfaces, 2 T3 interfaces
-
-cisco7140Duale3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 266 }
-
--- 7140 Series chassis with 2 10/100 FE interfaces, 2 E3 interfaces
-
-cisco7140Dualat3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 267 }
-
--- 7140 Series chassis with 2 10/100 FE interfaces, 2 T3 ATM interfaces
-
-cisco7140Dualae3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 268 }
-
--- 7140 Series chassis with 2 10/100 FE interfaces, 2 E3 ATM interfaces
-
-cisco7140Dualmm3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 269 }
-
--- 7140 Series chassis with 2 10/100 FE interfaces, 2 OC3MM ATM interfaces
-
-cisco827QuadV  OBJECT IDENTIFIER
-    ::= { ciscoProducts 270 }
-
--- Cisco 800 platform with 1 ethernet, 1 ADSL DMT issue 2, and 4 voice POTS FXS ports
-
-ciscoUBR7246VXR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 271 }
-
--- Cisco 7246 Universal Broadband Router, VXR series
-
-cisco10400  OBJECT IDENTIFIER
-    ::= { ciscoProducts 272 }
-
--- Cisco 10000 platform with 10 slots
-
-cisco12016  OBJECT IDENTIFIER
-    ::= { ciscoProducts 273 }
-
--- Cisco 12000 platform with 16 slots
-
-ciscoAs5400  OBJECT IDENTIFIER
-    ::= { ciscoProducts 274 }
-
--- Cisco AS5400 platform
-
-cat2948gL3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 275 }
-
--- Cisco Catalyst WS-C2948G-L3 48 port 10/100 Layer 3 switch with 2 GBIC ports
-
-cisco7140Octt1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 276 }
-
--- 7140 Series chassis with 8 integrated T1/E1 serial ports
-
-cisco7140Dualfe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 277 }
-
--- 7140 Series chassis with 2 integrated 10/100 FE interfaces
-
-cat3548XL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 278 }
-
--- Catalyst 3548XL switch (WS-C3548-XL)
-
-ciscoVG200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 279 }
-
--- Cisco Voice Gateway 200 controlled by Cisco Call Manager
-
-cat6006  OBJECT IDENTIFIER
-    ::= { ciscoProducts 280 }
-
--- Catalyst 6000 with 6 slots
-
-cat6009  OBJECT IDENTIFIER
-    ::= { ciscoProducts 281 }
-
--- Catalyst 6000 with 9 slots
-
-cat6506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 282 }
-
--- Catalyst 6000 Plus with 6 slots
-
-cat6509  OBJECT IDENTIFIER
-    ::= { ciscoProducts 283 }
-
--- Catalyst 6000 Plus with 9 slots
-
-cisco827  OBJECT IDENTIFIER
-    ::= { ciscoProducts 284 }
-
--- Cisco 800 platform with 1 ethernet, 1 ADSL DMT issue 2
-
-ciscoManagementEngine1100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 285 }
-
--- Cisco Management Engine 1100 for doing distributed SNMP polling
-
-ciscoMc3810V3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 286 }
-
--- Cisco MC3810-V3, capable of data, voice and video.  Supports 2 additional ports than the MC3810-V, used for optional access cards.
-
-cat3524tXLEn  OBJECT IDENTIFIER
-    ::= { ciscoProducts 287 }
-
--- Cisco Catalyst 3524 switch (WS-C3524T-XL-EN) with 24 10/100 ports and 2 GBIC gigabit ports.  Runs Enterprise edition software and provides telephony power to attached IP telephones
-
-cisco7507z  OBJECT IDENTIFIER
-    ::= { ciscoProducts 288 }
-
--- Cisco 7507z chassis, Czbus capable, 7 slots
-
-cisco7513z  OBJECT IDENTIFIER
-    ::= { ciscoProducts 289 }
-
--- Cisco 7513z chassis, Czbus capable, 13 slots
-
-cisco7507mx  OBJECT IDENTIFIER
-    ::= { ciscoProducts 290 }
-
--- Cisco 7507mx chassis, Czbus capable, TDM (Time Division Multiplexing) backplane support, 7 slots
-
-cisco7513mx  OBJECT IDENTIFIER
-    ::= { ciscoProducts 291 }
-
--- Cisco 7513mx chassis, Czbus capable, TDM (Time Division Multiplexing) backplane support, 13 slots
-
-ciscoUBR912C  OBJECT IDENTIFIER
-    ::= { ciscoProducts 292 }
-
--- Cisco uBR912-C Cable Modem with CSU/DSU WIC
-
-ciscoUBR912S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 293 }
-
--- Cisco uBR912-S Cable Modem with Serial WIC
-
-ciscoUBR914  OBJECT IDENTIFIER
-    ::= { ciscoProducts 294 }
-
--- Cisco uBR914 Cable Modem with removable WIC
-
-cisco802J  OBJECT IDENTIFIER
-    ::= { ciscoProducts 295 }
-
--- Cisco 800 platform with 1 ethernet, 1 BRI S/T, and 1 Japanese BRI U
-
-cisco804J  OBJECT IDENTIFIER
-    ::= { ciscoProducts 296 }
-
--- Cisco 800 platform with 1 ethernet, 2 POTS, 1 BRI/ST, and 1 Japanese BRI U
-
-cisco6160  OBJECT IDENTIFIER
-    ::= { ciscoProducts 297 }
-
--- Cisco 6160 DSLAM chassis
-
-cat4908gL3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 298 }
-
--- Catalyst 4908G-L3 (WS-C4908G-L3) Mid-range fixed configuration layer 3 switch with 6 GBIC based Gigabit Ethernet ports
-
-cisco6015  OBJECT IDENTIFIER
-    ::= { ciscoProducts 299 }
-
--- Cisco 6015 DSLAM chassis
-
-cat4232L3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 300 }
-
--- Cisco Catalyst 4232-L3 layer 3 line card that is treated as a standalone system by the NMS
-
-catalyst6kMsfc2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 301 }
-
--- Multilevel Switching Feature Card Version 2 for Catalyst 6000 that is treated as a standalone system by the NMS
-
-cisco7750Mrp200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 302 }
-
--- Cisco ICS 7750 Multiservice Route Processor 200
-
-cisco7750Ssp80  OBJECT IDENTIFIER
-    ::= { ciscoProducts 303 }
-
--- Cisco ICS 7750 System Switch Processor 80
-
-ciscoMGX8230  OBJECT IDENTIFIER
-    ::= { ciscoProducts 304 }
-
--- Multi Service Switch with 16 half-height slots
-
-ciscoMGX8250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 305 }
-
--- Multi Service Switch with 32 half-height slots
-
-ciscoCVA122  OBJECT IDENTIFIER
-    ::= { ciscoProducts 306 }
-
--- Cisco CVA122 Cable Voice Adapter (Residential Cable Modem with two Voice Ports)
-
-ciscoCVA124  OBJECT IDENTIFIER
-    ::= { ciscoProducts 307 }
-
--- Cisco CVA124 Cable Voice Adapter (Residential Cable Modem with four Voice Ports)
-
-ciscoAs5850  OBJECT IDENTIFIER
-    ::= { ciscoProducts 308 }
-
--- High End Dial Access Server
-
-cat6509Sp  OBJECT IDENTIFIER
-    ::= { ciscoProducts 310 }
-
--- 9-slot Constellation+ vertical slot chassis
-
-ciscoMGX8240  OBJECT IDENTIFIER
-    ::= { ciscoProducts 311 }
-
--- High Density Circuit Emulation Service Gateway for Private Line Service
-
-cat4840gL3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 312 }
-
--- Catalyst 4840G-L3 (WS-C4840G) Layer 3 Ethernet Switching System with Server Load Balancing
-
-ciscoAS5350  OBJECT IDENTIFIER
-    ::= { ciscoProducts 313 }
-
--- Cisco low end Access server platform
-
-cisco7750  OBJECT IDENTIFIER
-    ::= { ciscoProducts 314 }
-
--- Cisco Integrated Communication System (ICS) 7750
-
-ciscoMGX8950  OBJECT IDENTIFIER
-    ::= { ciscoProducts 315 }
-
--- Multiservice Gigabit Switch(180Gb switch) with 32 half height slots
-
-ciscoUBR925  OBJECT IDENTIFIER
-    ::= { ciscoProducts 316 }
-
--- Cisco UBR925 Cable Modem/Router with VOIP and hardware accelerated IPSEC
-
-ciscoUBR10012  OBJECT IDENTIFIER
-    ::= { ciscoProducts 317 }
-
--- Cisco uBR10000 platform with 8 broadband slots and 4 WAN slots
-
-catalyst4kGateway  OBJECT IDENTIFIER
-    ::= { ciscoProducts 318 }
-
--- Catalyst 4000 Access Gateway line card supporting voice and WAN (Wide Area Network) interfaces as well as conferencing and transcoding services for operation with the Cisco Call Manager
-
-cisco2650  OBJECT IDENTIFIER
-    ::= { ciscoProducts 319 }
-
--- c2650 platform with 1 integrated fast ethernet interface
-
-cisco2651  OBJECT IDENTIFIER
-    ::= { ciscoProducts 320 }
-
--- c2650 platform with 2 integrated fast ethernet interfaces
-
-cisco826QuadV  OBJECT IDENTIFIER
-    ::= { ciscoProducts 321 }
-
--- Cisco 800 platform with 1 ethernet, 1 ADSL over ISDN and 4 voice POTS FXS ports
-
-cisco826  OBJECT IDENTIFIER
-    ::= { ciscoProducts 322 }
-
--- Cisco 800 platform with 1 ethernet, 1 ADSL over ISDN
-
-catalyst295012  OBJECT IDENTIFIER
-    ::= { ciscoProducts 323 }
-
--- Cisco Catalyst c2950 switch  with 12 10/100BaseTX ports (WS-c2950-12)
-
-catalyst295024  OBJECT IDENTIFIER
-    ::= { ciscoProducts 324 }
-
--- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports (WS-c2950-24)
-
-catalyst295024C  OBJECT IDENTIFIER
-    ::= { ciscoProducts 325 }
-
--- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 100BASE-FX uplink ports (WS-c2950C-24)
-
-cisco1751  OBJECT IDENTIFIER
-    ::= { ciscoProducts 326 }
-
--- Digital voice capable Cisco 1700 platform with 2 WIC/VIC slots and 1 VIC-only slot
-
-cisco1730Iad8Fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 327 }
-
-
-cisco1730Iad16Fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 328 }
-
-
-cisco626  OBJECT IDENTIFIER
-    ::= { ciscoProducts 329 }
-
--- Cisco 600 DSL CPE pltaform with ADSL, DMT issue 1, 25M ATM interface
-
-cisco627  OBJECT IDENTIFIER
-    ::= { ciscoProducts 330 }
-
--- Cisco 600 DSL CPE pltaform with ADSL, DMT issue 2, 25M ATM interface
-
-cisco633  OBJECT IDENTIFIER
-    ::= { ciscoProducts 331 }
-
--- Cisco 600 DSL CPE platform with SDSL, 2B1Q line coding, serial interface (V.35/X.21)
-
-cisco673  OBJECT IDENTIFIER
-    ::= { ciscoProducts 332 }
-
--- Cisco 600 DSL CPE platform with SDSL, 2B1Q line coding, ethernet interface
-
-cisco675  OBJECT IDENTIFIER
-    ::= { ciscoProducts 333 }
-
--- Cisco 600 DSL CPE platform with ADSL, CAP, ethernet interface, POTS connector
-
-cisco675e  OBJECT IDENTIFIER
-    ::= { ciscoProducts 334 }
-
--- Cisco 600 DSL CPE platform with ADSL, CAP, ethernet interface, universal power supply
-
-cisco676  OBJECT IDENTIFIER
-    ::= { ciscoProducts 335 }
-
--- Cisco 600 DSL CPE platform with ADSL, DMT issue 1, ethernet interface
-
-cisco677  OBJECT IDENTIFIER
-    ::= { ciscoProducts 336 }
-
--- Cisco 600 DSL CPE platform with ADSL, DMT issue 2, ethernet interface
-
-cisco678  OBJECT IDENTIFIER
-    ::= { ciscoProducts 337 }
-
--- Cisco 600 DSL CPE platform with ADSL, CAP/DMT/G.Lite, ethernet interface
-
-cisco3661Ac  OBJECT IDENTIFIER
-    ::= { ciscoProducts 338 }
-
--- 1 Fast Ethernet version of c3660 with a AC power supply
-
-cisco3661Dc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 339 }
-
--- 1 Fast Ethernet version of c3660 with a DC power supply
-
-cisco3662Ac  OBJECT IDENTIFIER
-    ::= { ciscoProducts 340 }
-
--- 2 Fast Ethernet version of c3660 with a AC power supply
-
-cisco3662Dc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 341 }
-
--- 2 Fast Ethernet version of c3660 with a DC power supply
-
-cisco3662AcCo  OBJECT IDENTIFIER
-    ::= { ciscoProducts 342 }
-
--- 2 Fast Ethernet version of c3660 with a AC power supply for Telco's
-
-cisco3662DcCo  OBJECT IDENTIFIER
-    ::= { ciscoProducts 343 }
-
--- 2 Fast Ethernet version of c3660 with a DC power supply for Telco's
-
-ciscoUBR7111  OBJECT IDENTIFIER
-    ::= { ciscoProducts 344 }
-
--- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC11C) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
-
-ciscoUBR7111E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 345 }
-
--- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC11E) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
-
-ciscoUBR7114  OBJECT IDENTIFIER
-    ::= { ciscoProducts 346 }
-
--- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC14C) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
-
-ciscoUBR7114E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 347 }
-
--- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC14E) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
-
-cisco12010  OBJECT IDENTIFIER
-    ::= { ciscoProducts 348 }
-
--- Cisco 12000 platform with 10 slots
-
-cisco8110  OBJECT IDENTIFIER
-    ::= { ciscoProducts 349 }
-
--- Cisco 8110 (ATM network termination device) with 3 Line Interface module slots
-
-cisco8120  OBJECT IDENTIFIER
-    ::= { ciscoProducts 350 }
-
-
-ciscoUBR905  OBJECT IDENTIFIER
-    ::= { ciscoProducts 351 }
-
--- Cisco uBR905 Cable Modem with hardware accelerated IPSEC
-
-ciscoIDS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 352 }
-
-
-ciscoSOHO77  OBJECT IDENTIFIER
-    ::= { ciscoProducts 353 }
-
--- Cisco SOHO (Small Office Home Office) ADSL Router, 1 Ethernet and 1 ADSL G.992.1 (G.DMT) and G.992.2 (G.Lite) Interface
-
-ciscoSOHO76  OBJECT IDENTIFIER
-    ::= { ciscoProducts 354 }
-
--- Cisco SOHO (Small Office Home Office) ADSL over ISDN Router, 1 Ethernet and 1 ADSL ETSI/ITU-T G.992.1 Annex B (G.DMT) Interface
-
-cisco7150Dualfe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 355 }
-
--- 7150 Series chassis with 2 integrated 10/100 FE interfaces
-
-cisco7150Octt1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 356 }
-
--- 7150 Series chassis with 8 integrated T1/E1 serial ports
-
-cisco7150Dualt3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 357 }
-
--- 7150 Series chassis with 2 10/100 FE interfaces, 2 T3 interfaces
-
-ciscoOlympus  OBJECT IDENTIFIER
-    ::= { ciscoProducts 358 }
-
--- Cisco VPN (Virtual Private Network) Router with  4 10/100/1000 Gigabitethernet integrated interfaces
-
-catalyst2950t24  OBJECT IDENTIFIER
-    ::= { ciscoProducts 359 }
-
--- Cisco Catalyst c2950 switch with 24 10/100BaseT ports and 2 10/100/1000BaseT ports
-
-ciscoVPS1110  OBJECT IDENTIFIER
-    ::= { ciscoProducts 360 }
-
--- Cisco VLAN Policy Server 1110 manages VLAN-based policies to control user access to a LAN, leveraging existing authentication mechanisms such as Windows Domain Controllers and Novell's NDS. This policy server is part of CiscoWorks2000 User Registration Tool product.
-
-ciscoContentEngine  OBJECT IDENTIFIER
-    ::= { ciscoProducts 361 }
-
--- Cisco Content Engine.  The Cisco Content Engine is a Content Networking product that accelerates content delivery, ensuring maximum scalability and availability of content.  The Content Engines offer caching, Content Delivery Network (CDN) services, employee internet management (e.g., URL filtering) and proxy services
-
-ciscoIAD2420  OBJECT IDENTIFIER
-    ::= { ciscoProducts 362 }
-
--- Integrated Access Device 2420 (IAD2420) chassis with Analog (8/16) FXS ports with T1 or ADSL (Asymmetrical Digital Subscriber Line) Uplinks
-
-cisco677i  OBJECT IDENTIFIER
-    ::= { ciscoProducts 363 }
-
--- Cisco 600 DSL CPE platform with ASDL, DMT issue 2 over ISDN, ethernet interface
-
-cisco674  OBJECT IDENTIFIER
-    ::= { ciscoProducts 364 }
-
--- Cisco 600 DSL CPE platform with G.SHDSL, ethernet interface
-
-ciscoDPA7630  OBJECT IDENTIFIER
-    ::= { ciscoProducts 365 }
-
--- The Cisco Digital PBX Adapter (DPA) enables the integration of Cisco Call Manager with Octel voice mail systems
-
-catalyst355024  OBJECT IDENTIFIER
-    ::= { ciscoProducts 366 }
-
--- Catalyst 3550 24 10/100 ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch
-
-catalyst355048  OBJECT IDENTIFIER
-    ::= { ciscoProducts 367 }
-
--- Catalyst 3550 48 10/100 ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch
-
-catalyst355012T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 368 }
-
--- Catalyst 3550 12 1000T ports fixed configuration Layer 2/Layer 3 Ethernet Switch
-
-catalyst2924LREXL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 369 }
-
--- Cisco Catalyst c2924XL switch (WS-C2924-LRE-XL) with 24 10BaseS VDSL ports and 4 10/100BaseTX ports
-
-catalyst2912LREXL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 370 }
-
--- Cisco Catalyst c2912XL switch (WS-C2912-LRE-XL) with 12 10BaseS VDSL ports and 4 10/100BaseTX ports
-
-ciscoCVA122E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 371 }
-
--- Cisco CVA122-e Cable Voice Adapter(Residential Cable Modem with two voice ports)- European version
-
-ciscoCVA124E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 372 }
-
--- Cisco CVA124-e Cable Voice Adapter(Residential Cable Modem with four voice ports)- European version
-
-ciscoURM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 373 }
-
--- Universal Router Module for the IGX platform
-
-ciscoURM2FE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 374 }
-
--- Universal router module with 2 Fast Ethernet interfaces for IGX platform
-
-ciscoURM2FE2V  OBJECT IDENTIFIER
-    ::= { ciscoProducts 375 }
-
--- Universal Router Module, with 2 Fast Ethernet ports, and 2 digital voice ports (T1 or E1)
-
-cisco7401VXR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 376 }
-
--- Cisco 7400 Family, 1 Slot router
-
-cisco951  OBJECT IDENTIFIER
-    ::= { ciscoProducts 377 }
-
-
-cisco952  OBJECT IDENTIFIER
-    ::= { ciscoProducts 378 }
-
-
-ciscoCAP340  OBJECT IDENTIFIER
-    ::= { ciscoProducts 379 }
-
--- Aironet Wireless LAN Access Point 340 series
-
-ciscoCAP350  OBJECT IDENTIFIER
-    ::= { ciscoProducts 380 }
-
--- Cisco Wireless LAN Access Point 350 series
-
-ciscoDPA7610  OBJECT IDENTIFIER
-    ::= { ciscoProducts 381 }
-
--- The Cisco Digital PBX Adapter (DPA) enables the integration of Cisco Call Manager with Octel voice mail systems.
-
-cisco828  OBJECT IDENTIFIER
-    ::= { ciscoProducts 382 }
-
--- Cisco 800 platform with 1 Ethernet, 1 G.991.2 (G.shdsl) Interface, data only model
-
-ciscoSOHO78  OBJECT IDENTIFIER
-    ::= { ciscoProducts 383 }
-
-
-cisco806  OBJECT IDENTIFIER
-    ::= { ciscoProducts 384 }
-
--- Cisco SOHO (Small Office Home Office) router with 4 hubbed 10BaseT Ethernet LAN interfaces and 1 10BaseT Ethernet WAN interface
-
-cisco12416  OBJECT IDENTIFIER
-    ::= { ciscoProducts 385 }
-
--- Cisco 12000 platform with 16 slots and 10G fabric card
-
-cat2948gL3Dc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 386 }
-
--- A fixed-configuration Layer 3 Ethernet switch featuring IP, IPX, and IP mulitcast with 48 10/100BaseTX ports using DC power
-
-cat4908gL3Dc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 387 }
-
--- A fixed-configuration L3 Ethernet switch featuring IP,IPX and IP multicast with 8 GBIC ports using DC power
-
-cisco12406  OBJECT IDENTIFIER
-    ::= { ciscoProducts 388 }
-
--- Cisco 12400 platform with 6 slots
-
-ciscoPIXFirewall506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 389 }
-
--- Cisco PIX Firewall 506
-
-ciscoPIXFirewall515  OBJECT IDENTIFIER
-    ::= { ciscoProducts 390 }
-
--- Cisco PIX Firewall 515
-
-ciscoPIXFirewall520  OBJECT IDENTIFIER
-    ::= { ciscoProducts 391 }
-
--- Cisco PIX Firewall 520
-
-ciscoPIXFirewall525  OBJECT IDENTIFIER
-    ::= { ciscoProducts 392 }
-
--- Cisco PIX Firewall 525
-
-ciscoPIXFirewall535  OBJECT IDENTIFIER
-    ::= { ciscoProducts 393 }
-
--- Cisco PIX Firewall 535
-
-cisco12410  OBJECT IDENTIFIER
-    ::= { ciscoProducts 394 }
-
--- Cisco 12410 platform with 10 slots
-
-cisco811  OBJECT IDENTIFIER
-    ::= { ciscoProducts 395 }
-
--- ISDN router for Japan with 1 10BaseT Ethernet port, 1 ISDN BRI(Basic Rate Interface) U, integrated DSU(Data Service Unit)
-
-cisco813  OBJECT IDENTIFIER
-    ::= { ciscoProducts 396 }
-
--- ISDN router forJapan with 10 BaseT 4 ports hub , 1 ISDN BRI(Basic Rate Interface) U, integrated DSU(Data Service Unit) and 2 RJ-11
-
-cisco10720  OBJECT IDENTIFIER
-    ::= { ciscoProducts 397 }
-
--- IP + Optical Access Router
-
-ciscoMWR1900  OBJECT IDENTIFIER
-    ::= { ciscoProducts 398 }
-
--- The Mobile Wireless router is a router targeted at application in a cell site Base Transciever Station (BTS) providing T1/E1 backhaul connections to the aggregation node in Radio Access Networks (RAN)
-
-cisco4224  OBJECT IDENTIFIER
-    ::= { ciscoProducts 399 }
-
--- A standalone 24 port powered Ethernet switch, router and voice gateway
-
-ciscoWSC6513  OBJECT IDENTIFIER
-    ::= { ciscoProducts 400 }
-
--- Catalyst 6000 series chassis with 13 slots
-
-cisco7603  OBJECT IDENTIFIER
-    ::= { ciscoProducts 401 }
-
--- Cisco Optical Services Router 7600 Series Chassis with 3 slots
-
-cisco7606  OBJECT IDENTIFIER
-    ::= { ciscoProducts 402 }
-
--- Cisco Optical Services Router 7600 Series Chassis with 6 slots
-
-cisco7401ASR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 403 }
-
--- Cisco 7400 platform, ASR series with 1 slot
-
-ciscoVG248  OBJECT IDENTIFIER
-    ::= { ciscoProducts 404 }
-
--- Cisco VoIP Voice Gateway for connecting analog telephones fax machines to a Cisco Call Manager based system
-
-ciscoHSE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 405 }
-
--- Cisco Hosting Solution Engine 1105 manages Cisco powered data centers and Points of Presence with routers, switches, server load balancers, firewalls, intrusion detection systems and other layer 4-7 content delivery products
-
-ciscoONS15540ESP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 406 }
-
--- Cisco ONS 15540 Extended Services Platform
-
-ciscoSN5420  OBJECT IDENTIFIER
-    ::= { ciscoProducts 407 }
-
--- SRBU Storage Router 1 Fiber Channel port, 1 Gigabit Ethernet port
-
-ciscoIcs7750Ce300  OBJECT IDENTIFIER
-    ::= { ciscoProducts 408 }
-
-
-ciscoCe507  OBJECT IDENTIFIER
-    ::= { ciscoProducts 409 }
-
--- Cisco Content Engine Model 507
-
-ciscoCe560  OBJECT IDENTIFIER
-    ::= { ciscoProducts 410 }
-
--- Cisco Content Engine Model 560
-
-ciscoCe590  OBJECT IDENTIFIER
-    ::= { ciscoProducts 411 }
-
--- Cisco Content Engine Model 590
-
-ciscoCe7320  OBJECT IDENTIFIER
-    ::= { ciscoProducts 412 }
-
--- Cisco Content Engine Model 7320
-
-cisco2691  OBJECT IDENTIFIER
-    ::= { ciscoProducts 413 }
-
--- One Network Module slot, three WIC slot, two Fast Ethernet port MARS router
-
-cisco3725  OBJECT IDENTIFIER
-    ::= { ciscoProducts 414 }
-
--- Two Network Module slot, three WIC slot, two Fast Ethernet port MARS router
-
-cisco3640A  OBJECT IDENTIFIER
-    ::= { ciscoProducts 415 }
-
-
-cisco1760  OBJECT IDENTIFIER
-    ::= { ciscoProducts 416 }
-
--- Analog/digital voice capable, 19" rack-mount (1RU) Cisco 1700 platform with 2 WIC/VIC slots and 2 VIC-only slots
-
-ciscoPIXFirewall501  OBJECT IDENTIFIER
-    ::= { ciscoProducts 417 }
-
--- Cisco PIX Firewall 501
-
-cisco2610M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 418 }
-
--- c2600M with 1 integrated ethernet interface
-
-cisco2611M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 419 }
-
--- c2600M with 2 integrated ethernet interfaces
-
-ciscoGP10  OBJECT IDENTIFIER
-    ::= { ciscoProducts 420 }
-
-
-ciscoMC21  OBJECT IDENTIFIER
-    ::= { ciscoProducts 421 }
-
-
-ciscoSN51  OBJECT IDENTIFIER
-    ::= { ciscoProducts 422 }
-
-
-cisco12404  OBJECT IDENTIFIER
-    ::= { ciscoProducts 423 }
-
--- Cisco 12400 platform with 4 slots
-
-cisco9004  OBJECT IDENTIFIER
-    ::= { ciscoProducts 424 }
-
--- Cisco 9000 Chassis
-
-cisco3631Co  OBJECT IDENTIFIER
-    ::= { ciscoProducts 425 }
-
--- Two Network Module Slot , two WIC slot, one Fast Ethernet port MARS router
-
-catalyst295012G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 427 }
-
--- Cisco Catalyst c2950 switch with 12 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
-
-catalyst295024G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 428 }
-
--- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
-
-catalyst295048G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 429 }
-
--- isco Catalyst c2950 switch with 48 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
-
-catalyst295024S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 430 }
-
--- Cisco Catalyst c2950 switch with 24 10/100 BaseSX ports (Single Mode) and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
-
-catalyst355012G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 431 }
-
--- 10 Gig (GBIC) + 2 10/100/1000baseT ports, fixed configuration layer 2/3 Ethernet switch
-
-ciscoCE507AV  OBJECT IDENTIFIER
-    ::= { ciscoProducts 432 }
-
--- Cisco Content Engine Model 507-AV
-
-ciscoCE560AV  OBJECT IDENTIFIER
-    ::= { ciscoProducts 433 }
-
--- Cisco Content Engine Model 560-AV
-
-ciscoIE2105  OBJECT IDENTIFIER
-    ::= { ciscoProducts 434 }
-
--- The Cisco Intelligence Engine 2100 series is a new form of network device that provides intelligent network interface to applications and users
-
-ciscoMGX8850Pxm1E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 435 }
-
--- PXM1E Controller based 32 full-height slot MGX8850
-
-cisco3745  OBJECT IDENTIFIER
-    ::= { ciscoProducts 436 }
-
--- 3700 family four slot modular router
-
-cisco10005  OBJECT IDENTIFIER
-    ::= { ciscoProducts 437 }
-
--- Cisco 10000 platform with 7 slots
-
-cisco10008  OBJECT IDENTIFIER
-    ::= { ciscoProducts 438 }
-
--- Cisco 10000 platform with 10 slots
-
-cisco7304  OBJECT IDENTIFIER
-    ::= { ciscoProducts 439 }
-
--- Cisco 7304 Chassis
-
-ciscoRpmXf  OBJECT IDENTIFIER
-    ::= { ciscoProducts 440 }
-
--- Chassis for RPM-XF router module
-
-ciscoOsm4oc3PosSmIr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 441 }
-
-
-ciscoOsm4oc3PosMmSr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 442 }
-
-
-ciscoOsm4oc3PosSmLr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 443 }
-
-
-cisco1721  OBJECT IDENTIFIER
-    ::= { ciscoProducts 444 }
-
--- Enhanced 1720 with support for onboard Fast Ethernet and 2 WAN Interface cards and optional hardware encryption module
-
-cat4000Sup3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 445 }
-
-
-cisco827H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 446 }
-
--- Cisco 800 platform with 4-port 10Base-T Ethernet, and 1 ADSL over POTS Interface, data only model
-
-ciscoSOHO77H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 447 }
-
-
-cat4006  OBJECT IDENTIFIER
-    ::= { ciscoProducts 448 }
-
--- Catalyst 4000 with 6 slots (WS-C4006)
-
-ciscoWSC6503  OBJECT IDENTIFIER
-    ::= { ciscoProducts 449 }
-
--- Catalyst 6000 series chassis with 3 slots
-
-ciscoPIXFirewall506E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 450 }
-
--- Cisco PIX Firewall 506E
-
-ciscoPIXFirewall515E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 451 }
-
--- Cisco PIX Firewall 515E
-
-cat355024Dc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 452 }
-
--- Catalyst 3550 24 10/100Base-Tx ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch with DC power
-
-cat355024Mmf  OBJECT IDENTIFIER
-    ::= { ciscoProducts 453 }
-
--- Catalyst 3550 24 10/100Mbps Multimode Fiber ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch
-
-ciscoCE2636  OBJECT IDENTIFIER
-    ::= { ciscoProducts 454 }
-
--- Cisco Content Engine Module for 26xx and 36xx series platforms
-
-ciscoDwCE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 455 }
-
--- Double Wide Cisco Content Engine Module for 26xx
-
-cisco7750Mrp300  OBJECT IDENTIFIER
-    ::= { ciscoProducts 456 }
-
--- Cisco ICS 7750 Multiservice Route Processor 300
-
-ciscoRPMPR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 457 }
-
--- For RPM-PR router blade in MGX series switch
-
-cisco14MGX8830Pxm1E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 458 }
-
--- PXM1E Controller based 14 slot MGX8830
-
-ciscoWlse  OBJECT IDENTIFIER
-    ::= { ciscoProducts 459 }
-
--- Wireless LAN Solution Engine
-
-ciscoONS15530  OBJECT IDENTIFIER
-    ::= { ciscoProducts 460 }
-
--- Cisco ONS 15530 platform
-
-ciscoONS15530NEBS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 461 }
-
--- Cisco ONS 15530 Chassis, NEBS compliant
-
-ciscoONS15530ETSI  OBJECT IDENTIFIER
-    ::= { ciscoProducts 462 }
-
--- Cisco ONS 15530 Chassis, ETSI compliant
-
-ciscoSOHO71  OBJECT IDENTIFIER
-    ::= { ciscoProducts 463 }
-
-
-cisco6400UAC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 464 }
-
--- Cisco 6400 Universal Access Concentrator
-
-ciscoAIRAP1200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 474 }
-
--- 1200 series WLAN Access Point with 1 10/100TX port, 1 CardBus slot, 1 Mini PCI slot
-
-ciscoSN5428  OBJECT IDENTIFIER
-    ::= { ciscoProducts 475 }
-
--- Storage Networking 5428 storage router with 2 SFP (Small Form  Factor Pluggable) GBIC Gigabit Ethernet ports and 8 SFP GBIC Fibre Channel ports
-
-cisco2610XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 466 }
-
--- Cisco c2610XM platform 1 integrated fast ethernet interface with SDRAM
-
-cisco2611XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 467 }
-
--- Cisco c2611XM platform 2 integrated fast ethernet interfaces with SDRAM
-
-cisco2620XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 468 }
-
--- Cisco c2620XM platform 1 integrated fast ethernet interface with SDRAM
-
-cisco2621XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 469 }
-
--- Cisco c2621XM platform 2 integrated fast ethernet interfaces with SDRAM
-
-cisco2650XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 470 }
-
--- Cisco c2650XM platform 1 integrated fast ethernet interface with SDRAM
-
-cisco2651XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 471 }
-
--- Cisco c2651XM platform 2 integrated fast ethernet interfaces with SDRAM
-
-catalyst295024GDC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 472 }
-
--- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots and DC power(WS-c2950G-24-DC)
-
-cisco7301  OBJECT IDENTIFIER
-    ::= { ciscoProducts 476 }
-
--- Cisco 7300 platform, 1 Rack Unit (RU) application specific router with 1 slot
-
-cisco12816  OBJECT IDENTIFIER
-    ::= { ciscoProducts 477 }
-
--- Cisco 12816 platform with 16 slots and 40G fabric card
-
-cisco12810  OBJECT IDENTIFIER
-    ::= { ciscoProducts 478 }
-
--- Cisco 12810 platform with 10 slots and 40G fabric card
-
-cisco3250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 479 }
-
--- cisco 3250 mobile Router
-
-catalyst295024SX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 480 }
-
--- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 fixed 1000Base Multimode fiber (SX) ports
-
-ciscoONS15540ESPx  OBJECT IDENTIFIER
-    ::= { ciscoProducts 481 }
-
--- Cisco ONS 15540 Extended Services Platform with external optical patch system
-
-catalyst295024LRESt  OBJECT IDENTIFIER
-    ::= { ciscoProducts 482 }
-
--- Cisco Catalyst c2950 switch with 24 10BaseS VDSL Ports and 2 ST ( SFP or 10/100/1000 Base T) (WS-C2950ST-24-LRE)
-
-catalyst29508LRESt  OBJECT IDENTIFIER
-    ::= { ciscoProducts 483 }
-
--- Cisco Catalyst c2950 switch with 8 10BaseS VDSL Ports and 2 ST (SFP or 10/100/1000 Base T) (WS-C2950ST-8-LRE)
-
-catalyst295024LREG  OBJECT IDENTIFIER
-    ::= { ciscoProducts 484 }
-
--- Cisco Catalyst c2950 switch with 24 10BaseS VDSL Ports and 2 GBIC ( Gigabit Interface Converter ) slots (WS-C2950G-24-LRE)
-
-catalyst355024PWR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 485 }
-
--- Catalyst 3550 24 10/100 ports with inline power and 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch
-
-ciscoCDM4630  OBJECT IDENTIFIER
-    ::= { ciscoProducts 486 }
-
--- Cisco Content Distribution Manager Model 4630
-
-ciscoCDM4650  OBJECT IDENTIFIER
-    ::= { ciscoProducts 487 }
-
--- Cisco Content Distribution Manager Model 4650
-
-catalyst2955T12  OBJECT IDENTIFIER
-    ::= { ciscoProducts 488 }
-
--- Cisco Catalyst c2955 Industrial switch with 12 10/100 BaseTX ports and 2 10/100/1000 Base-TX ports
-
-catalyst2955C12  OBJECT IDENTIFIER
-    ::= { ciscoProducts 489 }
-
--- Cisco Catalyst c2955 Industrial switch with 12 10/100 Base TX ports and 2 100 Base-FX ports
-
-ciscoCE508  OBJECT IDENTIFIER
-    ::= { ciscoProducts 490 }
-
--- Cisco Content Engine Model 508
-
-ciscoCE565  OBJECT IDENTIFIER
-    ::= { ciscoProducts 491 }
-
--- Cisco Content Engine Model 565
-
-ciscoCE7325  OBJECT IDENTIFIER
-    ::= { ciscoProducts 492 }
-
--- Cisco Content Engine Model 7325
-
-ciscoONS15454  OBJECT IDENTIFIER
-    ::= { ciscoProducts 493 }
-
--- Cisco ONS 15454 Platform
-
-ciscoONS15327  OBJECT IDENTIFIER
-    ::= { ciscoProducts 494 }
-
--- Cisco ONS 15327 Platform
-
-cisco837  OBJECT IDENTIFIER
-    ::= { ciscoProducts 495 }
-
--- Cisco 837 platform with 4-port 10/100 Base-T Ethernet Switch,1 ADSL over POTS interface,data only model, hardware encryption
-
-ciscoSOHO97  OBJECT IDENTIFIER
-    ::= { ciscoProducts 496 }
-
--- SOHO (Small Office Home Office) Router with 4-port 10/100 Base-T Ethernet Switch,1 ADSL over POTS interface,data only model
-
-cisco831  OBJECT IDENTIFIER
-    ::= { ciscoProducts 497 }
-
--- Cisco 831 platform with 4-port 10/100 Base-T Ethernet Switch, 1 10Base-T Ethernet WAN interface, hardware encryption
-
-ciscoSOHO91  OBJECT IDENTIFIER
-    ::= { ciscoProducts 498 }
-
--- SOHO (Small Office Home Office)Router with 4-port 10/100 Base-T Ethernet Switch, 1 10Base-T Ethernet WAN interface
-
-cisco836  OBJECT IDENTIFIER
-    ::= { ciscoProducts 499 }
-
--- Cisco 836 platform with 4-port 10/100 Base-T Ethernet Switch, 1 ADSL over ISDN interface,1 ISDN BRI S/T interface, hardware encryption
-
-ciscoSOHO96  OBJECT IDENTIFIER
-    ::= { ciscoProducts 500 }
-
--- SOHO (Small Office Home Office)Router with 4-port 10/100 Base-T Ethernet Switch, 1 ADSL over ISDN interface, 1 ISDN BRI S/T interface
-
-cat4507  OBJECT IDENTIFIER
-    ::= { ciscoProducts 501 }
-
--- Catalyst 4000 with 7 slots (WS-C4507)
-
-cat4506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 502 }
-
--- Catalyst 4000 with 6 slots (WS-C4506)
-
-cat4503  OBJECT IDENTIFIER
-    ::= { ciscoProducts 503 }
-
--- Catalyst 4000 with 3 slots (WS-C4503)
-
-ciscoCE7305  OBJECT IDENTIFIER
-    ::= { ciscoProducts 504 }
-
--- Cisco Content Engine Model 7305
-
-ciscoCE510  OBJECT IDENTIFIER
-    ::= { ciscoProducts 505 }
-
--- Cisco Content Engine Model 510
-
-ciscoAIRAP1100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 507 }
-
--- 1100 series WLAN Access Point with 1 10/100TX port, 1 IEEE 802.11 radio port.
-
-catalyst2955S12  OBJECT IDENTIFIER
-    ::= { ciscoProducts 508 }
-
--- Cisco Catalyst c2955 Industrial switch with 12 10/100 Base T ports and 2 100 Base-LX Single Mode Uplink ports
-
-cisco7609  OBJECT IDENTIFIER
-    ::= { ciscoProducts 509 }
-
--- Cisco 7600 Series Chassis with 9 slots
-
-ciscoWSC65509  OBJECT IDENTIFIER
-    ::= { ciscoProducts 510 }
-
-
-catalyst375024  OBJECT IDENTIFIER
-    ::= { ciscoProducts 511 }
-
--- Catalyst 3750 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
-
-catalyst375048  OBJECT IDENTIFIER
-    ::= { ciscoProducts 512 }
-
--- Catalyst 3750 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
-
-catalyst375024TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 513 }
-
--- Catalyst 3750 24TS: 24 10/100/1000 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
-
-catalyst375024T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 514 }
-
--- Catalyst 3750 24T: 24 10/100/1000 ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
-
-catalyst37xxStack  OBJECT IDENTIFIER
-    ::= { ciscoProducts 516 }
-
--- A stack of any catalyst37xx stack-able ethernet switches with unified identity (as a single unified switch), control and management.
-
-ciscoGSS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 517 }
-
--- The Global Site Selector (GSS) is a network appliance that performs global server load balancing for geographically dispersed server load balancers and caches using DNS resolution.
-
-ciscoPrimaryGSSM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 518 }
-
--- The Primary Global Site Selector Manager (GSSM) serves as the central management station for a Global Site Selector (GSS) Network.
-
-ciscoStandbyGSSM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 519 }
-
--- The Standby Global Site Selector Manager (GSSM) serves as the backup to the Primary GSSM in a Global Site Selector(GSS) Network.
-
-ciscoMWR1941DC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 520 }
-
--- The Mobile Wireless Router (MWR-1941-DC) is a router with a universal power supply targeted at application in a cell site Base Transceiver Station (BTS) providing T1/E1 backhaul connections to the aggregation node in Radio Access Networks (RAN)
-
-ciscoDSC9216K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 521 }
-
--- DS-C9216-K9    -  MDS 9216 16-port 2Gbps FC + 1-slot Modular Switch
-
-cat6500FirewallSm  OBJECT IDENTIFIER
-    ::= { ciscoProducts 522 }
-
--- High performance firewall blade for Catalyst 6500 Series
-
-ciscoSCA11000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 523 }
-
-
-ciscoCSM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 524 }
-
--- Cisco Content Switching Module (CSM) which load balancing internet traffic based on the layer 4 through layer 7 information in the content.
-
-ciscoAIRAP1210  OBJECT IDENTIFIER
-    ::= { ciscoProducts 525 }
-
--- 1200 series WLAN Access Point on Cisco IOS platform with 1 10/100TX port, 1 CardBus slot, 1 Mini PCI slot.
-
-ciscoSCA211000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 526 }
-
-
-catalyst297024  OBJECT IDENTIFIER
-    ::= { ciscoProducts 527 }
-
--- Catalyst 2970 24: 24 10/100/1000 ports fixed configuration Layer 2 Ethernet  switch
-
-cisco7613  OBJECT IDENTIFIER
-    ::= { ciscoProducts 528 }
-
--- Cisco Internet router 7600 Series Chassis with 13 slots
-
-ciscoSN54282  OBJECT IDENTIFIER
-    ::= { ciscoProducts 529 }
-
-
-catalyst3750Ge12Sfp  OBJECT IDENTIFIER
-    ::= { ciscoProducts 530 }
-
--- Cisco Catalyst c3750 switch with 12 SFP (Small Form  FactorPluggable) Gigabit Ethernet ports
-
-ciscoCR4430  OBJECT IDENTIFIER
-    ::= { ciscoProducts 531 }
-
--- Cisco Content Router Model 4430
-
-ciscoCR4450  OBJECT IDENTIFIER
-    ::= { ciscoProducts 532 }
-
--- Cisco Content Router Model 4450
-
-ciscoAIRBR1410  OBJECT IDENTIFIER
-    ::= { ciscoProducts 533 }
-
--- 1410 Series Wireless LAN Bridge on Cisco IOS platform with 1 10/100Tx port and 1 5-GHz radio
-
-ciscoWSC6509neba  OBJECT IDENTIFIER
-    ::= { ciscoProducts 534 }
-
--- Catalyst 6500 series chassis with 9 slots
-
-catalyst375048PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 535 }
-
--- Catalyst 3750 48 10/100 In-Line Power Ethernet ports + 2 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Plugable)
-
-catalyst375024PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 536 }
-
--- Catalyst 3750 24 10/100 In-Line Power Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Plugable)
-
-catalyst4510  OBJECT IDENTIFIER
-    ::= { ciscoProducts 537 }
-
--- Catalyst 4000 with 10 slots (WS-C4510R)
-
-cisco1711  OBJECT IDENTIFIER
-    ::= { ciscoProducts 538 }
-
--- Enhanced security router with 4 FastEthernet switch ports, 1 Analog modem port, 1 FastEthernet port and a hardware encryption module
-
-cisco1712  OBJECT IDENTIFIER
-    ::= { ciscoProducts 539 }
-
--- Enhanced security router with 4 FastEthernet switch ports, 1 Basic Rate Interface(S/T)  data port, 1 FastEthernet port and a hardware encryption module.
-
-catalyst29408TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 540 }
-
--- Catalyst 2940 L2 switch with 8 10/100 copper ports and 1 10/100/1000 copper uplink port.
-
-catalyst29408TF  OBJECT IDENTIFIER
-    ::= { ciscoProducts 542 }
-
--- Catalyst 2940 L2 switch with 8 10/100 copper ports, 1 100 FX Uplink port and 1 Gigabit SFP Module slot.
-
-cisco3825  OBJECT IDENTIFIER
-    ::= { ciscoProducts 543 }
-
--- Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800 family router
-
-cisco3845  OBJECT IDENTIFIER
-    ::= { ciscoProducts 544 }
-
--- Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800 family router
-
-cisco2430Iad24Fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 545 }
-
--- IAD2430 with 24FXS, 2FE
-
-cisco2431Iad8Fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 546 }
-
--- IAD2431 with 8FXS, 2FE, 1T1/E1
-
-cisco2431Iad16Fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 547 }
-
--- IAD2431 with 16FXS, 2FE, 1T1/E1
-
-cisco2431Iad1T1E1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 548 }
-
--- IAD2431 with 2FE, 2T1/E1
-
-cisco2432Iad24Fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 549 }
-
--- IAD2432 with 24FXS, 2FE, 2T1E1
-
-cisco1701ADSLBRI  OBJECT IDENTIFIER
-    ::= { ciscoProducts 550 }
-
--- Bacardi is a fixed configuration sku with ADSL WIC and ISDN BRI (S/T) or (S/T-V2) WIC
-
-catalyst2950St24LRE997  OBJECT IDENTIFIER
-    ::= { ciscoProducts 551 }
-
--- Catalyst2950 Long Reach Ethernet switch that confirms to ETSI 997 with 24 LRE interfaces, 2 10/100/1000 Small form factor copper interfaces and DC power supply(WS-C2950ST-24-LRE-997)
-
-ciscoAirAp350IOS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 552 }
-
--- Cisco Wireless LAN Access Point 350 series on IOS platform with 1 10/100TX port, 1 IEEE 802.11 radio port
-
-cisco3220  OBJECT IDENTIFIER
-    ::= { ciscoProducts 553 }
-
--- 3220 - Mobile Access Router (MAR)
-
-cat6500SslSm  OBJECT IDENTIFIER
-    ::= { ciscoProducts 554 }
-
--- SSLSM is a High-Speed SSL Termination Engine for Catalyst 6000 family of platforms that terminates and accelarates Secure Socket Layer (SSL) transactions in Web server environement.
-
-ciscoSIMSE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 555 }
-
--- ciscoSIMSE is an appliance - CiscoWorks Security Information Management Solution Engine
-
-ciscoESSE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 556 }
-
--- Cisco Ethernet Subscriber Solution Engine
-
-catalyst6kSup720  OBJECT IDENTIFIER
-    ::= { ciscoProducts 557 }
-
--- Catalyst 6500 Supervisor Module 720 CPU board that is treated as a standalone system by the NMS
-
-ciscoVG224  OBJECT IDENTIFIER
-    ::= { ciscoProducts 558 }
-
--- Line side Analog Gateway with 24FXS Analog ports
-
-catalyst295048T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 559 }
-
--- Cisco Catalyst c2950 switch with 48 10/100BaseT ports and 2 fixed 10/100/1000BaseT ports
-
-catalyst295048SX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 560 }
-
--- Cisco Catalyst c2950 switch with 48 10/100BaseT ports and 2 fixed 1000Base Multimode fiber (SX) ports
-
-catalyst297024TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 561 }
-
--- Catalyst 2970 24TS: 24 10/100/1000 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2 Ethernet  switch
-
-ciscoNmNam  OBJECT IDENTIFIER
-    ::= { ciscoProducts 562 }
-
--- Cisco NM-NAM, NAM for the branch office routers
-
-catalyst356024PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 563 }
-
--- Catalyst 3750 24 10/100 ports with In-Line Power + 2 Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Switch.(SFP Small Formfactor Pluggable)
-
-catalyst356048PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 564 }
-
--- Catalyst 3750 48 10/100 ports with In-Line Power + 4 Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Switch.(SFP Small Formfactor Pluggable)
-
-ciscoAIRBR1300  OBJECT IDENTIFIER
-    ::= { ciscoProducts 565 }
-
--- Cisco Aironet 1300 Series Wireless Bridge with 1 10/100TX Ethernet port, 1 IEEE 802.11g radio port
-
-cisco851  OBJECT IDENTIFIER
-    ::= { ciscoProducts 566 }
-
--- Cisco 851 platform with 1 10/100T ethernet WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, hardware encryption and Wireless LAN card
-
-cisco857  OBJECT IDENTIFIER
-    ::= { ciscoProducts 567 }
-
--- Cisco 857 platform with 1 DSL over POTS WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, hardware encryption and an optional Wireless LAN card
-
-cisco876  OBJECT IDENTIFIER
-    ::= { ciscoProducts 568 }
-
--- Cisco 876 platform with 1 ADSL over ISDN WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, 1 ISDN BRI S/T interface, hardware encryption and an optional Wireless LAN card
-
-cisco877  OBJECT IDENTIFIER
-    ::= { ciscoProducts 569 }
-
--- Cisco 877 platform with 1 ADSL over POTS WAN interface, 4-port 10/100 BASE-T LAN Ethernet switch, 4 USB ports, hardware encryption and an optional Wireless LAN card
-
-cisco878  OBJECT IDENTIFIER
-    ::= { ciscoProducts 570 }
-
--- Cisco 878 platform with 1 SHDSL WAN interface, 4-port 1 0/100 Base-T LAN Ethernet switch, 4 USB ports, 1 ISDN BRI S/T interface, hardware encryption and an optional Wireless LAN card.
-
-cisco871  OBJECT IDENTIFIER
-    ::= { ciscoProducts 571 }
-
--- Cisco 871 platform with 1 10/100T ethernet WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, hardware encryption and an optional Wireless LAN card
-
-uMG9820  OBJECT IDENTIFIER
-    ::= { ciscoProducts 572 }
-
-
-catalyst6kGateway  OBJECT IDENTIFIER
-    ::= { ciscoProducts 573 }
-
--- Catalyst 6000 Acess Gateway line card supporting voice and WAN(Wide Area Network) interfaces as well as conferencing and transcoding services
-
-catalyst375024ME  OBJECT IDENTIFIER
-    ::= { ciscoProducts 574 }
-
--- Metro Ethernet Catalyst 3750   24-10/100 + 2 SFP (Small Formfactor Pluggable) ports for downlinks and 2 SFP ES(Enhanched Service) ports for uplinks
-
-catalyst4000NAM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 575 }
-
--- Network analysis Module (NAM) for Catalyst 4000
-
-cisco2811  OBJECT IDENTIFIER
-    ::= { ciscoProducts 576 }
-
--- Cisco 2800 series router with one Network Module slot, four HWIC slots, two fast etherenet and integrated VPN
-
-cisco2821  OBJECT IDENTIFIER
-    ::= { ciscoProducts 577 }
-
--- Cisco 2800 series router with one Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and intergrated VPN
-
-cisco2851  OBJECT IDENTIFIER
-    ::= { ciscoProducts 578 }
-
--- Cisco 2800 series router with one double wide Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and integrated VPN
-
-cisco3201WMIC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 581 }
-
-
-ciscoMCS7815I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 582 }
-
--- Cisco Media Convergence Server 7815 (IBM)
-
-ciscoMCS7825H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 583 }
-
--- Cisco Media Convergence Server 7825 (HP)
-
-ciscoMCS7835H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 584 }
-
--- Cisco Media Convergence Server 7835 (HP)
-
-ciscoMCS7835I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 585 }
-
--- Cisco Media Convergence Server 7835 (IBM)
-
-ciscoMCS7845H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 586 }
-
--- Cisco Media Convergence Server 7845 (HP)
-
-ciscoMCS7845I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 587 }
-
--- Cisco Media Convergence Server 7845 (IBM)
-
-ciscoMCS7855I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 588 }
-
--- Cisco Media Convergence Server 7855 (IBM)
-
-ciscoMCS7865I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 589 }
-
--- Cisco Media Convergence Server 7865 (IBM)
-
-cisco12006  OBJECT IDENTIFIER
-    ::= { ciscoProducts 590 }
-
--- Cisco 12000 platform with 6 slots
-
-catalyst3750G16TD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 591 }
-
--- Cisco Catalyst 3750 switch with 16 gigabit and one 10G ethernet port (WS-C3750G-16TD)
-
-ciscoIGESM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 592 }
-
--- Cisco Systems Intelligent Gigabit Ethernet Switch Module for IBM eServer BladeCenter (OS-CIGESM-18TT-E)
-
-ciscoCCM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 593 }
-
-cisco1718  OBJECT IDENTIFIER
-    ::= { ciscoProducts 594 }
-
-
-ciscoCe511K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 595 }
-
--- Cisco Content Engine Model CE-511-K9
-
-ciscoCe566K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 596 }
-
--- Cisco Content Engine Model CE-566-K9
-
-ciscoMGX8830Pxm45  OBJECT IDENTIFIER
-    ::= { ciscoProducts 597 }
-
-
-ciscoMGX8880  OBJECT IDENTIFIER
-    ::= { ciscoProducts 598 }
-
--- Cisco MGX8880 switch with 32 half height slots
-
-ciscoWsSvcWLAN1K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 599 }
-
--- Wireless LAN Module (WS-SVC-WLAN-1-K9) is a Komodo+ based line card for Cat6K family of platforms, which provides wireless domain services (WDS) for IEEE 802.11 wireless clients
-
-ciscoCe7306K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 600 }
-
--- Cisco Content Engine Model CE-7306-K9
-
-ciscoCe7326K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 601 }
-
--- Cisco Content Engine Model CE-7326-K9
-
-catalyst3750G24PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 602 }
-
--- Catalyst 3750 24 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
-
-catalyst3750G48PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 603 }
-
--- Catalyst 3750 48 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
-
-catalyst3750G48TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 604 }
-
--- Catalyst 3750 48 10/100/1000 ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
-
-ciscoBMGX8830Pxm45  OBJECT IDENTIFIER
-    ::= { ciscoProducts 606 }
-
--- PXM45 based Multiservice Switch (Model B) with 14 half height slots
-
-ciscoBMGX8830Pxm1E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 607 }
-
--- PXM1E based Multiservice Switch (Model B) with 14 half height slots
-
-ciscoBMGX8850Pxm45  OBJECT IDENTIFIER
-    ::= { ciscoProducts 608 }
-
--- PXM45 based Multiservice Gigabit Switch (ModelB) with 32 half height slots
-
-ciscoBMGX8850Pxm1E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 609 }
-
--- PXM1E based Multiservice Gigabit Switch (ModelB) with 32 half height slots
-
-ciscoSSLCSM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 610 }
-
-
-ciscoNetworkRegistrar  OBJECT IDENTIFIER
-    ::= { ciscoProducts 611 }
-
--- Cisco Network Registrar (CNR) is a full-featured DNS/DHCP system that provides scalable naming and addressing services for enterprise and service provider networks.
-
-ciscoCe501K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 612 }
-
--- Cisco Content Engine Model CE-501-K9
-
-ciscoCRS16S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 613 }
-
--- Cisco CRS-1 Series Single Chassis Carrier Routing System
-
-catalyst3560G24PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 614 }
-
--- Catalyst 3560 24 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. (SFP Small Form factor Pluggable)
-
-catalyst3560G24TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 615 }
-
--- Catalyst 3560 24 10/100/1000 Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch (SFP Small Form factor Pluggable)
-
-catalyst3560G48PS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 616 }
-
--- Catalyst 3560 48 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. (SFP Small Form factor Pluggable)
-
-catalyst3560G48TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 617 }
-
--- Catalyst 3560 48 10/100/1000 ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. (SFP Small Form factor Pluggable)
-
-ciscoAIRAP1130  OBJECT IDENTIFIER
-    ::= { ciscoProducts 618 }
-
--- Cisco Aironet 1130 series WLAN Access Point with 1 10/100TX port, dual IEEE 802.11a and 802.11g  radio port
-
-cisco2801  OBJECT IDENTIFIER
-    ::= { ciscoProducts 619 }
-
--- 1700 Next Generation voice enabled router with 4 slots
-
-cisco1841  OBJECT IDENTIFIER
-    ::= { ciscoProducts 620 }
-
--- 1700 Next Generation data only router with 2 slots
-
-ciscoWsSvcMWAM1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 621 }
-
--- Multiprocessor WAN Application Module (WS-SVC-MWAM-1) is a multipurpose blade built for the Cat6k platform
-
-ciscoNMCUE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 622 }
-
--- Cisco Unity Express network module (NM-CUE)
-
-ciscoAIMCUE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 623 }
-
--- Cisco Unity Express advanced integration module (AIM-CUE)
-
-catalyst3750G24TS1U  OBJECT IDENTIFIER
-    ::= { ciscoProducts 624 }
-
--- Catalyst 3750 24 10/100/1000 Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
-
-cisco371098HP001  OBJECT IDENTIFIER
-    ::= { ciscoProducts 625 }
-
--- 24 port Gigabit Ethernet switch module for HP ProLiant BL p-class server chassis
-
-catalyst4948  OBJECT IDENTIFIER
-    ::= { ciscoProducts 626 }
-
--- Fixed configuration Catalyst 4000 with 48 10/100/1000BaseT ports and 4 1000BaseX SFP ports (WS-C4948)
-
-ciscoSB101  OBJECT IDENTIFIER
-    ::= { ciscoProducts 627 }
-
-
-ciscoSB106  OBJECT IDENTIFIER
-    ::= { ciscoProducts 628 }
-
-
-ciscoSB107  OBJECT IDENTIFIER
-    ::= { ciscoProducts 629 }
-
-
-ciscoWLSE1130  OBJECT IDENTIFIER
-    ::= { ciscoProducts 630 }
-
--- Cisco WLAN Solution Engine (WLSE) 1130 monitors and configures a WLAN with Cisco WAP and Bridges
-
-ciscoWLSE1030  OBJECT IDENTIFIER
-    ::= { ciscoProducts 631 }
-
--- Cisco WLSE Express 1030 is a  WLSE that monitors and configures a WLAN with Cisco WAP and Bridges with AAA functionality
-
-ciscoHSE1140  OBJECT IDENTIFIER
-    ::= { ciscoProducts 632 }
-
--- Cisco Hosting Solution Engine 1140 manages Cisco powered data centers and Points of Presence with routers, switches, server load balancers, firewalls, intrusion detection systems and other layer 4-7 content delivery products
-
-catalyst356024TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 633 }
-
--- Catalyst 3560 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-catalyst356048TS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 634 }
-
--- Catalyst 3560 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch
-
-ciscoWsSvcadsm1K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 635 }
-
-
-ciscoWsSvcagsm1K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 636 }
-
-
-ciscoONS15310  OBJECT IDENTIFIER
-    ::= { ciscoProducts 637 }
-
-
-cisco1801  OBJECT IDENTIFIER
-    ::= { ciscoProducts 638 }
-
--- Cisco 1800 platform with 1 ADSL over POTS WAN interface, 1 ISDNBRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
-
-cisco1802  OBJECT IDENTIFIER
-    ::= { ciscoProducts 639 }
-
--- Cisco 1800 platform with 1 ADSL over ISDN WAN interface, 1 ISDN BRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
-
-cisco1803  OBJECT IDENTIFIER
-    ::= { ciscoProducts 640 }
-
--- Cisco 1800 platform with 1 G.SHDSL 4-wire interface, 1 ISDN BRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
-
-cisco1811  OBJECT IDENTIFIER
-    ::= { ciscoProducts 641 }
-
--- Cisco 1800 platform with V.92 Modem, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
-
-cisco1812  OBJECT IDENTIFIER
-    ::= { ciscoProducts 642 }
-
--- Cisco 1800 platform with ISDN BRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
-
-ciscoCRS8S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 643 }
-
--- Cisco CRS-1 Series 8 Slots Carrier Routing System
-
-ciscoIDS4210  OBJECT IDENTIFIER
-    ::= { ciscoProducts 645 }
-
--- Cisco Intrusion Detection System 4210
-
-ciscoIDS4215  OBJECT IDENTIFIER
-    ::= { ciscoProducts 646 }
-
--- Cisco Intrusion Detection System 4215
-
-ciscoIDS4235  OBJECT IDENTIFIER
-    ::= { ciscoProducts 647 }
-
--- Cisco Intrusion Detection System 4235
-
-ciscoIPS4240  OBJECT IDENTIFIER
-    ::= { ciscoProducts 648 }
-
--- Cisco Intrusion Prevention System 4240
-
-ciscoIDS4250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 649 }
-
--- Cisco Intrusion Detection System 4250
-
-ciscoIDS4250SX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 650 }
-
--- Cisco Intrusion Detection System 4250 SX
-
-ciscoIDS4250XL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 651 }
-
--- Cisco Intrusion Detection System 4250 XL
-
-ciscoIPS4255  OBJECT IDENTIFIER
-    ::= { ciscoProducts 652 }
-
--- Cisco Intrusion Prevention System 4255
-
-ciscoIDSIDSM2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 653 }
-
--- Cisco Intrusion Detection System Module IDSM2
-
-ciscoIDSNMCIDS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 654 }
-
--- Cisco Intrusion Detection System Network Module NM-CIDS
-
-ciscoIPSSSM20  OBJECT IDENTIFIER
-    ::= { ciscoProducts 655 }
-
--- Cisco Intrusion Prevention System Security Service Module SSM-20
-
-catalyst375024FS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 656 }
-
--- Catalyst 3750 24 100BaseFX ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-ciscoWSC6504E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 657 }
-
--- Catalyst 6000 series chassis with 4 slots
-
-cisco7604  OBJECT IDENTIFIER
-    ::= { ciscoProducts 658 }
-
--- Cisco Optical Services Router 7600 Series Chassis with 4 slots
-
-catalyst494810GE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 659 }
-
--- Catalyst 4000 series fixed configuration switch with 48 10/100/1000BaseT wirespeed ports and two 10Gbps ports
-
-ciscoIGESMSFP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 660 }
-
--- Cisco Systems Intelligent Gigabit Ethernet Switch Module with external SFPs for IBM eServer BladeCenter (OS-CIGESM-18-SFP-E)
-
-ciscoFE6326K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 661 }
-
--- Cisco File Engine Model FE-6326-K9
-
-ciscoIPSSSM10  OBJECT IDENTIFIER
-    ::= { ciscoProducts 662 }
-
--- Cisco Intrusion Prevention System Security Service Module SSM-10
-
-ciscoNme16Es1Ge  OBJECT IDENTIFIER
-    ::= { ciscoProducts 663 }
-
--- EtherSwitch Service Module 16 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-ciscoNmeX24Es1Ge  OBJECT IDENTIFIER
-    ::= { ciscoProducts 664 }
-
--- EtherSwitch Service Module 23 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-ciscoNmeXd24Es2St  OBJECT IDENTIFIER
-    ::= { ciscoProducts 665 }
-
--- EtherSwitch Service Module 24 10/100 ports + 1 Ethernet Gigabit SFP port fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
-
-ciscoNmeXd48Es2Ge  OBJECT IDENTIFIER
-    ::= { ciscoProducts 666 }
-
--- EtherSwitch Service Module 48 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-cisco3202WMIC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 667 }
-
-
-ciscoAs5400XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 668 }
-
--- Cisco AS5400XM platform
-
-ciscoASA5510  OBJECT IDENTIFIER
-    ::= { ciscoProducts 669 }
-
--- Cisco Adaptive Security Appliance 5510
-
-ciscoASA5520  OBJECT IDENTIFIER
-    ::= { ciscoProducts 670 }
-
--- Cisco Adaptive Security Appliance 5520
-
-ciscoASA5520sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 671 }
-
--- Cisco Adaptive Security Appliance 5520 Security Context
-
-ciscoASA5540  OBJECT IDENTIFIER
-    ::= { ciscoProducts 672 }
-
--- Cisco Adaptive Security Appliance 5540
-
-ciscoASA5540sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 673 }
-
--- Cisco Adaptive Security Appliance 5540 Security Context
-
-ciscoWsSvcFwm1sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 674 }
-
--- Firewall Services Module for Catalyst 6500 Series Security Context
-
-ciscoPIXFirewall535sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 675 }
-
--- Cisco PIX Firewall 535 Security Context
-
-ciscoPIXFirewall525sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 676 }
-
--- Cisco PIX Firewall 525 Security Context
-
-ciscoPIXFirewall515Esc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 677 }
-
--- Cisco PIX Firewall 515E Security Context
-
-ciscoPIXFirewall515sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 678 }
-
--- Cisco PIX Firewall 515 Security Context
-
-ciscoAs5350XM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 679 }
-
--- Low end AS5350XM platfrom
-
-ciscoFe7326K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 680 }
-
--- Cisco File Engine Model FE-7326-K9
-
-ciscoFe511K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 681 }
-
--- Cisco File Engine Model FE-511-K9
-
-ciscoSCEDispatcher  OBJECT IDENTIFIER
-    ::= { ciscoProducts 682 }
-
--- Cisco Service Control Engine Dispatcher
-
-ciscoSCE1000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 683 }
-
--- Cisco SCE1000 Service Control Engine
-
-ciscoSCE2000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 684 }
-
--- Cisco SCE2000 Service Control Engine
-
-ciscoAIRAP1240  OBJECT IDENTIFIER
-    ::= { ciscoProducts 685 }
-
--- Cisco Aironet 1240 series WLAN Access Point with 1 10/100TX port, dual IEEE 802.11a and 802.11g radio ports, external antenna connectors
-
-ciscoDSC9120CLK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 686 }
-
--- DS-C9120-CL-K9  - MDS 9120-CL, 20-Port 4 Gbps Fibre Channel Fabric Switch, Commercial
-
-ciscoFe611K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 687 }
-
--- Cisco File Engine Model FE-611-K9
-
-catalyst3750Ge12SfpDc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 688 }
-
--- Cisco Catalyst c3750 switch with 12 SFP (Small Form Factor Plugable) Gigabit Ethernet ports and DC power supply
-
-cisco3271  OBJECT IDENTIFIER
-    ::= { ciscoProducts 689 }
-
-
-cisco3272  OBJECT IDENTIFIER
-    ::= { ciscoProducts 690 }
-
-
-cisco3241  OBJECT IDENTIFIER
-    ::= { ciscoProducts 691 }
-
-
-cisco3242  OBJECT IDENTIFIER
-    ::= { ciscoProducts 692 }
-
-
-ciscoICM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 693 }
-
--- Cisco Systems Intelligent Contact Management
-
-catalyst296024  OBJECT IDENTIFIER
-    ::= { ciscoProducts 694 }
-
--- Catalyst 2960 24 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst296048  OBJECT IDENTIFIER
-    ::= { ciscoProducts 695 }
-
--- Catalyst 2960 48 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet Switch
-
-catalyst2960G24  OBJECT IDENTIFIER
-    ::= { ciscoProducts 696 }
-
--- Catalyst 2960 20 10/100/1000 ports + 4 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch.
-
-catalyst2960G48  OBJECT IDENTIFIER
-    ::= { ciscoProducts 697 }
-
--- Catalyst 2960 44 10/100/1000 ports + 4 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch.
-
-catalyst45503  OBJECT IDENTIFIER
-    ::= { ciscoProducts 698 }
-
-
-catalyst45506  OBJECT IDENTIFIER
-    ::= { ciscoProducts 699 }
-
-
-catalyst45507  OBJECT IDENTIFIER
-    ::= { ciscoProducts 700 }
-
-
-catalyst455010  OBJECT IDENTIFIER
-    ::= { ciscoProducts 701 }
-
-
-ciscoNme16Es1GeNoPwr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 702 }
-
--- EtherSwitch Service Module 16 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch with no inline power
-
-ciscoNmeX24Es1GeNoPwr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 703 }
-
--- EtherSwitch Service Module 23 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch with no inline power
-
-ciscoNmeXd24Es2StNoPwr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 704 }
-
--- EtherSwitch Service Module 24 10/100 ports + 1 Ethernet Gigabit SFP port fixed configuration Layer 2/Layer 3 Ethernet Stackable switch with no inline power
-
-ciscoNmeXd48Es2GeNoPwr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 705 }
-
--- EtherSwitch Service Module 48 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch with no inline power
-
-catalyst6kMsfc2a  OBJECT IDENTIFIER
-    ::= { ciscoProducts 706 }
-
--- Multilevel Switching Feature Card Version 2a for Catalyst 6000 that is treated as a standalone system by the NMS
-
-ciscoEDI  OBJECT IDENTIFIER
-    ::= { ciscoProducts 707 }
-
--- Cisco Enhanced Device Interface Server
-
-ciscoCe611K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 708 }
-
--- Cisco Content Engine Model CE-611-K9
-
-ciscoWLSEs20  OBJECT IDENTIFIER
-    ::= { ciscoProducts 709 }
-
--- Cisco Wireless LAN Solution Engine S20.
-
-ciscoMPX  OBJECT IDENTIFIER
-    ::= { ciscoProducts 710 }
-
--- Cisco MeetingPlace Express
-
-ciscoNMCUEEC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 711 }
-
--- Cisco Unity Express network module with enhanced capacity (NM-CUE-EC)
-
-ciscoWLSE1132  OBJECT IDENTIFIER
-    ::= { ciscoProducts 712 }
-
--- Cisco Wireless LAN Solution Engine WLSE-1132-K9
-
-ciscoME6340ACA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 713 }
-
--- DSL Switch 48 port ADSL2/2+, Annex A, AC
-
-ciscoME6340DCA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 714 }
-
--- DSL Switch 48 port ADSL2/2+, Annex A, DC
-
-ciscoME6340DCB  OBJECT IDENTIFIER
-    ::= { ciscoProducts 715 }
-
--- DSL Switch 48 port ADSL2/2+, Annex B, DC
-
-catalyst296024TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 716 }
-
--- Catalyst 2960 24 10/100 ports + 2 10/100/1000 ports fixed configuration Layer 2 Ethernet switch
-
-catalyst296048TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 717 }
-
--- Catalyst 2960 48 10/100 ports + 2 10/100/1000 ports fixed configuration Layer 2 Ethernet switch
-
-ciscoIGESMSFPT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 718 }
-
--- Cisco Systems Intelligent Gigabit Ethernet Switch Module for IBM eServer BladeCenter Telco Chassis (OS-CIGESM-18TT-E)
-
-ciscoMEC6524gs8s  OBJECT IDENTIFIER
-    ::= { ciscoProducts 719 }
-
--- Cisco ME 6524 chassis with 24 port SFP and 8 SFP uplinks
-
-ciscoMEC6524gt8s  OBJECT IDENTIFIER
-    ::= { ciscoProducts 720 }
-
--- Cisco ME 6524 chassis with 24 port 10/100/1000BaseT and 8 SFP uplinks
-
-ciscoMEC6724s10x2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 721 }
-
-
-ciscoMEC6724t10x2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 722 }
-
-
-ciscoPaldron  OBJECT IDENTIFIER
-    ::= { ciscoProducts 723 }
-
--- ARM Development Platform
-
-catalystsExpress50024TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 724 }
-
--- Catalyst Express 500 24 10/100 ports + 2 Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalystsExpress50024LC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 725 }
-
--- Catalyst Express 500 24 10/100 ports (4 Power Over Ethernet Ports) + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalystsExpress50024PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 726 }
-
--- Catalyst Express 500 24  Power Over Ethernet Ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalystsExpress50012TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 727 }
-
--- Catalyst Express 500 8 Gigabit Ethernet Ports + 4 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-ciscoIGESMT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 728 }
-
--- Cisco Systems Intelligent Gigabit Ethernet Switch Module for IBM eServer BladeCenter Telco Chassis (OS-CIGESM-18TT-E)
-
-ciscoACE04G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 729 }
-
-
-ciscoACE10K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 730 }
-
--- Application Control Engine Module in Cat6500
-
-cisco5750  OBJECT IDENTIFIER
-    ::= { ciscoProducts 731 }
-
--- High Assurance Router
-
-ciscoMWR1941DCA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 732 }
-
--- The Mobile Wireless Router (MWR-1941-DC-A) is a router with a universal power supply targeted at application in a cell site Base Transceiver Station (BTS) providing backhaul connections to the aggregation node in Radio Access Networks (RAN) and support for AIM module
-
-cisco815  OBJECT IDENTIFIER
-    ::= { ciscoProducts 733 }
-
--- Cisco 815 platform fixed configuration cable modem router with 4 FastEthernet switch ports, 1 Cable modem port, 1 FastEthernet port
-
-cisco240024TSA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 734 }
-
--- Metro Ethernet 2400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2 Ethernet switch, AC power.
-
-cisco240024TSD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 735 }
-
--- Metro Ethernet 2400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2 Ethernet switch, DC power.
-
-cisco340024TSA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 736 }
-
--- Metro Ethernet 3400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power.
-
-cisco340024TSD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 737 }
-
--- Metro Ethernet 3400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, DC power.
-
-ciscoCrs18Linecard  OBJECT IDENTIFIER
-    ::= { ciscoProducts 738 }
-
--- Cisco CRS-1 Series 8 slot Line Card Chassis
-
-ciscoCrs1Fabric  OBJECT IDENTIFIER
-    ::= { ciscoProducts 739 }
-
--- Cisco CRS-1 Series Fabric Card Chassis
-
-ciscoFE2636  OBJECT IDENTIFIER
-    ::= { ciscoProducts 740 }
-
--- Cisco File Engine Module for 26xx and 36xx series platforms
-
-ciscoIDS4220  OBJECT IDENTIFIER
-    ::= { ciscoProducts 741 }
-
--- Cisco Intrusion Detection System 4220
-
-ciscoIDS4230  OBJECT IDENTIFIER
-    ::= { ciscoProducts 742 }
-
--- Cisco Intrusion Detection System 4230
-
-ciscoIPS4260  OBJECT IDENTIFIER
-    ::= { ciscoProducts 743 }
-
--- Cisco Intrusion Prevention System 4260
-
-ciscoWsSvcSAMIBB  OBJECT IDENTIFIER
-    ::= { ciscoProducts 744 }
-
--- Service and Application Module for IP
-
-ciscoASA5505  OBJECT IDENTIFIER
-    ::= { ciscoProducts 745 }
-
--- Cisco Adaptive Security Appliance 5505
-
-ciscoMCS7825I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 746 }
-
--- Cisco Media Convergence Server 7825 (IBM)
-
-ciscoWsC3750g24ps  OBJECT IDENTIFIER
-    ::= { ciscoProducts 747 }
-
--- Cisco 3750 24+2 port 10/100/1000 Switch with integrated Cisco 4402 Wireless Controller
-
-ciscoWs3020Hpq  OBJECT IDENTIFIER
-    ::= { ciscoProducts 748 }
-
--- Cisco Catalyst Bladeswitch 3020 for HP
-
-ciscoWs3030Del  OBJECT IDENTIFIER
-    ::= { ciscoProducts 749 }
-
--- Cisco Catalyst Bladeswitch 3030 for Dell
-
-ciscoSpaOc48posSfp  OBJECT IDENTIFIER
-    ::= { ciscoProducts 750 }
-
--- 1-port OC48/STM16 POS/RPR SFP Optics Shared Port Adapter
-
-catalyst6kEnhancedGateway  OBJECT IDENTIFIER
-    ::= { ciscoProducts 751 }
-
-
-ciscoWLSE1133  OBJECT IDENTIFIER
-    ::= { ciscoProducts 752 }
-
--- Cisco Wireless LAN Solution Engine WLSE-1133.
-
-ciscoASA5550  OBJECT IDENTIFIER
-    ::= { ciscoProducts 753 }
-
--- Cisco Adaptive Security Appliance 5550
-
-ciscoNMAONK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 754 }
-
--- Cisco 2600/3700/ISR AON Module (NM-AON-K9)
-
-ciscoNMAONWS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 755 }
-
--- Catalyst 6500 Series AON Module (WS-SVC-AON-1-K9)
-
-ciscoNMAONAPS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 756 }
-
--- Cisco AON 8300 Series Appliance (APL-AON-8340-K9)
-
-ciscoWae612K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 757 }
-
--- Cisco Wide Area Engine Model WAE-612-K9
-
-ciscoAIRAP1250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 758 }
-
--- 1250 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11a/b/g/n slots
-
-ciscoCe512K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 759 }
-
--- Cisco Content Engine CE-512-K9
-
-ciscoFe512K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 760 }
-
--- Cisco File Engine Model FE-512-K9
-
-ciscoCe612K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 761 }
-
--- Cisco Content Engine Model CE-612-K9
-
-ciscoFe612K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 762 }
-
--- Cisco File Engine Model FE-612-K9
-
-ciscoASA5550sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 763 }
-
--- Cisco Adaptive Security Appliance 5550 Security Context
-
-ciscoASA5520sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 764 }
-
--- Cisco Adaptive Security Appliance 5520 System Context
-
-ciscoASA5540sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 765 }
-
--- Cisco Adaptive Security Appliance 5540 System Context
-
-ciscoASA5550sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 766 }
-
--- Cisco Adaptive Security Appliance 5550 System Context
-
-ciscoWsSvcFwm1sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 767 }
-
--- Firewall Services Module for Catalyst 6500 Series System Context
-
-ciscoPIXFirewall515sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 768 }
-
--- Cisco PIX Firewall 515 System Context
-
-ciscoPIXFirewall515Esy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 769 }
-
--- Cisco PIX Firewall 515E System Context
-
-ciscoPIXFirewall525sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 770 }
-
--- Cisco PIX Firewall 525 System Context
-
-ciscoPIXFirewall535sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 771 }
-
--- Cisco PIX Firewall 535 System Context
-
-ciscoIpRanOpt4p  OBJECT IDENTIFIER
-    ::= { ciscoProducts 772 }
-
--- The Mobile Wireless IP-RAN 4-Processor card for ONS platform with 4 Gigabit Ethernet ports
-
-ciscoASA5510sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 773 }
-
--- Cisco Adaptive Security Appliance 5510 Security Context
-
-ciscoASA5510sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 774 }
-
--- Cisco Adaptive Security Appliance 5510 System
-
-ciscoJumpgate  OBJECT IDENTIFIER
-    ::= { ciscoProducts 775 }
-
-
-ciscoOe512K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 776 }
-
--- Cisco Optimization Engine Model OE-512-K9
-
-ciscoOe612K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 777 }
-
--- Cisco Optimization Engine Model OE-612-K9
-
-catalyst3750G24WS25  OBJECT IDENTIFIER
-    ::= { ciscoProducts 778 }
-
--- Catalyst 3750 Unified Access Switch with 24 10/100/1000 Power over Ethernet ports + 2 Gigabit Ethernet SFP ports and integrated Wireless Controller supporting up to 25 Access Points
-
-catalyst3750G24WS50  OBJECT IDENTIFIER
-    ::= { ciscoProducts 779 }
-
--- Catalyst 3750 Unified Access Switch with 24 10/100/1000 Power over Ethernet ports + 2 Gigabit Ethernet SFP ports and integrated Wireless Controller supporting up to 50 Access Points
-
-ciscoMe3400g12CsA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 780 }
-
--- Metro Ethernet 3400, 12 GE/SFP ports + 4 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power
-
-ciscoMe3400g12CsD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 781 }
-
--- Metro Ethernet 3400, 12 GE/SFP ports + 4 SFP ports fixed configuration Layer 2/3 Ethernet switch, DC power
-
-cisco877M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 782 }
-
--- Cisco 877 platform with 1 ADSL Annex M over POTS WAN interface, 4-port 10/100 BASE-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
-
-cisco1801M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 783 }
-
--- Cisco 1800 platform with 1 ADSL Annex M over POTS WAN interface, 8-port 10/100 BASE-T LAN Ethernet switch, 1 ISDN BRI S/T interface and an optional Wireless LAN
-
-catalystWsCBS3040FSC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 784 }
-
--- Cisco Catalyst Blade Switch 3040 for FSC
-
-ciscoOe511K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 785 }
-
--- Cisco Optimization Engine Model OE-511-K9
-
-ciscoOe611K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 786 }
-
--- Cisco Optimization Engine Model OE-611-K9
-
-ciscoOe7326K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 787 }
-
--- Cisco Optimization Engine Model OE-7326-K9
-
-ciscoMe492410GE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 788 }
-
--- Metro Ethernet fixed configuration box with 2 Ten Gigabit X2 ports and 24+4 One Gigabit SFP ports
-
-catalyst3750E24TD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 789 }
-
--- Catalyst 3750E 24 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
-
-catalyst3750E48TD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 790 }
-
--- Catalyst 3750E 48 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
-
-catalyst3750E48PD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 791 }
-
--- Catalyst 3750E 48 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
-
-catalyst3750E24PD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 792 }
-
--- Catalyst 3750E 24 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
-
-catalyst3560E24TD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 793 }
-
--- Catalyst 3560E 24 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-catalyst3560E48TD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 794 }
-
--- Catalyst 3560E 48 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-catalyst3560E24PD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 795 }
-
--- Catalyst 3560E 24 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-catalyst3560E48PD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 796 }
-
--- Catalyst 3560E 48 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
-
-catalyst35608PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 797 }
-
--- Catalyst 3560 8 10/100 Power over Ethernet ports + 1  dual purpose Gigabit Ethernet port fixed configuration Layer 2 /Layer 3 Ethernet switch
-
-catalyst29608TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 798 }
-
--- Catalyst 2960 8 10/100 ports + 1  dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
-
-catalyst2960G8TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 799 }
-
--- Catalyst 2960 7 10/100/1000 ports + 1  dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
-
-ciscoTSPri  OBJECT IDENTIFIER
-    ::= { ciscoProducts 800 }
-
--- Cisco TelePresence Primary Codec
-
-ciscoTSSec  OBJECT IDENTIFIER
-    ::= { ciscoProducts 801 }
-
--- Cisco TelePresence Secondary Codec
-
-ciscoUWIpPhone7921G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 802 }
-
--- Cisco Unified Wireless IP Phone 7921G with IEEE 802.11a/b/g interface
-
-ciscoUWIpPhone7920  OBJECT IDENTIFIER
-    ::= { ciscoProducts 803 }
-
--- Cisco Unified Wireless IP Phone 7920 with IEEE 802.11b interface
-
-cisco3200WirelessMic  OBJECT IDENTIFIER
-    ::= { ciscoProducts 804 }
-
--- Cisco 3200 Wireless Mobile Interface Card
-
-ciscoISRWireless  OBJECT IDENTIFIER
-    ::= { ciscoProducts 805 }
-
--- Cisco Integrated Services Router with Wireless
-
-ciscoIPSVirtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 806 }
-
--- Cisco Intrusion Prevention System virtual sensor
-
-ciscoIDS4215Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 807 }
-
--- Cisco Intrusion Detection System 4215 virtual sensor
-
-ciscoIDS4235Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 808 }
-
--- Cisco Intrusion Detection System 4235 virtual sensor
-
-ciscoIDS4250Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 809 }
-
--- Cisco Intrusion Detection System 4250 virtual sensor
-
-ciscoIDS4250SXVirtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 810 }
-
--- Cisco Intrusion Detection System 4250 SX virtual sensor
-
-ciscoIDS4250XLVirtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 811 }
-
--- Cisco Intrusion Detection System 4250 XL virtual sensor
-
-ciscoIDS4240Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 812 }
-
--- Cisco Intrusion Prevention Detection System 4240 virtual sensor
-
-ciscoIDS4255Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 813 }
-
--- Cisco Intrusion Prevention Detection System 4255 virtual sensor
-
-ciscoIDS4260Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 814 }
-
--- Cisco Intrusion Prevention Detection System 4260 virtual sensor
-
-ciscoIDSIDSM2Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 815 }
-
--- Cisco Intrusion Detection System Module IDSM2 virtual sensor
-
-ciscoIPSSSM20Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 816 }
-
--- Cisco Intrusion Prevention System Security Service Module SSM-20 virtual sensor
-
-ciscoIPSSSM10Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 817 }
-
--- Cisco Intrusion Prevention System Security Service Module SSM-10 virtual sensor
-
-ciscoNMWLCE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 818 }
-
--- Integrated service router series 28xx/38xx with Wireless Lan Controller Network Module.
-
-cisco3205WirelessMic  OBJECT IDENTIFIER
-    ::= { ciscoProducts 819 }
-
--- Cisco 3205 Wireless MIC (Mobile Interface card) with 802.11a wireless interface in the PC104+ form factor. An interface card for the existing MAR 3200 products(Mobile Access Router)
-
-cisco5720  OBJECT IDENTIFIER
-    ::= { ciscoProducts 820 }
-
--- Integrated Encryption Router
-
-cisco7201  OBJECT IDENTIFIER
-    ::= { ciscoProducts 821 }
-
--- Cisco 7201 platform, 1 Rack Unit (RU) application specific router with 1 slot
-
-ciscoCrs14S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 822 }
-
--- Cisco CRS-1 Series 4 Slots System
-
-ciscoNmWae  OBJECT IDENTIFIER
-    ::= { ciscoProducts 823 }
-
--- Wide Area Application Engine Network Module
-
-ciscoACE4710K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 824 }
-
--- ACE 4710 Application Control Engine Appliance
-
-ciscoMe3400g2csA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 825 }
-
--- Metro Ethernet 3400, 2 GE/SFP ports + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power
-
-ciscoNmeNam  OBJECT IDENTIFIER
-    ::= { ciscoProducts 826 }
-
--- Cisco NME-NAM, Network Analysis Module (NAM) for the branch office routers
-
-ciscoUbr7225Vxr  OBJECT IDENTIFIER
-    ::= { ciscoProducts 827 }
-
--- Cisco 7225 Universal Broadband Router, VXR series
-
-ciscoAirWlc2106K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 828 }
-
--- This is a replacement for device WLAN Controller with product name WLC2006.
-
-ciscoMwr1951DC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 829 }
-
-
-ciscoIPS4270  OBJECT IDENTIFIER
-    ::= { ciscoProducts 830 }
-
--- IPS 4270 Intrusion Prevention Sensor
-
-ciscoIPS4270Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 831 }
-
--- IPS 4270 Intrusion Prevention Virtual Sensor
-
-ciscoWSC6509ve  OBJECT IDENTIFIER
-    ::= { ciscoProducts 832 }
-
--- Catalyst 6500 enhanced 9-slot vertical chassis
-
-cisco5740  OBJECT IDENTIFIER
-    ::= { ciscoProducts 833 }
-
--- Integrated Encryption Router
-
-cisco861  OBJECT IDENTIFIER
-    ::= { ciscoProducts 834 }
-
--- c861 with 1 FE, 4 switch ports, 1 Console/Aux port, and an optional Wireless LAN
-
-cisco866  OBJECT IDENTIFIER
-    ::= { ciscoProducts 835 }
-
-
-cisco867  OBJECT IDENTIFIER
-    ::= { ciscoProducts 836 }
-
--- c867 with 1 ADSL2/2+ AnnexA,4 switch ports, 1 Console/Aux port, and an optional Wireless LAN
-
-cisco881  OBJECT IDENTIFIER
-    ::= { ciscoProducts 837 }
-
--- c881 with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, and an optional Wireless LAN.
-
-cisco881G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 838 }
-
--- c881G with 1 FE, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
-
-ciscoIad881F  OBJECT IDENTIFIER
-    ::= { ciscoProducts 839 }
-
--- IAD881IF with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, and an optional Wireless LAN
-
-cisco881Srst  OBJECT IDENTIFIER
-    ::= { ciscoProducts 840 }
-
--- c881SRST with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN FXO port, and an optional Wireless LAN
-
-ciscoIad881B  OBJECT IDENTIFIER
-    ::= { ciscoProducts 841 }
-
--- IAD881B with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 2 PBX BRI ports, and an optional Wireless LAN
-
-cisco886  OBJECT IDENTIFIER
-    ::= { ciscoProducts 842 }
-
--- c886 with 1 ADSL2/2+ AnnexB, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
-
-cisco886G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 843 }
-
--- c886G with 1 ADSL2/2+ AnnexB,4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
-
-ciscoIad886F  OBJECT IDENTIFIER
-    ::= { ciscoProducts 844 }
-
--- IAD886F with 1 ADSL2/2+ AnnexB, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
-
-ciscoIad886B  OBJECT IDENTIFIER
-    ::= { ciscoProducts 845 }
-
--- IAD886B with 1 ADSL2/2+ AnnexB, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
-
-cisco886Srst  OBJECT IDENTIFIER
-    ::= { ciscoProducts 846 }
-
--- c886SRST with 1 ADSL2/2+ Annex B, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
-
-cisco887  OBJECT IDENTIFIER
-    ::= { ciscoProducts 847 }
-
--- c887 with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
-
-cisco887G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 848 }
-
--- c887G with 1 ADSL2/2+ AnnexA,4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
-
-ciscoIad887F  OBJECT IDENTIFIER
-    ::= { ciscoProducts 849 }
-
--- IAD887 with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
-
-ciscoIad887B  OBJECT IDENTIFIER
-    ::= { ciscoProducts 850 }
-
--- IAD887B with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
-
-cisco887Srst  OBJECT IDENTIFIER
-    ::= { ciscoProducts 851 }
-
--- c887SRST with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
-
-cisco888  OBJECT IDENTIFIER
-    ::= { ciscoProducts 852 }
-
--- c888 with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN.
-
-cisco888G  OBJECT IDENTIFIER
-    ::= { ciscoProducts 853 }
-
--- c888G with 1 G.SHDSL, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
-
-ciscoIad888F  OBJECT IDENTIFIER
-    ::= { ciscoProducts 854 }
-
--- IAD888F with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
-
-ciscoIad888B  OBJECT IDENTIFIER
-    ::= { ciscoProducts 855 }
-
--- IAD888B with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
-
-cisco888Srst  OBJECT IDENTIFIER
-    ::= { ciscoProducts 856 }
-
--- c888SRST with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
-
-cisco891  OBJECT IDENTIFIER
-    ::= { ciscoProducts 857 }
-
--- c891 with 1 GE, 8 switch ports, 2 USB 2.0 ports, 2 Console/Aux ports, 1 V.92, 1 Backup FE, and an optional Wireless LAN
-
-cisco892  OBJECT IDENTIFIER
-    ::= { ciscoProducts 858 }
-
--- c892 with 1GE, 8 switch ports, 2 USB 2.0 ports, 2 Console/Aux ports, 1 ISDN, 1 Backup FE, and an optional Wireless LAN
-
-cisco885D3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 859 }
-
-
-ciscoIad885FD3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 860 }
-
-
-cisco885EJ3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 861 }
-
-
-cisco7603s  OBJECT IDENTIFIER
-    ::= { ciscoProducts 862 }
-
--- Cisco 7600 S-Series Chassis with 3 slots
-
-cisco7606s  OBJECT IDENTIFIER
-    ::= { ciscoProducts 863 }
-
--- Cisco 7600 S-Series Chassis with 6 slots
-
-cisco7609s  OBJECT IDENTIFIER
-    ::= { ciscoProducts 864 }
-
--- Cisco 7600 S-Series Chassis with 9 slots
-
-cisco7600Seb  OBJECT IDENTIFIER
-    ::= { ciscoProducts 865 }
-
-
-ciscoNMECUE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 866 }
-
--- Cisco Unity Express Network Module Enhanced (NME-CUE)
-
-ciscoAIM2CUE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 867 }
-
--- Cisco Unity Express advanced integration module 2 (AIM2-CUE)
-
-ciscoUC500  OBJECT IDENTIFIER
-    ::= { ciscoProducts 868 }
-
--- Unified Communication 500 Series (UC500)
-
-cisco860Ap  OBJECT IDENTIFIER
-    ::= { ciscoProducts 869 }
-
--- Cisco 860 AP is the embedded wireless access point module for Cisco 860 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz.
-
-cisco880Ap  OBJECT IDENTIFIER
-    ::= { ciscoProducts 870 }
-
--- Cisco 880 AP is the embedded wireless access point module for Cisco 880 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz.
-
-cisco890Ap  OBJECT IDENTIFIER
-    ::= { ciscoProducts 871 }
-
--- Cisco 890 AP is the embedded wireless access point module for Cisco 890 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz and one IEEE 802.11 a/n radio port which operates in 5 GHz
-
-cisco1900Ap  OBJECT IDENTIFIER
-    ::= { ciscoProducts 872 }
-
--- Cisco 1900 AP is the embedded wireless access point module for Cisco 1900 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz and one IEEE 802.11 a/n radio port which operates in 5 GHz
-
-cisco340024FSA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 873 }
-
--- Metro Ethernet 3400, 24 100BaseFX Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch
-
-catalyst4503e  OBJECT IDENTIFIER
-    ::= { ciscoProducts 874 }
-
--- Catalyst 4500 E-series with 3 slots (WS-C4503-E)
-
-catalyst4506e  OBJECT IDENTIFIER
-    ::= { ciscoProducts 875 }
-
--- Catalyst 4500 E-series with 6 slots (WS-C4506-E)
-
-catalyst4507re  OBJECT IDENTIFIER
-    ::= { ciscoProducts 876 }
-
--- Catalyst 4500 E-series with 7 slots (WS-C4507R-E)
-
-catalyst4510re  OBJECT IDENTIFIER
-    ::= { ciscoProducts 877 }
-
--- Catalyst 4500 E-series with 10 slots (WS-C4510R-E)
-
-ciscoUC520s8U4FXOK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 878 }
-
--- UC500 with support for 8 switch ports and 4 FXO ports
-
-ciscoUC520s8U4FXOWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 879 }
-
--- UC500 with support for 8 switch ports, 4 FXO ports, and Wi-Fi
-
-ciscoUC520s8U2BRIK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 880 }
-
--- UC500 with support for 8 switch ports and 2 BRI
-
-ciscoUC520s8U2BRIWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 881 }
-
--- UC500 with support for 8 switch ports and 2 BRI, and Wi-Fi
-
-ciscoUC520s16U4FXOK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 882 }
-
--- UC500 with support for 16 switch ports and 4 FXO ports
-
-ciscoUC520s16U4FXOWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 883 }
-
--- UC500 with support for 16 switch ports, 4 FXO ports, and Wi-Fi
-
-ciscoUC520s16U2BRIK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 884 }
-
--- UC500 with support for 16 switch ports and 2 BRI
-
-ciscoUC520s16U2BRIWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 885 }
-
--- UC500 with support for 16 switch ports and 2 BRI, and Wi-Fi
-
-ciscoUC520m32U8FXOK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 886 }
-
--- UC500 with support for 32 switch ports and 8 FXO ports
-
-ciscoUC520m32U8FXOWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 887 }
-
--- UC500 with support for 32 switch ports and 8 FXO ports, and Wi-Fi
-
-ciscoUC520m32U4BRIK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 888 }
-
--- UC500 with support for 32 switch ports and 4 BRI
-
-ciscoUC520m32U4BRIWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 889 }
-
--- UC500 with support for 32 switch ports and 4 BRI, and Wi-Fi
-
-ciscoUC520m48U12FXOK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 890 }
-
--- UC500 with support for 48 switch ports and 12 FXO ports
-
-ciscoUC520m48U12FXOWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 891 }
-
--- UC500 with support for 48 switch ports and 12 FXO ports, and Wi-Fi
-
-ciscoUC520m48U6BRIK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 892 }
-
--- UC500 with support for 48 switch ports and 6 BRI
-
-ciscoUC520m48U6BRIWK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 893 }
-
--- UC500 with support for 48 switch ports and 6 BRI, and Wi-Fi
-
-ciscoUC520m48U1T1E1FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 894 }
-
--- UC500 with support for 48 switch ports and 1 T1
-
-ciscoUC520m48U1T1E1BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 895 }
-
--- UC500 with support for 48 switch ports and 1 T1, and Wi-Fi
-
-catalyst65xxVirtualSwitch  OBJECT IDENTIFIER
-    ::= { ciscoProducts 896 }
-
--- 65xx Virtual sSwitch
-
-catalystExpress5208PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 897 }
-
--- Catalyst Express 520 8 10/100 Power over Ethernet ports + 1 dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
-
-ciscoMCS7816I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 898 }
-
--- Cisco Media Convergence Server 7816 (IBM)
-
-ciscoMCS7828I  OBJECT IDENTIFIER
-    ::= { ciscoProducts 899 }
-
--- Cisco Media Convergence Server 7828 (IBM)
-
-ciscoMCS7816H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 900 }
-
--- Cisco Media Convergence Server 7816 (HP)
-
-ciscoMCS7828H  OBJECT IDENTIFIER
-    ::= { ciscoProducts 901 }
-
--- Cisco Media Convergence Server 7828 (HP)
-
-cisco1861Uc2BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 902 }
-
--- C1861 UC with support for 2 BRI ports and CUE
-
-cisco1861Uc4FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 903 }
-
--- C1861 UC with support for 4 FXO ports and CUE
-
-cisco1861Srst2BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 904 }
-
--- C1861 SRST with support for 2BRI ports
-
-cisco1861Srst4FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 905 }
-
--- C1861 SRST with support for 4 FXO ports
-
-ciscoNmeApa  OBJECT IDENTIFIER
-    ::= { ciscoProducts 906 }
-
--- Integrated Service Engine for Application Performance Assurance.
-
-ciscoOe7330K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 907 }
-
--- Cisco Optimization Engine Model OE-7330-K9
-
-ciscoOe7350K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 908 }
-
--- Cisco Optimization Engine Model OE-7350-K9
-
-ciscoWsCbs3110gS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 909 }
-
-
-ciscoWsCbs3110gSt  OBJECT IDENTIFIER
-    ::= { ciscoProducts 910 }
-
-
-ciscoWsCbs3110xS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 911 }
-
-
-ciscoWsCbs3110xSt  OBJECT IDENTIFIER
-    ::= { ciscoProducts 912 }
-
-
-ciscoSce8000  OBJECT IDENTIFIER
-    ::= { ciscoProducts 913 }
-
--- Cisco SCE8000 Service Control Engine
-
-ciscoASA5580  OBJECT IDENTIFIER
-    ::= { ciscoProducts 914 }
-
--- Cisco Adaptive Security Appliance 5580
-
-ciscoASA5580sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 915 }
-
--- Cisco Adaptive Security Appliance 5580 Security Context
-
-ciscoASA5580sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 916 }
-
--- Cisco Adaptive Security Appliance 5580 System Context
-
-cat4900M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 917 }
-
--- Catalyst 4900M series chassis with fixed 8 10Gig port base system with 2 additional half height line card slots ( WS-C4900M )
-
-catWsCbs3120gS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 918 }
-
-
-catWsCbs3120xS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 919 }
-
-
-catWsCbs3032Del  OBJECT IDENTIFIER
-    ::= { ciscoProducts 920 }
-
--- WS-CBS3032-DEL: Cisco Catalyst Stackable Blade Switch for FSC with 8 1Gigabit Uplink ports
-
-catWsCbs3130gS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 921 }
-
-
-catWsCbs3130xS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 922 }
-
-
-ciscoASR1002  OBJECT IDENTIFIER
-    ::= { ciscoProducts 923 }
-
--- Cisco Aggregation Services Router 1000 Series with 2RU Chassis
-
-ciscoASR1004  OBJECT IDENTIFIER
-    ::= { ciscoProducts 924 }
-
--- Cisco Aggregation Services Router 1000 Series With 4RU Chassis
-
-ciscoASR1006  OBJECT IDENTIFIER
-    ::= { ciscoProducts 925 }
-
--- Cisco Aggregation Services Router 1000 Series With 6RU Chassis
-
-cisco520WirelessController  OBJECT IDENTIFIER
-    ::= { ciscoProducts 926 }
-
--- Cisco 500 series Wireless controller for Small Medium Business Market
-
-cat296048TCS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 927 }
-
--- Catalyst 2960 48 10/100 ports plus 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-cat296024TCS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 928 }
-
--- Catalyst 2960 24 10/100 ports plus 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-cat296024S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 929 }
-
--- Catalyst 2960 24 10/100 ports Layer 2 Ethernet switch
-
-cat3560e12d  OBJECT IDENTIFIER
-    ::= { ciscoProducts 930 }
-
--- Catalyst 3560E 12 Ten GE (X2) ports
-
-ciscoCatRfgw  OBJECT IDENTIFIER
-    ::= { ciscoProducts 931 }
-
--- Cisco RF gateway, with 2SUP+10RF+2TCC+12RFSW slots, Display, Fan Tray
-
-catExpress52024TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 932 }
-
--- Catalyst Express 520 24 10/100 ports + 2 Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catExpress52024LC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 933 }
-
--- Catalyst Express 520 24 10/100 ports (4 Power Over Ethernet Ports) + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catExpress52024PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 934 }
-
--- Catalyst Express 520 24 Power Over Ethernet Ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catExpress520G24TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 935 }
-
--- Catalyst Express 520 24 Gigabit Ethernet Ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-ciscoCDScde100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 936 }
-
--- Cisco Content Delivery System Model CDE-100
-
-ciscoCDScde200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 937 }
-
--- Cisco Content Delivery System Model CDE-200
-
-ciscoCDScde300  OBJECT IDENTIFIER
-    ::= { ciscoProducts 938 }
-
--- Cisco Content Delivery System Model CDE-300
-
-cisco1861SrstCue2BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 939 }
-
--- C1861 SRST with support for 2 BRI ports and CUE
-
-cisco1861SrstCue4FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 940 }
-
--- C1861 SRST with support for 4 FXO ports and CUE
-
-ciscoVFrameDataCenter  OBJECT IDENTIFIER
-    ::= { ciscoProducts 941 }
-
--- Data center provisioning and virtualization
-
-ciscoVQEServer  OBJECT IDENTIFIER
-    ::= { ciscoProducts 942 }
-
--- Cisco VQE(Video Quality Experience) offers service providers a set of technologies and products associated with the delivery of IPTV video services.
-
-ciscoIPSSSM40Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 943 }
-
--- Cisco Intrusion Prevention  System Security Service Module SSM-40 Virtual Sensor
-
-ciscoIPSSSM40  OBJECT IDENTIFIER
-    ::= { ciscoProducts 944 }
-
--- Cisco Intrusion Prevention  System Security Service Module SSM-40 Sensor
-
-ciscoVgd1t3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 945 }
-
--- VGD Voice Gateway with 1xCT3 supporting CCM and MGCP
-
-ciscoCBS3100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 946 }
-
-
-ciscoCBS3110  OBJECT IDENTIFIER
-    ::= { ciscoProducts 947 }
-
-
-ciscoCBS3120  OBJECT IDENTIFIER
-    ::= { ciscoProducts 948 }
-
-
-ciscoCBS3130  OBJECT IDENTIFIER
-    ::= { ciscoProducts 949 }
-
-
-catalyst296024PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 950 }
-
--- 24 10/100 In-Line Power Ethernet ports plus 2 dual purpose Gigabit Ethernet ports
-
-catalyst296024LT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 951 }
-
--- 24 10/100, 8 POE and 2T ports switch
-
-catalyst2960PD8TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 952 }
-
--- 8 10/100 ports plus 1T PD port switch
-
-ciscoSpa2x1geSynce  OBJECT IDENTIFIER
-    ::= { ciscoProducts 953 }
-
-
-ciscoN5kC5020pBa  OBJECT IDENTIFIER
-    ::= { ciscoProducts 954 }
-
--- N5020 Chassis, 1AC PS, 40 SFP+ Ports. Modules Sold Seperate
-
-ciscoN5kC5020pBd  OBJECT IDENTIFIER
-    ::= { ciscoProducts 955 }
-
--- N5020 Chassis, 1DC PS, 40 SFP+ Ports. Modules Sold Seperate
-
-catalyst3560E12SD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 956 }
-
--- Catalyst 3560E, 12 SFP Gigabit Ethernet ports + 2 TenGigabit Ethernet (X2) ports
-
-ciscoOe674  OBJECT IDENTIFIER
-    ::= { ciscoProducts 957 }
-
--- Cisco Optimization Engine 674
-
-ciscoIE30004TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 958 }
-
--- Cisco Industrial Ethernet 3000 Switch, 4 10/100 + 2 T/SFP
-
-ciscoIE30008TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 959 }
-
--- Cisco Industrial Ethernet 3000 Switch, 8 10/100 + 2 T/SFP
-
-ciscoRAIE1783MS06T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 960 }
-
--- Cisco Rockwell brand Industrial Ethernet  Switch, 4 10/100 + 2 T/SFP
-
-ciscoRAIE1783MS10T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 961 }
-
--- Cisco Rockwell brand Industrial Ethernet Switch, 8 10/100 + 2 T/SFP
-
-cisco2435Iad8fxs  OBJECT IDENTIFIER
-    ::= { ciscoProducts 962 }
-
--- IAD2435 with 8FXS, 2FE and 1T1/E1
-
-ciscoVG204  OBJECT IDENTIFIER
-    ::= { ciscoProducts 963 }
-
--- Line side Analog Gateway with 4FXS Analog ports
-
-ciscoVG202  OBJECT IDENTIFIER
-    ::= { ciscoProducts 964 }
-
--- Line side Analog Gateway with 2FXS Analog ports
-
-catalyst291824TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 965 }
-
--- Catalyst 2918 24 10/100 ports + 2 10/100/1000 Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst291824TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 966 }
-
--- Catalyst 2918 24 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst291848TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 967 }
-
--- Catalyst 2918 48 10/100 ports + 2 10/100/1000 Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst291848TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 968 }
-
--- Catalyst 2918 48 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-ciscoVQETools  OBJECT IDENTIFIER
-    ::= { ciscoProducts 969 }
-
--- Cisco CDE110 appliances hosting VQE Channel Provisioning Tool (VCPT) and VQE Client Channel Configuration Delivery Server
-
-ciscoUC520m24U4BRIK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 970 }
-
--- UC500 with support for 24U CME Base, CUE and Phone FL w/4BRI, 1VIC
-
-ciscoUC520m24U8FXOK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 971 }
-
--- UC500 with support for 24U CME Base, CUE and Phone FL w/8FXO, 1VIC
-
-ciscoUC520s16U2BRIWK9J  OBJECT IDENTIFIER
-    ::= { ciscoProducts 972 }
-
--- UC500 for Japan with support for 16 switch ports and 2 BRI, and Wi-Fi
-
-ciscoUC520s8U2BRIWK9J  OBJECT IDENTIFIER
-    ::= { ciscoProducts 973 }
-
--- UC500 for Japan with support for 8 switch ports and 2 BRI, and Wi-Fi
-
-ciscoVSIntSp  OBJECT IDENTIFIER
-    ::= { ciscoProducts 974 }
-
--- Cisco Video Stream Integrated Services
-
-ciscoVSSP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 975 }
-
--- Cisco Video Stream Services Platform
-
-ciscoVSHydecoder  OBJECT IDENTIFIER
-    ::= { ciscoProducts 976 }
-
--- Cisco Video Stream Hybrid Decoder
-
-ciscoVSDecoder  OBJECT IDENTIFIER
-    ::= { ciscoProducts 977 }
-
--- Cisco Video Stream Decoder
-
-ciscoVSEncoder4P  OBJECT IDENTIFIER
-    ::= { ciscoProducts 978 }
-
--- Cisco Video Stream Encoder 4 Port
-
-ciscoVSEncoder1P  OBJECT IDENTIFIER
-    ::= { ciscoProducts 979 }
-
--- Cisco Video Stream Encoder 1 Port
-
-ciscoSCS1000K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 980 }
-
--- Smart Care 1000 Series Network Appliance
-
-cisco1805  OBJECT IDENTIFIER
-    ::= { ciscoProducts 981 }
-
--- Cisco1805 is a repackaging effort for design to address the low end cable access market. C1805 is deployed as cut down and fixed version of Cisco C1841
-
-ciscoCe7341  OBJECT IDENTIFIER
-    ::= { ciscoProducts 982 }
-
--- Cisco Content Engine
-
-ciscoCe7371  OBJECT IDENTIFIER
-    ::= { ciscoProducts 983 }
-
--- Cisco Content Engine
-
-cisco7613s  OBJECT IDENTIFIER
-    ::= { ciscoProducts 984 }
-
-
-ciscoOe574  OBJECT IDENTIFIER
-    ::= { ciscoProducts 985 }
-
--- Cisco Optimization Engine 574
-
-ciscoOe474  OBJECT IDENTIFIER
-    ::= { ciscoProducts 986 }
-
--- Cisco Optimization Engine 474
-
-ciscoOe274  OBJECT IDENTIFIER
-    ::= { ciscoProducts 987 }
-
--- Cisco Optimization Engine 274
-
-ciscoAp801agn  OBJECT IDENTIFIER
-    ::= { ciscoProducts 988 }
-
--- Cisco AP801 Access Point with dual IEEE 802.11a/g/n radio ports
-
-ciscoAp801gn  OBJECT IDENTIFIER
-    ::= { ciscoProducts 989 }
-
--- Cisco AP801 Access Point with single IEEE 802.11g/n radio port
-
-cisco1861WSrstCue4FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 990 }
-
--- C1861 SRST with support for 4 FXO ports, Wireless and CUE
-
-cisco1861WSrstCue2BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 991 }
-
--- C1861 SRST with support for 2 BRI ports, Wireless and CUE
-
-cisco1861WSrst4FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 992 }
-
--- C1861 SRST with support for 4 FXO ports and Wireless
-
-cisco1861WSrst2BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 993 }
-
--- C1861 SRST with support for 2 BRI ports and Wireless
-
-cisco1861WUc4FK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 994 }
-
--- 1861 UC with support for 4 FXO ports, Wireless and CUE
-
-cisco1861WUc2BK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 995 }
-
--- 1861 UC with support for 2 BRI ports, Wireless and CUE
-
-ciscoCe674  OBJECT IDENTIFIER
-    ::= { ciscoProducts 996 }
-
--- Cisco Content Engine 674
-
-ciscoVQEIST  OBJECT IDENTIFIER
-    ::= { ciscoProducts 997 }
-
--- VQE-IST is an Integrated Server Tool that combines services from VQE Server and VQE Tools
-
-ciscoAIRAP1160  OBJECT IDENTIFIER
-    ::= { ciscoProducts 998 }
-
-
-ciscoWsCbs3012Ibm  OBJECT IDENTIFIER
-    ::= { ciscoProducts 999 }
-
-
-ciscoWsCbs3012IbmI  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1000 }
-
-
-ciscoWsCbs3125gS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1001 }
-
-
-ciscoWsCbs3125xS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1002 }
-
-
-ciscoTSPriG2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1003 }
-
--- Cisco TelePresence Primary Codec, Generation 2
-
-catalyst492810GE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1004 }
-
--- Fixed configuration Catalyst 4000 with 28 1000BaseX SFP port
-
-catalyst296048TTS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1005 }
-
--- Catalyst 2960 48 10/100 ports + 2 10/100/1000 Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst29608TCS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1006 }
-
--- Catalyst 2960 8 10/100 ports + 1 dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
-
-ciscoMe3400eg2csA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1007 }
-
--- Metro Ethernet 3400E, 2 GE/SFP ports + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power
-
-ciscoMe3400eg12csM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1008 }
-
--- Metro Ethernet 3400 , 12 GE/SFP ports + 4 SFP ports fixed configuration Layer 2/3 Ethernet switch, modular power
-
-ciscoMe3400e24tsM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1009 }
-
--- Metro Ethernet 3400E, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, modular power
-
-ciscoIPSSSC5Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1010 }
-
--- Cisco Intrusion Prevention System Security Service Card SSC-5 Virtual Sensor
-
-ciscoSR520FE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1011 }
-
--- SR520 with 1 10/100T ethernet WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
-
-ciscoSR520ADSL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1012 }
-
--- SR520 with 1 ADSL over POTS WAN interface, 4-port 10/100 BASE-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
-
-ciscoSR520ADSLi  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1013 }
-
--- SR520 with 1 ADSL over ISDN WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
-
-ciscoMwr2941DC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1014 }
-
--- The Mobile Wireless router MWR-2941-DC is a router targeted at application in a cell site Base Transciever Station (BTS) providing Radio Access Network (RAN) optimization
-
-catalyst356012PCS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1015 }
-
--- Catalyst 3560 12 10/100 Power over Ethernet ports + 1 dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
-
-catalyst296048PSTL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1016 }
-
--- Catalyst 2960 48 10/100 Power over Ethernet ports + 2 10/100/1000 Ethernet Ports + 2 SFP fixed configuration Layer 2 Ethernet switch
-
-ciscoASR9010  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1017 }
-
--- Cisco Aggregation Services Router (ASR) 9010 Chassis
-
-ciscoASR9006  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1018 }
-
--- Cisco Aggregation Services Router (ASR) 9006 Chassis
-
-catalyst3560v224tsD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1019 }
-
--- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable switch, DC power
-
-catalyst3560v224ts  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1020 }
-
--- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable switch
-
-catalyst3560v224ps  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1021 }
-
--- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable PoE switch
-
-catalyst3750v224ts  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1022 }
-
--- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch
-
-catalyst3750v224ps  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1023 }
-
--- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable PoE switch
-
-catalyst3560v248ts  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1024 }
-
--- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable switch
-
-catalyst3560v248ps  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1025 }
-
--- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable PoE switch
-
-catalyst3750v248ts  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1026 }
-
--- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch
-
-catalyst3750v248ps  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1027 }
-
--- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable PoE switch
-
-ciscoHwicCableD2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1028 }
-
--- This HWIC supports DOCSIS 2.0 in modular Integrated Service Routers as well as IAD2430 series routers
-
-ciscoHwicCableEJ2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1029 }
-
--- This HWIC supports Euro-DOCSIS 2.0, and J-DOCSIS 2.0 in modular Integrated Service Routers as well as IAD2430 series routers
-
-ciscoBr1430  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1030 }
-
--- Cisco 1400 series wireless LAN bridge
-
-ciscoAIRBR1430  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1031 }
-
--- Cisco 1430 Series Wireless LAN Bridge with 4 GigabitEthernet Ports and one  4.9GHz  802.11A  or  5.8GHz 802.11N radio
-
-ciscoNamApp2204  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1032 }
-
--- Cisco NAM Appliance 2204
-
-ciscoNamApp2220  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1033 }
-
--- Cisco NAM Appliance 2220
-
-ciscoAIRAP1141  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1034 }
-
--- Cisco Aironet 1140 series WLAN Access Point with one 10/100/1000TX port and single IEEE 802.11n radio port
-
-ciscoAIRAP1142  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1035 }
-
--- Cisco Aironet 1140 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
-
-ciscoASR14K4S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1036 }
-
--- Cisco ASR14000 Series 4-Slot System
-
-ciscoASR14K8S  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1037 }
-
--- Cisco ASR14000 Series 8-Slot System
-
-cisco18xxx  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1038 }
-
-
-ciscoIPSSSC5  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1039 }
-
--- Cisco Intrusion Prevention System Security Service Card SSC-5
-
-cisco887Vdsl2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1040 }
-
--- c887Vdsl2 with 1 VDSL2 only over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port and 1 ISDN
-
-cisco3945  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1041 }
-
--- CISCO3945/K9 with SPE150(3 GE, 4  EHWIC, 4 DSP, 4 SM, 256MB CF, 1GB DRAM, IPB)
-
-cisco3925  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1042 }
-
--- CISCO3925/K9 with SPE100(3 GE,  4 EHWIC, 4 DSP, 2 SM, 256MB CF, 1GB DRAM, IPB)
-
-cisco2951  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1043 }
-
--- CISCO2951/K9 with 3 GE, 4 EHWIC, 3 DSP, 2 SM, 256 MB CF, 512 MB DRAM, IPB
-
-cisco2921  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1044 }
-
--- CISCO2921/K9 with 3 GE, 4 EHWIC, 3 DSP, 1 SM, 256 MB CF, 512 MB DRAM, IPB
-
-cisco2911  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1045 }
-
--- CISCO2911/K9 with 3 GE, 4 EHWIC, 2 DSP, 1 SM , 256 MB CF, 512 MB DRAM, IPB
-
-cisco2901  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1046 }
-
--- CISCO2901/K9 with 2 GE, 4 EHWIC, 2 DSP, 256 MB CF, 512 MBDRAM, IP BASE
-
-cisco1941  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1047 }
-
--- CISCO1941/K9  with 2 GE, 2 EHWIC, 256 MB CF, 256 MB DRAM, IP BASE
-
-ciscoSm2k15Es1GePoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1048 }
-
--- EtherSwitch Service Module Layer2 + PoE + 15 10/100 + 1 10/100/1000
-
-ciscoSm3k15Es1GePoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1049 }
-
--- EtherSwitch Service Module Layer3 + PoE + 15 10/100 + 1 10/100/1000
-
-ciscoSm3k16GePoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1050 }
-
--- EtherSwitch Service Module Layer3 + PoE + 16 10/100/1000
-
-ciscoSm2k23Es1Ge  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1051 }
-
--- EtherSwitch Service Module Layer2 + no PoE + 23 10/100 + 1 10/100/1000
-
-ciscoSm2k23Es1GePoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1052 }
-
--- EtherSwitch Service Module Layer2 + PoE + 23 10/100 + 1 10/100/1000
-
-ciscoSm3k23Es1GePoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1053 }
-
--- EtherSwitch Service Module Layer3 + PoE + 23 10/100 + 1 10/100/1000
-
-ciscoSm3k24GePoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1054 }
-
--- EtherSwitch Service Module Layer3 + PoE + 24 10/100/1000
-
-ciscoSmXd2k48Es2SFP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1055 }
-
--- EtherSwitch Service Module Layer2 + no PoE + 48 10/100 + 2 SFP
-
-ciscoSmXd3k48Es2SFPPoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1056 }
-
--- EtherSwitch Service Module Layer3 + PoE + 48 10/100 + 2 SFP
-
-ciscoSmXd3k48Ge2SFPPoe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1057 }
-
--- EtherSwitch Service ModuleLayer3 + PoE + 48 10/100/1000 + 2 SFP
-
-ciscoEsw52024pK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1058 }
-
--- 24-port 10/100 Ethernet Switch with PoE
-
-ciscoEsw54024pK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1059 }
-
--- 24-port 10/100/1000 Ethernet Switch with PoE
-
-ciscoEsw52048pK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1060 }
-
--- 48-port 10/100 Ethernet Switch with PoE
-
-ciscoEsw52024K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1061 }
-
--- 24-port 10/100 Ethernet Switch
-
-ciscoEsw54024K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1062 }
-
--- 24-port 10/100/1000 Ethernet
-
-ciscoEsw52048K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1063 }
-
--- 48-port 10/100 Ethernet Switch
-
-ciscoEsw54048K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1064 }
-
--- 48-port 10/100/1000 Ethernet Switch
-
-cisco1861  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1065 }
-
--- Cisco C1861 Base System
-
-ciscoUC520  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1066 }
-
--- UC520 Base System
-
-catalystWSC2975GS48PSL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1067 }
-
-
-catalystC2975Stack  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1068 }
-
-
-cisco5500Wlc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1069 }
-
--- Cisco 5500 series Wireless LAN Controller
-
-ciscoSR520T1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1070 }
-
--- Security router with 2 FE and 1 T1 port. Supports voice and data
-
-ciscoPwrC3900Poe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1071 }
-
--- Cisco 3925/3945 AC Power Supply with Power Over Ethernet (PWR-3900-POE)
-
-ciscoPwrC3900AC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1072 }
-
--- Cisco 3925/3945 AC Power Supply (PWR-3900-AC)
-
-ciscoPwrC2921C2951Poe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1073 }
-
--- Cisco 2921/2951 AC Power Supply with Power Over Ethernet (PWR-2921-51-POE)
-
-ciscoPwrC2921C2951AC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1074 }
-
--- Cisco 2921/2951 AC Power Supply (PWR-2921-51-AC)
-
-ciscoPwrC2911Poe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1075 }
-
--- Cisco 2911 AC Power Supply with Power Over Ethernet (PWR-2911-POE)
-
-ciscoPwrC2911AC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1076 }
-
--- Cisco 2911 AC Power Supply (PWR-2911-AC)
-
-ciscoPwrC2901Poe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1077 }
-
--- Cisco 2901 AC Power Supply with Power Over Ethernet(PWR-2901-POE)
-
-ciscoPwrC1941C2901AC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1078 }
-
--- Cisco 2901 AC Power Supply (PWR-2901-AC)
-
-ciscoPwrC1941Poe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1079 }
-
--- Cisco 1941 AC Power Supply with Power Over Ethernet (PWR-1941-POE)
-
-ciscoPwrC3900DC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1080 }
-
--- Cisco 3925/3945 DC Power Supply (PWR-3900-DC)
-
-ciscoPwrC2921C2951DC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1081 }
-
--- Cisco 2921/2951 DC Power Supply (PWR-2921-51-DC)
-
-ciscoPwrC2911DC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1082 }
-
--- Cisco 2911 DC power Supply (PWR-2911-DC)
-
-ciscoRpsAdptrC2921C2951  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1083 }
-
--- Cisco 2921/2951 RPS Adaptor for use with external rps(RPS-ADPTR-2921-51)
-
-ciscoRpsAdptrC2911  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1084 }
-
--- Cisco 2911 RPS Adaptor for use with external rps (RPS-ADPTR-2911)
-
-ciscoIPSSSC2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1085 }
-
-
-ciscoIPSSSC2Virtual  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1086 }
-
-
-catalystWSCBS3140XS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1087 }
-
-
-catalystWSCBS3140GS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1088 }
-
-
-catalystWSCBS3042FSC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1089 }
-
-
-catalystWSCBS3150XS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1090 }
-
-
-catalystWSCBS3150GS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1091 }
-
-
-catalystWSCBS3052NEC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1092 }
-
-
-ciscoCBS3140Stack  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1093 }
-
--- A stack of any CBS3140 switch modules.
-
-ciscoCBS3150Stack  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1094 }
-
--- A stack of any CBS3150 switch modules.
-
-cisco1941W  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1095 }
-
--- CISCO1941W-A/K9 with 802.11 a/b/g/ n  FCC compliant WLAN ISM
-
-ciscoC888E  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1096 }
-
-
-ciscoC888EG  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1097 }
-
-
-ciscoIad888EB  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1098 }
-
-
-ciscoIad888EF  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1099 }
-
-
-ciscoC888ESRST  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1100 }
-
-
-ciscoASA5505W  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1101 }
-
-
-cisco3845nv  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1102 }
-
--- Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800nv family router
-
-cisco3825nv  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1103 }
-
--- Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800nv family router
-
-catalystWSC235048TD  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1104 }
-
--- Catalyst 2350 48 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2 Ethernet Switch
-
-cisco887M  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1105 }
-
--- c887 with 1 ADSL2/2+ AnnexM,4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
-
-ciscoVg250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1106 }
-
-
-ciscoVg226e  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1107 }
-
-
-ciscoDsIbm8GfcK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1108 }
-
-
-ciscoDsHp8GfcK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1109 }
-
-
-ciscoDsDell8GfcK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1110 }
-
-
-ciscoDsC9148K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1111 }
-
-
-ciscoCeVirtualBlade  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1112 }
-
--- Cisco Content Engine
-
-ciscoCDScde420  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1113 }
-
--- Cisco Content Delivery System Model CDE-420
-
-ciscoCDScde220  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1114 }
-
--- Cisco Content Delivery System Model CDE-220
-
-ciscoCDScde110  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1115 }
-
--- Cisco Content Delivery System Model CDE-110
-
-ciscoASR1002F  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1116 }
-
--- Cisco Aggregation Services Router 1000 Series with 2RU Fixed Chassis
-
-ciscoSecureAccessControlSystem  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1117 }
-
--- Cisco Secure Access Control System
-
-cisco861Npe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1118 }
-
-
-cisco881Npe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1119 }
-
-
-cisco881GNpe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1120 }
-
-
-cisco887Npe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1121 }
-
-
-cisco888GNpe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1122 }
-
-
-cisco891Npe  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1123 }
-
-
-ciscoAIRAP3501  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1124 }
-
-
-ciscoAIRAP3502  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1125 }
-
-
-ciscoCDScde400  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1126 }
-
--- Cisco Content Delivery System Model CDE-400
-
-ciscoSA520K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1127 }
-
-
-ciscoSA520WK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1128 }
-
-
-ciscoSA540K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1129 }
-
-
-ciscoSps2004B  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1130 }
-
--- Metro Ethernet Switch with 1 1000Base-BX-U WAN port and 5 10/100/1000M LAN ports
-
-ciscoSps204B  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1131 }
-
--- Metro Ethernet Switch with 1 100Base-BX-U WAN and 5 10/100/1000M LAN ports
-
-ciscoUC560T1E1K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1132 }
-
-
-ciscoUC560BRIK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1133 }
-
-
-ciscoUC560FXOK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1134 }
-
-
-ciscoAp541nAK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1135 }
-
--- 802.11a/b/g/n Wireless LAN Access Point for North America, FCC band plan
-
-ciscoAp541nEK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1136 }
-
--- 802.11a/b/g/n Wireless LAN Access Point for Europe, ETSI band plan
-
-ciscoAp541nNK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1137 }
-
--- 802.11a/b/g/n Wireless LAN Access Point for ANZ band plan
-
-cisco887GVdsl2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1138 }
-
--- c887GVdsl2 with 1 VDSL2 only over POTS,4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
-
-cisco887SrstVdsl2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1139 }
-
--- c887SRSTVdsl2 with 1 VDSL2 over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
-
-ciscoUc540wFxoK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1140 }
-
-
-ciscoUc540wBriK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1141 }
-
-
-ciscoCaServer  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1142 }
-
-
-ciscoCaManager  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1143 }
-
-
-cisco3925SPE200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1144 }
-
--- Cisco 3925 w/SPE200(4 GE, 3 EHWIC, 3 DSP,  2 SM)
-
-cisco3945SPE250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1145 }
-
--- Cisco 3945 w/SPE250(4 GE, 3 EHWIC, 3 DSP, 4 SM)
-
-catalyst296024LCS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1146 }
-
--- Catalyst 2960 8 10/100 Power over Ethernet ports + 16 10/100 Ethernet ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst296024PCS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1147 }
-
--- Catalyst 2960 24 10/100 Power over Ethernet ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
-
-catalyst296048PSTS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1148 }
-
--- Catalyst 2960 48 10/100 Power over Ethernet ports + 2 10/100/1000 Ethernet ports + 2 SFP fixed configuration Layer 2 Ethernet switch
-
-ciscoISM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1149 }
-
-
-ciscoSM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1150 }
-
-
-ciscoNMEAXP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1151 }
-
--- Cisco Application Extension Platform Network Module Enhanced (NME-AXP)
-
-ciscoAIMAXP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1152 }
-
--- Cisco Application Extension Platform advanced integration module (AIM-AXP)
-
-ciscoAIM2AXP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1153 }
-
--- Cisco Application Extension Platform advanced integration module 2(AIM2-AXP)
-
-ciscoSRP521  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1154 }
-
--- Service Ready Platform router with Fast Ethernet WAN port
-
-ciscoSRP526  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1155 }
-
--- Service Ready Platform router with ADSL2+ over ISDN WAN port
-
-ciscoSRP527  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1156 }
-
--- Service Ready Platform router with ADSL2+ over POTS WAN port
-
-ciscoSRP541  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1157 }
-
--- Service Ready Platform router with GE WAN port
-
-ciscoSRP546  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1158 }
-
--- Service Ready Platform router with ADSL2+ over ISDN WAN port as well as GE WAN port
-
-ciscoSRP547  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1159 }
-
--- Service Ready Platform router with ADSL2+ over POTS WAN port as well as GE WAN port
-
-ciscoVS510FXO  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1160 }
-
--- Call control solution for 4-24 phone
-
-ciscoNmWae900  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1161 }
-
--- Cisco Network Module Intergrated Service Engine 900
-
-ciscoNmWae700  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1162 }
-
--- Cisco Network Module Intergrated Service Engine 700
-
-cisco5940RA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1163 }
-
-
-cisco5940RC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1164 }
-
-
-ciscoASR1001  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1165 }
-
-
-ciscoASR1013  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1166 }
-
-
-ciscoCDScde205  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1167 }
-
--- Cisco Content Delivery System Model CDE-205
-
-ciscoPwr1941AC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1168 }
-
--- C1941 AC Power Supply
-
-ciscoNamWaasVirtualBlade  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1169 }
-
--- Cisco Network Analysis Module (NAM) Virtual Blade on WAAS appliance
-
-ciscoRaie1783Rms06t  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1170 }
-
--- Cisco Rockwell brand Layer 3 Industrial Ethernet  Switch, 4 10/100 + 2 T/SFP
-
-ciscoRaie1783Rms10t  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1171 }
-
--- Cisco Rockwell brand Industrial Ethernet Switch, 8 10/100 + 2 T/SFP
-
-cisco1941WEK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1172 }
-
--- CISCO1941W-E/K9 Router w/ 802.11 a/b/g/n ETSI Compliant WLAN ISM
-
-cisco1941WPK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1173 }
-
--- CISCO1941W-P/K9 Router w/ 802.11 a/b/g/n Japan Compliant WLAN ISM
-
-cisco1941WNK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1174 }
-
--- CISCO1941W-N/K9 Router w/ 802.11 a/b/g/n Aus, NZ Compliant WLAN ISM
-
-ciscoMXE5600  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1175 }
-
--- Cisco MXE 5600 platform, 1 Rack Unit (RU) application specific device with 8 slots
-
-ciscoEsw5408pK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1176 }
-
--- Cisco ESW 540 8-port 10/100/1000 PoE switch
-
-ciscoEsw5208pK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1177 }
-
--- Cisco ESW 520 8-port 10/100 PoW switch
-
-catalyst4948e10GE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1178 }
-
--- Catalyst 4000 series fixed configuration switch with 48 10/100/1000BaseT ports and four 10Gbps/1Gbps SFP+/SFP ports(WS-C4948E)
-
-cat2960x48tsS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1179 }
-
-
-cat2960x24tsS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1180 }
-
-
-cat2960xs48fpdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1181 }
-
-
-cat2960xs48lpdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1182 }
-
-
-cat2960xs48ltdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1183 }
-
-
-cat2960xs24pdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1184 }
-
-
-cat2960xs24tdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1185 }
-
-
-cat2960xs48fpsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1186 }
-
-
-cat2960xs48lpsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1187 }
-
-
-cat2960xs24psL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1188 }
-
-
-cat2960xs48tsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1189 }
-
-
-cat2960xs24tsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1190 }
-
-
-cisco1921k9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1191 }
-
--- CISCO1921/K9 with 2 GE, 2 EHWIC, 256 MB flash memory, 512 MB DRAM, IP BASE
-
-cisco1905k9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1192 }
-
-
-ciscoPwrC1921C1905AC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1193 }
-
-
-ciscoASA5585Ssp10  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1194 }
-
-
-ciscoASA5585Ssp20  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1195 }
-
-
-ciscoASA5585Ssp40  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1196 }
-
-
-ciscoASA5585Ssp60  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1197 }
-
-
-ciscoASA5585Ssp10sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1198 }
-
-
-ciscoASA5585Ssp20sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1199 }
-
-
-ciscoASA5585Ssp40sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1200 }
-
-
-ciscoASA5585Ssp60sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1201 }
-
-
-ciscoASA5585Ssp10sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1202 }
-
-
-ciscoASA5585Ssp20sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1203 }
-
-
-ciscoASA5585Ssp40sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1204 }
-
-
-ciscoASA5585Ssp60sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1205 }
-
-
-cisco3925SPE250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1206 }
-
-
-cisco3945SPE200  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1207 }
-
-
-cat29xxStack  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1208 }
-
-
-ciscoOeNm302  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1209 }
-
-
-ciscoOeNm502  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1210 }
-
-
-ciscoOeNm522  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1211 }
-
-
-ciscoOeSmSre700  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1212 }
-
-
-ciscoOeSmSre900  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1213 }
-
-
-ciscoVsaNam  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1214 }
-
--- Virtual Switch NAM for Nexus1010
-
-ciscoMwr2941DCA  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1215 }
-
--- The Mobile Wireless router MWR-2941-DC-A is a router targeted at application in a cell site Base Transciever Station (BTS) providing Radio Access Network (RAN) optimization
-
-ciscoN7KC7018IOS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1216 }
-
-
-ciscoN7KC7010IOS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1217 }
-
-
-ciscoN4KDellEth  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1218 }
-
-
-ciscoN4KDellCiscoEth  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1219 }
-
-
-cisco1941WCK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1220 }
-
--- CISCO1941W-C/K9 Router w/ 802.11 a/b/g/n China Compliant WLAN ISM
-
-ciscoCDScde2202s3  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1221 }
-
--- Cisco Content Delivery System Model CDE-220-2S3
-
-cat3750x24  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1222 }
-
--- Catalyst 3750X 24 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
-
-cat3750x48  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1223 }
-
--- Catalyst 3750X 48 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
-
-cat3750x24P  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1224 }
-
--- Catalyst 3750X 24 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
-
-cat3750x48P  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1225 }
-
--- Catalyst 3750X 48 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
-
-cat3560x24  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1226 }
-
--- Catalyst 3560X 24 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
-
-cat3560x48  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1227 }
-
--- Catalyst 3560X 48 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
-
-cat3560x24P  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1228 }
-
--- Catalyst 3560X 24 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
-
-cat3560x48P  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1229 }
-
--- Catalyst 3560X 48 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
-
-ciscoNMEAIR  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1230 }
-
-
-ciscoACE30K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1231 }
-
--- Application Control Engine Module in Cat6500
-
-ciscoASA5585SspIps10  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1232 }
-
--- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-10
-
-ciscoASA5585SspIps20  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1233 }
-
--- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-20
-
-ciscoASA5585SspIps40  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1234 }
-
--- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-40
-
-ciscoASA5585SspIps60  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1235 }
-
--- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-60
-
-cisco1841CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1236 }
-
--- Cisco 1841C/K9 data only router with 2 HWIC slots
-
-cisco2801CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1237 }
-
--- Cisco 2801C/K9 router with 4 HWIC slots
-
-cisco2811CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1238 }
-
--- Cisco 2811C/K9 router with one Network Module slot, four HWIC slots, two fast ethernet and integrated VPN
-
-cisco2821CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1239 }
-
--- Cisco 2821C/K9 router with one Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and intergrated VPN
-
-cisco2851CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1240 }
-
-
-cisco3825CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1241 }
-
--- Cisco 3825C/K9 router with Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports
-
-cisco3845CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1242 }
-
--- Cisco 3845C/K9 router with Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports
-
-cisco3825CnvK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1243 }
-
-
-cisco3845CnvK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1244 }
-
-
-ciscoCGS252024TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1245 }
-
-
-ciscoCGS252016S8PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1246 }
-
-
-ciscoAIRAP1262  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1247 }
-
-
-ciscoAIRAP1261  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1248 }
-
-
-cisco892F  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1249 }
-
-
-ciscoMe3600x24fsM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1250 }
-
-
-ciscoMe3600x24tsM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1251 }
-
-
-ciscoMe3800x24fsM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1252 }
-
-
-ciscoCGR2010  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1253 }
-
-
-ciscoPwrCGR20xxCGS25xxPoeAC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1254 }
-
-
-ciscoPwrCGR20xxCGS25xxPoeDC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1255 }
-
-
-catWsC2960s48tsS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1256 }
-
--- Catalyst 2960S 48 Gig Downlinks and 2 SFP uplink, Non-stackable module
-
-catWsC2960s24tsS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1257 }
-
--- Catalyst 2960S 24 Gig Downlinks and 2 SFP uplink, Non-stackable module
-
-catWsC2960s48fpdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1258 }
-
--- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 740W
-
-catWsC2960s48ldpL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1259 }
-
--- Catalyst 2960S 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 370W
-
-catWsC2960s48tdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1260 }
-
--- Catalyst 2960S 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
-
-catWsC2960s24pdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1261 }
-
--- Catalyst 2960S 24 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 370W
-
-catWsC2960s24tdL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1262 }
-
--- Catalyst 2960S 24 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
-
-catWsC2960s48fpsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1263 }
-
--- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 740W
-
-catWsC2960s48lpsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1264 }
-
--- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 370W
-
-catWsC2960s24psL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1265 }
-
--- Catalyst 2960S 24 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 370W
-
-catWsC2960s48tsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1266 }
-
--- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module
-
-catWsC2960s24tsL  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1267 }
-
--- Catalyst 2960S 24 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module
-
-cisco1906CK9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1268 }
-
--- Cisco 1906C/K9 router  with 2 GE, Serial 1T, 1 EHWIC, 256 MB flash memory, 512 MB DRAM
-
-ciscoAIRAP1042  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1269 }
-
-
-ciscoAIRAP1041  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1270 }
-
-
-cisco887VaM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1271 }
-
-
-cisco867Va  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1272 }
-
-
-cisco886Va  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1273 }
-
-
-cisco887Va  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1274 }
-
-
-ciscoASASm1sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1275 }
-
-
-ciscoASASm1sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1276 }
-
-
-ciscoASASm1  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1277 }
-
-
-cat2960cPD8TT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1278 }
-
-
-ciscoAirCt2504K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1279 }
-
--- Szabla: Cisco 2500 Series Wireless LAN Controller
-
-ciscoISMAXP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1280 }
-
--- Cisco Application Extension Platform Internal Service Module (ISM) with Services Ready Engine (SRE) for ISR routers
-
-ciscoSMAXP  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1281 }
-
--- Cisco Application Extension Platform Service Module (SM) with Services Ready Engine (SRE) for ISR routers
-
-ciscoAxpSmSre900  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1282 }
-
--- Cisco Application Extension Platform Service Module (SM) with Services Ready Engine (SM-SRE-900-K9) for ISR routers
-
-ciscoAxpSmSre700  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1283 }
-
--- Cisco Application Extension Platform Service Module (SM) with Services Ready Engine (SM-SRE-700-K9) for ISR routers
-
-ciscoAxpIsmSre300  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1284 }
-
--- Cisco Application Extension Platform Internal Service Module (ISM) with Services Ready Engine (ISM-SRE-300-K9) for ISR routers
-
-ciscoCDSAVSM  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1285 }
-
--- Cisco Content Delivery System Model AVSM line card
-
-cat4507rpluse  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1286 }
-
-
-cat4510rpluse  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1287 }
-
-
-ciscoAxpNme302  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1288 }
-
--- Cisco Application Extension Platform Network Module Enhanced (NME-APPRE-302-K9) for ISR routers
-
-ciscoAxpNme502  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1289 }
-
--- Cisco Application Extension Platform Network Module Enhanced (NME-APPRE-502-K9) for ISR routers
-
-ciscoAxpNme522  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1290 }
-
--- Cisco Application Extension Platform Network Module Enhanced (NME-APPRE-522-K9) for ISR routers
-
-ciscoACE20K9  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1291 }
-
--- Application Control Engine Module in Cat6500
-
-ciscoWsC236048tdS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1292 }
-
-
-ciscoWiSM2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1293 }
-
-
-ciscoCDScde250  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1294 }
-
--- Cisco Content Delivery System Model CDE-250
-
-cisco7500Wlc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1295 }
-
-
-ciscoAnmVirtualApp  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1296 }
-
--- Cisco Application Networking Manager Virtual Appliance
-
-ciscoECDS3100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1297 }
-
--- Cisco Enterprise Content Delivery System Model ECDS-3100
-
-ciscoECDS1100  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1298 }
-
--- Cisco Enterprise Content Delivery System Model ECDS-1100
-
-cisco881G2  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1299 }
-
-
-catWsC3750v224fsS  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1300 }
-
-
-ciscoOeVWaas  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1301 }
-
-
-ciscoASA5585Ssp10K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1302 }
-
-
-ciscoASA5585Ssp20K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1303 }
-
-
-ciscoASA5585Ssp40K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1304 }
-
-
-ciscoASA5585Ssp60K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1305 }
-
-
-ciscoASA5585Ssp10K7sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1306 }
-
-
-ciscoASA5585Ssp20K7sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1307 }
-
-
-ciscoASA5585Ssp40K7sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1308 }
-
-
-ciscoASA5585Ssp60K7sc  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1309 }
-
-
-ciscoASA5585Ssp10K7sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1310 }
-
-
-ciscoASA5585Ssp20K7sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1311 }
-
-
-ciscoASA5585Ssp40K7sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1312 }
-
-
-ciscoASA5585Ssp60K7sy  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1313 }
-
-
-ciscoSreSmNam  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1314 }
-
--- Cisco Network Analysis Module (NAM) on SM-SRE
-
-cat2960cPD8PT  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1315 }
-
-
-cat2960cG8TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1316 }
-
-
-cat3560cG8PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1317 }
-
-
-cat3560cG8TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1318 }
-
-
-ciscoIE301016S8PC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1319 }
-
-
-ciscoIE301024TC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1320 }
-
-
-ciscoRAIE1783RMSB10T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1321 }
-
-
-ciscoRAIE1783RMSB06T  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1322 }
-
-
-ciscoASA5585SspIps10K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1323 }
-
-
-ciscoASA5585SspIps20K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1324 }
-
-
-ciscoASA5585SspIps40K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1325 }
-
-
-ciscoASA5585SspIps60K7  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1326 }
-
-
-catalyst4948ef10GE  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1327 }
-
-
-cat292824TCC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1328 }
-
-
-cat292848TCC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1329 }
-
-
-cat292824LTC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1330 }
-
-
-ciscoCrs16SB  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1331 }
-
-
-ciscoQuad  OBJECT IDENTIFIER
-    ::= { ciscoProducts 1332 }
-
-
-ciscoPwrC2935PoeAC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 9998 }
-
-
-ciscoPwrC2935PoeDC  OBJECT IDENTIFIER
-    ::= { ciscoProducts 9999 }
+catalyst8510msr OBJECT IDENTIFIER ::= { ciscoProducts 230 }		-- Catalyst ATM 8510 Multiservice Switching Router 
+catalyst8515msr OBJECT IDENTIFIER ::= { ciscoProducts 231 }		-- Catalyst ATM 8515 Multiservice Switching Router
+ciscoIGX8410 OBJECT IDENTIFIER ::= { ciscoProducts 232 }		-- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with 8 slots 
+ciscoIGX8420 OBJECT IDENTIFIER ::= { ciscoProducts 233 }		-- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with 16 slots 
+ciscoIGX8430 OBJECT IDENTIFIER ::= { ciscoProducts 234 }		-- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with 32 slots
+ciscoIGX8450 OBJECT IDENTIFIER ::= { ciscoProducts 235 }		-- Cisco IGX8400 (Integrated Gigabit eXchange) series wide-area switch with integrated MGX feeder 
+ciscoBPX8620 OBJECT IDENTIFIER ::= { ciscoProducts 237 }		-- Cisco BPX8600 (Broadband Packet eXchange) series basic wide-area switch with 15 slots
+ciscoBPX8650 OBJECT IDENTIFIER ::= { ciscoProducts 238 }		-- Cisco BPX8600 (Broadband Packet eXchange) series wide-area switch with integrated tag switching controller and 15 slots 
+ciscoBPX8680 OBJECT IDENTIFIER ::= { ciscoProducts 239 }		-- Cisco BPX8600 (Broadband Packet eXchange) series wide-area switch with integrated MGX feeder and 15 slots 
+ciscoCacheEngine OBJECT IDENTIFIER ::= { ciscoProducts 240 }		-- Cisco Cache Engine
+ciscoCat6000 OBJECT IDENTIFIER ::= { ciscoProducts 241 }		-- Cisco Catalyst 6000 
+ciscoBPXSes OBJECT IDENTIFIER ::= { ciscoProducts 242 }		-- Cisco BPX (Broadband Packet eXchange) Service Expansion Slot controller
+ciscoIGXSes OBJECT IDENTIFIER ::= { ciscoProducts 243 }		-- Cisco IGX (Integrated Gigabit eXchange) Service Expansion Slot controller/feeder, used in IGX8410/IGX8420/IGX8430 switches. 
+ciscoLocalDirector OBJECT IDENTIFIER ::= { ciscoProducts 244 }	-- Cisco Local Director
+cisco805 OBJECT IDENTIFIER ::= { ciscoProducts 245 }			-- Cisco 800 platform with 1 ethernet and 1 serial WIC 
+catalyst3508GXL OBJECT IDENTIFIER ::= { ciscoProducts 246 }		-- Cisco Catalyst 3508G-XL switch with 8 GBIC Gigabit ports, can run Standard or Enterprise edition software. 
+catalyst3512XL OBJECT IDENTIFIER ::= { ciscoProducts 247 }		-- Cisco Catalyst 3512XL switch with 12 10/100BaseTX ports and 2 GBIC Gigabit ports, can run Standard or Enterprise edition software. 
+catalyst3524XL OBJECT IDENTIFIER ::= { ciscoProducts 248 }		-- Cisco Catalyst 3524XL switch with 24 10/100BaseTX ports and 2 GBIC Gigabit ports, can run Standard or Enterprise edition software. 
+cisco1407 OBJECT IDENTIFIER ::= { ciscoProducts 249 }			-- Cisco 1400 series router with 1 Ethernet and 1 ADSL interface, with 1407 chipset
+cisco1417 OBJECT IDENTIFIER ::= { ciscoProducts 250 }			-- Cisco 1400 series router with 1 Ethernet and 1 ADSL interface, with 1417 chipset 
+cisco6100 OBJECT IDENTIFIER ::= { ciscoProducts 251 }			-- Cisco 6100 DSLAM Chassis
+cisco6130 OBJECT IDENTIFIER ::= { ciscoProducts 252 }			-- Cisco 6130 DSLAM Chassis
+cisco6260 OBJECT IDENTIFIER ::= { ciscoProducts 253 }			-- Cisco 6260 DSLAM Chassis
+ciscoOpticalRegenerator OBJECT IDENTIFIER ::= { ciscoProducts 254 }	-- Cisco Optical Regenerator 
+ciscoUBR924 OBJECT IDENTIFIER ::= { ciscoProducts 255 }		-- Cisco UBR Cable Modem which is a UBR904 with 2 FXS Voice ports 
+ciscoWSX6302Msm OBJECT IDENTIFIER ::= { ciscoProducts 256 }             -- Catalyst 6000 or 6500 Series Multilayer Switch Module WS-X6302-MSM that directly interfaces to the switch's backplane to provide layer 3 switching.
+catalyst5kRsfc OBJECT IDENTIFIER ::= { ciscoProducts 257 }		-- Router Switching Feature Card for the Catalyst 5000 that is treated as a standalone system by the NMS 
+catalyst6kMsfc  OBJECT IDENTIFIER ::= { ciscoProducts 258 }      -- Multilevel Switching Feature Card for Catalyst 6000 that is treated as a standalone system by the NMS
+cisco7120Quadt1 OBJECT IDENTIFIER ::= { ciscoProducts 259 }		-- 7120 Series chassis with 2 10/100 FE interfaces, 4 T1/E1 interfaces 
+cisco7120T3 OBJECT IDENTIFIER ::= { ciscoProducts 260 }		-- 7120 Series chassis with 2 10/100 FE interfaces, 1 T3 interface 
+cisco7120E3 OBJECT IDENTIFIER ::= { ciscoProducts 261 }		-- 7120 Series chassis with 2 10/100 FE interfaces, 1 E3 interface 
+cisco7120At3 OBJECT IDENTIFIER ::= { ciscoProducts 262 }		-- 7120 Series chassis with 2 10/100 FE interfaces, 1 T3 ATM interface 
+cisco7120Ae3 OBJECT IDENTIFIER ::= { ciscoProducts 263 }		-- 7120 Series chassis with 2 10/100 FE interfaces, 1 E3 ATM interface 
+cisco7120Smi3 OBJECT IDENTIFIER ::= { ciscoProducts 264 }		-- 7120 Series chassis with 2 10/100 FE interfaces, 1 OC3SMI ATM interface 
+cisco7140Dualt3 OBJECT IDENTIFIER ::= { ciscoProducts 265 }		-- 7140 Series chassis with 2 10/100 FE interfaces, 2 T3 interfaces 
+cisco7140Duale3 OBJECT IDENTIFIER ::= { ciscoProducts 266 }		-- 7140 Series chassis with 2 10/100 FE interfaces, 2 E3 interfaces 
+cisco7140Dualat3 OBJECT IDENTIFIER ::= { ciscoProducts 267 }		-- 7140 Series chassis with 2 10/100 FE interfaces, 2 T3 ATM interfaces 
+cisco7140Dualae3 OBJECT IDENTIFIER ::= { ciscoProducts 268 }		-- 7140 Series chassis with 2 10/100 FE interfaces, 2 E3 ATM interfaces 
+cisco7140Dualmm3 OBJECT IDENTIFIER ::= { ciscoProducts 269 }		-- 7140 Series chassis with 2 10/100 FE interfaces, 2 OC3MM ATM interfaces 
+cisco827QuadV OBJECT IDENTIFIER ::= { ciscoProducts 270 }		-- Cisco 800 platform with 1 ethernet, 1 ADSL DMT issue 2, and 4 voice POTS FXS ports
+ciscoUBR7246VXR OBJECT IDENTIFIER ::= { ciscoProducts 271 }           -- Cisco 7246 Universal Broadband Router, VXR series
+cisco10400 OBJECT IDENTIFIER ::= { ciscoProducts 272 }		-- Cisco 10000 platform with 10 slots
+cisco12016 OBJECT IDENTIFIER ::= { ciscoProducts 273 }		-- Cisco 12000 platform with 16 slots
+ciscoAs5400 OBJECT IDENTIFIER ::= { ciscoProducts 274 }		-- Cisco AS5400 platform
+cat2948gL3 OBJECT IDENTIFIER ::= { ciscoProducts 275 }		-- Cisco Catalyst WS-C2948G-L3 48 port 10/100 Layer 3 switch with 2 GBIC ports
+cisco7140Octt1 OBJECT IDENTIFIER ::= { ciscoProducts 276 }		-- 7140 Series chassis with 8 integrated T1/E1 serial ports
+cisco7140Dualfe OBJECT IDENTIFIER ::= { ciscoProducts 277 }		-- 7140 Series chassis with 2 integrated 10/100 FE interfaces
+cat3548XL OBJECT IDENTIFIER ::= { ciscoProducts 278 }			-- Catalyst 3548XL switch (WS-C3548-XL)
+ciscoVG200 OBJECT IDENTIFIER ::= { ciscoProducts 279 }		-- Cisco Voice Gateway 200 controlled by Cisco Call Manager
+cat6006 OBJECT IDENTIFIER ::= { ciscoProducts 280 }			-- Catalyst 6000 with 6 slots
+cat6009 OBJECT IDENTIFIER ::= { ciscoProducts 281 }			-- Catalyst 6000 with 9 slots
+cat6506 OBJECT IDENTIFIER ::= { ciscoProducts 282 }			-- Catalyst 6000 Plus with 6 slots
+cat6509 OBJECT IDENTIFIER ::= { ciscoProducts 283 }			-- Catalyst 6000 Plus with 9 slots
+cisco827 OBJECT IDENTIFIER ::= { ciscoProducts 284 }			-- Cisco 800 platform with 1 ethernet, 1 ADSL DMT issue 2
+ciscoManagementEngine1100 OBJECT IDENTIFIER ::= { ciscoProducts 285 }	-- Cisco Management Engine 1100 for doing distributed SNMP polling
+ciscoMc3810V3 OBJECT IDENTIFIER ::= { ciscoProducts 286 }		-- Cisco MC3810-V3, capable of data, voice and video.  Supports 2 additional ports than the MC3810-V, used for optional access cards.
+cat3524tXLEn OBJECT IDENTIFIER ::= { ciscoProducts 287 }		-- Cisco Catalyst 3524 switch (WS-C3524T-XL-EN) with 24 10/100 ports and 2 GBIC gigabit ports.  Runs Enterprise edition software and provides telephony power to attached IP telephones
+cisco7507z OBJECT IDENTIFIER ::= { ciscoProducts 288 }		-- Cisco 7507z chassis, Czbus capable, 7 slots
+cisco7513z OBJECT IDENTIFIER ::= { ciscoProducts 289 }		-- Cisco 7513z chassis, Czbus capable, 13 slots
+cisco7507mx OBJECT IDENTIFIER ::= { ciscoProducts 290 }		-- Cisco 7507mx chassis, Czbus capable, TDM (Time Division Multiplexing) backplane support, 7 slots
+cisco7513mx OBJECT IDENTIFIER ::= { ciscoProducts 291 }		-- Cisco 7513mx chassis, Czbus capable, TDM (Time Division Multiplexing) backplane support, 13 slots
+ciscoUBR912C OBJECT IDENTIFIER ::= { ciscoProducts 292 }		-- Cisco uBR912-C Cable Modem with CSU/DSU WIC
+ciscoUBR912S OBJECT IDENTIFIER ::= { ciscoProducts 293 }		-- Cisco uBR912-S Cable Modem with Serial WIC
+ciscoUBR914 OBJECT IDENTIFIER ::= { ciscoProducts 294 }		-- Cisco uBR914 Cable Modem with removable WIC
+cisco802J OBJECT IDENTIFIER ::= { ciscoProducts 295 }			-- Cisco 800 platform with 1 ethernet, 1 BRI S/T, and 1 Japanese BRI U
+cisco804J OBJECT IDENTIFIER ::= { ciscoProducts 296 }			-- Cisco 800 platform with 1 ethernet, 2 POTS, 1 BRI/ST, and 1 Japanese BRI U
+cisco6160 OBJECT IDENTIFIER ::= { ciscoProducts 297 }			-- Cisco 6160 DSLAM chassis
+cat4908gL3 OBJECT IDENTIFIER ::= { ciscoProducts 298 }		-- Catalyst 4908G-L3 (WS-C4908G-L3) Mid-range fixed configuration layer 3 switch with 6 GBIC based Gigabit Ethernet ports
+cisco6015 OBJECT IDENTIFIER ::= { ciscoProducts 299 }			-- Cisco 6015 DSLAM chassis
+cat4232L3 OBJECT IDENTIFIER ::= { ciscoProducts 300 }		-- Cisco Catalyst 4232-L3 layer 3 line card that is treated as a standalone system by the NMS
+catalyst6kMsfc2  OBJECT IDENTIFIER ::= { ciscoProducts 301 }      -- Multilevel Switching Feature Card Version 2 for Catalyst 6000 that is treated as a standalone system by the NMS
+cisco7750Mrp200 OBJECT IDENTIFIER ::= { ciscoProducts 302 }			-- Cisco ICS 7750 Multiservice Route Processor 200
+cisco7750Ssp80 OBJECT IDENTIFIER ::= { ciscoProducts 303 }			-- Cisco ICS 7750 System Switch Processor 80
+ciscoMGX8230 OBJECT IDENTIFIER ::= { ciscoProducts 304 }		-- Multi Service Switch with 16 half-height slots 
+ciscoMGX8250 OBJECT IDENTIFIER ::= { ciscoProducts 305 }		-- Multi Service Switch with 32 half-height slots 
+ciscoCVA122 OBJECT IDENTIFIER ::= { ciscoProducts 306 }		-- Cisco CVA122 Cable Voice Adapter (Residential Cable Modem with two Voice Ports) 
+ciscoCVA124 OBJECT IDENTIFIER ::= { ciscoProducts 307 }		-- Cisco CVA124 Cable Voice Adapter (Residential Cable Modem with four Voice Ports)
+ciscoAs5850 OBJECT IDENTIFIER ::= { ciscoProducts 308 }		-- High End Dial Access Server
+cat6509Sp OBJECT IDENTIFIER ::= { ciscoProducts 310 }		-- 9-slot Constellation+ vertical slot chassis
+ciscoMGX8240 OBJECT IDENTIFIER ::= { ciscoProducts 311 }	-- High Density Circuit Emulation Service Gateway for Private Line Service
+cat4840gL3 OBJECT IDENTIFIER ::= { ciscoProducts 312 }		--  Catalyst 4840G-L3 (WS-C4840G) Layer 3 Ethernet Switching System with Server Load Balancing
+ciscoAS5350 OBJECT IDENTIFIER ::= { ciscoProducts 313 }		--  Cisco low end Access server platform
+cisco7750 OBJECT IDENTIFIER ::= { ciscoProducts 314 }		--  Cisco Integrated Communication System (ICS) 7750
+ciscoMGX8950 OBJECT IDENTIFIER ::= { ciscoProducts 315 }		--  Multiservice Gigabit Switch(180Gb switch) with 32 half height slots 
+ciscoUBR925 OBJECT IDENTIFIER ::= { ciscoProducts 316 }		-- Cisco UBR925 Cable Modem/Router with VOIP and hardware accelerated IPSEC
+ciscoUBR10012 OBJECT IDENTIFIER ::= { ciscoProducts 317 }	-- Cisco uBR10000 platform with 8 broadband slots and 4 WAN slots
+catalyst4kGateway OBJECT IDENTIFIER ::= { ciscoProducts 318 }	-- Catalyst 4000 Access Gateway line card supporting voice and WAN (Wide Area Network) interfaces as well as conferencing and transcoding services for operation with the Cisco Call Manager
+cisco2650 OBJECT IDENTIFIER ::= { ciscoProducts 319 }		-- c2650 platform with 1 integrated fast ethernet interface 
+cisco2651 OBJECT IDENTIFIER ::= { ciscoProducts 320 }		-- c2650 platform with 2 integrated fast ethernet interfaces	
+cisco826QuadV OBJECT IDENTIFIER ::= { ciscoProducts 321 }	-- Cisco 800 platform with 1 ethernet, 1 ADSL over ISDN and 4 voice POTS FXS ports
+cisco826 OBJECT IDENTIFIER ::= { ciscoProducts 322 }		-- Cisco 800 platform with 1 ethernet, 1 ADSL over ISDN 
+catalyst295012 OBJECT IDENTIFIER ::= { ciscoProducts 323 }	-- Cisco Catalyst c2950 switch  with 12 10/100BaseTX ports (WS-c2950-12)
+catalyst295024 OBJECT IDENTIFIER ::= { ciscoProducts 324 }	-- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports (WS-c2950-24)
+catalyst295024C OBJECT IDENTIFIER ::= { ciscoProducts 325 }	-- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 100BASE-FX uplink ports (WS-c2950C-24)
+cisco1751 OBJECT IDENTIFIER ::= { ciscoProducts 326 }		-- Digital voice capable Cisco 1700 platform with 2 WIC/VIC slots and 1 VIC-only slot 
+cisco1730Iad8Fxs OBJECT IDENTIFIER ::= { ciscoProducts 327 }	-- Cisco 1700 class IAD (Integrated Access Device) with 8 FXS (Foreign Exchange Station) ports and DSL (Digital Subscriber Line) WIC
+cisco1730Iad16Fxs OBJECT IDENTIFIER ::= { ciscoProducts 328 }	-- Cisco 1700 class IAD (Integrated Access Device) with 16 FXS (Foreign Exchange Station) ports and DSL (Digital Subscriber Line) WIC
+cisco626 OBJECT IDENTIFIER ::= { ciscoProducts 329 }		-- Cisco 600 DSL CPE pltaform with ADSL, DMT issue 1, 25M ATM interface
+cisco627 OBJECT IDENTIFIER ::= { ciscoProducts 330 }		-- Cisco 600 DSL CPE pltaform with ADSL, DMT issue 2, 25M ATM interface
+cisco633 OBJECT IDENTIFIER ::= { ciscoProducts 331 }		-- Cisco 600 DSL CPE platform with SDSL, 2B1Q line coding, serial interface (V.35/X.21)
+cisco673 OBJECT IDENTIFIER ::= { ciscoProducts 332 }		-- Cisco 600 DSL CPE platform with SDSL, 2B1Q line coding, ethernet interface
+cisco675 OBJECT IDENTIFIER ::= { ciscoProducts 333 }		-- Cisco 600 DSL CPE platform with ADSL, CAP, ethernet interface, POTS connector
+cisco675e OBJECT IDENTIFIER ::= { ciscoProducts 334 }		-- Cisco 600 DSL CPE platform with ADSL, CAP, ethernet interface, universal power supply
+cisco676 OBJECT IDENTIFIER ::= { ciscoProducts 335 }		-- Cisco 600 DSL CPE platform with ADSL, DMT issue 1, ethernet interface
+cisco677 OBJECT IDENTIFIER ::= { ciscoProducts 336 }		-- Cisco 600 DSL CPE platform with ADSL, DMT issue 2, ethernet interface
+cisco678 OBJECT IDENTIFIER ::= { ciscoProducts 337 }		-- Cisco 600 DSL CPE platform with ADSL, CAP/DMT/G.Lite, ethernet interface
+cisco3661Ac OBJECT IDENTIFIER ::= { ciscoProducts 338 }		-- 1 Fast Ethernet version of c3660 with a AC power supply
+cisco3661Dc OBJECT IDENTIFIER ::= { ciscoProducts 339 }		-- 1 Fast Ethernet version of c3660 with a DC power supply
+cisco3662Ac OBJECT IDENTIFIER ::= { ciscoProducts 340 }		-- 2 Fast Ethernet version of c3660 with a AC power supply
+cisco3662Dc OBJECT IDENTIFIER ::= { ciscoProducts 341 }		-- 2 Fast Ethernet version of c3660 with a DC power supply
+cisco3662AcCo OBJECT IDENTIFIER ::= { ciscoProducts 342 }		-- 2 Fast Ethernet version of c3660 with a AC power supply for Telco's
+cisco3662DcCo OBJECT IDENTIFIER ::= { ciscoProducts 343 }		-- 2 Fast Ethernet version of c3660 with a DC power supply for Telco's
+ciscoUBR7111 OBJECT IDENTIFIER ::= { ciscoProducts 344 }	-- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC11C) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
+ciscoUBR7111E OBJECT IDENTIFIER ::= { ciscoProducts 345 }	-- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC11E) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
+ciscoUBR7114 OBJECT IDENTIFIER ::= { ciscoProducts 346 }	-- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC14C) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
+ciscoUBR7114E OBJECT IDENTIFIER ::= { ciscoProducts 347 }	-- Low-end version of the Universal Broadband Router with 1 PA slot, 1 fixed RF line card (MC14E) and integrated upconvertor, designed for hotels, MDUs and smaller cable operators
+cisco12010 OBJECT IDENTIFIER ::= { ciscoProducts 348 }	-- Cisco 12000 platform with 10 slots
+cisco8110 OBJECT IDENTIFIER ::= { ciscoProducts 349 }	-- Cisco 8110 (ATM network termination device) with 3 Line Interface module slots
+cisco8120 OBJECT IDENTIFIER ::= { ciscoProducts 350 }	-- Cisco 8120 (ATM network termination device) with 3 Line Interface module(LIM) slots, and 2 Wan Interface Card (WIC)
+ciscoUBR905 OBJECT IDENTIFIER ::= { ciscoProducts 351 }	-- Cisco uBR905 Cable Modem with hardware accelerated IPSEC
+ciscoIDS OBJECT IDENTIFIER ::= { ciscoProducts 352 }	-- CS IDS is a network-based, real-time intrusion detection system.  The NetRanger system has a distributed architecture and consists of two physical components: the Director, a scalable remote management system, and the Sensor, a high-performance, "plug-and-play" appliance
+ciscoSOHO77 OBJECT IDENTIFIER ::= { ciscoProducts 353 }    -- Cisco SOHO (Small Office Home Office) ADSL Router, 1 Ethernet and 1 ADSL G.992.1 (G.DMT) and G.992.2 (G.Lite) Interface
+ciscoSOHO76 OBJECT IDENTIFIER ::= { ciscoProducts 354 }    -- Cisco SOHO (Small Office Home Office) ADSL over ISDN Router, 1 Ethernet and 1 ADSL ETSI/ITU-T G.992.1 Annex B (G.DMT) Interface
+cisco7150Dualfe OBJECT IDENTIFIER ::= { ciscoProducts 355 }	-- 7150 Series chassis with 2 integrated 10/100 FE interfaces
+cisco7150Octt1 OBJECT IDENTIFIER ::= { ciscoProducts 356 }	-- 7150 Series chassis with 8 integrated T1/E1 serial ports
+cisco7150Dualt3 OBJECT IDENTIFIER ::= { ciscoProducts 357 }	-- 7150 Series chassis with 2 10/100 FE interfaces, 2 T3 interfaces
+ciscoOlympus OBJECT IDENTIFIER ::= { ciscoProducts 358 } 	-- Cisco VPN (Virtual Private Network) Router with  4 10/100/1000 Gigabitethernet integrated interfaces 
+catalyst2950t24 OBJECT IDENTIFIER ::= { ciscoProducts 359 }	-- Cisco Catalyst c2950 switch with 24 10/100BaseT ports and 2 10/100/1000BaseT ports 
+ciscoVPS1110 OBJECT IDENTIFIER ::= { ciscoProducts 360 }	-- Cisco VLAN Policy Server 1110 manages VLAN-based policies to control user access to a LAN, leveraging existing authentication mechanisms such as Windows Domain Controllers and Novell's NDS. This policy server is part of CiscoWorks2000 User Registration Tool product.
+ciscoContentEngine OBJECT IDENTIFIER ::= { ciscoProducts 361 }	-- Cisco Content Engine.  The Cisco Content Engine is a Content Networking product that accelerates content delivery, ensuring maximum scalability and availability of content.  The Content Engines offer caching, Content Delivery Network (CDN) services, employee internet management (e.g., URL filtering) and proxy services
+ciscoIAD2420 OBJECT IDENTIFIER ::= { ciscoProducts 362 }	-- Integrated Access Device 2420 (IAD2420) chassis with Analog (8/16) FXS ports with T1 or ADSL (Asymmetrical Digital Subscriber Line) Uplinks
+cisco677i OBJECT IDENTIFIER ::= { ciscoProducts 363 }		-- Cisco 600 DSL CPE platform with ASDL, DMT issue 2 over ISDN, ethernet interface
+cisco674 OBJECT IDENTIFIER ::= { ciscoProducts 364 }		-- Cisco 600 DSL CPE platform with G.SHDSL, ethernet interface
+ciscoDPA7630 OBJECT IDENTIFIER ::= { ciscoProducts 365 }	-- The Cisco Digital PBX Adapter (DPA) enables the integration of Cisco Call Manager with Octel voice mail systems
+catalyst355024 OBJECT IDENTIFIER ::= { ciscoProducts 366 }	--  Catalyst 3550 24 10/100 ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch 
+catalyst355048 OBJECT IDENTIFIER ::= { ciscoProducts 367 }	--  Catalyst 3550 48 10/100 ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch 
+catalyst355012T OBJECT IDENTIFIER ::= { ciscoProducts 368 }	--  Catalyst 3550 12 1000T ports fixed configuration Layer 2/Layer 3 Ethernet Switch
+catalyst2924LREXL OBJECT IDENTIFIER ::= { ciscoProducts 369 }	--  Cisco Catalyst c2924XL switch (WS-C2924-LRE-XL) with 24 10BaseS VDSL ports and 4 10/100BaseTX ports
+catalyst2912LREXL OBJECT IDENTIFIER ::= { ciscoProducts 370 }	--  Cisco Catalyst c2912XL switch (WS-C2912-LRE-XL) with 12 10BaseS VDSL ports and 4 10/100BaseTX ports
+ciscoCVA122E OBJECT IDENTIFIER ::= { ciscoProducts 371 }	-- Cisco CVA122-e Cable Voice Adapter(Residential Cable Modem with two voice ports)- European version
+ciscoCVA124E OBJECT IDENTIFIER ::= { ciscoProducts 372 }	-- Cisco CVA124-e Cable Voice Adapter(Residential Cable Modem with four voice ports)- European version
+ciscoURM OBJECT IDENTIFIER ::= { ciscoProducts 373 }		-- Universal Router Module for the IGX platform
+ciscoURM2FE OBJECT IDENTIFIER ::= { ciscoProducts 374 }		-- Universal router module with 2 Fast Ethernet interfaces for IGX platform
+ciscoURM2FE2V OBJECT IDENTIFIER ::= { ciscoProducts 375 }	-- Universal Router Module, with 2 Fast Ethernet ports, and 2 digital voice ports (T1 or E1)
+cisco7401VXR OBJECT IDENTIFIER ::= { ciscoProducts 376 }	-- Cisco 7400 Family, 1 Slot router 
+cisco951 OBJECT IDENTIFIER ::= { ciscoProducts 377 }		-- VOFDM and DOCSIS based wireless access router with 1 ethernet interface, and 1 wireless interface
+cisco952 OBJECT IDENTIFIER ::= { ciscoProducts 378 }		-- VOFDM and DOCSIS based wireless access router with 1 ethernet interface, 1 wireless interface, and 2 POTS voice ports
+ciscoCAP340 OBJECT IDENTIFIER ::= { ciscoProducts 379 }		-- Aironet Wireless LAN Access Point 340 series
+ciscoCAP350 OBJECT IDENTIFIER ::= { ciscoProducts 380 }		-- Cisco Wireless LAN Access Point 350 series 
+ciscoDPA7610 OBJECT IDENTIFIER ::= { ciscoProducts 381 }	-- The Cisco Digital PBX Adapter (DPA) enables the integration of Cisco Call Manager with Octel voice mail systems.
+cisco828	OBJECT IDENTIFIER ::= { ciscoProducts 382 }	-- Cisco 800 platform with 1 Ethernet, 1 G.991.2 (G.shdsl) Interface, data only model
+ciscoSOHO78	OBJECT IDENTIFIER ::= { ciscoProducts 383 }	-- SOHO (Small Office Home Office) G.SHDSL Router, 1 Ethernet and 1 G.991.2 (G.shdsl) Interface, data only model
+cisco806	OBJECT IDENTIFIER ::= { ciscoProducts 384 }	-- Cisco SOHO (Small Office Home Office) router with 4 hubbed 10BaseT Ethernet LAN interfaces and 1 10BaseT Ethernet WAN interface
+cisco12416	OBJECT IDENTIFIER ::= { ciscoProducts 385 }	-- Cisco 12000 platform with 16 slots and 10G fabric card 
+cat2948gL3Dc    OBJECT IDENTIFIER ::= { ciscoProducts 386 }     -- A fixed-configuration Layer 3 Ethernet switch featuring IP, IPX, and IP mulitcast with 48 10/100BaseTX ports using DC power
+cat4908gL3Dc    OBJECT IDENTIFIER ::= { ciscoProducts 387 }     -- A fixed-configuration L3 Ethernet switch featuring IP,IPX and IP multicast with 8 GBIC ports using DC power
+cisco12406      OBJECT IDENTIFIER ::= { ciscoProducts 388 }     -- Cisco 12400 platform with 6 slots
+ciscoPIXFirewall506	OBJECT IDENTIFIER ::= { ciscoProducts 389 }	-- Cisco PIX Firewall 506
+ciscoPIXFirewall515	OBJECT IDENTIFIER ::= { ciscoProducts 390 }	-- Cisco PIX Firewall 515
+ciscoPIXFirewall520	OBJECT IDENTIFIER ::= { ciscoProducts 391 }	-- Cisco PIX Firewall 520
+ciscoPIXFirewall525	OBJECT IDENTIFIER ::= { ciscoProducts 392 }	-- Cisco PIX Firewall 525
+ciscoPIXFirewall535	OBJECT IDENTIFIER ::= { ciscoProducts 393 }	-- Cisco PIX Firewall 535
+cisco12410		OBJECT IDENTIFIER ::= { ciscoProducts 394 }	-- Cisco 12410 platform with 10 slots
+cisco811		OBJECT IDENTIFIER ::= { ciscoProducts 395 }	-- ISDN router for Japan with 1 10BaseT Ethernet port, 1 ISDN BRI(Basic Rate Interface) U, integrated DSU(Data Service Unit)
+cisco813		OBJECT IDENTIFIER ::= { ciscoProducts 396 }	-- ISDN router forJapan with 10 BaseT 4 ports hub , 1 ISDN BRI(Basic Rate Interface) U, integrated DSU(Data Service Unit) and 2 RJ-11
+cisco10720		OBJECT IDENTIFIER ::= { ciscoProducts 397 }	-- IP + Optical Access Router
+ciscoMWR1900		OBJECT IDENTIFIER ::= { ciscoProducts 398 }	-- The Mobile Wireless router is a router targeted at application in a cell site Base Transciever Station (BTS) providing T1/E1 backhaul connections to the aggregation node in Radio Access Networks (RAN)
+cisco4224		OBJECT IDENTIFIER ::= { ciscoProducts 399 }	-- A standalone 24 port powered Ethernet switch, router and voice gateway
+ciscoWSC6513		OBJECT IDENTIFIER ::= { ciscoProducts 400 }	-- Catalyst 6000 series chassis with 13 slots 
+cisco7603		OBJECT IDENTIFIER ::= { ciscoProducts 401 }	-- Cisco Optical Services Router 7600 Series Chassis with 3 slots 
+cisco7606		OBJECT IDENTIFIER ::= { ciscoProducts 402 }	-- Cisco Optical Services Router 7600 Series Chassis with 6 slots 
+cisco7401ASR		OBJECT IDENTIFIER ::= { ciscoProducts 403 }	-- Cisco 7400 platform, ASR series with 1 slot 
+ciscoVG248		OBJECT IDENTIFIER ::= { ciscoProducts 404 }	-- Cisco VoIP Voice Gateway for connecting analog telephones fax machines to a Cisco Call Manager based system 
+ciscoHSE		OBJECT IDENTIFIER ::= { ciscoProducts 405 }	-- Cisco Hosting Solution Engine 1105 manages Cisco powered data centers and Points of Presence with routers, switches, server load balancers, firewalls, intrusion detection systems and other layer 4-7 content delivery products
+ciscoONS15540ESP	OBJECT IDENTIFIER ::= { ciscoProducts 406 }	-- Cisco ONS 15540 Extended Services Platform
+ciscoSN5420		OBJECT IDENTIFIER ::= { ciscoProducts 407 }	-- SRBU Storage Router 1 Fiber Channel port, 1 Gigabit Ethernet port 
+ciscoIcs7750Ce300	OBJECT IDENTIFIER ::= { ciscoProducts 408 }	-- Cisco ICS 7750 Content Engine
+ciscoCe507		OBJECT IDENTIFIER ::= { ciscoProducts 409 }	-- Cisco Content Engine Model 507
+ciscoCe560		OBJECT IDENTIFIER ::= { ciscoProducts 410 }	-- Cisco Content Engine Model 560
+ciscoCe590		OBJECT IDENTIFIER ::= { ciscoProducts 411 }	-- Cisco Content Engine Model 590
+ciscoCe7320		OBJECT IDENTIFIER ::= { ciscoProducts 412 }	-- Cisco Content Engine Model 7320
+cisco2691		OBJECT IDENTIFIER ::= { ciscoProducts 413 }	-- One Network Module slot, three WIC slot, two Fast Ethernet port MARS router 
+cisco3725		OBJECT IDENTIFIER ::= { ciscoProducts 414 }	-- Two Network Module slot, three WIC slot, two Fast Ethernet port MARS router 
+cisco3640A		OBJECT IDENTIFIER ::= { ciscoProducts 415 }	-- Cisco 3640 4-slot Modular Router
+cisco1760		OBJECT IDENTIFIER ::= { ciscoProducts 416 }	-- Analog/digital voice capable, 19" rack-mount (1RU) Cisco 1700 platform with 2 WIC/VIC slots and 2 VIC-only slots 
+ciscoPIXFirewall501	OBJECT IDENTIFIER ::= { ciscoProducts 417 }	-- Cisco PIX Firewall 501
+cisco2610M		OBJECT IDENTIFIER ::= { ciscoProducts 418 }	-- c2600M with 1 integrated ethernet interface
+cisco2611M		OBJECT IDENTIFIER ::= { ciscoProducts 419 }	-- c2600M with 2 integrated ethernet interfaces
+ciscoGP10		OBJECT IDENTIFIER ::= { ciscoProducts 420 }	-- Cisco GSM Port
+ciscoMC21		OBJECT IDENTIFIER ::= { ciscoProducts 421 }	-- Cisco GSM Mobility Controller
+ciscoSN51		OBJECT IDENTIFIER ::= { ciscoProducts 422 }	-- Cisco GPRS Service Node
+cisco12404		OBJECT IDENTIFIER ::= { ciscoProducts 423 }	-- Cisco 12400 platform with 4 slots
+cisco9004		OBJECT IDENTIFIER ::= { ciscoProducts 424 }	-- Cisco 9000 Chassis
+cisco3631Co		OBJECT IDENTIFIER ::= { ciscoProducts 425 }	-- Two Network Module Slot , two WIC slot, one Fast Ethernet port MARS router 
+catalyst295012G		OBJECT IDENTIFIER ::= { ciscoProducts 427 }	-- Cisco Catalyst c2950 switch with 12 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12) 
+catalyst295024G		OBJECT IDENTIFIER ::= { ciscoProducts 428 }	-- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
+catalyst295048G		OBJECT IDENTIFIER ::= { ciscoProducts 429 }	-- isco Catalyst c2950 switch with 48 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
+catalyst295024S		OBJECT IDENTIFIER ::= { ciscoProducts 430 }	-- Cisco Catalyst c2950 switch with 24 10/100 BaseSX ports (Single Mode) and 2 GBIC (Gigabit Interface Converter) slots (WS-c2950g-12)
+catalyst355012G		OBJECT IDENTIFIER ::= { ciscoProducts 431 }	-- 10 Gig (GBIC) + 2 10/100/1000baseT ports, fixed configuration layer 2/3 Ethernet switch 
+ciscoCE507AV		OBJECT IDENTIFIER ::= { ciscoProducts 432 }	-- Cisco Content Engine Model 507-AV
+ciscoCE560AV		OBJECT IDENTIFIER ::= { ciscoProducts 433 }	-- Cisco Content Engine Model 560-AV
+ciscoIE2105		OBJECT IDENTIFIER ::= { ciscoProducts 434 }	-- The Cisco Intelligence Engine 2100 series is a new form of network device that provides intelligent network interface to applications and users
+ciscoMGX8850Pxm1E	OBJECT IDENTIFIER ::= { ciscoProducts 435 }	-- PXM1E Controller based 32 full-height slot MGX8850 
+cisco3745		OBJECT IDENTIFIER ::= { ciscoProducts 436 }	-- 3700 family four slot modular router 
+cisco10005		OBJECT IDENTIFIER ::= { ciscoProducts 437 }	-- Cisco 10000 platform with 7 slots
+cisco10008		OBJECT IDENTIFIER ::= { ciscoProducts 438 }	-- Cisco 10000 platform with 10 slots 
+cisco7304		OBJECT IDENTIFIER ::= { ciscoProducts 439 }	-- Cisco 7304 Chassis
+ciscoRpmXf		OBJECT IDENTIFIER ::= { ciscoProducts 440 }	-- Chassis for RPM-XF router module 
+ciscoOsm4oc3PosSmIr	OBJECT IDENTIFIER ::= { ciscoProducts 441 }	-- Optical Service Module, 4 port OC3 pos, Singlemode, Intermediate Range with 4 Gigabit Ethernet ports
+ciscoOsm4oc3PosMmSr	OBJECT IDENTIFIER ::= { ciscoProducts 442 }	-- Optical Service Module, 4 port OC3 POS, Multimode, Short Range with 4 Gigabit Ethernet ports
+ciscoOsm4oc3PosSmLr	OBJECT IDENTIFIER ::= { ciscoProducts 443 }	-- Optical Service Module, 4 port OC3 POS, Singlemode, Long Range with 4 Gigabit Ethernet ports
+cisco1721		OBJECT IDENTIFIER ::= { ciscoProducts 444 }	-- Enhanced 1720 with support for onboard Fast Ethernet and 2 WAN Interface cards and optional hardware encryption module 
+cat4000Sup3		OBJECT IDENTIFIER ::= { ciscoProducts 445 }	-- Catalyst 4000 Supervisor III
+cisco827H		OBJECT IDENTIFIER ::= { ciscoProducts 446 }	-- Cisco 800 platform with 4-port 10Base-T Ethernet, and 1 ADSL over POTS Interface, data only model 
+ciscoSOHO77H		OBJECT IDENTIFIER ::= { ciscoProducts 447 }	-- SOHO (Small Office Home Office) Router, 4-port 10Base-T Ethernet, and 1 ADSL over POTS Interface, data only model
+cat4006			OBJECT IDENTIFIER ::= { ciscoProducts 448 }	-- Catalyst 4000 with 6 slots (WS-C4006)
+ciscoWSC6503		OBJECT IDENTIFIER ::= { ciscoProducts 449 }	-- Catalyst 6000 series chassis with 3 slots 
+ciscoPIXFirewall506E	OBJECT IDENTIFIER ::= { ciscoProducts 450 }	-- Cisco PIX Firewall 506E 
+ciscoPIXFirewall515E	OBJECT IDENTIFIER ::= { ciscoProducts 451 }	-- Cisco PIX Firewall 515E
+cat355024Dc		OBJECT IDENTIFIER ::= { ciscoProducts 452 }	-- Catalyst 3550 24 10/100Base-Tx ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch with DC power 
+cat355024Mmf		OBJECT IDENTIFIER ::= { ciscoProducts 453 }	-- Catalyst 3550 24 10/100Mbps Multimode Fiber ports + 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch
+ciscoCE2636		OBJECT IDENTIFIER ::= { ciscoProducts 454 }	-- Cisco Content Engine Module for 26xx and 36xx series platforms
+ciscoDwCE		OBJECT IDENTIFIER ::= { ciscoProducts 455 }	-- Double Wide Cisco Content Engine Module for 26xx
+cisco7750Mrp300		OBJECT IDENTIFIER ::= { ciscoProducts 456 }	-- Cisco ICS 7750 Multiservice Route Processor 300 
+ciscoRPMPR              OBJECT IDENTIFIER ::= { ciscoProducts 457 }      -- For RPM-PR router blade in MGX series switch
+cisco14MGX8830Pxm1E     OBJECT IDENTIFIER ::= { ciscoProducts 458 }     -- PXM1E Controller based 14 slot MGX8830 
+ciscoWlse               OBJECT IDENTIFIER ::= { ciscoProducts 459 }     -- Wireless LAN Solution Engine 
+ciscoONS15530		OBJECT IDENTIFIER ::= { ciscoProducts 460 }	-- Cisco ONS 15530 platform
+ciscoONS15530NEBS       OBJECT IDENTIFIER ::= { ciscoProducts 461 }     -- Cisco ONS 15530 Chassis, NEBS compliant
+ciscoONS15530ETSI       OBJECT IDENTIFIER ::= { ciscoProducts 462 }     -- Cisco ONS 15530 Chassis, ETSI compliant
+ciscoSOHO71             OBJECT IDENTIFIER ::= { ciscoProducts 463 }     -- Cisco SOHO Platform(Small Office Home Office) router having 10BaseT 4 ports hubed Ethernet LAN interface and 1 10BaseT Ethernet WAN Interface
+cisco6400UAC            OBJECT IDENTIFIER ::= { ciscoProducts 464 }     -- Cisco 6400 Universal Access Concentrator
+ciscoAIRAP1200		OBJECT IDENTIFIER ::= { ciscoProducts 474 }	-- 1200 series WLAN Access Point with 1 10/100TX port, 1 CardBus slot, 1 Mini PCI slot
+ciscoSN5428		OBJECT IDENTIFIER ::= { ciscoProducts 475 }	-- Storage Networking 5428 storage router with 2 SFP (Small Form  Factor Pluggable) GBIC Gigabit Ethernet ports and 8 SFP GBIC Fibre Channel ports 
+cisco2610XM             OBJECT IDENTIFIER ::= { ciscoProducts 466 }     -- Cisco c2610XM platform 1 integrated fast ethernet interface with SDRAM
+cisco2611XM             OBJECT IDENTIFIER ::= { ciscoProducts 467 }     -- Cisco c2611XM platform 2 integrated fast ethernet interfaces with SDRAM
+cisco2620XM             OBJECT IDENTIFIER ::= { ciscoProducts 468 }     -- Cisco c2620XM platform 1 integrated fast ethernet interface with SDRAM
+cisco2621XM             OBJECT IDENTIFIER ::= { ciscoProducts 469 }     -- Cisco c2621XM platform 2 integrated fast ethernet interfaces with SDRAM
+cisco2650XM             OBJECT IDENTIFIER ::= { ciscoProducts 470 }     -- Cisco c2650XM platform 1 integrated fast ethernet interface with SDRAM
+cisco2651XM             OBJECT IDENTIFIER ::= { ciscoProducts 471 }     -- Cisco c2651XM platform 2 integrated fast ethernet interfaces with SDRAM
+catalyst295024GDC	OBJECT IDENTIFIER ::= { ciscoProducts 472 }	-- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 GBIC (Gigabit Interface Converter) slots and DC power(WS-c2950G-24-DC)
+cisco7301		OBJECT IDENTIFIER ::= { ciscoProducts 476 }	-- Cisco 7300 platform, 1 Rack Unit (RU) application specific router with 1 slot 
+cisco12816		OBJECT IDENTIFIER ::= { ciscoProducts 477 }	-- Cisco 12816 platform with 16 slots and 40G fabric card
+cisco12810		OBJECT IDENTIFIER ::= { ciscoProducts 478 }	-- Cisco 12810 platform with 10 slots and 40G fabric card
+cisco3250		OBJECT IDENTIFIER ::= { ciscoProducts 479 }	-- cisco 3250 mobile Router
+catalyst295024SX 	OBJECT IDENTIFIER ::= { ciscoProducts 480 }	-- Cisco Catalyst c2950 switch with 24 10/100 BaseTX ports and 2 fixed 1000Base Multimode fiber (SX) ports 
+ciscoONS15540ESPx	OBJECT IDENTIFIER ::= { ciscoProducts 481 }	-- Cisco ONS 15540 Extended Services Platform with external optical patch system
+catalyst295024LRESt	OBJECT IDENTIFIER ::= { ciscoProducts 482 }	-- Cisco Catalyst c2950 switch with 24 10BaseS VDSL Ports and 2 ST ( SFP or 10/100/1000 Base T) (WS-C2950ST-24-LRE)
+catalyst29508LRESt	OBJECT IDENTIFIER ::= { ciscoProducts 483 }	-- Cisco Catalyst c2950 switch with 8 10BaseS VDSL Ports and 2 ST (SFP or 10/100/1000 Base T) (WS-C2950ST-8-LRE)
+catalyst295024LREG	OBJECT IDENTIFIER ::= { ciscoProducts 484 }	-- Cisco Catalyst c2950 switch with 24 10BaseS VDSL Ports and 2 GBIC ( Gigabit Interface Converter ) slots (WS-C2950G-24-LRE)
+catalyst355024PWR	OBJECT IDENTIFIER ::= { ciscoProducts 485 } 	-- Catalyst 3550 24 10/100 ports with inline power and 2 Gig uplinks fixed configuration Layer 2/Layer 3 Ethernet Switch 
+ciscoCDM4630		OBJECT IDENTIFIER ::= { ciscoProducts 486 }	-- Cisco Content Distribution Manager Model 4630
+ciscoCDM4650		OBJECT IDENTIFIER ::= { ciscoProducts 487 }	-- Cisco Content Distribution Manager Model 4650
+catalyst2955T12		OBJECT IDENTIFIER ::= { ciscoProducts 488 }	-- Cisco Catalyst c2955 Industrial switch with 12 10/100 BaseTX ports and 2 10/100/1000 Base-TX ports
+catalyst2955C12		OBJECT IDENTIFIER ::= { ciscoProducts 489 }	-- Cisco Catalyst c2955 Industrial switch with 12 10/100 Base TX ports and 2 100 Base-FX ports
+ciscoCE508		OBJECT IDENTIFIER ::= { ciscoProducts 490 }	-- Cisco Content Engine Model 508
+ciscoCE565		OBJECT IDENTIFIER ::= { ciscoProducts 491 }	-- Cisco Content Engine Model 565
+ciscoCE7325		OBJECT IDENTIFIER ::= { ciscoProducts 492 }	-- Cisco Content Engine Model 7325
+ciscoONS15454		OBJECT IDENTIFIER ::= { ciscoProducts 493 }	-- Cisco ONS 15454 Platform
+ciscoONS15327		OBJECT IDENTIFIER ::= { ciscoProducts 494 }	-- Cisco ONS 15327 Platform
+cisco837		OBJECT IDENTIFIER ::= { ciscoProducts 495 }	-- Cisco 837 platform with 4-port 10/100 Base-T Ethernet Switch,1 ADSL over POTS interface,data only model, hardware encryption 
+ciscoSOHO97             OBJECT IDENTIFIER ::= { ciscoProducts 496 }     -- SOHO (Small Office Home Office) Router with 4-port 10/100 Base-T Ethernet Switch,1 ADSL over POTS interface,data only model 
+cisco831                OBJECT IDENTIFIER ::= { ciscoProducts 497 }     -- Cisco 831 platform with 4-port 10/100 Base-T Ethernet Switch, 1 10Base-T Ethernet WAN interface, hardware encryption 
+ciscoSOHO91		OBJECT IDENTIFIER ::= { ciscoProducts 498 }     -- SOHO (Small Office Home Office)Router with 4-port 10/100 Base-T Ethernet Switch, 1 10Base-T Ethernet WAN interface 
+cisco836                OBJECT IDENTIFIER ::= { ciscoProducts 499 }     -- Cisco 836 platform with 4-port 10/100 Base-T Ethernet Switch, 1 ADSL over ISDN interface,1 ISDN BRI S/T interface, hardware encryption 
+ciscoSOHO96		OBJECT IDENTIFIER ::= { ciscoProducts 500 }     -- SOHO (Small Office Home Office)Router with 4-port 10/100 Base-T Ethernet Switch, 1 ADSL over ISDN interface, 1 ISDN BRI S/T interface 
+cat4507			OBJECT IDENTIFIER ::= { ciscoProducts 501 }	-- Catalyst 4000 with 7 slots (WS-C4507)
+cat4506			OBJECT IDENTIFIER ::= { ciscoProducts 502 }	-- Catalyst 4000 with 6 slots (WS-C4506) 
+cat4503			OBJECT IDENTIFIER ::= { ciscoProducts 503 }	-- Catalyst 4000 with 3 slots (WS-C4503) 
+ciscoCE7305		OBJECT IDENTIFIER ::= { ciscoProducts 504 }	-- Cisco Content Engine Model 7305 
+ciscoCE510		OBJECT IDENTIFIER ::= { ciscoProducts 505 }	-- Cisco Content Engine Model 510 
+ciscoAIRAP1100		OBJECT IDENTIFIER ::= { ciscoProducts 507 }	-- 1100 series WLAN Access Point with 1 10/100TX port, 1 IEEE 802.11 radio port.
+catalyst2955S12		OBJECT IDENTIFIER ::= { ciscoProducts 508 }	-- Cisco Catalyst c2955 Industrial switch with 12 10/100 Base T ports and 2 100 Base-LX Single Mode Uplink ports 
+cisco7609		OBJECT IDENTIFIER ::= { ciscoProducts 509 } -- Cisco 7600 Series Chassis with 9 slots 
+ciscoWSC65509		OBJECT IDENTIFIER ::= { ciscoProducts 510 } -- Catalyst 9 slots chassis
+catalyst375024		OBJECT IDENTIFIER ::= { ciscoProducts 511 } -- Catalyst 3750 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
+catalyst375048		OBJECT IDENTIFIER ::= { ciscoProducts 512 } -- Catalyst 3750 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
+catalyst375024TS	OBJECT IDENTIFIER ::= { ciscoProducts 513 } -- Catalyst 3750 24TS: 24 10/100/1000 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
+catalyst375024T		OBJECT IDENTIFIER ::= { ciscoProducts 514 } -- Catalyst 3750 24T: 24 10/100/1000 ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch.
+catalyst37xxStack	OBJECT IDENTIFIER ::= { ciscoProducts 516 } -- A stack of any catalyst37xx stack-able ethernet switches with unified identity (as a single unified switch), control and management.
+ciscoGSS		OBJECT IDENTIFIER ::= { ciscoProducts 517 } -- The Global Site Selector (GSS) is a network appliance that performs global server load balancing for geographically dispersed server load balancers and caches using DNS resolution.
+ciscoPrimaryGSSM	OBJECT IDENTIFIER ::= { ciscoProducts 518 } -- The Primary Global Site Selector Manager (GSSM) serves as the central management station for a Global Site Selector (GSS) Network.
+ciscoStandbyGSSM	OBJECT IDENTIFIER ::= { ciscoProducts 519 } -- The Standby Global Site Selector Manager (GSSM) serves as the backup to the Primary GSSM in a Global Site Selector(GSS) Network.                                  
+ciscoMWR1941DC		OBJECT IDENTIFIER ::= { ciscoProducts 520 } -- The Mobile Wireless Router (MWR-1941-DC) is a router with a universal power supply targeted at application in a cell site Base Transceiver Station (BTS) providing T1/E1 backhaul connections to the aggregation node in Radio Access Networks (RAN)
+ciscoDSC9216K9		OBJECT IDENTIFIER ::= { ciscoProducts 521 }	-- DS-C9216-K9    -  MDS 9216 16-port 2Gbps FC + 1-slot Modular Switch
+cat6500FirewallSm	OBJECT IDENTIFIER ::= { ciscoProducts 522 }	-- 	High performance firewall blade for Catalyst 6500 Series
+ciscoSCA11000		OBJECT IDENTIFIER ::= { ciscoProducts 523 }	-- The Cisco SCA 11000 Series Secure Content Accelerator is an appliance-based solution that increases the number of secure connections supported by a Web site by offloading the processor-intensive tasks related to securing traffic with Secure Sockets Layer (SSL)
+ciscoCSM		OBJECT IDENTIFIER ::= { ciscoProducts 524 }	-- Cisco Content Switching Module (CSM) which load balancing internet traffic based on the layer 4 through layer 7 information in the content.
+ciscoAIRAP1210		OBJECT IDENTIFIER ::= { ciscoProducts 525 }	-- 1200 series WLAN Access Point on Cisco IOS platform with 1 10/100TX port, 1 CardBus slot, 1 Mini PCI slot.
+ciscoSCA211000		OBJECT IDENTIFIER ::= { ciscoProducts 526 }	-- The Cisco SCA2 11000 Series Secure Content Accelerator is an appliance-based solution that increases the number of secure connections supported by a Web site by offloading the processor-intensive tasks related to securing traffic with Secure Sockets Layer (SSL)
+catalyst297024		OBJECT IDENTIFIER ::= { ciscoProducts 527 }	-- Catalyst 2970 24: 24 10/100/1000 ports fixed configuration Layer 2 Ethernet  switch 
+cisco7613		OBJECT IDENTIFIER ::= { ciscoProducts 528 }	-- Cisco Internet router 7600 Series Chassis with 13 slots 
+ciscoSN54282		OBJECT IDENTIFIER ::= { ciscoProducts 529 }	-- Storage Networking 5428-2 storage router with 2 SFP (Small Form Factor Pluggable) GBIC Gigabit Ethernet ports and 8 SFP GBIC Fibre Channel ports.
+catalyst3750Ge12Sfp	OBJECT IDENTIFIER ::= { ciscoProducts 530 }	-- Cisco Catalyst c3750 switch with 12 SFP (Small Form  FactorPluggable) Gigabit Ethernet ports 
+ciscoCR4430		OBJECT IDENTIFIER ::= { ciscoProducts 531 }	-- Cisco Content Router Model 4430 
+ciscoCR4450		OBJECT IDENTIFIER ::= { ciscoProducts 532 }	-- Cisco Content Router Model 4450 
+ciscoAIRBR1410		OBJECT IDENTIFIER ::= { ciscoProducts 533 }	-- 1410 Series Wireless LAN Bridge on Cisco IOS platform with 1 10/100Tx port and 1 5-GHz radio
+ciscoWSC6509neba	OBJECT IDENTIFIER ::= { ciscoProducts 534 } -- Catalyst 6500 series chassis with 9 slots
+catalyst375048PS	OBJECT IDENTIFIER ::= { ciscoProducts 535 } --	Catalyst 3750 48 10/100 In-Line Power Ethernet ports + 2 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Plugable)
+catalyst375024PS	OBJECT IDENTIFIER ::= { ciscoProducts 536 } --	Catalyst 3750 24 10/100 In-Line Power Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Plugable)
+catalyst4510		OBJECT IDENTIFIER ::= { ciscoProducts 537 } --	Catalyst 4000 with 10 slots (WS-C4510R) 
+cisco1711		OBJECT IDENTIFIER ::= { ciscoProducts 538 } --	Enhanced security router with 4 FastEthernet switch ports, 1 Analog modem port, 1 FastEthernet port and a hardware encryption module 
+cisco1712		OBJECT IDENTIFIER ::= { ciscoProducts 539 } --	Enhanced security router with 4 FastEthernet switch ports, 1 Basic Rate Interface(S/T)  data port, 1 FastEthernet port and a hardware encryption module. 
+catalyst29408TT 	OBJECT IDENTIFIER ::= { ciscoProducts 540 } --	Catalyst 2940 L2 switch with 8 10/100 copper ports and 1 10/100/1000 copper uplink port.
+catalyst29408TF 	OBJECT IDENTIFIER ::= { ciscoProducts 542 } --	Catalyst 2940 L2 switch with 8 10/100 copper ports, 1 100 FX Uplink port and 1 Gigabit SFP Module slot.
+cisco3825		OBJECT IDENTIFIER ::= { ciscoProducts 543 } -- Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800 family router
+cisco3845		OBJECT IDENTIFIER ::= { ciscoProducts 544 } -- Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800 family router
+cisco2430Iad24Fxs	OBJECT IDENTIFIER ::= { ciscoProducts 545 } -- IAD2430 with 24FXS, 2FE 
+cisco2431Iad8Fxs	OBJECT IDENTIFIER ::= { ciscoProducts 546 } -- IAD2431 with 8FXS, 2FE, 1T1/E1 
+cisco2431Iad16Fxs	OBJECT IDENTIFIER ::= { ciscoProducts 547 } -- IAD2431 with 16FXS, 2FE, 1T1/E1 
+cisco2431Iad1T1E1	OBJECT IDENTIFIER ::= { ciscoProducts 548 } -- IAD2431 with 2FE, 2T1/E1 
+cisco2432Iad24Fxs	OBJECT IDENTIFIER ::= { ciscoProducts 549 } -- IAD2432 with 24FXS, 2FE, 2T1E1 
+cisco1701ADSLBRI	OBJECT IDENTIFIER ::= { ciscoProducts 550 } -- Bacardi is a fixed configuration sku with ADSL WIC and ISDN BRI (S/T) or (S/T-V2) WIC 
+catalyst2950St24LRE997	OBJECT IDENTIFIER ::= { ciscoProducts 551 } -- Catalyst2950 Long Reach Ethernet switch that confirms to ETSI 997 with 24 LRE interfaces, 2 10/100/1000 Small form factor copper interfaces and DC power supply(WS-C2950ST-24-LRE-997)
+ciscoAirAp350IOS	OBJECT IDENTIFIER ::= { ciscoProducts 552 } -- Cisco Wireless LAN Access Point 350 series on IOS platform with 1 10/100TX port, 1 IEEE 802.11 radio port
+cisco3220		OBJECT IDENTIFIER ::= { ciscoProducts 553 } -- 3220 - Mobile Access Router (MAR) 
+cat6500SslSm		OBJECT IDENTIFIER ::= { ciscoProducts 554 } -- SSLSM is a High-Speed SSL Termination Engine for Catalyst 6000 family of platforms that terminates and accelarates Secure Socket Layer (SSL) transactions in Web server environement.
+ciscoSIMSE		OBJECT IDENTIFIER ::= { ciscoProducts 555 } -- ciscoSIMSE is an appliance - CiscoWorks Security Information Management Solution Engine
+ciscoESSE		OBJECT IDENTIFIER ::= { ciscoProducts 556 } -- Cisco Ethernet Subscriber Solution Engine
+catalyst6kSup720	OBJECT IDENTIFIER ::= { ciscoProducts 557 } -- Catalyst 6500 Supervisor Module 720 CPU board that is treated as a standalone system by the NMS 
+ciscoVG224		OBJECT IDENTIFIER ::= { ciscoProducts 558 } -- Line side Analog Gateway with 24FXS Analog ports
+catalyst295048T		OBJECT IDENTIFIER ::= { ciscoProducts 559 } -- Cisco Catalyst c2950 switch with 48 10/100BaseT ports and 2 fixed 10/100/1000BaseT ports 
+catalyst295048SX	OBJECT IDENTIFIER ::= { ciscoProducts 560 } -- Cisco Catalyst c2950 switch with 48 10/100BaseT ports and 2 fixed 1000Base Multimode fiber (SX) ports 
+catalyst297024TS	OBJECT IDENTIFIER ::= { ciscoProducts 561 } -- Catalyst 2970 24TS: 24 10/100/1000 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2 Ethernet  switch 
+ciscoNmNam	OBJECT IDENTIFIER ::= { ciscoProducts 562 } -- Cisco NM-NAM, NAM for the branch office routers
+catalyst356024PS	OBJECT IDENTIFIER ::= { ciscoProducts 563 } -- Catalyst 3750 24 10/100 ports with In-Line Power + 2 Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Switch.(SFP Small Formfactor Pluggable) 
+catalyst356048PS	OBJECT IDENTIFIER ::= { ciscoProducts 564 } -- Catalyst 3750 48 10/100 ports with In-Line Power + 4 Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Switch.(SFP Small Formfactor Pluggable) 
+ciscoAIRBR1300		OBJECT IDENTIFIER ::= { ciscoProducts 565 } -- Cisco Aironet 1300 Series Wireless Bridge with 1 10/100TX Ethernet port, 1 IEEE 802.11g radio port
+cisco851		OBJECT IDENTIFIER ::= { ciscoProducts 566 } -- Cisco 851 platform with 1 10/100T ethernet WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, hardware encryption and Wireless LAN card
+cisco857		OBJECT IDENTIFIER ::= { ciscoProducts 567 } -- Cisco 857 platform with 1 DSL over POTS WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, hardware encryption and an optional Wireless LAN card 
+cisco876		OBJECT IDENTIFIER ::= { ciscoProducts 568 } -- Cisco 876 platform with 1 ADSL over ISDN WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, 1 ISDN BRI S/T interface, hardware encryption and an optional Wireless LAN card 
+cisco877		OBJECT IDENTIFIER ::= { ciscoProducts 569 } -- Cisco 877 platform with 1 ADSL over POTS WAN interface, 4-port 10/100 BASE-T LAN Ethernet switch, 4 USB ports, hardware encryption and an optional Wireless LAN card 
+cisco878		OBJECT IDENTIFIER ::= { ciscoProducts 570 } -- Cisco 878 platform with 1 SHDSL WAN interface, 4-port 1 0/100 Base-T LAN Ethernet switch, 4 USB ports, 1 ISDN BRI S/T interface, hardware encryption and an optional Wireless LAN card.
+cisco871		OBJECT IDENTIFIER ::= { ciscoProducts 571 } --  Cisco 871 platform with 1 10/100T ethernet WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, 4 USB ports, hardware encryption and an optional Wireless LAN card 
+uMG9820			OBJECT IDENTIFIER ::= { ciscoProducts 572 } -- A stand-alone "pizza-box" video QAM device enabling delivery of VOD/SVOD/NVPR services via low-cost, line-rate GbE transport solutions from centralized servers to local cable hubs
+catalyst6kGateway	OBJECT IDENTIFIER ::= { ciscoProducts 573 } -- Catalyst 6000 Acess Gateway line card supporting voice and WAN(Wide Area Network) interfaces as well as conferencing and transcoding services
+catalyst375024ME	OBJECT IDENTIFIER ::= { ciscoProducts 574 } --	Metro Ethernet Catalyst 3750   24-10/100 + 2 SFP (Small Formfactor Pluggable) ports for downlinks and 2 SFP ES(Enhanched Service) ports for uplinks
+catalyst4000NAM		OBJECT IDENTIFIER ::= { ciscoProducts 575 } --  Network analysis Module (NAM) for Catalyst 4000
+cisco2811		OBJECT IDENTIFIER ::= { ciscoProducts 576 } --	Cisco 2800 series router with one Network Module slot, four HWIC slots, two fast etherenet and integrated VPN
+cisco2821		OBJECT IDENTIFIER ::= { ciscoProducts 577 } --	Cisco 2800 series router with one Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and intergrated VPN
+cisco2851		OBJECT IDENTIFIER ::= { ciscoProducts 578 } --	Cisco 2800 series router with one double wide Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and integrated VPN
+cisco3201WMIC		OBJECT IDENTIFIER ::= { ciscoProducts 581 } --  Cisco 3201 Wireless MIC (Mobile Interface card) with 802.11g wireless interface in the PC104+ form factor. An interface card for the existing MAR 3200 products(Mobile Access Router)
+ciscoMCS7815I		OBJECT IDENTIFIER ::= { ciscoProducts 582 } --  Cisco Media Convergence Server 7815 (IBM)
+ciscoMCS7825H		OBJECT IDENTIFIER ::= { ciscoProducts 583 } --  Cisco Media Convergence Server 7825 (HP)
+ciscoMCS7835H		OBJECT IDENTIFIER ::= { ciscoProducts 584 } --  Cisco Media Convergence Server 7835 (HP)
+ciscoMCS7835I		OBJECT IDENTIFIER ::= { ciscoProducts 585 } --  Cisco Media Convergence Server 7835 (IBM)
+ciscoMCS7845H		OBJECT IDENTIFIER ::= { ciscoProducts 586 } --  Cisco Media Convergence Server 7845 (HP)
+ciscoMCS7845I		OBJECT IDENTIFIER ::= { ciscoProducts 587 } --  Cisco Media Convergence Server 7845 (IBM)
+ciscoMCS7855I		OBJECT IDENTIFIER ::= { ciscoProducts 588 } --  Cisco Media Convergence Server 7855 (IBM)
+ciscoMCS7865I		OBJECT IDENTIFIER ::= { ciscoProducts 589 } --  Cisco Media Convergence Server 7865 (IBM)
+cisco12006		OBJECT IDENTIFIER ::= { ciscoProducts 590 } --  Cisco 12000 platform with 6 slots
+catalyst3750G16TD	OBJECT IDENTIFIER ::= { ciscoProducts 591 } --  Cisco Catalyst 3750 switch with 16 gigabit and one 10G ethernet port (WS-C3750G-16TD)
+ciscoIGESM		OBJECT IDENTIFIER ::= { ciscoProducts 592 } --  Cisco Systems Intelligent Gigabit Ethernet Switch Module for IBM eServer BladeCenter (OS-CIGESM-18TT-E)
+ciscoCCM		OBJECT IDENTIFIER ::= { ciscoProducts 593 }
+cisco1718		OBJECT IDENTIFIER ::= { ciscoProducts 594 } --  Voice capable Cisco 1700 Router with 4 FastEthernet switch ports, 1 FastEthernet port and 4 FXS-DID ports
+ciscoCe511K9		OBJECT IDENTIFIER ::= { ciscoProducts 595 } --  Cisco Content Engine Model CE-511-K9
+ciscoCe566K9		OBJECT IDENTIFIER ::= { ciscoProducts 596 } --  Cisco Content Engine Model CE-566-K9
+ciscoMGX8830Pxm45	OBJECT IDENTIFIER ::= { ciscoProducts 597 } --  PXM45 controller-based 7 full-height-slot MGX8830
+ciscoMGX8880		OBJECT IDENTIFIER ::= { ciscoProducts 598 } --  Cisco MGX8880 switch with 32 half height slots
+ciscoWsSvcWLAN1K9		OBJECT IDENTIFIER ::= { ciscoProducts 599 } --  Wireless LAN Module (WS-SVC-WLAN-1-K9) is a Komodo+ based line card for Cat6K family of platforms, which provides wireless domain services (WDS) for IEEE 802.11 wireless clients
+ciscoCe7306K9		OBJECT IDENTIFIER ::= { ciscoProducts 600 } --  Cisco Content Engine Model CE-7306-K9
+ciscoCe7326K9		OBJECT IDENTIFIER ::= { ciscoProducts 601 } --  Cisco Content Engine Model CE-7326-K9
+catalyst3750G24PS	OBJECT IDENTIFIER ::= { ciscoProducts 602 } --  Catalyst 3750 24 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
+catalyst3750G48PS	OBJECT IDENTIFIER ::= { ciscoProducts 603 } --  Catalyst 3750 48 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
+catalyst3750G48TS	OBJECT IDENTIFIER ::= { ciscoProducts 604 } --  Catalyst 3750 48 10/100/1000 ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
+ciscoBMGX8830Pxm45	OBJECT IDENTIFIER ::= { ciscoProducts 606 } --  PXM45 based Multiservice Switch (Model B) with 14 half height slots
+ciscoBMGX8830Pxm1E	OBJECT IDENTIFIER ::= { ciscoProducts 607 } --  PXM1E based Multiservice Switch (Model B) with 14 half height slots
+ciscoBMGX8850Pxm45	OBJECT IDENTIFIER ::= { ciscoProducts 608 } --  PXM45 based Multiservice Gigabit Switch (ModelB) with 32 half height slots
+ciscoBMGX8850Pxm1E	OBJECT IDENTIFIER ::= { ciscoProducts 609 } --  PXM1E based Multiservice Gigabit Switch (ModelB) with 32 half height slots
+ciscoSSLCSM		OBJECT IDENTIFIER ::= { ciscoProducts 610 } --  SCSM is an SSL Termination daughtercard for the Content Switching Module (CSM) that accelerates Secure Socket Layer (SSL) transactions
+ciscoNetworkRegistrar	OBJECT IDENTIFIER ::= { ciscoProducts 611 } --  Cisco Network Registrar (CNR) is a full-featured DNS/DHCP system that provides scalable naming and addressing services for enterprise and service provider networks.
+ciscoCe501K9		OBJECT IDENTIFIER ::= { ciscoProducts 612 } --  Cisco Content Engine Model CE-501-K9
+ciscoCRS16S		OBJECT IDENTIFIER ::= { ciscoProducts 613 } --	Cisco CRS-1 Series Single Chassis Carrier Routing System
+catalyst3560G24PS	OBJECT IDENTIFIER ::= { ciscoProducts 614 } --	Catalyst 3560 24 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. (SFP Small Form factor Pluggable)
+catalyst3560G24TS	OBJECT IDENTIFIER ::= { ciscoProducts 615 } --	Catalyst 3560 24 10/100/1000 Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch (SFP Small Form factor Pluggable)
+catalyst3560G48PS	OBJECT IDENTIFIER ::= { ciscoProducts 616 } --	Catalyst 3560 48 10/100/1000 Power over Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. (SFP Small Form factor Pluggable)
+catalyst3560G48TS	OBJECT IDENTIFIER ::= { ciscoProducts 617 } --	Catalyst 3560 48 10/100/1000 ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. (SFP Small Form factor Pluggable)
+ciscoAIRAP1130		OBJECT IDENTIFIER ::= { ciscoProducts 618 } --	Cisco Aironet 1130 series WLAN Access Point with 1 10/100TX port, dual IEEE 802.11a and 802.11g  radio port
+cisco2801		OBJECT IDENTIFIER ::= { ciscoProducts 619 } --  1700 Next Generation voice enabled router with 4 slots
+cisco1841		OBJECT IDENTIFIER ::= { ciscoProducts 620 } --  1700 Next Generation data only router with 2 slots
+ciscoWsSvcMWAM1		OBJECT IDENTIFIER ::= { ciscoProducts 621 } --  Multiprocessor WAN Application Module (WS-SVC-MWAM-1) is a multipurpose blade built for the Cat6k platform
+ciscoNMCUE		OBJECT IDENTIFIER ::= { ciscoProducts 622 } --	Cisco Unity Express network module (NM-CUE) 
+ciscoAIMCUE		OBJECT IDENTIFIER ::= { ciscoProducts 623 } --	Cisco Unity Express advanced integration module (AIM-CUE) 
+catalyst3750G24TS1U	OBJECT IDENTIFIER ::= { ciscoProducts 624 } --  Catalyst 3750 24 10/100/1000 Ethernet ports + 4 Gigabit Ethernet SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. (SFP Small Form factor Pluggable)
+cisco371098HP001	OBJECT IDENTIFIER ::= { ciscoProducts 625 } --  24 port Gigabit Ethernet switch module for HP ProLiant BL p-class server chassis
+catalyst4948		OBJECT IDENTIFIER ::= { ciscoProducts 626 } --  Fixed configuration Catalyst 4000 with 48 10/100/1000BaseT ports and 4 1000BaseX SFP ports (WS-C4948)
+ciscoSB101		OBJECT IDENTIFIER ::= { ciscoProducts 627 } --  Small Buisness Router with 4-port 10/100 Base-T Ethernet Switch, 1 10Base-T Ethernet WAN interface
+ciscoSB106		OBJECT IDENTIFIER ::= { ciscoProducts 628 } --  (Small Buisness)Router with 4-port 10/100 Base-T Ethernet Switch, 1 ADSL over ISDN interface, 1 ISDN BRI S/T interface
+ciscoSB107		OBJECT IDENTIFIER ::= { ciscoProducts 629 } --  (Small Buisness)Router with 4-port 10/100 Base-T Ethernet Switch, 1 ADSL over POTS interface, data only model
+ciscoWLSE1130		OBJECT IDENTIFIER ::= { ciscoProducts 630 } --  Cisco WLAN Solution Engine (WLSE) 1130 monitors and configures a WLAN with Cisco WAP and Bridges
+ciscoWLSE1030		OBJECT IDENTIFIER ::= { ciscoProducts 631 } --  Cisco WLSE Express 1030 is a  WLSE that monitors and configures a WLAN with Cisco WAP and Bridges with AAA functionality
+ciscoHSE1140		OBJECT IDENTIFIER ::= { ciscoProducts 632 } --  Cisco Hosting Solution Engine 1140 manages Cisco powered data centers and Points of Presence with routers, switches, server load balancers, firewalls, intrusion detection systems and other layer 4-7 content delivery products
+catalyst356024TS	OBJECT IDENTIFIER ::= { ciscoProducts 633 } --  Catalyst 3560 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch. 
+catalyst356048TS	OBJECT IDENTIFIER ::= { ciscoProducts 634 } --  Catalyst 3560 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch
+ciscoWsSvcadsm1K9	OBJECT IDENTIFIER ::= { ciscoProducts 635 } --  DDOS Detector Service Module
+ciscoWsSvcagsm1K9	OBJECT IDENTIFIER ::= { ciscoProducts 636 } --  DDOS Guard Service Module
+ciscoONS15310	OBJECT IDENTIFIER ::= { ciscoProducts 637 } --  Cisco ONS 15310 Platform
+cisco1801	OBJECT IDENTIFIER ::= { ciscoProducts 638 } --  Cisco 1800 platform with 1 ADSL over POTS WAN interface, 1 ISDNBRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card. 
+cisco1802	OBJECT IDENTIFIER ::= { ciscoProducts 639 } --  Cisco 1800 platform with 1 ADSL over ISDN WAN interface, 1 ISDN BRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
+cisco1803	OBJECT IDENTIFIER ::= { ciscoProducts 640 } --  Cisco 1800 platform with 1 G.SHDSL 4-wire interface, 1 ISDN BRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
+cisco1811	OBJECT IDENTIFIER ::= { ciscoProducts 641 } --  Cisco 1800 platform with V.92 Modem, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
+cisco1812	OBJECT IDENTIFIER ::= { ciscoProducts 642 } --  Cisco 1800 platform with ISDN BRI S/T interface, 8-port 10/100 Base-T LAN Ethernet switch, 2 USB ports and an optional Wireless LAN card.
+ciscoCRS8S	OBJECT IDENTIFIER ::= { ciscoProducts 643 } -- Cisco CRS-1 Series 8 Slots Carrier Routing System
+ciscoIDS4210	OBJECT IDENTIFIER ::= { ciscoProducts 645 } --  Cisco Intrusion Detection System 4210
+ciscoIDS4215	OBJECT IDENTIFIER ::= { ciscoProducts 646 } --  Cisco Intrusion Detection System 4215
+ciscoIDS4235	OBJECT IDENTIFIER ::= { ciscoProducts 647 } --  Cisco Intrusion Detection System 4235
+ciscoIPS4240	OBJECT IDENTIFIER ::= { ciscoProducts 648 } --  Cisco Intrusion Prevention System 4240
+ciscoIDS4250	OBJECT IDENTIFIER ::= { ciscoProducts 649 } --  Cisco Intrusion Detection System 4250
+ciscoIDS4250SX	OBJECT IDENTIFIER ::= { ciscoProducts 650 } --  Cisco Intrusion Detection System 4250 SX
+ciscoIDS4250XL	OBJECT IDENTIFIER ::= { ciscoProducts 651 } --  Cisco Intrusion Detection System 4250 XL
+ciscoIPS4255	OBJECT IDENTIFIER ::= { ciscoProducts 652 } --  Cisco Intrusion Prevention System 4255
+ciscoIDSIDSM2	OBJECT IDENTIFIER ::= { ciscoProducts 653 } --  Cisco Intrusion Detection System Module IDSM2
+ciscoIDSNMCIDS	OBJECT IDENTIFIER ::= { ciscoProducts 654 } --  Cisco Intrusion Detection System Network Module NM-CIDS
+ciscoIPSSSM20	OBJECT IDENTIFIER ::= { ciscoProducts 655 } --  Cisco Intrusion Prevention System Security Service Module SSM-20
+catalyst375024FS	OBJECT IDENTIFIER ::= { ciscoProducts 656 } --  Catalyst 3750 24 100BaseFX ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch.
+ciscoWSC6504E	OBJECT IDENTIFIER ::= { ciscoProducts 657 } --  Catalyst 6000 series chassis with 4 slots 
+cisco7604	OBJECT IDENTIFIER ::= { ciscoProducts 658 } --  Cisco Optical Services Router 7600 Series Chassis with 4 slots 
+catalyst494810GE	OBJECT IDENTIFIER ::= { ciscoProducts 659 } --  Catalyst 4000 series fixed configuration switch with 48 10/100/1000BaseT wirespeed ports and two 10Gbps ports 
+ciscoIGESMSFP		OBJECT IDENTIFIER ::= { ciscoProducts 660 } --  Cisco Systems Intelligent Gigabit Ethernet Switch Module with external SFPs for IBM eServer BladeCenter (OS-CIGESM-18-SFP-E)
+ciscoFE6326K9		OBJECT IDENTIFIER ::= { ciscoProducts 661 } -- Cisco File Engine Model FE-6326-K9 
+ciscoIPSSSM10		OBJECT IDENTIFIER ::= { ciscoProducts 662 } -- Cisco Intrusion Prevention System Security Service Module SSM-10 
+ciscoNme16Es1Ge		OBJECT IDENTIFIER ::= { ciscoProducts 663 } -- EtherSwitch Service Module 16 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch.
+ciscoNmeX24Es1Ge		OBJECT IDENTIFIER ::= { ciscoProducts 664 } -- EtherSwitch Service Module 23 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch.
+ciscoNmeXd24Es2St		OBJECT IDENTIFIER ::= { ciscoProducts 665 } -- EtherSwitch Service Module 24 10/100 ports + 1 Ethernet Gigabit SFP port fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
+ciscoNmeXd48Es2Ge		OBJECT IDENTIFIER ::= { ciscoProducts 666 } -- EtherSwitch Service Module 48 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch.
+cisco3202WMIC		OBJECT IDENTIFIER ::= { ciscoProducts 667 } -- Cisco 3201 4.9GHz  Wireless MIC (Mobile Interface card) with 4.9GHz  Radio Moudle  in the PC104+ form factor. An interface card for the existing MAR 3200 products(MobileAccess Router)
+ciscoAs5400XM		OBJECT IDENTIFIER ::= { ciscoProducts 668 } -- Cisco AS5400XM platform
+ciscoASA5510		OBJECT IDENTIFIER ::= { ciscoProducts 669 } -- Cisco Adaptive Security Appliance 5510
+ciscoASA5520		OBJECT IDENTIFIER ::= { ciscoProducts 670 } -- Cisco Adaptive Security Appliance 5520
+ciscoASA5520sc		OBJECT IDENTIFIER ::= { ciscoProducts 671 } -- Cisco Adaptive Security Appliance 5520 Security Context
+ciscoASA5540		OBJECT IDENTIFIER ::= { ciscoProducts 672 } -- Cisco Adaptive Security Appliance 5540
+ciscoASA5540sc		OBJECT IDENTIFIER ::= { ciscoProducts 673 } -- Cisco Adaptive Security Appliance 5540 Security Context
+ciscoWsSvcFwm1sc		OBJECT IDENTIFIER ::= { ciscoProducts 674 } -- Firewall Services Module for Catalyst 6500 Series Security Context
+ciscoPIXFirewall535sc		OBJECT IDENTIFIER ::= { ciscoProducts 675 } -- Cisco PIX Firewall 535 Security Context
+ciscoPIXFirewall525sc		OBJECT IDENTIFIER ::= { ciscoProducts 676 } -- Cisco PIX Firewall 525 Security Context
+ciscoPIXFirewall515Esc		OBJECT IDENTIFIER ::= { ciscoProducts 677 } -- Cisco PIX Firewall 515E Security Context
+ciscoPIXFirewall515sc		OBJECT IDENTIFIER ::= { ciscoProducts 678 } -- Cisco PIX Firewall 515 Security Context
+ciscoAs5350XM		OBJECT IDENTIFIER ::= { ciscoProducts 679 } -- Low end AS5350XM platfrom
+ciscoFe7326K9		OBJECT IDENTIFIER ::= { ciscoProducts 680 } -- Cisco File Engine Model FE-7326-K9
+ciscoFe511K9		OBJECT IDENTIFIER ::= { ciscoProducts 681 } -- Cisco File Engine Model FE-511-K9
+ciscoSCEDispatcher		OBJECT IDENTIFIER ::= { ciscoProducts 682 } -- Cisco Service Control Engine Dispatcher
+ciscoSCE1000		OBJECT IDENTIFIER ::= { ciscoProducts 683 } -- Cisco SCE1000 Service Control Engine
+ciscoSCE2000		OBJECT IDENTIFIER ::= { ciscoProducts 684 } -- Cisco SCE2000 Service Control Engine
+ciscoAIRAP1240		OBJECT IDENTIFIER ::= { ciscoProducts 685 } -- Cisco Aironet 1240 series WLAN Access Point with 1 10/100TX port, dual IEEE 802.11a and 802.11g radio ports, external antenna connectors 
+ciscoDSC9120CLK9		OBJECT IDENTIFIER ::= { ciscoProducts 686 } -- DS-C9120-CL-K9  - MDS 9120-CL, 20-Port 4 Gbps Fibre Channel Fabric Switch, Commercial
+ciscoFe611K9		OBJECT IDENTIFIER ::= { ciscoProducts 687 } -- Cisco File Engine Model FE-611-K9
+catalyst3750Ge12SfpDc		OBJECT IDENTIFIER ::= { ciscoProducts 688 } -- Cisco Catalyst c3750 switch with 12 SFP (Small Form Factor Plugable) Gigabit Ethernet ports and DC power supply 
+cisco3271		OBJECT IDENTIFIER ::= { ciscoProducts 689 } -- HMARC with 2FE and 2GE interfaces.
+cisco3272		OBJECT IDENTIFIER ::= { ciscoProducts 690 } -- HMARC with 2FE, 1GE and 1 GE Fiber Optic interfaces.
+cisco3241		OBJECT IDENTIFIER ::= { ciscoProducts 691 } -- EFHMARC with 3FE, 1GE and 1 GE copper interfaces.
+cisco3242		OBJECT IDENTIFIER ::= { ciscoProducts 692 } -- EFHMARC with 3FE, 1GE and 1 GE copper interfaces.
+ciscoICM		OBJECT IDENTIFIER ::= { ciscoProducts 693 } -- Cisco Systems Intelligent Contact Management
+catalyst296024		OBJECT IDENTIFIER ::= { ciscoProducts 694 } -- Catalyst 2960 24 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch 
+catalyst296048		OBJECT IDENTIFIER ::= { ciscoProducts 695 } -- Catalyst 2960 48 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet Switch 
+catalyst2960G24		OBJECT IDENTIFIER ::= { ciscoProducts 696 } -- Catalyst 2960 20 10/100/1000 ports + 4 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch.
+catalyst2960G48		OBJECT IDENTIFIER ::= { ciscoProducts 697 } -- Catalyst 2960 44 10/100/1000 ports + 4 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch.
+catalyst45503		OBJECT IDENTIFIER ::= { ciscoProducts 698 } -- Catalyst 4500 with 3 slots (WS-C4550-3)
+catalyst45506		OBJECT IDENTIFIER ::= { ciscoProducts 699 } -- Catalyst 4500 with 6 slots (WS-C4550-6)
+catalyst45507		OBJECT IDENTIFIER ::= { ciscoProducts 700 } -- Catalyst 4500 with 7 slots (WS-C4550-7R)
+catalyst455010		OBJECT IDENTIFIER ::= { ciscoProducts 701 } -- Catalyst 4500 with 10 slots (WS-C4550-10R)
+ciscoNme16Es1GeNoPwr		OBJECT IDENTIFIER ::= { ciscoProducts 702 } -- EtherSwitch Service Module 16 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch with no inline power
+ciscoNmeX24Es1GeNoPwr		OBJECT IDENTIFIER ::= { ciscoProducts 703 } -- EtherSwitch Service Module 23 10/100 ports + 1 Ethernet Gigabit port fixed configuration Layer 2/Layer 3 Ethernet switch with no inline power
+ciscoNmeXd24Es2StNoPwr		OBJECT IDENTIFIER ::= { ciscoProducts 704 } -- EtherSwitch Service Module 24 10/100 ports + 1 Ethernet Gigabit SFP port fixed configuration Layer 2/Layer 3 Ethernet Stackable switch with no inline power
+ciscoNmeXd48Es2GeNoPwr		OBJECT IDENTIFIER ::= { ciscoProducts 705 } -- EtherSwitch Service Module 48 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet switch with no inline power
+catalyst6kMsfc2a		OBJECT IDENTIFIER ::= { ciscoProducts 706 } -- Multilevel Switching Feature Card Version 2a for Catalyst 6000 that is treated as a standalone system by the NMS
+ciscoEDI		OBJECT IDENTIFIER ::= { ciscoProducts 707 } -- Cisco Enhanced Device Interface Server
+ciscoCe611K9		OBJECT IDENTIFIER ::= { ciscoProducts 708 } -- Cisco Content Engine Model CE-611-K9
+ciscoWLSEs20		OBJECT IDENTIFIER ::= { ciscoProducts 709 } -- Cisco Wireless LAN Solution Engine S20.
+ciscoMPX		OBJECT IDENTIFIER ::= { ciscoProducts 710 } -- Cisco MeetingPlace Express
+ciscoNMCUEEC		OBJECT IDENTIFIER ::= { ciscoProducts 711 } -- Cisco Unity Express network module with enhanced capacity (NM-CUE-EC)
+ciscoWLSE1132		OBJECT IDENTIFIER ::= { ciscoProducts 712 } -- Cisco Wireless LAN Solution Engine WLSE-1132-K9
+ciscoME6340ACA	OBJECT IDENTIFIER ::= { ciscoProducts 713 } -- DSL Switch 48 port ADSL2/2+, Annex A, AC
+ciscoME6340DCA	OBJECT IDENTIFIER ::= { ciscoProducts 714 } -- DSL Switch 48 port ADSL2/2+, Annex A, DC
+ciscoME6340DCB	OBJECT IDENTIFIER ::= { ciscoProducts 715 } -- DSL Switch 48 port ADSL2/2+, Annex B, DC
+catalyst296024TT	OBJECT IDENTIFIER ::= { ciscoProducts 716 } -- Catalyst 2960 24 10/100 ports + 2 10/100/1000 ports fixed configuration Layer 2 Ethernet switch 
+catalyst296048TT	OBJECT IDENTIFIER ::= { ciscoProducts 717 } -- Catalyst 2960 48 10/100 ports + 2 10/100/1000 ports fixed configuration Layer 2 Ethernet switch
+ciscoIGESMSFPT		OBJECT IDENTIFIER ::= { ciscoProducts 718 } --  Cisco Systems Intelligent Gigabit Ethernet Switch Module for IBM eServer BladeCenter Telco Chassis (OS-CIGESM-18TT-E)
+ciscoMEC6524gs8s	OBJECT IDENTIFIER ::= { ciscoProducts 719 } --  Cisco ME 6524 chassis with 24 port SFP and 8 SFP uplinks
+ciscoMEC6524gt8s	OBJECT IDENTIFIER ::= { ciscoProducts 720 } --  Cisco ME 6524 chassis with 24 port 10/100/1000BaseT and 8 SFP uplinks
+ciscoMEC6724s10x2	OBJECT IDENTIFIER ::= { ciscoProducts 721 } --  Cisco ME 6724 chassis with 24 port SFP and 2 10G uplinks
+ciscoMEC6724t10x2	OBJECT IDENTIFIER ::= { ciscoProducts 722 } --  Cisco ME 6724 chassis with 24 port 10/100/1000BaseT and 2 10G uplinks
+ciscoPaldron		OBJECT IDENTIFIER ::= { ciscoProducts 723 } --  ARM Development Platform
+catalystsExpress50024TT		OBJECT IDENTIFIER ::= { ciscoProducts 724 } --  Catalyst Express 500 24 10/100 ports + 2 Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch 
+catalystsExpress50024LC		OBJECT IDENTIFIER ::= { ciscoProducts 725 } --  Catalyst Express 500 24 10/100 ports (4 Power Over Ethernet Ports) + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalystsExpress50024PC		OBJECT IDENTIFIER ::= { ciscoProducts 726 } --  Catalyst Express 500 24  Power Over Ethernet Ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch 
+catalystsExpress50012TC		OBJECT IDENTIFIER ::= { ciscoProducts 727 } --  Catalyst Express 500 8 Gigabit Ethernet Ports + 4 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch 
+ciscoIGESMT		OBJECT IDENTIFIER ::= { ciscoProducts 728 } --  Cisco Systems Intelligent Gigabit Ethernet Switch Module for IBM eServer BladeCenter Telco Chassis (OS-CIGESM-18TT-E)
+ciscoACE04G		OBJECT IDENTIFIER ::= { ciscoProducts 729 } --  Application Control Engine 4 G Module in Cat6500
+ciscoACE10K9		OBJECT IDENTIFIER ::= { ciscoProducts 730 } --  Application Control Engine Module in Cat6500
+cisco5750		OBJECT IDENTIFIER ::= { ciscoProducts 731 } --  High Assurance Router
+ciscoMWR1941DCA		OBJECT IDENTIFIER ::= { ciscoProducts 732 } -- The Mobile Wireless Router (MWR-1941-DC-A) is a router with a universal power supply targeted at application in a cell site Base Transceiver Station (BTS) providing backhaul connections to the aggregation node in Radio Access Networks (RAN) and support for AIM module
+cisco815		OBJECT IDENTIFIER ::= { ciscoProducts 733 } --  Cisco 815 platform fixed configuration cable modem router with 4 FastEthernet switch ports, 1 Cable modem port, 1 FastEthernet port
+cisco240024TSA		OBJECT IDENTIFIER ::= { ciscoProducts 734 } --  Metro Ethernet 2400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2 Ethernet switch, AC power.
+cisco240024TSD		OBJECT IDENTIFIER ::= { ciscoProducts 735 } -- Metro Ethernet 2400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2 Ethernet switch, DC power.
+cisco340024TSA		OBJECT IDENTIFIER ::= { ciscoProducts 736 } -- Metro Ethernet 3400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power.
+cisco340024TSD		OBJECT IDENTIFIER ::= { ciscoProducts 737 } -- Metro Ethernet 3400, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, DC power.
+ciscoCrs18Linecard	OBJECT IDENTIFIER ::= { ciscoProducts 738 } -- Cisco CRS-1 Series 8 slot Line Card Chassis
+ciscoCrs1Fabric		OBJECT IDENTIFIER ::= { ciscoProducts 739 } -- Cisco CRS-1 Series Fabric Card Chassis
+ciscoFE2636		OBJECT IDENTIFIER ::= { ciscoProducts 740 } -- Cisco File Engine Module for 26xx and 36xx series platforms
+ciscoIDS4220		OBJECT IDENTIFIER ::= { ciscoProducts 741 } -- Cisco Intrusion Detection System 4220
+ciscoIDS4230		OBJECT IDENTIFIER ::= { ciscoProducts 742 } -- Cisco Intrusion Detection System 4230
+ciscoIPS4260		OBJECT IDENTIFIER ::= { ciscoProducts 743 } -- Cisco Intrusion Prevention System 4260 
+ciscoWsSvcSAMIBB	OBJECT IDENTIFIER ::= { ciscoProducts 744 } -- Service and Application Module for IP   
+ciscoASA5505		OBJECT IDENTIFIER ::= { ciscoProducts 745 } -- Cisco Adaptive Security Appliance 5505
+ciscoMCS7825I		OBJECT IDENTIFIER ::= { ciscoProducts 746 } -- Cisco Media Convergence Server 7825 (IBM)
+ciscoWsC3750g24ps	OBJECT IDENTIFIER ::= { ciscoProducts 747 } -- Cisco 3750 24+2 port 10/100/1000 Switch with integrated Cisco 4402 Wireless Controller
+ciscoWs3020Hpq		OBJECT IDENTIFIER ::= { ciscoProducts 748 } -- Cisco Catalyst Bladeswitch 3020 for HP
+ciscoWs3030Del		OBJECT IDENTIFIER ::= { ciscoProducts 749 } -- Cisco Catalyst Bladeswitch 3030 for Dell
+ciscoSpaOc48posSfp	OBJECT IDENTIFIER ::= { ciscoProducts 750 } -- 1-port OC48/STM16 POS/RPR SFP Optics Shared Port Adapter
+catalyst6kEnhancedGateway		OBJECT IDENTIFIER ::= { ciscoProducts 751 } -- Catalyst 6000 Access gateway enhanced line card supporting voice and WAN( Wide Area Network) interfaces as well as conferencing and transcoding services
+ciscoWLSE1133		OBJECT IDENTIFIER ::= { ciscoProducts 752 } -- Cisco Wireless LAN Solution Engine WLSE-1133.
+ciscoASA5550		OBJECT IDENTIFIER ::= { ciscoProducts 753 } -- Cisco Adaptive Security Appliance 5550
+ciscoNMAONK9            OBJECT IDENTIFIER ::= { ciscoProducts 754 } -- Cisco 2600/3700/ISR AON Module (NM-AON-K9)
+ciscoNMAONWS            OBJECT IDENTIFIER ::= { ciscoProducts 755 } -- Catalyst 6500 Series AON Module (WS-SVC-AON-1-K9)
+ciscoNMAONAPS		OBJECT IDENTIFIER ::= { ciscoProducts 756 } -- Cisco AON 8300 Series Appliance (APL-AON-8340-K9)
+ciscoWae612K9		OBJECT IDENTIFIER ::= { ciscoProducts 757 } -- Cisco Wide Area Engine Model WAE-612-K9
+ciscoAIRAP1250		OBJECT IDENTIFIER ::= { ciscoProducts 758 } -- 1250 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11a/b/g/n slots
+ciscoCe512K9 		OBJECT IDENTIFIER ::= { ciscoProducts 759 } -- Cisco Content Engine CE-512-K9
+ciscoFe512K9		OBJECT IDENTIFIER ::= { ciscoProducts 760 } -- Cisco File Engine Model FE-512-K9
+ciscoCe612K9		OBJECT IDENTIFIER ::= { ciscoProducts 761 } -- Cisco Content Engine Model CE-612-K9
+ciscoFe612K9		OBJECT IDENTIFIER ::= { ciscoProducts 762 } -- Cisco File Engine Model FE-612-K9
+ciscoASA5550sc		OBJECT IDENTIFIER ::= { ciscoProducts 763 } -- Cisco Adaptive Security Appliance 5550 Security Context
+ciscoASA5520sy		OBJECT IDENTIFIER ::= { ciscoProducts 764 } -- Cisco Adaptive Security Appliance 5520 System Context
+ciscoASA5540sy		OBJECT IDENTIFIER ::= { ciscoProducts 765 } -- Cisco Adaptive Security Appliance 5540 System Context
+ciscoASA5550sy		OBJECT IDENTIFIER ::= { ciscoProducts 766 } -- Cisco Adaptive Security Appliance 5550 System Context
+ciscoWsSvcFwm1sy	OBJECT IDENTIFIER ::= { ciscoProducts 767 } -- Firewall Services Module for Catalyst 6500 Series System Context
+ciscoPIXFirewall515sy	OBJECT IDENTIFIER ::= { ciscoProducts 768 } -- Cisco PIX Firewall 515 System Context
+ciscoPIXFirewall515Esy	OBJECT IDENTIFIER ::= { ciscoProducts 769 } -- Cisco PIX Firewall 515E System Context
+ciscoPIXFirewall525sy	OBJECT IDENTIFIER ::= { ciscoProducts 770 } -- Cisco PIX Firewall 525 System Context
+ciscoPIXFirewall535sy	OBJECT IDENTIFIER ::= { ciscoProducts 771 } -- Cisco PIX Firewall 535 System Context
+ciscoIpRanOpt4p		OBJECT IDENTIFIER ::= { ciscoProducts 772 } -- The Mobile Wireless IP-RAN 4-Processor card for ONS platform with 4 Gigabit Ethernet ports
+ciscoASA5510sc		OBJECT IDENTIFIER ::= { ciscoProducts 773 } -- Cisco Adaptive Security Appliance 5510 Security Context
+ciscoASA5510sy		OBJECT IDENTIFIER ::= { ciscoProducts 774 } -- Cisco Adaptive Security Appliance 5510 System
+ciscoJumpgate		OBJECT IDENTIFIER ::= { ciscoProducts 775 } -- Prototype plaform used for maintaining the IOS to ARM processor port done in the Technology Center
+ciscoOe512K9		OBJECT IDENTIFIER ::= { ciscoProducts 776 } -- Cisco Optimization Engine Model OE-512-K9 
+ciscoOe612K9		OBJECT IDENTIFIER ::= { ciscoProducts 777 } -- Cisco Optimization Engine Model OE-612-K9
+catalyst3750G24WS25	OBJECT IDENTIFIER ::= { ciscoProducts 778 } -- Catalyst 3750 Unified Access Switch with 24 10/100/1000 Power over Ethernet ports + 2 Gigabit Ethernet SFP ports and integrated Wireless Controller supporting up to 25 Access Points
+catalyst3750G24WS50	OBJECT IDENTIFIER ::= { ciscoProducts 779 } -- Catalyst 3750 Unified Access Switch with 24 10/100/1000 Power over Ethernet ports + 2 Gigabit Ethernet SFP ports and integrated Wireless Controller supporting up to 50 Access Points 
+ciscoMe3400g12CsA	OBJECT IDENTIFIER ::= { ciscoProducts 780 } -- Metro Ethernet 3400, 12 GE/SFP ports + 4 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power
+ciscoMe3400g12CsD	OBJECT IDENTIFIER ::= { ciscoProducts 781 } -- Metro Ethernet 3400, 12 GE/SFP ports + 4 SFP ports fixed configuration Layer 2/3 Ethernet switch, DC power
+cisco877M		OBJECT IDENTIFIER ::= { ciscoProducts 782 } -- Cisco 877 platform with 1 ADSL Annex M over POTS WAN interface, 4-port 10/100 BASE-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
+cisco1801M		OBJECT IDENTIFIER ::= { ciscoProducts 783 } -- Cisco 1800 platform with 1 ADSL Annex M over POTS WAN interface, 8-port 10/100 BASE-T LAN Ethernet switch, 1 ISDN BRI S/T interface and an optional Wireless LAN
+catalystWsCBS3040FSC	OBJECT IDENTIFIER ::= { ciscoProducts 784 } -- Cisco Catalyst Blade Switch 3040 for FSC
+ciscoOe511K9		OBJECT IDENTIFIER ::= { ciscoProducts 785 } -- Cisco Optimization Engine Model OE-511-K9
+ciscoOe611K9		OBJECT IDENTIFIER ::= { ciscoProducts 786 } -- Cisco Optimization Engine Model OE-611-K9
+ciscoOe7326K9		OBJECT IDENTIFIER ::= { ciscoProducts 787 } -- Cisco Optimization Engine Model OE-7326-K9
+ciscoMe492410GE		OBJECT IDENTIFIER ::= { ciscoProducts 788 } -- Metro Ethernet fixed configuration box with 2 Ten Gigabit X2 ports and 24+4 One Gigabit SFP ports
+catalyst3750E24TD	OBJECT IDENTIFIER ::= { ciscoProducts 789 } -- Catalyst 3750E 24 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch. 
+catalyst3750E48TD	OBJECT IDENTIFIER ::= { ciscoProducts 790 } -- Catalyst 3750E 48 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
+catalyst3750E48PD	OBJECT IDENTIFIER ::= { ciscoProducts 791 } -- Catalyst 3750E 48 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
+catalyst3750E24PD	OBJECT IDENTIFIER ::= { ciscoProducts 792 } -- Catalyst 3750E 24 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch.
+catalyst3560E24TD	OBJECT IDENTIFIER ::= { ciscoProducts 793 } -- Catalyst 3560E 24 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
+catalyst3560E48TD	OBJECT IDENTIFIER ::= { ciscoProducts 794 } -- Catalyst 3560E 48 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
+catalyst3560E24PD	OBJECT IDENTIFIER ::= { ciscoProducts 795 } -- Catalyst 3560E 24 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
+catalyst3560E48PD	OBJECT IDENTIFIER ::= { ciscoProducts 796 } -- Catalyst 3560E 48 10/100/1000 Power over Ethernet ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2/Layer 3 Ethernet switch.
+catalyst35608PC		OBJECT IDENTIFIER ::= { ciscoProducts 797 } -- Catalyst 3560 8 10/100 Power over Ethernet ports + 1  dual purpose Gigabit Ethernet port fixed configuration Layer 2 /Layer 3 Ethernet switch 
+catalyst29608TC		OBJECT IDENTIFIER ::= { ciscoProducts 798 } -- Catalyst 2960 8 10/100 ports + 1  dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
+catalyst2960G8TC	OBJECT IDENTIFIER ::= { ciscoProducts 799 } -- Catalyst 2960 7 10/100/1000 ports + 1  dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch 
+ciscoTSPri		OBJECT IDENTIFIER ::= { ciscoProducts 800 } -- Cisco TelePresence Primary Codec 
+ciscoTSSec		OBJECT IDENTIFIER ::= { ciscoProducts 801 } -- Cisco TelePresence Secondary Codec
+ciscoUWIpPhone7921G	OBJECT IDENTIFIER ::= { ciscoProducts 802 } -- Cisco Unified Wireless IP Phone 7921G with IEEE 802.11a/b/g interface
+ciscoUWIpPhone7920	OBJECT IDENTIFIER ::= { ciscoProducts 803 } -- Cisco Unified Wireless IP Phone 7920 with IEEE 802.11b interface
+cisco3200WirelessMic	OBJECT IDENTIFIER ::= { ciscoProducts 804 } -- Cisco 3200 Wireless Mobile Interface Card
+ciscoISRWireless	OBJECT IDENTIFIER ::= { ciscoProducts 805 } -- Cisco Integrated Services Router with Wireless
+ciscoIPSVirtual		OBJECT IDENTIFIER ::= { ciscoProducts 806 } -- Cisco Intrusion Prevention System virtual sensor
+ciscoIDS4215Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 807 } -- Cisco Intrusion Detection System 4215 virtual sensor
+ciscoIDS4235Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 808 } -- Cisco Intrusion Detection System 4235 virtual sensor
+ciscoIDS4250Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 809 } -- Cisco Intrusion Detection System 4250 virtual sensor
+ciscoIDS4250SXVirtual	OBJECT IDENTIFIER ::= { ciscoProducts 810 } -- Cisco Intrusion Detection System 4250 SX virtual sensor
+ciscoIDS4250XLVirtual	OBJECT IDENTIFIER ::= { ciscoProducts 811 } -- Cisco Intrusion Detection System 4250 XL virtual sensor
+ciscoIDS4240Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 812 } -- Cisco Intrusion Prevention Detection System 4240 virtual sensor
+ciscoIDS4255Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 813 } -- Cisco Intrusion Prevention Detection System 4255 virtual sensor
+ciscoIDS4260Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 814 } -- Cisco Intrusion Prevention Detection System 4260 virtual sensor
+ciscoIDSIDSM2Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 815 } -- Cisco Intrusion Detection System Module IDSM2 virtual sensor
+ciscoIPSSSM20Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 816 } -- Cisco Intrusion Prevention System Security Service Module SSM-20 virtual sensor
+ciscoIPSSSM10Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 817 } -- Cisco Intrusion Prevention System Security Service Module SSM-10 virtual sensor
+ciscoNMWLCE		OBJECT IDENTIFIER ::= { ciscoProducts 818 } -- Integrated service router series 28xx/38xx with Wireless Lan Controller Network Module.
+cisco3205WirelessMic	OBJECT IDENTIFIER ::= { ciscoProducts 819 } -- Cisco 3205 Wireless MIC (Mobile Interface card) with 802.11a wireless interface in the PC104+ form factor. An interface card for the existing MAR 3200 products(Mobile Access Router)
+cisco5720		OBJECT IDENTIFIER ::= { ciscoProducts 820 } -- Integrated Encryption Router
+cisco7201		OBJECT IDENTIFIER ::= { ciscoProducts 821 } -- Cisco 7201 platform, 1 Rack Unit (RU) application specific router with 1 slot
+ciscoCrs14S		OBJECT IDENTIFIER ::= { ciscoProducts 822 } -- Cisco CRS-1 Series 4 Slots System
+ciscoNmWae		OBJECT IDENTIFIER ::= { ciscoProducts 823 } -- Wide Area Application Engine Network Module
+ciscoACE4710K9		OBJECT IDENTIFIER ::= { ciscoProducts 824 } -- ACE 4710 Application Control Engine Appliance
+ciscoMe3400g2csA	OBJECT IDENTIFIER ::= { ciscoProducts 825 } -- Metro Ethernet 3400, 2 GE/SFP ports + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power
+ciscoNmeNam		OBJECT IDENTIFIER ::= { ciscoProducts 826 } -- Cisco NME-NAM, Network Analysis Module (NAM) for the branch office routers
+ciscoUbr7225Vxr		OBJECT IDENTIFIER ::= { ciscoProducts 827 } -- Cisco 7225 Universal Broadband Router, VXR series
+ciscoAirWlc2106K9	OBJECT IDENTIFIER ::= { ciscoProducts 828 } -- This is a replacement for device WLAN Controller with product name WLC2006. 
+ciscoMwr1951DC		OBJECT IDENTIFIER ::= { ciscoProducts 829 } -- The Mobile Wireless router MWR-1951-DC is a router targeted at application in a cell site Base Transciever Station (BTS) providing Radio Access Network (RAN) optimization through support of 8 IMA groups.
+ciscoIPS4270		OBJECT IDENTIFIER ::= { ciscoProducts 830 } -- IPS 4270 Intrusion Prevention Sensor
+ciscoIPS4270Virtual	OBJECT IDENTIFIER ::= { ciscoProducts 831 } -- IPS 4270 Intrusion Prevention Virtual Sensor
+ciscoWSC6509ve		OBJECT IDENTIFIER ::= { ciscoProducts 832 } -- Catalyst 6500 enhanced 9-slot vertical chassis
+cisco5740		OBJECT IDENTIFIER ::= { ciscoProducts 833 } -- Integrated Encryption Router
+cisco861		OBJECT IDENTIFIER ::= { ciscoProducts 834 } -- c861 with 1 FE, 4 switch ports, 1 Console/Aux port, and an optional Wireless LAN
+cisco866		OBJECT IDENTIFIER ::= { ciscoProducts 835 } -- c866 with 1 VDSL2 AnnexB, 4 switch ports, 1 Console/Aux port, and an optional Wireless LAN.
+cisco867		OBJECT IDENTIFIER ::= { ciscoProducts 836 } -- c867 with 1 ADSL2/2+ AnnexA,4 switch ports, 1 Console/Aux port, and an optional Wireless LAN
+cisco881		OBJECT IDENTIFIER ::= { ciscoProducts 837 } -- c881 with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, and an optional Wireless LAN.
+cisco881G		OBJECT IDENTIFIER ::= { ciscoProducts 838 } -- c881G with 1 FE, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
+ciscoIad881F		OBJECT IDENTIFIER ::= { ciscoProducts 839 } -- IAD881IF with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, and an optional Wireless LAN
+cisco881Srst		OBJECT IDENTIFIER ::= { ciscoProducts 840 } -- c881SRST with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN FXO port, and an optional Wireless LAN
+ciscoIad881B		OBJECT IDENTIFIER ::= { ciscoProducts 841 } -- IAD881B with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 2 PBX BRI ports, and an optional Wireless LAN
+cisco886		OBJECT IDENTIFIER ::= { ciscoProducts 842 } -- c886 with 1 ADSL2/2+ AnnexB, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
+cisco886G               OBJECT IDENTIFIER ::= { ciscoProducts 843 } -- c886G with 1 ADSL2/2+ AnnexB,4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
+ciscoIad886F            OBJECT IDENTIFIER ::= { ciscoProducts 844 } -- IAD886F with 1 ADSL2/2+ AnnexB, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
+ciscoIad886B            OBJECT IDENTIFIER ::= { ciscoProducts 845 } -- IAD886B with 1 ADSL2/2+ AnnexB, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
+cisco886Srst            OBJECT IDENTIFIER ::= { ciscoProducts 846 } -- c886SRST with 1 ADSL2/2+ Annex B, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
+cisco887                OBJECT IDENTIFIER ::= { ciscoProducts 847 } -- c887 with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
+cisco887G               OBJECT IDENTIFIER ::= { ciscoProducts 848 } -- c887G with 1 ADSL2/2+ AnnexA,4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
+ciscoIad887F            OBJECT IDENTIFIER ::= { ciscoProducts 849 } -- IAD887 with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
+ciscoIad887B            OBJECT IDENTIFIER ::= { ciscoProducts 850 } -- IAD887B with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
+cisco887Srst            OBJECT IDENTIFIER ::= { ciscoProducts 851 } -- c887SRST with 1 ADSL2/2+ AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
+cisco888		OBJECT IDENTIFIER ::= { ciscoProducts 852 } -- c888 with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN.
+cisco888G               OBJECT IDENTIFIER ::= { ciscoProducts 853 } -- c888G with 1 G.SHDSL, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
+ciscoIad888F		OBJECT IDENTIFIER ::= { ciscoProducts 854 } -- IAD888F with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
+ciscoIad888B		OBJECT IDENTIFIER ::= { ciscoProducts 855 } -- IAD888B with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
+cisco888Srst		OBJECT IDENTIFIER ::= { ciscoProducts 856 } -- c888SRST with 1 G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
+cisco891		OBJECT IDENTIFIER ::= { ciscoProducts 857 } -- c891 with 1 GE, 8 switch ports, 2 USB 2.0 ports, 2 Console/Aux ports, 1 V.92, 1 Backup FE, and an optional Wireless LAN
+cisco892		OBJECT IDENTIFIER ::= { ciscoProducts 858 } -- c892 with 1GE, 8 switch ports, 2 USB 2.0 ports, 2 Console/Aux ports, 1 ISDN, 1 Backup FE, and an optional Wireless LAN
+cisco885D3		OBJECT IDENTIFIER ::= { ciscoProducts 859 } -- c885-D-3 with 1 US Docsis Cable, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, and an optional Wireless LAN.
+ciscoIad885FD3		OBJECT IDENTIFIER ::= { ciscoProducts 860 } -- IAD885F-D-3 with 1 US Docsis Cable, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, and an optional Wireless LAN.
+cisco885EJ3		OBJECT IDENTIFIER ::= { ciscoProducts 861 } -- c885-E/J-3 with 1 Euro-Docsis Cable, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, and an optional Wireless LAN.
+cisco7603s		OBJECT IDENTIFIER ::= { ciscoProducts 862 } -- Cisco 7600 S-Series Chassis with 3 slots 
+cisco7606s		OBJECT IDENTIFIER ::= { ciscoProducts 863 } -- Cisco 7600 S-Series Chassis with 6 slots 
+cisco7609s              OBJECT IDENTIFIER ::= { ciscoProducts 864 } -- Cisco 7600 S-Series Chassis with 9 slots  
+cisco7600Seb		OBJECT IDENTIFIER ::= { ciscoProducts 865 } -- Service Engine Blade for Session Border Controller
+ciscoNMECUE		OBJECT IDENTIFIER ::= { ciscoProducts 866 } -- Cisco Unity Express Network Module Enhanced (NME-CUE) 
+ciscoAIM2CUE		OBJECT IDENTIFIER ::= { ciscoProducts 867 } -- Cisco Unity Express advanced integration module 2 (AIM2-CUE) 
+ciscoUC500		OBJECT IDENTIFIER ::= { ciscoProducts 868 } -- Unified Communication 500 Series (UC500) 
+cisco860Ap		OBJECT IDENTIFIER ::= { ciscoProducts 869 } -- Cisco 860 AP is the embedded wireless access point module for Cisco 860 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz. 
+cisco880Ap		OBJECT IDENTIFIER ::= { ciscoProducts 870 } -- Cisco 880 AP is the embedded wireless access point module for Cisco 880 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz.
+cisco890Ap		OBJECT IDENTIFIER ::= { ciscoProducts 871 } -- Cisco 890 AP is the embedded wireless access point module for Cisco 890 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz and one IEEE 802.11 a/n radio port which operates in 5 GHz
+cisco1900Ap		OBJECT IDENTIFIER ::= { ciscoProducts 872 } -- Cisco 1900 AP is the embedded wireless access point module for Cisco 1900 router. It has one IEEE 802.11 b/g/n radio port which operates in 2.4 GHz and one IEEE 802.11 a/n radio port which operates in 5 GHz
+cisco340024FSA		OBJECT IDENTIFIER ::= { ciscoProducts 873 } -- Metro Ethernet 3400, 24 100BaseFX Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch
+catalyst4503e		OBJECT IDENTIFIER ::= { ciscoProducts 874 } -- Catalyst 4500 E-series with 3 slots (WS-C4503-E)
+catalyst4506e		OBJECT IDENTIFIER ::= { ciscoProducts 875 } -- Catalyst 4500 E-series with 6 slots (WS-C4506-E)
+catalyst4507re		OBJECT IDENTIFIER ::= { ciscoProducts 876 } -- Catalyst 4500 E-series with 7 slots (WS-C4507R-E)
+catalyst4510re		OBJECT IDENTIFIER ::= { ciscoProducts 877 } -- Catalyst 4500 E-series with 10 slots (WS-C4510R-E)
+ciscoUC520s8U4FXOK9	OBJECT IDENTIFIER ::= { ciscoProducts 878 } -- UC500 with support for 8 switch ports and 4 FXO ports
+ciscoUC520s8U4FXOWK9	OBJECT IDENTIFIER ::= { ciscoProducts 879 } -- UC500 with support for 8 switch ports, 4 FXO ports, and Wi-Fi
+ciscoUC520s8U2BRIK9	OBJECT IDENTIFIER ::= { ciscoProducts 880 } -- UC500 with support for 8 switch ports and 2 BRI
+ciscoUC520s8U2BRIWK9	OBJECT IDENTIFIER ::= { ciscoProducts 881 } -- UC500 with support for 8 switch ports and 2 BRI, and Wi-Fi
+ciscoUC520s16U4FXOK9	OBJECT IDENTIFIER ::= { ciscoProducts 882 } -- UC500 with support for 16 switch ports and 4 FXO ports
+ciscoUC520s16U4FXOWK9	OBJECT IDENTIFIER ::= { ciscoProducts 883 } -- UC500 with support for 16 switch ports, 4 FXO ports, and Wi-Fi
+ciscoUC520s16U2BRIK9	OBJECT IDENTIFIER ::= { ciscoProducts 884 } -- UC500 with support for 16 switch ports and 2 BRI
+ciscoUC520s16U2BRIWK9	OBJECT IDENTIFIER ::= { ciscoProducts 885 } -- UC500 with support for 16 switch ports and 2 BRI, and Wi-Fi
+ciscoUC520m32U8FXOK9	OBJECT IDENTIFIER ::= { ciscoProducts 886 } -- UC500 with support for 32 switch ports and 8 FXO ports
+ciscoUC520m32U8FXOWK9	OBJECT IDENTIFIER ::= { ciscoProducts 887 } -- UC500 with support for 32 switch ports and 8 FXO ports, and Wi-Fi
+ciscoUC520m32U4BRIK9	OBJECT IDENTIFIER ::= { ciscoProducts 888 } -- UC500 with support for 32 switch ports and 4 BRI
+ciscoUC520m32U4BRIWK9	OBJECT IDENTIFIER ::= { ciscoProducts 889 } -- UC500 with support for 32 switch ports and 4 BRI, and Wi-Fi
+ciscoUC520m48U12FXOK9	OBJECT IDENTIFIER ::= { ciscoProducts 890 } -- UC500 with support for 48 switch ports and 12 FXO ports
+ciscoUC520m48U12FXOWK9	OBJECT IDENTIFIER ::= { ciscoProducts 891 } -- UC500 with support for 48 switch ports and 12 FXO ports, and Wi-Fi
+ciscoUC520m48U6BRIK9	OBJECT IDENTIFIER ::= { ciscoProducts 892 } -- UC500 with support for 48 switch ports and 6 BRI
+ciscoUC520m48U6BRIWK9	OBJECT IDENTIFIER ::= { ciscoProducts 893 } -- UC500 with support for 48 switch ports and 6 BRI, and Wi-Fi
+ciscoUC520m48U1T1E1FK9	OBJECT IDENTIFIER ::= { ciscoProducts 894 } -- UC500 with support for 48 switch ports and 1 T1
+ciscoUC520m48U1T1E1BK9	OBJECT IDENTIFIER ::= { ciscoProducts 895 } -- UC500 with support for 48 switch ports and 1 T1, and Wi-Fi
+catalyst65xxVirtualSwitch	 OBJECT IDENTIFIER ::= { ciscoProducts 896 } -- 65xx Virtual sSwitch
+catalystExpress5208PC		 OBJECT IDENTIFIER ::= { ciscoProducts 897 } -- Catalyst Express 520 8 10/100 Power over Ethernet ports + 1 dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
+ciscoMCS7816I			 OBJECT IDENTIFIER ::= { ciscoProducts 898 } -- Cisco Media Convergence Server 7816 (IBM)
+ciscoMCS7828I			OBJECT IDENTIFIER ::= { ciscoProducts 899 } -- Cisco Media Convergence Server 7828 (IBM)
+ciscoMCS7816H                   OBJECT IDENTIFIER ::= { ciscoProducts 900 } -- Cisco Media Convergence Server 7816 (HP)
+ciscoMCS7828H			OBJECT IDENTIFIER ::= { ciscoProducts 901 } -- Cisco Media Convergence Server 7828 (HP) 
+cisco1861Uc2BK9                 OBJECT IDENTIFIER ::= { ciscoProducts 902 } -- C1861 UC with support for 2 BRI ports and CUE
+cisco1861Uc4FK9                 OBJECT IDENTIFIER ::= { ciscoProducts 903 } -- C1861 UC with support for 4 FXO ports and CUE
+cisco1861Srst2BK9               OBJECT IDENTIFIER ::= { ciscoProducts 904 } -- C1861 SRST with support for 2BRI ports
+cisco1861Srst4FK9               OBJECT IDENTIFIER ::= { ciscoProducts 905 } -- C1861 SRST with support for 4 FXO ports
+ciscoNmeApa			OBJECT IDENTIFIER ::= { ciscoProducts 906 } -- Integrated Service Engine for Application Performance Assurance.
+ciscoOe7330K9			OBJECT IDENTIFIER ::= { ciscoProducts 907 } -- Cisco Optimization Engine Model OE-7330-K9
+ciscoOe7350K9			OBJECT IDENTIFIER ::= { ciscoProducts 908 } -- Cisco Optimization Engine Model OE-7350-K9
+ciscoWsCbs3110gS                OBJECT IDENTIFIER ::= { ciscoProducts 909 } -- Cisco Catalyst Stackable Blade Switch for IBM Enterprise Chassis with 4 1Gigabit Copper Uplink ports
+ciscoWsCbs3110gSt               OBJECT IDENTIFIER ::= { ciscoProducts 910 } -- Cisco Catalyst Stackable Blade Switch for IBM Telco Chassis with 4 1Gigabit Copper Uplink ports
+ciscoWsCbs3110xS                OBJECT IDENTIFIER ::= { ciscoProducts 911 } -- Cisco Catalyst Stackable Blade Switch for IBM Enterprise Chassis with 1 10Gigabit Uplink port
+ciscoWsCbs3110xSt               OBJECT IDENTIFIER ::= { ciscoProducts 912 } -- Cisco Catalyst Stackable for IBM Telco Chassis with 1 10Gigabit Uplink port
+ciscoSce8000                    OBJECT IDENTIFIER ::= { ciscoProducts 913 } -- Cisco SCE8000 Service Control Engine
+ciscoASA5580                    OBJECT IDENTIFIER ::= { ciscoProducts 914 } -- Cisco Adaptive Security Appliance 5580
+ciscoASA5580sc                  OBJECT IDENTIFIER ::= { ciscoProducts 915 } -- Cisco Adaptive Security Appliance 5580 Security Context
+ciscoASA5580sy                  OBJECT IDENTIFIER ::= { ciscoProducts 916 } -- Cisco Adaptive Security Appliance 5580 System Context
+cat4900M                        OBJECT IDENTIFIER ::= { ciscoProducts 917 } -- Catalyst 4900M series chassis with fixed 8 10Gig port base system with 2 additional half height line card slots ( WS-C4900M )
+catWsCbs3120gS                  OBJECT IDENTIFIER ::= { ciscoProducts 918 } -- WS-CBS3120G-S: Cisco Catalyst Stackable Blade Switch for HP C-Class Chassis with 8 1Gigabit Uplink ports
+catWsCbs3120xS                  OBJECT IDENTIFIER ::= { ciscoProducts 919 } -- WS-CBS3120X-S:Cisco Catalyst Stackable Blade Switch for HP C-Class Chassis with 4 1Gigabit and 2 10Gigabit Uplink ports
+catWsCbs3032Del                 OBJECT IDENTIFIER ::= { ciscoProducts 920 } -- WS-CBS3032-DEL: Cisco Catalyst Stackable Blade Switch for FSC with 8 1Gigabit Uplink ports
+catWsCbs3130gS                  OBJECT IDENTIFIER ::= { ciscoProducts 921 } -- WS-CBS3130G-S: Cisco Catalyst Stackable Blade Switch for FSC with 8 1Gigabit Uplink ports
+catWsCbs3130xS                  OBJECT IDENTIFIER ::= { ciscoProducts 922 } -- WS-CBS3130X-S:Cisco Catalyst Stackable Blade Switch for FSC with 4 1Gigabit and 2 10Gigabit Uplink ports
+ciscoASR1002                    OBJECT IDENTIFIER ::= { ciscoProducts 923 } -- Cisco Aggregation Services Router 1000 Series with 2RU Chassis
+ciscoASR1004                    OBJECT IDENTIFIER ::= { ciscoProducts 924 } -- Cisco Aggregation Services Router 1000 Series With 4RU Chassis
+ciscoASR1006                    OBJECT IDENTIFIER ::= { ciscoProducts 925 } -- Cisco Aggregation Services Router 1000 Series With 6RU Chassis
+cisco520WirelessController      OBJECT IDENTIFIER ::= { ciscoProducts 926 } -- Cisco 500 series Wireless controller for Small Medium Business Market
+cat296048TCS                    OBJECT IDENTIFIER ::= { ciscoProducts 927 } -- Catalyst 2960 48 10/100 ports plus 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+cat296024TCS                    OBJECT IDENTIFIER ::= { ciscoProducts 928 } -- Catalyst 2960 24 10/100 ports plus 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+cat296024S                      OBJECT IDENTIFIER ::= { ciscoProducts 929 } -- Catalyst 2960 24 10/100 ports Layer 2 Ethernet switch
+cat3560e12d                     OBJECT IDENTIFIER ::= { ciscoProducts 930 } -- Catalyst 3560E 12 Ten GE (X2) ports 
+ciscoCatRfgw                    OBJECT IDENTIFIER ::= { ciscoProducts 931 } -- Cisco RF gateway, with 2SUP+10RF+2TCC+12RFSW slots, Display, Fan Tray
+catExpress52024TT               OBJECT IDENTIFIER ::= { ciscoProducts 932 } -- Catalyst Express 520 24 10/100 ports + 2 Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catExpress52024LC               OBJECT IDENTIFIER ::= { ciscoProducts 933 } -- Catalyst Express 520 24 10/100 ports (4 Power Over Ethernet Ports) + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catExpress52024PC               OBJECT IDENTIFIER ::= { ciscoProducts 934 } -- Catalyst Express 520 24 Power Over Ethernet Ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catExpress520G24TC              OBJECT IDENTIFIER ::= { ciscoProducts 935 } -- Catalyst Express 520 24 Gigabit Ethernet Ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+ciscoCDScde100                  OBJECT IDENTIFIER ::= { ciscoProducts 936 } -- Cisco Content Delivery System Model CDE-100
+ciscoCDScde200                  OBJECT IDENTIFIER ::= { ciscoProducts 937 } -- Cisco Content Delivery System Model CDE-200
+ciscoCDScde300                  OBJECT IDENTIFIER ::= { ciscoProducts 938 } -- Cisco Content Delivery System Model CDE-300
+cisco1861SrstCue2BK9            OBJECT IDENTIFIER ::= { ciscoProducts 939 } -- C1861 SRST with support for 2 BRI ports and CUE
+cisco1861SrstCue4FK9            OBJECT IDENTIFIER ::= { ciscoProducts 940 } -- C1861 SRST with support for 4 FXO ports and CUE
+ciscoVFrameDataCenter           OBJECT IDENTIFIER ::= { ciscoProducts 941 } -- Data center provisioning and virtualization
+ciscoVQEServer                  OBJECT IDENTIFIER ::= { ciscoProducts 942 } -- Cisco VQE(Video Quality Experience) offers service providers a set of technologies and products associated with the delivery of IPTV video services. 
+ciscoIPSSSM40Virtual            OBJECT IDENTIFIER ::= { ciscoProducts 943 } -- Cisco Intrusion Prevention  System Security Service Module SSM-40 Virtual Sensor
+ciscoIPSSSM40                   OBJECT IDENTIFIER ::= { ciscoProducts 944 } -- Cisco Intrusion Prevention  System Security Service Module SSM-40 Sensor
+ciscoVgd1t3                     OBJECT IDENTIFIER ::= { ciscoProducts 945 } -- VGD Voice Gateway with 1xCT3 supporting CCM and MGCP  
+ciscoCBS3100                    OBJECT IDENTIFIER ::= { ciscoProducts 946 } -- A stack of any CBS3100 switch modules
+ciscoCBS3110                    OBJECT IDENTIFIER ::= { ciscoProducts 947 } -- A stack of any CBS3110 switch modules
+ciscoCBS3120                    OBJECT IDENTIFIER ::= { ciscoProducts 948 } -- A stack of any CBS3120 switch modules
+ciscoCBS3130                    OBJECT IDENTIFIER ::= { ciscoProducts 949 } -- A stack of any CBS3130 switch modules
+catalyst296024PC                OBJECT IDENTIFIER ::= { ciscoProducts 950 } -- 24 10/100 In-Line Power Ethernet ports plus 2 dual purpose Gigabit Ethernet ports
+catalyst296024LT                OBJECT IDENTIFIER ::= { ciscoProducts 951 } -- 24 10/100, 8 POE and 2T ports switch
+catalyst2960PD8TT               OBJECT IDENTIFIER ::= { ciscoProducts 952 } -- 8 10/100 ports plus 1T PD port switch
+ciscoSpa2x1geSynce              OBJECT IDENTIFIER ::= { ciscoProducts 953 } -- 2-port Synchronous Gigabit Ethernet Shared Port Adapter (SPA-2x1GE-SYNCE)
+ciscoN5kC5020pBa                OBJECT IDENTIFIER ::= { ciscoProducts 954 } -- N5020 Chassis, 1AC PS, 40 SFP+ Ports. Modules Sold Seperate
+ciscoN5kC5020pBd                OBJECT IDENTIFIER ::= { ciscoProducts 955 } -- N5020 Chassis, 1DC PS, 40 SFP+ Ports. Modules Sold Seperate 
+catalyst3560E12SD               OBJECT IDENTIFIER ::= { ciscoProducts 956 } -- Catalyst 3560E, 12 SFP Gigabit Ethernet ports + 2 TenGigabit Ethernet (X2) ports
+ciscoOe674                      OBJECT IDENTIFIER ::= { ciscoProducts 957 } -- Cisco Optimization Engine 674
+ciscoIE30004TC                  OBJECT IDENTIFIER ::= { ciscoProducts 958 } -- Cisco Industrial Ethernet 3000 Switch, 4 10/100 + 2 T/SFP
+ciscoIE30008TC                  OBJECT IDENTIFIER ::= { ciscoProducts 959 } -- Cisco Industrial Ethernet 3000 Switch, 8 10/100 + 2 T/SFP
+ciscoRAIE1783MS06T              OBJECT IDENTIFIER ::= { ciscoProducts 960 } -- Cisco Rockwell brand Industrial Ethernet  Switch, 4 10/100 + 2 T/SFP
+ciscoRAIE1783MS10T              OBJECT IDENTIFIER ::= { ciscoProducts 961 } -- Cisco Rockwell brand Industrial Ethernet Switch, 8 10/100 + 2 T/SFP
+cisco2435Iad8fxs                OBJECT IDENTIFIER ::= { ciscoProducts 962 } -- IAD2435 with 8FXS, 2FE and 1T1/E1
+ciscoVG204                      OBJECT IDENTIFIER ::= { ciscoProducts 963 } -- Line side Analog Gateway with 4FXS Analog ports
+ciscoVG202                      OBJECT IDENTIFIER ::= { ciscoProducts 964 } -- Line side Analog Gateway with 2FXS Analog ports
+catalyst291824TT                OBJECT IDENTIFIER ::= { ciscoProducts 965 } -- Catalyst 2918 24 10/100 ports + 2 10/100/1000 Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalyst291824TC                OBJECT IDENTIFIER ::= { ciscoProducts 966 } -- Catalyst 2918 24 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalyst291848TT                OBJECT IDENTIFIER ::= { ciscoProducts 967 } -- Catalyst 2918 48 10/100 ports + 2 10/100/1000 Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalyst291848TC                OBJECT IDENTIFIER ::= { ciscoProducts 968 } -- Catalyst 2918 48 10/100 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+ciscoVQETools                   OBJECT IDENTIFIER ::= { ciscoProducts 969 } -- Cisco CDE110 appliances hosting VQE Channel Provisioning Tool (VCPT) and VQE Client Channel Configuration Delivery Server
+ciscoUC520m24U4BRIK9            OBJECT IDENTIFIER ::= { ciscoProducts 970 } -- UC500 with support for 24U CME Base, CUE and Phone FL w/4BRI, 1VIC 
+ciscoUC520m24U8FXOK9            OBJECT IDENTIFIER ::= { ciscoProducts 971 } -- UC500 with support for 24U CME Base, CUE and Phone FL w/8FXO, 1VIC
+ciscoUC520s16U2BRIWK9J          OBJECT IDENTIFIER ::= { ciscoProducts 972 } -- UC500 for Japan with support for 16 switch ports and 2 BRI, and Wi-Fi
+ciscoUC520s8U2BRIWK9J           OBJECT IDENTIFIER ::= { ciscoProducts 973 } -- UC500 for Japan with support for 8 switch ports and 2 BRI, and Wi-Fi
+ciscoVSIntSp                    OBJECT IDENTIFIER ::= { ciscoProducts 974 } -- Cisco Video Stream Integrated Services
+ciscoVSSP                       OBJECT IDENTIFIER ::= { ciscoProducts 975 } -- Cisco Video Stream Services Platform
+ciscoVSHydecoder                OBJECT IDENTIFIER ::= { ciscoProducts 976 } -- Cisco Video Stream Hybrid Decoder
+ciscoVSDecoder                  OBJECT IDENTIFIER ::= { ciscoProducts 977 } -- Cisco Video Stream Decoder
+ciscoVSEncoder4P                OBJECT IDENTIFIER ::= { ciscoProducts 978 } -- Cisco Video Stream Encoder 4 Port
+ciscoVSEncoder1P                OBJECT IDENTIFIER ::= { ciscoProducts 979 } -- Cisco Video Stream Encoder 1 Port
+ciscoSCS1000K9                  OBJECT IDENTIFIER ::= { ciscoProducts 980 } -- Smart Care 1000 Series Network Appliance
+cisco1805                       OBJECT IDENTIFIER ::= { ciscoProducts 981 } -- Cisco1805 is a repackaging effort for design to address the low end cable access market. C1805 is deployed as cut down and fixed version of Cisco C1841
+ciscoCe7341                     OBJECT IDENTIFIER ::= { ciscoProducts 982 } -- Cisco Content Engine
+ciscoCe7371                     OBJECT IDENTIFIER ::= { ciscoProducts 983 } -- Cisco Content Engine
+cisco7613s                      OBJECT IDENTIFIER ::= { ciscoProducts 984 } -- Cisco 7600 S-Series Chassis with 13 slots
+ciscoOe574                      OBJECT IDENTIFIER ::= { ciscoProducts 985 } -- Cisco Optimization Engine 574
+ciscoOe474                      OBJECT IDENTIFIER ::= { ciscoProducts 986 } -- Cisco Optimization Engine 474
+ciscoOe274                      OBJECT IDENTIFIER ::= { ciscoProducts 987 } -- Cisco Optimization Engine 274
+ciscoAp801agn                   OBJECT IDENTIFIER ::= { ciscoProducts 988 } -- Cisco AP801 Access Point with dual IEEE 802.11a/g/n radio ports
+ciscoAp801gn                    OBJECT IDENTIFIER ::= { ciscoProducts 989 } -- Cisco AP801 Access Point with single IEEE 802.11g/n radio port
+cisco1861WSrstCue4FK9           OBJECT IDENTIFIER ::= { ciscoProducts 990 } -- C1861 SRST with support for 4 FXO ports, Wireless and CUE
+cisco1861WSrstCue2BK9           OBJECT IDENTIFIER ::= { ciscoProducts 991 } -- C1861 SRST with support for 2 BRI ports, Wireless and CUE
+cisco1861WSrst4FK9              OBJECT IDENTIFIER ::= { ciscoProducts 992 } -- C1861 SRST with support for 4 FXO ports and Wireless
+cisco1861WSrst2BK9              OBJECT IDENTIFIER ::= { ciscoProducts 993 } -- C1861 SRST with support for 2 BRI ports and Wireless
+cisco1861WUc4FK9                OBJECT IDENTIFIER ::= { ciscoProducts 994 } -- 1861 UC with support for 4 FXO ports, Wireless and CUE
+cisco1861WUc2BK9                OBJECT IDENTIFIER ::= { ciscoProducts 995 } -- 1861 UC with support for 2 BRI ports, Wireless and CUE
+ciscoCe674                      OBJECT IDENTIFIER ::= { ciscoProducts 996 } -- Cisco Content Engine 674
+ciscoVQEIST                     OBJECT IDENTIFIER ::= { ciscoProducts 997 } -- VQE-IST is an Integrated Server Tool that combines services from VQE Server and VQE Tools
+ciscoAIRAP1160                  OBJECT IDENTIFIER ::= { ciscoProducts 998 } -- Cisco Aironet 1160 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoWsCbs3012Ibm               OBJECT IDENTIFIER ::= { ciscoProducts 999 } -- Cisco Catalyst Blade Switch 3012 for IBM
+ciscoWsCbs3012IbmI              OBJECT IDENTIFIER ::= { ciscoProducts 1000 } -- Cisco Catalyst Blade Switch 3012 for IBM
+ciscoWsCbs3125gS                OBJECT IDENTIFIER ::= { ciscoProducts 1001 } -- Cisco Catalyst Blade Switch 3125G for HP
+ciscoWsCbs3125xS                OBJECT IDENTIFIER ::= { ciscoProducts 1002 } -- Cisco Catalyst Blade Switch 3125X for HP
+ciscoTSPriG2                    OBJECT IDENTIFIER ::= { ciscoProducts 1003 } -- Cisco TelePresence Primary Codec, Generation 2
+catalyst492810GE                OBJECT IDENTIFIER ::= { ciscoProducts 1004 } -- Fixed configuration Catalyst 4000 with 28 1000BaseX SFP port
+catalyst296048TTS               OBJECT IDENTIFIER ::= { ciscoProducts 1005 } -- Catalyst 2960 48 10/100 ports + 2 10/100/1000 Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalyst29608TCS                OBJECT IDENTIFIER ::= { ciscoProducts 1006 } -- Catalyst 2960 8 10/100 ports + 1 dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
+ciscoMe3400eg2csA               OBJECT IDENTIFIER ::= { ciscoProducts 1007 } -- Metro Ethernet 3400E, 2 GE/SFP ports + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, AC power
+ciscoMe3400eg12csM              OBJECT IDENTIFIER ::= { ciscoProducts 1008 } -- Metro Ethernet 3400 , 12 GE/SFP ports + 4 SFP ports fixed configuration Layer 2/3 Ethernet switch, modular power
+ciscoMe3400e24tsM               OBJECT IDENTIFIER ::= { ciscoProducts 1009 } -- Metro Ethernet 3400E, 24 10/100 Fast Ethernet + 2 SFP ports fixed configuration Layer 2/3 Ethernet switch, modular power
+ciscoIPSSSC5Virtual             OBJECT IDENTIFIER ::= { ciscoProducts 1010 } -- Cisco Intrusion Prevention System Security Service Card SSC-5 Virtual Sensor
+ciscoSR520FE                    OBJECT IDENTIFIER ::= { ciscoProducts 1011 } -- SR520 with 1 10/100T ethernet WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
+ciscoSR520ADSL                  OBJECT IDENTIFIER ::= { ciscoProducts 1012 } -- SR520 with 1 ADSL over POTS WAN interface, 4-port 10/100 BASE-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
+ciscoSR520ADSLi                 OBJECT IDENTIFIER ::= { ciscoProducts 1013 } -- SR520 with 1 ADSL over ISDN WAN interface, 4-port 10/100 Base-T LAN Ethernet switch, hardware encryption and an optional Wireless LAN card
+ciscoMwr2941DC                  OBJECT IDENTIFIER ::= { ciscoProducts 1014 } -- The Mobile Wireless router MWR-2941-DC is a router targeted at application in a cell site Base Transciever Station (BTS) providing Radio Access Network (RAN) optimization
+catalyst356012PCS               OBJECT IDENTIFIER ::= { ciscoProducts 1015 } -- Catalyst 3560 12 10/100 Power over Ethernet ports + 1 dual purpose Gigabit Ethernet port fixed configuration Layer 2 Ethernet switch
+catalyst296048PSTL              OBJECT IDENTIFIER ::= { ciscoProducts 1016 } -- Catalyst 2960 48 10/100 Power over Ethernet ports + 2 10/100/1000 Ethernet Ports + 2 SFP fixed configuration Layer 2 Ethernet switch
+ciscoASR9010                    OBJECT IDENTIFIER ::= { ciscoProducts 1017 } -- Cisco Aggregation Services Router (ASR) 9010 Chassis
+ciscoASR9006                    OBJECT IDENTIFIER ::= { ciscoProducts 1018 } -- Cisco Aggregation Services Router (ASR) 9006 Chassis
+catalyst3560v224tsD             OBJECT IDENTIFIER ::= { ciscoProducts 1019 } -- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable switch, DC power
+catalyst3560v224ts              OBJECT IDENTIFIER ::= { ciscoProducts 1020 } -- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable switch
+catalyst3560v224ps              OBJECT IDENTIFIER ::= { ciscoProducts 1021 } -- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable PoE switch
+catalyst3750v224ts              OBJECT IDENTIFIER ::= { ciscoProducts 1022 } -- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch
+catalyst3750v224ps              OBJECT IDENTIFIER ::= { ciscoProducts 1023 } -- 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable PoE switch
+catalyst3560v248ts              OBJECT IDENTIFIER ::= { ciscoProducts 1024 } -- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable switch
+catalyst3560v248ps              OBJECT IDENTIFIER ::= { ciscoProducts 1025 } -- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Non-stackable PoE switch
+catalyst3750v248ts              OBJECT IDENTIFIER ::= { ciscoProducts 1026 } -- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable switch
+catalyst3750v248ps              OBJECT IDENTIFIER ::= { ciscoProducts 1027 } -- 48 10/100 ports + 4 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet Stackable PoE switch
+ciscoHwicCableD2                OBJECT IDENTIFIER ::= { ciscoProducts 1028 } -- This HWIC supports DOCSIS 2.0 in modular Integrated Service Routers as well as IAD2430 series routers
+ciscoHwicCableEJ2               OBJECT IDENTIFIER ::= { ciscoProducts 1029 } -- This HWIC supports Euro-DOCSIS 2.0, and J-DOCSIS 2.0 in modular Integrated Service Routers as well as IAD2430 series routers 
+ciscoBr1430                     OBJECT IDENTIFIER ::= { ciscoProducts 1030 } -- Cisco 1400 series wireless LAN bridge 
+ciscoAIRBR1430                  OBJECT IDENTIFIER ::= { ciscoProducts 1031 } -- Cisco 1430 Series Wireless LAN Bridge with 4 GigabitEthernet Ports and one  4.9GHz  802.11A  or  5.8GHz 802.11N radio
+ciscoNamApp2204                 OBJECT IDENTIFIER ::= { ciscoProducts 1032 } -- Cisco NAM Appliance 2204
+ciscoNamApp2220                 OBJECT IDENTIFIER ::= { ciscoProducts 1033 } -- Cisco NAM Appliance 2220
+ciscoAIRAP1141                  OBJECT IDENTIFIER ::= { ciscoProducts 1034 } -- Cisco Aironet 1140 series WLAN Access Point with one 10/100/1000TX port and single IEEE 802.11n radio port
+ciscoAIRAP1142                  OBJECT IDENTIFIER ::= { ciscoProducts 1035 } -- Cisco Aironet 1140 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoASR14K4S                   OBJECT IDENTIFIER ::= { ciscoProducts 1036 } -- Cisco ASR14000 Series 4-Slot System
+ciscoASR14K8S                   OBJECT IDENTIFIER ::= { ciscoProducts 1037 } -- Cisco ASR14000 Series 8-Slot System
+cisco18xxx                      OBJECT IDENTIFIER ::= { ciscoProducts 1038 } -- Cisco 18000 platform BETA
+ciscoIPSSSC5                    OBJECT IDENTIFIER ::= { ciscoProducts 1039 } -- Cisco Intrusion Prevention System Security Service Card SSC-5
+cisco887Vdsl2                   OBJECT IDENTIFIER ::= { ciscoProducts 1040 } -- c887Vdsl2 with 1 VDSL2 only over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port and 1 ISDN
+cisco3945                       OBJECT IDENTIFIER ::= { ciscoProducts 1041 } -- CISCO3945/K9 with SPE150(3 GE, 4  EHWIC, 4 DSP, 4 SM, 256MB CF, 1GB DRAM, IPB)
+cisco3925                       OBJECT IDENTIFIER ::= { ciscoProducts 1042 } -- CISCO3925/K9 with SPE100(3 GE,  4 EHWIC, 4 DSP, 2 SM, 256MB CF, 1GB DRAM, IPB)
+cisco2951                       OBJECT IDENTIFIER ::= { ciscoProducts 1043 } -- CISCO2951/K9 with 3 GE, 4 EHWIC, 3 DSP, 2 SM, 256 MB CF, 512 MB DRAM, IPB
+cisco2921                       OBJECT IDENTIFIER ::= { ciscoProducts 1044 } -- CISCO2921/K9 with 3 GE, 4 EHWIC, 3 DSP, 1 SM, 256 MB CF, 512 MB DRAM, IPB
+cisco2911                       OBJECT IDENTIFIER ::= { ciscoProducts 1045 } -- CISCO2911/K9 with 3 GE, 4 EHWIC, 2 DSP, 1 SM , 256 MB CF, 512 MB DRAM, IPB
+cisco2901                       OBJECT IDENTIFIER ::= { ciscoProducts 1046 } -- CISCO2901/K9 with 2 GE, 4 EHWIC, 2 DSP, 256 MB CF, 512 MBDRAM, IP BASE
+cisco1941                       OBJECT IDENTIFIER ::= { ciscoProducts 1047 } -- CISCO1941/K9  with 2 GE, 2 EHWIC, 256 MB CF, 256 MB DRAM, IP BASE
+ciscoSm2k15Es1GePoe             OBJECT IDENTIFIER ::= { ciscoProducts 1048 } -- EtherSwitch Service Module Layer2 + PoE + 15 10/100 + 1 10/100/1000
+ciscoSm3k15Es1GePoe             OBJECT IDENTIFIER ::= { ciscoProducts 1049 } -- EtherSwitch Service Module Layer3 + PoE + 15 10/100 + 1 10/100/1000
+ciscoSm3k16GePoe                OBJECT IDENTIFIER ::= { ciscoProducts 1050 } -- EtherSwitch Service Module Layer3 + PoE + 16 10/100/1000
+ciscoSm2k23Es1Ge                OBJECT IDENTIFIER ::= { ciscoProducts 1051 } -- EtherSwitch Service Module Layer2 + no PoE + 23 10/100 + 1 10/100/1000
+ciscoSm2k23Es1GePoe             OBJECT IDENTIFIER ::= { ciscoProducts 1052 } -- EtherSwitch Service Module Layer2 + PoE + 23 10/100 + 1 10/100/1000
+ciscoSm3k23Es1GePoe             OBJECT IDENTIFIER ::= { ciscoProducts 1053 } -- EtherSwitch Service Module Layer3 + PoE + 23 10/100 + 1 10/100/1000
+ciscoSm3k24GePoe                OBJECT IDENTIFIER ::= { ciscoProducts 1054 } -- EtherSwitch Service Module Layer3 + PoE + 24 10/100/1000
+ciscoSmXd2k48Es2SFP             OBJECT IDENTIFIER ::= { ciscoProducts 1055 } -- EtherSwitch Service Module Layer2 + no PoE + 48 10/100 + 2 SFP
+ciscoSmXd3k48Es2SFPPoe          OBJECT IDENTIFIER ::= { ciscoProducts 1056 } -- EtherSwitch Service Module Layer3 + PoE + 48 10/100 + 2 SFP
+ciscoSmXd3k48Ge2SFPPoe          OBJECT IDENTIFIER ::= { ciscoProducts 1057 } -- EtherSwitch Service ModuleLayer3 + PoE + 48 10/100/1000 + 2 SFP
+ciscoEsw52024pK9                OBJECT IDENTIFIER ::= { ciscoProducts 1058 } -- 24-port 10/100 Ethernet Switch with PoE
+ciscoEsw54024pK9                OBJECT IDENTIFIER ::= { ciscoProducts 1059 } -- 24-port 10/100/1000 Ethernet Switch with PoE
+ciscoEsw52048pK9                OBJECT IDENTIFIER ::= { ciscoProducts 1060 } -- 48-port 10/100 Ethernet Switch with PoE
+ciscoEsw52024K9                 OBJECT IDENTIFIER ::= { ciscoProducts 1061 } -- 24-port 10/100 Ethernet Switch
+ciscoEsw54024K9                 OBJECT IDENTIFIER ::= { ciscoProducts 1062 } -- 24-port 10/100/1000 Ethernet
+ciscoEsw52048K9                 OBJECT IDENTIFIER ::= { ciscoProducts 1063 } -- 48-port 10/100 Ethernet Switch
+ciscoEsw54048K9                 OBJECT IDENTIFIER ::= { ciscoProducts 1064 } -- 48-port 10/100/1000 Ethernet Switch
+cisco1861                       OBJECT IDENTIFIER ::= { ciscoProducts 1065 } -- Cisco C1861 Base System
+ciscoUC520                      OBJECT IDENTIFIER ::= { ciscoProducts 1066 } -- UC520 Base System
+catalystWSC2975GS48PSL          OBJECT IDENTIFIER ::= { ciscoProducts 1067 } -- Catalyst 2975 48 10/100/1000 Power over Ethernet ports + 4 Gigabit SFP ports fixed configuration Layer 2 Ethernet Stackable Switch
+catalystC2975Stack              OBJECT IDENTIFIER ::= { ciscoProducts 1068 } -- A stack of Catalyst C2975 stackable ethernet switches
+cisco5500Wlc                    OBJECT IDENTIFIER ::= { ciscoProducts 1069 } -- Cisco 5500 series Wireless LAN Controller
+ciscoSR520T1                    OBJECT IDENTIFIER ::= { ciscoProducts 1070 } -- Security router with 2 FE and 1 T1 port. Supports voice and data
+ciscoPwrC3900Poe                OBJECT IDENTIFIER ::= { ciscoProducts 1071 } -- Cisco 3925/3945 AC Power Supply with Power Over Ethernet (PWR-3900-POE)
+ciscoPwrC3900AC                 OBJECT IDENTIFIER ::= { ciscoProducts 1072 } -- Cisco 3925/3945 AC Power Supply (PWR-3900-AC)
+ciscoPwrC2921C2951Poe           OBJECT IDENTIFIER ::= { ciscoProducts 1073 } -- Cisco 2921/2951 AC Power Supply with Power Over Ethernet (PWR-2921-51-POE)
+ciscoPwrC2921C2951AC            OBJECT IDENTIFIER ::= { ciscoProducts 1074 } -- Cisco 2921/2951 AC Power Supply (PWR-2921-51-AC)
+ciscoPwrC2911Poe                OBJECT IDENTIFIER ::= { ciscoProducts 1075 } -- Cisco 2911 AC Power Supply with Power Over Ethernet (PWR-2911-POE)
+ciscoPwrC2911AC                 OBJECT IDENTIFIER ::= { ciscoProducts 1076 } -- Cisco 2911 AC Power Supply (PWR-2911-AC)
+ciscoPwrC2901Poe                OBJECT IDENTIFIER ::= { ciscoProducts 1077 } -- Cisco 2901 AC Power Supply with Power Over Ethernet(PWR-2901-POE)
+ciscoPwrC1941C2901AC            OBJECT IDENTIFIER ::= { ciscoProducts 1078 } -- Cisco 2901 AC Power Supply (PWR-2901-AC)
+ciscoPwrC1941Poe                OBJECT IDENTIFIER ::= { ciscoProducts 1079 } -- Cisco 1941 AC Power Supply with Power Over Ethernet (PWR-1941-POE)
+ciscoPwrC3900DC                 OBJECT IDENTIFIER ::= { ciscoProducts 1080 } -- Cisco 3925/3945 DC Power Supply (PWR-3900-DC)
+ciscoPwrC2921C2951DC            OBJECT IDENTIFIER ::= { ciscoProducts 1081 } -- Cisco 2921/2951 DC Power Supply (PWR-2921-51-DC)
+ciscoPwrC2911DC                 OBJECT IDENTIFIER ::= { ciscoProducts 1082 } -- Cisco 2911 DC power Supply (PWR-2911-DC)
+ciscoRpsAdptrC2921C2951         OBJECT IDENTIFIER ::= { ciscoProducts 1083 } -- Cisco 2921/2951 RPS Adaptor for use with external rps(RPS-ADPTR-2921-51)
+ciscoRpsAdptrC2911              OBJECT IDENTIFIER ::= { ciscoProducts 1084 } -- Cisco 2911 RPS Adaptor for use with external rps (RPS-ADPTR-2911)
+ciscoIPSSSC2                    OBJECT IDENTIFIER ::= { ciscoProducts 1085 } -- Cisco Intrusion Prevention System Security Service Card SSC-2
+ciscoIPSSSC2Virtual             OBJECT IDENTIFIER ::= { ciscoProducts 1086 } -- Cisco Intrusion Prevention System Security Service Card SSC-2 Virtual Sensor
+catalystWSCBS3140XS             OBJECT IDENTIFIER ::= { ciscoProducts 1087 } -- Cisco Catalyst Blade Switch 3140X for FSC
+catalystWSCBS3140GS             OBJECT IDENTIFIER ::= { ciscoProducts 1088 } -- Cisco Catalyst Blade Switch 3140G for FSC
+catalystWSCBS3042FSC            OBJECT IDENTIFIER ::= { ciscoProducts 1089 } -- Cisco Catalyst Blade Switch 3042 for FSC
+catalystWSCBS3150XS             OBJECT IDENTIFIER ::= { ciscoProducts 1090 } -- Cisco Catalyst Blade Switch 3150X for NEC
+catalystWSCBS3150GS             OBJECT IDENTIFIER ::= { ciscoProducts 1091 } -- Cisco Catalyst Blade Switch 3150G for NEC
+catalystWSCBS3052NEC            OBJECT IDENTIFIER ::= { ciscoProducts 1092 } -- Cisco Catalyst Blade Switch 3052 for NEC
+ciscoCBS3140Stack               OBJECT IDENTIFIER ::= { ciscoProducts 1093 } -- A stack of any CBS3140 switch modules.
+ciscoCBS3150Stack               OBJECT IDENTIFIER ::= { ciscoProducts 1094 } -- A stack of any CBS3150 switch modules.
+cisco1941W                      OBJECT IDENTIFIER ::= { ciscoProducts 1095 } -- CISCO1941W-A/K9 with 802.11 a/b/g/ n  FCC compliant WLAN ISM
+ciscoC888E                      OBJECT IDENTIFIER ::= { ciscoProducts 1096 } -- c888E with 1 EFM based 4 pair G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
+ciscoC888EG                     OBJECT IDENTIFIER ::= { ciscoProducts 1097 } -- c888EG with 1 EFM based 4 pair G.SHDSL, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
+ciscoIad888EB                   OBJECT IDENTIFIER ::= { ciscoProducts 1098 } -- IAD888EB with 1 EFM based 4 pair G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 2 PBX BRI ports, and an optional Wireless LAN
+ciscoIad888EF                   OBJECT IDENTIFIER ::= { ciscoProducts 1099 } -- IAD888EF with 1 EFM based 4 pair G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, 4 FXS ports, and an optional Wireless LAN
+ciscoC888ESRST                  OBJECT IDENTIFIER ::= { ciscoProducts 1100 } -- c888ESRST with 1 EFM based 4 pair G.SHDSL, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
+ciscoASA5505W                   OBJECT IDENTIFIER ::= { ciscoProducts 1101 } -- Cisco Adaptive Security Appliance 5505 with integrated Cisco AP801 Access Point
+cisco3845nv                     OBJECT IDENTIFIER ::= { ciscoProducts 1102 } -- Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800nv family router
+cisco3825nv                     OBJECT IDENTIFIER ::= { ciscoProducts 1103 } -- Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports 3800nv family router
+catalystWSC235048TD             OBJECT IDENTIFIER ::= { ciscoProducts 1104 } -- Catalyst 2350 48 10/100/1000 ports + 2 TenGigabit Ethernet (X2) ports fixed configuration Layer 2 Ethernet Switch
+cisco887M                       OBJECT IDENTIFIER ::= { ciscoProducts 1105 } -- c887 with 1 ADSL2/2+ AnnexM,4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and an optional Wireless LAN
+ciscoVg250                      OBJECT IDENTIFIER ::= { ciscoProducts 1106 } -- 48 FXS port, 2 FXO port, and 2 GE port Analog Voice Gateway 
+ciscoVg226e                     OBJECT IDENTIFIER ::= { ciscoProducts 1107 } -- 24 Off-Premises Extension Lite FXS port, 2 FXO port, and 2 GE port Analog Voice Gateway
+ciscoDsIbm8GfcK9                OBJECT IDENTIFIER ::= { ciscoProducts 1108 } -- 8Gbps Fibre Channel Switch for IBM Blade Center
+ciscoDsHp8GfcK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1109 } -- 8Gbps Fibre Channel Switch for HP Blade System
+ciscoDsDell8GfcK9               OBJECT IDENTIFIER ::= { ciscoProducts 1110 } -- 8Gbps Fibre Channel Switch for DELL Chassis
+ciscoDsC9148K9                  OBJECT IDENTIFIER ::= { ciscoProducts 1111 } -- MDS 9148 Multilayer Fabric Switch
+ciscoCeVirtualBlade             OBJECT IDENTIFIER ::= { ciscoProducts 1112 } -- Cisco Content Engine
+ciscoCDScde420                  OBJECT IDENTIFIER ::= { ciscoProducts 1113 } -- Cisco Content Delivery System Model CDE-420
+ciscoCDScde220                  OBJECT IDENTIFIER ::= { ciscoProducts 1114 } -- Cisco Content Delivery System Model CDE-220
+ciscoCDScde110                  OBJECT IDENTIFIER ::= { ciscoProducts 1115 } -- Cisco Content Delivery System Model CDE-110
+ciscoASR1002F                   OBJECT IDENTIFIER ::= { ciscoProducts 1116 } -- Cisco Aggregation Services Router 1000 Series with 2RU Fixed Chassis
+ciscoSecureAccessControlSystem  OBJECT IDENTIFIER ::= { ciscoProducts 1117 } -- Cisco Secure Access Control System
+cisco861Npe                     OBJECT IDENTIFIER ::= { ciscoProducts 1118 } -- 1 FE, 4 switch ports, 1 Console/Aux port, an optional Wireless LAN, and no VPN payload encryption
+cisco881Npe                     OBJECT IDENTIFIER ::= { ciscoProducts 1119 } -- 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, an optional Wireless LAN, and no VPN payload encryption
+cisco881GNpe                    OBJECT IDENTIFIER ::= { ciscoProducts 1120 } -- 1 FE, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and no VPN payload encryption 
+cisco887Npe                     OBJECT IDENTIFIER ::= { ciscoProducts 1121 } -- 1 ADSL2 AnnexA, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN, and no VPN payload encryption
+cisco888GNpe                    OBJECT IDENTIFIER ::= { ciscoProducts 1122 } -- 1 G.SHDSL, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and no VPN payload encryption
+cisco891Npe                     OBJECT IDENTIFIER ::= { ciscoProducts 1123 } -- 1 GE, 8 switch ports, 2 USB 2.0 ports, 2 Console/Aux ports, 1 V.92, 1 Backup FE, and no VPN payload encryption
+ciscoAIRAP3501                  OBJECT IDENTIFIER ::= { ciscoProducts 1124 } -- Cisco Aironet 3500 Series WLAN Access Point with one 10/100/1000TX port and single IEEE 802.11n radio port
+ciscoAIRAP3502                  OBJECT IDENTIFIER ::= { ciscoProducts 1125 } -- Cisco Aironet 3500 Series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoCDScde400                  OBJECT IDENTIFIER ::= { ciscoProducts 1126 } -- Cisco Content Delivery System Model CDE-400
+ciscoSA520K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1127 } -- SA520 security router with 1-port 10/100 Base-T ethernet WAN interface, optional 1-port WAN/LAN interface and 4-port 10/100 Base-T LAN ethernet switch
+ciscoSA520WK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1128 } -- SA520 security and wireless router with 1-port 10/100 Base-T ethernet WAN interface, optional 1-port WAN/LAN interface and 4-port 10/100 Base-T LAN ethernet switch
+ciscoSA540K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1129 } -- SA540 with 1 10/100 Base-T ethernet WAN interface, 1 optional WAN/LAN port and 8-port 10/100 Base-T LAN ethernet switch
+ciscoSps2004B                   OBJECT IDENTIFIER ::= { ciscoProducts 1130 } -- Metro Ethernet Switch with 1 1000Base-BX-U WAN port and 5 10/100/1000M LAN ports
+ciscoSps204B                    OBJECT IDENTIFIER ::= { ciscoProducts 1131 } -- Metro Ethernet Switch with 1 100Base-BX-U WAN and 5 10/100/1000M LAN ports
+ciscoUC560T1E1K9                OBJECT IDENTIFIER ::= { ciscoProducts 1132 } -- UC560 with T1E1 and FXO
+ciscoUC560BRIK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1133 } -- UC560 with BRI
+ciscoUC560FXOK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1134 } -- UC560 with FXO
+ciscoAp541nAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1135 } -- 802.11a/b/g/n Wireless LAN Access Point for North America, FCC band plan
+ciscoAp541nEK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1136 } -- 802.11a/b/g/n Wireless LAN Access Point for Europe, ETSI band plan
+ciscoAp541nNK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1137 } -- 802.11a/b/g/n Wireless LAN Access Point for ANZ band plan
+cisco887GVdsl2                  OBJECT IDENTIFIER ::= { ciscoProducts 1138 } -- c887GVdsl2 with 1 VDSL2 only over POTS,4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 3G PCMCIA slot, and an optional Wireless LAN
+cisco887SrstVdsl2               OBJECT IDENTIFIER ::= { ciscoProducts 1139 } -- c887SRSTVdsl2 with 1 VDSL2 over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 1 PSTN BRI port, and an optional Wireless LAN
+ciscoUc540wFxoK9                OBJECT IDENTIFIER ::= { ciscoProducts 1140 } -- UC540 with support for 4 FXO interfaces, 8 PoE Fastethernet ports, and integrated Wi-Fi for voice and data access
+ciscoUc540wBriK9                OBJECT IDENTIFIER ::= { ciscoProducts 1141 } -- UC540 with support for 2 BRI interfaces, 8 PoE Fastethernet ports, and integrated Wi-Fi for voice and data access
+ciscoCaServer                   OBJECT IDENTIFIER ::= { ciscoProducts 1142 } -- Cisco Clean Access Server
+ciscoCaManager                  OBJECT IDENTIFIER ::= { ciscoProducts 1143 } -- Cisco Clean Access Manager
+cisco3925SPE200                 OBJECT IDENTIFIER ::= { ciscoProducts 1144 } -- Cisco 3925 w/SPE200(4 GE, 3 EHWIC, 3 DSP,  2 SM)
+cisco3945SPE250                 OBJECT IDENTIFIER ::= { ciscoProducts 1145 } -- Cisco 3945 w/SPE250(4 GE, 3 EHWIC, 3 DSP, 4 SM)
+catalyst296024LCS               OBJECT IDENTIFIER ::= { ciscoProducts 1146 } -- Catalyst 2960 8 10/100 Power over Ethernet ports + 16 10/100 Ethernet ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalyst296024PCS               OBJECT IDENTIFIER ::= { ciscoProducts 1147 } -- Catalyst 2960 24 10/100 Power over Ethernet ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet switch
+catalyst296048PSTS              OBJECT IDENTIFIER ::= { ciscoProducts 1148 } -- Catalyst 2960 48 10/100 Power over Ethernet ports + 2 10/100/1000 Ethernet ports + 2 SFP fixed configuration Layer 2 Ethernet switch
+ciscoISM                        OBJECT IDENTIFIER ::= { ciscoProducts 1149 } -- Cisco Internal Service Module (ISM) with Services Ready Engine (SRE) for ISR routers x900 series
+ciscoSM                         OBJECT IDENTIFIER ::= { ciscoProducts 1150 } -- Cisco Service Module (SM) with Services Ready Engine (SRE) for ISR routers x900 series
+ciscoNMEAXP                     OBJECT IDENTIFIER ::= { ciscoProducts 1151 } -- Cisco Application Extension Platform Network Module Enhanced (NME-AXP)
+ciscoAIMAXP                     OBJECT IDENTIFIER ::= { ciscoProducts 1152 } -- Cisco Application Extension Platform advanced integration module (AIM-AXP)
+ciscoAIM2AXP                    OBJECT IDENTIFIER ::= { ciscoProducts 1153 } -- Cisco Application Extension Platform advanced integration module 2(AIM2-AXP)
+ciscoSRP521                     OBJECT IDENTIFIER ::= { ciscoProducts 1154 } -- Service Ready Platform router with Fast Ethernet WAN port
+ciscoSRP526                     OBJECT IDENTIFIER ::= { ciscoProducts 1155 } -- Service Ready Platform router with ADSL2+ over ISDN WAN port
+ciscoSRP527                     OBJECT IDENTIFIER ::= { ciscoProducts 1156 } -- Service Ready Platform router with ADSL2+ over POTS WAN port
+ciscoSRP541                     OBJECT IDENTIFIER ::= { ciscoProducts 1157 } -- Service Ready Platform router with GE WAN port
+ciscoSRP546                     OBJECT IDENTIFIER ::= { ciscoProducts 1158 } -- Service Ready Platform router with ADSL2+ over ISDN WAN port as well as GE WAN port
+ciscoSRP547                     OBJECT IDENTIFIER ::= { ciscoProducts 1159 } -- Service Ready Platform router with ADSL2+ over POTS WAN port as well as GE WAN port
+ciscoVS510FXO                   OBJECT IDENTIFIER ::= { ciscoProducts 1160 } -- Call control solution for 4-24 phone
+ciscoNmWae900                   OBJECT IDENTIFIER ::= { ciscoProducts 1161 } -- Cisco Network Module Intergrated Service Engine 900
+ciscoNmWae700                   OBJECT IDENTIFIER ::= { ciscoProducts 1162 } -- Cisco Network Module Intergrated Service Engine 700
+cisco5940RA                     OBJECT IDENTIFIER ::= { ciscoProducts 1163 } -- Air cooled rugged router module
+cisco5940RC                     OBJECT IDENTIFIER ::= { ciscoProducts 1164 } -- Conduction cooled rugged router
+ciscoASR1001                    OBJECT IDENTIFIER ::= { ciscoProducts 1165 } -- Cisco Aggregation Services Router 1000 Series with 1RU Chassis
+ciscoASR1013                    OBJECT IDENTIFIER ::= { ciscoProducts 1166 } -- Cisco Aggregation Services Router 1000 Series with 13RU Chassis
+ciscoCDScde205                  OBJECT IDENTIFIER ::= { ciscoProducts 1167 } -- Cisco Content Delivery System Model CDE-205
+ciscoPwr1941AC                  OBJECT IDENTIFIER ::= { ciscoProducts 1168 } -- C1941 AC Power Supply
+ciscoNamWaasVirtualBlade        OBJECT IDENTIFIER ::= { ciscoProducts 1169 } -- Cisco Network Analysis Module (NAM) Virtual Blade on WAAS appliance
+ciscoRaie1783Rms06t             OBJECT IDENTIFIER ::= { ciscoProducts 1170 } -- Cisco Rockwell brand Layer 3 Industrial Ethernet  Switch, 4 10/100 + 2 T/SFP
+ciscoRaie1783Rms10t             OBJECT IDENTIFIER ::= { ciscoProducts 1171 } -- Cisco Rockwell brand Industrial Ethernet Switch, 8 10/100 + 2 T/SFP
+cisco1941WEK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1172 } -- CISCO1941W-E/K9 Router w/ 802.11 a/b/g/n ETSI Compliant WLAN ISM
+cisco1941WPK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1173 } -- CISCO1941W-P/K9 Router w/ 802.11 a/b/g/n Japan Compliant WLAN ISM
+cisco1941WNK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1174 } -- CISCO1941W-N/K9 Router w/ 802.11 a/b/g/n Aus, NZ Compliant WLAN ISM
+ciscoMXE5600                    OBJECT IDENTIFIER ::= { ciscoProducts 1175 } -- Cisco MXE 5600 platform, 1 Rack Unit (RU) application specific device with 8 slots
+ciscoEsw5408pK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1176 } -- Cisco ESW 540 8-port 10/100/1000 PoE switch
+ciscoEsw5208pK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1177 } -- Cisco ESW 520 8-port 10/100 PoW switch
+catalyst4948e10GE               OBJECT IDENTIFIER ::= { ciscoProducts 1178 } -- Catalyst 4000 series fixed configuration switch with 48 10/100/1000BaseT ports and four 10Gbps/1Gbps SFP+/SFP ports(WS-C4948E)
+cat2960x48tsS                   OBJECT IDENTIFIER ::= { ciscoProducts 1179 } --  Catalyst 2960X 48 Gig Downlinks and 2 SFP uplink, Non-stackable module
+cat2960x24tsS                   OBJECT IDENTIFIER ::= { ciscoProducts 1180 } --  Catalyst 2960X 24 Gig Downlinks and 2 SFP uplink, Non-stackable module
+cat2960xs48fpdL                 OBJECT IDENTIFIER ::= { ciscoProducts 1181 } --  Catalyst 2960X 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 740W
+cat2960xs48lpdL                 OBJECT IDENTIFIER ::= { ciscoProducts 1182 } --  Catalyst 2960X 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 370W
+cat2960xs48ltdL                 OBJECT IDENTIFIER ::= { ciscoProducts 1183 } --  Catalyst 2960X 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
+cat2960xs24pdL                  OBJECT IDENTIFIER ::= { ciscoProducts 1184 } --  Catalyst 2960X 24 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 370W
+cat2960xs24tdL                  OBJECT IDENTIFIER ::= { ciscoProducts 1185 } --  Catalyst 2960X 24 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
+cat2960xs48fpsL                 OBJECT IDENTIFIER ::= { ciscoProducts 1186 } --  Catalyst 2960X 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 740W
+cat2960xs48lpsL                 OBJECT IDENTIFIER ::= { ciscoProducts 1187 } --  Catalyst 2960X 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 370W
+cat2960xs24psL                  OBJECT IDENTIFIER ::= { ciscoProducts 1188 } --  Catalyst 2960X 24 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 370W
+cat2960xs48tsL                  OBJECT IDENTIFIER ::= { ciscoProducts 1189 } --  Catalyst 2960X 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module
+cat2960xs24tsL                  OBJECT IDENTIFIER ::= { ciscoProducts 1190 } --  Catalyst 2960X 24 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module
+cisco1921k9                     OBJECT IDENTIFIER ::= { ciscoProducts 1191 } --  CISCO1921/K9 with 2 GE, 2 EHWIC, 256 MB flash memory, 512 MB DRAM, IP BASE
+cisco1905k9                     OBJECT IDENTIFIER ::= { ciscoProducts 1192 } --  CISCO1905/K9  with 2 GE, Serial 1T, 1 EHWIC, 256 MB flash memory, 512 MB DRAM, IP BASE
+ciscoPwrC1921C1905AC            OBJECT IDENTIFIER ::= { ciscoProducts 1193 } --  Cisco 1921/K9 and 1905/K9 AC Power Supply (PWR-1921-1905-AC)
+ciscoASA5585Ssp10               OBJECT IDENTIFIER ::= { ciscoProducts 1194 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-10
+ciscoASA5585Ssp20               OBJECT IDENTIFIER ::= { ciscoProducts 1195 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-20
+ciscoASA5585Ssp40               OBJECT IDENTIFIER ::= { ciscoProducts 1196 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-40
+ciscoASA5585Ssp60               OBJECT IDENTIFIER ::= { ciscoProducts 1197 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-60
+ciscoASA5585Ssp10sc             OBJECT IDENTIFIER ::= { ciscoProducts 1198 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-10
+ciscoASA5585Ssp20sc             OBJECT IDENTIFIER ::= { ciscoProducts 1199 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-20
+ciscoASA5585Ssp40sc             OBJECT IDENTIFIER ::= { ciscoProducts 1200 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-40
+ciscoASA5585Ssp60sc             OBJECT IDENTIFIER ::= { ciscoProducts 1201 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-60
+ciscoASA5585Ssp10sy             OBJECT IDENTIFIER ::= { ciscoProducts 1202 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-10
+ciscoASA5585Ssp20sy             OBJECT IDENTIFIER ::= { ciscoProducts 1203 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-20
+ciscoASA5585Ssp40sy             OBJECT IDENTIFIER ::= { ciscoProducts 1204 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-40
+ciscoASA5585Ssp60sy             OBJECT IDENTIFIER ::= { ciscoProducts 1205 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-60
+cisco3925SPE250                 OBJECT IDENTIFIER ::= { ciscoProducts 1206 } -- Cisco 3925 w/SPE250(4 GE, 3 EHWIC, 3 DSP,  2 SM)
+cisco3945SPE200                 OBJECT IDENTIFIER ::= { ciscoProducts 1207 } -- Cisco 3945 w/SPE200(4 GE, 3 EHWIC, 3 DSP, 4 SM)
+cat29xxStack                    OBJECT IDENTIFIER ::= { ciscoProducts 1208 } -- A stack of any catalyst29xx stack-able ethernet switches with unified identity (as a single unified switch), control and management
+ciscoOeNm302                    OBJECT IDENTIFIER ::= { ciscoProducts 1209 } -- Wide Area Application Engine Network Module 302
+ciscoOeNm502                    OBJECT IDENTIFIER ::= { ciscoProducts 1210 } -- Wide Area Application Engine Network Module 502
+ciscoOeNm522                    OBJECT IDENTIFIER ::= { ciscoProducts 1211 } -- Wide Area Application Engine Network Module 522
+ciscoOeSmSre700                 OBJECT IDENTIFIER ::= { ciscoProducts 1212 } -- Wide Area Application Engine Service Module Service Ready Engine 700 K9
+ciscoOeSmSre900                 OBJECT IDENTIFIER ::= { ciscoProducts 1213 } -- Wide Area Application Engine Service Module Service Ready Engine 900 K9
+ciscoVsaNam                     OBJECT IDENTIFIER ::= { ciscoProducts 1214 } -- Virtual Switch NAM for Nexus1010
+ciscoMwr2941DCA                 OBJECT IDENTIFIER ::= { ciscoProducts 1215 } -- The Mobile Wireless router MWR-2941-DC-A is a router targeted at application in a cell site Base Transciever Station (BTS) providing Radio Access Network (RAN) optimization
+ciscoN7KC7018IOS                OBJECT IDENTIFIER ::= { ciscoProducts 1216 } -- Nexus 7000 series chassis with 18 slots running IOS image
+ciscoN7KC7010IOS                OBJECT IDENTIFIER ::= { ciscoProducts 1217 } -- Nexus 7000 series chassis with 10 slots running IOS image
+ciscoN4KDellEth                 OBJECT IDENTIFIER ::= { ciscoProducts 1218 } -- Chassis of Cisco 10Gb Ethernet Switch Module for Dell Bladecenter
+ciscoN4KDellCiscoEth            OBJECT IDENTIFIER ::= { ciscoProducts 1219 } -- Cisco 10Gb Ethernet Switch Module for Dell Bladecenter-Cisco sold version
+cisco1941WCK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1220 } -- CISCO1941W-C/K9 Router w/ 802.11 a/b/g/n China Compliant WLAN ISM
+ciscoCDScde2202s3               OBJECT IDENTIFIER ::= { ciscoProducts 1221 } -- Cisco Content Delivery System Model CDE-220-2S3
+cat3750x24                      OBJECT IDENTIFIER ::= { ciscoProducts 1222 } -- Catalyst 3750X 24 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat3750x48                      OBJECT IDENTIFIER ::= { ciscoProducts 1223 } -- Catalyst 3750X 48 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat3750x24P                     OBJECT IDENTIFIER ::= { ciscoProducts 1224 } -- Catalyst 3750X 24 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat3750x48P                     OBJECT IDENTIFIER ::= { ciscoProducts 1225 } -- Catalyst 3750X 48 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat3560x24                      OBJECT IDENTIFIER ::= { ciscoProducts 1226 } -- Catalyst 3560X 24 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
+cat3560x48                      OBJECT IDENTIFIER ::= { ciscoProducts 1227 } -- Catalyst 3560X 48 10/100/1000 Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
+cat3560x24P                     OBJECT IDENTIFIER ::= { ciscoProducts 1228 } -- Catalyst 3560X 24 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
+cat3560x48P                     OBJECT IDENTIFIER ::= { ciscoProducts 1229 } -- Catalyst 3560X 48 10/100/1000 PoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
+ciscoNMEAIR                     OBJECT IDENTIFIER ::= { ciscoProducts 1230 } -- Cisco Integrated Series Controllers
+ciscoACE30K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1231 } -- Application Control Engine Module in Cat6500
+ciscoASA5585SspIps10            OBJECT IDENTIFIER ::= { ciscoProducts 1232 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-10
+ciscoASA5585SspIps20            OBJECT IDENTIFIER ::= { ciscoProducts 1233 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-20
+ciscoASA5585SspIps40            OBJECT IDENTIFIER ::= { ciscoProducts 1234 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-40
+ciscoASA5585SspIps60            OBJECT IDENTIFIER ::= { ciscoProducts 1235 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services Processor-60
+cisco1841CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1236 } -- Cisco 1841C/K9 data only router with 2 HWIC slots
+cisco2801CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1237 } -- Cisco 2801C/K9 router with 4 HWIC slots
+cisco2811CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1238 } -- Cisco 2811C/K9 router with one Network Module slot, four HWIC slots, two fast ethernet and integrated VPN
+cisco2821CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1239 } -- Cisco 2821C/K9 router with one Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and intergrated VPN
+cisco2851CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1240 } -- Cisco 2851C/K9 router with one double wide Network Module slot, one EVM, four HWIC slots, two gigabit ethernet and integrated VPN
+cisco3825CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1241 } -- Cisco 3825C/K9 router with Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports
+cisco3845CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1242 } -- Cisco 3845C/K9 router with Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports
+cisco3825CnvK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1243 } -- Cisco 3825Cnv/K9 router with Two Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports
+cisco3845CnvK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1244 } -- Cisco 3845Cnv/K9 router with Four Network Module Slots, Four WIC slots, Two Gigabit Ethernet ports
+ciscoCGS252024TC                OBJECT IDENTIFIER ::= { ciscoProducts 1245 } --  Cisco Connected Grid 2520 Switch, 24 10/100 + 2 T/SFP
+ciscoCGS252016S8PC              OBJECT IDENTIFIER ::= { ciscoProducts 1246 } --  Cisco Connected Grid 2520 Switch, 16 100 SFP + 8 10/100 POE + 2 T/SFP
+ciscoAIRAP1262                  OBJECT IDENTIFIER ::= { ciscoProducts 1247 } -- Cisco Aironet 1260 Series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoAIRAP1261                  OBJECT IDENTIFIER ::= { ciscoProducts 1248 } -- Cisco Aironet 1260 Series WLAN Access Point with one 10/100/1000TX port and single IEEE 802.11n radio port
+cisco892F                       OBJECT IDENTIFIER ::= { ciscoProducts 1249 } -- c892F with 1GE/SFP port, 8 switch ports, 2 USB 2.0 ports, 2 Console/Aux ports, 1 ISDN, 1 Backup FE, and an optional Wireless LAN
+ciscoMe3600x24fsM               OBJECT IDENTIFIER ::= { ciscoProducts 1250 } -- Cisco ME 3600X Ethernet Access Switch, 24 GE SFP ports + 2 10Gbps/1Gbps SFP+/SFP ports fixed configuration Layer 2/3 Ethernet switch, modular power
+ciscoMe3600x24tsM               OBJECT IDENTIFIER ::= { ciscoProducts 1251 } -- Cisco ME 3600X Ethernet Access Switch, 24 10/100/1000 ports + 2 10Gbps/1Gbps SFP+/SFP ports fixed configuration Layer 2/3 Ethernet switch, modular power
+ciscoMe3800x24fsM               OBJECT IDENTIFIER ::= { ciscoProducts 1252 } -- Cisco ME 3800X Carrier Ethernet Switch Router, 24 GE SFP ports + 2 10Gbps/1Gbps SFP+/SFP ports fixed configuration Layer 2/3 Carrier Ethernet Switch Router, modular power
+ciscoCGR2010                    OBJECT IDENTIFIER ::= { ciscoProducts 1253 } -- CISCO Connected Grid Router 2010/K9 with 2 GE, 4 GRWIC, 256 MB CF, 1 GB DRAM, IP BASE
+ciscoPwrCGR20xxCGS25xxPoeAC     OBJECT IDENTIFIER ::= { ciscoProducts 1254 } -- Cisco Connected Grid Router 20xx/Switch 25xx AC Power Supply with Power Over Ethernet (PWR-CGR20xx-CGS25xx-POE-AC)
+ciscoPwrCGR20xxCGS25xxPoeDC     OBJECT IDENTIFIER ::= { ciscoProducts 1255 } -- Cisco Connected Grid Router 20xx/Switch 25xx DC Power Supply with Power Over Ethernet (PWR-CGR20xx-CGS25xx-POE-DC)
+catWsC2960s48tsS                OBJECT IDENTIFIER ::= { ciscoProducts 1256 } -- Catalyst 2960S 48 Gig Downlinks and 2 SFP uplink, Non-stackable module
+catWsC2960s24tsS                OBJECT IDENTIFIER ::= { ciscoProducts 1257 } -- Catalyst 2960S 24 Gig Downlinks and 2 SFP uplink, Non-stackable module
+catWsC2960s48fpdL               OBJECT IDENTIFIER ::= { ciscoProducts 1258 } -- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 740W
+catWsC2960s48ldpL               OBJECT IDENTIFIER ::= { ciscoProducts 1259 } -- Catalyst 2960S 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 370W
+catWsC2960s48tdL                OBJECT IDENTIFIER ::= { ciscoProducts 1260 } -- Catalyst 2960S 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
+catWsC2960s24pdL                OBJECT IDENTIFIER ::= { ciscoProducts 1261 } -- Catalyst 2960S 24 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 370W
+catWsC2960s24tdL                OBJECT IDENTIFIER ::= { ciscoProducts 1262 } -- Catalyst 2960S 24 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
+catWsC2960s48fpsL               OBJECT IDENTIFIER ::= { ciscoProducts 1263 } -- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 740W
+catWsC2960s48lpsL               OBJECT IDENTIFIER ::= { ciscoProducts 1264 } -- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 370W
+catWsC2960s24psL                OBJECT IDENTIFIER ::= { ciscoProducts 1265 } -- Catalyst 2960S 24 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module. POE support for 370W
+catWsC2960s48tsL                OBJECT IDENTIFIER ::= { ciscoProducts 1266 } -- Catalyst 2960S 48 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module
+catWsC2960s24tsL                OBJECT IDENTIFIER ::= { ciscoProducts 1267 } -- Catalyst 2960S 24 Gig Downlinks and 4 SFP uplink with support for a 2 x 10G stacking module
+cisco1906CK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1268 } -- Cisco 1906C/K9 router  with 2 GE, Serial 1T, 1 EHWIC, 256 MB flash memory, 512 MB DRAM
+ciscoAIRAP1042                  OBJECT IDENTIFIER ::= { ciscoProducts 1269 } -- Cisco Aironet 1040 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoAIRAP1041                  OBJECT IDENTIFIER ::= { ciscoProducts 1270 } -- Cisco Aironet 1040 series WLAN Access Point with one 10/100/1000TX port and single IEEE 802.11n radio port
+cisco887VaM                     OBJECT IDENTIFIER ::= { ciscoProducts 1271 } -- c887mv2 AnnexM with 1 VDSL/ADSL over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN and an optional Wireless LAN
+cisco867Va                      OBJECT IDENTIFIER ::= { ciscoProducts 1272 } -- c867v2 with 1 VDSL/ADSL over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN and an optional Wireless LAN
+cisco886Va                      OBJECT IDENTIFIER ::= { ciscoProducts 1273 } -- c886v2 with 1 VDSL/ADSL over ISDN, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN and an optional Wireless LAN
+cisco887Va                      OBJECT IDENTIFIER ::= { ciscoProducts 1274 } -- c887v2 with 1 VDSL/ADSL over POTS, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 1 ISDN and an optional Wireless LAN
+ciscoASASm1sc                   OBJECT IDENTIFIER ::= { ciscoProducts 1275 } -- Adaptive Security Appliance (ASA) Service Module for Catalyst Switches Security Context
+ciscoASASm1sy                   OBJECT IDENTIFIER ::= { ciscoProducts 1276 } -- Adaptive Security Appliance (ASA) Service Module for Catalyst Switches System Context
+ciscoASASm1                     OBJECT IDENTIFIER ::= { ciscoProducts 1277 } -- Adaptive Security Appliance (ASA) Service Module for Catalyst Switches
+cat2960cPD8TT                   OBJECT IDENTIFIER ::= { ciscoProducts 1278 } -- 8 10/100 ports + 2 Gigabit Ethernet PD ports fixed configuration layer 2 Ethernet Switch
+ciscoAirCt2504K9                OBJECT IDENTIFIER ::= { ciscoProducts 1279 } -- Szabla: Cisco 2500 Series Wireless LAN Controller
+ciscoISMAXP                     OBJECT IDENTIFIER ::= { ciscoProducts 1280 } -- Cisco Application Extension Platform Internal Service Module (ISM) with Services Ready Engine (SRE) for ISR routers
+ciscoSMAXP                      OBJECT IDENTIFIER ::= { ciscoProducts 1281 } -- Cisco Application Extension Platform Service Module (SM) with Services Ready Engine (SRE) for ISR routers
+ciscoAxpSmSre900                OBJECT IDENTIFIER ::= { ciscoProducts 1282 } -- Cisco Application Extension Platform Service Module (SM) with Services Ready Engine (SM-SRE-900-K9) for ISR routers     
+ciscoAxpSmSre700                OBJECT IDENTIFIER ::= { ciscoProducts 1283 } -- Cisco Application Extension Platform Service Module (SM) with Services Ready Engine (SM-SRE-700-K9) for ISR routers
+ciscoAxpIsmSre300               OBJECT IDENTIFIER ::= { ciscoProducts 1284 } -- Cisco Application Extension Platform Internal Service Module (ISM) with Services Ready Engine (ISM-SRE-300-K9) for ISR routers
+ciscoCDSISM                     OBJECT IDENTIFIER ::= { ciscoProducts 1285 } -- Cisco Content Delivery System Model ISM line card
+cat4507rpluse                   OBJECT IDENTIFIER ::= { ciscoProducts 1286 } -- Catalyst 4500 E-series with 7 slots for 48Gbps/slot (WS-C4507R+E)
+cat4510rpluse                   OBJECT IDENTIFIER ::= { ciscoProducts 1287 } -- Catalyst 4500 E-series with 10 slots for 48Gbps/slot (WS-C4510R+E)
+ciscoAxpNme302                  OBJECT IDENTIFIER ::= { ciscoProducts 1288 } -- Cisco Application Extension Platform Network Module Enhanced (NME-APPRE-302-K9) for ISR routers
+ciscoAxpNme502                  OBJECT IDENTIFIER ::= { ciscoProducts 1289 } -- Cisco Application Extension Platform Network Module Enhanced (NME-APPRE-502-K9) for ISR routers
+ciscoAxpNme522                  OBJECT IDENTIFIER ::= { ciscoProducts 1290 } -- Cisco Application Extension Platform Network Module Enhanced (NME-APPRE-522-K9) for ISR routers
+ciscoACE20K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1291 } -- Application Control Engine Module in Cat6500
+ciscoWsC236048tdS               OBJECT IDENTIFIER ::= { ciscoProducts 1292 } -- Catalyst 2360 Top Of Rack 48 GigE, 4 x 10G SFP+ LAN Lite
+ciscoWiSM2                      OBJECT IDENTIFIER ::= { ciscoProducts 1293 } -- Wireless Services Module: WiSM-2
+ciscoCDScde250                  OBJECT IDENTIFIER ::= { ciscoProducts 1294 } -- Cisco Content Delivery System Model CDE-250
+cisco7500Wlc                    OBJECT IDENTIFIER ::= { ciscoProducts 1295 } -- Cisco 7500 Series Wireless LAN Controller
+ciscoAnmVirtualApp              OBJECT IDENTIFIER ::= { ciscoProducts 1296 } -- Cisco Application Networking Manager Virtual Appliance
+ciscoECDS3100                   OBJECT IDENTIFIER ::= { ciscoProducts 1297 } -- Cisco Enterprise Content Delivery System Model ECDS-3100
+ciscoECDS1100                   OBJECT IDENTIFIER ::= { ciscoProducts 1298 } -- Cisco Enterprise Content Delivery System Model ECDS-1100
+cisco881G2                      OBJECT IDENTIFIER ::= { ciscoProducts 1299 } -- c881G with 1 FE, 4 switch ports, 1 USB 2.0 port, 1 Console/Aux port, 1 embedded PCIe 3G modem
+catWsC3750v224fsS               OBJECT IDENTIFIER ::= { ciscoProducts 1300 } -- Catalyst 3750 24FS: 24 10/100 ports + 2 Ethernet Gigabit SFP ports fixed configuration Layer 2/Layer 3 Ethernet  Stackable switch
+ciscoOeVWaas                    OBJECT IDENTIFIER ::= { ciscoProducts 1301 } -- Wide Area Application Engine Virtual Wide Area Application Services
+ciscoASA5585Ssp10K7             OBJECT IDENTIFIER ::= { ciscoProducts 1302 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-10 with No Payload Encryption
+ciscoASA5585Ssp20K7             OBJECT IDENTIFIER ::= { ciscoProducts 1303 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-20 with No Payload Encryption
+ciscoASA5585Ssp40K7             OBJECT IDENTIFIER ::= { ciscoProducts 1304 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-40 with No Payload Encryption
+ciscoASA5585Ssp60K7             OBJECT IDENTIFIER ::= { ciscoProducts 1305 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-60 with No Payload Encryption
+ciscoASA5585Ssp10K7sc           OBJECT IDENTIFIER ::= { ciscoProducts 1306 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-10 security context with No Payload Encryption
+ciscoASA5585Ssp20K7sc           OBJECT IDENTIFIER ::= { ciscoProducts 1307 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-20 security context with No Payload Encryption
+ciscoASA5585Ssp40K7sc           OBJECT IDENTIFIER ::= { ciscoProducts 1308 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-40 security context with No Payload Encryption
+ciscoASA5585Ssp60K7sc           OBJECT IDENTIFIER ::= { ciscoProducts 1309 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-60 security context with No Payload Encryption
+ciscoASA5585Ssp10K7sy           OBJECT IDENTIFIER ::= { ciscoProducts 1310 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-10 system with  No Payload Encryption
+ciscoASA5585Ssp20K7sy           OBJECT IDENTIFIER ::= { ciscoProducts 1311 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-20 system with  No Payload Encryption
+ciscoASA5585Ssp40K7sy           OBJECT IDENTIFIER ::= { ciscoProducts 1312 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-40 system with  No Payload Encryption
+ciscoASA5585Ssp60K7sy           OBJECT IDENTIFIER ::= { ciscoProducts 1313 } -- Cisco Adaptive Security Appliance 5585-X Security Services Processor-60 system with  No Payload Encryption
+ciscoSreSmNam                   OBJECT IDENTIFIER ::= { ciscoProducts 1314 } -- Cisco Network Analysis Module (NAM) on SM-SRE
+cat2960cPD8PT                   OBJECT IDENTIFIER ::= { ciscoProducts 1315 } -- Catalyst 2960c 8 10/100 POE ports + 2 Gigabit Ethernet POE+ PD ports fixed configuration Layer 2 Ethernet Switch
+cat2960cG8TC                    OBJECT IDENTIFIER ::= { ciscoProducts 1316 } -- Catalyst 2960c 8 10/100/1000 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2 Ethernet Switch
+cat3560cG8PC                    OBJECT IDENTIFIER ::= { ciscoProducts 1317 } -- Catalyst 3560c 8 10/100/1000 POE ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2/Layer 3 Ethernet Switch
+cat3560cG8TC                    OBJECT IDENTIFIER ::= { ciscoProducts 1318 } -- Catalyst 3560c 8 10/100/1000 ports + 2 dual purpose Gigabit Ethernet ports fixed configuration Layer 2/Layer 3 Ethernet Switch
+ciscoIE301016S8PC               OBJECT IDENTIFIER ::= { ciscoProducts 1319 } -- Cisco Industrial Ethernet 3010 Switch, 16 100 SFP + 8 10/100 + 2 T/SFP
+ciscoIE301024TC                 OBJECT IDENTIFIER ::= { ciscoProducts 1320 } -- Cisco Industrial Ethernet 3010 Switch, 24 10/100 + 2 T/SFP
+ciscoRAIE1783RMSB10T            OBJECT IDENTIFIER ::= { ciscoProducts 1321 } -- Stratix 8300 L3 Base Industrial Ethernet Switch, 8 10/100 + 2 T/SFP
+ciscoRAIE1783RMSB06T            OBJECT IDENTIFIER ::= { ciscoProducts 1322 } -- Stratix 8300 L3 Base Industrial Ethernet Switch, 4 10/100 + 2 T/SFP
+ciscoASA5585SspIps10K7          OBJECT IDENTIFIER ::= { ciscoProducts 1323 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services  Processor-10 with No Payload Encryption
+ciscoASA5585SspIps20K7          OBJECT IDENTIFIER ::= { ciscoProducts 1324 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services  Processor-20 with No Payload Encryption
+ciscoASA5585SspIps40K7          OBJECT IDENTIFIER ::= { ciscoProducts 1325 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services  Processor-40 with No Payload Encryption
+ciscoASA5585SspIps60K7          OBJECT IDENTIFIER ::= { ciscoProducts 1326 } -- Cisco Adaptive Security Appliance 5585-X IPS Security Services  Processor-60 with No Payload Encryption
+catalyst4948ef10GE              OBJECT IDENTIFIER ::= { ciscoProducts 1327 } -- Catalyst 4900 series front exhaust fixed configuration switch with 48 10/100/1000BaseT ports and four 10Gbps/1Gbps SFP+/SFP ports(WS-C4948E-F)
+cat292824TCC                    OBJECT IDENTIFIER ::= { ciscoProducts 1328 } -- Catalyst 24 10/100 ports + 2 10/100/1000 Ethernet ports
+cat292848TCC                    OBJECT IDENTIFIER ::= { ciscoProducts 1329 } -- Catalyst 48 10/100 ports + 2 10/100/1000 Ethernet ports
+cat292824LTC                    OBJECT IDENTIFIER ::= { ciscoProducts 1330 } -- Catalyst 24 10/100 ports with 8 POE ports + 2 10/100/1000 Ethernet ports. POE support for 123 W
+ciscoCrs16SB                    OBJECT IDENTIFIER ::= { ciscoProducts 1331 } -- Enhanced CRS 16 slots Line Card Chassis
+ciscoQuad                       OBJECT IDENTIFIER ::= { ciscoProducts 1332 } -- Enterprise Collaboration Platform.  Create collaborative teams by bringing together people, information, applications, and social media tools anytime, anywhere
+ciscoASASm1K7sc                 OBJECT IDENTIFIER ::= { ciscoProducts 1334 } -- Adaptive Security Appliance (ASA) Service Module for Catalyst Switches Security Context with No Payload Encryption
+ciscoASASm1K7sy                 OBJECT IDENTIFIER ::= { ciscoProducts 1335 } -- Adaptive Security Appliance (ASA) Service Module for Catalyst Switches System Context with No Payload Encryption
+ciscoASASm1K7                   OBJECT IDENTIFIER ::= { ciscoProducts 1336 } -- Adaptive Security Appliance (ASA) Service Module for Catalyst Switches with No Payload Encryption
+ciscoPwrCGR2010PoeAC            OBJECT IDENTIFIER ::= { ciscoProducts 1337 } -- Cisco Connected Grid Router 2010 AC Power Supply with Power Over Ethernet (PWR-cgr2010-POE-AC)
+ciscoPwrCGR2010PoeDC            OBJECT IDENTIFIER ::= { ciscoProducts 1338 } -- Cisco Connected Grid Router 2010 DC Power Supply with Power Over Ethernet (PWR-cgr2010-POE-DC)
+cisco1861eUc2BK9                OBJECT IDENTIFIER ::= { ciscoProducts 1339 } -- C1861E UC with support for 2 BRI ports and CUE
+cisco1861eUc4FK9                OBJECT IDENTIFIER ::= { ciscoProducts 1340 } --  C1861E UC with support for 4 FXO ports and CUE
+ciscoC1861eSrstFK9              OBJECT IDENTIFIER ::= { ciscoProducts 1341 } -- C1861E SRST with support for 4 FXO ports
+ciscoC1861eSrstBK9              OBJECT IDENTIFIER ::= { ciscoProducts 1342 } -- C1861E SRST with support for 2 BRI ports
+ciscoC1861eSrstCFK9             OBJECT IDENTIFIER ::= { ciscoProducts 1343 } -- C1861E SRST with support for 4 FXO ports and CUE
+ciscoC1861eSrstCBK9             OBJECT IDENTIFIER ::= { ciscoProducts 1344 } -- C1861E SRST with support for 4 BRI ports and CUE
+ciscoGrwicDes6s                 OBJECT IDENTIFIER ::= { ciscoProducts 1346 } -- Grid Router Switching Module with 2 GE(1 combo, 1 SFP) interfaces and 4 100FX interfaces
+ciscoGrwicDes2s8pc              OBJECT IDENTIFIER ::= { ciscoProducts 1347 } -- Grid Router Switching Module with 2 GE(1 combo, 1 SFP) interfaces and 8 100BaseT interfaces supporting PoE
+ciscoUCVirtualMachine           OBJECT IDENTIFIER ::= { ciscoProducts 1348 } -- VMware Virtual Machine for Cisco Unified Communications
+ciscoWave8541	                OBJECT IDENTIFIER ::= { ciscoProducts 1349 } --  Cisco Wide Area Virtualization Engine Model 8541
+ciscoWave7571	                OBJECT IDENTIFIER ::= { ciscoProducts 1350 } --  Cisco Wide Area Virtualization Engine Model 7571
+ciscoWave7541	                OBJECT IDENTIFIER ::= { ciscoProducts 1351 } --  Cisco Wide Area Virtualization Engine Model 7541
+ciscoWave694	                OBJECT IDENTIFIER ::= { ciscoProducts 1352 } --  Cisco Wide Area Virtualization Engine Model 694
+ciscoWave594	                OBJECT IDENTIFIER ::= { ciscoProducts 1353 } --  Cisco Wide Area Virtualization Engine Model 594
+ciscoWave294	                OBJECT IDENTIFIER ::= { ciscoProducts 1354 } --  Cisco Wide Area Virtualization Engine Model 294
+cisco5915RC                     OBJECT IDENTIFIER ::= { ciscoProducts 1355 } --  C5915 Embedded Services Router - Conduction Cooled
+cisco5915RA                     OBJECT IDENTIFIER ::= { ciscoProducts 1356 } --  C5915 Embedded Services Router - Air Cooled
+cisco867VAEK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1358 } -- Cisco 867VAEK9 with 4 FE switch ports, 1 GE LAN port, 1 GE WAN port,  and 1 multi-mode VDSL2/ ADSL2/2+ Annex A WAN port
+cisco866VAEK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1359 } -- Cisco 866VAEK9 with 4 FE switch ports, 1 GE LAN port, 1 GE WAN port, and 1 multi-mode VDSL2/ ADSL2/2+ Annex B WAN port
+cisco867VAE                     OBJECT IDENTIFIER ::= { ciscoProducts 1360 } -- Cisco 867VAE with 4 FE switch ports , 1 GE WAN port, and 1 multi-mode VDSL2/ ADSL2/2+ Annex A WAN port
+cisco866VAE                     OBJECT IDENTIFIER ::= { ciscoProducts 1361 } -- Cisco 866VAE with 4 FE switch ports, 1 GE WAN port, and 1 multi-mode VDSL2/ ADSL2/2+ Annex B WAN port
+ciscoAp802gn                    OBJECT IDENTIFIER ::= { ciscoProducts 1362 } -- Cisco AP802 Access Point with single IEEE 802.11g/n radio port
+ciscoAp802agn                   OBJECT IDENTIFIER ::= { ciscoProducts 1363 } -- Cisco AP802 Access Point with dual IEEE 802.11a/g/n radio ports
+catwsC2960C8tcS                 OBJECT IDENTIFIER ::= { ciscoProducts 1364 } -- Catalyst 2960C 8 10/100 FE ports + 2 Gig Dual Media Uplinks fixed configuration Layer 2 Ethernet switch, lanlite only
+catwsC2960C8tcL                 OBJECT IDENTIFIER ::= { ciscoProducts 1365 } -- Catalyst 2960C 8 10/100 FE ports + 2 Gig Dual Media Uplinks fixed configuration Layer 2 Ethernet switch
+catwsC2960C8pcL                 OBJECT IDENTIFIER ::= { ciscoProducts 1366 } -- Catalyst 2960C 8 10/100 FE with PoE + 2 Gig Dual Media Uplinks fixed configuration Layer 2 Ethernet switch
+catwsC2960C12pcL                OBJECT IDENTIFIER ::= { ciscoProducts 1367 } -- Catalyst 2960C 12 10/100 FE with POE + 2 Gig Dual Media Uplinks fixed configuration Layer 2 Ethernet switch
+catwsC3560CPD8ptS               OBJECT IDENTIFIER ::= { ciscoProducts 1368 } -- Catalyst 3560C 8 10/100/1000 with PoE and 2 Gig Copper PoE+ Uplinks fixed configuration Layer 2/Layer 3 Ethernet switch
+cisco1841ve                     OBJECT IDENTIFIER ::= { ciscoProducts 1369 } -- Cisco 1841ve data only router with 2 HWIC slots
+cisco2811ve                     OBJECT IDENTIFIER ::= { ciscoProducts 1370 } -- Cisco 2811ve router with one Network Module slot, four HWIC slots, two fast ethernet and integrated VPN
+cisco881WAK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1371 } -- C881W-A-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881WEK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1372 } -- C881W-E-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881WPK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1373 } -- C881W-P-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, Japan compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco886VaWEK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1374 } -- C886VA-W-E-K9 router with 1 ADSL2/2+ Annex B, 1 ISDN, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887VamWEK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1375 } -- C887VAM-W-E-K9 router with 1 ADSL2/2+ Annex M, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887VaWAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1376 } -- C887VA-W-A-K9 rouetr with 1 VDSL, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887VaWEK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1377 } -- C887VA-W-E-K9 with 1 VDSL, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco819GUK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1378 } -- C819G-U-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with GLOBAL HSPA R6, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819GSK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1379 } -- C819G-S-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with SPRINT EVDO RevA, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819GVK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1380 } -- C819G-V-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with Verizon EVDO RevA, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819GBK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1381 } -- C819G-B-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with BSNL EVDO RevA, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819G7AK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1382 } -- C819G+7-A-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819G7K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1383 } -- C819G+7-K9 router with 1 Gigabit Ethernet WAN, 4 Ethernet LAN, 1 3G with GLOBAL HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819HGUK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1384 } -- C819HG-U-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with GLOBAL HSPA R6, 1 Serial, 1 Console/Aux ports, 256MB flash memory, 512MB DRAM
+cisco819HGSK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1385 } -- C819HG-S-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with SPRINT EVDO RevA, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819HGVK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1386 } -- C819HG-V-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with Verizon EVDO RevA, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819HGBK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1387 } -- C819HG-B-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with BSNL EVDO RevA, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819HG7AK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1388 } -- C819HG+7-A-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 512MB DRAM
+cisco819HG7K9                   OBJECT IDENTIFIER ::= { ciscoProducts 1389 } -- C819HG+7-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Ethernet LAN, 1 3G with GLOBAL HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 256MB flash memory and 256MB DRAM
+cisco886Vag7K9                  OBJECT IDENTIFIER ::= { ciscoProducts 1390 } -- C886G w/ 1 WAN VDSL2/ADSL2+ over ISDN, 4 switch ports, 1 embedded Global 3G HSPA+ modem with GPS and SMS
+cisco887VagSK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1391 } -- C887G w/ 1 WAN VDSL2/ADSL2+ over POTS, 4 switch ports, 1 embedded Sprint 3G EVDO modem with GPS and SMS
+cisco887Vag7K9                  OBJECT IDENTIFIER ::= { ciscoProducts 1392 } -- C887G w/ 1 WAN VDSL2/ADSL2+ over POTS, 4 switch ports, 1 embedded Global 3G HSPA+ modem with GPS and SMS
+cisco887Vamg7K9                 OBJECT IDENTIFIER ::= { ciscoProducts 1393 } -- C887G w/ 1 WAN VDSL2/ADSL2+ over POTS (Annex M), 4 switch ports, 1 embedded Global 3G HSPA+ modem with GPS and SMS
+cisco888Eg7K9                   OBJECT IDENTIFIER ::= { ciscoProducts 1394 } -- C888EG w/ 1 WAN G.SHDSL (EFM), 4 switch ports, 1 embedded Global 3G  HSPA+ modem with GPS and SMS
+cisco881GUK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1395 } -- C881G w/ 1 WAN FE, 4 switch ports, 1 embedded Global 3G HSPA modem with GPS and SMS
+cisco881GSK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1396 } -- C881G w/ 1 WAN FE, 4 switch ports, 1 embedded Sprint 3G EVDO Rev A modem with GPS and SMS
+cisco881GVK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1397 } -- C881G w/ 1 WAN FE, 4 switch ports, 1 embedded Verizon 3G EVDO Rev A modem with GPS and SMS
+cisco881GBK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1398 } -- C881G w/ 1 WAN FE, 4 switch ports, 1 embedded BSNL 3G EVDO Rev A modem with GPS and SMS
+cisco881G7K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1399 } -- C881G w/ 1 WAN FE, 4 switch ports, 1 embedded Global 3G HSPA+ modem with GPS and SMS
+cisco881G7AK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1400 } -- C881G w/ 1 WAN FE, 4 switch ports, 1 embedded ATT 3G HSPA+ modem with GPS and SMS
+cat3750x24s                     OBJECT IDENTIFIER ::= { ciscoProducts 1404 } -- Catalyst 3750X 24 SFP Gigabit Ethernet Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat3750x12s                     OBJECT IDENTIFIER ::= { ciscoProducts 1405 } -- Catalyst 3750X 12 SFP Gigabit Ethernet Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+ciscoNME                        OBJECT IDENTIFIER ::= { ciscoProducts 1406 } -- Cisco Network Module Enhanced (NME) for ISR routers x800 series
+ciscoASA5512                    OBJECT IDENTIFIER ::= { ciscoProducts 1407 } -- ASA 5512 Adaptive Security Appliance
+ciscoASA5525                    OBJECT IDENTIFIER ::= { ciscoProducts 1408 } -- ASA 5515 Adaptive Security Appliance
+ciscoASA5545                    OBJECT IDENTIFIER ::= { ciscoProducts 1409 } -- ASA 5525 Adaptive Security Appliance
+ciscoASA5555                    OBJECT IDENTIFIER ::= { ciscoProducts 1410 } -- ASA 5555 Adaptive Security Appliance
+ciscoASA5512sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1411 } -- ASA 5512 Adaptive Security Appliance Security Context
+ciscoASA5525sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1412 } -- ASA 5515 Adaptive Security Appliance Security Context
+ciscoASA5545sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1413 } -- ASA 5525 Adaptive Security Appliance Security Context
+ciscoASA5555sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1414 } -- ASA 5555 Adaptive Security Appliance Security Context
+ciscoASA5512sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1415 } -- ASA 5512 Adaptive Security Appliance System Context
+ciscoASA5515sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1416 } -- ASA 5515 Adaptive Security Appliance System Context
+ciscoASA5525sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1417 } -- ASA 5525 Adaptive Security Appliance System Context
+ciscoASA5545sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1418 } -- ASA 5545 Adaptive Security Appliance System Context
+ciscoASA5555sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1419 } -- ASA 5555 Adaptive Security Appliance System Context
+ciscoASA5515sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1420 } -- ASA 5515 Adaptive Security Appliance Security Context
+ciscoASA5515                    OBJECT IDENTIFIER ::= { ciscoProducts 1421 } -- ASA 5515 Adaptive Security Appliance
+ciscoPCM                        OBJECT IDENTIFIER ::= { ciscoProducts 1422 } -- Cisco Prime Collaboration Manager
+ciscoIse3315K9                  OBJECT IDENTIFIER ::= { ciscoProducts 1423 } -- Policy Platform for User and Endpoint Network Authentication, Authorization, Posture Assessment, Endpoint Classification and Guest Management
+ciscoIse3395K9                  OBJECT IDENTIFIER ::= { ciscoProducts 1424 } -- Policy Platform for User and Endpoint Network Authentication, Authorization, Posture Assessment, Endpoint Classification and Guest Management
+ciscoIse3355K9                  OBJECT IDENTIFIER ::= { ciscoProducts 1425 } -- Policy Platform for User and Endpoint Network Authentication, Authorization, Posture Assessment, Endpoint Classification and Guest Management
+ciscoIseVmK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1426 } -- Policy Platform for User and Endpoint Network Authentication, Authorization, Posture Assessment, Endpoint Classification and Guest Management
+ciscoIPS4345                    OBJECT IDENTIFIER ::= { ciscoProducts 1428 } -- Cisco Intrusion Prevention System 4345
+ciscoIPS4360                    OBJECT IDENTIFIER ::= { ciscoProducts 1429 } -- Cisco Intrusion Prevention System 4360 
+ciscoEcdsVB                     OBJECT IDENTIFIER ::= { ciscoProducts 1432 } -- Cisco Media Delivery Engine
+ciscoTsCodecG2                  OBJECT IDENTIFIER ::= { ciscoProducts 1433 } -- Cisco Telepresence Generation 2 Codec
+ciscoTsCodecG2C                 OBJECT IDENTIFIER ::= { ciscoProducts 1434 } -- Cisco Telepresence Generation 2 Codec
+ciscoTSCodecG2RC                OBJECT IDENTIFIER ::= { ciscoProducts 1435 } -- Cisco Telepresence Generation 2R Codec
+ciscoTSCodecG2R                 OBJECT IDENTIFIER ::= { ciscoProducts 1436 } -- Cisco Telepresence Generation 2R Codec
+ciscoASA5585SspIps10Virtual     OBJECT IDENTIFIER ::= { ciscoProducts 1437 } -- Virtual Sensor for ASA5585-IPSSSP-10, IPS Security Services Module for ASA5585
+ciscoASA5585SspIps20Virtual     OBJECT IDENTIFIER ::= { ciscoProducts 1438 } -- Virtual Sensor for ASA5585-IPSSSP-20, IPS Security Services Module for ASA5585
+ciscoASA5585SspIps40Virtual     OBJECT IDENTIFIER ::= { ciscoProducts 1439 } -- Virtual Sensor for ASA5585-IPSSSP-40, IPS Security Services Module for ASA5585
+ciscoASA5585SspIps60Virtual     OBJECT IDENTIFIER ::= { ciscoProducts 1440 } -- Virtual Sensor for ASA5585-IPSSSP-60, IPS Security Services Module for ASA5585
+ciscoASR903                     OBJECT IDENTIFIER ::= { ciscoProducts 1441 } -- Cisco Aggregation Services Router 900 Series with 3RU Chassis
+ciscoASA5512K7                  OBJECT IDENTIFIER ::= { ciscoProducts 1442 } -- Cisco Adaptive Security Appliance (ASA) 5512 Adaptive Security Appliance with No Payload Encryption
+ciscoASA5515K7                  OBJECT IDENTIFIER ::= { ciscoProducts 1443 } -- Cisco Adaptive Security Appliance (ASA) 5515 Adaptive Security Appliance with No Payload Encryption
+ciscoASA5525K7                  OBJECT IDENTIFIER ::= { ciscoProducts 1444 } -- Cisco Adaptive Security Appliance (ASA) 5525 Adaptive Security Appliance with No Payload Encryption
+ciscoASA5545K7                  OBJECT IDENTIFIER ::= { ciscoProducts 1445 } -- Cisco Adaptive Security Appliance (ASA) 5545 Adaptive Security Appliance with No Payload Encryption
+ciscoASA5555K7                  OBJECT IDENTIFIER ::= { ciscoProducts 1446 } -- Cisco Adaptive Security Appliance (ASA) 5555 Adaptive Security Appliance with No Payload Encryption
+ciscoASA5512K7sc                OBJECT IDENTIFIER ::= { ciscoProducts 1447 } -- Cisco Adaptive Security Appliance (ASA) 5512 Adaptive Security Appliance Security Context with No Payload Encryption
+ciscoASA5515K7sc                OBJECT IDENTIFIER ::= { ciscoProducts 1448 } -- Cisco Adaptive Security Appliance (ASA) 5515 Adaptive Security Appliance Security Context with No Payload Encryption
+ciscoASA5525K7sc                OBJECT IDENTIFIER ::= { ciscoProducts 1449 } -- Cisco Adaptive Security Appliance (ASA) 5525 Adaptive Security Appliance Security Context with No Payload Encryption
+ciscoASA5545K7sc                OBJECT IDENTIFIER ::= { ciscoProducts 1450 } -- Cisco Adaptive Security Appliance (ASA) 5545 Adaptive Security Appliance Security Context with No Payload Encryption
+ciscoASA5555K7sc                OBJECT IDENTIFIER ::= { ciscoProducts 1451 } -- Cisco Adaptive Security Appliance (ASA) 5555 Adaptive Security Appliance Security Context with No Payload Encryption
+ciscoASA5512K7sy                OBJECT IDENTIFIER ::= { ciscoProducts 1452 } -- Cisco Adaptive Security Appliance (ASA) 5512 Adaptive Security Appliance System Context with No Payload Encryption
+ciscoASA5515K7sy                OBJECT IDENTIFIER ::= { ciscoProducts 1453 } -- Cisco Adaptive Security Appliance (ASA) 5515 Adaptive Security Appliance System Context with No Payload Encryption
+ciscoASA5525K7sy                OBJECT IDENTIFIER ::= { ciscoProducts 1454 } -- Cisco Adaptive Security Appliance (ASA) 5525 Adaptive Security Appliance System Context with No Payload Encryption
+ciscoASA5545K7sy                OBJECT IDENTIFIER ::= { ciscoProducts 1455 } -- Cisco Adaptive Security Appliance (ASA) 5545 Adaptive Security Appliance System Context with No Payload Encryption
+ciscoASA5555K7sy                OBJECT IDENTIFIER ::= { ciscoProducts 1456 } -- Cisco Adaptive Security Appliance (ASA) 5555 Adaptive Security Appliance System Context with No Payload Encryption
+ciscoASR5500                    OBJECT IDENTIFIER ::= { ciscoProducts 1457 } -- Cisco Systems ASR5500 Intelligent Mobile Gateway
+ciscoXfp10Ger192IrL             OBJECT IDENTIFIER ::= { ciscoProducts 1462 } -- XFP10GER-192IR-L XFP Module
+ciscoXfp10Glr192SrL             OBJECT IDENTIFIER ::= { ciscoProducts 1463 } -- XFP10GLR-192SR-L XFP Module
+ciscoXfp10Gzr192LrL             OBJECT IDENTIFIER ::= { ciscoProducts 1464 } -- XFP10GZR-192LR-L XFP Module
+catwsC3560C12pcS                OBJECT IDENTIFIER ::= { ciscoProducts 1465 } -- Catalyst 3560C 12 10/100 with PoE + 2 Gig Dual Media Uplinks fixed configuration Layer 2/Layer 3 Ethernet switch
+catwsC3560C8pcS                 OBJECT IDENTIFIER ::= { ciscoProducts 1466 } -- Catalyst 3560C 8 10/100 with PoE + 2 Gig Dual Media Uplinks fixed configuration Layer 2/Layer 3 Ethernet switch
+ciscoCRSFabBP                   OBJECT IDENTIFIER ::= { ciscoProducts 1467 } -- Cisco Fabric Bundle Ports of type Optical Interface Module (OIM) used in CRS Multi-chassis routers
+ciscoIE20004TS                  OBJECT IDENTIFIER ::= { ciscoProducts 1468 } -- Cisco Industrial Ethernet 2000 Switch, 4 10/100 T + 2 100 SFP 
+ciscoIE20004T                   OBJECT IDENTIFIER ::= { ciscoProducts 1469 } -- Cisco Industrial Ethernet 2000 Switch, 4 10/100 T + 2 100 T 
+ciscoIE20004TSG                 OBJECT IDENTIFIER ::= { ciscoProducts 1470 } -- Cisco Industrial Ethernet 2000 Switch, 4 10/100 T + 2 1000 SFP 
+ciscoIE20004TG                  OBJECT IDENTIFIER ::= { ciscoProducts 1471 } -- Cisco Industrial Ethernet 2000 Switch, 4 10/100 T + 2 1000 T 
+ciscoIE20008TC                  OBJECT IDENTIFIER ::= { ciscoProducts 1472 } -- Cisco Industrial Ethernet 2000 Switch, 8 10/100 T + 2 100 T/SFP
+ciscoIE20008TCG                 OBJECT IDENTIFIER ::= { ciscoProducts 1473 } -- Cisco Industrial Ethernet 2000 Switch, 8 10/100 T + 2 1000 T/SFP 
+ciscoIE200016TC                 OBJECT IDENTIFIER ::= { ciscoProducts 1474 } -- Cisco Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 100 T/SFP 
+ciscoIE200016TCG                OBJECT IDENTIFIER ::= { ciscoProducts 1475 } -- Cisco Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP 
+ciscoRAIE1783BMS06SL            OBJECT IDENTIFIER ::= { ciscoProducts 1476 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 4 10/100 T + 2 100 SFP 
+ciscoRAIE1783BMS06TL            OBJECT IDENTIFIER ::= { ciscoProducts 1477 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 4 10/100 T + 2 100 T
+ciscoRAIE1783BMS06TA            OBJECT IDENTIFIER ::= { ciscoProducts 1478 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 4 10/100 T + 2 100 T
+ciscoRAIE1783BMS06SGL           OBJECT IDENTIFIER ::= { ciscoProducts 1479 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 4 10/100 T + 2 1000 SFP
+ciscoRAIE1783BMS06SGA           OBJECT IDENTIFIER ::= { ciscoProducts 1480 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 4 10/100 T + 2 1000 SFP
+ciscoRAIE1783BMS06TGL           OBJECT IDENTIFIER ::= { ciscoProducts 1481 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 4 10/100 T + 2 1000 T
+ciscoRAIE1783BMS06TGA           OBJECT IDENTIFIER ::= { ciscoProducts 1482 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 4 10/100 T + 2 1000 T
+ciscoRAIE1783BMS10CL            OBJECT IDENTIFIER ::= { ciscoProducts 1483 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 8 10/100 T + 2 100 T/SFP
+ciscoRAIE1783BMS10CA            OBJECT IDENTIFIER ::= { ciscoProducts 1484 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 8 10/100 T + 2 100 T/SFP
+ciscoRAIE1783BMS10CGL           OBJECT IDENTIFIER ::= { ciscoProducts 1485 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 8 10/100 T + 2 1000 T/SFP
+ciscoRAIE1783BMS10CGA           OBJECT IDENTIFIER ::= { ciscoProducts 1486 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 8 10/100 T + 2 1000 T/SFP
+ciscoRAIE1783BMS10CGP           OBJECT IDENTIFIER ::= { ciscoProducts 1487 } -- Cisco Rockwell IA Base + 1588 Industrial Ethernet 2000 Switch, 8 10/100 T + 2 1000 T/SFP
+ciscoRAIE1783BMS10CGN           OBJECT IDENTIFIER ::= { ciscoProducts 1488 } -- Cisco Rockwell IA Base + 1588 + NAT Industrial Ethernet 2000 Switch, 8 10/100 T + 2 1000 T/SFP
+ciscoRAIE1783BMS20CL            OBJECT IDENTIFIER ::= { ciscoProducts 1489 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 100 T/SFP
+ciscoRAIE1783BMS20CA            OBJECT IDENTIFIER ::= { ciscoProducts 1490 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 100 T/SFP
+ciscoRAIE1783BMS20CGL           OBJECT IDENTIFIER ::= { ciscoProducts 1491 } -- Cisco Rockwell IA Lite Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP
+ciscoRAIE1783BMS20CGP           OBJECT IDENTIFIER ::= { ciscoProducts 1492 } -- Cisco Rockwell IA Base + 1588 Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP
+ciscoRAIE1783BMS20CGPK          OBJECT IDENTIFIER ::= { ciscoProducts 1493 } -- Cisco Rockwell IA Base + 1588 + Conformal coating Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP
+cisco819HG4GGK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1494 } -- C819HG-4G-G-K9 Hardened Fixed router with Global SKU LTE modem
+cisco819G4GAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1495 } -- C819G-4G-A-K9 Non-Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 AT&T LTE modem, 1 Serial, 1 Console/Aux ports, 256MB flash memory, 512MB DRAM
+cisco819G4GVK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1496 } -- C819G-4G-V-K9 None-Hardened Fixed router with Verizon LTE modem
+cisco819G4GGK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1497 } -- C819G-4G-G-K9 Non-Hardened Fixed router with Global SKU LTE modem
+
+ciscoUcsC200                    OBJECT IDENTIFIER ::= { ciscoProducts 1512 } -- The C200 is a Cisco Unified Computing System C-Series Rack-Mount Server. This is a high-density, two-socket, 1 Rack Unit rack-mount server
+ciscoUcsC210                    OBJECT IDENTIFIER ::= { ciscoProducts 1513 } -- The C210 is a Cisco Unified Computing System C-Series Rack-Mount Server. This is a general purpose, 2-socket, 2 rack unit (RU) rack-mount server
+ciscoUcsC250                    OBJECT IDENTIFIER ::= { ciscoProducts 1514 } -- The C250 is a Cisco Unified Computing System C-Series Rack-Mount Server. This is a high-performance, memory-intensive, 2-socket, 2 rack unit (RU) rack-mount server
+ciscoUcsC260                    OBJECT IDENTIFIER ::= { ciscoProducts 1515 } -- The C260 is a Cisco Unified Computing System C-Series Rack-Mount Server. This is a very high-density, memory and storage intensive, 2-socket 2-rack unit (RU) rack server
+ciscoUcsC460                    OBJECT IDENTIFIER ::= { ciscoProducts 1516 } -- The C460 is a Cisco Unified Computing System C-Series Rack-Mount Server. This is a  4-socket 4-rack unit (RU) rack server
+ciscoRAIE1783BMS06SA            OBJECT IDENTIFIER ::= { ciscoProducts 1519 } -- Cisco Rockwell IA Base Industrial Ethernet 2000 Switch, 4 10/100 T + 2 100 SFP
+ciscoIE200016TCGX               OBJECT IDENTIFIER ::= { ciscoProducts 1520 } -- Cisco Conformal coating Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP
+ciscoASR901                     OBJECT IDENTIFIER ::= { ciscoProducts 1521 } -- Pura-C platform
+ciscoASR901E                    OBJECT IDENTIFIER ::= { ciscoProducts 1522 } -- Pura-E platform
+ciscoOeSmSre910                 OBJECT IDENTIFIER ::= { ciscoProducts 1523 } -- Wide Area Application Engine Service Module Service Ready Engine 910 K9
+ciscoOeSmSre710                 OBJECT IDENTIFIER ::= { ciscoProducts 1524 } -- Wide Area Application Engine Service Module Service Ready Engine 710 K9
+ciscoASR1002X                   OBJECT IDENTIFIER ::= { ciscoProducts 1525 } -- Cisco Aggregation Services Router 1000 Series, ASR1002-X Chassis
+ciscoNam2304                    OBJECT IDENTIFIER ::= { ciscoProducts 1527 } -- Cisco NAM Appliance 2304
+ciscoNam2320                    OBJECT IDENTIFIER ::= { ciscoProducts 1528 } -- Cisco NAM Appliance 2320
+ciscoNam3                       OBJECT IDENTIFIER ::= { ciscoProducts 1529 } -- Cisco NAM-3 for Catalyst 6500
+cisco819HG4GAK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1530 } -- C819HG-4G-A-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 AT&T LTE modem, 1 Serial, 1 Console/Aux ports, 256MB flash memory, 512MB DRAM
+ciscoECDS50IVB                  OBJECT IDENTIFIER ::= { ciscoProducts 1536 } -- Cisco Enterprise Content Delivery System Model MDE50IVB
+ciscoVSR1000                    OBJECT IDENTIFIER ::= { ciscoProducts 1537 } -- Cisco Virtual Services Router 1000
+ciscoASR5000                    OBJECT IDENTIFIER ::= { ciscoProducts 1538 } -- Cisco Systems ASR5000 Intelligent Mobile Gateway
+ciscoflowAgent3000              OBJECT IDENTIFIER ::= { ciscoProducts 1539 } -- Cisco Integrated NetFlow Generation Agent
+ciscoTelePresenceMCU5310       OBJECT IDENTIFIER ::= { ciscoProducts 1540 } -- Cisco TelePresence MCU 5310
+ciscoTelePresenceMCU5320        OBJECT IDENTIFIER ::= { ciscoProducts 1541 } -- Cisco TelePresence MCU 5320
+cisco888ea                      OBJECT IDENTIFIER ::= { ciscoProducts 1542 } -- Cisco 888EA platform with 1 SHDSL WAN interface, 4-port 1 0/100 Base-T LAN Ethernet switch, 4 USB ports, 1 ISDN BRI S/T interface, hardware encryption and an optional Wireless LAN card
+ciscoVG350                      OBJECT IDENTIFIER ::= { ciscoProducts 1557 } -- VG350 High Density Analog Gateway (3 GE, 4 EHWIC, 4 DSP, 256MB CF, 1GB DRAM, 2 DWSM)
+cisco881GW7AK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1560 } -- C881GW+7-A-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 3G HSPA+ R7 with GPS, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881GW7EK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1561 } -- C881GW+7-E-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 3G HSPA+R7 with GPS, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881GWSAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1562 } -- C881GW-S-A-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 3G EVDO Rev A with GPS for Sprint, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881GWVAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1563 } -- C881GW-V-A-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 3G EVDO Rev A with GPS for Verizon, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887Vagw7AK9                OBJECT IDENTIFIER ::= { ciscoProducts 1564 } -- C887VAGW+7-A-K9 router with 1 WAN VDSL2/ADSL2+over POTS, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 3G HSPA+ R7 with GPS, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887Vagw7EK9                OBJECT IDENTIFIER ::= { ciscoProducts 1565 } -- C887VAGW+7-E-K9 router with 1 WAN VDSL2/ADSL2+ over POTS, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 3G HSPA+ R7 with GPS, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881WDAK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1566 } -- C881WD-A-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco881WDEK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1567 } -- C881WD-E-K9 router with 1 Fast Ethernet WAN, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887VaWDAK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1568 } -- C887VA-WD-A-K9 router with 1 WAN VDSL2/ADSL2+ over POTS, 4 Fast Ethernet LAN with 2 PoE, FCC compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco887VaWDEK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1569 } -- C887VA-WD-E-K9 router with 1 WAN VDSL2/ADSL2+ over POTS, 4 Fast Ethernet LAN with 2 PoE, ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB DRAM
+cisco819HGW7EK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1570 } -- C819HGW+7-E-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, ETSI compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGW7NK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1571 } -- C819HGW+7-N-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, ANZ compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGW7AAK9                OBJECT IDENTIFIER ::= { ciscoProducts 1572 } -- C819HGW+7-A-A-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, FCC compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGWVAK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1573 } -- C819HGW-V-A-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with Verizon EVDO RevA, 1 Serial, FCC compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGWSAK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1574 } -- C819HGW-S-A-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with SPRINT EVDO RevA, 1 Serial, FCC compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HK9                     OBJECT IDENTIFIER ::= { ciscoProducts 1575 } -- C819H-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HWDEK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1576 } -- C819HWD-E-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 Serial, ETSI compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HWDAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1577 } -- C819HWD-A-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 Serial, FCC compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco812G7K9                    OBJECT IDENTIFIER ::= { ciscoProducts 1578 } -- C812G+7-K9 Router with 1 Gigabit Ethernet WAN, 1 3G with HSPA+ Release 7, 1 Console/Aux ports, 512MB flash memory and 512MB DRAM
+cisco812GCIFI7EK9               OBJECT IDENTIFIER ::= { ciscoProducts 1579 } -- C812G-CIFI+7-E-K9 Router with 1 Gigabit Ethernet WAN, 1 3G with HSPA+ Release 7, ETSI compliant Wireless LAN, 1 Console/Aux ports, 512MB flash memory and 512MB DRAM
+cisco812GCIFI7NK9               OBJECT IDENTIFIER ::= { ciscoProducts 1580 } -- C812G-CIFI+7-N-K9 Router with 1 Gigabit Ethernet WAN, 1 3G with HSPA+ Release 7, ANZ compliant Wireless LAN, 1 Console/Aux ports, 512MB flash memory and 512MB DRAM
+cisco812GCIFIVAK9               OBJECT IDENTIFIER ::= { ciscoProducts 1581 } -- C812G-CIFI-V-A-K9 Router with 1 Gigabit Ethernet WAN, 1 3G with Verizon EVDO RevA, FCC compliant Wireless LAN, 1 Console/Aux ports, 512MB flash memory and 512MB DRAM
+cisco812GCIFISAK9               OBJECT IDENTIFIER ::= { ciscoProducts 1582 } -- C812G-CIFI-S-A-K9 Router with 1 Gigabit Ethernet WAN, 1 3G with SPRINT EVDO RevA, FCC compliant Wireless LAN, 1 Console/Aux ports, 512MB flash memory and 512MB DRAM
+cisco819GUMK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1583 } -- C819G-U-M-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with GLOBAL HSPA R6, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819GSMK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1584 } -- C819G-S-M-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with SPRINT EVDO RevA, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819GVMK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1585 } -- C819G-V-M-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with Verizon EVDO RevA, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819GBMK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1586 } -- C819G-B-M-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with BSNL EVDO RevA, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819G7AMK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1587 } -- C819G+7-A-M-K9 router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819G7MK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1588 } -- C819G+7-M-K9 router with 1 Gigabit Ethernet WAN, 4 Ethernet LAN, 1 3G with GLOBAL HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGUMK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1589 } -- C819HG-U-M-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with GLOBAL HSPA R6, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGSMK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1590 } -- C819HG-S-M-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with SPRINT EVDO RevA, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGVMK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1591 } -- C819HG-V-M-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with Verizon EVDO RevA, 1 Serial, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HGBMK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1592 } -- C819HG-B-M-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with BSNL EVDO RevA, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HG7AMK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1593 } -- C819HG+7-A-M-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 3G with ATT HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+cisco819HG7MK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1594 } -- C819HG+7-M-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Ethernet LAN, 1 3G with GLOBAL HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+ciscoCDScde2502s6               OBJECT IDENTIFIER ::= { ciscoProducts 1595 } -- Cisco Content Delivery System Model CDE-250-2S6
+ciscoCDScde2502m0               OBJECT IDENTIFIER ::= { ciscoProducts 1596 } -- Cisco Content Delivery System Model CDE-250-2M0
+ciscoCDScde2502s8               OBJECT IDENTIFIER ::= { ciscoProducts 1597 } -- Cisco Content Delivery System Model CDE-250-2S8
+cisco881V                       OBJECT IDENTIFIER ::= { ciscoProducts 1600 } -- cisco881V with 1 FE, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 2 PSTN BRI ports, 1 FXO port     
+cisco887vaV                     OBJECT IDENTIFIER ::= { ciscoProducts 1601 } -- cisco887vaV with 1 VDSL/ADSL2/2+ Annex A, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 2 PSTN BRI ports, 1 ISDN port
+cisco887vaVW                    OBJECT IDENTIFIER ::= { ciscoProducts 1602 } -- cisco887vaVW with 1 VDSL/ADSL2/2+ Annex A, 4 switch ports, 1 USB 1.1 port, 1 Console/Aux port, 4 FXS ports, 2 PSTN BRI ports, 1 ISDN port, Wireless LAN
+ciscoMDE10XVB                   OBJECT IDENTIFIER ::= { ciscoProducts 1603 } -- Cisco Enterprise Content Delivery System Model MDE10XVB
+cat4500X16                      OBJECT IDENTIFIER ::= { ciscoProducts 1605 } -- Cisco Catalyst 4500X series fixed 10GE aggregation switch with 16 10GE SFP+ ports
+cat4500X32                      OBJECT IDENTIFIER ::= { ciscoProducts 1606 } -- Cisco Catalyst 4500X series fixed 10GE aggregation switch with 32 10GE SFP+ ports 
+ciscoCDScde2502s9               OBJECT IDENTIFIER ::= { ciscoProducts 1607 } -- Cisco Content Delivery System Model CDE-250-2S9
+ciscoCDScde2502s10              OBJECT IDENTIFIER ::= { ciscoProducts 1608 } -- Cisco Content Delivery System Model CDE-250-2S10
+ciscoASA5585Nm20x1GE            OBJECT IDENTIFIER ::= { ciscoProducts 1610 } -- Cisco Adaptive Security Appliance 5585-X Half Width 20 Gigabit Ethernet Network Module
+ciscoCDScdeGeneric              OBJECT IDENTIFIER ::= { ciscoProducts 1611 } -- Cisco Content Delivery System Generic Hardware
+ciscoASA1000Vsy                 OBJECT IDENTIFIER ::= { ciscoProducts 1612 } -- Cisco Adaptive Security Appliance 1000V Cloud Firewall System Context
+ciscoASA1000Vsc                 OBJECT IDENTIFIER ::= { ciscoProducts 1613 } -- Cisco Adaptive Security Appliance 1000V Cloud Firewall Security Context
+ciscoASA1000V                   OBJECT IDENTIFIER ::= { ciscoProducts 1614 } -- Cisco Adaptive Security Appliance 1000V Cloud Firewall
+cisco8500WLC                    OBJECT IDENTIFIER ::= { ciscoProducts 1615 } -- Cisco 8500 Series Wireless LAN Controller
+ciscoASA5585Nm8x10GE            OBJECT IDENTIFIER ::= { ciscoProducts 1617 } -- Cisco Adaptive Security Appliance 5585-X Half Width 8 TenGigabit Ethernet Network Module
+ciscoASA5585Nm4x10GE            OBJECT IDENTIFIER ::= { ciscoProducts 1618 } -- Cisco Adaptive Security Appliance 5585-X Half Width 4 TenGigabit Ethernet Network Module
+ciscoISR4400                    OBJECT IDENTIFIER ::= { ciscoProducts 1619 } -- Cisco ISR 4400 Series Router
+cisco897VaMK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1622 } -- C897VA-M-K9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex M Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM 
+ciscoVirtualWlc                 OBJECT IDENTIFIER ::= { ciscoProducts 1631 } -- Cisco Virtual Wireless LAN Controller
+ciscoAIRAP802agn                OBJECT IDENTIFIER ::= { ciscoProducts 1632 } -- Cisco AP802 Smart Access Point with dual IEEE 802.11a/g/n radio ports
+ciscoAp802Hagn                  OBJECT IDENTIFIER ::= { ciscoProducts 1633 } -- Cisco AP802 Hardened Access Point with dual IEEE 802.11a/g/n radio ports for M2M environments
+ciscoE160DP                     OBJECT IDENTIFIER ::= { ciscoProducts 1634 } -- Cisco Integrated Management Controller (CIMC) UCS-E160DP-M1/K9
+ciscoE160D                      OBJECT IDENTIFIER ::= { ciscoProducts 1635 } -- Cisco Integrated Management Controller (CIMC) UCS-E160D-M1/K9
+ciscoE140DP                     OBJECT IDENTIFIER ::= { ciscoProducts 1636 } -- Cisco Integrated Management Controller (CIMC) UCS-E140DP-M1/K9
+ciscoE140D                      OBJECT IDENTIFIER ::= { ciscoProducts 1637 } -- Cisco Integrated Management Controller (CIMC) UCS-E140D-M1/K9
+ciscoE140S                      OBJECT IDENTIFIER ::= { ciscoProducts 1638 } -- Cisco Integrated Management Controller (CIMC) UCS-E140S-M1/K9
+ciscoASR9001                    OBJECT IDENTIFIER ::= { ciscoProducts 1639 } -- Cisco Aggregation Services Router (ASR) 9001 Chassis            
+ciscoASR9922                    OBJECT IDENTIFIER ::= { ciscoProducts 1640 } -- Cisco Aggregation Services Router (ASR) 9922 Chassis            
+cat385048P                      OBJECT IDENTIFIER ::= { ciscoProducts 1641 } -- Catalyst 3850 48P 10/100/1000 PoE+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat385024P                      OBJECT IDENTIFIER ::= { ciscoProducts 1642 } -- Catalyst 3850 24P 10/100/1000 PoE+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat385048                       OBJECT IDENTIFIER ::= { ciscoProducts 1643 } -- Catalyst 3850 48 10/100/1000 Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat385024                       OBJECT IDENTIFIER ::= { ciscoProducts 1644 } -- Catalyst 3850 24 10/100/1000 Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cisco5760wlc                    OBJECT IDENTIFIER ::= { ciscoProducts 1645 } -- Cisco 5760 Series Wireless Controller
+ciscoVSGateway                  OBJECT IDENTIFIER ::= { ciscoProducts 1646 } -- Cisco Virtual Security Gateway for Nexus 1000V Series Switch. Cisco NX-OS(tm) nexus, Software (nexus-1000v-mz), Nexus VSG chassis
+ciscoIbiza                      OBJECT IDENTIFIER ::= { ciscoProducts 1647 } -- Ibiza Cisco AP
+ciscoSkyros                     OBJECT IDENTIFIER ::= { ciscoProducts 1648 } -- Skyros Cisco AP
+ciscoAIRAP1601                  OBJECT IDENTIFIER ::= { ciscoProducts 1656 } -- Cisco Aironet 1600 series WLAN Access Point
+ciscoCRS8SB                     OBJECT IDENTIFIER ::= { ciscoProducts 1658 } -- Enhanced 8 Slots Carrier Routing system   
+ciscoAIRAP2602                  OBJECT IDENTIFIER ::= { ciscoProducts 1659 } -- Cisco Aironet 2600 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoAIRAP1602                  OBJECT IDENTIFIER ::= { ciscoProducts 1660 } -- Cisco Aironet 1600 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
+ciscoAIRAP3602                  OBJECT IDENTIFIER ::= { ciscoProducts 1661 } -- Cisco Aironet 3600 Series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio port
+ciscoAIRAP3601                  OBJECT IDENTIFIER ::= { ciscoProducts 1662 } -- Cisco Aironet 3600 Series WLAN Access Point with one 10/100/1000TX port and single IEEE 802.11n radio port
+ciscoAIRAP1552                  OBJECT IDENTIFIER ::= { ciscoProducts 1664 } -- Cisco Aironet 1550 Series Outdoor Mesh Access Points with dual radio
+ciscoAIRAP1553                  OBJECT IDENTIFIER ::= { ciscoProducts 1665 } -- Cisco Aironet 1550 Series outdoor Mesh Access Points with three radio ports
+ciscoNexus1010X                 OBJECT IDENTIFIER ::= { ciscoProducts 1667 } -- Large Virtual service Appliance
+ciscoNexus1110S                 OBJECT IDENTIFIER ::= { ciscoProducts 1668 } -- Gen-2 Base  Virtual service Appliance
+ciscoNexus1110X                 OBJECT IDENTIFIER ::= { ciscoProducts 1669 } -- Gen-2 Large  Virtual service Appliance
+ciscoNexus1110XL                OBJECT IDENTIFIER ::= { ciscoProducts 1670 } -- Gen-2 Extra Large  Virtual service Appliance
+ciscoHsE300K9                   OBJECT IDENTIFIER ::= { ciscoProducts 1674 } -- Cisco and HSJC co-brand edge 300 series switch.HSJC is a cisco partner in China Education market. It's a access device integrates both switch function and computing resource.
+cisco866VAEWEK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1675 } -- CISCO866VAE-W-E-K9 with 2 GE switch ports, 3 FE switch ports, 1 GE WAN port, 1 multi-mode VDSL2/ ADSL2/ADSL2+ Annex B WAN port, and ETSI compliant Wireless LAN
+cisco867VAEWAK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1676 } -- CISCO867VAE-W-A-K9  with 2 GE switch ports, 3 FE switch ports, 1 GE WAN port, 1 multi-mode VDSL2/ ADSL2/ADSL2+ Annex A WAN port, and FCC compliant Wireless LAN
+cisco867VAEWEK9                 OBJECT IDENTIFIER ::= { ciscoProducts 1677 } -- CISCO867VAE-W-E-K9 with 2 GE switch ports, 3 FE switch ports, 1 GE WAN port, 1 multi-mode VDSL2/ ADSL2/ADSL2+ Annex A WAN port, and ETSI compliant Wireless LAN
+cisco867VAEPOEWAK9              OBJECT IDENTIFIER ::= { ciscoProducts 1678 } -- CISCO867VAE-POE-W-A-K9 with 2 GE switch ports, 3 FE switch ports with one port POE, 1 GE WAN port, 1 multi-mode VDSL2/ADSL2/ADSL2+ Annex A WAN port, and FCC compliant Wireless LAN
+ciscoOeKWaas                    OBJECT IDENTIFIER ::= { ciscoProducts 1681 } -- Wide Area Application Engine Virtualized Wide Area Application Services instance running on the KVM hypervisor container (KWAAS)
+ciscoUcsC220                    OBJECT IDENTIFIER ::= { ciscoProducts 1682 } -- This one-rack unit (1RU) server offers superior performance and density over a wide range of business workloads, from web serving to distributed database
+ciscoUcsC240                    OBJECT IDENTIFIER ::= { ciscoProducts 1683 } -- This 2RU server is designed for both performance and expandability over a wide range of storage-intensive infrastructure workloads, from big data to collaboration
+ciscoUcsC22                     OBJECT IDENTIFIER ::= { ciscoProducts 1684 } -- This 1RU, 2-socket rack server design combines outstanding economics and a density-optimized feature set over a range of scale-out workloads, from IT and web infrastructure to distributed applications
+ciscoUcsC24                     OBJECT IDENTIFIER ::= { ciscoProducts 1685 } -- This 2RU, 2-socket rack server is designed for both outstanding economics and internal expandability over a range of storage-intensive infrastructure workloads, from IT and web infrastructure to big data
+ciscoCDScde2202s4               OBJECT IDENTIFIER ::= { ciscoProducts 1686 } -- Cisco Content Delivery System Model CDE-220-2S4
+ciscoCDScde4604r1               OBJECT IDENTIFIER ::= { ciscoProducts 1687 } -- Cisco Content Delivery System Model CDE-460-4R1
+catWsC2960x48fpdL               OBJECT IDENTIFIER ::= { ciscoProducts 1690 } -- Catalyst 2960X 48 Gig Downlinks, 2 SFP+ uplink, 2 x 10G stacking module, POE+ support for 740W
+catWsC2960x48lpdL               OBJECT IDENTIFIER ::= { ciscoProducts 1691 } -- Catalyst 2960X 48 Gig Downlinks, 2 SFP+ uplink, 2 x 10G stacking module, POE+ support for 370W
+catWsC2960x48tdL                OBJECT IDENTIFIER ::= { ciscoProducts 1692 } -- Catalyst 2960X 48 Gig Downlinks, 2 SFP+ uplink, 2 x 10G stacking module
+catWsC2960x24pdL                OBJECT IDENTIFIER ::= { ciscoProducts 1693 } -- Catalyst 2960X 24 Gig Downlinks, 2 SFP+ uplink, 2 x 10G stacking module, POE+ Support for 370W
+catWsC2960x24tdL                OBJECT IDENTIFIER ::= { ciscoProducts 1694 } -- Catalyst 2960X 24 Gig Downlinks, 2 SFP+ uplink, 2 x 10G stacking module
+catWsC2960x48fpsL               OBJECT IDENTIFIER ::= { ciscoProducts 1695 } -- Catalyst 2960X 48 Gig Downlinks, 4 SFP uplink with support for a 2 x 10G stacking module, POE+ support for 740W
+catWsC2960x48lpsL               OBJECT IDENTIFIER ::= { ciscoProducts 1696 } -- Catalyst 2960X 48 Gig Downlinks, 4 SFP uplink with support for a 2 x 10G stacking module, POE+ support for 370W
+catWsC2960x24psL                OBJECT IDENTIFIER ::= { ciscoProducts 1697 } -- Catalyst 2960X 24 Gig Downlinks, 4 SFP uplink with support for a 2 x 10G stacking module, POE+ support for 370W
+catWsC2960x48tsL                OBJECT IDENTIFIER ::= { ciscoProducts 1698 } -- Catalyst 2960X 48 Gig Downlinks, 4 SFP uplink with support for a 2 x 10G stacking module
+catWsC2960x24tsL                OBJECT IDENTIFIER ::= { ciscoProducts 1699 } -- Catalyst 2960X 24 Gig Downlinks, 4 SFP uplink with support for a 2 x 10G stacking module
+catWsC2960x24psqL               OBJECT IDENTIFIER ::= { ciscoProducts 1700 } -- Catalyst 2960X 24 Gig Downlinks, 2 copper, 2 SFP uplink NonStakable
+catWsC2960x48lpsS               OBJECT IDENTIFIER ::= { ciscoProducts 1701 } -- Catalyst 2960X 48 Gig Downlinks, 2 SFP uplink Non Stackable, POE+ support for 370W
+catWsC2960x24psS                OBJECT IDENTIFIER ::= { ciscoProducts 1702 } -- Catalyst 2960X 24 Gig Downlinks, 2 SFP uplink Non Stackable, POE+ support for 370W
+catWsC2960x48tsLL               OBJECT IDENTIFIER ::= { ciscoProducts 1703 } -- Catalyst 2960X 48 Gig Downlinks and 2 SFP uplink Non Stackable
+catWsC2960x24tsLL               OBJECT IDENTIFIER ::= { ciscoProducts 1704 } -- Catalyst 2960X 24 Gig Downlinks and 2 SFP uplink Non Stackable
+ciscoISR4441                    OBJECT IDENTIFIER ::= { ciscoProducts 1705 } -- Cisco ISR 4441 Router
+ciscoISR4442                    OBJECT IDENTIFIER ::= { ciscoProducts 1706 } -- Cisco ISR 4442 Router
+ciscoISR4451                    OBJECT IDENTIFIER ::= { ciscoProducts 1707 } -- Cisco ISR 4451 Router
+ciscoISR4452                    OBJECT IDENTIFIER ::= { ciscoProducts 1708 } -- Cisco ISR 4452 Router
+ciscoASR9912                    OBJECT IDENTIFIER ::= { ciscoProducts 1709 } -- Cisco Aggregation Services Router (ASR) 9912 Chassis
+ciscoIE20008TCGN                OBJECT IDENTIFIER ::= { ciscoProducts 1714 } -- 8+2 combo Gig uplink port, Base SW with 1588 & NAT
+ciscoIE200016TCGN               OBJECT IDENTIFIER ::= { ciscoProducts 1715 } -- 16+2 SFP FE port+2 combo Gig uplink port, Base SW with 1588 & NAT
+ciscoIem30004SM                 OBJECT IDENTIFIER ::= { ciscoProducts 1720 } -- Cisco Industrial Ethernet Switch Expansion Module IE3000, 4 10/100 SFP
+ciscoIem30008SM                 OBJECT IDENTIFIER ::= { ciscoProducts 1721 } -- Cisco Industrial Ethernet Switch Expansion Module IE3000, 8 10/100 SFP 
+cisco1783MX04S                  OBJECT IDENTIFIER ::= { ciscoProducts 1722 } -- Cisco-Rockwell Industrial Ethernet Switch Expansion Module IE3000, 4 10/100 SFP
+cisco1783MX08S                  OBJECT IDENTIFIER ::= { ciscoProducts 1723 } -- Cisco-Rockwell Industrial Ethernet Switch Expansion Module IE3000, 8 10/100 SFP
+ciscoASR901TenGigDCE            OBJECT IDENTIFIER ::= { ciscoProducts 1724 } -- ASR901 DC platform with 10G interfaces
+ciscoASR901TenGigACE            OBJECT IDENTIFIER ::= { ciscoProducts 1725 } -- ASR901 AC platform with 10G interfaces
+ciscoASR901TenGigDC             OBJECT IDENTIFIER ::= { ciscoProducts 1726 } -- ASR901 DC platform with 10G and TDM interfaces
+ciscoASR901TenGigAC             OBJECT IDENTIFIER ::= { ciscoProducts 1727 } -- ASR901 AC platform with 10G interface
+ciscoIE200016TCGP               OBJECT IDENTIFIER ::= { ciscoProducts 1729 } -- Cisco Base + Lite Industrial Ethernet 2000 Switch, 12 10/100 T + 2 1000 T/SFP + 4 POE 
+ciscoIE200016TCGEP              OBJECT IDENTIFIER ::= { ciscoProducts 1730 } -- Cisco Base + 1588 Industrial Ethernet 2000 Switch, 12 10/100 T + 2 1000 T/SFP + 4 POE 
+ciscoIE200016TCGNXP             OBJECT IDENTIFIER ::= { ciscoProducts 1731 } -- Cisco Base + NAT + 1588 + Conformal Coating  Industrial Ethernet 2000 Switch, 12 10/100 T + 2 1000 T/SFP + 4 POE
+cat4xxxVirtualSwitch            OBJECT IDENTIFIER ::= { ciscoProducts 1732 } -- Catalyst 4xxx Virtual Switch
+ciscoRAIE1783BMS20CGN           OBJECT IDENTIFIER ::= { ciscoProducts 1733 } -- Cisco Rockwell IA Base + 1588+NAT Industrial Ethernet 2000 Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP 
+ciscoRAIE1783BMS12T4E2CGP       OBJECT IDENTIFIER ::= { ciscoProducts 1735 } -- Rockwell IA Base + 1588 Industrial Ethernet 2000 Switch, 12 10/100 T + 2 1000 T/SFP + 4 POE 
+ciscoRAIE1783BMS12T4E2CGNK      OBJECT IDENTIFIER ::= { ciscoProducts 1736 } -- Rockwell IA Base + NAT + 1588 + Conformal Coating  Industrial Ethernet 2000 Switch, 12 10/100 T + 2 1000 T/SFP + 4 POE 
+ciscoMds9848512K9SM             OBJECT IDENTIFIER ::= { ciscoProducts 1737 }  -- FCoE Line Card Module for MDS 9710 10 Slot Director switch chassis
+ciscoMds9710SM                  OBJECT IDENTIFIER ::= { ciscoProducts 1738 }  -- Supervisor Module for MDS 9710 10 Slot Director switch chassis
+ciscoMds9710FM                  OBJECT IDENTIFIER ::= { ciscoProducts 1739 }  -- Fabric Module for MDS 9710 10 Slot Director switch chassis
+ciscoMds9710FCS                 OBJECT IDENTIFIER ::= { ciscoProducts 1740 }  -- MDS 9710 10 Slot Director switch chassis
+ciscoMDS9250iIFSPS              OBJECT IDENTIFIER ::= { ciscoProducts 1741 }  -- MDS 9250 Multiprotocol Fabric Switch, with support for FC, FCoE and FC-IP Protocols
+ciscoMDS9250iIFSDC              OBJECT IDENTIFIER ::= { ciscoProducts 1742 }  -- Daughter card for MDS 9250i Intelligent Fabric Switch. MDS 9250 Multiprotocol Fabric Switch, with support for FC, FCoE and FC-IP Protocols
+ciscoMDS9250iIFS                OBJECT IDENTIFIER ::= { ciscoProducts 1743 }  -- MDS 9250 Multiprotocol Fabric Switch, with support for FC, FCoE and FC-IP Protocols
+ciscoNexus1000VH                OBJECT IDENTIFIER ::= { ciscoProducts 1744 }  -- Nexus 1000v on a microsoft hypervisor HyperV
+cat38xxstack                    OBJECT IDENTIFIER ::= { ciscoProducts 1745 }  -- A stack of any catalyst38xx stack-able ethernet switches with unified identity (as a single unified switch), control and management
+ciscoVG202XM                    OBJECT IDENTIFIER ::= { ciscoProducts 1746 }  -- Line side Analog Gateway VG202XM with 2FXS Analog ports
+ciscoVG204XM                    OBJECT IDENTIFIER ::= { ciscoProducts 1747 }  -- Line side Analog Gateway VG204XM with 4FXS Analog ports
+ciscoWsC2960P48PstL             OBJECT IDENTIFIER ::= { ciscoProducts 1748 } -- 48-port PoE, 2+2 1G uplinks, LAN Base
+ciscoWsC2960P24PcL              OBJECT IDENTIFIER ::= { ciscoProducts 1749 } -- 24-port PoE, 2/2 1G uplinks, LAN Base
+ciscoWsC2960P24LcL              OBJECT IDENTIFIER ::= { ciscoProducts 1750 } -- 24-port, partial PoE 2/2 1G uplinks, LAN Base
+ciscoWsC2960P48TcL              OBJECT IDENTIFIER ::= { ciscoProducts 1751 } -- 48-port, 2/2 1G uplinks, LAN Base
+ciscoWsC2960P24TcL              OBJECT IDENTIFIER ::= { ciscoProducts 1752 } -- 24-port, 2/2 1G uplinks, LAN Base
+ciscoWsC2960P48PstS             OBJECT IDENTIFIER ::= { ciscoProducts 1753 } -- 48-port PoE, 2+2 1G uplinks, LAN Lite
+ciscoWsC2960P24PcS              OBJECT IDENTIFIER ::= { ciscoProducts 1754 } -- 24-port PoE, 2/2 1G uplinks, LAN Lite
+ciscoWsC2960P24LcS              OBJECT IDENTIFIER ::= { ciscoProducts 1755 } -- 24-port, partial PoE 2/2 1G uplinks, LAN Lite
+ciscoWsC2960P48TcS              OBJECT IDENTIFIER ::= { ciscoProducts 1756 } -- 48-port, 2/2 1G uplinks, LAN Lite
+ciscoWsC2960P24TcS              OBJECT IDENTIFIER ::= { ciscoProducts 1757 } -- 24-port, 2/2 1G uplinks, LAN Lite
+ciscoASR9904                    OBJECT IDENTIFIER ::= { ciscoProducts 1762 } -- Cisco Aggregation Services Router (ASR) 9904 Chassis 
+ciscoME2600X                    OBJECT IDENTIFIER ::= { ciscoProducts 1763 } -- Cisco ME 2600X Series Ethernet Access Switches is Cisco's switches built specifically for the Fiber to the Home/Premise (FTTH/FTTP) services with 10G capability. It is 1-rack-unit (1RU), fixed-form-factor platform hardware-optimized for ANSI,ETSI & AC Power configurations 
+ciscoPanini                     OBJECT IDENTIFIER ::= { ciscoProducts 1764 } -- Converged NG routing platform for core/edge markets 
+ciscoC6807xl                    OBJECT IDENTIFIER ::= { ciscoProducts 1765 } -- Catalyst 6800 series chassis with 7 slots 
+cat385024U                      OBJECT IDENTIFIER ::= { ciscoProducts 1767 } -- Catalyst 3850 24 10/100/1000 UPoE Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat385048U                      OBJECT IDENTIFIER ::= { ciscoProducts 1768 } -- Catalyst 3850 48 10/100/1000 UPoE Ports Layer 2/Layer 3 Ethernet Stackable Switch
+ciscoVG310                      OBJECT IDENTIFIER ::= { ciscoProducts 1769 } -- VG310 Medium Density Voice  Gateway (2 GE, 1 24 onboard  analog FXS, 1  EHWIC, 1 PVDM3, 1 CF, 1GB DRAM)
+ciscoVG320                      OBJECT IDENTIFIER ::= { ciscoProducts 1770 } -- VG320 Medium Density Voice  Gateway (2 GE, 1 24 onboard  analog FXS, 1  EHWIC, 1 PVDM3, 1 CF, 1GB DRAM)
+cat45Sup8e                      OBJECT IDENTIFIER ::= { ciscoProducts 1796 } -- Catalyst 4500 Sup 8-E Wired Wireless Convergence, 928 Gbps Wired, 8x10Gbps SFP+ uplink ports
+ciscoWsC2960XR48FpdI            OBJECT IDENTIFIER ::= { ciscoProducts 1797 } -- Catalyst 2960XR 48 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable with POE support for 740W 
+ciscoWsC2960XR48LpdI            OBJECT IDENTIFIER ::= { ciscoProducts 1798 } -- Catalyst 2960XR 48 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable with POE support for 370W 
+ciscoWsC2960XR48TdI             OBJECT IDENTIFIER ::= { ciscoProducts 1799 } -- Catalyst 2960XR 48 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable 
+ciscoWsC2960XR24PdI             OBJECT IDENTIFIER ::= { ciscoProducts 1800 } -- Catalyst 2960XR 24 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable with POE support for 370W 
+ciscoWsC2960XR24TdI             OBJECT IDENTIFIER ::= { ciscoProducts 1801 } -- Catalyst 2960XR 24 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable 
+ciscoWsC2960XR48FpsI            OBJECT IDENTIFIER ::= { ciscoProducts 1802 } -- Catalyst 2960XR 48 Gig Downlinks and 4 SFP uplinks IP Lite Stackable with POE support for 740W 
+ciscoWsC2960XR48LpsI            OBJECT IDENTIFIER ::= { ciscoProducts 1803 } -- Catalyst 2960XR 48 Gig Downlinks and 4 SFP uplinks IP Lite Stackable with POE support for 370W 
+ciscoWsC2960XR48TsI             OBJECT IDENTIFIER ::= { ciscoProducts 1804 } -- Catalyst 2960XR 48 Gig Downlinks and 4 SFP uplinks IP Lite Stackable 
+ciscoWsC2960XR24PsI             OBJECT IDENTIFIER ::= { ciscoProducts 1805 } -- Catalyst 2960XR 24 Gig Downlinks and 4 SFP uplinks IP Lite Stackable with POE support for 370W 
+ciscoWsC2960XR24TsI             OBJECT IDENTIFIER ::= { ciscoProducts 1806 } -- Catalyst 2960XR 24 Gig Downlinks and 4 SFP uplinks IP Lite Stackable 
+ciscoA901S4SGFD                 OBJECT IDENTIFIER ::= { ciscoProducts 1818 } -- Agora platform - 4 external Ports (4 SFP) + 1 Gland Interface, DC PSU 
+ciscoA901S3SGFD                 OBJECT IDENTIFIER ::= { ciscoProducts 1819 } -- Agora platform - 3 external Ports (3 SFP+1Cu) + 1 Gland Interface, DC PSU 
+ciscoA901S2SGFD                 OBJECT IDENTIFIER ::= { ciscoProducts 1820 } -- Agora platform - 3 external Ports (2 SFP+2Cu) + 1 Gland Interface, DC PSU 
+ciscoA901S3SGFAH                OBJECT IDENTIFIER ::= { ciscoProducts 1821 } -- Agora platform - AC, 3 External Ports (3SFP) + 1 Gland Interface, AC PSU, 1sec holdover for 1 PoE+ 
+ciscoA901S2SGFAH                OBJECT IDENTIFIER ::= { ciscoProducts 1822 } -- Agora platform - AC, 3 External Ports (2 SFP+1 Cu) + 1 Gland Interface, AC PSU, 1sec holdover for 1 PoE+ 
+ciscoIE2000U4STSG               OBJECT IDENTIFIER ::= { ciscoProducts 1839 } -- Cisco Industrial Ethernet 2000U Switch, 4 10/100 SFP + 2 1000 SFP 
+ciscoIE2000U16TCGP              OBJECT IDENTIFIER ::= { ciscoProducts 1840 } -- Cisco Industrial Ethernet 2000U Switch, 16 10/100 T (4 PoE) + 2 1000 T/SFP until Jun 2013, contact kavenkat
+ciscoIE20008T67B                OBJECT IDENTIFIER ::= { ciscoProducts 1841 } -- Cisco IE2000 IP67 Variant Switch with  8 port 10/100 downlink, LAN Base Image  
+ciscoIE200016T67B               OBJECT IDENTIFIER ::= { ciscoProducts 1842 } -- Cisco IE2000 IP67 Variant Switch with  16 port 10/100 downlink, LAN Base Image
+ciscoIE200024T67B               OBJECT IDENTIFIER ::= { ciscoProducts 1843 } -- Cisco IE2000 IP67 Variant Switch with  24 port 10/100 downlink, LAN Base Image
+ciscoIE20008T67PGE              OBJECT IDENTIFIER ::= { ciscoProducts 1844 } -- Cisco IE2000 IP67 Variant Switch with  4 port 10/100 downlink, 4-port POE /POE+, 2 10/100/1000 uplink, LAN Base Image, can support PTP, NAT
+ciscoIE200016T67PGE             OBJECT IDENTIFIER ::= { ciscoProducts 1845 } -- Cisco IE2000 IP67 Variant Switch with  8 port 10/100 downlink, 8-port POE / 4-port POE+, 2 10/100/1000 uplink, LAN Base Image, can support PTP, NAT
+ciscoRAIE1783ZMS8TA             OBJECT IDENTIFIER ::= { ciscoProducts 1846 } -- Rockwell IE2000 IP67 Variant Switch with  8 port 10/100 downlink, LAN Base Image
+ciscoRAIE1783ZMS16TA            OBJECT IDENTIFIER ::= { ciscoProducts 1847 } -- Rockwell IE2000 IP67 Variant Switch with  16 port 10/100 downlink, LAN Base Image
+ciscoRAIE1783ZMS24TA            OBJECT IDENTIFIER ::= { ciscoProducts 1848 } -- Rockwell IE2000 IP67 Variant Switch with  24 port 10/100 downlink, LAN Base Image
+ciscoRAIE1783ZMS4T4E2TGP        OBJECT IDENTIFIER ::= { ciscoProducts 1849 } -- Rockwell IE2000 IP67 Variant Switch with  4 port 10/100 downlink, 4-port POE /POE+, 2 10/100/1000 uplink,  LAN Base Image, can support PTP, NAT
+ciscoRAIE1783ZMS8T8E2TGP        OBJECT IDENTIFIER ::= { ciscoProducts 1850 } -- Rockwell IE2000 IP67 Variant Switch with  8 port 10/100 downlink, 8-port POE / 4-port POE+, 2 10/100/1000 uplink, LAN Base Image, can support PTP, NAT
+ciscoNcs6008                    OBJECT IDENTIFIER ::= { ciscoProducts 1851 } -- NCS 6008 System (2RPs, 6FCs, 2 FANs, Power)
+ciscoC881K9                     OBJECT IDENTIFIER ::= { ciscoProducts 1852 } -- C881 router with 1 Fast Ethernet Primary WAN, 4 Fast Ethernet LAN, 2 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC886VaK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1853 } -- C886VA-K9 router with 1 VDSL2/ADSL2+ Annex B Primary WAN, 1 ISDN BRI S/T interface, 4 Fast Ethernet LAN, 2 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC886VaJK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1854 } -- C886VA-J-K9 router with 1 VDSL2/ADSL2+ Annex J Primary WAN, 1 ISDN BRI S/T interface, 4 Fast Ethernet LAN, 2 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC887VaK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1855 } -- C887VA-K9 router with 1 VDSL2/ADSL2+ Annex A Primary WAN, 4 Fast Ethernet LAN, 2 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC887VaMK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1856 } -- C887VA-M-K9 router with 1 VDSL2/ADSL2+ Annex M Primary WAN, 4 Fast Ethernet LAN, 2 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC888K9                     OBJECT IDENTIFIER ::= { ciscoProducts 1857 } -- C888-K9 router with 1 EFM/ATM over G.SHDSL Primary WAN, 1 ISDN BRI S/T interface, 4 Fast Ethernet LAN, 2 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM
+ciscoC891FK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1858 } -- C891F-K9 router with 1 Giga Ethernet Primary WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet Primary WAN, 1 Fast Ethernet WAN, 1 V.92, 1 ISDN BRI S/T interface, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC891FwAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1859 } -- C891FW-A-K9 router with 1 Giga Ethernet Primary WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet Primary WAN, 1 Fast Ethernet WAN, 1 V.92, 1 ISDN BRI S/T interface, 1 Dual 2.4/5GHz with FCC compliant Wireless LAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+ciscoC891FwEK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1860 } -- C891FW-E-K9 router with 1 Giga Ethernet Primary WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet Primary WAN, 1 Fast Ethernet WAN, 1 V.92, 1 ISDN BRI S/T interface, 1 Dual 2.4/5GHz with EU or ETSI compliant Wireless LAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM 
+cisco1783WAP5100xK9             OBJECT IDENTIFIER ::= { ciscoProducts 1862 } -- Cisco Rockwell Industrial Automation Wireless AP 5100, one 10/100/1000 BASE-T, Dual-band autonomous 802.11a/g/n 
+ciscoCDScde2502s5               OBJECT IDENTIFIER ::= { ciscoProducts 1863 } -- Cisco Content Delivery System Model CDE-250-2S5
+ciscoUcsE140S                   OBJECT IDENTIFIER ::= { ciscoProducts 1864 } -- UCS E-Series Server 4-Core Ivy Bridge Single wide Service module (UCS-E140S-M2/K9)
+ciscoNXNAM1                     OBJECT IDENTIFIER ::= { ciscoProducts 1865 } -- Cisco NX-NAM1 for Nexus 7000
+ciscoC6800ia48fpdL              OBJECT IDENTIFIER ::= { ciscoProducts 1866 } -- Catalyst 6800IA 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module. POE support for 740W
+ciscoC6800ia48tdL               OBJECT IDENTIFIER ::= { ciscoProducts 1867 } -- Catalyst 6800IA 48 Gig Downlinks and 2 SFP+ uplink with support for a 2 x 10G stacking module
+ciscoIE2000U4TG                 OBJECT IDENTIFIER ::= { ciscoProducts 1868 } -- Cisco Industrial Ethernet 2000U Switch, 4 10/100 T + 2 1000 T 
+ciscoIE2000U4TSG                OBJECT IDENTIFIER ::= { ciscoProducts 1869 } -- Cisco Industrial Ethernet 2000U Switch, 4 10/100 T + 2 1000 SFP 
+ciscoIE2000U8TCG                OBJECT IDENTIFIER ::= { ciscoProducts 1870 } -- Cisco Industrial Ethernet 2000U Switch, 8 10/100 T + 2 1000 T/SFP 
+ciscoIE2000U16TCG               OBJECT IDENTIFIER ::= { ciscoProducts 1871 } -- Cisco Industrial Ethernet 2000U Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP 
+ciscoIE2000U16TCGX              OBJECT IDENTIFIER ::= { ciscoProducts 1872 } -- Cisco Conformal coating Industrial Ethernet 2000U Switch, 16 10/100 T + 2 100 T + 2 1000 T/SFP 
+ciscoAIRAP702                   OBJECT IDENTIFIER ::= { ciscoProducts 1874 } -- Cisco Aironet 702 Series (IEEE 802.11n) Access Point
+ciscoAIRAP1532                  OBJECT IDENTIFIER ::= { ciscoProducts 1875 } -- Cisco Aironet 1530 Series (IEEE 802.11n) Access Point
+ciscoEsxNAM                     OBJECT IDENTIFIER ::= { ciscoProducts 1876 } -- Network Analysis Module running on ESX Hypervisor
+ciscoKvmNAM                     OBJECT IDENTIFIER ::= { ciscoProducts 1877 } -- Network Analysis Module running on KVM Hypervisor
+ciscoHyperNAM                   OBJECT IDENTIFIER ::= { ciscoProducts 1878 } -- Network Analysis Module running on Hyper-V Hypervisor
+ciscoC385024S                   OBJECT IDENTIFIER ::= { ciscoProducts 1879 } -- Catalyst 3850 24 100/1000 SFP Ports Layer 2/Layer 3 Ethernet Stackable Switch
+ciscoC385012S                   OBJECT IDENTIFIER ::= { ciscoProducts 1880 } -- Catalyst 3850 12 100/1000 SFP Ports Layer 2/Layer 3 Ethernet Stackable Switch
+ciscoC365048PQ                  OBJECT IDENTIFIER ::= { ciscoProducts 1881 } -- Cisco Catalyst 3650 48 Port POE 4x10G Uplink
+ciscoC365048TQ                  OBJECT IDENTIFIER ::= { ciscoProducts 1882 } -- Cisco Catalyst 3650 48 Port Data 4x10G Uplink
+ciscoASR902                     OBJECT IDENTIFIER ::= { ciscoProducts 1897 } -- Cisco Aggregation Services Router 900 Series with 2RU Chassis
+ciscoME1200                     OBJECT IDENTIFIER ::= { ciscoProducts 1899 } -- Cisco ME 1200 Carrier Ethernet Access Demarcation  Device 
+ciscoN9Kc9508                   OBJECT IDENTIFIER ::= { ciscoProducts 1915 } -- Nexus 9500 series chassis with 8 slots 
+ciscoWapAP702                   OBJECT IDENTIFIER ::= { ciscoProducts 1916 } -- Wireless Access Point 700 
+ciscoWapAP2602                  OBJECT IDENTIFIER ::= { ciscoProducts 1917 } -- Wireless Access Point 2600 
+ciscoWapAP1602                  OBJECT IDENTIFIER ::= { ciscoProducts 1918 } -- Wireless Access Point 1600 
+ciscoN9KC93128TX                OBJECT IDENTIFIER ::= { ciscoProducts 1923 } -- 3RU TOR, 96x10GT+8x40G QSFP 
+ciscoN9KC9396PX                 OBJECT IDENTIFIER ::= { ciscoProducts 1925 } -- 2RU TOR, 48x10GF+12x40G QSFP 
+ciscoUcsEN120S                  OBJECT IDENTIFIER ::= { ciscoProducts 1931 } -- UCS E-Series Network compute engine 2-Core Service module (UCS-EN120S-M2/K9)
+ciscoC68xxVirtualSwitch         OBJECT IDENTIFIER ::= { ciscoProducts 1934 } -- 68xx Virtual Switch 
+ciscoC6880x                     OBJECT IDENTIFIER ::= { ciscoProducts 1936 } -- Catalyst 6880 chassis 
+ciscoCPT50                      OBJECT IDENTIFIER ::= { ciscoProducts 1937 } -- Cisco Carrier Packet Transport (CPT) 50 
+ciscoCSE340WG32K9               OBJECT IDENTIFIER ::= { ciscoProducts 1940 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G
+ciscoCSE340WG32AK9              OBJECT IDENTIFIER ::= { ciscoProducts 1941 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For American)
+ciscoCSE340WG32CK9              OBJECT IDENTIFIER ::= { ciscoProducts 1942 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For China)
+ciscoCSE340WG32EK9              OBJECT IDENTIFIER ::= { ciscoProducts 1943 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For Europe)
+ciscoCSE340WG32NK9              OBJECT IDENTIFIER ::= { ciscoProducts 1944 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For New-Zealand-Australia)
+ciscoCSE340WM32K9               OBJECT IDENTIFIER ::= { ciscoProducts 1945 } -- Cisco Edge 340 Digital Media Player DMP model, equipped with 32G SSD, WiFi chip, support 2.4G
+ciscoCSE340WM32AK9              OBJECT IDENTIFIER ::= { ciscoProducts 1946 } -- Cisco Edge 340 Digital Media Player DMP model, equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For American)
+ciscoCSE340WM32CK9              OBJECT IDENTIFIER ::= { ciscoProducts 1947 } -- Cisco Edge 340 Digital Media Player DMP model, equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For China)
+ciscoCSE340WM32EK9              OBJECT IDENTIFIER ::= { ciscoProducts 1948 } -- Cisco Edge 340 Digital Media Player DMP model, equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For Europe)
+ciscoCSE340WM32NK9              OBJECT IDENTIFIER ::= { ciscoProducts 1949 } -- Cisco Edge 340 Digital Media Player DMP model, equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For New-Zealand-Australia)
+ciscoitpRT1081K9                        OBJECT IDENTIFIER ::= { ciscoProducts 1952 } -- Router 1081 Fast Ethernet Router
+ciscoitpRT1091FK9                       OBJECT IDENTIFIER ::= { ciscoProducts 1953 } -- Router 1091 GigaE SecRouter
+ciscoitpPwr30WAC                        OBJECT IDENTIFIER ::= { ciscoProducts 1954 } -- Power Supply 30 Watt AC
+ciscoitpPwr60WAC                        OBJECT IDENTIFIER ::= { ciscoProducts 1955 } -- Power Supply 60 Watt AC
+ciscoitpPwr60WACV2                      OBJECT IDENTIFIER ::= { ciscoProducts 1956 } -- Power Supply 60 Watt AC
+ciscoitpPwr125WAC                       OBJECT IDENTIFIER ::= { ciscoProducts 1957 } -- POE power supply
+ciscoitpRT2241K9                        OBJECT IDENTIFIER ::= { ciscoProducts 1958 } -- Router 2241 w/2 GE,2 EHWIC slots,256MB CF,512MB DRAM,IP Base
+ciscoitpRT2221K9                        OBJECT IDENTIFIER ::= { ciscoProducts 1959 } -- Router 2221 Modular Router, 2 GE, 2 EHWIC slots, 512DRAM, IP Base
+ciscoitpRT2241WCK9                      OBJECT IDENTIFIER ::= { ciscoProducts 1960 } -- Router 2241 Router w/802.11 a/b/g/n China Compliant WLAN ISM
+ciscoitpAxpIsmSre300                    OBJECT IDENTIFIER ::= { ciscoProducts 1961 } -- Internal Services Module (ISM) with Services Ready Engine
+ciscoitpPwr2241AC                       OBJECT IDENTIFIER ::= { ciscoProducts 1962 } -- Router 2241 AC Power Supply
+ciscoitpRT3211K9                        OBJECT IDENTIFIER ::= { ciscoProducts 1963 } -- Router 3211 w/3 GE,4 EHWIC,2 DSP,1 SM,256MB CF,512MB DRAM,IPB
+ciscoitpRT3221K9                        OBJECT IDENTIFIER ::= { ciscoProducts 1964 } -- Router 3221 w/3 GE,4 EHWIC,3 DSP,1 SM,256MB CF,512MB DRAM,IPB
+ciscoitpRT3201K9                        OBJECT IDENTIFIER ::= { ciscoProducts 1965 } -- Router 3201 w/2 GE,4 EHWIC,2 DSP,256MB CF,512MB DRAM,IP Base
+ciscoitpPwrRT3201AC                     OBJECT IDENTIFIER ::= { ciscoProducts 1966 } -- Router 3201 AC Power Supply
+ciscoitpPwrRT3211AC                     OBJECT IDENTIFIER ::= { ciscoProducts 1967 } -- Router 3211 AC Power Supply
+ciscoitpPwrRT3211DC                     OBJECT IDENTIFIER ::= { ciscoProducts 1968 } -- Router 3211 DC Power Supply
+ciscoitpPwrRT32AC                       OBJECT IDENTIFIER ::= { ciscoProducts 1969 } -- Router 3200 AC Power Supply
+ciscoitpRpsAdptrRT3211                  OBJECT IDENTIFIER ::= { ciscoProducts 1970 } -- Router 3211 RPS Adapter for use with External RPS
+ciscoitpRpsAdptrRT32                    OBJECT IDENTIFIER ::= { ciscoProducts 1971 } -- Router 3200 RPS Adapter for use with External RPS
+ciscoitpAxpSmSre710                     OBJECT IDENTIFIER ::= { ciscoProducts 1972 } -- SRE 710 (4GB MEM,500GB 7K HDD,1C CPU) for router bundle
+ciscoitpAxpSmSre910                     OBJECT IDENTIFIER ::= { ciscoProducts 1973 } -- SRE 910 (4-8GB MEM,2x500GB 7k HDD,2C CPU) for router bundle
+ciscoN9Kc9516                           OBJECT IDENTIFIER ::= { ciscoProducts 1996 } -- Nexus 9500 series chassis with 16 slots
+ciscoN9Kc9504                           OBJECT IDENTIFIER ::= { ciscoProducts 1997 } -- Nexus 9500 series chassis with 4 slots
+ciscoDoorCGR1240                        OBJECT IDENTIFIER ::= { ciscoProducts 1998 } -- Cisco Connected Grid Router CGR1240 physical door entity
+ciscoWRP500                             OBJECT IDENTIFIER ::= { ciscoProducts 2000 } -- WRP500 is targeted for small business network environments from a Hosted Service Provider
+cisco897VABK9                           OBJECT IDENTIFIER ::= { ciscoProducts 2008 } -- C897VAB-K9 router with 1 VDSL2 withbonding/ADSL2+ WAN , 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet Primary WAN, 8 Giga Ethernet LAN,4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM
+cisco819HWDCK9                          OBJECT IDENTIFIER ::= { ciscoProducts 2023 } -- C819HWD-C-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 Serial, CCC Mark compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+catAIRCT57006                      OBJECT IDENTIFIER ::= { ciscoProducts 2026 } -- AIR-CT5760-6 Catalyst 5700 Series Wireless Controller with 6 TenGE Interfaces
+cisco897VAGLTEGAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2053 } -- 4G LTE  Global(Europe & Australia) router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex A Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 ISDN BRI S/T interface, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM 
+ciscoIOG910WK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2063 } -- Programmable IoT Sensor Gateway, 1 Combo (GE/SFP), 1 open slot for 802.15.4 module, 1 slot for external storage. 802.11 b/g/n Wi-Fi
+ciscoIOG910GK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2064 } -- Programmable IoT Sensor Gateway, 1 Combo (GE/SFP), 1 open slot for 802.15.4 module, 1 slot for external storage. 3G HSPA and CDMA EV-DO selective
+ciscoIOG910K9                       OBJECT IDENTIFIER ::= { ciscoProducts 2065 } -- Programmable IoT Sensor Gateway, 1 Combo (GE/SFP), 1 open slot for 802.15.4 module, 1 slot for external storage
+cat36xxstack                        OBJECT IDENTIFIER ::= { ciscoProducts 2066 } -- A stack of any catalyst36xx stack-able ethernet switches with unified identity (as a single unified switch), control and management
+cat57xxstack                        OBJECT IDENTIFIER ::= { ciscoProducts 2067 } -- A stack of any Wireless LAN 57xx stack-able controllers with unified identity (as a single unified switch), control and management
+ciscoCSE340G32K9                    OBJECT IDENTIFIER ::= { ciscoProducts 2094 } -- Cisco Edge 340 Digital Media Player none wifi, general model, equipped with 32G SSD
+ciscoCSE340M32K9                    OBJECT IDENTIFIER ::= { ciscoProducts 2095 } -- Cisco Edge 340 Digital Media Player none wifi, DMP model, equipped with 32G SSD
+ciscoSCE10000                       OBJECT IDENTIFIER ::= { ciscoProducts 2096 } -- Cisco service control engine 10000
+ciscoVirtualSCE                     OBJECT IDENTIFIER ::= { ciscoProducts 2097 } -- Cisco virtual service control engine
+ciscoASR901AC10GS                   OBJECT IDENTIFIER ::= { ciscoProducts 2098 } -- ASR901 10GS AC platform
+ciscoASR901DC10GS                   OBJECT IDENTIFIER ::= { ciscoProducts 2099 } -- ASR901 10GS DC platform
+ciscoASR92024SZIM                   OBJECT IDENTIFIER ::= { ciscoProducts 2100 } -- Cisco ASR920 Series - 24GE and 4-10GE- Modular PSU and IM 
+ciscoASR92024TZM                    OBJECT IDENTIFIER ::= { ciscoProducts 2101 } -- Cisco ASR920 Series - 24GE Copper and 4-10GE - Modular PSU
+ciscoASR92024SZM                    OBJECT IDENTIFIER ::= { ciscoProducts 2102 } -- Cisco ASR920 Series - 24GE Fiber and 4-10GE - Modular PSU  
+ciscoWallander1x1GESKU              OBJECT IDENTIFIER ::= { ciscoProducts 2112 } -- This is a giga-bit ethernet card which can be plugged into host such like ISR4451, this will provide one giga-bit eth interface (both RJ45 and SFP are supported).
+ciscoWallander2x1GESKU              OBJECT IDENTIFIER ::= { ciscoProducts 2113 } -- This is a giga-bit ethernet card which can be plugged into host such like ISR4451, this will provide two giga-bit eth interface (both RJ45 and SFP are supported).
+ciscoSNS3495K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2139 } -- Cisco Secure Network Server platform SNS-3495 appliance
+ciscoSNS3415K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2140 } -- Cisco Secure Network Server platform SNS-3415 appliance
+ciscoASR9204SZD                     OBJECT IDENTIFIER ::= { ciscoProducts 2155 } -- Cisco ASR920 Series - 2GE and 4-10GE -DC model
+ciscoASR9208SZ0A                    OBJECT IDENTIFIER ::= { ciscoProducts 2156 } -- Cisco ASR920 Series - 8GE and 4-10GE - Outdoor AC model
+ciscoASR92012CZA                    OBJECT IDENTIFIER ::= { ciscoProducts 2157 } -- Cisco ASR920 Series - 12GE and 2-10GE - AC model
+ciscoASR92012CZD                    OBJECT IDENTIFIER ::= { ciscoProducts 2158 } -- Cisco ASR920 Series - 12GE and 2-10GE - DC model
+ciscoASR9204SZA                     OBJECT IDENTIFIER ::= { ciscoProducts 2159 } -- Cisco ASR920 Series - 2GE and 4-10GE -AC model
+ciscoASR9208SZ0D                    OBJECT IDENTIFIER ::= { ciscoProducts 2160 } -- Cisco ASR920 Series - 8GE and 4-10GE - Outdoor DC model
+ciscoC3850E12XS                     OBJECT IDENTIFIER ::= { ciscoProducts 2162 } -- Cisco Catalyst 3850E 12 Port 10G Fiber Switch
+ciscoC3850E24XS                     OBJECT IDENTIFIER ::= { ciscoProducts 2163 } -- Cisco Catalyst 3850E 24 Port 10G Fiber Switch
+ciscoC3850E48XS                     OBJECT IDENTIFIER ::= { ciscoProducts 2164 } -- Cisco Catalyst 3850E 48 Port 10G Fiber Switch
+ciscoRAIE1783ZMS4T4E2TGN            OBJECT IDENTIFIER ::= { ciscoProducts 2168 } -- Cisco IE2000 IP67 Variant with  4 port 10/100 downlink, 4 port POE/POE+ downlink, 2 10/100/1000 uplink, w/FPGA, LAN Base Image, PTP and NAT Support
+ciscoRAIE1783ZMS8T8E2TGN            OBJECT IDENTIFIER ::= { ciscoProducts 2169 } -- Cisco IE2000 IP67 Variant with 8 port 10/100 downlink, 8 port POE/POE+ downlink, 2 10/100/1000 uplink, w/FPGA, LAN Base Image, PTP and NAT Support
+ciscoUCSC220M4                      OBJECT IDENTIFIER ::= { ciscoProducts 2178 } -- Cisco UCS C220 M4 Rack server
+ciscoUCSC240M4                      OBJECT IDENTIFIER ::= { ciscoProducts 2179 } -- Cisco UCS C240 M4 Rack server
+ciscoUCSC3160                       OBJECT IDENTIFIER ::= { ciscoProducts 2180 } -- Cisco UCS C3160 Rack server
+cisco1941WTK9                       OBJECT IDENTIFIER ::= { ciscoProducts 2181 } -- CISCO1941W-T/K9 with 802.11 a/b/g/ n  Israel Compliant WLAN ISM 
+ciscoCDScde2802s5                   OBJECT IDENTIFIER ::= { ciscoProducts 2185 } -- Cisco Content Delivery System Model CDE-280-2S5
+ciscoCDScde2802s10                  OBJECT IDENTIFIER ::= { ciscoProducts 2186 } -- Cisco Content Delivery System Model CDE-280-2S10
+ciscoCDScde2802s21                  OBJECT IDENTIFIER ::= { ciscoProducts 2187 } -- Cisco Content Delivery System Model CDE-280-2S21
+ciscoCDScde2802h0                   OBJECT IDENTIFIER ::= { ciscoProducts 2188 } -- Cisco Content Delivery System Model CDE-280-2H0
+ciscoCDScde2802h13                  OBJECT IDENTIFIER ::= { ciscoProducts 2189 } -- Cisco Content Delivery System Model CDE-280-2H13
+ciscoCDScde2802h26                  OBJECT IDENTIFIER ::= { ciscoProducts 2190 } -- Cisco Content Delivery System Model CDE-280-2H26
+cisco1941WIK9                       OBJECT IDENTIFIER ::= { ciscoProducts 2192 } -- Cisco 1941W-I/K9 with 802.11 a/b/g/ n  Israel Compliant WLAN ISM
+ciscoFp7030K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2193  } -- Cisco FirePOWER 7030 Appliance, 1U
+ciscoFp7050K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2194  } -- Cisco FirePOWER 7050 Appliance, 1U
+ciscoFp7110K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2195  } -- Cisco FirePOWER 7110 Appliance, 1U
+ciscoFp7110FiK9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2196  } -- Cisco FirePOWER 7110 Appliance, Fi, 1U
+ciscoFp7115K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2197  } -- Cisco FirePOWER 7115 Appliance, 1U
+ciscoFp7120K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2198  } -- Cisco FirePOWER 7120 Appliance, 1U
+ciscoFp7120FiK9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2199  } -- Cisco FirePOWER 7120 Appliance, Fi, 1U
+ciscoFp7125K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2200  } -- Cisco FirePOWER 7125 Appliance, 1U
+ciscoFp8120K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2201  } -- Cisco FirePOWER 8120 Appliance, 1U
+ciscoFp8130K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2202  } -- Cisco FirePOWER 8130 Appliance, 1U
+ciscoFp8140K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2203  } -- Cisco FirePOWER 8140 Appliance, 1U
+ciscoFp8250K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2204  } -- Cisco FirePOWER 8250 Appliance, 2U
+ciscoFp8260K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2205  } -- Cisco FirePOWER 8260 Appliance, 4U
+ciscoFp8270K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2206  } -- Cisco FirePOWER 8270 Appliance, 6U
+ciscoFp8290K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2207  } -- Cisco FirePOWER 8290 Appliance, 8U
+ciscoFp8350K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2208  } -- Cisco FirePOWER 8350 Appliance, 2U
+ciscoFp8360K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2209  } -- Cisco FirePOWER 8360 Appliance, 4U
+ciscoFp8370K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2210  } -- Cisco FirePOWER 8370 Appliance, 6U
+ciscoFp8390K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2211  } -- Cisco FirePOWER 8390 Appliance, 8U
+ciscoFs750K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2212  } -- Cisco FireSIGHT Management Center 750 Appliance, 1U
+ciscoFs1500K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2213  } -- Cisco FireSIGHT Management Center 1500 Appliance, 1U
+ciscoFs3500K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2214  } -- Cisco FireSIGHT Management Center 3500 Appliance, 1U
+ciscoFs4000K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2215  } -- Cisco FireSIGHT Management Center 4000 Appliance, 1U
+ciscoAmp7150K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2216  } -- Cisco FirePOWER AMP7150 Appliance, 1U
+ciscoAmp8050K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2217  } -- Cisco FirePOWER AMP8050 Appliance, 1U
+ciscoAmp8150K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2218  } -- Cisco FirePOWER AMP8150 Appliance, 1U
+ciscoAmp8350K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2219  } -- Cisco FirePOWER AMP8350 Appliance, 2U
+ciscoAmp8360K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2220  } -- Cisco FirePOWER AMP8360 Appliance, 4U
+ciscoAmp8370K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2221  } -- Cisco FirePOWER AMP8370 Appliance, 6U
+ciscoAmp8390K9	                    OBJECT IDENTIFIER ::= { ciscoProducts 2222  } -- Cisco FirePOWER AMP8390 Appliance, 8U
+ciscoFpSsl1500K9	            OBJECT IDENTIFIER ::= { ciscoProducts 2223  } -- FirePOWER SSL1500 Appliance, 1U
+ciscoFpSsl1500FiK9	            OBJECT IDENTIFIER ::= { ciscoProducts 2224  } -- FirePOWER SSL1500 Appliance, Fi, 1U
+ciscoFpSsl2000K9	            OBJECT IDENTIFIER ::= { ciscoProducts 2225  } -- Cisco FirePOWER SSL2000 Appliance, 1U
+ciscoFpSsl8200K9	            OBJECT IDENTIFIER ::= { ciscoProducts 2226  } -- Cisco FirePOWER SSL8200 Appliance, 2U
+ciscoFp7010K9                       OBJECT IDENTIFIER ::= { ciscoProducts 2227  } -- Cisco FirePOWER 7010 Appliance, 1U
+ciscoFp7020K9                       OBJECT IDENTIFIER ::= { ciscoProducts 2228  } -- Cisco FirePOWER 7020 Appliance, 1U 
 
 END
 


### PR DESCRIPTION
This is needed to detect some of the newer Cisco devices like the ASA5512 with Security contexts.