### PR TITLE
Also added the ifAdmin check to next if statement

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -258,7 +258,7 @@ foreach ($ports as $port)
         $port['update'][$oid] = NULL;
         log_event($oid . ": ".$port[$oid]." -> NULL", $device, 'interface', $port['port_id']);
         if ($debug) { echo($oid . ": ".$port[$oid]." -> NULL "); } else { echo($oid . " "); }
-      } elseif ($port[$oid] != $this_port[$oid]) {
+      } elseif ($port[$oid] != $this_port[$oid] && $this_port['ifAdminStatus'] != 'down') {
         $port['update'][$oid] = $this_port[$oid];
         log_event($oid . ": ".$port[$oid]." -> " . $this_port[$oid], $device, 'interface', $port['port_id']);
         if ($debug) { echo($oid . ": ".$port[$oid]." -> " . $this_port[$oid]." "); } else { echo($oid . " "); }


### PR DESCRIPTION
The ports just ended up being matched by the next elseif check as well so added the ifAdmin status check to this.

Also tested to ensure that a change of vlan on an interface is still logged as intended.