### PR TITLE
Made poller message box a link to /poll-log/

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -331,7 +331,7 @@ echo('<em>        Powered by <a href="/about/" target="_blank">' . $config['proj
 }
 
 if(dbFetchCell("SELECT COUNT(`device_id`) FROM `devices` WHERE `last_polled` <= DATE_ADD(NOW(), INTERVAL - 15 minute) AND `ignore` = 0 AND `disabled` = 0 AND status = 1",array()) > 0) {
-    $msg_box[] = array('type' => 'warning', 'message' => "It appears as though you have some devices that haven't completed polling within the last 15 minutes, you may want to check that out :)",'title' => 'Devices unpolled');
+    $msg_box[] = array('type' => 'warning', 'message' => "<a href=\"poll-log/\">It appears as though you have some devices that haven't completed polling within the last 15 minutes, you may want to check that out :)</a>",'title' => 'Devices unpolled');
 }
 
 if(is_array($msg_box)) {


### PR DESCRIPTION
Rather than just warn users, not takes them to the poll-log page