### PR TITLE
New global Object Cache

### DIFF
--- a/html/includes/object-cache.inc.php
+++ b/html/includes/object-cache.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+include_once($config['install_dir'].'/includes/object-cache.inc.php');
+
 // FIXME queries such as the one below should probably go into index.php?
 
 // FIXME: This appears to keep a complete cache of device details in memory for every page load.
@@ -19,48 +21,9 @@ foreach (dbFetchRows("SELECT * FROM `devices` ORDER BY `hostname`") as $device)
   $cache['device_types'][$device['type']]++;
 }
 
-if($_SESSION['userlevel'] >= 5)
-{
-  $devices['count']     = dbFetchCell("SELECT COUNT(*) FROM devices");
-  $devices['up']        = dbFetchCell("SELECT COUNT(*) FROM devices WHERE `status` = '1' AND `ignore` = '0'  AND `disabled` = '0'");
-  $devices['down']      = dbFetchCell("SELECT COUNT(*) FROM devices WHERE `status` = '0' AND `ignore` = '0'  AND `disabled` = '0'");
-  $devices['ignored']   = dbFetchCell("SELECT COUNT(*) FROM devices WHERE `ignore` = '1' AND `disabled` = '0'");
-  $devices['disabled']  = dbFetchCell("SELECT COUNT(*) FROM devices WHERE `disabled` = '1'");
-
-  $ports['count']       = dbFetchCell("SELECT COUNT(*) FROM ports WHERE `deleted` = '0'");
-  $ports['up']          = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'up'");
-  $ports['down']        = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'down' AND I.`ifAdminStatus` = 'up'");
-  $ports['shutdown']    = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifAdminStatus` = 'down'");
-  $ports['errored']     = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND (I.`ifInErrors_delta` > '0' OR I.`ifOutErrors_delta` > '0')");
-  $ports['ignored']     = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND (I.`ignore` = '1' OR D.`ignore` = '1')");
-
-  $services['count']    = dbFetchCell("SELECT COUNT(*) FROM services");
-  $services['up']       = dbFetchCell("SELECT COUNT(*) FROM services WHERE `service_ignore` = '0' AND `service_disabled` = '0' AND `service_status` = '1'");
-  $services['down']     = dbFetchCell("SELECT COUNT(*) FROM services WHERE `service_ignore` = '0' AND `service_disabled` = '0' AND `service_status` = '0'");
-  $services['ignored']  = dbFetchCell("SELECT COUNT(*) FROM services WHERE `service_ignore` = '1' AND `service_disabled` = '0'");
-  $services['disabled'] = dbFetchCell("SELECT COUNT(*) FROM services WHERE `service_disabled` = '1'");
-}
-else
-{
-  $devices['count']     = dbFetchCell("SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id`", array($_SESSION['user_id']));
-  $devices['up']        = dbFetchCell("SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`status` = '1' AND D.`ignore` = '0' AND D.`disabled` = '0'", array($_SESSION['user_id']));
-  $devices['down']      = dbFetchCell("SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`status` = '0' AND D.`ignore` = '0' AND D.`disabled` = '0'", array($_SESSION['user_id']));
-  $devices['ignored']   = dbFetchCell("SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`ignore` = '1' AND D.`disabled` = '0'", array($_SESSION['user_id']));
-  $devices['disabled']  = dbFetchCell("SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`disabled` = '1'", array($_SESSION['user_id']));
-
-  $ports['count']       = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id`", array($_SESSION['user_id']));
-  $ports['up']          = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'up'", array($_SESSION['user_id']));
-  $ports['down']        = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'down' AND I.`ifAdminStatus` = 'up'", array($_SESSION['user_id']));
-  $ports['shutdown']    = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifAdminStatus` = 'down'", array($_SESSION['user_id']));
-  $ports['errored']     = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND (I.`ifInErrors_delta` > '0' OR I.`ifOutErrors_delta` > '0')", array($_SESSION['user_id']));
-  $ports['ignored']     = dbFetchCell("SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND (I.`ignore` = '1' OR D.`ignore` = '1')", array($_SESSION['user_id']));
-
-  $services['count']    = dbFetchCell("SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id`", array($_SESSION['user_id']));
-  $services['up']       = dbFetchCell("SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_ignore` = '0' AND S.`service_disabled` = '0' AND S.`service_status` = '1'", array($_SESSION['user_id']));
-  $services['down']     = dbFetchCell("SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_ignore` = '0' AND S.`service_disabled` = '0' AND S.`service_status` = '0'", array($_SESSION['user_id']));
-  $services['ignored']  = dbFetchCell("SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_ignore` = '1' AND S.`service_disabled` = '0'", array($_SESSION['user_id']));
-  $services['disabled'] = dbFetchCell("SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_disabled` = '1'", array($_SESSION['user_id']));
-}
+$devices  = new ObjCache('devices');
+$ports    = new ObjCache('ports');
+$services = new ObjCache('services');
 
 if ($devices['down'])  { $devices['bgcolour'] = "#ffcccc"; } else { $devices['bgcolour'] = "transparent"; }
 if ($ports['down'])    { $ports['bgcolour'] = "#ffcccc"; } else { $ports['bgcolour'] = "#e5e5e5"; }

