### PR TITLE
Fixed the issue with ports constantly logging descr changes

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -277,8 +277,15 @@ foreach ($ports as $port)
         $attrib_key = "port_descr_".$attrib;
         if ($port_ifAlias[$attrib] != $port[$attrib_key])
         {
+          if (!isset($port_ifAlias[$attrib])) {
+              $port_ifAlias[$attrib] = array('NULL');
+              $log_port = 'NULL';
+          } else {
+              $log_port = $port_ifAlias[$attrib];
+          }
           $port['update'][$attrib_key] = $port_ifAlias[$attrib];
-          log_event($attrib . ": ".$port[$attrib_key]." -> " . $port_ifAlias[$attrib], $device, 'interface', $port['port_id']);
+          log_event($attrib . ": ".$port[$attrib_key]." -> " . $log_port, $device, 'interface', $port['port_id']);
+          unset($log_port);
         }
       }
     }


### PR DESCRIPTION
This fixes the following scenario:

Set a description on an interface
Poll
Remove description
Poll - message logged
Poll - message logged
Repeat.

http://i.imgur.com/JldRmb0.png

This now resolves that.

Issue #672 