### PR TITLE
Hide divider when no plugins are enabled

### DIFF
--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -433,8 +433,12 @@ Plugins::call('menu');
 
 if ($_SESSION['userlevel'] >= '10')
 {
-  echo(' 
+  if (dbFetchCell("SELECT COUNT(*) from `plugins` WHERE plugin_active = '1'") > 0) {
+    echo('
             <li role="presentation" class="divider"></li>
+    ');
+  }
+  echo('
             <li><a href="plugin/view=admin"> <i class="fa fa-lock fa-fw fa-lg"></i>Plugin Admin</a></li>
   ');
 }


### PR DESCRIPTION
Hopefully I didn't mess it up this time.