### PR TITLE
Updated footer link to use variable

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -311,7 +311,7 @@ if($config['enable_footer'] == 1) {
     <div class="row">
       <div class="col-md-12 text-center">
 <?php
-echo('<h5>Powered by <a href="http://www.librenms.org/" target="_blank" class="red">' . $config['project_name'].'</a>.</h5>');
+echo('<h5>Powered by <a href="' . $config['project_home'] . '" target="_blank" class="red">' . $config['project_name'].'</a>.</h5>');
 ?>
       </div>
     </div>

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -102,6 +102,7 @@ if (isset($_SERVER["SERVER_NAME"]) && isset($_SERVER["SERVER_PORT"]))
 }
 
 $config['project_url']      = "https://github.com/librenms/";
+$config['project_home']     = 'http://www.librenms.org/';
 $config['project_issues']   = "https://github.com/librenms/librenms/issues";
 $config['site_style']       = "light"; // Options are dark or light
 $config['stylesheet']       = "css/styles.css";


### PR DESCRIPTION
Updated footer url to use new config option.

Reason for not using the github project_url is to get people to the website itself, they've either already installed it and are running it or they are using the demo.