### PR TITLE
Added redirect when a POST value is found

### DIFF
--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -108,6 +108,9 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
       setcookie("auth", $_COOKIE['auth'], time()+60*60*24*$config['auth_remember'], "/", null, false, true);
     }
     $permissions = permissions_cache($_SESSION['user_id']);
+    if (isset($_POST['username'])) {
+        header('Location: '.$_SERVER['REQUEST_URI'],TRUE,303);
+    }
   }
   elseif (isset($_SESSION['username']))
   {

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -110,6 +110,7 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
     $permissions = permissions_cache($_SESSION['user_id']);
     if (isset($_POST['username'])) {
         header('Location: '.$_SERVER['REQUEST_URI'],TRUE,303);
+        exit;
     }
   }
   elseif (isset($_SESSION['username']))


### PR DESCRIPTION
This fixes #652.

We check if _POST['username'] exists meaning someone is just logging in, if we have that then we issue a redirect. The 303 is to redirect using GET otherwise POST is used which causes a loop