### PR TITLE
Added fallback to grab serial and version for ibm switches

### DIFF
--- a/includes/polling/os/ibmnos.inc.php
+++ b/includes/polling/os/ibmnos.inc.php
@@ -28,6 +28,12 @@ if (strpos($sysdescr_value, 'IBM Networking Operating System') !== false) {
         $version = trim(snmp_get($device, ".1.3.6.1.4.1.20301.2.7.13.1.1.1.10.0", "-Ovq") , '" ');
         $serial = trim(snmp_get($device, ".1.3.6.1.4.1.20301.100.100.14.9.0", "-Ovq") , '" ');
     }
+    if (empty($version)) {
+        $version = trim(snmp_get($device, ".1.3.6.1.2.1.47.1.1.1.1.10.1", "-Ovq") , '" ');
+    }
+    if (empty($serial)) {
+        $serial = trim(snmp_get($device, ".1.3.6.1.2.1.47.1.1.1.1.11.1", "-Ovq") , '" ');
+    }
 } elseif (strpos($sysdescr_value, 'IBM Flex System Fabric') !== false) {
     $hardware = str_replace("IBM Flex System Fabric", "", $sysdescr_value);
     $version = trim(snmp_get($device, ".1.3.6.1.2.1.47.1.1.1.1.10.1", "-Ovq") , '" ');


### PR DESCRIPTION
Really simple, rather than relying on the model number and if we haven't coded support we just fall back to using the default mib oids to try and be a catch all.