### PR TITLE
Set yocto division and multiplier to 1

### DIFF
--- a/includes/discovery/entity-sensor.inc.php
+++ b/includes/discovery/entity-sensor.inc.php
@@ -69,6 +69,7 @@ if (is_array($oids))
       if ($entry['entPhySensorScale'] == "kilo")  { $divisor = "1"; $multiplier = "1000"; }
       if ($entry['entPhySensorScale'] == "mega")  { $divisor = "1"; $multiplier = "1000000"; }
       if ($entry['entPhySensorScale'] == "giga")  { $divisor = "1"; $multiplier = "1000000000"; }
+      if ($entry['entPhySensorScale'] == "yocto")  { $divisor = "1"; $multiplier = "1";  }
 
       if (is_numeric($entry['entPhySensorPrecision']) && $entry['entPhySensorPrecision'] > "0") { $divisor = $divisor . str_pad('', $entry['entPhySensorPrecision'], "0"); }
       $current = $current * $multiplier / $divisor;


### PR DESCRIPTION
Not all entPhySensorScale responses are checked, yocto is missing so this has been set. At present it would default to being blank so not causing any issues but it does mean that eventlogs are generated for every sensor on every poll regardless of them changing.

This is report in #631 and @Rosiak has confirmed this fix works.

We need to take a proper look at the sensor support as something isn't correct in how the calcs are done but this resolves this specific issue for now and I'm confident does so without affecting anything existing.