### PR TITLE
Added missing CPU id for Cisco SB

### DIFF
--- a/includes/discovery/processors/ciscosb.inc.php
+++ b/includes/discovery/processors/ciscosb.inc.php
@@ -14,10 +14,10 @@ if ($device['os'] == "ciscosb") {
     echo("Cisco SB : ");
 
     $descr = "CPU";
-    $usage = snmp_get($device, "rlCpuUtilDuringLastMinute", "-Ovqn", "CISCOSB-rndMng");
+    $usage = snmp_get($device, "rlCpuUtilDuringLastMinute.0", "-Ovqn", "CISCOSB-rndMng");
 
     if (is_numeric($usage)) {
-        discover_processor($valid['processor'], $device, "CISCOSB-rndMng::rlCpuUtilDuringLastMinute", "0", "ciscosb", $descr, "1", $usage, NULL, NULL);
+        discover_processor($valid['processor'], $device, "CISCOSB-rndMng::rlCpuUtilDuringLastMinute.0", "0", "ciscosb", $descr, "1", $usage, NULL, NULL);
     }
 }
 


### PR DESCRIPTION
Apparently I forgot the CPU id when changing from hardcoded id to using the mib. This PR fixes this issue.