### PR TITLE
Added OS to the default discovery modules

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -537,6 +537,7 @@ $config['poller_modules']['cisco-asa-firewall']           = 1;
 // List of discovery modules. Need to be in this array to be
 // considered for execution.
 
+$config['discovery_modules']['os']                        = 1;
 $config['discovery_modules']['ports']                     = 1;
 $config['discovery_modules']['ports-stack']               = 1;
 $config['discovery_modules']['entity-physical']           = 1;

--- a/includes/discovery/os.inc.php
+++ b/includes/discovery/os.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+echo("OS: ");
+
 // MYSQL Check - FIXME
 // 1 UPDATE
 


### PR DESCRIPTION
Without this, the OS discovery never re-runs unless you manually select -m os on the command line for a discovery.

Re-running the os discovery module is needed to detect changes to the OS such as the device is replaced with something with a different OS or if we include a new OS definition at which point currently no existing devices would be auto updated.