### PR TITLE
Stopped logging being output if user not logged in

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -338,7 +338,7 @@ toastr.options.extendedTimeOut = 20;
   echo("</script>");
 }
 
-if (is_array($sql_debug) && is_array($php_debug)) {
+if (is_array($sql_debug) && is_array($php_debug) && $_SESSION['authenticated'] === TRUE) {
 
     include_once "includes/print-debug.php";
 


### PR DESCRIPTION
At present on the login page you can put debug=yes. We shouldn't allow this so now it checks if authenticated before showing the data.