### PR TITLE
Updated ipsec polling to clean up data and check before inserting

### DIFF
--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -6,7 +6,12 @@ $ipsec_array = snmpwalk_cache_oid($device, "cipSecTunnelEntry", array(), "CISCO-
 $ike_array   = snmpwalk_cache_oid($device, "cikeTunnelEntry", array(), "CISCO-IPSEC-FLOW-MONITOR-MIB");
 
 $tunnels_db = dbFetchRows("SELECT * FROM `ipsec_tunnels` WHERE `device_id` = ?", array($device['device_id']));
-foreach ($tunnels_db as $tunnel) { $tunnels[$tunnel['peer_addr']] = $tunnel;}
+foreach ($tunnels_db as $tunnel) {
+    if (empty($tunnel['peer_addr']) && empty($tunnel['local_addr'])) {
+        dbDelete('ipsec_tunnels', '`tunnel_id` = ?', array($tunnel['tunnel_id']));
+    }
+    $tunnels[$tunnel['peer_addr']] = $tunnel;
+}
 
 foreach ($ipsec_array as $index => $tunnel)
 {
@@ -42,7 +47,7 @@ foreach ($ipsec_array as $index => $tunnel)
                    "cikeTunLocalName" => "tunnel_name",
                    "cikeTunLocalValue" => "local_addr");
 
-  if (!is_array($tunnels[$tunnel['cikeTunRemoteValue']]))
+  if (!is_array($tunnels[$tunnel['cikeTunRemoteValue']]) && !empty($tunnel['cikeTunRemoteValue']))
   {
     $tunnel_id = dbInsert(array('device_id' => $device['device_id'], 'peer_addr' => $tunnel['cikeTunRemoteValue'], 'local_addr' => $tunnel['cikeTunLocalValue'], 'tunnel_name' => $tunnel['cikeTunLocalName']), 'ipsec_tunnels');
   } else {


### PR DESCRIPTION
Somehow ipsec_tunnels table ends up with a single invalid record per device.

This now removes the db entry if peer_addr and local_addr is empty.

Before adding a new entry it checks for a cikeTunRemoteValue value (peer_addr).