### PR TITLE
Allow matching HP switches like "HP A5120-24G SI Switch Software Version..."

### DIFF
--- a/includes/discovery/os/comware.inc.php
+++ b/includes/discovery/os/comware.inc.php
@@ -3,7 +3,7 @@
 if (!$os)
 {
   if (strstr($sysDescr, "Comware")) { $os = "comware"; }
-  else if(preg_match('/HP [a-zA-Z0-9-]+ Switch Software Version/',$sysDescr)) { $os = "comware"; }
+  else if(preg_match('/HP [a-zA-Z0-9- ]+ Switch Software Version/',$sysDescr)) { $os = "comware"; }
 }
 
 ?>


### PR DESCRIPTION
This is pretty horrible and I expect it to break more later.  However, it should fix issue #801.