### PR TITLE
Display devices with empty type as generic

### DIFF
--- a/html/pages/devices.inc.php
+++ b/html/pages/devices.inc.php
@@ -22,7 +22,13 @@ if (!empty($vars['os']))       { $where .= " AND os = ?";          $sql_param[] 
 if (!empty($vars['version']))  { $where .= " AND version = ?";     $sql_param[] = $vars['version']; }
 if (!empty($vars['hardware'])) { $where .= " AND hardware = ?";    $sql_param[] = $vars['hardware']; }
 if (!empty($vars['features'])) { $where .= " AND features = ?";    $sql_param[] = $vars['features']; }
-if (!empty($vars['type']))     { $where .= " AND type = ?";        $sql_param[] = $vars['type']; }
+if (!empty($vars['type']))     {
+  if ($vars['type'] == 'generic') {
+    $where .= " AND ( type = ? OR type = '')";        $sql_param[] = $vars['type'];
+  } else {
+    $where .= " AND type = ?";        $sql_param[] = $vars['type'];
+  }
+}
 if (!empty($vars['state']))    {
   $where .= " AND status= ?";       $sql_param[] = $state;
   $where .= " AND disabled='0' AND `ignore`='0'"; $sql_param[] = '';


### PR DESCRIPTION
Some of my devices didn't get a type set automatically. In the menu the "generic" type is visible, but clicking it, didn't list those devices. This patch also shows those devices if generic is selcted.

A better sollution would probably be to set the type to 'generic' on device creation, so that no devices with empty types are in the database in the first place, but this was the quickest fix for me.