--- a/includes/caches/devices.inc.php
+++ b/includes/caches/devices.inc.php
@@ -1,0 +1,52 @@
+<?php
+
+if( $_SESSION['userlevel'] >= 5 ) {
+
+	$data['count'] = array(
+		'query'  => "SELECT COUNT(*) FROM devices",
+	);
+
+	$data['up'] = array(
+		'query'  => "SELECT COUNT(*) FROM devices WHERE `status` = '1' AND `ignore` = '0'  AND `disabled` = '0'",
+	);
+
+	$data['down'] = array(
+		'query'  => "SELECT COUNT(*) FROM devices WHERE `status` = '0' AND `ignore` = '0'  AND `disabled` = '0'",
+	);
+
+	$data['ignored'] = array(
+		'query'  => "SELECT COUNT(*) FROM devices WHERE `ignore` = '1' AND `disabled` = '0'",
+	);
+
+	$data['disabled'] = array(
+		'query'  => "SELECT COUNT(*) FROM devices WHERE `disabled` = '1'",
+	);
+
+} else {
+
+  $data['count'] = array(
+		'query' => "SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id`",
+		'params' => array($_SESSION['user_id'])
+	);
+
+  $data['up'] = array(
+		'query'  => "SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`status` = '1' AND D.`ignore` = '0' AND D.`disabled` = '0'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+  $data['down'] = array(
+		'query' => "SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`status` = '0' AND D.`ignore` = '0' AND D.`disabled` = '0'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+  $data['ignored'] = array(
+		'query' => "SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`ignore` = '1' AND D.`disabled` = '0'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+  $data['disabled'] = array(
+		'query' => "SELECT COUNT(*) FROM devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND D.`disabled` = '1'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+}

--- a/includes/caches/ports.inc.php
+++ b/includes/caches/ports.inc.php
@@ -1,0 +1,61 @@
+<?php
+
+if( $_SESSION['userlevel'] >= 5 ) {
+
+	$data['count'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports WHERE `deleted` = '0'",
+	);
+
+	$data['up'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'up'",
+	);
+
+	$data['down'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'down' AND I.`ifAdminStatus` = 'up'",
+	);
+
+	$data['shutdown'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifAdminStatus` = 'down'",
+	);
+
+	$data['errored'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND (I.`ifInErrors_delta` > '0' OR I.`ifOutErrors_delta` > '0')",
+	);
+
+	$data['ignored'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND (I.`ignore` = '1' OR D.`ignore` = '1')",
+	);
+
+} else {
+
+	$data['count'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id`",
+		'params' => array($_SESSION['user_id'])
+	);
+
+	$data['up'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'up'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+	$data['down'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'down' AND I.`ifAdminStatus` = 'up'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+	$data['shutdown'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifAdminStatus` = 'down'",
+		'params' => array($_SESSION['user_id'])
+	);
+
+	$data['errored'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND (I.`ifInErrors_delta` > '0' OR I.`ifOutErrors_delta` > '0')",
+		'params' => array($_SESSION['user_id'])
+	);
+
+	$data['ignored'] = array(
+		'query'  => "SELECT COUNT(*) FROM ports AS I, devices AS D, devices_perms AS P WHERE I.`deleted` = '0' AND P.`user_id` = ? AND P.`device_id` = D.`device_id` AND I.`device_id` = D.`device_id` AND (I.`ignore` = '1' OR D.`ignore` = '1')",
+		'params' => array($_SESSION['user_id'])
+	);
+
+}

--- a/includes/caches/services.inc.php
+++ b/includes/caches/services.inc.php
@@ -1,0 +1,38 @@
+<?php
+
+if( $_SESSION['userlevel'] >= 5 ) {
+
+	$data['count']    = array( 'query' => "SELECT COUNT(*) FROM services");
+	$data['up']       = array( 'query' => "SELECT COUNT(*) FROM services WHERE `service_ignore` = '0' AND `service_disabled` = '0' AND `service_status` = '1'");
+	$data['down']     = array( 'query' => "SELECT COUNT(*) FROM services WHERE `service_ignore` = '0' AND `service_disabled` = '0' AND `service_status` = '0'");
+	$data['ignored']  = array( 'query' => "SELECT COUNT(*) FROM services WHERE `service_ignore` = '1' AND `service_disabled` = '0'");
+	$data['disabled'] = array( 'query' => "SELECT COUNT(*) FROM services WHERE `service_disabled` = '1'");
+
+} else {
+
+	$data['count']    = array(
+		'query' => "SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id`",
+		'params' => array($_SESSION['user_id'])
+	);
+
+  $data['up']       = array(
+  	'query' => "SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_ignore` = '0' AND S.`service_disabled` = '0' AND S.`service_status` = '1'",
+  	'params' => array($_SESSION['user_id'])
+	);
+
+  $data['down']     = array(
+  	'query' => "SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_ignore` = '0' AND S.`service_disabled` = '0' AND S.`service_status` = '0'",
+  	'params' => array($_SESSION['user_id'])
+  );
+
+  $data['ignored']  = array(
+  	'query' => "SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_ignore` = '1' AND S.`service_disabled` = '0'",
+  	'params' => array($_SESSION['user_id'])
+  );
+
+  $data['disabled'] = array(
+  	'query' => "SELECT COUNT(*) FROM services AS S, devices AS D, devices_perms AS P WHERE P.`user_id` = ? AND P.`device_id` = D.`device_id` AND S.`device_id` = D.`device_id` AND S.`service_disabled` = '1'",
+  	'params' => array($_SESSION['user_id'])
+  );
+
+}

--- a/includes/object-cache.inc.php
+++ b/includes/object-cache.inc.php
@@ -1,0 +1,113 @@
+<?php
+
+/* Copyright (C) 2015 Daniel Preussker <f0o@devilcode.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+/**
+ * Object-Cache
+ * @author f0o <f0o@devilcode.org>
+ * @copyright 2015 f0o, LibreNMS
+ * @license GPL
+ * @package LibreNMS
+ * @subpackage Cache
+ */
+
+class ObjCache implements ArrayAccess {
+	private $data = array();
+	private $obj  = "";
+
+	/**
+	 * Initialize ObjCache
+	 * @param string $obj Name of Object
+	 * @return void
+	 */
+	public function __construct( $obj ) {
+		global $config;
+		$this->obj = $obj;
+		if( isset($GLOBALS['_ObjCache'][$obj]) ) {
+			$this->data = $GLOBALS['_ObjCacheSkell'][$obj];
+		} else {
+			if( !is_array($GLOBALS['_ObjCacheSkell']) ) {
+				$GLOBALS['_ObjCacheSkell'] = array();
+			}
+			if( !is_array($GLOBALS['_ObjCache']) ) {
+				$GLOBALS['_ObjCache'] = array();
+			}
+			if( file_exists($config['install_dir'].'/includes/caches/'.$obj.'.inc.php') ) {
+				$data = array();
+				include($config['install_dir'].'/includes/caches/'.$obj.'.inc.php');
+				$this->data = $data;
+				$GLOBALS['_ObjCacheSkell'][$obj] = $this->data;
+				if( !is_array($GLOBALS['_ObjCache'][$obj]) ) {
+					$GLOBALS['_ObjCache'][$obj] = $this->data;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check if data exists
+	 * @param string $obj Name of Data-Object
+	 * @return boolean
+	 */
+	public function offsetExists( $obj ) {
+		if( isset($this->data[$obj]) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Get Data-Object
+	 * @param string $obj Name of Data-Object
+	 * @return mixed
+	 */
+	public function offsetGet( $obj ) {
+		if( isset($this->data[$obj]) ) {
+			if( isset($this->data[$obj]['value']) ) {
+				return $this->data[$obj]['value'];
+			} elseif( isset($GLOBALS['_ObjCache'][$this->obj][$obj]['value']) ) {
+				return $GLOBALS['_ObjCache'][$this->obj][$obj]['value'];
+			} else {
+				$GLOBALS['_ObjCache'][$this->obj][$obj]['value'] = dbFetchCell($this->data[$obj]['query'],$this->data[$obj]['params']);
+				return $GLOBALS['_ObjCache'][$this->obj][$obj]['value'];
+			}
+		}
+	}
+
+	/**
+	 * Overrides internal Cache-Object
+	 * @param string $obj Name of Data-Object
+	 * @param mixed $value Value
+	 * @return boolean
+	 */
+	public function offsetSet( $obj, $value ) {
+		if( !is_array($this->data[$obj]) ) {
+			$this->data[$obj] = array();
+		}
+		$this->data[$obj]['value'] = $value;
+		return $this->data[$obj]['value'];
+	}
+
+	/**
+	 * Reset Data-Object
+	 * @param string $obj Name of Data-Object
+	 * @return mixed
+	 */
+	public function offsetUnset( $obj ) {
+		unset($this->data[$obj]['value']);
+		return true;
+	}
+
+}


### PR DESCRIPTION
This approach actually caches the DB-lookups and makes use of a lazy-load inspired way of loading all the data.

The old object-cache.inc.php fired a load of queries to the DB and defined a set of local variables with their results. Most of the queries made aren't always used, this slows down page load in some cases.

The proposed PR uses an instruction file located at `includes/caches/<object-name>.inc.php` to obtain a list of queries to perform.
The code stores values from the DB in the `$GLOBALS` array to cache them, This way the actual instance of the Object can be discarded and re-created but the cached data remains and wont result in a additional DB-Query.
The code also only Queries the DB if no shared cache exists and only Queries explicitly for the requested value instead of all at once.

This is a Drop-In-Replacement. The Class acts like an Array. It is possible to overlay local values, these are not traversed into the shared-cache and thus wont affect other code throughout the application.

Request for Comment :)