### PR TITLE
Added autodiscovery for ospf

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -148,7 +148,7 @@ echo("OSPF Discovery: ");
 
 if ($config['autodiscovery']['ospf'] === TRUE) {
     echo "enabled\n";
-    foreach (dbFetchRow("SELECT DISTINCT(`ospfNbrIpAddr`),`device_id` FROM `ospf_nbrs`") as $nbr) {
+    foreach (dbFetchRows("SELECT DISTINCT(`ospfNbrIpAddr`),`device_id` FROM `ospf_nbrs`") as $nbr) {
         $ip = $nbr['ospfNbrIpAddr'];
         $device_id = $nbr['device_id'];
         if (match_network($config['autodiscovery']['nets-exclude'], $ip)) {


### PR DESCRIPTION
We already have a config option to turn this on but I can't find any code that says it would actually perform a discovery. hopefully I've not just wasted my time :)

$config['autodiscovery']['ospf']           = TRUE;

ospf is done in polling rather than discovery like bgp. So, I've added a new section to discovery/discovery-protocols.inc.php that grabs the already existing data from the mysql table ospf_nbrs  and does a reverse dns lookup on the nbrIP and passes that to the normal discovery function.

Works for me on a gns3 test lab.

It doesn't add any data to the links table for the map as I couldn't see a correlation between the tables but also, the remote port ids won't get discovered until a poll.

Resolves issue #754 