### PR TITLE
Fixed label width on devices screen

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1606,7 +1606,7 @@ tr.search:nth-child(odd) {
     height: 600px;
 }
 
-.75pc-width {
+.threeqtr-width {
     display:block;
     width: 75%;
 }

--- a/html/pages/devices.inc.php
+++ b/html/pages/devices.inc.php
@@ -149,7 +149,7 @@ var grid = $("#devices").bootgrid({
     columnSelection: false,
     formatters: {
         "status": function(column,row) {
-            return "<h4><span class='label label-"+row.extra+" 75pc-width'>" + row.msg + "</span></h4>";
+            return "<h4><span class='label label-"+row.extra+" threeqtr-width'>" + row.msg + "</span></h4>";
         }
     },
     templates: {


### PR DESCRIPTION
I changed this at the last minute before the origin pr from full-width to 75pc-width.

Turns out you can't use numbers in css for some reason so this is now threeqtr-width