### PR TITLE
Updated adding devices for distributed poller

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -20,6 +20,23 @@ include("config.php");
 include("includes/definitions.inc.php");
 include("includes/functions.php");
 
+$options = getopt("g:f::");
+
+echo $options['g'];
+if (isset($options['g']) && $options['g'] >= 0) {
+    $cmd = array_shift($argv);
+    array_shift($argv);
+    array_shift($argv);
+    array_unshift($argv, $cmd);
+    $poller_group = $options['g'];
+}
+if (isset($options['f']) && $options['f'] == 0) {
+    $cmd = array_shift($argv);
+    array_shift($argv);
+    array_unshift($argv, $cmd);
+    $force_add = 1;
+}
+
 if (!empty($argv[1]))
 {
   $host      = strtolower($argv[1]);
@@ -70,7 +87,7 @@ if (!empty($argv[1]))
       if ($seclevel === "nanp")
         { array_push($config['snmp']['v3'], $v3); }
 
-      $device_id = addHost($host, $snmpver, $port, $transport);
+      $device_id = addHost($host, $snmpver, $port, $transport,0,$poller_group,$force_add);
 
     }
     elseif ($seclevel === "anp" or $seclevel === "authNoPriv")
@@ -99,7 +116,7 @@ if (!empty($argv[1]))
       }
 
       array_push($config['snmp']['v3'], $v3);
-      $device_id = addHost($host, $snmpver, $port, $transport);
+      $device_id = addHost($host, $snmpver, $port, $transport,0,$poller_group,$force_add);
 
     }
     elseif ($seclevel === "ap" or $seclevel === "authPriv")
@@ -132,7 +149,7 @@ if (!empty($argv[1]))
       }
 
       array_push($config['snmp']['v3'], $v3);
-      $device_id = addHost($host, $snmpver, $port, $transport);
+      $device_id = addHost($host, $snmpver, $port, $transport,0,$poller_group,$force_add);
 
     }
     else
@@ -166,7 +183,7 @@ if (!empty($argv[1]))
       $config['snmp']['community'] = array($community);
     }
 
-    $device_id = addHost($host, $snmpver, $port, $transport);
+    $device_id = addHost($host, $snmpver, $port, $transport,0,$poller_group,$force_add);
   }
 
   if ($snmpver)
@@ -181,7 +198,7 @@ if (!empty($argv[1]))
   while (!$device_id && count($snmpversions))
   {
     $snmpver = array_shift($snmpversions);
-    $device_id = addHost($host, $snmpver, $port, $transport);
+    $device_id = addHost($host, $snmpver, $port, $transport,0,$poller_group,$force_add);
   }
 
   if ($device_id)
