### PR TITLE
Updated old email alerting doc to tell people to use new alerting doc

### DIFF
--- a/doc/Extensions/Email-Alerting.md
+++ b/doc/Extensions/Email-Alerting.md
@@ -1,3 +1,7 @@
+### **This page is deprecated**
+
+#### Please see [The new alerting docs](http://docs.librenms.org/Extensions/Alerting/#transports-email)
+
 Currently, the email alerts needs to be set up in the config. If you want to enable it, paste this in your config and change it:
 
 ```php


### PR DESCRIPTION
The old doc is correct at the moment but trying to point people to the new one.

Never sure if we should actually just delete the contents / file for things like this so took the safe option incase it's linked to from anywhere else.