### PR TITLE
Updated docs on removing default site

### DIFF
--- a/doc/Installation/Installation-(Debian-Ubuntu).md
+++ b/doc/Installation/Installation-(Debian-Ubuntu).md
@@ -117,6 +117,10 @@ Change `librenms.example.com` to the appropriate hostname for your domain, then 
     a2enmod rewrite
     service apache2 restart
 
+If this is the only site you are hosting on this server (it should be :)) then you will need to disable the default site setup in Ubuntu:
+
+    a2dissite 000-default
+
 (To get to your LibreNMS install externally, you'll also need add it to your DNS or hosts file.)
 
 ### Manual vs. web installer ###


### PR DESCRIPTION
By default a site 000-default is created on Ubuntu and this will display when trying to get to the librenms web ui, this warns users that they should disable this if it's the only site on there.