### PR TITLE
Added alter statement to add index to alert_log table

### DIFF
--- a/sql-schema/047.sql
+++ b/sql-schema/047.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `alert_log` ADD INDEX (  `time_logged` );


### PR DESCRIPTION
This took 30 seconds on a large install with 2957629 entries and no impact to web ui at the time.

This is so we can run big queries on the time_logged column.