### PR TITLE
Add support for LDAP directories using member ...

### DIFF
--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -30,7 +30,7 @@ function authenticate($username,$password)
       }
       else
       {
-        if (ldap_compare($ds,$config['auth_ldap_group'],'memberUid',$username))
+        if (ldap_compare($ds,$config['auth_ldap_group'], $config['auth_ldap_groupmemberattr'],get_membername($username))===true)
         {
           return 1;
         }
@@ -97,7 +97,7 @@ function get_userlevel($username)
   $userlevel = 0;
 
   # Find all defined groups $username is in
-  $filter = "(&(|(cn=" . join(")(cn=", array_keys($config['auth_ldap_groups'])) . "))(memberUid=" . $username . "))";
+  $filter = "(&(|(cn=" . join(")(cn=", array_keys($config['auth_ldap_groups'])) . "))(". $config['auth_ldap_groupmemberattr']. "=" . get_membername($username) . "))";
   $search = ldap_search($ds, $config['auth_ldap_groupbase'], $filter);
   $entries = ldap_get_entries($ds, $search);
 
@@ -154,7 +154,7 @@ function get_userlist()
       $realname = $entry['cn'][0];
       $user_id  = $entry['uidnumber'][0];
 
-      if (!isset($config['auth_ldap_group']) || ldap_compare($ds,$config['auth_ldap_group'],'memberUid',$username))
+      if (!isset($config['auth_ldap_group']) || ldap_compare($ds,$config['auth_ldap_group'],$config['auth_ldap_groupmemberattr'],get_membername($username))===true)
       {
         $userlist[] = array('username' => $username, 'realname' => $realname, 'user_id' => $user_id);
       }
@@ -180,6 +180,20 @@ function update_user($user_id,$realname,$level,$can_modify_passwd,$email)
 {
   # not supported
   return 0;
+}
+
+function get_membername ($username)
+{
+  global $config;
+  if ($config['auth_ldap_groupmembertype'] == "fulldn") 
+  {
+    $membername = $config['auth_ldap_prefix'] . $username . $config['auth_ldap_suffix'];
+  }
+  else
+  {
+    $membername = $username;
+  }
+  return $membername;
 }
 
 ?>

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -416,6 +416,7 @@ $config['auth_ldap_groupbase'] = "ou=group,dc=example,dc=com";
 $config['auth_ldap_groups']['admin']['level'] = 10;
 $config['auth_ldap_groups']['pfy']['level'] = 7;
 $config['auth_ldap_groups']['support']['level'] = 1;
+$config['auth_ldap_groupmemberattr'] = "memberUid";
 
 // Sensors
 


### PR DESCRIPTION
... in stead of memberUid and DN in stead of username for group members.

Used the same variables as Observium, see http://www.observium.org/wiki/Authentication_modules#OpenLDAP
Have not looked at the Observium code.

Also, eDirectory returns "-1" (or UNDEFINED when using /usr/bin/ldapcompare) when checking for a non existing attribute. Therefore '===true' is necessary.


Works for me, but someone should test it with another LDAP directory obviously. 