### PR TITLE
Added Alert-Groups (Backend)

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -25,7 +25,6 @@
 
 include_once("includes/defaults.inc.php");
 include_once("config.php");
-
 $lock = false;
 if( file_exists($config['install_dir']."/.alerts.lock") ) {
 	$pids = explode("\n", trim(`ps -e | grep php | awk '{print $1}'`));

--- a/html/forms/create-alert-item.inc.php
+++ b/html/forms/create-alert-item.inc.php
@@ -53,7 +53,7 @@ if(empty($rule)) {
             $update_message = "ERROR: Failed to edit Rule: <i>".$rule."</i>";
         }
     } else {
-        if( dbInsert(array('device_id'=>$device_id,'rule'=>$rule,'severity'=>mres($_POST['severity']),'extra'=>$extra_json,'name'=>$name),'alert_rules') ) {
+        if( dbInsert(array('target'=>$device_id,'rule'=>$rule,'severity'=>mres($_POST['severity']),'extra'=>$extra_json,'name'=>$name),'alert_rules') ) {
             $update_message = "Added Rule: <i>$name: $rule</i>";
         } else {
             $update_message = "ERROR: Failed to add Rule: <i>".$rule."</i>";

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -597,7 +597,7 @@ function add_edit_rule() {
             } else {
                 $message = 'Failed to update existing alert rule';
             }
-        } elseif( dbInsert(array('device_id'=>$device_id,'rule'=>$rule,'severity'=>$severity,'disabled'=>$disabled,'extra'=>$extra_json),'alert_rules') ) {
+        } elseif( dbInsert(array('target'=>$device_id,'rule'=>$rule,'severity'=>$severity,'disabled'=>$disabled,'extra'=>$extra_json),'alert_rules') ) {
             $status = 'ok';
             $code = 200;
         } else {

--- a/html/includes/print-alert-rules.php
+++ b/html/includes/print-alert-rules.php
@@ -12,14 +12,14 @@ $no_refresh = TRUE;
 <?php
 
 if(isset($_POST['create-default'])) {
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%devices.status != "1" && %devices.disabled = "0" && %devices.ignore = "0"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Devices up/down');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%devices.uptime < "300" && %devices.disabled = "0" && %devices.ignore = "0"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'Device rebooted');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%bgpPeers.bgpPeerState != "established"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'BGP Session down');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%bgpPeers.bgpPeerFsmEstablishedTime < "300" && %bgpPeers.bgpPeerState = "established"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'BGP Session establised');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%ports.ifOperStatus != "up" && %ports.ifAdminStatus = "up" && %ports.deleted = "0" && %ports.ignore = "0" && %ports.disabled = "0"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'Port status up/down');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '((%ports.ifInOctets_rate*8)/%ports.ifSpeed)*100 >= 80', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Port utilisation over threshold');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%sensors.sensor_current > %sensors.sensor_limit', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Sensor over limit');
-    $default_rules[] = array('device_id' => '-1', 'rule' => '%sensors.sensor_current < %sensors.sensor_limit_low', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Sensor under limit');
+    $default_rules[] = array('target' => '-1', 'rule' => '%devices.status != "1" && %devices.disabled = "0" && %devices.ignore = "0"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Devices up/down');
+    $default_rules[] = array('target' => '-1', 'rule' => '%devices.uptime < "300" && %devices.disabled = "0" && %devices.ignore = "0"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'Device rebooted');
+    $default_rules[] = array('target' => '-1', 'rule' => '%bgpPeers.bgpPeerState != "established"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'BGP Session down');
+    $default_rules[] = array('target' => '-1', 'rule' => '%bgpPeers.bgpPeerFsmEstablishedTime < "300" && %bgpPeers.bgpPeerState = "established"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'BGP Session establised');
+    $default_rules[] = array('target' => '-1', 'rule' => '%ports.ifOperStatus != "up" && %ports.ifAdminStatus = "up" && %ports.deleted = "0" && %ports.ignore = "0" && %ports.disabled = "0"', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"1","delay":"300"}', 'disabled' => 0, 'name' => 'Port status up/down');
+    $default_rules[] = array('target' => '-1', 'rule' => '((%ports.ifInOctets_rate*8)/%ports.ifSpeed)*100 >= 80', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Port utilisation over threshold');
+    $default_rules[] = array('target' => '-1', 'rule' => '%sensors.sensor_current > %sensors.sensor_limit', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Sensor over limit');
+    $default_rules[] = array('target' => '-1', 'rule' => '%sensors.sensor_current < %sensors.sensor_limit_low', 'severity' => 'critical', 'extra' => '{"mute":false,"count":"-1","delay":"300"}', 'disabled' => 0, 'name' => 'Sensor under limit');
     foreach( $default_rules as $add_rule ) {
         dbInsert($add_rule,'alert_rules');
     }
@@ -73,10 +73,10 @@ $full_query = "SELECT *";
 $sql = '';
 $param = array();
 if(isset($device['device_id']) && $device['device_id'] > 0) {
-    $sql = 'WHERE (device_id=? OR device_id="-1")';
+    $sql = 'WHERE (target=? OR target="-1")';
     $param = array($device['device_id']);
 }
-$query = " FROM alert_rules $sql ORDER BY device_id,id";
+$query = " FROM alert_rules $sql ORDER BY target,id";
 $count_query = $count_query . $query;
 $count = dbFetchCell($count_query,$param);
 if(!isset($_POST['page_number']) && $_POST['page_number'] < 1) {
@@ -140,7 +140,7 @@ foreach( dbFetchRows($full_query, $param) as $rule ) {
         echo "</td>";
         echo "<td>";
         if ($_SESSION['userlevel'] >= '10') {
-            echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-target='#create-alert' data-device_id='".$rule['device_id']."' data-alert_id='".$rule['id']."' name='edit-alert-rule'><span class='glyphicon glyphicon-pencil' aria-hidden='true'></span></button> ";
+            echo "<button type='button' class='btn btn-primary btn-sm' data-toggle='modal' data-target='#create-alert' data-device_id='".$rule['target']."' data-alert_id='".$rule['id']."' name='edit-alert-rule'><span class='glyphicon glyphicon-pencil' aria-hidden='true'></span></button> ";
             echo "<button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule'><span class='glyphicon glyphicon-trash' aria-hidden='true'></span></button>";
         }
         echo "</td>";

--- a/sql-schema/045.sql
+++ b/sql-schema/045.sql
@@ -1,0 +1,3 @@
+ALTER TABLE  `alert_rules` CHANGE  `device_id`  `device_id` VARCHAR( 255 ) NOT NULL;
+ALTER TABLE  `alert_rules` CHANGE  `device_id`  `target` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;
+CREATE TABLE IF NOT EXISTS `alert_groups` (  `id` int(11) NOT NULL AUTO_INCREMENT,  `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',  `desc` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',  PRIMARY KEY (`id`)) ENGINE=InnoDB  DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This PR adds Alert-Groups.

Alert-Groups are created in the table `alert_groups`. It expects a `name` and a `desc`. Both can be any kind of text.

A device is added to the group by adding an entry into the `device_attribs` table using `alert_group` for `attrib_type` and the group's `alert_groups.id` for `attrib_value`.

To maintain overview, the column `alert_rules.device_id` has been renamed to `alert_rules.target`.

To apply a rule to an alert-group, set `alert_rules.target` to `alert_groups.id` prefixed with a `g`.
Example: `g1` for Group with `alert_groups.id` of 1.

This PR does not include any form of Frontend to populate the tables. This will be done separately. 

__Note:__ Because this PR renames a widely used column it requires indepth testing and revision!
Please drop me some comments in case I missed some files that still depend on `alert_rules.device_id` !

(Related: #616)