### PR TITLE
add new hipchat transport for alerts

### DIFF
--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -13,6 +13,7 @@ Table of Content:
     - [Nagios-Compatible](#transports-nagios)
     - [IRC](#transports-irc)
     - [Slack](#transports-slack)
+    - [HipChat](#transports-hipchat)
 - [Entities](#entities)
     - [Devices](#entity-devices)
     - [BGP Peers](#entity-bgppeers)
@@ -190,6 +191,47 @@ $config['alert']['transports']['slack'][] = array('url' => "https://hooks.slack.
 $config['alert']['transports']['slack'][] = array('url' => "https://hooks.slack.com/services/A12B34CDE/F56GH78JK/L901LmNopqrSTUVw2w3XYZAB4C", 'channel' => '@john', 'username' => 'LibreNMS', 'icon_emoji' => ':ghost:');
 
 ```
+
+## <a name="transports-hipchat">HipChat</a>
+
+The HipChat transport requires the following:
+
+__room_id__: HipChat Room ID
+__url__: HipChat API URL+API Key
+__from__: The name that will be displayed
+
+The HipChat transport makes the following optional:
+
+__color__: Any of HipChat's supported message colors
+__message_format__: Any of HipChat's supported message formats
+__notify__: 0 or 1
+
+See the HipChat API Documentation for
+[rooms/message](https://www.hipchat.com/docs/api/method/rooms/message)
+for details on acceptable values.
+
+> You may notice that the link points at the "deprecated" v1 API.  This is
+> because the v2 API is still in beta.
+
+Below are two examples of sending messages to a HipChat room.
+
+```php
+$config['alert']['transports']['hipchat'][] = array("url" => "https://api.hipchat.com/v1/rooms/message?auth_token=9109jawregoaih",
+                                                    "room_id" => "1234567",
+                                                    "from" => "LibreNMS");
+
+$config['alert']['transports']['hipchat'][] = array("url" => "https://api.hipchat.com/v1/rooms/message?auth_token=109jawregoaihj",
+                                                    "room_id" => "7654321",
+                                                    "from" => "LibreNMS",
+                                                    "color" => "red",
+                                                    "notify" => 1,
+                                                    "message_format" => "text");
+```
+
+> Note: The default message format for HipChat messages is HTML.  It is
+> recommended that you specify the `text` message format to prevent unexpected
+> results, such as HipChat attempting to interpret angled brackets (`<` and
+> `>`).
 
 # <a name="entities">Entities
 

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -196,15 +196,16 @@ $config['alert']['transports']['slack'][] = array('url' => "https://hooks.slack.
 
 The HipChat transport requires the following:
 
-__room_id__: HipChat Room ID
-__url__: HipChat API URL+API Key
-__from__: The name that will be displayed
+__room_id__ = HipChat Room ID
+
+__url__ = HipChat API URL+API Key
+__from__ = The name that will be displayed
 
 The HipChat transport makes the following optional:
 
-__color__: Any of HipChat's supported message colors
-__message_format__: Any of HipChat's supported message formats
-__notify__: 0 or 1
+__color__ = Any of HipChat's supported message colors
+__message_format__ = Any of HipChat's supported message formats
+__notify__ = 0 or 1
 
 See the HipChat API Documentation for
 [rooms/message](https://www.hipchat.com/docs/api/method/rooms/message)

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -205,7 +205,9 @@ __from__ = The name that will be displayed
 The HipChat transport makes the following optional:
 
 __color__ = Any of HipChat's supported message colors
+
 __message_format__ = Any of HipChat's supported message formats
+
 __notify__ = 0 or 1
 
 See the HipChat API Documentation for

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -199,6 +199,7 @@ The HipChat transport requires the following:
 __room_id__ = HipChat Room ID
 
 __url__ = HipChat API URL+API Key
+
 __from__ = The name that will be displayed
 
 The HipChat transport makes the following optional:

--- a/includes/alerts/transport.hipchat.php
+++ b/includes/alerts/transport.hipchat.php
@@ -1,0 +1,55 @@
+/* Copyright (C) 2014 Daniel Preussker <f0o@devilcode.org>, Tyler Christiansen <code@tylerc.me>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+/*
+ * API Transport
+ * @author Tyler Christiansen <code@tylerc.me>
+ * @copyright 2014 Daniel Preussker, Tyler Christiansen, LibreNMS
+ * @license GPL
+ * @package LibreNMS
+ * @subpackage Alerts
+ */
+
+foreach($opts as $option) {
+  $url = $option['url'];
+  foreach($obj as $key=>$value) {
+    $api = str_replace("%".$key, $method == "get" ? urlencode($value) : $value, $api);
+  }
+  $curl = curl_init();
+  $data = array(
+    "message" => $obj["msg"],
+    "room_id" => $option["room_id"],
+    "from" => $option["from"],
+    "color" => $option["color"],
+    "notify" => $option["notify"],
+    "message_format" => $option["message_format"]
+  );
+  // Sane default of making the message color green if the message indicates
+  // that the alert recovered.
+  if(strpos($data["message"], "recovered")) { $data["color"] = "green"; }
+  curl_setopt($curl, CURLOPT_URL, $url);
+  curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($curl, CURLOPT_POST, true);
+  curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+  $ret = curl_exec($curl);
+
+  $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+  if($code != 200) {
+    var_dump("API '$url' returnd Error");
+    var_dump("Params: " . $message);
+    var_dump("Return: " . $ret);
+    return false;
+  }
+}
+return true;


### PR DESCRIPTION
Largely pulls from [transport.slack.php](includes/alerts/transport.slack.php) with HipChat-specific parameters.