### PR TITLE
Added serial number detection for Cisco ASA

### DIFF
--- a/includes/polling/os/asa.inc.php
+++ b/includes/polling/os/asa.inc.php
@@ -1,0 +1,5 @@
+<?php
+
+$serial = trim(snmp_get($device, "entPhysicalSerialNum.1", "-Osqv", "ENTITY-MIB:CISCO-ENTITY-VENDORTYPE-OID-MIB"));
+
+?>


### PR DESCRIPTION
Now grabs the chassis serial number.

Tested against:

ASA5505
ASA5510
ASA5512