### PR TITLE
Added support for poller groups in discovery

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -98,7 +98,11 @@ include("includes/sql-schema/update.php");
 
 $discovered_devices = 0;
 
-foreach (dbFetch("SELECT * FROM `devices` WHERE status = 1 AND disabled = 0 $where ORDER BY device_id DESC") as $device)
+if ($config['distributed_poller'] === TRUE) {
+    $where .= " AND poller_group=?";
+    $params = array($config['distributed_poller_group']);
+}
+foreach (dbFetch("SELECT * FROM `devices` WHERE status = 1 AND disabled = 0 $where ORDER BY device_id DESC",$params) as $device)
 {
   discover_device($device, $options);
 }


### PR DESCRIPTION
Discovery processes will now pull out the devices assigned to the poller group. this is skipped if distributed poller is FALSE.