### PR TITLE
Shorten interface names on map

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -737,4 +737,13 @@ function get_client_ip() {
     return $client_ip;
 }
 
+function shorten_interface_type($string) {
+
+    return str_ireplace(
+               array('FastEthernet','GigbitEthernet','TenGigabitEthernet','Port-Channel','Ethernet'),
+               array('Fa','Gi','Te','Po','Eth'),
+               $string
+           );
+}
+
 ?>

--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -46,11 +46,11 @@ if (is_array($tmp_devices[0])) {
         foreach ($tmp_devices as $k=>$v) {
             if ($v['id'] == $link_devices['local_device_id']) {
                 $from = $v['id'];
-                $port = $link_devices['local_port'];
+                $port = shorten_interface_type($link_devices['local_port']);
             }
             if ($v['id'] == $link_devices['remote_device_id']) {
                 $to = $v['id'];
-                $port .= ' > ' .$link_devices['remote_port'];
+                $port .= ' > ' .shorten_interface_type($link_devices['remote_port']);
             }
         }
         $speed = $link_devices['ifSpeed']/1000/1000;

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -264,13 +264,4 @@ function rrdtool_escape($string, $maxlength = NULL)
   }
 }
 
-function shorten_interface_type($string) {
-
-    return str_ireplace(
-               array('FastEthernet','GigbitEthernet','TenGigabitEthernet','Port-Channel','Ethernet'),
-               array('Fa','Gi','Te','Po','Eth'),
-               $string
-           );
-}
-
 ?>


### PR DESCRIPTION
Had to move the shorten_interface_type() function as it was in a file not included for anything other than graphs.

Tested this still works ok in graphs (html/includes/functions.inc.php is included in graph.php)

Fix for issue #743