### PR TITLE
Future-Proof db-cleanup on device deletion

### DIFF
--- a/html/pages/delhost.inc.php
+++ b/html/pages/delhost.inc.php
@@ -23,7 +23,7 @@ if (is_numeric($_REQUEST['id']))
 ');
   if ($_REQUEST['confirm'])
   {
-    print_message(delete_device(mres($_REQUEST['id']))."\n");
+    print_message(nl2br(delete_device(mres($_REQUEST['id'])))."\n");
   }
   else
   {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -249,14 +249,11 @@ function delete_device($id)
     $ret .= "Removed interface $int_id ($int_if)\n";
   }
 
-  dbDelete('devices', "`device_id` =  ?", array($id));
-
-  $device_tables = array('entPhysical', 'devices_attribs', 'devices_perms', 'bgpPeers', 'vlans', 'vrfs', 'storage', 'alerts', 'eventlog',
-                         'syslog', 'ports', 'services', 'toner', 'frequency', 'current', 'sensors','ciscoASA');
-
-  foreach ($device_tables as $table)
-  {
-    dbDelete($table, "`device_id` =  ?", array($id));
+  $fields = array('device_id','host');
+  foreach( $fields as $field ) {
+    foreach( dbFetch("SELECT table_name FROM information_schema.columns WHERE table_schema = ? AND column_name = ?",array($config['db_name'],$field)) as $table ) {
+      dbDelete($table, "`$field` =  ?", array($id));
+    }
   }
 
   shell_exec("rm -rf ".trim($config['rrd_dir'])."/$host");


### PR DESCRIPTION
Solves #588, #587 

Does a dynamic lookup on all tables that use `device_id` or `host` and deletes entries containing the appropriate device_id.

The fields to lookup for are stored in an array so it can be extended when required for non-standardized tables.

Code was tested against a historically grown setup and removed all traces of the host from the DB.