### PR TITLE
Fixed ORIG_PATH_INFO being logged in error_log

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -12,7 +12,7 @@
  *
  */
 
-$_SERVER['PATH_INFO'] = (isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : $_SERVER['ORIG_PATH_INFO']);
+$_SERVER['PATH_INFO'] = !empty($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : (!empty($_SERVER['ORIG_PATH_INFO']) ? $_SERVER['ORIG_PATH_INFO'] : '');
 
 function logErrors($errno, $errstr, $errfile, $errline) {
     global $php_debug;


### PR DESCRIPTION
This fixes:

PHP Notice:  Undefined index: ORIG_PATH_INFO in /opt/librenms/html/index.php on line 15

When some browses to /index.php, this is because ORIG_PATH_INFO or PATH_INFO is not set as it's not in the URL. When something like /eventlog/ is used then one of them will be, this just adds another check for ORIG_PATH_INFO and if that's not set either then default to blank - at this stage something else is up if the user is browsing to /something/

Fixes issue #726 