@@ -194,11 +211,13 @@ if (!empty($argv[1]))
 
 print $console_color->convert("\n" . $config['project_name_version']." Add Host Tool
 
-Usage (SNMPv1/2c): ./addhost.php <%Whostname%n> [community] [v1|v2c] [port] [" . implode("|",$config['snmp']['transports']) . "]
-Usage (SNMPv3)   :  Config Defaults : ./addhost.php <%Whostname%n> any v3 [user] [port] [" . implode("|",$config['snmp']['transports']) . "]
-                   No Auth, No Priv : ./addhost.php <%Whostname%n> nanp v3 [user] [port] [" . implode("|",$config['snmp']['transports']) . "]
-                      Auth, No Priv : ./addhost.php <%Whostname%n> anp v3 <user> <password> [md5|sha] [port] [" . implode("|",$config['snmp']['transports']) . "]
-                      Auth,    Priv : ./addhost.php <%Whostname%n> ap v3 <user> <password> <enckey> [md5|sha] [aes|dsa] [port] [" . implode("|",$config['snmp']['transports']) . "]
+Usage (SNMPv1/2c): ./addhost.php [-g <poller group>] [-f] <%Whostname%n> [community] [v1|v2c] [port] [" . implode("|",$config['snmp']['transports']) . "]
+Usage (SNMPv3)   :  Config Defaults : ./addhost.php [-g <poller group>] [-f]<%Whostname%n> any v3 [user] [port] [" . implode("|",$config['snmp']['transports']) . "]
+                   No Auth, No Priv : ./addhost.php [-g <poller group>] [-f]<%Whostname%n> nanp v3 [user] [port] [" . implode("|",$config['snmp']['transports']) . "]
+                      Auth, No Priv : ./addhost.php [-g <poller group>] [-f]<%Whostname%n> anp v3 <user> <password> [md5|sha] [port] [" . implode("|",$config['snmp']['transports']) . "]
+                      Auth,    Priv : ./addhost.php [-g <poller group>] [-f]<%Whostname%n> ap v3 <user> <password> <enckey> [md5|sha] [aes|dsa] [port] [" . implode("|",$config['snmp']['transports']) . "]
+-g <poller group> allows you to add a device to be pinned to a specific poller when using distributed polling. X can be any number associated with a poller group
+-f forces the device to be added by skipping the icmp and snmp check against the host.
 %rRemember to run discovery for the host afterwards.%n
 
 ");

--- a/doc/API/API-Docs.md
+++ b/doc/API/API-Docs.md
@@ -364,6 +364,8 @@ Input (JSON):
  - port: SNMP port (defaults to port defined in config).
  - transport: SNMP protocol (defaults to transport defined in config).
  - version: SNMP version to use, v1, v2c or v3. Defaults to v2c.
+ - poller_group: This is the poller_group id used for distributed poller setup. Defaults to 0.
+ - force_add: Force the device to be added regardless of it being able to respond to snmp or icmp.
 
  For SNMP v1 or v2c
 

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -207,6 +207,8 @@ function add_device()
   $hostname = $data['hostname'];
   $port = $data['port'] ? mres($data['port']) : $config['snmp']['port'];
   $transport = $data['transport'] ? mres($data['transport']) : "udp";
+  $poller_group = $data['poller_group'] ? mres($data['poller_group']) : 0;
+  $force_add = $data['force_add'] ? mres($data['force_add']) : 0;
   if($data['version'] == "v1" || $data['version'] == "v2c")
   {
     if ($data['community'])
@@ -237,7 +239,7 @@ function add_device()
   }
   if(empty($message))
   {
-    $result = addHost($hostname, $snmpver, $port, $transport, 1);
+    $result = addHost($hostname, $snmpver, $port, $transport, 1, $poller_group,$force_add);
     if($result)
     {
       $code = 201;

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -51,7 +51,13 @@ if ($_POST['hostname'])
       print_error("Unsupported SNMP Version. There was a dropdown menu, how did you reach this error ?");
     }
     $poller_group = $_POST['poller_group'];
-    $result = addHost($hostname, $snmpver, $port, $transport,0,$poller_group);
+    $force_add = $_POST['force_add'];
+    if ($force_add == 'on') {
+        $force_add = 1;
+    } else {
+        $force_add = 0;
+    }
+    $result = addHost($hostname, $snmpver, $port, $transport,0,$poller_group,$force_add);
     if ($result)
     {
       print_message("Device added ($result)");
@@ -193,6 +199,15 @@ if ($config['distributed_poller'] === TRUE) {
 
     echo('
               </select>
+          </div>
+      </div>
+      <div class="form-group">
+          <div class="col-sm-offset-3 col-sm-9">
+              <div class="checkbox">
+                  <label>
+                      <input type="checkbox" name="force_add" id="force_add"> Force add
+                  </label>
+              </div>
           </div>
       </div>
     ');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -278,7 +278,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
     if (!(inet_pton($host))) 
     {
       // Test reachability
-      if (isPingable($host) || $force_add == 1)
+      if ($force_add == 1 || isPingable($host))
       {
         if (empty($snmpver))
         {
@@ -310,7 +310,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
           {
             $device = deviceArray($host, NULL, $snmpver, $port, $transport, $v3);
             if($quiet == '0') { print_message("Trying v3 parameters " . $v3['authname'] . "/" .  $v3['authlevel'] . " ... "); }
-            if (isSNMPable($device) || $force_add == 1)
+            if ($force_add == 1 || isSNMPable($device))
             {
               $snmphost = snmp_get($device, "sysName.0", "-Oqv", "SNMPv2-MIB");
               if (empty($snmphost) or ($snmphost == $host || $hostshort = $host))
@@ -332,7 +332,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
           {
             $device = deviceArray($host, $community, $snmpver, $port, $transport, NULL);
             if($quiet == '0') { print_message("Trying community $community ..."); }
-            if (isSNMPable($device) || $force_add == 1)
+            if ($force_add == 1 || isSNMPable($device))
             {
               $snmphost = snmp_get($device, "sysName.0", "-Oqv", "SNMPv2-MIB");
               if (empty($snmphost) || ($snmphost && ($snmphost == $host || $hostshort = $host)))

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -266,7 +266,7 @@ function delete_device($id)
   return $ret;
 }
 
-function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0', $poller_group = '0')
+function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0', $poller_group = '0', $force_add = '0')
 {
   global $config;
 
@@ -278,7 +278,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
     if (!(inet_pton($host))) 
     {
       // Test reachability
-      if (isPingable($host))
+      if (isPingable($host) || $force_add == 1)
       {
         if (empty($snmpver))
         {
@@ -310,7 +310,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
           {
             $device = deviceArray($host, NULL, $snmpver, $port, $transport, $v3);
             if($quiet == '0') { print_message("Trying v3 parameters " . $v3['authname'] . "/" .  $v3['authlevel'] . " ... "); }
-            if (isSNMPable($device))
+            if (isSNMPable($device) || $force_add == 1)
             {
               $snmphost = snmp_get($device, "sysName.0", "-Oqv", "SNMPv2-MIB");
               if (empty($snmphost) or ($snmphost == $host || $hostshort = $host))
@@ -332,7 +332,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
           {
             $device = deviceArray($host, $community, $snmpver, $port, $transport, NULL);
             if($quiet == '0') { print_message("Trying community $community ..."); }
-            if (isSNMPable($device))
+            if (isSNMPable($device) || $force_add == 1)
             {
               $snmphost = snmp_get($device, "sysName.0", "-Oqv", "SNMPv2-MIB");
               if (empty($snmphost) || ($snmphost && ($snmphost == $host || $hostshort = $host)))


### PR DESCRIPTION
This is going to seem bizarre but....:

1. It allows adding a device and skip the icmp / snmp check. This is needed for devices you pin to a poller which may not be contactable from outside (i.e behind a NAT firewall). Once the device is added, the poller will pick this up as normal.

2. Added ability to specify the poller group when adding a device.

3. Updated the command line, Webui and API to support these new options.