### PR TITLE
fixes #739

### DIFF
--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -32,8 +32,11 @@ function authenticate($username,$password)
       {
         $ldap_groups = get_group_list();
         foreach($ldap_groups as $ldap_group) {
-          if (ldap_compare($ds, $ldap_group, $config['auth_ldap_groupmemberattr'], get_membername($username))===true)
-          {
+          $ldap_comparison = ldap_compare($ds,
+                                          $ldap_group, 
+                                          $config['auth_ldap_groupmemberattr'],
+                                          get_membername($username));
+          if($ldap_comparison === true) {
             return 1;
           }
         }
@@ -158,8 +161,11 @@ function get_userlist()
       $user_id  = $entry['uidnumber'][0];
       $ldap_groups = get_group_list();
       foreach($ldap_groups as $ldap_group) {
-        if (!isset($config['auth_ldap_group']) || ldap_compare($ds, $ldap_group, $config['auth_ldap_groupmemberattr'], get_membername($username))===true)
-        {
+        $ldap_comparison = ldap_compare($ds,
+                                        $ldap_group, 
+                                        $config['auth_ldap_groupmemberattr'],
+                                        get_membername($username));
+        if (!isset($config['auth_ldap_group']) || ldap_compare($ldap_comparison === true)) {
           $userlist[] = array('username' => $username, 'realname' => $realname, 'user_id' => $user_id);
         }
       }
@@ -206,8 +212,10 @@ function get_group_list() {
 
   $ldap_groups = array();
   $default_group = 'cn=groupname,ou=groups,dc=example,dc=com';
-  if($config['auth_ldap_group'] !== $default_group) {
-    array_push($ldap_groups, $config['auth_ldap_group']);
+  if(isset($config['auth_ldap_group'])) {
+    if($config['auth_ldap_group'] !== $default_group) {
+      array_push($ldap_groups, $config['auth_ldap_group']);
+    }
   }
   foreach($config['auth_ldap_groups'] as $key => $value) {
     $dn = "cn=$key," . $config['auth_ldap_groupbase'];

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -165,7 +165,7 @@ function get_userlist()
                                         $ldap_group, 
                                         $config['auth_ldap_groupmemberattr'],
                                         get_membername($username));
-        if (!isset($config['auth_ldap_group']) || ldap_compare($ldap_comparison === true)) {
+        if (!isset($config['auth_ldap_group']) || $ldap_comparison === true) {
           $userlist[] = array('username' => $username, 'realname' => $realname, 'user_id' => $user_id);
         }
       }

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -214,12 +214,12 @@ function get_group_list() {
   $default_group = 'cn=groupname,ou=groups,dc=example,dc=com';
   if(isset($config['auth_ldap_group'])) {
     if($config['auth_ldap_group'] !== $default_group) {
-      array_push($ldap_groups, $config['auth_ldap_group']);
+      $ldap_groups[] = $config['auth_ldap_group'];
     }
   }
   foreach($config['auth_ldap_groups'] as $key => $value) {
     $dn = "cn=$key," . $config['auth_ldap_groupbase'];
-    array_push($ldap_groups, $dn);
+    $ldap_groups[] = $dn;
   }
   return $ldap_groups;
 }

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -32,7 +32,7 @@ function authenticate($username,$password)
       {
         $ldap_groups = get_group_list();
         foreach($ldap_groups as $ldap_group) {
-          if (ldap_compare($ds,$ldap_group, $config['auth_ldap_groupmemberattr'],get_membername($username))===true)
+          if (ldap_compare($ds, $ldap_group, $config['auth_ldap_groupmemberattr'], get_membername($username))===true)
           {
             return 1;
           }
@@ -158,7 +158,7 @@ function get_userlist()
       $user_id  = $entry['uidnumber'][0];
       $ldap_groups = get_group_list();
       foreach($ldap_groups as $ldap_group) {
-        if (!isset($config['auth_ldap_group']) || ldap_compare($ds,$config['auth_ldap_group'],$config['auth_ldap_groupmemberattr'],get_membername($username))===true)
+        if (!isset($config['auth_ldap_group']) || ldap_compare($ds, $ldap_group, $config['auth_ldap_groupmemberattr'], get_membername($username))===true)
         {
           $userlist[] = array('username' => $username, 'realname' => $realname, 'user_id' => $user_id);
         }
@@ -202,6 +202,8 @@ function get_membername ($username)
 }
 
 function get_group_list() {
+  global $config;
+
   $ldap_groups = [];
   $ldap_groups[] = $config['auth_ldap_groupbase'];
   foreach($config['auth_ldap_groups'] as $key => $value) {

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -204,11 +204,14 @@ function get_membername ($username)
 function get_group_list() {
   global $config;
 
-  $ldap_groups = [];
-  $ldap_groups[] = $config['auth_ldap_groupbase'];
+  $ldap_groups = array();
+  $default_group = 'cn=groupname,ou=groups,dc=example,dc=com';
+  if($config['auth_ldap_group'] !== $default_group) {
+    array_push($ldap_groups, $config['auth_ldap_group']);
+  }
   foreach($config['auth_ldap_groups'] as $key => $value) {
     $dn = "cn=$key," . $config['auth_ldap_groupbase'];
-    $ldap_groups[] = $dn;
+    array_push($ldap_groups, $dn);
   }
   return $ldap_groups;
 }


### PR DESCRIPTION
This PR fixes #739, a regression introduced by #707 caused by increased security.  This PR accomplishes this by building a list of possible groups, including backward compatibility with `$config['auth_ldap_group']`.  It maintains the security features introduced by #707.  It iterates through all possible groups for authentication.  Authorization continues to be handled in the normal way.