### PR TITLE
Detect Cisco ASA HW and OS Ver

### DIFF
--- a/includes/polling/os/asa.inc.php
+++ b/includes/polling/os/asa.inc.php
@@ -1,5 +1,30 @@
 <?php
 
-$serial = trim(snmp_get($device, "entPhysicalSerialNum.1", "-Osqv", "ENTITY-MIB:CISCO-ENTITY-VENDORTYPE-OID-MIB"));
+/*
+ * LibreNMS Cisco wireless controller information module
+ *
+ * Copyright (c) 2016 Tuomas Riihimäki <tuomari@iudex.fi>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+*/
+
+$oids = "entPhysicalModelName.1 entPhysicalSoftwareRev.1 entPhysicalSerialNum.1";
+
+$data = snmp_get_multi($device, $oids, "-OQUs", "ENTITY-MIB");
+
+if (isset($data[1]['entPhysicalSoftwareRev']) && $data[1]['entPhysicalSoftwareRev'] != "") {
+    $version = $data[1]['entPhysicalSoftwareRev'];
+}
+
+if (isset($data[1]['entPhysicalModelName']) && $data[1]['entPhysicalModelName'] != "") {
+    $hardware = $data[1]['entPhysicalModelName'];
+}
+
+if (isset($data[1]['entPhysicalSerialNum']) && $data[1]['entPhysicalSerialNum'] != "") {
+    $serial = $data[1]['entPhysicalSerialNum'];
+}
 
 ?>


### PR DESCRIPTION
- Now detects Cisco ASA HW and OS Ver, somehow this went missing
- Code used from ciscowlc.inc.php, Copyright information included
- Tested against various 5505 and 5515 OS Versions.