### PR TITLE
Lowerecased table name processors

### DIFF
--- a/includes/discovery/processors.inc.php
+++ b/includes/discovery/processors.inc.php
@@ -25,7 +25,7 @@ foreach (dbFetchRows($sql) as $test_processor)
   if (!$valid['processor'][$processor_type][$processor_index])
   {
     echo("-");
-    dbDelete('Processors', '`processor_id` = ?', array($test_processor['processor_id']));
+    dbDelete('processors', '`processor_id` = ?', array($test_processor['processor_id']));
     log_event("Processor removed: type ".$processor_type." index ".$processor_index." descr ". $test_processor['processor_descr'], $device, 'processor', $test_processor['processor_id']);
   }
   unset($processor_oid); unset($processor_type);


### PR DESCRIPTION
This resolves issue #747.

Before the processors table had a capital P in the dbDelete statement which means it fails all the time.

this will now clear out processors which aren't being graphed but listed as though they should be.