### PR TITLE
This log_event would always trigger if a port was admin down, we now skip over those interfaces

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -253,7 +253,7 @@ foreach ($ports as $port)
     // Update IF-MIB data
     foreach ($data_oids as $oid)
     {
-      if ($port[$oid] != $this_port[$oid] && !isset($this_port[$oid]))
+      if ($port[$oid] != $this_port[$oid] && !isset($this_port[$oid]) && $this_port['ifAdminStatus'] != 'down')
       {
         $port['update'][$oid] = NULL;
         log_event($oid . ": ".$port[$oid]." -> NULL", $device, 'interface', $port['port_id']);


### PR DESCRIPTION
This log_event is triggered when a port isn't a trunk or vlan port which they aren't when admin down.