### PR TITLE
Added a hard limit for explode on oid

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -58,7 +58,7 @@ function snmp_get_multi($device, $oids, $options = "-OQUs", $mib = NULL, $mibdir
   {
     list($oid,$value) = explode("=", $entry);
     $oid = trim($oid); $value = trim($value);
-    list($oid, $index) = explode(".", $oid);
+    list($oid, $index) = explode(".", $oid,2);
     if (!strstr($value, "at this OID") && isset($oid) && isset($index))
     {
       $array[$index][$oid] = $value;


### PR DESCRIPTION
This is to deal with oid's that have multiple indices and is need for an incoming patch from someone :)

Looking at what uses this I can't see anything that could be affected by this change so we should be all good. The same explode is done in other oid lookups correctly.