### PR TITLE
Update to Juniper MIBs and altered juniper hardware rewrite.

### DIFF
--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -204,6 +204,7 @@ $rewrite_junos_hardware = array(
   'jnxProductNameIBM4274E08J08E' => 'IBM4274E08J08E', # ?
   'jnxProductNameIBM4274E16J16E' => 'IBM4274E16J16E', # ?
   'jnxProductNameMX80' => 'MX80',
+  'jnxProductName' => '',
 );
 
 $rewrite_cisco_hardware = array(

--- a/mibs/junos/mib-802.1TC.txt
+++ b/mibs/junos/mib-802.1TC.txt
@@ -1,0 +1,475 @@
+IEEE8021-TC-MIB DEFINITIONS ::= BEGIN
+
+-- =============================================================
+-- TEXTUAL-CONVENTIONs MIB for IEEE 802.1
+-- =============================================================
+
+IMPORTS
+    MODULE-IDENTITY, Unsigned32, org
+        FROM SNMPv2-SMI -- RFC 2578
+    TEXTUAL-CONVENTION
+        FROM SNMPv2-TC; -- RFC 2579
+
+ieee8021TcMib MODULE-IDENTITY
+    LAST-UPDATED "200811180000Z" -- November 18, 2008
+    ORGANIZATION "IEEE 802.1 Working Group"
+    CONTACT-INFO
+        "  WG-URL: http://grouper.ieee.org/groups/802/1/index.html
+         WG-EMail: stds-802-1@ieee.org
+
+          Contact: David Levi
+           Postal: 4655 GREAT AMERICA PARKWAY
+                   SANTA CLARA, CALIFORNIA
+                   95054
+                   USA
+              Tel: +1-408-495-5138
+           E-mail: dlevi@nortel.com
+
+          Contact: Kevin Nolish
+           Postal: 5000 Ericsson Drive
+                   Warrendale, PA
+                   15086
+                   USA
+              Tel: +1-724-742-6989
+           E-mail: kevin.nolish@ericsson.com"
+    DESCRIPTION
+        "Textual conventions used throughout the various IEEE 802.1 MIB
+         modules.
+
+         Unless otherwise indicated, the references in this MIB
+         module are to IEEE 802.1Q-2005 as amended by IEEE 802.1ad,
+         IEEE 802.1ak, IEEE 802.1ag and IEEE 802.1ah.
+
+         Copyright (C) IEEE.
+         This version of this MIB module is part of IEEE802.1Q;
+         see the draft itself for full legal notices."
+    REVISION     "200811180000Z" -- November 18, 2008
+    DESCRIPTION
+         "Added textual conventions needed to support the IEEE 802.1
+          MIBs for PBB-TE.  Additionally, some textual conventions were
+          modified for the same reason."
+
+    REVISION     "200810150000Z" -- October 15, 2008
+    DESCRIPTION
+         "Initial version."
+    ::= { org ieee(111) standards-association-numbers-series-standards(2)
+          lan-man-stds(802) ieee802dot1(1) 1 1 }
+
+ieee802dot1mibs OBJECT IDENTIFIER
+    ::= { org ieee(111) standards-association-numbers-series-standards(2)
+          lan-man-stds(802) ieee802dot1(1) 1 }
+
+-- =============================================================
+-- Textual Conventions
+-- =============================================================
+
+IEEE8021PbbComponentIdentifier ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The component identifier is used to distinguish between the
+        multiple virtual bridge instances within a PB or PBB.  Each
+        virtual bridge instance is called a component.  In simple
+        situations where there is only a single component the default
+        value is 1.  The component is identified by a component
+        identifier unique within the BEB and by a MAC address unique
+        within the PBBN.  Each component is associated with a Backbone
+        Edge Bridge (BEB) Configuration managed object."
+    REFERENCE "12.3 l)"
+    SYNTAX       Unsigned32 (1..4294967295)
+
+IEEE8021PbbComponentIdentifierOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The component identifier is used to distinguish between the
+        multiple virtual bridge instances within a PB or PBB.  In simple
+        situations where there is only a single component the default
+        value is 1.  The component is identified by a component
+        identifier unique within the BEB and by a MAC address unique
+        within the PBBN.  Each component is associated with a Backbone
+        Edge Bridge (BEB) Configuration managed object.
+
+        The special value '0' means 'no component identifier'.  When
+        this TC is used as the SYNTAX of an object, that object must
+        specify the its exact meaning for this value."
+    REFERENCE "12.3 l)"
+    SYNTAX       Unsigned32 (0 | 1..4294967295)
+
+IEEE8021PbbServiceIdentifier ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The service instance identifier is used at the Customer
+        Backbone Port of a PBB to distinguish a service instance
+        (Local-SID). If the Local-SID field is supported, it is
+        used to perform a bidirectional 1:1 mapping between the
+        Backbone I-SID and the Local-SID. If the Local-SID field
+        is not supported, the Local-SID value is the same as the
+        Backbone I-SID value."
+    REFERENCE "12.16.3, 12.16.5"
+    SYNTAX       Unsigned32 (256..16777214)
+
+IEEE8021PbbServiceIdentifierOrUnassigned ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The service instance identifier is used at the Customer
+        Backbone Port of a PBB to distinguish a service instance
+        (Local-SID). If the Local-SID field is supported, it is
+        used to perform a bidirectional 1:1 mapping between the
+        Backbone I-SID and the Local-SID. If the Local-SID field
+        is not supported, the Local-SID value is the same as the
+        Backbone I-SID value.
+
+        The special value of 1 indicates an unassigned I-SID."
+    REFERENCE "12.16.3, 12.16.5"
+    SYNTAX       Unsigned32 (1|256..16777214)
+
+IEEE8021PbbIngressEgress ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+        "A 2 bit selector which determines if frames on this VIP may
+        ingress to the PBBN but not egress the PBBN, egress to the
+        PBBN but not ingress the PBBN, or both ingress and egress
+        the PBBN."
+    REFERENCE "12.16.3, 12.16.5, 12.16.6"
+    SYNTAX       BITS {
+                     ingress(0),
+                     egress(1)
+                 }
+
+IEEE8021PriorityCodePoint ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+        "Bridge ports may encode or decode the PCP value of the 
+        frames that traverse the port. This textual convention 
+        names the possible encoding and decoding schemes that
+        the port may use.  The priority and drop_eligible
+        parameters are encoded in the Priority Code Point (PCP)
+        field of the VLAN tag using the Priority Code Point
+        Encoding Table for the Port, and they are decoded from
+        the PCP using the Priority Code Point Decoding Table."
+    REFERENCE "12.6.2.6"
+    SYNTAX       INTEGER {
+                     codePoint8p0d(1),
+                     codePoint7p1d(2),
+                     codePoint6p2d(3),
+                     codePoint5p3d(4)
+                 }
+
+IEEE8021BridgePortNumber ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "An integer that uniquely identifies a bridge port, as
+        specified in 17.3.2.2 of IEEE 802.1ap.
+        This value is used within the spanning tree
+        protocol to identify this port to neighbor bridges."
+    REFERENCE "17.3.2.2"
+    SYNTAX       Unsigned32 (1..65535)
+
+IEEE8021BridgePortNumberOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "An integer that uniquely identifies a bridge port, as
+        specified in 17.3.2.2 of IEEE 802.1ap.  The value 0
+        means no port number, and this must be clarified in the
+        DESCRIPTION clause of any object defined using this
+        TEXTUAL-CONVENTION."
+    REFERENCE "17.3.2.2"
+    SYNTAX       Unsigned32 (0..65535)
+
+IEEE8021BridgePortType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+        "A port type.  The possible port types are:
+
+             customerVlanPort(2) - Indicates a port is a C-tag
+                 aware port of an enterprise VLAN aware bridge.
+
+             providerNetworkPort(3) - Indicates a port is an S-tag
+                 aware port of a Provider Bridge or Backbone Edge
+                 Bridge used for connections within a PBN or PBBN.
+
+             customerNetworkPort(4) - Indicates a port is an S-tag
+                 aware port of a Provider Bridge or Backbone Edge
+                 Bridge used for connections to the exterior of a
+                 PBN or PBBN.
+
+             customerEdgePort(5) - Indicates a port is a C-tag
+                 aware port of a Provider Bridge used for connections
+                 to the exterior of a PBN or PBBN.
+
+             customerBackbonePort(6) - Indicates a port is a I-tag
+                 aware port of a Backbone Edge Bridge's B-component.
+
+             virtualInstancePort(7) - Indicates a port is a virtual
+                 S-tag aware port within a Backbone Edge Bridge's
+                 I-component which is responsible for handling
+                 S-tagged traffic for a specific backbone service
+                 instance.
+
+             dBridgePort(8) - Indicates a port is a VLAN-unaware
+                 member of an 802.1D bridge."
+    REFERENCE   "12.16.1.1.3 h4), 12.16.2.1/2,
+                 12.13.1.1, 12.13.1.2, 12.15.2.1, 12.15.2.2"
+    SYNTAX       INTEGER {
+                     none(1),
+                     customerVlanPort(2),
+                     providerNetworkPort(3),
+                     customerNetworkPort(4),
+                     customerEdgePort(5),
+                     customerBackbonePort(6),
+                     virtualInstancePort(7),
+                     dBridgePort(8)
+                 }
+
+IEEE8021VlanIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "A value used to index per-VLAN tables: values of 0 and
+        4095 are not permitted.  If the value is between 1 and
+        4094 inclusive, it represents an IEEE 802.1Q VLAN-ID with
+        global scope within a given bridged domain (see VlanId
+        textual convention).  If the value is greater than 4095,
+        then it represents a VLAN with scope local to the
+        particular agent, i.e., one without a global VLAN-ID
+        assigned to it.  Such VLANs are outside the scope of
+        IEEE 802.1Q, but it is convenient to be able to manage them
+        in the same way using this MIB."
+    REFERENCE   "9.6"
+    SYNTAX      Unsigned32 (1..4094|4096..4294967295)
+
+IEEE8021VlanIndexOrWildcard ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "A value used to index per-VLAN tables.  The value 0 is not
+        permitted, while the value 4095 represents a 'wildcard'
+        value.  An object whose SYNTAX is IEEE8021VlanIndexOrWildcard
+        must specify in its DESCRIPTION the specific meaning of the
+        wildcard value.  If the value is between 1 and
+        4094 inclusive, it represents an IEEE 802.1Q VLAN-ID with
+        global scope within a given bridged domain (see VlanId
+        textual convention).  If the value is greater than 4095,
+        then it represents a VLAN with scope local to the
+        particular agent, i.e., one without a global VLAN-ID
+        assigned to it.  Such VLANs are outside the scope of
+        IEEE 802.1Q, but it is convenient to be able to manage them
+        in the same way using this MIB."
+    REFERENCE   "9.6"
+    SYNTAX      Unsigned32 (1..4294967295)
+
+IEEE8021MstIdentifier ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "In an MSTP Bridge, an MSTID, i.e., a value used to identify
+        a spanning tree (or MST) instance.  In the PBB-TE environment
+        the value 4094 is used to identify VIDs managed by the PBB-TE
+        procedures."
+    SYNTAX      Unsigned32 (1..4094)
+
+IEEE8021ServiceSelectorType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "A value that represents a type (and thereby the format)
+        of a IEEE8021ServiceSelectorValue.  The value can be one of
+        the following:
+
+        ieeeReserved(0)   Reserved for definition by IEEE 802.1
+                          recommend to not use zero unless
+                          absolutely needed.
+        vlanId(1)         12-Bit identifier as described in IEEE802.1Q.
+        isid(2)           24-Bit identifier as described in IEEE802.1ah.
+        tesid(3)          32 Bit identifier as described below
+        ieeeReserved(xx)  Reserved for definition by IEEE 802.1
+                          xx values can be [4..7].
+
+        To support future extensions, the IEEE8021ServiceSelectorType
+        textual convention SHOULD NOT be sub-typed in object type
+        definitions.  It MAY be sub-typed in compliance statements in
+        order to require only a subset of these address types for a
+        compliant implementation.
+
+        The tesid is used as a service selector for MAs that are present
+        in bridges that implement PBB-TE functionality.  A selector of
+        this type is interpreted as a 32 bit unsigned value of type
+        IEEE8021PbbTeTSidId.  This type is used to index the
+        Ieee8021PbbTeTeSidTable to find the ESPs which comprise the TE
+        Service Instance named by this TE-SID value.
+
+        Implementations MUST ensure that IEEE8021ServiceSelectorType
+        objects and any dependent objects (e.g.,
+        IEEE8021ServiceSelectorValue objects) are consistent.  An
+        inconsistentValue error MUST be generated if an attempt to
+        change an IEEE8021ServiceSelectorType object would, for
+        example, lead to an undefined IEEE8021ServiceSelectorValue value."
+    SYNTAX      INTEGER {
+                    vlanId(1),
+                    isid(2),
+                    tesid(3)
+                }
+
+IEEE8021ServiceSelectorValueOrNone ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "An integer that uniquely identifies a generic MAC service,
+         or none.  Examples of service selectors are a VLAN-ID
+         (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
+
+         An IEEE8021ServiceSelectorValueOrNone value is always
+         interpreted within the context of an
+         IEEE8021ServiceSelectorType value.  Every usage of the
+         IEEE8021ServiceSelectorValueOrNone textual convention is
+         required to specify the IEEE8021ServiceSelectorType object
+         that provides the context.  It is suggested that the
+         IEEE8021ServiceSelectorType object be logically registered
+         before the object(s) that use the
+         IEEE8021ServiceSelectorValueOrNone textual convention, if
+         they appear in the same logical row.
+
+         The value of an IEEE8021ServiceSelectorValueOrNone object
+         must always be consistent with the value of the associated
+         IEEE8021ServiceSelectorType object.  Attempts to set an
+         IEEE8021ServiceSelectorValueOrNone object to a value
+         inconsistent with the associated
+         IEEE8021ServiceSelectorType must fail with an
+         inconsistentValue error.
+
+         The special value of zero is used to indicate that no
+         service selector is present or used.  This can be used in
+         any situation where an object or a table entry MUST either
+         refer to a specific service, or not make a selection.
+
+         Note that a MIB object that is defined using this
+         TEXTUAL-CONVENTION SHOULD clarify the meaning of
+         'no service' (i.e., the special value 0), as well as the
+         maximum value (i.e., 4094, for a VLAN ID)."
+    SYNTAX       Unsigned32 (0 | 1..4294967295)
+
+IEEE8021ServiceSelectorValue ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "An integer that uniquely identifies a generic MAC service.
+         Examples of service selectors are a VLAN-ID (IEEE 802.1Q)
+         and an I-SID (IEEE 802.1ah).
+
+         An IEEE8021ServiceSelectorValue value is always interpreted
+         within the context of an IEEE8021ServiceSelectorType value.
+         Every usage of the IEEE8021ServiceSelectorValue textual
+         convention is required to specify the
+         IEEE8021ServiceSelectorType object that provides the context.
+         It is suggested that the IEEE8021ServiceSelectorType object
+         be logically registered before the object(s) that use the
+         IEEE8021ServiceSelectorValue textual convention, if they
+         appear in the same logical row.
+
+         The value of an IEEE8021ServiceSelectorValue object must
+         always be consistent with the value of the associated
+         IEEE8021ServiceSelectorType object.  Attempts to set an
+         IEEE8021ServiceSelectorValue object to a value inconsistent
+         with the associated IEEE8021ServiceSelectorType must fail
+         with an inconsistentValue error.
+
+         Note that a MIB object that is defined using this
+         TEXTUAL-CONVENTION SHOULD clarify the
+         maximum value (i.e., 4094, for a VLAN ID)."
+    SYNTAX       Unsigned32 (1..4294967295)
+
+IEEE8021PortAcceptableFrameTypes ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "Acceptable frame types on a port."
+    REFERENCE   "12.10.1.3, 12.13.3.3, 12.13.3.4"
+    SYNTAX      INTEGER {
+                    admitAll(1),
+                    admitUntaggedAndPriority(2),
+                    admitTagged(3)
+                }
+
+IEEE8021PriorityValue ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "An 802.1Q user priority value."
+   REFERENCE   "12.13.3.3"
+    SYNTAX      Unsigned32 (0..7)
+
+IEEE8021PbbTeProtectionGroupId ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "The PbbTeProtectionGroupId identifier is used to distinguish 
+         protection group instances present in the B Component of
+         an IB-BEB."
+    REFERENCE "12.19.2"
+    SYNTAX       Unsigned32 (1..429467295)
+
+IEEE8021PbbTeEsp ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+       "This textual convention is used to represent the logical
+        components that comprise the 3-tuple that identifies an
+        Ethernet Switched Path.  The 3-tuple consists of a
+        destination MAC address, a source MAC address and a VID.
+        Bytes (1..6) of this textual convention contain the
+        ESP-MAC-DA, bytes (7..12) contain the ESP-MAC-SA, and bytes
+        (13..14) contain the ESP-VID."
+    REFERENCE "802.1Qay 3.2"
+    SYNTAX OCTET STRING ( SIZE(14))
+
+IEEE8021PbbTeTSidId ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS current
+    DESCRIPTION
+       "This textual convention is used to represent an identifier
+        that refers to a TE Service Instance.  Note that, internally
+        a TE-SID is implementation dependent.  This textual convention
+        defines the external representation of TE-SID values."
+    REFERENCE
+        "802.1Qay 3.11"
+    SYNTAX  Unsigned32 (1..42947295)
+
+IEEE8021PbbTeProtectionGroupConfigAdmin ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "This textual convention is used to represent administrative
+        commands that can be issued to a protection group.  The value
+        noAdmin(1) is used to indicate that no administrative action
+        is to be performed."  
+    REFERENCE "26.10.3.3.5
+               26.10.3.3.6
+               26.10.3.3.7
+               12.19.2.3.2"
+    SYNTAX    INTEGER {
+                 clear(1),
+                 lockOutProtection(2),
+                 forceSwitch(3),
+                 manualSwitchToProtection(4),
+                 manualSwitchToWorking(5)
+              }
+
+IEEE8021PbbTeProtectionGroupActiveRequests ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+       "This textual convention is used to represent the status of
+        active requests within a protection group."
+    REFERENCE
+       "12.19.2.1.3 d)"
+   SYNTAX   INTEGER {
+                noRequest(1),
+                loP(2),
+                fs(3),
+                pSFH(4),
+                wSFH(5),
+                manualSwitchToProtection(6),
+                manualSwitchToWorking(7)
+            }
+
+END

--- a/mibs/junos/mib-802.1ag.txt
+++ b/mibs/junos/mib-802.1ag.txt
@@ -1,0 +1,3820 @@
+IEEE8021-CFM-MIB DEFINITIONS ::= BEGIN
+
+-- ******************************************************************
+-- IEEE 802.1ag(TM) CFM MIB
+-- ******************************************************************
+
+IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE,
+    NOTIFICATION-TYPE,
+    Integer32, Counter32,
+    Unsigned32               FROM SNMPv2-SMI    -- [RFC2578]
+    TEXTUAL-CONVENTION,
+    TimeInterval,
+    TimeStamp, RowStatus,
+    TruthValue, MacAddress,
+    TDomain, TAddress        FROM SNMPv2-TC     -- [RFC2579]
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP,
+    NOTIFICATION-GROUP       FROM SNMPv2-CONF   -- [RFC2580]
+    InterfaceIndex,
+    InterfaceIndexOrZero     FROM IF-MIB        -- [RFC2863]
+    LldpChassisId,
+    LldpChassisIdSubtype,
+    LldpPortId,
+    LldpPortIdSubtype        FROM LLDP-MIB      -- [IEEExxx]
+    VlanIdOrNone, VlanId     FROM Q-BRIDGE-MIB  -- [RFC4363]
+    ieee802dot1mibs,
+    IEEE8021VlanIndex        FROM IEEE8021-TC-MIB
+   ;
+
+ieee8021CfmMib   MODULE-IDENTITY
+    LAST-UPDATED "200811180000Z" -- November 18, 2008
+    ORGANIZATION "IEEE 802.1 Working Group"
+    CONTACT-INFO
+       "WG-URL:   http://grouper.ieee.org/groups/802/1/index.html
+        WG-EMail: stds-802-1@ieee.org 
+
+        Contact:  David Elie-Dit-Cosaque
+
+                  Alcatel-Lucent
+                  3400 W. Plano Pkwy.
+                  Plano, TX 75075, USA
+
+        E-mail:   david.elie_dit_cosaque@alcatel-lucent.com
+
+        Contact:  Norman Finn
+
+                  Cisco Systems
+                  170 W. Tasman Drive
+                  San Jose, CA 95134, USA
+
+        E-mail:   nfinn@cisco.com
+       "
+   DESCRIPTION 
+      "Connectivity Fault Management module for managing IEEE 802.1ag
+
+       Unless otherwise indicated, the references in this MIB
+       module are to IEEE 802.1Q-2005 as amended by IEEE 802.1ad,
+       IEEE 802.1ak, IEEE 802.1ag and IEEE 802.1ah.
+
+       Copyright (C) IEEE.
+       This version of this MIB module is part of IEEE802.1Q;
+       see the draft itself for full legal notices."
+
+   REVISION       "200811180000Z" -- November 18, 2008
+   DESCRIPTION
+
+      "Added new columns to the dot1agCfmMepTable to support new
+       MEP functionality required for PBB-TE support.  Modified
+       dot1agCfmMepDbTable to support new functionality requried
+       for PBB-TE.  Modified conformance clauses to indicate objects
+       needed for PBB-TE support."
+
+   REVISION       "200810150000Z" -- October 15, 2008
+   DESCRIPTION 
+      "The IEEE8021-CFM-MIB Module was originally included in IEEE 
+       802.1ag-2007. Some objects in this module are deprecated and 
+       replaced by objects in the IEEE8021-CFM-V2-MIB module
+       defined in 802.1ap.
+
+       This revision is included in IEEE 802.1ap"
+
+   REVISION       "200706100000Z"    -- 06/10/2007 00:00GMT
+   DESCRIPTION 
+      "Included in IEEE 802.1ag-2007
+
+        Copyright (C) IEEE802.1."
+
+    ::= { ieee802dot1mibs  8 }
+
+dot1agNotifications      OBJECT IDENTIFIER ::= { ieee8021CfmMib 0 }
+dot1agMIBObjects         OBJECT IDENTIFIER ::= { ieee8021CfmMib 1 }
+dot1agCfmConformance     OBJECT IDENTIFIER ::= { ieee8021CfmMib 2 }
+
+-- ******************************************************************
+-- Groups in the CFM MIB Module
+-- ******************************************************************
+dot1agCfmStack           OBJECT IDENTIFIER ::= { dot1agMIBObjects 1 }
+dot1agCfmDefaultMd       OBJECT IDENTIFIER ::= { dot1agMIBObjects 2 }
+dot1agCfmVlan            OBJECT IDENTIFIER ::= { dot1agMIBObjects 3 }
+dot1agCfmConfigErrorList OBJECT IDENTIFIER ::= { dot1agMIBObjects 4 }
+dot1agCfmMd              OBJECT IDENTIFIER ::= { dot1agMIBObjects 5 }
+dot1agCfmMa              OBJECT IDENTIFIER ::= { dot1agMIBObjects 6 }
+dot1agCfmMep             OBJECT IDENTIFIER ::= { dot1agMIBObjects 7 }
+
+-- ******************************************************************
+-- Textual conventions
+-- ******************************************************************
+
+Dot1agCfmMaintDomainNameType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "A value that represents a type (and thereby the format)
+        of a Dot1agCfmMaintDomainName.  The value can be one of
+        the following:
+
+
+        ieeeReserved(0)   Reserved for definition by IEEE 802.1
+                          recommend to not use zero unless
+                          absolutely needed.
+        none(1)           No format specified, usually because
+                          there is not (yet) a Maintenance
+                          Domain Name. In this case, a zero
+                          length OCTET STRING for the Domain
+                          Name field is acceptable.
+        dnsLikeName(2)    Domain Name like string, globally unique
+                          text string derived from a DNS name.
+        macAddrAndUint(3) MAC address + 2-octet (unsigned) integer.
+        charString(4)     RFC2579 DisplayString, except that the
+                          character codes 0-31 (decimal) are not
+                          used.
+        ieeeReserved(xx)  Reserved for definition by IEEE 802.1
+                          xx values can be [5..31] and [64..255]
+        ituReserved(xx)   Reserved for definition by  ITU-T Y.1731
+                          xx values range from [32..63]
+
+        To support future extensions, the Dot1agCfmMaintDomainNameType
+        textual convention SHOULD NOT be sub-typed in object type
+        definitions.  It MAY be sub-typed in compliance statements in
+        order to require only a subset of these address types for a
+        compliant implementation.
+
+        Implementations MUST ensure that Dot1agCfmMaintDomainNameType
+        objects and any dependent objects (e.g.,
+        Dot1agCfmMaintDomainName objects) are consistent.  An
+        inconsistentValue error MUST be generated if an attempt to
+        change an Dot1agCfmMaintDomainNameType object would, for
+        example, lead to an undefined Dot1agCfmMaintDomainName value.
+        In particular,
+        Dot1agCfmMaintDomainNameType/Dot1agCfmMaintDomainName pairs
+        MUST be changed together if the nameType changes.
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  none              (1),
+                  dnsLikeName       (2),
+                  macAddressAndUint (3),
+                  charString        (4)
+                }
+
+Dot1agCfmMaintDomainName ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Denotes a generic Maintenance Domain Name.
+
+        A Dot1agCfmMaintDomainName value is always interpreted within
+        the context of a Dot1agCfmMaintDomainNameType value.  Every
+        usage of the Dot1agCfmMaintDomainName textual convention is
+        required to specify the Dot1agCfmMaintDomainNameType object
+        that provides the context.  It is suggested that the
+        Dot1agCfmMaintDomainNameType object be logically registered
+        before the object(s) that use the Dot1agCfmMaintDomainName
+        textual convention, if they appear in the same logical row.
+
+        The value of a Dot1agCfmMaintDomainName object MUST always
+        be consistent with the value of the associated
+        Dot1agCfmMaintDomainNameType object. Attempts to set
+        an Dot1agCfmMaintDomainName object to a value inconsistent
+        with the associated Dot1agCfmMaintDomainNameType MUST fail
+        with an inconsistentValue error.
+
+        When this textual convention is used as the syntax of an
+        index object, there may be issues with the limit of 128
+        sub-identifiers specified in SMIv2, IETF STD 58.  In this
+        case, the object definition MUST include a 'SIZE' clause
+        to limit the number of potential instance sub-identifiers;
+        otherwise the applicable constraints MUST be stated in
+        the appropriate conceptual row DESCRIPTION clauses, or
+        in the surrounding documentation if there is no single
+        DESCRIPTION clause that is appropriate.
+
+        A value of none(1) in the associated
+        Dot1agCfmMaintDomainNameType object means that no Maintenance
+        Domain name is present, and the contents of the
+        Dot1agCfmMaintDomainName object are meaningless.
+
+        See the DESCRIPTION of the Dot1agCfmMaintAssocNameType
+        TEXTUAL-CONVENTION for a discussion of the length limits on
+        the Maintenance Domain name and Maintenance Association name.
+       "
+    REFERENCE
+         "21.6.5"
+    SYNTAX      OCTET STRING (SIZE(1..43))
+
+Dot1agCfmMaintAssocNameType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "A value that represents a type (and thereby the format)
+        of a Dot1agCfmMaintAssocName.  The value can be one of
+        the following:
+
+        ieeeReserved(0)   Reserved for definition by IEEE 802.1
+                          recommend to not use zero unless
+                          absolutely needed.
+        primaryVid(1)     Primary VLAN ID.
+                          12 bits represented in a 2-octet integer:
+                          - 4 least significant bits of the first
+                            byte contains the 4 most significant 
+                            bits of the 12 bits primary VID
+                          - second byte contains the 8 least
+                            significant bits of the primary VID
+
+                                 0 1 2 3 4 5 6 7 8
+                                 +-+-+-+-+-+-+-+-+
+                                 |0 0 0 0| (MSB) |
+                                 +-+-+-+-+-+-+-+-+
+                                 |  VID   LSB    |
+                                 +-+-+-+-+-+-+-+-+
+
+        charString(2)     RFC2579 DisplayString, except that the
+                          character codes 0-31 (decimal) are not
+                          used. (1..45) octets
+        unsignedInt16 (3) 2-octet integer/big endian
+        rfc2865VpnId(4)   RFC 2685 VPN ID
+                          3 octet VPN authority Organizationally
+                          Unique Identifier followed by 4 octet VPN
+                          index identifying VPN according to the OUI:
+
+                                 0 1 2 3 4 5 6 7 8
+                                 +-+-+-+-+-+-+-+-+
+                                 | VPN OUI (MSB) |
+                                 +-+-+-+-+-+-+-+-+
+                                 |   VPN OUI     |
+                                 +-+-+-+-+-+-+-+-+
+                                 | VPN OUI (LSB) |
+                                 +-+-+-+-+-+-+-+-+
+                                 |VPN Index (MSB)|
+                                 +-+-+-+-+-+-+-+-+
+                                 |  VPN Index    |
+                                 +-+-+-+-+-+-+-+-+
+                                 |  VPN Index    |
+                                 +-+-+-+-+-+-+-+-+
+                                 |VPN Index (LSB)|
+                                 +-+-+-+-+-+-+-+-+
+
+        ieeeReserved(xx)  Reserved for definition by IEEE 802.1
+                          xx values can be [5..31] and [64..255]
+        ituReserved(xx)   Reserved for definition by  ITU-T Y.1731
+                          xx values range from [32..63]
+
+        To support future extensions, the Dot1agCfmMaintAssocNameType
+        textual convention SHOULD NOT be sub-typed in object type
+        definitions.  It MAY be sub-typed in compliance statements in
+        order to require only a subset of these address types for a
+        compliant implementation.
+
+        Implementations MUST ensure that Dot1agCfmMaintAssocNameType
+        objects and any dependent objects (e.g.,
+        Dot1agCfmMaintAssocName objects) are consistent.  An
+        inconsistentValue error MUST be generated if an attempt to
+        change an Dot1agCfmMaintAssocNameType object would, for
+        example, lead to an undefined Dot1agCfmMaintAssocName value.
+        In particular,
+        Dot1agCfmMaintAssocNameType/Dot1agCfmMaintAssocName pairs
+        MUST be changed together if the nameType changes.
+
+        The Maintenance Domain name and Maintenance Association name,
+        when put together into the CCM PDU, MUST total 48 octets or
+        less.  If the Dot1agCfmMaintDomainNameType object contains
+        none(1), then the Dot1agCfmMaintAssocName object MUST be
+        45 octets or less in length.  Otherwise, the length of
+        the Dot1agCfmMaintDomainName object plus the length of the
+        Dot1agCfmMaintAssocName object, added together, MUST total
+        less than or equal to 44 octets.
+       " 
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  primaryVid        (1),
+                  charString        (2),
+                  unsignedInt16     (3),
+                  rfc2865VpnId      (4)
+                }
+
+Dot1agCfmMaintAssocName ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Denotes a generic Maintenance Association Name. It is the
+        part of the Maintenance Association Identifier which is
+        unique within the Maintenance Domain Name and is appended
+        to the Maintenance Domain Name to form the Maintenance
+        Association Identifier (MAID).
+
+        A Dot1agCfmMaintAssocName value is always interpreted within
+        the context of a Dot1agCfmMaintAssocNameType value.  Every
+        usage of the Dot1agCfmMaintAssocName textual convention is
+        required to specify the Dot1agCfmMaintAssocNameType object
+        that provides the context.  It is suggested that the
+        Dot1agCfmMaintAssocNameType object be logically registered
+        before the object(s) that use the Dot1agCfmMaintAssocName
+        textual convention, if they appear in the same logical row.
+
+        The value of a Dot1agCfmMaintAssocName object MUST 
+        always be consistent with the value of the associated
+        Dot1agCfmMaintAssocNameType object. Attempts to set
+        an Dot1agCfmMaintAssocName object to a value inconsistent
+        with the associated Dot1agCfmMaintAssocNameType MUST fail
+        with an inconsistentValue error.
+
+        When this textual convention is used as the syntax of an
+        index object, there may be issues with the limit of 128
+        sub-identifiers specified in SMIv2, IETF STD 58.  In this
+        case, the object definition MUST include a 'SIZE' clause
+        to limit the number of potential instance sub-identifiers;
+        otherwise the applicable constraints MUST be stated in
+        the appropriate conceptual row DESCRIPTION clauses, or
+        in the surrounding documentation if there is no single
+        DESCRIPTION clause that is appropriate.
+       "
+    REFERENCE
+       "802.1ag clauses 21.6.5.4, 21.6.5.5, 21.6.5.6"
+    SYNTAX      OCTET STRING (SIZE(1..45))
+
+
+Dot1agCfmMDLevel ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+       "Integer identifying the Maintenance Domain Level (MD Level).
+        Higher numbers correspond to higher Maintenance Domains,
+        those with the greatest physical reach, with the highest
+        values for customers' CFM PDUs.  Lower numbers correspond
+        to lower Maintenance Domains, those with more limited
+        physical reach, with the lowest values for CFM PDUs
+        protecting single bridges or physical links.
+       "
+    REFERENCE
+       "802.1ag clauses 18.3, 21.4.1"
+    SYNTAX      Integer32 (0..7)
+
+Dot1agCfmMDLevelOrNone ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+       "Integer identifying the Maintenance Domain Level (MD Level).
+        Higher numbers correspond to higher Maintenance Domains,
+        those with the greatest physical reach, with the highest
+        values for customers' CFM packets.  Lower numbers correspond
+        to lower Maintenance Domains, those with more limited
+        physical reach, with the lowest values for CFM PDUs
+        protecting single bridges or physical links.
+
+        The value (-1) is reserved to indicate that no MA Level has
+        been assigned.
+       "
+    REFERENCE
+       "802.1ag clauses 18.3, 12.14.3.1.3:c"
+    SYNTAX      Integer32 (-1 | 0..7)
+
+Dot1agCfmMpDirection ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Indicates the direction in which the Maintenance
+        association (MEP or MIP) faces on the bridge port:
+
+        down(1)    Sends Continuity Check Messages away from the
+                   MAC Relay Entity.
+        up(2)      Sends Continuity Check Messages towards the
+                   MAC Relay Entity.
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  down  (1),
+                  up    (2)
+                }
+
+Dot1agCfmPortStatus ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "An enumerated value from he Port Status TLV from the last CCM
+        received from the last MEP. It indicates the ability of the
+        Bridge Port on which the transmitting MEP resides to pass
+        ordinary data, regardless of the status of the MAC
+        (Table 21-10).
+
+        psNoPortStateTLV(0) Indicates either that no CCM has been
+                            received or that no port status TLV was
+                            present in the last CCM received.
+
+        psBlocked(1)        Ordinary data cannot pass freely through
+                            the port on which the remote MEP resides.
+                            Value of enableRmepDefect is equal to
+                            false.
+
+        psUp(2):            Ordinary data can pass freely through
+                            the port on which the remote MEP resides.
+                            Value of enableRmepDefect is equal to
+                            true.
+
+        NOTE: A 0 value is used for psNoPortStateTLV, so that
+              additional code points can be added in a manner
+              consistent with the Dot1agCfmInterfaceStatus textual
+              convention.
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  psNoPortStateTLV  (0),
+                  psBlocked         (1),
+                  psUp              (2)
+                }
+
+Dot1agCfmInterfaceStatus ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "An enumerated value from the Interface Status TLV from the 
+        last CCM received from the last MEP. It indicates the status
+        of the Interface within which the MEP transmitting the CCM
+        is configured, or the next lower Interface in the Interface
+        Stack, if the MEP is not configured within an Interface.
+
+    isNoInterfaceStatusTLV(0)  Indicates either that no CCM has been
+                          received or that no interface status TLV
+                          was present in the last CCM received.
+
+    isUp(1)               The interface is ready to pass packets.
+
+    isDown(2)             The interface cannot pass packets
+
+    isTesting(3)          The interface is in some test mode.
+   
+    isUnknown(4)          The interface status cannot be determined
+                          for some reason.
+
+    isDormant(5)          The interface is not in a state to pass
+                          packets but is in a pending state, waiting
+                          for some external event.
+    
+    isNotPresent(6)       Some component of the interface is missing
+    
+    isLowerLayerDown(7)   The interface is down due to state of the
+                          lower layer interfaces
+
+        NOTE: A 0 value is used for isNoInterfaceStatusTLV, so that
+              these code points can be kept consistent with new code
+              points added to ifOperStatus in the IF-MIB.
+
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  isNoInterfaceStatusTLV  (0),
+                  isUp                    (1),
+                  isDown                  (2),
+                  isTesting               (3),
+                  isUnknown               (4),
+                  isDormant               (5),
+                  isNotPresent            (6),
+                  isLowerLayerDown        (7)
+                }
+
+Dot1agCfmHighestDefectPri ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "An enumerated value, equal to the contents of the variable
+        highestDefect (20.33.9 and Table 20-1), indicating the
+        highest-priority defect that has been present since the MEP
+        Fault Notification Generator State Machine was last in the 
+        FNG_RESET state, either:
+
+        none(0)           no defects since FNG_RESET
+        defRDICCM(1)      DefRDICCM
+        defMACstatus(2)   DefMACstatus
+        defRemoteCCM(3)   DefRemoteCCM
+        defErrorCCM(4)    DefErrorCCM
+        defXconCCM(5)     DefXconCCM
+
+        The value 0 is used for no defects so that additional higher
+        priority values can be added, if needed, at a later time, and
+        so that these values correspond with those in
+        Dot1agCfmLowestAlarmPri.
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  none              (0),
+                  defRDICCM         (1),
+                  defMACstatus      (2),
+                  defRemoteCCM      (3),
+                  defErrorCCM       (4),
+                  defXconCCM        (5)
+                }
+
+Dot1agCfmLowestAlarmPri ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "An integer value specifying the lowest priority defect
+        that is allowed to generate a Fault Alarm (20.9.5), either:
+
+        allDef(1)           DefRDICCM, DefMACstatus, DefRemoteCCM,
+                            DefErrorCCM, and DefXconCCM;
+        macRemErrXcon(2)    Only DefMACstatus, DefRemoteCCM,
+                            DefErrorCCM, and DefXconCCM (default);
+        remErrXcon(3)       Only DefRemoteCCM, DefErrorCCM,
+                            and DefXconCCM;
+        errXcon(4)          Only DefErrorCCM and DefXconCCM;
+        xcon(5)             Only DefXconCCM; or
+        noXcon(6)           No defects DefXcon or lower are to be
+                            reported;
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  allDef            (1),
+                  macRemErrXcon     (2),
+                  remErrXcon        (3),
+                  errXcon           (4),
+                  xcon              (5),
+                  noXcon            (6)
+                }
+
+Dot1agCfmMepId ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+       "Maintenance association End Point Identifier (MEPID): A small
+        integer, unique over a given Maintenance Association,
+        identifying a specific MEP.
+       "
+    REFERENCE
+       "802.1ag clauses 3.19 and 19.2.1"
+    SYNTAX      Unsigned32 (1..8191)
+
+Dot1agCfmMepIdOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+       "Maintenance association End Point Identifier (MEPID): A small
+        integer, unique over a given Maintenance Association,
+        identifying a specific MEP.
+ 
+        The special value 0 is allowed to indicate special cases, for
+        example that no MEPID is configured.
+
+        Whenever an object is defined with this SYNTAX, then the
+        DESCRIPTION clause of such an object MUST specify what the
+        special value of 0 means.
+       "
+    REFERENCE
+       "19.2.1"
+    SYNTAX      Unsigned32 (0 | 1..8191)
+
+Dot1agCfmMhfCreation ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Indicates if the Management Entity can create MHFs.
+        The valid values are:
+
+        defMHFnone(1)      No MHFs can be created for this VID.
+        defMHFdefault(2)   MHFs can be created on this VID on any
+                           Bridge port through which this VID can
+                           pass.
+        defMHFexplicit(3)  MHFs can be created for this VID only on
+                           Bridge ports through which this VID can
+                           pass, and only if a MEP is created at some
+                           lower MD Level.
+        defMHFdefer(4)     The creation of MHFs is determined by the
+                           corresponding Maintenance Domain variable
+                           (dot1agCfmMaCompMhfCreation).
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  defMHFnone     (1),
+                  defMHFdefault  (2),
+                  defMHFexplicit (3),
+                  defMHFdefer    (4)
+                }
+
+Dot1agCfmIdPermission ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Indicates what, if anything, is to be included in the Sender
+        ID TLV transmitted in CCMs, LBMs, LTMs, and LTRs.  The valid
+        values are:
+
+        sendIdNone(1)      The Sender ID TLV is not to be sent.
+        sendIdChassis(2)   The Chassis ID Length, Chassis ID
+                           Subtype, and Chassis ID fields of  the
+                           Sender ID TLV are to be sent.
+        sendIdManage(3)    The Management Address Length and
+                           Management Address of the Sender ID TLV
+                           are to be sent.
+        sendIdChassisManage(4) The Chassis ID Length, Chassis ID
+                           Subtype, Chassis ID, Management Address
+                           Length and Management Address fields are
+                           all to be sent.
+        sendIdDefer(5)     The contents of the Sender ID TLV are
+                           determined by the corresponding
+                           Maintenance Domain variable
+                           (dot1agCfmMaCompIdPermission).
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  sendIdNone          (1),
+                  sendIdChassis       (2),
+                  sendIdManage        (3),
+                  sendIdChassisManage (4),
+                  sendIdDefer         (5)
+                }
+
+Dot1agCfmCcmInterval ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Indicates the interval at which CCMs are sent by a MEP.
+        The possible values are:
+        intervalInvalid(0) No CCMs are sent (disabled).
+        interval300Hz(1)   CCMs are sent every 3 1/3 milliseconds
+                           (300Hz).
+        interval10ms(2)    CCMs are sent every 10 milliseconds.
+        interval100ms(3)   CCMs are sent every 100 milliseconds.
+        interval1s(4)      CCMs are sent every 1 second.
+        interval10s(5)     CCMs are sent every 10 seconds.
+        interval1min(6)    CCMs are sent every minute.
+        interval10min(7)   CCMs are sent every 10 minutes.
+
+        Note: enumerations start at zero to match the 'CCM Interval
+              field' protocol field.
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  intervalInvalid   (0),
+                  interval300Hz     (1),
+                  interval10ms      (2),
+                  interval100ms     (3),
+                  interval1s        (4),
+                  interval10s       (5),
+                  interval1min      (6),
+                  interval10min     (7)
+                }
+
+Dot1agCfmFngState ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Indicates the diferent states of the MEP Fault Notification
+        Generator State Machine.
+
+        fngReset(1)            No defect has been present since the
+                               dot1agCfmMepFngResetTime timer
+                               expired, or since the state machine
+                               was last reset.
+
+        fngDefect(2)           A defect is present, but not for a
+                               long enough time to be reported 
+                               (dot1agCfmMepFngAlarmTime).
+
+        fngReportDefect(3)     A momentary state during which the
+                               defect is reported by sending a
+                               dot1agCfmFaultAlarm notification,
+                               if that action is enabled.
+
+        fngDefectReported(4)   A defect is present, and some defect
+                               has been reported.
+
+        fngDefectClearing(5)   No defect is present, but the
+                               dot1agCfmMepFngResetTime timer has
+                               not yet expired.
+       "
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  fngReset          (1),
+                  fngDefect         (2),
+                  fngReportDefect   (3),
+                  fngDefectReported (4),
+                  fngDefectClearing (5)
+                }
+
+Dot1agCfmRelayActionFieldValue ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Possible values the Relay action field can take."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:g, 20.36.2.5, 21.9.5, and
+        Table 21-27"
+    SYNTAX      INTEGER {
+                  rlyHit     (1),
+                  rlyFdb     (2),
+                  rlyMpdb    (3)
+                }
+               
+Dot1agCfmIngressActionFieldValue ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Possible values returned in the ingress action field."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:g, 20.36.2.6, 21.9.8.1, and
+        Table 21-30
+       "
+    SYNTAX      INTEGER {
+                  ingNoTlv    (0),
+                  ingOk       (1),
+                  ingDown     (2),
+                  ingBlocked  (3),
+                  ingVid      (4)
+                }
+
+Dot1agCfmEgressActionFieldValue ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Possible values returned in the egress action field"
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:o, 20.36.2.10, 21.9.9.1, and
+        Table 21-32"
+    SYNTAX      INTEGER {
+                  egrNoTlv    (0),
+                  egrOK       (1),
+                  egrDown     (2),
+                  egrBlocked  (3),
+                  egrVid      (4)
+                }
+
+Dot1agCfmRemoteMepState::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "Operational state of the remote MEP state machine.  This
+        state machine monitors the reception of valid CCMs from a
+        remote MEP with a specific MEPID.  It uses a timer that
+        expires in 3.5 times the length of time indicated by the
+        dot1agCfmMaNetCcmInterval object.
+
+        rMepIdle(1)            Momentary state during reset.
+
+        rMepStart(2)           The timer has not expired since the
+                               state machine was reset, and no valid
+                               CCM has yet been received.
+
+        rMepFailed(3)          The timer has expired, both since the
+                               state machine was reset, and since a
+                               valid CCM was received.
+
+        rMepOk(4)              The timer has not expired since a
+                               valid CCM was received.
+"
+    REFERENCE
+       "i."
+    SYNTAX      INTEGER {
+                  rMepIdle    (1),
+                  rMepStart   (2),
+                  rMepFailed  (3),
+                  rMepOk      (4)
+                }
+
+Dot1afCfmIndexIntegerNextFree ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+      "An integer which may be used as a new Index in a table.
+
+       The special value of 0 indicates that no more new entries can
+       be created in the relevant table.
+
+       When a MIB is used for configuration, an object with this
+       SYNTAX always contains a legal value (if non-zero) for an
+       index that is not currently used in the relevant table. The
+       Command Generator (Network Management Application) reads this
+       variable and uses the (non-zero) value read when creating a
+       new row with an SNMP SET.  When the SET is performed, the
+       Command Responder (agent) MUST determine whether the value is
+       indeed still unused; Two Network Management Applications may
+       attempt to create a row (configuration entry) simultaneously
+       and use the same value. If it is currently unused, the SET
+       succeeds and the Command Responder (agent) changes the value
+       of this object, according to an implementation-specific
+       algorithm.  If the value is in use, however, the SET fails.
+       The Network Management Application MUST then re-read this
+       variable to obtain a new usable value.
+
+       An OBJECT-TYPE definition using this SYNTAX MUST specify the
+       relevant table for which the object is providing this
+       functionality.
+      "
+    SYNTAX      Unsigned32 (0..4294967295)
+
+Dot1agCfmMepDefects ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "A MEP can detect and report a number of defects, and multiple
+        defects can be present at the same time. These defects are:
+
+        bDefRDICCM(0) A remote MEP is reported the RDI bit in its
+                     last CCM.
+        bDefMACstatus(1) Either some remote MEP is reporting its
+                     Interface Status TLV as not isUp, or all remote
+                     MEPs are reporting a Port Status TLV that
+                     contains some value other than psUp.
+        bDefRemoteCCM(2) The MEP is not receiving valid CCMs from at
+                     least one of the remote MEPs.
+        bDefErrorCCM(3) The MEP has received at least one invalid CCM
+                     whose CCM Interval has not yet timed out.
+        bDefXconCCM(4) The MEP has received at least one CCM from
+                     either another MAID or a lower MD Level whose
+                     CCM Interval has not yet timed out.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:o, 12.14.7.1.3:p, 12.14.7.1.3:q,
+        12.14.7.1.3:r, and 12.14.7.1.3:s."
+    SYNTAX BITS {
+                bDefRDICCM(0),
+                bDefMACstatus(1),
+                bDefRemoteCCM(2),
+                bDefErrorCCM(3),
+                bDefXconCCM(4)
+               }
+
+Dot1agCfmConfigErrors ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+       "While making the MIP creation evaluation described in 802.1ag
+        clause 22.2.3, the management entity can encounter errors in
+        the configuration. These are possible errors that can be
+        encountered:
+
+        CFMleak(0)   MA x is associated with a specific VID list,
+                     one or more of the VIDs in MA x can pass through
+                     the Bridge Port, no Down MEP is configured on
+                     any Bridge Port for MA x, and some other MA y,
+                     at a higher MD Level than MA x, and associated
+                     with at least one of the VID(s) also in MA x,
+                     does have a MEP configured on the Bridge Port.
+
+        conflictingVids(1)  MA x is associated with a specific VID
+                     list, an Up MEP is configured on MA x on the
+                     Bridge Port, and some other MA y, associated
+                     with at least one of the VID(s) also in MA x,
+                     also has an Up MEP configured on some Bridge
+                     Port.
+
+        ExcessiveLevels(2)  The number of different MD Levels at
+                     which MIPs are to be created on this port
+                     exceeds the Bridge's capabilities (see
+                     subclause 22.3).
+
+        OverlappedLevels(3) A MEP is created for one VID at one MD
+                     Level, but a MEP is configured on another
+                     VID at that MD Level or higher, exceeding
+                     the Bridge's capabilities.
+       "
+    REFERENCE
+       "i."
+    SYNTAX BITS {
+                cfmLeak(0),
+                conflictingVids(1),
+                excessiveLevels(2),
+                overlappedLevels(3)
+                }
+
+Dot1agCfmPbbComponentIdentifier
+::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+       "A Provider Backbone Bridge (PBB) can comprise a number of
+        components, each of which can be managed in a manner
+        essentially equivalent to an 802.1Q bridge.  In order to access
+        these components easily, an index is used in a number of
+        tables.  If any two tables are indexed by
+        Dot1agCfmPbbComponentIdentifier, then entries in those tables
+        indexed by the same value of Dot1agCfmPbbComponentIdentifier
+        correspond to the same component.
+       "
+    REFERENCE
+       "12.3 l)"
+    SYNTAX      Unsigned32 (1..4294967295)
+
+-- ******************************************************************
+-- The Stack Object. This group will contain all the MIBs objects
+-- needed to access the Stack managed object.
+-- ******************************************************************
+
+-- ******************************************************************
+-- The CFM Stack Table
+-- ******************************************************************
+
+dot1agCfmStackTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmStackEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "There is one CFM Stack table per bridge. It permits
+        the retrieval of information about the Maintenance Points
+        configured on any given interface.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.2"
+    ::= { dot1agCfmStack 1 }
+
+dot1agCfmStackEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmStackEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The Stack table entry
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+"
+    INDEX { dot1agCfmStackifIndex, dot1agCfmStackVlanIdOrNone,
+            dot1agCfmStackMdLevel, dot1agCfmStackDirection
+          }
+    ::= { dot1agCfmStackTable 1 }
+
+Dot1agCfmStackEntry ::= SEQUENCE {
+      dot1agCfmStackifIndex       InterfaceIndex,
+      dot1agCfmStackVlanIdOrNone  VlanIdOrNone,
+      dot1agCfmStackMdLevel       Dot1agCfmMDLevel,
+      dot1agCfmStackDirection     Dot1agCfmMpDirection,
+      dot1agCfmStackMdIndex       Unsigned32,
+      dot1agCfmStackMaIndex       Unsigned32,
+      dot1agCfmStackMepId         Dot1agCfmMepIdOrZero,
+      dot1agCfmStackMacAddress    MacAddress
+    }
+
+dot1agCfmStackifIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "This object represents the  Bridge Port or aggregated port
+        on which MEPs or MHFs might be configured.
+
+        Upon a restart of the system, the system SHALL, if necessary,
+        change the value of this variable, and  rearrange the
+        dot1agCfmStackTable, so that it indexes the entry in the
+        interface table with the same value of ifAlias that it
+        indexed before the system restart.  If no such entry exists,
+        then the system SHALL delete all entries in the
+        dot1agCfmStackTable with the interface index.
+        **NOTE: this object is deprecated due to re-indexing of
+    the table.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.2.1.2:a"
+    ::= { dot1agCfmStackEntry 1 }
+
+dot1agCfmStackVlanIdOrNone OBJECT-TYPE
+    SYNTAX      VlanIdOrNone
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "VLAN ID to which the MP is attached, or 0, if none.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.2.1.2:d, 22.1.7"
+    ::= { dot1agCfmStackEntry 2 }
+
+dot1agCfmStackMdLevel OBJECT-TYPE
+    SYNTAX      Dot1agCfmMDLevel
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "MD Level of the Maintenance Point.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.2.1.2:b"
+    ::= { dot1agCfmStackEntry 3 }
+
+dot1agCfmStackDirection OBJECT-TYPE
+    SYNTAX      Dot1agCfmMpDirection
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "Direction in which the MP faces on the Bridge Port
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.2.1.2:c"
+    ::= { dot1agCfmStackEntry 4 }
+
+dot1agCfmStackMdIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+       "The index of the Maintenance Domain in the dot1agCfmMdTable
+        to which the MP is associated, or 0, if none.
+       "
+    REFERENCE
+       "12.14.2.1.3:b"
+    ::= { dot1agCfmStackEntry 5 }
+
+dot1agCfmStackMaIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+       "The index of the MA in the dot1agCfmMaNetTable and
+        dot1agCfmMaCompTable to which the MP is associated, or 0, if
+        none.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.2.1.3:c"
+    ::= { dot1agCfmStackEntry 6 }
+
+dot1agCfmStackMepId OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+       "If an MEP is configured, the MEPID, else 0"
+    REFERENCE
+       "12.14.2.1.3:d
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    ::= { dot1agCfmStackEntry 7 }
+
+dot1agCfmStackMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+       "MAC address of the MP.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+      "12.14.2.1.3:e"
+    ::= { dot1agCfmStackEntry 8 }
+
+-- ******************************************************************
+-- The VLAN Table
+-- ******************************************************************
+
+dot1agCfmVlanTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmVlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "This table defines the association of VIDs into VLANs.  There
+        is an entry in this table, for each component of the bridge,
+        for each VID that is:
+            a) a VID belonging to a VLAN associated with more than
+               one VID; and
+            b) not the Primary VLAN of that VID.
+        The entry in this table contains the Primary VID of the VLAN.
+
+        By default, this table is empty, meaning that every VID is
+        the Primary VID of a single-VID VLAN.
+
+        VLANs that are associated with only one VID SHOULD NOT have
+        an entry in this table.
+
+        The writable objects in this table need to be persistent
+        upon reboot or restart of a device.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.3.1.3:a, 12.14.3.2.2:a, 12.14.5.3.2:c,
+        12.14.6.1.3:b, 22.1.5."
+    ::= { dot1agCfmVlan 1 }
+
+dot1agCfmVlanEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmVlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The VLAN table entry.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    INDEX { dot1agCfmVlanComponentId, dot1agCfmVlanVid }
+    ::= { dot1agCfmVlanTable 1 }
+
+Dot1agCfmVlanEntry ::= SEQUENCE {
+      dot1agCfmVlanComponentId Dot1agCfmPbbComponentIdentifier,
+      dot1agCfmVlanVid         VlanId,
+      dot1agCfmVlanPrimaryVid  VlanId,
+      dot1agCfmVlanRowStatus   RowStatus
+    }
+
+dot1agCfmVlanComponentId OBJECT-TYPE
+    SYNTAX      Dot1agCfmPbbComponentIdentifier
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The bridge component within the system to which the information
+        in this dot1agCfmVlanEntry applies.  If the system is not a
+        Bridge, or if only one component is present in the Bridge, then
+        this variable (index) MUST be equal to 1.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.3 l)"
+    ::= { dot1agCfmVlanEntry 1 }
+
+dot1agCfmVlanVid OBJECT-TYPE
+    SYNTAX      VlanId
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "This is a VLAN ID belonging to a VLAN that is associated with
+        more than one VLAN ID, and this is not the Primary VID of the
+        VLAN.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    ::= { dot1agCfmVlanEntry 2 }
+
+dot1agCfmVlanPrimaryVid OBJECT-TYPE
+    SYNTAX      VlanId
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "This is the Primary VLAN ID of the VLAN with which this
+        entry's dot1agCfmVlanVid is associated.  This value MUST not
+        equal the value of dot1agCfmVlanVid.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    ::= { dot1agCfmVlanEntry 3 }
+
+dot1agCfmVlanRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    ::= { dot1agCfmVlanEntry 4 }
+
+-- *******************************************************************
+-- The Default MD Level object. This group will contain all the
+-- MIB objects needed to access and modify default MD level
+-- managed objects.
+-- *******************************************************************
+
+dot1agCfmDefaultMdDefLevel OBJECT-TYPE
+    SYNTAX      Dot1agCfmMDLevel
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+       "A value indicating the MD Level at which MHFs are to be
+        created, and Sender ID TLV transmission by those MHFs is to
+        be controlled, for each dot1agCfmDefaultMdEntry whose
+        dot1agCfmDefaultMdLevel object contains the value -1.
+
+        After this initialization, this object needs to be persistent
+        upon reboot or restart of a device.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.3.1.3:c, 12.14.3.2.2:b"
+    DEFVAL {0}
+    ::= { dot1agCfmDefaultMd 1 }
+
+dot1agCfmDefaultMdDefMhfCreation OBJECT-TYPE
+    SYNTAX      Dot1agCfmMhfCreation {
+                  defMHFnone     (1),
+                  defMHFdefault  (2),
+                  defMHFexplicit (3)
+                }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+       "A value indicating if the Management entity can create MHFs
+        (MIP Half Function) for the VID, for each
+        dot1agCfmDefaultMdEntry whose dot1agCfmDefaultMdMhfCreation
+        object contains the value defMHFdefer.  Since, in this
+        variable, there is no encompassing Maintenance Domain, the
+        value defMHFdefer is not allowed.
+
+        After this initialization, this object needs to be persistent
+        upon reboot or restart of a device.
+       "
+    REFERENCE
+       "12.14.3.1.3:d"
+    DEFVAL {defMHFnone}
+    ::= { dot1agCfmDefaultMd 2 }
+
+dot1agCfmDefaultMdDefIdPermission OBJECT-TYPE
+    SYNTAX      Dot1agCfmIdPermission {
+                  sendIdNone          (1),
+                  sendIdChassis       (2),
+                  sendIdManage        (3),
+                  sendIdChassisManage (4)
+                }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+       "Enumerated value indicating what, if anything, is to be
+        included in the Sender ID TLV (21.5.3) transmitted by MHFs
+        created by the Default Maintenance Domain, for each
+        dot1agCfmDefaultMdEntry whose dot1agCfmDefaultMdIdPermission
+        object contains the value sendIdDefer.  Since, in this
+        variable, there is no encompassing Maintenance Domain, the
+        value sendIdDefer is not allowed.
+
+        After this initialization, this object needs to be persistent
+        upon reboot or restart of a device.
+       "
+    REFERENCE
+       "12.14.3.1.3:e"
+    DEFVAL { sendIdNone }
+    ::= { dot1agCfmDefaultMd 3 }
+
+-- *******************************************************************
+-- The Default MD Level Table
+-- *******************************************************************
+
+dot1agCfmDefaultMdTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmDefaultMdEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "For each bridge component, the Default MD Level Managed Object
+        controls MHF creation for VIDs that are not attached to a
+        specific Maintenance Association Managed Object, and Sender ID
+        TLV transmission by those MHFs.
+
+        For each Bridge Port, and for each VLAN ID whose data can
+        pass through that Bridge Port, an entry in this table is
+        used by the algorithm in subclause 22.2.3 only if there is no
+        entry in the Maintenance Association table defining an MA
+        for the same VLAN ID and MD Level as this table's entry, and
+        on which MA an Up MEP is defined.  If there exists such an
+        MA, that MA's objects are used by the algorithm in
+        subclause 22.2.3 in place of this table entry's objects.  The
+        agent maintains the value of dot1agCfmDefaultMdStatus to
+        indicate whether this entry is overridden by an MA.
+
+        When first initialized, the agent creates this table
+        automatically with entries for all VLAN IDs,
+        with the default values specified for each object.
+
+        After this initialization, the writable objects in this
+        table need to be persistent upon reboot or restart of a
+        device.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       " 12.14.3"
+    ::= { dot1agCfmDefaultMd 4 }
+
+dot1agCfmDefaultMdEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmDefaultMdEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The Default MD Level table entry.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    INDEX { dot1agCfmDefaultMdComponentId,
+            dot1agCfmDefaultMdPrimaryVid }
+    ::= { dot1agCfmDefaultMdTable 1 }
+
+Dot1agCfmDefaultMdEntry ::= SEQUENCE {
+      dot1agCfmDefaultMdComponentId  Dot1agCfmPbbComponentIdentifier,
+      dot1agCfmDefaultMdPrimaryVid   VlanId,
+      dot1agCfmDefaultMdStatus       TruthValue,
+      dot1agCfmDefaultMdLevel        Dot1agCfmMDLevelOrNone,
+      dot1agCfmDefaultMdMhfCreation  Dot1agCfmMhfCreation,
+      dot1agCfmDefaultMdIdPermission Dot1agCfmIdPermission
+    }
+
+dot1agCfmDefaultMdComponentId OBJECT-TYPE
+    SYNTAX      Dot1agCfmPbbComponentIdentifier
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The bridge component within the system to which the information
+        in this dot1agCfmDefaultMdEntry applies.  If the system is not
+        a Bridge, or if only one component is present in the Bridge,
+        then this variable (index) MUST be equal to 1.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.3 l)"
+    ::= { dot1agCfmDefaultMdEntry 1 }
+
+dot1agCfmDefaultMdPrimaryVid OBJECT-TYPE
+    SYNTAX      VlanId
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The Primary VID of the VLAN to which this entry's objects
+        apply.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    ::= { dot1agCfmDefaultMdEntry 2 }
+
+dot1agCfmDefaultMdStatus OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+       "State of this Default MD Level table entry.  True if there is
+        no entry in the Maintenance Association table defining an MA
+        for the same VLAN ID and MD Level as this table's entry, and
+        on which MA an Up MEP is defined, else false.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.3.1.3:b"
+    ::= { dot1agCfmDefaultMdEntry 3 }
+
+dot1agCfmDefaultMdLevel OBJECT-TYPE
+    SYNTAX      Dot1agCfmMDLevelOrNone
+    MAX-ACCESS  read-write
+    STATUS      deprecated
+    DESCRIPTION
+       "A value indicating the MD Level at which MHFs are to be
+        created, and Sender ID TLV transmission by those MHFs is to
+        be controlled, for the VLAN to which this entry's objects
+        apply.  If this object has the value -1, the MD Level for MHF
+        creation for this VLAN is controlled by
+        dot1agCfmDefaultMdDefLevel.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.3.1.3:c, 12.14.3.2.2:b"
+    DEFVAL {-1}
+    ::= { dot1agCfmDefaultMdEntry 4 }
+
+dot1agCfmDefaultMdMhfCreation OBJECT-TYPE
+    SYNTAX      Dot1agCfmMhfCreation
+    MAX-ACCESS  read-write
+    STATUS      deprecated
+    DESCRIPTION
+       "A value indicating if the Management entity can create MHFs
+        (MIP Half Function) for this VID at this MD Level.  If this
+        object has the value defMHFdefer, MHF creation for this VLAN
+        is controlled by dot1agCfmDefaultMdDefMhfCreation.
+
+        The value of this variable is meaningless if the values of
+        dot1agCfmDefaultMdStatus is false.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.3.1.3:d"
+    DEFVAL {defMHFdefer}
+    ::= { dot1agCfmDefaultMdEntry 5 }
+
+dot1agCfmDefaultMdIdPermission OBJECT-TYPE
+    SYNTAX      Dot1agCfmIdPermission
+    MAX-ACCESS  read-write
+    STATUS      deprecated
+    DESCRIPTION
+       "Enumerated value indicating what, if anything, is to be
+        included in the Sender ID TLV (21.5.3) transmitted by MHFs
+        created by the Default Maintenance Domain.  If this object
+        has the value sendIdDefer, Sender ID TLV transmission for
+        this VLAN is controlled by dot1agCfmDefaultMdDefIdPermission.
+
+        The value of this variable is meaningless if the values of
+        dot1agCfmDefaultMdStatus is false.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.3.1.3:e"
+    DEFVAL { sendIdDefer }
+    ::= { dot1agCfmDefaultMdEntry 6 }
+
+-- ******************************************************************
+-- The CFM configuration error list managed object. This group will
+-- contain all the MIB objects used to read the interfaces and VIDs
+-- configured incorrectly.
+-- ******************************************************************
+
+-- ******************************************************************
+-- The CFM Configuration Error List Table
+-- ******************************************************************
+
+dot1agCfmConfigErrorListTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmConfigErrorListEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The CFM Configuration Error List table provides a list of
+        Interfaces and VIDs that are incorrectly configured.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.4"
+    ::= {dot1agCfmConfigErrorList 1}
+
+dot1agCfmConfigErrorListEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmConfigErrorListEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The Config Error List Table  entry
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    INDEX { dot1agCfmConfigErrorListVid,
+            dot1agCfmConfigErrorListIfIndex
+          }
+    ::= { dot1agCfmConfigErrorListTable 1}
+
+Dot1agCfmConfigErrorListEntry ::= SEQUENCE {
+      dot1agCfmConfigErrorListVid         VlanId,
+      dot1agCfmConfigErrorListIfIndex     InterfaceIndex,
+      dot1agCfmConfigErrorListErrorType   Dot1agCfmConfigErrors
+    }
+
+
+dot1agCfmConfigErrorListVid OBJECT-TYPE
+    SYNTAX      VlanId
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The VLAN ID of the VLAN with interfaces in error.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.4.1.2:a"
+    ::= { dot1agCfmConfigErrorListEntry 1 }
+
+dot1agCfmConfigErrorListIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "This object is the IfIndex of the interface.
+
+        Upon a restart of the system, the system SHALL, if necessary,
+        change the value of this variable so that it indexes the
+        entry in the interface table with the same value of ifAlias
+        that it indexed before the system restart.  If no such
+        entry exists, then the system SHALL delete any entries in
+        dot1agCfmConfigErrorListTable indexed by that
+        InterfaceIndex value.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.4.1.2:b"
+    ::= { dot1agCfmConfigErrorListEntry 2 }
+
+dot1agCfmConfigErrorListErrorType OBJECT-TYPE
+    SYNTAX      Dot1agCfmConfigErrors
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+       "A vector of Boolean error conditions from 22.2.4, any of
+        which may be true:
+
+        0) CFMleak;
+        1) ConflictingVids;
+        2) ExcessiveLevels;
+        3) OverlappedLevels.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.4.1.3:b"
+    ::= { dot1agCfmConfigErrorListEntry 3 }
+
+-- ******************************************************************
+-- The Maintenance Domain Managed Object.  This group contains all  
+-- the MIB objects used to maintain Maintenance Domains.
+-- ******************************************************************
+
+dot1agCfmMdTableNextIndex OBJECT-TYPE
+    SYNTAX      Dot1afCfmIndexIntegerNextFree
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "This object contains an unused value for dot1agCfmMdIndex in
+        the dot1agCfmMdTable, or a zero to indicate that none exist.
+       "
+    ::= { dot1agCfmMd 1 }
+
+-- ******************************************************************
+-- The Maintenance Domain Table
+-- ******************************************************************
+
+dot1agCfmMdTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmMdEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Domain table. Each row in the table
+        represents a different Maintenance Domain.
+
+        A Maintenance Domain is described in 802.1ag (3.22) as the
+        network or the part of the network for which faults in
+        connectivity are to be managed. The boundary of a Maintenance
+        Domain is defined by a set of DSAPs, each of which can become
+        a point of connectivity to a service instance.
+       "
+    REFERENCE
+       "802.1ag clauses 3.22 and 18.1"
+    ::= { dot1agCfmMd 2 }
+
+dot1agCfmMdEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmMdEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Domain table entry. This entry is not lost
+        upon reboot. It is backed up by stable storage.
+       "
+    INDEX {dot1agCfmMdIndex }
+    ::= { dot1agCfmMdTable 1 }
+
+Dot1agCfmMdEntry ::= SEQUENCE {
+      dot1agCfmMdIndex                Unsigned32,
+      dot1agCfmMdFormat               Dot1agCfmMaintDomainNameType,
+      dot1agCfmMdName                 Dot1agCfmMaintDomainName,
+      dot1agCfmMdMdLevel              Dot1agCfmMDLevel,
+      dot1agCfmMdMhfCreation          Dot1agCfmMhfCreation,
+      dot1agCfmMdMhfIdPermission      Dot1agCfmIdPermission,
+      dot1agCfmMdMaNextIndex          Dot1afCfmIndexIntegerNextFree,
+      dot1agCfmMdRowStatus            RowStatus
+    }
+
+dot1agCfmMdIndex OBJECT-TYPE
+    SYNTAX      Unsigned32(1..4294967295)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The index to the Maintenance Domain table.
+
+        dot1agCfmMdTableNextIndex needs to be inspected to find an
+        available index for row-creation.
+
+        Referential integrity is required, i.e., the index needs to be
+        persistent upon a reboot or restart of a device.  The index
+        can never be reused for other Maintenance Domain.  The index
+        value SHOULD keep increasing up to the time that they wrap
+        around. This is to facilitate access control based on OID.
+       "
+    ::= { dot1agCfmMdEntry 1 }
+
+dot1agCfmMdFormat OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaintDomainNameType
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The type (and thereby format) of the Maintenance Domain Name."
+    REFERENCE
+       "21.6.5.1"
+    DEFVAL { charString }
+    ::= { dot1agCfmMdEntry 2 }
+
+dot1agCfmMdName OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaintDomainName
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Domain name. The type/format of this object
+        is determined by the value of the dot1agCfmMdNameType object.
+          
+        Each Maintenance Domain has unique name amongst all those
+        used or available to a service provider or operator.  It
+        facilitates easy identification of administrative
+        responsibility for each Maintenance Domain.
+
+        Clause 3.24 defines a Maintenance Domain name as the
+        identifier, unique over the domain for which CFM is to
+        protect against accidental concatenation of Service
+        Instances, of a particular Maintenance Domain.
+       "
+    REFERENCE
+       "802.1ag clauses 3.24, 12.14.5, and 21.6.5.3"
+    DEFVAL { "DEFAULT" }
+    ::= { dot1agCfmMdEntry 3 }
+
+dot1agCfmMdMdLevel OBJECT-TYPE
+    SYNTAX      Dot1agCfmMDLevel
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Domain Level."
+    REFERENCE
+       "12.14.5.1.3:b"
+    DEFVAL { 0 }
+    ::= { dot1agCfmMdEntry 4 }
+
+dot1agCfmMdMhfCreation OBJECT-TYPE
+    SYNTAX      Dot1agCfmMhfCreation {
+                  defMHFnone     (1),
+                  defMHFdefault  (2),
+                  defMHFexplicit (3)
+                }
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Enumerated value indicating whether the management entity can
+        create MHFs (MIP Half Function) for this Maintenance Domain.
+        Since, in this variable, there is no encompassing Maintenance
+        Domain, the value defMHFdefer is not allowed.
+       "
+    REFERENCE
+       "12.14.5.1.3:c"
+    DEFVAL { defMHFnone }
+    ::= { dot1agCfmMdEntry 5 }
+
+dot1agCfmMdMhfIdPermission OBJECT-TYPE
+    SYNTAX      Dot1agCfmIdPermission {
+                  sendIdNone          (1),
+                  sendIdChassis       (2),
+                  sendIdManage        (3),
+                  sendIdChassisManage (4)
+                }
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Enumerated value indicating what, if anything, is to be
+        included in the Sender ID TLV (21.5.3) transmitted by MPs
+        configured in this Maintenance Domain.  Since, in this
+        variable, there is no encompassing Maintenance Domain, the
+        value sendIdDefer is not allowed.
+       "
+    REFERENCE
+       "12.14.5.1.3:d"
+    DEFVAL { sendIdNone }
+    ::= { dot1agCfmMdEntry 6 }
+
+dot1agCfmMdMaNextIndex OBJECT-TYPE
+    SYNTAX      Dot1afCfmIndexIntegerNextFree
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Value to be used as the index of the MA table entries, both
+        the dot1agCfmMaNetTable and the dot1agCfmMaCompTable, for
+        this Maintenance Domain when the management entity wants to
+        create a new row in those tables.
+       "
+   ::= { dot1agCfmMdEntry 7 }
+
+dot1agCfmMdRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+       "
+    ::= { dot1agCfmMdEntry 8 }
+
+-- ******************************************************************
+-- The Maintenance Association Object. This group contains all the
+-- MIB objects used to read, create, modify, and delete Maintenance
+-- Associations in the MIB.
+-- ******************************************************************
+
+-- ******************************************************************
+-- The Maintenance Association (MA) Network Table
+-- ******************************************************************
+
+dot1agCfmMaNetTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmMaNetEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Association table.  Each row in the table
+        represents an MA.  An MA is a set of MEPs, each configured
+        with a single service instance.
+
+        This is the part of the complete MA table that is constant
+        across all Bridges in a Maintenance Domain, and across all
+        components of a single Bridge.  That part of the MA table that
+        can vary from Bridge component to Bridge component is contained
+        in the dot1agCfmMaCompTable.
+
+        Creation of a Service Instance establishes a connectionless
+        association among the selected DSAPs.  Configuring a
+        Maintenance association End Point (MEP) at each of the
+        DSAPs creates a Maintenance Association (MA) to monitor
+        that connectionless connectivity.  The MA is identified by a
+        Short MA Name that is unique within the Maintenance Domain
+        and chosen to facilitate easy identification of the Service
+        Instance.  Together, the Maintenance Domain Name and the
+        Short MA Name form the Maintenance Association Identifier
+        (MAID) that is carried in CFM Messages to identify
+        incorrect connectivity among Service Instances.  A small
+        integer, the Maintenance association End Point Identifier
+        (MEPID), identifies each MEP among those configured on a
+        single MA (802.1ag clauses 3.19 and 18.2).
+
+        This table uses two indices, first index is the index of the
+        Maintenance Domain table.  The second index is the same as the
+        index of the dot1agCfmMaCompEntry for the same MA.
+
+        The writable objects in this table need to be persistent
+        upon reboot or restart of a device.
+
+       "
+    REFERENCE
+       "18.2"
+    ::= { dot1agCfmMa 1 }
+
+dot1agCfmMaNetEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaNetEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The MA table entry."
+    INDEX {dot1agCfmMdIndex, dot1agCfmMaIndex }
+    ::= { dot1agCfmMaNetTable 1 }
+
+Dot1agCfmMaNetEntry ::= SEQUENCE {
+      dot1agCfmMaIndex                   Unsigned32,
+      dot1agCfmMaNetFormat               Dot1agCfmMaintAssocNameType,
+      dot1agCfmMaNetName                 Dot1agCfmMaintAssocName,
+      dot1agCfmMaNetCcmInterval          Dot1agCfmCcmInterval,
+      dot1agCfmMaNetRowStatus            RowStatus
+    }
+
+dot1agCfmMaIndex OBJECT-TYPE
+    SYNTAX      Unsigned32(1..4294967295)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+
+       "Index of the MA table dot1agCfmMdMaNextIndex needs to
+        be inspected to find an available index for row-creation.
+       "
+    ::= { dot1agCfmMaNetEntry 1 }
+
+dot1agCfmMaNetFormat OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaintAssocNameType
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The type (and thereby format) of the Maintenance Association
+        Name.
+       "
+    REFERENCE
+       "802.1ag clauses 21.6.5.4"
+    ::= { dot1agCfmMaNetEntry 2 }
+
+dot1agCfmMaNetName OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaintAssocName
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The Short Maintenance Association name. The type/format of
+        this object is determined by the value of the
+        dot1agCfmMaNetNameType object.  This name MUST be unique within
+        a maintenance domain.
+       "
+    REFERENCE
+       "802.1ag clauses 21.6.5.6, and Table 21-20"
+    ::= { dot1agCfmMaNetEntry 3 }
+
+dot1agCfmMaNetCcmInterval OBJECT-TYPE
+    SYNTAX      Dot1agCfmCcmInterval
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Interval between CCM transmissions to be used by all MEPs
+        in the MA.
+       "
+    REFERENCE
+       "12.14.6.1.3:e"
+    DEFVAL { interval1s }
+    ::= { dot1agCfmMaNetEntry 4 }
+
+dot1agCfmMaNetRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+       "
+    ::= { dot1agCfmMaNetEntry 5 }
+
+-- ******************************************************************
+-- The Maintenance Association (MA) Component Table
+-- ******************************************************************
+
+dot1agCfmMaCompTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmMaCompEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The Maintenance Association table.  Each row in the table
+        represents an MA.  An MA is a set of MEPs, each configured
+        with a single service instance.
+
+        This is the part of the complete MA table that is variable
+        across the Bridges in a Maintenance Domain, or across the
+        components of a single Bridge.  That part of the MA table that
+        is constant across the Bridges and their components in a
+        Maintenance Domain is contained in the dot1agCfmMaNetTable.
+
+        This table uses three indices, first index is the
+        Dot1agCfmPbbComponentIdentifier that identifies the component
+        within the Bridge for which the information in the
+        dot1agCfmMaCompEntry applies.  The second is the index of the
+        Maintenance Domain table.  The third index is the same as the
+        index of the dot1agCfmMaNetEntry for the same MA.
+
+        The writable objects in this table need to be persistent
+        upon reboot or restart of a device.
+
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "18.2"
+    ::= { dot1agCfmMa 2 }
+
+dot1agCfmMaCompEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaCompEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The MA table entry.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    INDEX {dot1agCfmMaComponentId,
+           dot1agCfmMdIndex, dot1agCfmMaIndex }
+    ::= { dot1agCfmMaCompTable 1 }
+
+Dot1agCfmMaCompEntry ::= SEQUENCE {
+      dot1agCfmMaComponentId         Dot1agCfmPbbComponentIdentifier,
+      dot1agCfmMaCompPrimaryVlanId   VlanIdOrNone,
+      dot1agCfmMaCompMhfCreation     Dot1agCfmMhfCreation,
+      dot1agCfmMaCompIdPermission    Dot1agCfmIdPermission,
+      dot1agCfmMaCompNumberOfVids    Unsigned32,
+      dot1agCfmMaCompRowStatus       RowStatus
+    }
+
+dot1agCfmMaComponentId OBJECT-TYPE
+    SYNTAX      Dot1agCfmPbbComponentIdentifier
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The bridge component within the system to which the information
+        in this dot1agCfmMaCompEntry applies.  If the system is not a
+        Bridge, or if only one component is present in the Bridge, then
+        this variable (index) MUST be equal to 1.
+    **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.3 l)"
+    ::= { dot1agCfmMaCompEntry 1 }
+
+dot1agCfmMaCompPrimaryVlanId OBJECT-TYPE
+    SYNTAX      VlanIdOrNone
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "The Primary VLAN ID with which the Maintenance Association is
+        associated, or 0 if the MA is not attached to any VID.  If
+        the MA is associated with more than one VID, the
+        dot1agCfmVlanTable lists them.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.6.1.3:b"
+    ::= { dot1agCfmMaCompEntry 2 }
+
+dot1agCfmMaCompMhfCreation OBJECT-TYPE
+    SYNTAX      Dot1agCfmMhfCreation
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "Indicates if the Management entity can create MHFs (MIP Half
+        Function) for this MA.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.6.1.3:c"
+    DEFVAL { defMHFdefer }
+    ::= { dot1agCfmMaCompEntry 3 }
+
+dot1agCfmMaCompIdPermission OBJECT-TYPE
+    SYNTAX      Dot1agCfmIdPermission
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "Enumerated value indicating what, if anything, is to be
+        included in the Sender ID TLV (21.5.3) transmitted by MPs
+        configured in this MA.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.6.1.3:d"
+    DEFVAL { sendIdDefer }
+    ::= { dot1agCfmMaCompEntry 4 }
+
+dot1agCfmMaCompNumberOfVids OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "The number of VIDs associated with the MA.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    REFERENCE
+       "12.14.6.1.3:b"
+    ::= { dot1agCfmMaCompEntry 5 }
+
+dot1agCfmMaCompRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      deprecated
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+        **NOTE: this object is deprecated due to re-indexing of the 
+    table.
+       "
+    ::= { dot1agCfmMaCompEntry 6 }
+
+-- ******************************************************************
+-- The list of known MEPs for a given MA
+-- ******************************************************************
+
+dot1agCfmMaMepListTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmMaMepListEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "List of MEPIDs that belong to this MA.
+ 
+        Clause 12.14.6.1.3 specifies that a list of MEPIDs in all
+        bridges in that MA, but since SNMP SMI does not allow to
+        state in a MIB that an object in a table is an array, the 
+        information has to be stored in another table with two
+        indices, being the first index, the index of the table that 
+        contains the list or array.
+
+        For all bridges in which the same MAID {dot1agCfmMdFormat,
+        dot1agCfmMdName, dot1agCfmMaNetFormat, and dot1agCfmMaNetName}
+        is configured, the same set of dot1agCfmMaMepListIdentifiers
+        MUST be configured in the bridges' dot1agCfmMaMepListTables.
+        This allows each MEP to determine whether or not it is
+        receiving CCMs from all of the other MEPs in the MA.
+
+        For example, if one were creating a new MA whose MAID were
+        {charString, 'Dom1', charString, 'MA1'}, that had 2 MEPs, whose
+        MEPIDs were 1 and 3, one could, in Bridge A:
+         1. Get a new MD index d from dot1agCfmMdTableNextIndex.
+         2. Create the Maintenance Domain {charString, 'Dom1'}.
+         3. Get a new MA index a from dot1agCfmMdMaNextIndex [d].
+         4. Create the Maintenance Association {charString, 'MA1'}.
+         5. Create a new dot1agCfmMaMepListEntry for each of the MEPs
+            in the MA: [d, a, 1] and [d, a, 3].
+         6. Create one of the new MEPs, say [d, a, 1].
+        Then, in Bridge B:
+         7. Do all of these steps 1-6, except for using the other MEPID
+            for the new MEP in Step 6, in this example, MEPID 3.
+        Note that, when creating the MA, MEP List Table, and MEP
+        entries in the second bridge, the indices 'd' and 'a'
+        identifying the MAID {charString, 'Dom1', charString, 'MA1'}
+        may have different values than those in the first Bridge.
+       "
+    REFERENCE
+       "12.14.6.1.3:g"
+    ::= { dot1agCfmMa 3 }
+
+dot1agCfmMaMepListEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmMaMepListEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The known MEPS table entry."
+    INDEX { dot1agCfmMdIndex,
+            dot1agCfmMaIndex,
+            dot1agCfmMaMepListIdentifier
+          }
+    ::= { dot1agCfmMaMepListTable 1 }
+
+Dot1agCfmMaMepListEntry ::= SEQUENCE {
+      dot1agCfmMaMepListIdentifier  Dot1agCfmMepId,
+      dot1agCfmMaMepListRowStatus   RowStatus
+    }
+
+dot1agCfmMaMepListIdentifier OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepId
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "MEPID"
+    REFERENCE
+       "12.14.6.1.3:g"
+    ::= { dot1agCfmMaMepListEntry 1 }
+
+dot1agCfmMaMepListRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The status of the row. Read SNMPv2-TC (RFC1903) for an
+        explanation of the possible values this object can take.
+       "
+    ::= { dot1agCfmMaMepListEntry 2 }
+
+-- ******************************************************************
+-- The MEP Object.  This object represents a Maintenance End
+-- Point as described in 802.1ag document.
+-- ******************************************************************
+
+-- ******************************************************************
+-- The MEP Table
+-- ******************************************************************
+
+dot1agCfmMepTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmMepEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Association End Point (MEP) table.
+
+        Each row in the table represents a different MEP.  A MEP is
+        an actively managed CFM entity, associated with a specific
+        DSAP of a Service Instance, which can generate and receive
+        CFM PDUs and track any responses.  It is an end point of a
+        single Maintenance Association, and is an endpoint of a
+        separate Maintenance Entity for each of the other MEPs in
+        the same Maintenance Association (802.1ag clause 3.19).
+
+        This table uses three indices. The first two indices are the
+        indices of the Maintenance Domain and MA tables, the reason
+        being that a MEP is always related to an MA and Maintenance
+        Domain.
+
+        The MEP table also stores all the managed objects for sending
+        LBM and LTM.
+
+        *LBM Managed objects
+
+        LBM Managed objects in the MEP table
+        enables the management entity to initiate
+        transmission of Loopback messages.  It will signal the MEP
+        that it SHOULD transmit some number of Loopback messages
+        and detect the detection (or lack thereof) of the
+        corresponding Loopback messages.
+
+        Steps to use entries in this table:
+
+        1) Wait for dot1agCfmMepTransmitLbmStatus value to be
+           false.  To do this do this sequence:
+           a. an SNMP GET for both SnmpSetSerialNo and
+              dot1agCfmMepTransmitLbmStatus objects (in same SNMP
+              PDU).
+           b. Check if value for dot1agCfmMepTransmitLbmStatus is false.
+              - if not, wait x seconds, go to step a above.
+              - if yes, save the value of SnmpSetSerialNo and go
+                to step 2) below
+        2) Change dot1agCfmMepTransmitLbmStatus value from false to
+           true to ensure no other management entity will use
+           the service. In order to not disturb a possible other NMS
+           do this by sending an SNMP SET for both SnmpSetSerialNo
+           and dot1agCfmMepTransmitLbmStatus objects (in same SNMP
+           PDU,  and make sure SNmpSetSerialNo is the first varBind).
+           For the SnmpSetSerialNo varBind, use the value that you
+           obtained in step 1)a.. This ensures that two cooperating
+           NMSes will not step on each others toes.
+           Setting this MIB object does not set the corresponding
+           LBIactive state machine variable.
+        3) Setup the different data to be sent (number of messages,
+           optional TLVs,...), except do not set
+           dot1agCfmMepTransmitLbmMessages.
+        4) Record the current values of dot1agCfmMepLbrIn,
+           dot1agCfmMepLbrInOutOfOrder, and dot1agCfmMepLbrBadMsdu.
+        6) Set dot1agCfmMepTransmitLbmMessages to a non-zero value to
+           initiate transmission of Loopback messages.
+           The dot1agCfmMepTransmitLbmMessages indicates the
+           number of LBMs to be sent and is not decremented as
+           loopbacks are actually sent. dot1agCfmMepTransmitLbmMessages
+           is not equivalent to the LBMsToSend state machine variable.
+        7) Check the value of dot1agCfmMepTransmitLbmResultOK to
+           find out if the operation was successfully initiated or
+           not.
+        8) Monitor the value of dot1agCfmMepTransmitLbmStatus.
+           When it is reset to false, the last LBM has been transmitted.
+           Wait an additional 5 seconds to ensure that all LBRs have
+           been returned.
+        9) Compare dot1agCfmMepLbrIn, dot1agCfmMepLbrInOutOfOrder,
+           and dot1agCfmMepLbrBadMsdu to their old values from step
+           4, above, to get the results of the test.
+
+        *LTM Managed objects
+        The LTM Managed objects in the MEP table are used in a manner
+        similar to that described for LBM transmission, above.  Upon
+        successfully initiating the transmission, the variables
+        dot1agCfmMepTransmitLtmSeqNumber and
+        dot1agCfmMepTransmitLtmEgressIdentifier return the information
+        required to recover the results of the LTM from the
+        dot1agCfmLtrTable.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7 and 19.2"
+    ::= { dot1agCfmMep 1 }
+
+dot1agCfmMepEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The MEP table entry"
+    INDEX { dot1agCfmMdIndex,
+            dot1agCfmMaIndex,
+            dot1agCfmMepIdentifier
+          }
+    ::= { dot1agCfmMepTable 1 }
+
+Dot1agCfmMepEntry ::= SEQUENCE {
+      dot1agCfmMepIdentifier                   Dot1agCfmMepId,
+      dot1agCfmMepIfIndex                      InterfaceIndexOrZero,
+      dot1agCfmMepDirection                    Dot1agCfmMpDirection,
+      dot1agCfmMepPrimaryVid                   Unsigned32,
+      dot1agCfmMepActive                       TruthValue,
+      dot1agCfmMepFngState                     Dot1agCfmFngState,
+      dot1agCfmMepCciEnabled                   TruthValue,
+      dot1agCfmMepCcmLtmPriority               Unsigned32,
+      dot1agCfmMepMacAddress                   MacAddress,
+      dot1agCfmMepLowPrDef                 Dot1agCfmLowestAlarmPri,
+      dot1agCfmMepFngAlarmTime                 TimeInterval,
+      dot1agCfmMepFngResetTime                 TimeInterval,
+      dot1agCfmMepHighestPrDefect          Dot1agCfmHighestDefectPri,
+      dot1agCfmMepDefects                      Dot1agCfmMepDefects,
+      dot1agCfmMepErrorCcmLastFailure          OCTET STRING,
+      dot1agCfmMepXconCcmLastFailure           OCTET STRING,
+      dot1agCfmMepCcmSequenceErrors            Counter32,
+      dot1agCfmMepCciSentCcms                  Counter32,
+      dot1agCfmMepNextLbmTransId               Unsigned32,
+      dot1agCfmMepLbrIn                        Counter32,
+      dot1agCfmMepLbrInOutOfOrder              Counter32,
+      dot1agCfmMepLbrBadMsdu                   Counter32,
+      dot1agCfmMepLtmNextSeqNumber             Unsigned32,
+      dot1agCfmMepUnexpLtrIn                   Counter32,
+      dot1agCfmMepLbrOut                       Counter32,
+      dot1agCfmMepTransmitLbmStatus            TruthValue,
+      dot1agCfmMepTransmitLbmDestMacAddress    MacAddress,
+      dot1agCfmMepTransmitLbmDestMepId         Dot1agCfmMepIdOrZero,
+      dot1agCfmMepTransmitLbmDestIsMepId       TruthValue,
+      dot1agCfmMepTransmitLbmMessages          Integer32,
+      dot1agCfmMepTransmitLbmDataTlv           OCTET STRING,
+      dot1agCfmMepTransmitLbmVlanPriority      Integer32,
+      dot1agCfmMepTransmitLbmVlanDropEnable    TruthValue,
+      dot1agCfmMepTransmitLbmResultOK          TruthValue,
+      dot1agCfmMepTransmitLbmSeqNumber         Unsigned32,
+      dot1agCfmMepTransmitLtmStatus            TruthValue,
+      dot1agCfmMepTransmitLtmFlags             BITS,
+      dot1agCfmMepTransmitLtmTargetMacAddress  MacAddress,
+      dot1agCfmMepTransmitLtmTargetMepId       Dot1agCfmMepIdOrZero,
+      dot1agCfmMepTransmitLtmTargetIsMepId     TruthValue,
+      dot1agCfmMepTransmitLtmTtl               Unsigned32,
+      dot1agCfmMepTransmitLtmResult            TruthValue,
+      dot1agCfmMepTransmitLtmSeqNumber         Unsigned32,
+      dot1agCfmMepTransmitLtmEgressIdentifier  OCTET STRING,
+      dot1agCfmMepRowStatus                    RowStatus,
+      dot1agCfmMepPbbTeCanReportPbbTePresence     TruthValue,
+      dot1agCfmMepPbbTeTrafficMismatchDefect      TruthValue,
+      dot1agCfmMepPbbTransmitLbmLtmReverseVid     IEEE8021VlanIndex,
+      dot1agCfmMepPbbTeMismatchAlarm              TruthValue,
+      dot1agCfmMepPbbTeLocalMismatchDefect        TruthValue,
+      dot1agCfmMepPbbTeMismatchSinceReset         TruthValue
+    }
+
+dot1agCfmMepIdentifier OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepId
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Integer that is unique among all the MEPs in the same MA.
+        Other definition is: a small integer, unique over a given
+        Maintenance Association, identifying a specific Maintenance
+        association End Point (3.19).
+
+        MEP Identifier is also known as the MEPID.
+       "
+    REFERENCE
+       "802.1ag clauses 3.19, 19.2 and 12.14.7"
+    ::= { dot1agCfmMepEntry 1 }
+
+dot1agCfmMepIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "This object is the interface index of the interface either a
+        bridge port, or an aggregated IEEE 802.1 link within a bridge
+        port, to which the MEP is attached.
+
+        Upon a restart of the system, the system SHALL, if necessary,
+        change the value of this variable so that it indexes the
+        entry in the interface table with the same value of ifAlias
+        that it indexed before the system restart.  If no such
+        entry exists, then the system SHALL set this variable to 0.
+       "
+    REFERENCE
+       "12.14.7.1.3:b"
+    ::= { dot1agCfmMepEntry 2 }
+
+dot1agCfmMepDirection OBJECT-TYPE
+    SYNTAX      Dot1agCfmMpDirection
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The direction in which the MEP faces on the Bridge port."
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:c and 19.2"
+    ::= { dot1agCfmMepEntry 3 }
+
+dot1agCfmMepPrimaryVid OBJECT-TYPE
+    SYNTAX      Unsigned32(0..16777215)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "An integer indicating the Primary VID of the MEP, always
+        one of the VIDs assigned to the MEP's MA.  The value 0
+        indicates that either the Primary VID is that of the
+        MEP's MA, or that the MEP's MA is associated with no VID."
+   REFERENCE
+       "802.1ag clauses 12.14.7.1.3:d"
+   DEFVAL { 0 }
+    ::= { dot1agCfmMepEntry 4 }
+
+dot1agCfmMepActive OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Administrative state of the MEP
+
+        A Boolean indicating the administrative state of the MEP.
+
+        True indicates that the MEP is to function normally, and
+        false that it is to cease functioning."
+   REFERENCE
+       "802.1ag clauses 12.14.7.1.3:e and 20.9.1"
+   DEFVAL { false }
+   ::= { dot1agCfmMepEntry 5 }
+
+dot1agCfmMepFngState OBJECT-TYPE
+    SYNTAX      Dot1agCfmFngState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Current state of the MEP Fault Notification Generator
+        State Machine.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:f and 20.35"
+    DEFVAL { fngReset }
+    ::= { dot1agCfmMepEntry 6 }
+
+dot1agCfmMepCciEnabled OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "If set to true, the MEP will generate CCM messages."
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:g and 20.10.1"
+    DEFVAL { false }
+    ::= { dot1agCfmMepEntry 7 }
+
+dot1agCfmMepCcmLtmPriority OBJECT-TYPE
+    SYNTAX      Unsigned32 (0..7)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The priority value for CCMs and LTMs transmitted by the MEP.
+        Default Value is the highest priority value allowed to pass
+        through the bridge port for any of this MEPs VIDs.
+        The management entity can obtain the default value for this 
+        variable from the priority regeneration table by extracting the 
+        highest priority value in this table on this MEPs bridge port.
+        (1 is lowest, then 2, then 0, then 3-7).
+       "
+    REFERENCE
+       "12.14.7.1.3:h"
+    ::= { dot1agCfmMepEntry 8 }
+
+dot1agCfmMepMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "MAC address of the MEP."
+    REFERENCE
+      "12.14.7.1.3:i and 19.4"
+    ::= { dot1agCfmMepEntry 9 }
+
+dot1agCfmMepLowPrDef OBJECT-TYPE
+    SYNTAX      Dot1agCfmLowestAlarmPri
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "An integer value specifying the lowest priority defect 
+        that is allowed to generate fault alarm.
+       "
+    REFERENCE
+       "12.14.7.1.3:k and 20.9.5 and Table 20-1"
+    DEFVAL { macRemErrXcon }
+    ::= { dot1agCfmMepEntry 10}
+
+dot1agCfmMepFngAlarmTime OBJECT-TYPE
+    SYNTAX      TimeInterval (250..1000)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The time that defects MUST be present before a Fault Alarm is
+        issued (fngAlarmTime. 20.33.3) (default 2.5s).
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:l and 20.33.3"
+    DEFVAL { 250 }
+    ::= { dot1agCfmMepEntry 11 }
+
+dot1agCfmMepFngResetTime OBJECT-TYPE
+    SYNTAX      TimeInterval (250..1000)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The time that defects MUST be absent before resetting a
+        Fault Alarm (fngResetTime, 20.33.4) (default 10s).
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:m and 20.33.4"
+    DEFVAL { 1000 }
+    ::= { dot1agCfmMepEntry 12 }
+   
+dot1agCfmMepHighestPrDefect OBJECT-TYPE
+    SYNTAX   Dot1agCfmHighestDefectPri
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The highest priority defect that has been present since the
+        MEPs Fault Notification Generator State Machine was last in
+        the FNG_RESET state.
+       "
+    REFERENCE
+       "12.14.7.1.3:n  20.33.9 and Table 21-1"
+    ::= { dot1agCfmMepEntry 13 }
+
+dot1agCfmMepDefects OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepDefects
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "A vector of Boolean error conditions from Table 20-1, any of
+        which may be true:
+
+        DefRDICCM(0)
+        DefMACstatus(1)
+        DefRemoteCCM(2)
+        DefErrorCCM(3)
+        DefXconCCM(4)
+       "
+    REFERENCE
+       ".1ag clauses 12.14.7.1.3:o, 12.14.7.1.3:p, 12.14.7.1.3:q,
+        12.14.7.1.3:r, 12.14.7.1.3:s, 20.21.3, 20.23.3, 20.33.5,
+        20.33.6, 20.33.7."
+    ::= { dot1agCfmMepEntry 14 }
+
+dot1agCfmMepErrorCcmLastFailure OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..1522))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The last-received CCM that triggered an DefErrorCCM fault."
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:t and 20.21.2"
+    ::= { dot1agCfmMepEntry 15 }
+
+dot1agCfmMepXconCcmLastFailure OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..1522))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The last-received CCM that triggered a DefXconCCM fault."
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:u and 20.23.2"
+    ::= { dot1agCfmMepEntry 16 }
+
+dot1agCfmMepCcmSequenceErrors OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The total number of out-of-sequence CCMs received from all
+        remote MEPs.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:v and 20.16.12"
+    ::= { dot1agCfmMepEntry 17 }
+
+dot1agCfmMepCciSentCcms OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Total number of Continuity Check messages transmitted."
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:w and 20.10.2"
+    ::= { dot1agCfmMepEntry 18 }
+
+dot1agCfmMepNextLbmTransId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Next sequence number/transaction identifier to be sent in a
+        Loopback message. This sequence number can be zero because
+        it wraps around.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.1.3:x and 20.28.2"
+    ::= { dot1agCfmMepEntry 19 }
+
+dot1agCfmMepLbrIn OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Total number of valid, in-order Loopback Replies received."
+    REFERENCE
+       "12.14.7.1.3:y and 20.31.1"
+    ::= { dot1agCfmMepEntry 20 }
+
+dot1agCfmMepLbrInOutOfOrder OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The total number of valid, out-of-order Loopback Replies
+        received.
+       "
+    REFERENCE
+       "12.14.7.1.3:z and 20.31.1"
+    ::= { dot1agCfmMepEntry 21 }
+
+dot1agCfmMepLbrBadMsdu OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The total number of LBRs received whose
+        mac_service_data_unit did not match (except for the OpCode)
+        that of the corresponding LBM (20.2.3).
+       "
+    REFERENCE
+       "12.14.7.1.3:aa  20.2.3"
+    ::= { dot1agCfmMepEntry 22}
+
+dot1agCfmMepLtmNextSeqNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Next transaction identifier/sequence number to be sent in a
+        Linktrace message. This sequence number can be zero because
+        it wraps around.
+       "
+    REFERENCE
+       "12.14.7.1.3:ab and 20.36.1"
+    ::= { dot1agCfmMepEntry 23 }
+
+dot1agCfmMepUnexpLtrIn OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The total number of unexpected LTRs received (20.39.1).
+       "
+    REFERENCE
+       "12.14.7.1.3:ac  20.39.1"
+    ::= { dot1agCfmMepEntry 24 }
+
+dot1agCfmMepLbrOut OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Total number of Loopback Replies transmitted."
+    REFERENCE
+       "12.14.7.1.3:ad and 20.26.2"
+    ::= { dot1agCfmMepEntry 25 }
+
+dot1agCfmMepTransmitLbmStatus OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "A Boolean flag set to true by the MEP Loopback Initiator State
+       Machine or an MIB manager to indicate
+       that another LBM is being transmitted.
+       Reset to false by the MEP Loopback Initiator State Machine."
+   DEFVAL { false }
+   ::= { dot1agCfmMepEntry 26 }
+
+dot1agCfmMepTransmitLbmDestMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The Target MAC Address Field to be transmitted: A unicast
+        destination MAC address.
+        This address will be used if the value of the column
+        dot1agCfmMepTransmitLbmDestIsMepId is 'false'.
+       "
+    REFERENCE
+       "12.14.7.3.2:b"
+    ::= { dot1agCfmMepEntry 27 }
+
+dot1agCfmMepTransmitLbmDestMepId OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepIdOrZero
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance association End Point Identifier of another
+        MEP in the same Maintenance Association to which the LBM is
+        to be sent.
+        This address will be used if the value of the column
+        dot1agCfmMepTransmitLbmDestIsMepId is 'true'.
+       "
+    REFERENCE
+       "12.14.7.3.2:b"
+    ::= { dot1agCfmMepEntry 28 }
+
+dot1agCfmMepTransmitLbmDestIsMepId OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "True indicates that MEPID of the target MEP is used for
+        Loopback transmission.
+        False indicates that unicast destination MAC address of the
+        target MEP is used for Loopback transmission.
+       "
+    REFERENCE
+       "12.14.7.3.2:b"
+    ::= {dot1agCfmMepEntry 29 }
+
+dot1agCfmMepTransmitLbmMessages OBJECT-TYPE
+    SYNTAX      Integer32(1..1024)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The number of Loopback messages to be transmitted."
+    REFERENCE
+       "12.14.7.3.2:c"
+    DEFVAL { 1 }
+    ::= {dot1agCfmMepEntry 30 }
+
+dot1agCfmMepTransmitLbmDataTlv OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "An arbitrary amount of data to be included in the Data TLV,
+        if the Data TLV is selected to be sent.  The intent is to be able
+        to fill the frame carrying the CFM PDU to its maximum length.
+        This may lead to fragmentation in some cases.
+       "
+    REFERENCE
+       "12.14.7.3.2:d"
+    ::= { dot1agCfmMepEntry 31 }
+
+dot1agCfmMepTransmitLbmVlanPriority OBJECT-TYPE
+    SYNTAX      Integer32(0..7)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Priority. 3 bit value to be used in the VLAN tag, if present
+        in the transmitted frame.
+
+        The default value is CCM priority.
+       "
+    REFERENCE
+       "12.14.7.3.2:e"
+    ::= { dot1agCfmMepEntry 32 }
+
+dot1agCfmMepTransmitLbmVlanDropEnable OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Drop Enable bit value to be used in the VLAN tag, if present
+        in the transmitted frame.
+
+        For more information about VLAN Drop Enable, please check
+        IEEE 802.1ad.
+       "
+    REFERENCE
+       "12.14.7.3.2:e"
+    DEFVAL { true }
+    ::= { dot1agCfmMepEntry 33 }
+
+dot1agCfmMepTransmitLbmResultOK OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Indicates the result of the operation:
+
+        - true       The Loopback Message(s) will be
+                     (or has been) sent.
+        - false      The Loopback Message(s) will not
+                     be sent.
+       "
+    REFERENCE
+       "12.14.7.3.3:a"
+    DEFVAL { true }
+    ::= { dot1agCfmMepEntry 34 }
+
+dot1agCfmMepTransmitLbmSeqNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The Loopback Transaction Identifier
+       (dot1agCfmMepNextLbmTransId) of the first LBM (to be) sent.
+        The value returned is undefined if
+        dot1agCfmMepTransmitLbmResultOK is false.
+       "
+    REFERENCE
+       "12.14.7.3.3:a"
+    ::= { dot1agCfmMepEntry 35 }
+
+dot1agCfmMepTransmitLtmStatus OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "A Boolean flag set to true by the bridge port to indicate
+       that another LTM may be transmitted. 
+       Reset to false by the MEP Linktrace Initiator State Machine."
+   DEFVAL { true }
+   ::= { dot1agCfmMepEntry 36 }
+
+dot1agCfmMepTransmitLtmFlags OBJECT-TYPE
+    SYNTAX      BITS {
+                  useFDBonly   (0)
+                }
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The flags field for LTMs transmitted by the MEP."
+    REFERENCE
+       "12.14.7.4.2:b and 20.37.1"
+    DEFVAL { {useFDBonly } }
+    ::= { dot1agCfmMepEntry 37 }
+
+dot1agCfmMepTransmitLtmTargetMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The Target MAC Address Field to be transmitted: A unicast
+        destination MAC address.
+        This address will be used if the value of the column
+        dot1agCfmMepTransmitLtmTargetIsMepId is 'false'.
+       "
+    REFERENCE
+       "12.14.7.4.2:c"
+    ::= { dot1agCfmMepEntry 38 }
+
+dot1agCfmMepTransmitLtmTargetMepId OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepIdOrZero
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "An indication of the Target MAC Address Field to be
+        transmitted:
+        The Maintenance association End Point Identifier of
+        another MEP in the same Maintenance Association
+        This address will be used if the value of the column
+        dot1agCfmMepTransmitLtmTargetIsMepId is 'true'.
+       "
+    REFERENCE
+       "12.14.7.4.2:c"
+    ::= { dot1agCfmMepEntry 39 }
+
+dot1agCfmMepTransmitLtmTargetIsMepId OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "True indicates that MEPID of the target MEP is used for
+        Linktrace transmission.
+        False indicates that unicast destination MAC address of the
+        target MEP is used for Loopback transmission.
+       "
+    REFERENCE
+       "12.14.7.4.2:c"
+    ::= { dot1agCfmMepEntry 40 }
+
+dot1agCfmMepTransmitLtmTtl OBJECT-TYPE
+    SYNTAX      Unsigned32 (0..255)
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The LTM TTL field. Default value, if not specified, is 64.
+        The TTL field indicates the number of hops remaining to the
+        LTM.  Decremented by 1 by each Linktrace Responder that
+        handles the LTM.  The value returned in the LTR is one less
+        than that received in the LTM.  If the LTM TTL is 0 or 1, the
+        LTM is not forwarded to the next hop, and if 0, no LTR is
+        generated.
+       "
+    REFERENCE
+       "12.14.7.4.2:d and 21.8.4"
+    DEFVAL {64}
+    ::= { dot1agCfmMepEntry 41 }
+
+dot1agCfmMepTransmitLtmResult OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Indicates the result of the operation:
+
+        - true    The Linktrace Message will be (or has been) sent.
+        - false   The Linktrace Message will not be sent"
+    REFERENCE
+       "12.14.7.4.3:a"
+    DEFVAL { true }
+    ::= { dot1agCfmMepEntry 42 }
+
+dot1agCfmMepTransmitLtmSeqNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The LTM Transaction Identifier
+        (dot1agCfmMepLtmNextSeqNumber) of the LTM sent.
+        The value returned is undefined if
+        dot1agCfmMepTransmitLtmResult is false.
+       "
+    REFERENCE
+       "12.14.7.4.3:a"
+    ::= { dot1agCfmMepEntry 43 }
+
+dot1agCfmMepTransmitLtmEgressIdentifier OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(8))
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Identifies the MEP Linktrace Initiator that is originating,
+        or the Linktrace Responder that is forwarding, this LTM.
+        The low-order six octets contain a 48-bit IEEE MAC address
+        unique to the system in which the MEP Linktrace Initiator
+        or Linktrace Responder resides.  The high-order two octets
+        contain a value sufficient to uniquely identify the MEP
+        Linktrace Initiator or Linktrace Responder within that system.
+
+        For most Bridges, the address of any MAC attached to the
+        Bridge will suffice for the low-order six octets, and 0 for
+        the high-order octets.  In some situations, e.g., if multiple
+        virtual Bridges utilizing emulated LANs are implemented in a
+        single physical system, the high-order two octets can be used
+        to differentiate among the transmitting entities.
+
+        The value returned is undefined if
+        dot1agCfmMepTransmitLtmResult is false.
+       "
+    REFERENCE
+       "12.14.7.4.3:b and 21.8.8"
+    ::= { dot1agCfmMepEntry 44 }
+   
+dot1agCfmMepRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+       "
+   ::= { dot1agCfmMepEntry 45 }
+
+dot1agCfmMepPbbTeCanReportPbbTePresence OBJECT-TYPE
+   SYNTAX       TruthValue
+   MAX-ACCESS   read-create
+   STATUS       current
+   DESCRIPTION
+      "A Boolean valued parameter that is set to true if the system
+       has the capability to report the presence of traffic and that
+       the capability is enabled. Traffic presence reporting is an
+       optional PBB-TE feature."
+   REFERENCE
+      "12.14.7.1.3:af and 21.6.1.4"
+   DEFVAL { false }
+   ::= { dot1agCfmMepEntry 46 }
+
+dot1agCfmMepPbbTeTrafficMismatchDefect OBJECT-TYPE
+   SYNTAX       TruthValue
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+      "A Boolean valued parameter that is set to true if the system
+       has detected a traffic field mismatch defect.  Mismatch detection
+        is an optional PBB-TE feature."
+   REFERENCE
+      "12.14.7.1.3:ah and 21.6.1.4"
+   ::= { dot1agCfmMepEntry 47 }
+
+dot1agCfmMepPbbTransmitLbmLtmReverseVid OBJECT-TYPE
+   SYNTAX       IEEE8021VlanIndex
+   MAX-ACCESS   read-create
+   STATUS       current
+   DESCRIPTION
+      "This column specifies the value to use in the Reverse VID value
+       field of PBB-TE MIP TLVs contained within TransmitLTM pdus."
+   REFERENCE
+      "12.14.7.4.2"
+   ::= { dot1agCfmMepEntry 48 }
+
+dot1agCfmMepPbbTeMismatchAlarm OBJECT-TYPE
+   SYNTAX       TruthValue
+   MAX-ACCESS   read-create
+   STATUS       current
+   DESCRIPTION
+      "A Boolean valued parameter that is set to true if the system
+       is to allow a mismatch defect to generate a fault alarm."
+   REFERENCE
+      "12.14.7.1.3:ag and 21.6.1.4"
+   DEFVAL { false }
+   ::= { dot1agCfmMepEntry 49 }
+
+dot1agCfmMepPbbTeLocalMismatchDefect OBJECT-TYPE
+   SYNTAX       TruthValue
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+      "A Boolean valued parameter that is set to true if the system
+       has detected a local mismatch defect.  Mismatch detection
+       is an optional PBB-TE feature."
+   REFERENCE
+      "12.14.7.1.3:ai and 21.6.1.4"
+   ::= { dot1agCfmMepEntry 50 }
+
+dot1agCfmMepPbbTeMismatchSinceReset OBJECT-TYPE
+   SYNTAX       TruthValue
+   MAX-ACCESS   read-only
+   STATUS       current
+   DESCRIPTION
+      "A Boolean valued parameter indicating if the mismatch defect
+       has been present since the MEP Mismatch Fault Notification
+       Generator was last in the MFNG_RESET state."
+   REFERENCE
+      "12.14.7.1.3:aj"
+   ::= { dot1agCfmMepEntry 51 }
+
+
+
+-- ******************************************************************
+-- The Linktrace Reply Table
+-- ******************************************************************
+
+dot1agCfmLtrTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmLtrEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "This table extends the MEP table and contains a list of
+        Linktrace replies received by a specific MEP in response to
+        a linktrace message.
+
+        SNMP SMI does not allow to state in a MIB that an object in
+        a table is an array.  The solution is to take the index (or
+        indices) of the first table and add one or more indices.
+       "
+    REFERENCE
+       "12.14.7.5"
+    ::= { dot1agCfmMep 2 }
+
+dot1agCfmLtrEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmLtrEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Linktrace Reply table entry."
+    INDEX { dot1agCfmMdIndex,
+            dot1agCfmMaIndex,
+            dot1agCfmMepIdentifier,
+            dot1agCfmLtrSeqNumber,
+            dot1agCfmLtrReceiveOrder
+          }
+    ::= { dot1agCfmLtrTable 1 }
+
+Dot1agCfmLtrEntry ::= SEQUENCE {
+      dot1agCfmLtrSeqNumber            Unsigned32,
+      dot1agCfmLtrReceiveOrder         Unsigned32,
+      dot1agCfmLtrTtl                  Unsigned32,
+      dot1agCfmLtrForwarded            TruthValue,
+      dot1agCfmLtrTerminalMep          TruthValue,
+      dot1agCfmLtrLastEgressIdentifier OCTET STRING,
+      dot1agCfmLtrNextEgressIdentifier OCTET STRING,
+      dot1agCfmLtrRelay            Dot1agCfmRelayActionFieldValue,
+      dot1agCfmLtrChassisIdSubtype     LldpChassisIdSubtype,
+      dot1agCfmLtrChassisId            LldpChassisId,
+      dot1agCfmLtrManAddressDomain     TDomain,
+      dot1agCfmLtrManAddress           TAddress,
+      dot1agCfmLtrIngress          Dot1agCfmIngressActionFieldValue,
+      dot1agCfmLtrIngressMac           MacAddress,
+      dot1agCfmLtrIngressPortIdSubtype LldpPortIdSubtype,
+      dot1agCfmLtrIngressPortId        LldpPortId,
+      dot1agCfmLtrEgress           Dot1agCfmEgressActionFieldValue,
+      dot1agCfmLtrEgressMac            MacAddress,
+      dot1agCfmLtrEgressPortIdSubtype  LldpPortIdSubtype,
+      dot1agCfmLtrEgressPortId         LldpPortId,
+      dot1agCfmLtrOrganizationSpecificTlv  OCTET STRING
+    }
+
+dot1agCfmLtrSeqNumber OBJECT-TYPE
+    SYNTAX      Unsigned32 (0..4294967295)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Transaction identifier/Sequence number returned by a previous
+        transmit linktrace message command, indicating which LTM's
+        response is going to be returned.
+       "
+    REFERENCE
+       "12.14.7.5.2:b"
+    ::= { dot1agCfmLtrEntry 1}
+
+dot1agCfmLtrReceiveOrder OBJECT-TYPE
+    SYNTAX      Unsigned32(1..4294967295)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "An index to distinguish among multiple LTRs with the same LTR
+        Transaction Identifier field value.  dot1agCfmLtrReceiveOrder
+        are assigned sequentially from 1, in the order that the
+        Linktrace Initiator received the LTRs.
+       "
+    REFERENCE
+       "12.14.7.5.2:c"
+    ::= { dot1agCfmLtrEntry 2 }
+
+dot1agCfmLtrTtl OBJECT-TYPE
+    SYNTAX      Unsigned32 (0..255)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "TTL field value for a returned LTR."
+    REFERENCE
+       "12.14.7.5 and 20.36.2.2"
+    ::= { dot1agCfmLtrEntry 3 }
+
+dot1agCfmLtrForwarded OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Indicates if a LTM was forwarded by the responding MP, as
+        returned in the 'FwdYes' flag of the flags field.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:c and 20.36.2.1"
+    ::= { dot1agCfmLtrEntry 4 }
+
+dot1agCfmLtrTerminalMep OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "A Boolean value stating whether the forwarded LTM reached a
+        MEP enclosing its MA, as returned in the Terminal MEP flag of
+        the Flags field.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:d and 20.36.2.1"
+    ::= { dot1agCfmLtrEntry 5 }
+
+dot1agCfmLtrLastEgressIdentifier OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(8))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "An octet field holding the Last Egress Identifier returned
+        in the LTR Egress Identifier TLV of the LTR.
+        The Last Egress Identifier identifies the MEP Linktrace 
+        Initiator that originated, or the Linktrace Responder that 
+        forwarded, the LTM to which this LTR is the response.  This
+        is the same value as the Egress Identifier TLV of that LTM.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:e and 20.36.2.3"
+    ::= { dot1agCfmLtrEntry 6 }
+
+dot1agCfmLtrNextEgressIdentifier OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(8))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "An octet field holding the Next Egress Identifier returned
+        in the LTR Egress Identifier TLV of the LTR.  The Next Egress
+        Identifier Identifies the Linktrace Responder that
+        transmitted this LTR, and can forward the LTM to the next
+        hop.  This is the same value as the Egress Identifier TLV of
+        the forwarded LTM, if any. If the FwdYes bit of the Flags
+        field is false, the contents of this field are undefined,
+        i.e., any value can be transmitted, and the field is ignored
+        by the receiver.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:f and 20.36.2.4"
+    ::= { dot1agCfmLtrEntry 7 }
+
+dot1agCfmLtrRelay OBJECT-TYPE
+    SYNTAX      Dot1agCfmRelayActionFieldValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Value returned in the Relay Action field."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:g and 20.36.2.5"
+    ::= { dot1agCfmLtrEntry 8 }
+
+dot1agCfmLtrChassisIdSubtype OBJECT-TYPE
+    SYNTAX      LldpChassisIdSubtype
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "This object specifies the format of the Chassis ID returned
+        in the Sender ID TLV of the LTR, if any.  This value is
+        meaningless if the dot1agCfmLtrChassisId has a length of 0."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:h and 21.5.3.2"
+    ::= { dot1agCfmLtrEntry 9 }
+
+dot1agCfmLtrChassisId OBJECT-TYPE
+    SYNTAX      LldpChassisId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The Chassis ID returned in the Sender ID TLV of the LTR, if
+        any. The format of this object is determined by the
+        value of the dot1agCfmLtrChassisIdSubtype object.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:i and 21.5.3.3"
+    ::= { dot1agCfmLtrEntry 10 }
+
+dot1agCfmLtrManAddressDomain OBJECT-TYPE
+    SYNTAX      TDomain
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The TDomain that identifies the type and format of
+        the related dot1agCfmMepDbManAddress object, used to access
+        the SNMP agent of the system transmitting the LTR.  Received
+        in the LTR Sender ID TLV from that system.
+
+        Typical values will be one of (not all inclusive) list:
+
+
+           snmpUDPDomain          (from SNMPv2-TM, RFC3417)
+           snmpIeee802Domain      (from SNMP-IEEE802-TM-MIB, RFC4789)
+
+        The value 'zeroDotZero' (from RFC2578) indicates 'no management
+        address was present in the LTR', in which case the related
+        object dot1agCfmMepDbManAddress MUST have a zero-length OCTET
+        STRING as a value.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:j, 21.5.3.5, 21.9.6"
+    ::= { dot1agCfmLtrEntry 11 }
+
+dot1agCfmLtrManAddress OBJECT-TYPE
+    SYNTAX      TAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The TAddress that can be used to access the SNMP
+        agent of the system transmitting the CCM, received in the CCM
+        Sender ID TLV from that system.
+
+        If the related object dot1agCfmLtrManAddressDomain contains
+        the value 'zeroDotZero', this object dot1agCfmLtrManAddress
+        MUST have a zero-length OCTET STRING as a value.
+      "
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:j, 21.5.3.7, 21.9.6"
+    ::= { dot1agCfmLtrEntry 12 }
+
+dot1agCfmLtrIngress OBJECT-TYPE
+    SYNTAX      Dot1agCfmIngressActionFieldValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The value returned in the Ingress Action Field of the LTM.
+        The value ingNoTlv(0) indicates that no Reply Ingress TLV was
+        returned in the LTM."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:k and 20.36.2.6"
+    ::= { dot1agCfmLtrEntry 13 }
+
+dot1agCfmLtrIngressMac OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "MAC address returned in the ingress MAC address field.
+        If the dot1agCfmLtrIngress object contains the value
+        ingNoTlv(0), then the contents of this object are meaningless."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:l and 20.36.2.7"
+    ::= { dot1agCfmLtrEntry 14 }
+
+dot1agCfmLtrIngressPortIdSubtype OBJECT-TYPE
+    SYNTAX      LldpPortIdSubtype
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Format of the Ingress Port ID.
+        If the dot1agCfmLtrIngress object contains the value
+        ingNoTlv(0), then the contents of this object are meaningless."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:m and 20.36.2.8"
+   ::= { dot1agCfmLtrEntry 15 }
+
+dot1agCfmLtrIngressPortId OBJECT-TYPE
+    SYNTAX      LldpPortId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Ingress Port ID. The format of this object is determined by
+        the value of the dot1agCfmLtrIngressPortIdSubtype object.
+        If the dot1agCfmLtrIngress object contains the value
+        ingNoTlv(0), then the contents of this object are meaningless."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:n and 20.36.2.9"
+    ::= { dot1agCfmLtrEntry 16 }
+
+dot1agCfmLtrEgress OBJECT-TYPE
+    SYNTAX      Dot1agCfmEgressActionFieldValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The value returned in the Egress Action Field of the LTM.
+        The value egrNoTlv(0) indicates that no Reply Egress TLV was
+        returned in the LTM."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:o and 20.36.2.10"
+    ::= { dot1agCfmLtrEntry 17 }
+
+dot1agCfmLtrEgressMac OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "MAC address returned in the egress MAC address field.
+        If the dot1agCfmLtrEgress object contains the value
+        egrNoTlv(0), then the contents of this object are meaningless."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:p and 20.36.2.11"
+    ::= { dot1agCfmLtrEntry 18 }
+
+dot1agCfmLtrEgressPortIdSubtype OBJECT-TYPE
+    SYNTAX      LldpPortIdSubtype
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Format of the egress Port ID.
+        If the dot1agCfmLtrEgress object contains the value
+        egrNoTlv(0), then the contents of this object are meaningless."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:q and 20.36.2.12"
+    ::= { dot1agCfmLtrEntry 19 }
+
+dot1agCfmLtrEgressPortId OBJECT-TYPE
+    SYNTAX      LldpPortId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Egress Port ID. The format of this object is determined by
+        the value of the dot1agCfmLtrEgressPortIdSubtype object.
+        If the dot1agCfmLtrEgress object contains the value
+        egrNoTlv(0), then the contents of this object are meaningless."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:r and 20.36.2.13"
+    ::= { dot1agCfmLtrEntry 20 }
+
+dot1agCfmLtrOrganizationSpecificTlv OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(0|4..1500))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "All Organization specific TLVs returned in the LTR, if
+        any.  Includes all octets including and following the TLV
+        Length field of each TLV, concatenated together."
+    REFERENCE
+       "802.1ag clauses 12.14.7.5.3:s, 21.5.2"
+    ::= { dot1agCfmLtrEntry 21 }
+
+-- ******************************************************************
+-- The MEP Database Table
+-- ******************************************************************
+
+dot1agCfmMepDbTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Dot1agCfmMepDbEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The MEP Database. A database, maintained by every MEP, that
+        maintains received information about other MEPs in the
+        Maintenance Domain.
+
+        The SMI does not allow to state in a MIB that an object in
+        a table is an array. The solution is to take the index (or
+        indices) of the first table and add one or more indices.
+       "
+    REFERENCE
+       "19.2.15"
+    ::= { dot1agCfmMep 3 }
+
+dot1agCfmMepDbEntry OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepDbEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The MEP Database table entry."
+    INDEX { dot1agCfmMdIndex,
+            dot1agCfmMaIndex,
+            dot1agCfmMepIdentifier,
+            dot1agCfmMepDbRMepIdentifier
+          }
+    ::= { dot1agCfmMepDbTable 1 }
+
+Dot1agCfmMepDbEntry ::= SEQUENCE {
+      dot1agCfmMepDbRMepIdentifier         Dot1agCfmMepId,
+      dot1agCfmMepDbRMepState              Dot1agCfmRemoteMepState,
+      dot1agCfmMepDbRMepFailedOkTime       TimeStamp,
+      dot1agCfmMepDbMacAddress             MacAddress,
+      dot1agCfmMepDbRdi                    TruthValue,
+      dot1agCfmMepDbPortStatusTlv          Dot1agCfmPortStatus,
+      dot1agCfmMepDbInterfaceStatusTlv     Dot1agCfmInterfaceStatus,
+      dot1agCfmMepDbChassisIdSubtype       LldpChassisIdSubtype,
+      dot1agCfmMepDbChassisId              LldpChassisId,
+      dot1agCfmMepDbManAddressDomain       TDomain,
+      dot1agCfmMepDbManAddress             TAddress,
+      dot1agCfmMepDbRMepIsActive           TruthValue
+    }
+
+dot1agCfmMepDbRMepIdentifier OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepId
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Maintenance association End Point Identifier of a remote MEP
+        whose information from the MEP Database is to be returned.
+       "
+    REFERENCE
+       "12.14.7.6.2:b"
+    ::= { dot1agCfmMepDbEntry 1 }
+
+dot1agCfmMepDbRMepState OBJECT-TYPE
+    SYNTAX      Dot1agCfmRemoteMepState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The operational state of the remote MEP IFF State machines."
+    REFERENCE
+       "12.14.7.6.3:b and 20.22"
+    ::= { dot1agCfmMepDbEntry 2}
+
+dot1agCfmMepDbRMepFailedOkTime OBJECT-TYPE
+    SYNTAX      TimeStamp
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The time (SysUpTime) at which the IFF Remote MEP state machine
+        last entered either the RMEP_FAILED or RMEP_OK state.
+       "
+    REFERENCE
+       "12.14.7.6.3:c"
+    ::= { dot1agCfmMepDbEntry 3 }
+
+dot1agCfmMepDbMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The MAC address of the remote MEP."
+    REFERENCE
+       "12.14.7.6.3:d and 20.19.7"
+    ::= { dot1agCfmMepDbEntry 4 }
+
+dot1agCfmMepDbRdi OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "State of the RDI bit in the last received CCM (true for
+        RDI=1), or false if none has been received.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.6.3:e and 20.19.2"
+    ::= { dot1agCfmMepDbEntry 5 }
+
+dot1agCfmMepDbPortStatusTlv OBJECT-TYPE
+    SYNTAX      Dot1agCfmPortStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "An enumerated value of the Port status TLV received in the
+        last CCM from the remote MEP or the default value
+        psNoPortStateTLV indicating either no CCM has been received,
+        or that nor port status TLV was received in the last CCM.
+       "
+    REFERENCE
+       "12.14.7.6.3:f and 20.19.3"
+    DEFVAL { psNoPortStateTLV }
+    ::= { dot1agCfmMepDbEntry 6}
+   
+dot1agCfmMepDbInterfaceStatusTlv OBJECT-TYPE
+    SYNTAX      Dot1agCfmInterfaceStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "An enumerated value of the Interface status TLV received
+        in the last CCM from the remote MEP or the default value
+        isNoInterfaceStatus TLV indicating either no CCM has been
+        received, or that no interface status TLV was received in
+        the last CCM.
+       "
+    REFERENCE
+       "12.14.7.6.3:g and 20.19.4"
+    DEFVAL { isNoInterfaceStatusTLV }
+    ::= { dot1agCfmMepDbEntry 7}
+
+dot1agCfmMepDbChassisIdSubtype OBJECT-TYPE
+    SYNTAX      LldpChassisIdSubtype
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "This object specifies the format of the Chassis ID received
+        in the last CCM."
+    REFERENCE
+       "802.1ag clauses 12.14.7.6.3:h and 21.5.3.2"
+    ::= { dot1agCfmMepDbEntry 8 }
+
+dot1agCfmMepDbChassisId OBJECT-TYPE
+    SYNTAX      LldpChassisId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The Chassis ID. The format of this object is determined by the
+        value of the dot1agCfmLtrChassisIdSubtype object.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.6.3:h and 21.5.3.3"
+    ::= { dot1agCfmMepDbEntry 9 }
+
+dot1agCfmMepDbManAddressDomain OBJECT-TYPE
+    SYNTAX      TDomain
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The TDomain that identifies the type and format of
+        the related dot1agCfmMepDbManAddress object, used to access
+        the SNMP agent of the system transmitting the CCM.  Received
+        in the CCM Sender ID TLV from that system.
+
+        Typical values will be one of (not all inclusive) list:
+
+
+           snmpUDPDomain          (from SNMPv2-TM, RFC3417)
+           snmpIeee802Domain      (from SNMP-IEEE802-TM-MIB, RFC4789)
+
+        The value 'zeroDotZero' (from RFC2578) indicates 'no management
+        address was present in the LTR', in which case the related
+        object dot1agCfmMepDbManAddress MUST have a zero-length OCTET
+        STRING as a value.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.6.3:h, 21.5.3.5, 21.6.7"
+    ::= { dot1agCfmMepDbEntry 10 }
+
+dot1agCfmMepDbManAddress OBJECT-TYPE
+    SYNTAX      TAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The TAddress that can be used to access the SNMP
+        agent of the system transmitting the CCM, received in the CCM
+        Sender ID TLV from that system.
+
+        If the related object dot1agCfmMepDbManAddressDomain contains
+        the value 'zeroDotZero', this object dot1agCfmMepDbManAddress
+        MUST have a zero-length OCTET STRING as a value.
+       "
+    REFERENCE
+       "802.1ag clauses 12.14.7.6.3:h, 21.5.3.7, 21.6.7"
+    ::= { dot1agCfmMepDbEntry 11 }
+
+dot1agCfmMepDbRMepIsActive OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "A Boolean value stating if the remote MEP is active."
+    REFERENCE
+       "12.14.7.1.3:af"
+    ::= { dot1agCfmMepDbEntry 12 }
+
+-- ******************************************************************
+-- NOTIFICATIONS (TRAPS)
+-- These notifications will be sent to the management entity
+-- whenever a MEP loses/restores contact with one or more other MEPs.
+-- ******************************************************************
+
+dot1agCfmFaultAlarm NOTIFICATION-TYPE
+    OBJECTS     { dot1agCfmMepHighestPrDefect
+                }
+    STATUS      current
+    DESCRIPTION
+       "A MEP has a persistent defect condition. A notification
+        (fault alarm) is sent to the management entity with the OID
+        of the MEP that has detected the fault.
+
+        Whenever a MEP has a persistent defect,
+        it may or may not generate a Fault Alarm to warn the system
+        administrator of the problem, as controlled by the MEP
+        Fault Notification Generator State Machine and associated
+        Managed Objects. Only the highest-priority defect, as shown
+        in Table 20-1, is reported in the Fault Alarm.
+
+        If a defect with a higher priority is raised after a Fault
+        Alarm has been issued, another Fault Alarm is issued.
+
+        The management entity receiving the notification can identify
+        the system from the network source address of the
+        notification, and can identify the MEP reporting the defect
+        by the indices in the OID of the dot1agCfmMepHighestPrDefect
+        variable in the notification:
+
+           dot1agCfmMdIndex - Also the index of the MEP's
+                              Maintenance Domain table entry
+                              (dot1agCfmMdTable).
+           dot1agCfmMaIndex - Also an index (with the MD table index)
+                              of the MEP's Maintenance Association
+                              network table entry
+                              (dot1agCfmMaNetTable), and (with the MD
+                              table index and component ID) of the
+                              MEP's MA component table entry
+                              (dot1agCfmMaCompTable).
+           dot1agCfmMepIdentifier - MEP Identifier and final index
+                              into the MEP table (dot1agCfmMepTable).
+       "
+    REFERENCE
+       "12.14.7.7"
+    ::= { dot1agNotifications 1 }
+
+-- ******************************************************************
+-- IEEE 802.1ag MIB Module - Conformance Information
+-- ******************************************************************
+
+dot1agCfmCompliances OBJECT IDENTIFIER ::= { dot1agCfmConformance 1 }
+dot1agCfmGroups      OBJECT IDENTIFIER ::= { dot1agCfmConformance 2 }
+
+-- ******************************************************************
+-- Units of conformance
+-- ******************************************************************
+dot1agCfmStackGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmStackMdIndex,
+      dot1agCfmStackMaIndex,
+      dot1agCfmStackMepId,
+      dot1agCfmStackMacAddress
+    }
+    STATUS      deprecated
+    DESCRIPTION
+       "Objects for the Stack group."
+    ::= { dot1agCfmGroups 1 }
+
+dot1agCfmDefaultMdGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmDefaultMdDefLevel,
+      dot1agCfmDefaultMdDefMhfCreation,
+      dot1agCfmDefaultMdDefIdPermission,
+      dot1agCfmDefaultMdStatus,
+      dot1agCfmDefaultMdLevel,
+      dot1agCfmDefaultMdMhfCreation,
+      dot1agCfmDefaultMdIdPermission
+    }
+    STATUS      deprecated
+    DESCRIPTION
+       "Objects for the Default MD Level group."
+    ::= { dot1agCfmGroups 2 }
+
+dot1agCfmVlanIdGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmVlanPrimaryVid,
+      dot1agCfmVlanRowStatus
+   }
+    STATUS      deprecated
+    DESCRIPTION
+       "Objects for the VLAN ID group."
+    ::= { dot1agCfmGroups 3 }
+
+dot1agCfmConfigErrorListGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmConfigErrorListErrorType
+    }
+    STATUS deprecated
+    DESCRIPTION
+       "Objects for the CFM Configuration Error List Group."
+    ::= {dot1agCfmGroups 4 }
+
+dot1agCfmMdGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMdTableNextIndex,
+      dot1agCfmMdName,
+      dot1agCfmMdFormat,
+      dot1agCfmMdMdLevel,
+      dot1agCfmMdMhfCreation,
+      dot1agCfmMdMhfIdPermission,
+      dot1agCfmMdMaNextIndex,
+      dot1agCfmMdRowStatus
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the Maintenance Domain Group."
+    ::={dot1agCfmGroups 5 }
+
+dot1agCfmMaGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMaNetFormat,
+      dot1agCfmMaNetName,
+      dot1agCfmMaNetCcmInterval,
+      dot1agCfmMaNetRowStatus,
+      dot1agCfmMaCompPrimaryVlanId,
+      dot1agCfmMaCompMhfCreation,
+      dot1agCfmMaCompIdPermission,
+      dot1agCfmMaCompRowStatus,
+      dot1agCfmMaCompNumberOfVids,
+      dot1agCfmMaMepListRowStatus
+    }
+    STATUS      deprecated
+    DESCRIPTION
+       "Objects for the MA group."
+    ::= { dot1agCfmGroups 6 }
+
+dot1agCfmMepGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMepIfIndex,
+      dot1agCfmMepDirection,
+      dot1agCfmMepPrimaryVid,
+      dot1agCfmMepActive,
+      dot1agCfmMepFngState,
+      dot1agCfmMepCciEnabled,
+      dot1agCfmMepCcmLtmPriority,
+      dot1agCfmMepMacAddress,
+      dot1agCfmMepLowPrDef,
+      dot1agCfmMepFngAlarmTime,
+      dot1agCfmMepFngResetTime,
+      dot1agCfmMepHighestPrDefect,
+      dot1agCfmMepDefects,
+      dot1agCfmMepErrorCcmLastFailure,
+      dot1agCfmMepXconCcmLastFailure,
+      dot1agCfmMepCcmSequenceErrors,
+      dot1agCfmMepCciSentCcms,
+      dot1agCfmMepNextLbmTransId,
+      dot1agCfmMepLbrIn,
+      dot1agCfmMepLbrInOutOfOrder,
+      dot1agCfmMepLbrBadMsdu,
+      dot1agCfmMepLtmNextSeqNumber,
+      dot1agCfmMepUnexpLtrIn,
+      dot1agCfmMepLbrOut,
+      dot1agCfmMepTransmitLbmStatus,
+      dot1agCfmMepTransmitLbmDestMacAddress,
+      dot1agCfmMepTransmitLbmDestMepId,
+      dot1agCfmMepTransmitLbmDestIsMepId,
+      dot1agCfmMepTransmitLbmMessages,
+      dot1agCfmMepTransmitLbmDataTlv,
+      dot1agCfmMepTransmitLbmVlanPriority,
+      dot1agCfmMepTransmitLbmVlanDropEnable,
+      dot1agCfmMepTransmitLbmResultOK,
+      dot1agCfmMepTransmitLbmSeqNumber,
+      dot1agCfmMepTransmitLtmStatus,
+      dot1agCfmMepTransmitLtmFlags,
+      dot1agCfmMepTransmitLtmTargetMacAddress,
+      dot1agCfmMepTransmitLtmTargetMepId,
+      dot1agCfmMepTransmitLtmTargetIsMepId,
+      dot1agCfmMepTransmitLtmTtl,
+      dot1agCfmMepTransmitLtmResult,
+      dot1agCfmMepTransmitLtmSeqNumber,
+      dot1agCfmMepTransmitLtmEgressIdentifier,
+      dot1agCfmMepRowStatus,
+      dot1agCfmLtrForwarded,
+      dot1agCfmLtrRelay,
+      dot1agCfmLtrChassisIdSubtype,
+      dot1agCfmLtrChassisId,
+      dot1agCfmLtrManAddress,
+      dot1agCfmLtrManAddressDomain,
+      dot1agCfmLtrIngress,
+      dot1agCfmLtrIngressMac,
+      dot1agCfmLtrIngressPortIdSubtype,
+      dot1agCfmLtrIngressPortId,
+      dot1agCfmLtrEgress,
+      dot1agCfmLtrEgressMac,
+      dot1agCfmLtrEgressPortIdSubtype,
+      dot1agCfmLtrEgressPortId,
+      dot1agCfmLtrTerminalMep,
+      dot1agCfmLtrLastEgressIdentifier,
+      dot1agCfmLtrNextEgressIdentifier,
+      dot1agCfmLtrTtl,
+      dot1agCfmLtrOrganizationSpecificTlv
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the MEP group."
+    ::= { dot1agCfmGroups 7 }
+
+dot1agCfmMepDbGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMepDbRMepState,
+      dot1agCfmMepDbRMepFailedOkTime,
+      dot1agCfmMepDbMacAddress,
+      dot1agCfmMepDbRdi,
+      dot1agCfmMepDbPortStatusTlv,
+      dot1agCfmMepDbInterfaceStatusTlv,
+      dot1agCfmMepDbChassisIdSubtype,
+      dot1agCfmMepDbChassisId,
+      dot1agCfmMepDbManAddressDomain,
+      dot1agCfmMepDbManAddress
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the MEP group."
+    ::= { dot1agCfmGroups 8 }
+
+dot1agCfmNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+      dot1agCfmFaultAlarm
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the Notifications group."
+    ::= { dot1agCfmGroups 9 }
+
+
+ieee8021CfmMaNetGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMaNetFormat,
+      dot1agCfmMaNetName,
+      dot1agCfmMaNetCcmInterval,
+      dot1agCfmMaNetRowStatus,
+      dot1agCfmMaMepListRowStatus
+
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the MA Net group."
+    ::= { dot1agCfmGroups 10 }
+
+ieee8021CfmDefaultMdDefGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmDefaultMdDefLevel,
+      dot1agCfmDefaultMdDefMhfCreation,
+      dot1agCfmDefaultMdDefIdPermission
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the Default MD default Level group."
+    ::= { dot1agCfmGroups 11 }
+
+ieee8021CfmPbbTeExtensionGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMepDbRMepIsActive,
+      dot1agCfmMepPbbTransmitLbmLtmReverseVid
+    }
+    STATUS     current
+    DESCRIPTION
+       "Objects needed for systems that support PBB-TE CFM functionality."
+    ::= { dot1agCfmGroups 12 } 
+
+ieee8021CfmPbbTeTrafficBitGroup OBJECT-GROUP
+    OBJECTS {
+      dot1agCfmMepDbManAddress,
+      dot1agCfmMepPbbTeCanReportPbbTePresence,
+      dot1agCfmMepPbbTeMismatchAlarm,
+      dot1agCfmMepPbbTeTrafficMismatchDefect,
+      dot1agCfmMepPbbTeLocalMismatchDefect,
+      dot1agCfmMepPbbTeMismatchSinceReset
+    }
+    STATUS     current
+    DESCRIPTION
+       "Objects needed for PBB-TE supporting systems that support the
+        optional traffic bit."
+    ::= { dot1agCfmGroups 13 } 
+
+-- ******************************************************************
+-- MIB Module Compliance statements
+-- ******************************************************************
+
+dot1agCfmCompliance MODULE-COMPLIANCE
+    STATUS      deprecated
+    DESCRIPTION
+       "The compliance statement for support of the CFM MIB module."
+    MODULE
+        MANDATORY-GROUPS {
+            dot1agCfmStackGroup,
+            dot1agCfmDefaultMdGroup,
+            dot1agCfmConfigErrorListGroup,
+            dot1agCfmMdGroup,
+            dot1agCfmMaGroup,
+            dot1agCfmMepGroup,
+            dot1agCfmMepDbGroup,
+            dot1agCfmNotificationsGroup
+         }
+
+    GROUP dot1agCfmVlanIdGroup
+    DESCRIPTION "The VLAN ID group is optional."
+
+    OBJECT dot1agCfmMepLbrBadMsdu
+    MIN-ACCESS not-accessible
+    DESCRIPTION "The dot1agCfmMepLbrBadMsdu variable is optional.  It
+                 MUST not be present if the system cannot compare a
+                 received LBR to the corresponding LBM."
+
+    OBJECT dot1agCfmMdRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT dot1agCfmMaNetRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT dot1agCfmMaCompRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT dot1agCfmVlanRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT  dot1agCfmMaMepListRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT  dot1agCfmMepRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    ::= { dot1agCfmCompliances 1 }
+END
+

--- a/mibs/junos/mib-802.1ap.txt
+++ b/mibs/junos/mib-802.1ap.txt
@@ -1,0 +1,913 @@
+IEEE8021-CFM-V2-MIB DEFINITIONS ::= BEGIN
+
+-- ******************************************************************
+-- IEEE P802.1ag(TM) CFM MIB
+-- ******************************************************************
+
+IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE, 
+    Unsigned32               FROM SNMPv2-SMI    -- [RFC2578]
+    RowStatus,
+    TruthValue, MacAddress
+                             FROM SNMPv2-TC     -- [RFC2579]
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP 
+                             FROM SNMPv2-CONF   -- [RFC2580]
+    InterfaceIndex
+                             FROM IF-MIB        -- [RFC2863]
+    IEEE8021ServiceSelectorType,
+    IEEE8021ServiceSelectorValue,
+    IEEE8021ServiceSelectorValueOrNone,
+    IEEE8021PbbComponentIdentifier,
+    ieee802dot1mibs          FROM IEEE8021-TC-MIB
+--cfm types
+    Dot1agCfmMhfCreation,
+    Dot1agCfmIdPermission,
+    Dot1agCfmMDLevel,
+    Dot1agCfmMpDirection,
+    Dot1agCfmMepIdOrZero,
+    Dot1agCfmMDLevelOrNone,
+    Dot1agCfmConfigErrors,
+-- cfm indexes
+    dot1agCfmMdIndex,
+    dot1agCfmMaIndex,
+--cfm groups
+    dot1agCfmStack,
+    dot1agCfmDefaultMd,
+    dot1agCfmVlan,
+    dot1agCfmConfigErrorList, 
+    dot1agCfmMa,
+-- cfm row items
+    dot1agCfmMepLbrBadMsdu,
+    dot1agCfmMdRowStatus,
+    dot1agCfmMaNetRowStatus,
+    dot1agCfmMaMepListRowStatus,
+    dot1agCfmMepRowStatus,
+--cfm conformance groups
+    dot1agCfmCompliances,
+    dot1agCfmGroups,
+    dot1agCfmMdGroup,
+    dot1agCfmMepGroup,
+    dot1agCfmMepDbGroup,
+    dot1agCfmNotificationsGroup,
+    ieee8021CfmDefaultMdDefGroup,
+    ieee8021CfmMaNetGroup             FROM IEEE8021-CFM-MIB
+   ;
+
+ieee8021CfmV2Mib   MODULE-IDENTITY
+    LAST-UPDATED "200810150000Z" -- October 15, 2008
+    ORGANIZATION "IEEE 802.1 Working Group"
+    CONTACT-INFO
+       "WG-URL:   http://grouper.ieee.org/groups/802/1/index.html
+        WG-EMail: stds-802-1@ieee.org 
+
+        Contact:  David Elie-Dit-Cosaque
+
+                  Alcatel-Lucent
+                  3400 W. Plano Pkwy.
+                  Plano, TX 75075, USA
+
+        E-mail:   david.elie_dit_cosaque@alcatel-lucent.com
+
+        Contact:  Norman Finn
+
+                  Cisco Systems
+                  170 W. Tasman Drive
+                  San Jose, CA 95134, USA
+
+        E-mail:   nfinn@cisco.com
+
+        Contact: David Levi
+
+                 4655 GREAT AMERICA PARKWAY
+                 SANTA CLARA, CA 95054, USA
+
+        Tel:     +1-408-495-5138
+
+        E-mail:  dlevi@nortel.com
+       "
+   DESCRIPTION 
+      "Connectivity Fault Management V2 module for 
+       managing IEEE 802.1ag-2007.
+
+       Unless otherwise indicated, the references in this MIB
+       module are to IEEE 802.1Q-2005 as amended by IEEE 802.1ad,
+       IEEE 802.1ak, IEEE 802.1ag and IEEE 802.1ah.
+
+       Copyright (C) IEEE.
+       This version of this MIB module is part of IEEE802.1Q;
+       see the draft itself for full legal notices."
+
+   REVISION       "200810150000Z" -- October 15, 2008
+   DESCRIPTION 
+      "The IEEE8021-CFM-V2-MIB Module contains objects that 
+       replace those deprecated in the IEEE8021-CFM-MIB module.
+
+       This version is included in IEEE 802.1ap"
+
+    ::= { ieee802dot1mibs 7 }
+
+
+-- ******************************************************************
+-- Note: Re-indexed 802.1ag tables 
+-- ******************************************************************
+-- This section contains new tables replacing deprecated tables in 
+-- this version of the MIB
+
+-- ******************************************************************
+-- The CFM Stack Table
+-- ******************************************************************
+
+ieee8021CfmStackTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Ieee8021CfmStackEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "There is one CFM Stack table per bridge. It permits
+        the retrieval of information about the Maintenance Points
+        configured on any given interface.
+       "
+    REFERENCE
+       "12.14.2"
+    ::= { dot1agCfmStack 2 }
+
+ieee8021CfmStackEntry OBJECT-TYPE
+    SYNTAX      Ieee8021CfmStackEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Stack table entry."
+    INDEX { ieee8021CfmStackifIndex, ieee8021CfmStackServiceSelectorType,
+            ieee8021CfmStackServiceSelectorOrNone,
+            ieee8021CfmStackMdLevel, ieee8021CfmStackDirection
+          }
+    ::= { ieee8021CfmStackTable 1 }
+
+Ieee8021CfmStackEntry ::= SEQUENCE {
+      ieee8021CfmStackifIndex                    InterfaceIndex,
+      ieee8021CfmStackServiceSelectorType        IEEE8021ServiceSelectorType,
+      ieee8021CfmStackServiceSelectorOrNone      IEEE8021ServiceSelectorValueOrNone,
+      ieee8021CfmStackMdLevel                    Dot1agCfmMDLevel,
+      ieee8021CfmStackDirection                  Dot1agCfmMpDirection,
+      ieee8021CfmStackMdIndex                    Unsigned32,
+      ieee8021CfmStackMaIndex                    Unsigned32,
+      ieee8021CfmStackMepId                      Dot1agCfmMepIdOrZero,
+      ieee8021CfmStackMacAddress                 MacAddress
+    }
+
+ieee8021CfmStackifIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "This object represents the  Bridge Port or aggregated port
+        on which MEPs or MHFs might be configured.
+
+        Upon a restart of the system, the system SHALL, if necessary,
+        change the value of this variable, and  rearrange the
+        ieee8021CfmStackTable, so that it indexes the entry in the
+        interface table with the same value of ifAlias that it
+        indexed before the system restart.  If no such entry exists,
+        then the system SHALL delete all entries in the
+        ieee8021CfmStackTable with the interface index.
+       "
+    REFERENCE
+       "12.14.2.1.2:a"
+    ::= { ieee8021CfmStackEntry 1 }
+
+ieee8021CfmStackServiceSelectorType OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorType
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Type of the Service Selector identifier indicated by ieee8021CfmStackServiceSelectorOrNone.
+        See textual convention IEEE8021ServiceSelectorType for details.
+       "
+    REFERENCE
+       "12.14.2.1.2:d, 22.1.7"
+    ::= { ieee8021CfmStackEntry 2 }
+
+ieee8021CfmStackServiceSelectorOrNone OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorValueOrNone
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Service Selector identifier to which the MP is attached, or 0, if none.
+        See textual convention IEEE8021ServiceSelectorValue for details.
+       "
+    REFERENCE
+       "12.14.2.1.2:d, 22.1.7"
+    ::= { ieee8021CfmStackEntry 3 }
+
+ieee8021CfmStackMdLevel OBJECT-TYPE
+    SYNTAX      Dot1agCfmMDLevel
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "MD Level of the Maintenance Point."
+    REFERENCE
+       "12.14.2.1.2:b"
+    ::= { ieee8021CfmStackEntry 4 }
+
+ieee8021CfmStackDirection OBJECT-TYPE
+    SYNTAX      Dot1agCfmMpDirection
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Direction in which the MP faces on the Bridge Port.
+       "
+    REFERENCE
+       "12.14.2.1.2:c"
+    ::= { ieee8021CfmStackEntry 5 }
+
+ieee8021CfmStackMdIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The index of the Maintenance Domain in the ieee8021CfmMdTable
+        to which the MP is associated, or 0, if none."
+    REFERENCE
+       "12.14.2.1.3:b"
+    ::= { ieee8021CfmStackEntry 6 }
+
+ieee8021CfmStackMaIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The index of the MA in the ieee8021CfmMaNetTable and
+        ieee8021CfmMaCompTable to which the MP is associated, or 0, if
+        none."
+    REFERENCE
+       "12.14.2.1.3:c"
+    ::= { ieee8021CfmStackEntry 7 }
+
+ieee8021CfmStackMepId OBJECT-TYPE
+    SYNTAX      Dot1agCfmMepIdOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "If an MEP is configured, the MEPID, else 0"
+    REFERENCE
+       "12.14.2.1.3:d"
+    ::= { ieee8021CfmStackEntry 8 }
+
+ieee8021CfmStackMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "MAC address of the MP."
+    REFERENCE
+      "12.14.2.1.3:e"
+    ::= { ieee8021CfmStackEntry 9 }
+
+-- ******************************************************************
+-- The CFM VLAN Table
+-- ******************************************************************
+
+ieee8021CfmVlanTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Ieee8021CfmVlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "This table defines the association of VIDs into VLANs.  There
+        is an entry in this table, for each component of the bridge,
+        for each VID that is:
+            a) a VID belonging to a VLAN associated with more than
+               one VID; and
+            b) not the Primary VLAN of that VID.
+        The entry in this table contains the Primary VID of the VLAN.
+
+        By default, this table is empty, meaning that every VID is
+        the Primary VID of a single-VID VLAN.
+
+        VLANs that are associated with only one VID SHOULD NOT have
+        an entry in this table.
+
+        The writable objects in this table need to be persistent
+        upon reboot or restart of a device.
+       "
+    REFERENCE
+       "12.14.3.1.3:a, 12.14.3.2.2:a, 12.14.5.3.2:c,
+        12.14.6.1.3:b, 22.1.5."
+    ::= { dot1agCfmVlan 2 }
+
+ieee8021CfmVlanEntry OBJECT-TYPE
+    SYNTAX      Ieee8021CfmVlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The VLAN table entry."
+    INDEX { ieee8021CfmVlanComponentId,
+            ieee8021CfmVlanSelector}
+    ::= { ieee8021CfmVlanTable 1 }
+
+Ieee8021CfmVlanEntry ::= SEQUENCE {
+      ieee8021CfmVlanComponentId                IEEE8021PbbComponentIdentifier,
+      ieee8021CfmVlanSelector                   IEEE8021ServiceSelectorValue,
+      ieee8021CfmVlanPrimarySelector            IEEE8021ServiceSelectorValue,
+      ieee8021CfmVlanRowStatus                  RowStatus
+    }
+
+ieee8021CfmVlanComponentId OBJECT-TYPE
+    SYNTAX      IEEE8021PbbComponentIdentifier
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The bridge component within the system to which the information
+        in this ieee8021CfmVlanEntry applies.  If the system is not a
+        Bridge, or if only one component is present in the Bridge, then
+        this variable (index) MUST be equal to 1.
+       "
+    REFERENCE
+       "12.3 l)"
+    ::= { ieee8021CfmVlanEntry 1 }
+
+ieee8021CfmVlanSelector OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorValue 
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "This is a service ID belonging to a service that is associated
+        with more than one Service Selector identifiers, and this is not the Primary 
+        Service ID of the service. The type of this Service Selector is the same
+        as the primary Service Selector's type defined by ieee8021CfmMaCompPrimarySelectorType 
+        in the ieee8021CfmMaCompTable.
+       "
+    ::= { ieee8021CfmVlanEntry 3 }
+
+ieee8021CfmVlanPrimarySelector OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "This is the Primary Service selector for a Service that is associated
+        with more than one Service Selector identifiers. This value MUST not
+        equal the value of ieee8021CfmVlanSelector. The type of this Service Selector is the same
+        as the primary Service Selector's type defined by ieee8021CfmMaCompPrimarySelectorType 
+        in the ieee8021CfmMaCompTable.
+       "
+    ::= { ieee8021CfmVlanEntry 5 }
+
+ieee8021CfmVlanRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+       "
+    ::= { ieee8021CfmVlanEntry 6 }
+
+
+-- *******************************************************************
+-- The CFM Default MD Level Table
+-- *******************************************************************
+
+ieee8021CfmDefaultMdTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Ieee8021CfmDefaultMdEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "For each bridge component, the Default MD Level Managed Object
+        controls MHF creation for VIDs that are not attached to a
+        specific Maintenance Association Managed Object, and Sender ID
+        TLV transmission by those MHFs.
+
+        For each Bridge Port, and for each VLAN ID whose data can
+        pass through that Bridge Port, an entry in this table is
+        used by the algorithm in subclause 22.2.3 only if there is no
+        entry in the Maintenance Association table defining an MA
+        for the same VLAN ID and MD Level as this table's entry, and
+        on which MA an Up MEP is defined.  If there exists such an
+        MA, that MA's objects are used by the algorithm in
+        subclause 22.2.3 in place of this table entry's objects.  The
+        agent maintains the value of ieee8021CfmDefaultMdStatus to
+        indicate whether this entry is overridden by an MA.
+
+        When first initialized, the agent creates this table
+        automatically with entries for all VLAN IDs,
+        with the default values specified for each object.
+
+        After this initialization, the writable objects in this
+        table need to be persistent upon reboot or restart of a
+        device.
+       "
+    REFERENCE
+       "12.14.3"
+    ::= { dot1agCfmDefaultMd 5 }
+
+ieee8021CfmDefaultMdEntry OBJECT-TYPE
+    SYNTAX      Ieee8021CfmDefaultMdEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Default MD Level table entry."
+    INDEX { ieee8021CfmDefaultMdComponentId,
+            ieee8021CfmDefaultMdPrimarySelectorType,
+            ieee8021CfmDefaultMdPrimarySelector}
+    ::= { ieee8021CfmDefaultMdTable 1 }
+
+Ieee8021CfmDefaultMdEntry ::= SEQUENCE {
+      ieee8021CfmDefaultMdComponentId            IEEE8021PbbComponentIdentifier,
+      ieee8021CfmDefaultMdPrimarySelectorType    IEEE8021ServiceSelectorType,
+      ieee8021CfmDefaultMdPrimarySelector        IEEE8021ServiceSelectorValue,
+      ieee8021CfmDefaultMdStatus                 TruthValue,
+      ieee8021CfmDefaultMdLevel                  Dot1agCfmMDLevelOrNone,
+      ieee8021CfmDefaultMdMhfCreation            Dot1agCfmMhfCreation,
+      ieee8021CfmDefaultMdIdPermission           Dot1agCfmIdPermission
+    }
+
+ieee8021CfmDefaultMdComponentId OBJECT-TYPE
+    SYNTAX      IEEE8021PbbComponentIdentifier
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The bridge component within the system to which the information
+        in this ieee8021CfmDefaultMdEntry applies.  If the system is not
+        a Bridge, or if only one component is present in the Bridge,
+        then this variable (index) MUST be equal to 1.
+       "
+    REFERENCE
+       "12.3 l)"
+    ::= { ieee8021CfmDefaultMdEntry 1 }
+
+ieee8021CfmDefaultMdPrimarySelectorType OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorType
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Type of the Primary Service Selector identifier indicated by 
+        ieee8021CfmDefaultMdPrimarySelector. See textual
+        convention IEEE8021ServiceSelectorType for details.
+       "
+    ::= { ieee8021CfmDefaultMdEntry 2 }
+
+ieee8021CfmDefaultMdPrimarySelector OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorValue
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Primary Service Selector identifier of a Service Instance with 
+        no MA configured. See IEEE8021ServiceSelectorValue for details.
+       "
+    ::= { ieee8021CfmDefaultMdEntry 3 }
+
+ieee8021CfmDefaultMdStatus OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "State of this Default MD Level table entry.  True if there is
+        no entry in the Maintenance Association table defining an MA
+        for the same VLAN ID and MD Level as this table's entry, and
+        on which MA an Up MEP is defined, else false.
+       "
+    REFERENCE
+       "12.14.3.1.3:b"
+    ::= { ieee8021CfmDefaultMdEntry 4 }
+
+ieee8021CfmDefaultMdLevel OBJECT-TYPE
+    SYNTAX      Dot1agCfmMDLevelOrNone
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "A value indicating the MD Level at which MHFs are to be
+        created, and Sender ID TLV transmission by those MHFs is to
+        be controlled, for the VLAN to which this entry's objects
+        apply.  If this object has the value -1, the MD Level for MHF
+        creation for this VLAN is controlled by
+        ieee8021CfmDefaultMdDefLevel.
+       "
+    REFERENCE
+       "12.14.3.1.3:c, 12.14.3.2.2:b"
+    DEFVAL {-1}
+    ::= { ieee8021CfmDefaultMdEntry 5 }
+
+ieee8021CfmDefaultMdMhfCreation OBJECT-TYPE
+    SYNTAX      Dot1agCfmMhfCreation
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "A value indicating if the Management entity can create MHFs
+        (MIP Half Function) for this VID at this MD Level.  If this
+        object has the value defMHFdefer, MHF creation for this VLAN
+        is controlled by ieee8021CfmDefaultMdDefMhfCreation.
+
+        The value of this variable is meaningless if the values of
+        ieee8021CfmDefaultMdStatus is false.
+       "
+    REFERENCE
+       "12.14.3.1.3:d"
+    DEFVAL {defMHFdefer}
+    ::= { ieee8021CfmDefaultMdEntry 6 }
+
+ieee8021CfmDefaultMdIdPermission OBJECT-TYPE
+    SYNTAX      Dot1agCfmIdPermission
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "Enumerated value indicating what, if anything, is to be
+        included in the Sender ID TLV (21.5.3) transmitted by MHFs
+        created by the Default Maintenance Domain.  If this object
+        has the value sendIdDefer, Sender ID TLV transmission for
+        this VLAN is controlled by ieee8021CfmDefaultMdDefIdPermission.
+
+        The value of this variable is meaningless if the values of
+        ieee8021CfmDefaultMdStatus is false.
+       "
+    REFERENCE
+       "12.14.3.1.3:e"
+    DEFVAL { sendIdDefer }
+    ::= { ieee8021CfmDefaultMdEntry 7 }
+
+
+-- ******************************************************************
+-- The CFM Configuration Error List Table
+-- ******************************************************************
+
+ieee8021CfmConfigErrorListTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Ieee8021CfmConfigErrorListEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The CFM Configuration Error List table provides a list of
+        Interfaces and VIDs that are incorrectly configured.
+       "
+    REFERENCE
+       "12.14.4"
+    ::= {dot1agCfmConfigErrorList 2}
+
+ieee8021CfmConfigErrorListEntry OBJECT-TYPE
+    SYNTAX      Ieee8021CfmConfigErrorListEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Config Error List Table  entry"
+    INDEX { ieee8021CfmConfigErrorListSelectorType,
+            ieee8021CfmConfigErrorListSelector,
+            ieee8021CfmConfigErrorListIfIndex
+          }
+    ::= { ieee8021CfmConfigErrorListTable 1}
+
+Ieee8021CfmConfigErrorListEntry ::= SEQUENCE {
+      ieee8021CfmConfigErrorListSelectorType           IEEE8021ServiceSelectorType,
+      ieee8021CfmConfigErrorListSelector               IEEE8021ServiceSelectorValue,
+      ieee8021CfmConfigErrorListIfIndex                InterfaceIndex,
+      ieee8021CfmConfigErrorListErrorType              Dot1agCfmConfigErrors
+    }
+
+ieee8021CfmConfigErrorListSelectorType OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorType
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "Type of the Service Selector identifier indicated by
+        ieee8021CfmConfigErrorListSelector. See textual 
+        convention IEEE8021ServiceSelectorType for details.
+       "
+    REFERENCE
+       "12.14.4.1.2:a"
+    ::= { ieee8021CfmConfigErrorListEntry 1 }
+
+ieee8021CfmConfigErrorListSelector OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorValue
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Service Selector Identifier of the Service with interfaces
+        in error. See IEEE8021ServiceSelectorValue for details.
+       "
+    REFERENCE
+       "12.14.4.1.2:a"
+    ::= { ieee8021CfmConfigErrorListEntry 2 }
+
+ieee8021CfmConfigErrorListIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "This object is the IfIndex of the interface.
+
+        Upon a restart of the system, the system SHALL, if necessary,
+        change the value of this variable so that it indexes the
+        entry in the interface table with the same value of ifAlias
+        that it indexed before the system restart.  If no such
+        entry exists, then the system SHALL delete any entries in
+        ieee8021CfmConfigErrorListTable indexed by that
+        InterfaceIndex value.
+       "
+    REFERENCE
+       "12.14.4.1.2:b"
+    ::= { ieee8021CfmConfigErrorListEntry 3 }
+
+ieee8021CfmConfigErrorListErrorType OBJECT-TYPE
+    SYNTAX      Dot1agCfmConfigErrors
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "A vector of Boolean error conditions from 22.2.4, any of
+        which may be true:
+
+        0) CFMleak;
+        1) ConflictingVids;
+        2) ExcessiveLevels;
+        3) OverlappedLevels.
+       "
+    REFERENCE
+       "12.14.4.1.3:b"
+    ::= { ieee8021CfmConfigErrorListEntry 4 }
+
+-- ******************************************************************
+-- The CFM Maintenance Association (MA) Component Table
+-- ******************************************************************
+
+ieee8021CfmMaCompTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Ieee8021CfmMaCompEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The Maintenance Association table.  Each row in the table
+        represents an MA.  An MA is a set of MEPs, each configured
+        with a single service instance.
+
+        This is the part of the complete MA table that is variable
+        across the Bridges in a Maintenance Domain, or across the
+        components of a single Bridge.  That part of the MA table that
+        is constant across the Bridges and their components in a
+        Maintenance Domain is contained in the ieee8021CfmMaNetTable.
+
+        This table uses three indices, first index is the
+        IEEE8021PbbComponentIdentifier that identifies the component
+        within the Bridge for which the information in the
+        ieee8021CfmMaCompEntry applies.  The second is the index of the
+        Maintenance Domain table.  The third index is the same as the
+        index of the ieee8021CfmMaNetEntry for the same MA.
+
+        The writable objects in this table need to be persistent
+        upon reboot or restart of a device.
+
+       "
+    REFERENCE
+       "18.2"
+    ::= { dot1agCfmMa 4 }
+
+ieee8021CfmMaCompEntry OBJECT-TYPE
+    SYNTAX      Ieee8021CfmMaCompEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The MA table entry."
+    INDEX {ieee8021CfmMaComponentId,
+           dot1agCfmMdIndex, dot1agCfmMaIndex }
+    ::= { ieee8021CfmMaCompTable 1 }
+
+Ieee8021CfmMaCompEntry ::= SEQUENCE {
+      ieee8021CfmMaComponentId                 IEEE8021PbbComponentIdentifier,
+      ieee8021CfmMaCompPrimarySelectorType     IEEE8021ServiceSelectorType,
+      ieee8021CfmMaCompPrimarySelectorOrNone   IEEE8021ServiceSelectorValueOrNone,
+      ieee8021CfmMaCompMhfCreation             Dot1agCfmMhfCreation,
+      ieee8021CfmMaCompIdPermission            Dot1agCfmIdPermission,
+      ieee8021CfmMaCompNumberOfVids            Unsigned32,
+      ieee8021CfmMaCompRowStatus               RowStatus
+    }
+
+ieee8021CfmMaComponentId OBJECT-TYPE
+    SYNTAX      IEEE8021PbbComponentIdentifier
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The bridge component within the system to which the information
+        in this ieee8021CfmMaCompEntry applies.  If the system is not a
+        Bridge, or if only one component is present in the Bridge, then
+        this variable (index) MUST be equal to 1.
+       "
+    REFERENCE
+       "12.3 l)"
+    ::= { ieee8021CfmMaCompEntry 1 }
+
+ieee8021CfmMaCompPrimarySelectorType OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorType
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Type of the Service Selector identifiers indicated by 
+        ieee8021CfmMaCompPrimarySelectorOrNone. If the service instance is defined by more 
+        than one Service Selector, this parameter also indicates the type of the 
+        ieee8021CfmVlanPrimarySelector and ieee8021CfmVlanSelector in the ieee8021CfmVlanTable. 
+        In Services instances made of multiple Service Selector identifiers, ensures that the
+        type of the Service selector identifiers is the same. See textual convention 
+        Dot1agCfmServiceSelectorType for details.
+       "
+    REFERENCE
+       "12.14.6.1.3:b"
+    ::= { ieee8021CfmMaCompEntry 2 }
+
+ieee8021CfmMaCompPrimarySelectorOrNone OBJECT-TYPE
+    SYNTAX      IEEE8021ServiceSelectorValueOrNone
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Service Selector identifier to which the MP is attached, or 0, if none.
+        If the MA is associated with more than one Service Selectors Identifiers, the
+        ieee8021CfmVlanTable lists them.
+       "
+    REFERENCE
+       "12.14.6.1.3:b"
+    ::= { ieee8021CfmMaCompEntry 3 }
+
+
+ieee8021CfmMaCompMhfCreation OBJECT-TYPE
+    SYNTAX      Dot1agCfmMhfCreation
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Indicates if the Management entity can create MHFs (MIP Half
+        Function) for this MA.
+       "
+    REFERENCE
+       "12.14.6.1.3:c"
+    DEFVAL { defMHFdefer }
+    ::= { ieee8021CfmMaCompEntry 4 }
+
+ieee8021CfmMaCompIdPermission OBJECT-TYPE
+    SYNTAX      Dot1agCfmIdPermission
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "Enumerated value indicating what, if anything, is to be
+        included in the Sender ID TLV (21.5.3) transmitted by MPs
+        configured in this MA.
+       "
+    REFERENCE
+       "12.14.6.1.3:d"
+    DEFVAL { sendIdDefer }
+    ::= { ieee8021CfmMaCompEntry 5 }
+
+ieee8021CfmMaCompNumberOfVids OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The number of VIDs associated with the MA.
+       "
+    REFERENCE
+       "12.14.6.1.3:b"
+    ::= { ieee8021CfmMaCompEntry 6 }
+
+ieee8021CfmMaCompRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+       "The status of the row.
+
+        The writable columns in a row can not be changed if the row
+        is active. All columns MUST have a valid value before a row
+        can be activated.
+       "
+    ::= { ieee8021CfmMaCompEntry 7 }
+
+-- ******************************************************************
+-- Units of conformance
+-- ******************************************************************
+
+ieee8021CfmStackGroup OBJECT-GROUP
+    OBJECTS {
+      ieee8021CfmStackMdIndex,
+      ieee8021CfmStackMaIndex,
+      ieee8021CfmStackMepId,
+      ieee8021CfmStackMacAddress
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the Stack group."
+    ::= { dot1agCfmGroups 14 }
+
+ieee8021CfmMaGroup OBJECT-GROUP
+    OBJECTS {
+      ieee8021CfmMaCompPrimarySelectorType,
+      ieee8021CfmMaCompPrimarySelectorOrNone,
+      ieee8021CfmMaCompMhfCreation,
+      ieee8021CfmMaCompIdPermission,
+      ieee8021CfmMaCompRowStatus,
+      ieee8021CfmMaCompNumberOfVids
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the MA group."
+    ::= { dot1agCfmGroups 15 }
+
+ieee8021CfmDefaultMdGroup OBJECT-GROUP
+    OBJECTS {
+      ieee8021CfmDefaultMdStatus,
+      ieee8021CfmDefaultMdLevel,
+      ieee8021CfmDefaultMdMhfCreation,
+      ieee8021CfmDefaultMdIdPermission
+    }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the Default MD Level group."
+    ::= { dot1agCfmGroups 16 }
+
+ieee8021CfmVlanIdGroup OBJECT-GROUP
+    OBJECTS {
+      ieee8021CfmVlanPrimarySelector,
+      ieee8021CfmVlanRowStatus
+   }
+    STATUS      current
+    DESCRIPTION
+       "Objects for the VLAN ID group."
+    ::= { dot1agCfmGroups 17 }
+
+ieee8021CfmConfigErrorListGroup OBJECT-GROUP
+    OBJECTS {
+      ieee8021CfmConfigErrorListErrorType
+    }
+    STATUS current
+    DESCRIPTION
+       "Objects for the CFM Configuration Error List Group."
+    ::= {dot1agCfmGroups 18 }
+
+-- ******************************************************************
+-- MIB Module Compliance statements
+-- ******************************************************************
+
+ieee8021CfmComplianceV2 MODULE-COMPLIANCE
+    STATUS      current
+    DESCRIPTION
+       "The compliance statement for support of the CFM MIB module."
+
+    MODULE
+        MANDATORY-GROUPS {
+            ieee8021CfmStackGroup,
+            ieee8021CfmMaGroup,
+            ieee8021CfmDefaultMdGroup,
+            ieee8021CfmConfigErrorListGroup
+         }
+
+    GROUP ieee8021CfmVlanIdGroup
+    DESCRIPTION "The VLAN ID group is optional."
+
+    OBJECT ieee8021CfmMaCompRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT ieee8021CfmVlanRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    MODULE IEEE8021-CFM-MIB
+        MANDATORY-GROUPS {
+            dot1agCfmMdGroup,
+            dot1agCfmMepGroup,
+            dot1agCfmMepDbGroup,
+            dot1agCfmNotificationsGroup,
+            ieee8021CfmDefaultMdDefGroup,
+            ieee8021CfmMaNetGroup
+         }
+
+    OBJECT dot1agCfmMepLbrBadMsdu
+    MIN-ACCESS not-accessible
+    DESCRIPTION "The dot1agCfmMepLbrBadMsdu variable is optional.  It
+                 MUST not be present if the system cannot compare a
+                 received LBR to the corresponding LBM."
+
+    OBJECT dot1agCfmMdRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT dot1agCfmMaNetRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+     OBJECT  dot1agCfmMaMepListRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    OBJECT  dot1agCfmMepRowStatus
+      SYNTAX       RowStatus { active(1), notInService(2) }
+      WRITE-SYNTAX RowStatus { notInService(2), createAndGo(4),
+                               destroy(6) }
+      DESCRIPTION "Support for createAndWait is not required."
+
+    ::= { dot1agCfmCompliances 2 }
+
+END
+

--- a/mibs/junos/mib-IANA-ADDRESS-FAMILY-NUMBERS-MIB.txt
+++ b/mibs/junos/mib-IANA-ADDRESS-FAMILY-NUMBERS-MIB.txt
@@ -1,0 +1,129 @@
+
+
+  IANA-ADDRESS-FAMILY-NUMBERS-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+      MODULE-IDENTITY,
+      mib-2                               FROM SNMPv2-SMI
+      TEXTUAL-CONVENTION                  FROM SNMPv2-TC;
+
+  ianaAddressFamilyNumbers MODULE-IDENTITY
+      LAST-UPDATED "200203140000Z"  -- March 14, 2002
+      ORGANIZATION "IANA"
+      CONTACT-INFO
+          "Postal:    Internet Assigned Numbers Authority
+                      Internet Corporation for Assigned Names
+		      and Numbers
+                      4676 Admiralty Way, Suite 330
+                      Marina del Rey, CA 90292-6601
+                      USA
+
+          Tel:    +1  310-823-9358
+          E-Mail: iana@iana.org"
+      DESCRIPTION
+          "The MIB module defines the AddressFamilyNumbers
+          textual convention."
+
+      -- revision history
+
+      REVISION     "200203140000Z"  -- March 14, 2002
+      DESCRIPTION  "AddressFamilyNumbers assignment 22 to 
+                   fibreChannelWWPN. AddressFamilyNumbers 
+                   assignment 23 to fibreChannelWWNN.
+                   AddressFamilyNumers assignment 24 to gwid."
+
+      REVISION     "200009080000Z"  -- September 8, 2000
+      DESCRIPTION  "AddressFamilyNumbers assignment 19 to xtpOverIpv4.  
+                   AddressFamilyNumbers assignment 20 to xtpOverIpv6.  
+                   AddressFamilyNumbers assignment 21 to xtpNativeModeXTP."
+
+      REVISION     "200003010000Z"  -- March 1, 2000
+      DESCRIPTION  "AddressFamilyNumbers assignment 17 to distinguishedName. 
+                   AddressFamilyNumbers assignment 18 to asNumber."
+
+      REVISION     "200002040000Z"  -- February 4, 2000
+      DESCRIPTION  "AddressFamilyNumbers assignment 16 to dns."
+
+      REVISION     "9908260000Z"  -- August 26, 1999
+      DESCRIPTION  "Initial version, published as RFC 2677."
+
+      ::= { mib-2 72 }
+
+
+  AddressFamilyNumbers ::= TEXTUAL-CONVENTION
+
+      STATUS       current
+      DESCRIPTION
+          "The definition of this textual convention with the
+          addition of newly assigned values is published
+          periodically by the IANA, in either the Assigned
+          Numbers RFC, or some derivative of it specific to
+          Internet Network Management number assignments.
+          (The latest arrangements can be obtained by
+          contacting the IANA.)
+
+          The enumerations are described as:
+
+          other(0),    -- none of the following
+          ipV4(1),     -- IP Version 4
+          ipV6(2),     -- IP Version 6
+          nsap(3),     -- NSAP
+          hdlc(4),     -- (8-bit multidrop)
+          bbn1822(5),
+          all802(6),   -- (includes all 802 media
+                       --   plus Ethernet 'canonical format')
+          e163(7),
+          e164(8),     -- (SMDS, Frame Relay, ATM)
+          f69(9),      -- (Telex)
+          x121(10),    -- (X.25, Frame Relay)
+          ipx(11),     -- IPX (Internet Protocol Exchange)
+          appleTalk(12),  -- Apple Talk
+          decnetIV(13),   -- DEC Net Phase IV
+          banyanVines(14),  -- Banyan Vines
+          e164withNsap(15),
+                       -- (E.164 with NSAP format subaddress)
+          dns(16),     -- (Domain Name System)
+          distinguishedName(17), -- (Distinguished Name, per X.500)
+          asNumber(18), -- (16-bit quantity, per the AS number space)
+          xtpOverIpv4(19),  -- XTP over IP version 4
+          xtpOverIpv6(20),  -- XTP over IP version 6
+          xtpNativeModeXTP(21),  -- XTP native mode XTP
+          fibreChannelWWPN(22),  -- Fibre Channel World-Wide Port Name 
+          fibreChannelWWNN(23),  -- Fibre Channel World-Wide Node Name
+          gwid(24),    -- Gateway Identifier 
+          reserved(65535)
+
+
+
+          Requests for new values should be made to IANA via
+          email (iana@iana.org)."
+
+      SYNTAX  INTEGER {
+                  other(0),
+                  ipV4(1),
+                  ipV6(2),
+                  nsap(3),
+                  hdlc(4),
+                  bbn1822(5),
+                  all802(6),
+                  e163(7),
+                  e164(8),
+                  f69(9),
+                  x121(10),
+                  ipx(11),
+                  appleTalk(12),
+                  decnetIV(13),
+                  banyanVines(14),
+                  e164withNsap(15),
+                  dns(16),
+                  distinguishedName(17), -- (Distinguished Name, per X.500)
+                  asNumber(18), -- (16-bit quantity, per the AS number space)
+                  xtpOverIpv4(19),
+                  xtpOverIpv6(20),
+                  xtpNativeModeXTP(21),
+                  fibreChannelWWPN(22),
+                  fibreChannelWWNN(23),
+                  gwid(24),
+                  reserved(65535)
+              }
+      END

--- a/mibs/junos/mib-IANAifType-MIB.txt
+++ b/mibs/junos/mib-IANAifType-MIB.txt
@@ -1,4 +1,3 @@
-
    IANAifType-MIB DEFINITIONS ::= BEGIN
 
    IMPORTS
@@ -6,7 +5,7 @@
        TEXTUAL-CONVENTION          FROM SNMPv2-TC;
 
    ianaifType MODULE-IDENTITY
-       LAST-UPDATED "200101120000Z"  -- Jan 12, 2001
+       LAST-UPDATED "201009210000Z"  -- September 21, 2010
        ORGANIZATION "IANA"
        CONTACT-INFO "        Internet Assigned Numbers Authority
 
@@ -15,31 +14,208 @@
                              Marina del Rey, CA 90292
 
                      Tel:    +1 310 823 9358
-                     E-Mail: iana@iana.org"
+                     E-Mail: iana&iana.org"
 
        DESCRIPTION  "This MIB module defines the IANAifType Textual
                      Convention, and thus the enumerated values of
                      the ifType object defined in MIB-II's ifTable."
+
+       REVISION     "201009210000Z"  -- September 21, 2010
+       DESCRIPTION  "Registration of new IANAifTypes 256 and 257."
+
+       REVISION     "201007210000Z"  -- July 21, 2010
+       DESCRIPTION  "Registration of new IANAifType 255."
+                     
+       REVISION     "201002110000Z"  -- February 11, 2010
+       DESCRIPTION  "Registration of new IANAifType 254."
+                     
+       REVISION     "201002080000Z"  -- February 08, 2010
+       DESCRIPTION  "Registration of new IANAifTypes 252 and 253."
+
+       REVISION     "200905060000Z"  -- May 06, 2009
+       DESCRIPTION  "Registration of new IANAifType 251."
+
+       REVISION     "200902060000Z"  -- February 06, 2009
+       DESCRIPTION  "Registration of new IANAtunnelType 15."
+
+       REVISION     "200810090000Z"  -- October 09, 2008
+       DESCRIPTION  "Registration of new IANAifType 250."
+
+       REVISION     "200808120000Z"  -- August 12, 2008
+       DESCRIPTION  "Registration of new IANAifType 249."
+
+       REVISION     "200807220000Z"  -- July 22, 2008
+       DESCRIPTION  "Registration of new IANAifTypes 247 and 248."
+
+       REVISION     "200806240000Z"  -- June 24, 2008
+       DESCRIPTION  "Registration of new IANAifType 246."
+
+       REVISION     "200805290000Z"  -- May 29, 2008
+       DESCRIPTION  "Registration of new IANAifType 245."
+
+       REVISION     "200709130000Z"  -- September 13, 2007
+       DESCRIPTION  "Registration of new IANAifTypes 243 and 244."
+
+       REVISION     "200705290000Z"  -- May 29, 2007
+       DESCRIPTION  "Changed the description for IANAifType 228."
+
+       REVISION     "200703080000Z"  -- March 08, 2007
+       DESCRIPTION  "Registration of new IANAifType 242."
+
+       REVISION     "200701230000Z"  -- January 23, 2007
+       DESCRIPTION  "Registration of new IANAifTypes 239, 240, and 241." 
+
+       REVISION     "200610170000Z"  -- October 17, 2006
+       DESCRIPTION  "Deprecated/Obsoleted IANAifType 230.  Registration of 
+                     IANAifType 238." 
+
+       REVISION     "200609250000Z"  -- September 25, 2006
+       DESCRIPTION  "Changed the description for IANA ifType 
+                     184 and added new IANA ifType 237."  
+
+       REVISION     "200608170000Z"  -- August 17, 2006
+       DESCRIPTION  "Changed the descriptions for IANAifTypes
+                     20 and 21."   
+
+       REVISION     "200608110000Z"  -- August 11, 2006
+       DESCRIPTION  "Changed the descriptions for IANAifTypes
+                     7, 11, 62, 69, and 117."   
+
+       REVISION     "200607250000Z"  -- July 25, 2006
+       DESCRIPTION  "Registration of new IANA ifType 236."
+
+       REVISION     "200606140000Z"  -- June 14, 2006
+       DESCRIPTION  "Registration of new IANA ifType 235."
+
+       REVISION     "200603310000Z"  -- March 31, 2006
+       DESCRIPTION  "Registration of new IANA ifType 234."
+	   
+       REVISION     "200603300000Z"  -- March 30, 2006
+       DESCRIPTION  "Registration of new IANA ifType 233."
+       
+       REVISION     "200512220000Z"  -- December 22, 2005
+       DESCRIPTION  "Registration of new IANA ifTypes 231 and 232."
+	   
+       REVISION     "200510100000Z"  -- October 10, 2005
+       DESCRIPTION  "Registration of new IANA ifType 230."
+
+       REVISION     "200509090000Z"  -- September 09, 2005
+       DESCRIPTION  "Registration of new IANA ifType 229."
+
+       REVISION     "200505270000Z"  -- May 27, 2005
+       DESCRIPTION  "Registration of new IANA ifType 228."
+
+       REVISION     "200503030000Z"  -- March 3, 2005
+       DESCRIPTION  "Added the IANAtunnelType TC and deprecated
+	                 IANAifType sixToFour (215) per RFC4087."
+
+       REVISION     "200411220000Z"  -- November 22, 2004
+       DESCRIPTION  "Registration of new IANA ifType 227 per RFC4631."
+
+       REVISION     "200406170000Z"  -- June 17, 2004
+       DESCRIPTION  "Registration of new IANA ifType 226."
+
+       REVISION     "200405120000Z"  -- May 12, 2004
+       DESCRIPTION  "Added description for IANAifType 6, and 
+	                 changed the descriptions for IANAifTypes
+                     180, 181, and 182."
+
+       REVISION     "200405070000Z"  -- May 7, 2004
+       DESCRIPTION  "Registration of new IANAifType 225."
+
+       REVISION     "200308250000Z"  -- Aug 25, 2003
+       DESCRIPTION  "Deprecated IANAifTypes 7 and 11. Obsoleted
+                     IANAifTypes 62, 69, and 117.  ethernetCsmacd (6)
+                     should be used instead of these values"
+
+       REVISION     "200308180000Z"  -- Aug 18, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     224."
+
+       REVISION     "200308070000Z"  -- Aug 7, 2003
+       DESCRIPTION  "Registration of new IANAifTypes
+                     222 and 223."
+
+       REVISION     "200303180000Z"  -- Mar 18, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     221."
+
+       REVISION     "200301130000Z"  -- Jan 13, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     220."
+
+       REVISION     "200210170000Z"  -- Oct 17, 2002
+       DESCRIPTION  "Registration of new IANAifType
+                     219."
+	   
+       REVISION     "200207160000Z"  -- Jul 16, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     217 and 218."
+
+       REVISION     "200207100000Z"  -- Jul 10, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     215 and 216."
+
+       REVISION     "200206190000Z"  -- Jun 19, 2002
+       DESCRIPTION  "Registration of new IANAifType
+                     214."
+	   
+       REVISION     "200201040000Z"  -- Jan 4, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     211, 212 and 213."
+
+       REVISION     "200112200000Z"  -- Dec 20, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     209 and 210."
+
+       REVISION     "200111150000Z"  -- Nov 15, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     207 and 208."
+
+
+       REVISION     "200111060000Z"  -- Nov 6, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     206."
+
+
+       REVISION     "200111020000Z"  -- Nov 2, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     205."
+
+
+       REVISION     "200110160000Z"  -- Oct 16, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     199, 200, 201, 202, 203, and 204."
+
+
+       REVISION     "200109190000Z"  -- Sept 19, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     198."
+
+       REVISION     "200105110000Z"  -- May 11, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     197."
+
        
        REVISION     "200101120000Z"  -- Jan 12, 2001
        DESCRIPTION  "Registration of new IANAifTypes
-                    195 and 196."
+                     195 and 196."
 
        REVISION     "200012190000Z"  -- Dec 19, 2000
        DESCRIPTION  "Registration of new IANAifTypes
-                    193 and 194."
+                     193 and 194."
 
        REVISION     "200012070000Z"  -- Dec 07, 2000
        DESCRIPTION  "Registration of new IANAifTypes
-                    191 and 192."
+                     191 and 192."
 
        REVISION     "200012040000Z"  -- Dec 04, 2000
        DESCRIPTION  "Registration of new IANAifType
-                    190."
+                     190."
 
        REVISION     "200010170000Z"  -- Oct 17, 2000
        DESCRIPTION  "Registration of new IANAifTypes
-                    188 and 189."  
+                     188 and 189."  
 
        REVISION     "200010020000Z"  -- Oct 02, 2000
        DESCRIPTION  "Registration of new IANAifType 187." 
@@ -62,7 +238,6 @@
        REVISION     "200004250000Z"  -- Apr 25, 2000
        DESCRIPTION  "Registration of new IANAifTypes 168 and 169."       
 	
-
        REVISION     "200003060000Z"  -- Mar 6, 2000
        DESCRIPTION  "Fixed a missing semi-colon in the IMPORT.
                      Also cleaned up the REVISION log a bit.
@@ -98,7 +273,7 @@
                IANA.)
 
                Requests for new values should be made to IANA via
-               email (iana@iana.org).
+               email (iana&iana.org).
 
                The relationship between the assignment of ifType
                values and of OIDs to particular media-specific MIBs
@@ -116,12 +291,15 @@
                    hdh1822(3),
                    ddnX25(4),
                    rfc877x25(5),
-                   ethernetCsmacd(6),
-                   iso88023Csmacd(7),
+                   ethernetCsmacd(6), -- for all ethernet-like interfaces,
+                                      -- regardless of speed, as per RFC3635
+                   iso88023Csmacd(7), -- Deprecated via RFC3635
+                                      -- ethernetCsmacd (6) should be used instead
                    iso88024TokenBus(8),
                    iso88025TokenRing(9),
                    iso88026Man(10),
-                   starLan(11),
+                   starLan(11), -- Deprecated via RFC3635
+                                -- ethernetCsmacd (6) should be used instead
                    proteon10Mbit(12),
                    proteon80Mbit(13),
                    hyperchannel(14),
@@ -130,8 +308,10 @@
                    sdlc(17),
                    ds1(18),            -- DS1-MIB
                    e1(19),             -- Obsolete see DS1-MIB
-                   basicISDN(20),
-                   primaryISDN(21),
+                   basicISDN(20),              -- no longer used
+                                               -- see also RFC2127
+                   primaryISDN(21),            -- no longer used
+                                               -- see also RFC2127
                    propPointToPointSerial(22), -- proprietary serial
                    ppp(23),
                    softwareLoopback(24),
@@ -174,17 +354,19 @@
                    aflane8023(59),     -- ATM Emulated LAN for 802.3
                    aflane8025(60),     -- ATM Emulated LAN for 802.5
                    cctEmul(61),        -- ATM Emulated circuit          
-                   fastEther(62),      -- Fast Ethernet (100BaseT)
+                   fastEther(62),      -- Obsoleted via RFC3635
+                                       -- ethernetCsmacd (6) should be used instead
                    isdn(63),           -- ISDN and X.25           
                    v11(64),            -- CCITT V.11/X.21             
                    v36(65),            -- CCITT V.36                  
                    g703at64k(66),      -- CCITT G703 at 64Kbps
                    g703at2mb(67),      -- Obsolete see DS1-MIB
                    qllc(68),           -- SNA QLLC                    
-                   fastEtherFX(69),    -- Fast Ethernet (100BaseFX)   
+                   fastEtherFX(69),    -- Obsoleted via RFC3635
+                                       -- ethernetCsmacd (6) should be used instead
                    channel(70),        -- channel                     
                    ieee80211(71),      -- radio spread spectrum       
-	           ibm370parChan(72),  -- IBM System 360/370 OEMI Channel
+                   ibm370parChan(72),  -- IBM System 360/370 OEMI Channel
                    escon(73),          -- IBM Enterprise Systems Connection
                    dlsw(74),           -- Data Link Switching
                    isdns(75),          -- ISDN S/T interface
@@ -219,61 +401,62 @@
                    voiceOverIp(104),   -- voice over IP encapsulation
                    atmDxi(105),        -- ATM DXI
                    atmFuni(106),       -- ATM FUNI
-		   atmIma (107),       -- ATM IMA		   
+                   atmIma (107),       -- ATM IMA		   
                    pppMultilinkBundle(108), -- PPP Multilink Bundle
                    ipOverCdlc (109),   -- IBM ipOverCdlc
-		   ipOverClaw (110),   -- IBM Common Link Access to Workstn
+                   ipOverClaw (110),   -- IBM Common Link Access to Workstn
                    stackToStack (111), -- IBM stackToStack
                    virtualIpAddress (112), -- IBM VIPA
-		   mpc (113),          -- IBM multi-protocol channel support
-		   ipOverAtm (114),    -- IBM ipOverAtm
-		   iso88025Fiber (115), -- ISO 802.5j Fiber Token Ring
-		   tdlc (116),	       -- IBM twinaxial data link control
-		   gigabitEthernet (117), -- Gigabit Ethernet
-		   hdlc (118),         -- HDLC
-		   lapf (119),	       -- LAP F
-		   v37 (120),	       -- V.37
-		   x25mlp (121),       -- Multi-Link Protocol
-		   x25huntGroup (122), -- X25 Hunt Group
-		   trasnpHdlc (123),   -- Transp HDLC
-		   interleave (124),   -- Interleave channel
-		   fast (125),         -- Fast channel
-		   ip (126),	       -- IP (for APPN HPR in IP networks)
-		   docsCableMaclayer (127),  -- CATV Mac Layer
-		   docsCableDownstream (128), -- CATV Downstream interface
-		   docsCableUpstream (129),  -- CATV Upstream interface
-		   a12MppSwitch (130), -- Avalon Parallel Processor
-		   tunnel (131),       -- Encapsulation interface
-		   coffee (132),       -- coffee pot
-		   ces (133),          -- Circuit Emulation Service
-		   atmSubInterface (134), -- ATM Sub Interface
-		   l2vlan (135),       -- Layer 2 Virtual LAN using 802.1Q
-		   l3ipvlan (136),     -- Layer 3 Virtual LAN using IP
-		   l3ipxvlan (137),    -- Layer 3 Virtual LAN using IPX
-		   digitalPowerline (138), -- IP over Power Lines	
-		   mediaMailOverIp (139), -- Multimedia Mail over IP
-		   dtm (140),        -- Dynamic syncronous Transfer Mode
-		   dcn (141),    -- Data Communications Network
-		   ipForward (142),    -- IP Forwarding Interface
-		   msdsl (143),       -- Multi-rate Symmetric DSL
-		   ieee1394 (144), -- IEEE1394 High Performance Serial Bus
-		   if-gsn (145),       --   HIPPI-6400 
-		   dvbRccMacLayer (146), -- DVB-RCC MAC Layer
-		   dvbRccDownstream (147),  -- DVB-RCC Downstream Channel
-		   dvbRccUpstream (148),  -- DVB-RCC Upstream Channel
-		   atmVirtual (149),   -- ATM Virtual Interface
-		   mplsTunnel (150),   -- MPLS Tunnel Virtual Interface
-		   srp (151),	-- Spatial Reuse Protocol	
-		   voiceOverAtm (152),  -- Voice Over ATM
-		   voiceOverFrameRelay (153),   -- Voice Over Frame Relay 
-		   idsl (154),		-- Digital Subscriber Loop over ISDN
-		   compositeLink (155),  -- Avici Composite Link Interface
-		   ss7SigLink (156),     -- SS7 Signaling Link 
-		   propWirelessP2P (157),  --  Prop. P2P wireless interface
-		   frForward (158),    -- Frame Forward Interface
-		   rfc1483 (159),	-- Multiprotocol over ATM AAL5
-		   usb (160),		-- USB Interface
-		   ieee8023adLag (161),  -- IEEE 802.3ad Link Aggregate
+                   mpc (113),          -- IBM multi-protocol channel support
+                   ipOverAtm (114),    -- IBM ipOverAtm
+                   iso88025Fiber (115), -- ISO 802.5j Fiber Token Ring
+                   tdlc (116),	       -- IBM twinaxial data link control
+                   gigabitEthernet (117), -- Obsoleted via RFC3635
+                                          -- ethernetCsmacd (6) should be used instead
+                   hdlc (118),         -- HDLC
+                   lapf (119),	       -- LAP F
+                   v37 (120),	       -- V.37
+                   x25mlp (121),       -- Multi-Link Protocol
+                   x25huntGroup (122), -- X25 Hunt Group
+                   transpHdlc (123),   -- Transp HDLC
+                   interleave (124),   -- Interleave channel
+                   fast (125),         -- Fast channel
+                   ip (126),	       -- IP (for APPN HPR in IP networks)
+                   docsCableMaclayer (127),  -- CATV Mac Layer
+                   docsCableDownstream (128), -- CATV Downstream interface
+                   docsCableUpstream (129),  -- CATV Upstream interface
+                   a12MppSwitch (130), -- Avalon Parallel Processor
+                   tunnel (131),       -- Encapsulation interface
+                   coffee (132),       -- coffee pot
+                   ces (133),          -- Circuit Emulation Service
+                   atmSubInterface (134), -- ATM Sub Interface
+                   l2vlan (135),       -- Layer 2 Virtual LAN using 802.1Q
+                   l3ipvlan (136),     -- Layer 3 Virtual LAN using IP
+                   l3ipxvlan (137),    -- Layer 3 Virtual LAN using IPX
+                   digitalPowerline (138), -- IP over Power Lines	
+                   mediaMailOverIp (139), -- Multimedia Mail over IP
+                   dtm (140),        -- Dynamic syncronous Transfer Mode
+                   dcn (141),    -- Data Communications Network
+                   ipForward (142),    -- IP Forwarding Interface
+                   msdsl (143),       -- Multi-rate Symmetric DSL
+                   ieee1394 (144), -- IEEE1394 High Performance Serial Bus
+                   if-gsn (145),       --   HIPPI-6400 
+                   dvbRccMacLayer (146), -- DVB-RCC MAC Layer
+                   dvbRccDownstream (147),  -- DVB-RCC Downstream Channel
+                   dvbRccUpstream (148),  -- DVB-RCC Upstream Channel
+                   atmVirtual (149),   -- ATM Virtual Interface
+                   mplsTunnel (150),   -- MPLS Tunnel Virtual Interface
+                   srp (151),	-- Spatial Reuse Protocol	
+                   voiceOverAtm (152),  -- Voice Over ATM
+                   voiceOverFrameRelay (153),   -- Voice Over Frame Relay 
+                   idsl (154),		-- Digital Subscriber Loop over ISDN
+                   compositeLink (155),  -- Avici Composite Link Interface
+                   ss7SigLink (156),     -- SS7 Signaling Link 
+                   propWirelessP2P (157),  --  Prop. P2P wireless interface
+                   frForward (158),    -- Frame Forward Interface
+                   rfc1483 (159),	-- Multiprotocol over ATM AAL5
+                   usb (160),		-- USB Interface
+                   ieee8023adLag (161),  -- IEEE 802.3ad Link Aggregate
                    bgppolicyaccounting (162), -- BGP Policy Accounting
                    frf16MfrBundle (163), -- FRF .16 Multilink Frame Relay 
                    h323Gatekeeper (164), -- H323 Gatekeeper
@@ -284,7 +467,7 @@
                    shdsl (169), -- Multirate HDSL2
                    ds1FDL (170), -- Facility Data Link 4Kbps on a DS1
                    pos (171), -- Packet over SONET/SDH Interface
-                   dvbAsiln (172), -- DVB-ASI Input
+                   dvbAsiIn (172), -- DVB-ASI Input
                    dvbAsiOut (173), -- DVB-ASI Output 
                    plc (174), -- Power Line Communtications
                    nfas (175), -- Non Facility Associated Signaling
@@ -292,11 +475,14 @@
                    gr303RDT (177), -- Remote Digital Terminal
                    gr303IDT (178), -- Integrated Digital Terminal
                    isup (179), -- ISUP
-                   propDocsWirelessMaclayer (180), -- prop/Maclayer
-                   propDocsWirelessDownstream (181), -- prop/Downstream
-                   propDocsWirelessUpstream (182), -- prop/Upstream
+                   propDocsWirelessMaclayer (180), -- Cisco proprietary Maclayer
+                   propDocsWirelessDownstream (181), -- Cisco proprietary Downstream
+                   propDocsWirelessUpstream (182), -- Cisco proprietary Upstream
                    hiperlan2 (183), -- HIPERLAN Type 2 Radio Interface
                    propBWAp2Mp (184), -- PropBroadbandWirelessAccesspt2multipt
+                             -- use of this iftype for IEEE 802.16 WMAN
+                             -- interfaces as per IEEE Std 802.16f is
+                             -- deprecated and ifType 237 should be used instead.
                    sonetOverheadChannel (185), -- SONET Overhead Channel
                    digitalWrapperOverheadChannel (186), -- Digital Wrapper
                    aal2 (187), -- ATM adaptation layer 2
@@ -304,11 +490,122 @@
                    atmRadio (189), -- ATM over radio links   
                    imt (190), -- Inter Machine Trunks
                    mvl (191), -- Multiple Virtual Lines DSL
-                   reachDSL (192), -- Long Rach DSL
+                   reachDSL (192), -- Long Reach DSL
                    frDlciEndPt (193), -- Frame Relay DLCI End Point
                    atmVciEndPt (194), -- ATM VCI End Point
                    opticalChannel (195), -- Optical Channel
-                   opticalTransport (196) -- Optical Transport
-}
+                   opticalTransport (196), -- Optical Transport
+                   propAtm (197), --  Proprietary ATM       
+                   voiceOverCable (198), -- Voice Over Cable Interface
+                   infiniband (199), -- Infiniband
+                   teLink (200), -- TE Link
+                   q2931 (201), -- Q.2931
+                   virtualTg (202), -- Virtual Trunk Group
+                   sipTg (203), -- SIP Trunk Group
+                   sipSig (204), -- SIP Signaling   
+                   docsCableUpstreamChannel (205), -- CATV Upstream Channel
+                   econet (206), -- Acorn Econet
+                   pon155 (207), -- FSAN 155Mb Symetrical PON interface
+                   pon622 (208), -- FSAN622Mb Symetrical PON interface
+                   bridge (209), -- Transparent bridge interface
+                   linegroup (210), -- Interface common to multiple lines   
+                   voiceEMFGD (211), -- voice E&M Feature Group D
+                   voiceFGDEANA (212), -- voice FGD Exchange Access North American
+                   voiceDID (213), -- voice Direct Inward Dialing
+                   mpegTransport (214), -- MPEG transport interface
+                   sixToFour (215), -- 6to4 interface (DEPRECATED)
+                   gtp (216), -- GTP (GPRS Tunneling Protocol)
+                   pdnEtherLoop1 (217), -- Paradyne EtherLoop 1
+                   pdnEtherLoop2 (218), -- Paradyne EtherLoop 2
+                   opticalChannelGroup (219), -- Optical Channel Group
+                   homepna (220), -- HomePNA ITU-T G.989
+                   gfp (221), -- Generic Framing Procedure (GFP)
+                   ciscoISLvlan (222), -- Layer 2 Virtual LAN using Cisco ISL
+                   actelisMetaLOOP (223), -- Acteleis proprietary MetaLOOP High Speed Link 
+                   fcipLink (224), -- FCIP Link 
+                   rpr (225), -- Resilient Packet Ring Interface Type
+                   qam (226), -- RF Qam Interface
+                   lmp (227), -- Link Management Protocol
+                   cblVectaStar (228), -- Cambridge Broadband Networks Limited VectaStar
+                   docsCableMCmtsDownstream (229), -- CATV Modular CMTS Downstream Interface
+                   adsl2 (230), -- Asymmetric Digital Subscriber Loop Version 2 
+                                -- (DEPRECATED/OBSOLETED - please use adsl2plus 238 instead)
+                   macSecControlledIF (231), -- MACSecControlled 
+                   macSecUncontrolledIF (232), -- MACSecUncontrolled
+                   aviciOpticalEther (233), -- Avici Optical Ethernet Aggregate
+                   atmbond (234), -- atmbond
+                   voiceFGDOS (235), -- voice FGD Operator Services
+                   mocaVersion1 (236), -- MultiMedia over Coax Alliance (MoCA) Interface
+                             -- as documented in information provided privately to IANA
+                   ieee80216WMAN (237), -- IEEE 802.16 WMAN interface
+                   adsl2plus (238), -- Asymmetric Digital Subscriber Loop Version 2, 
+                                   -- Version 2 Plus and all variants
+                   dvbRcsMacLayer (239), -- DVB-RCS MAC Layer
+                   dvbTdm (240), -- DVB Satellite TDM
+                   dvbRcsTdma (241), -- DVB-RCS TDMA
+                   x86Laps (242), -- LAPS based on ITU-T X.86/Y.1323
+                   wwanPP (243), -- 3GPP WWAN
+                   wwanPP2 (244), -- 3GPP2 WWAN
+                   voiceEBS (245), -- voice P-phone EBS physical interface
+                   ifPwType (246), -- Pseudowire interface type
+                   ilan (247), -- Internal LAN on a bridge per IEEE 802.1ap
+                   pip (248), -- Provider Instance Port on a bridge per IEEE 802.1ah PBB
+                   aluELP (249), -- Alcatel-Lucent Ethernet Link Protection
+                   gpon (250), -- Gigabit-capable passive optical networks (G-PON) as per ITU-T G.948
+                   vdsl2 (251), -- Very high speed digital subscriber line Version 2 (as per ITU-T Recommendation G.993.2)
+                   capwapDot11Profile (252), -- WLAN Profile Interface
+                   capwapDot11Bss (253), -- WLAN BSS Interface
+                   capwapWtpVirtualRadio (254), -- WTP Virtual Radio Interface
+                   bits (255), -- bitsport
+                   docsCableUpstreamRfPort (256), -- DOCSIS CATV Upstream RF Port
+                   cableDownstreamRfPort (257) -- CATV downstream RF port
+                   }
+
+IANAtunnelType ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+            "The encapsulation method used by a tunnel. The value
+            direct indicates that a packet is encapsulated
+            directly within a normal IP header, with no
+            intermediate header, and unicast to the remote tunnel
+            endpoint (e.g., an RFC 2003 IP-in-IP tunnel, or an RFC
+            1933 IPv6-in-IPv4 tunnel). The value minimal indicates
+            that a Minimal Forwarding Header (RFC 2004) is
+            inserted between the outer header and the payload
+            packet. The value UDP indicates that the payload
+            packet is encapsulated within a normal UDP packet
+            (e.g., RFC 1234).
+
+            The values sixToFour, sixOverFour, and isatap
+            indicates that an IPv6 packet is encapsulated directly
+            within an IPv4 header, with no intermediate header,
+            and unicast to the destination determined by the 6to4,
+            6over4, or ISATAP protocol.
+
+            The remaining protocol-specific values indicate that a
+            header of the protocol of that name is inserted
+            between the outer header and the payload header.
+
+            The assignment policy for IANAtunnelType values is
+            identical to the policy for assigning IANAifType
+            values."
+    SYNTAX     INTEGER {
+                   other(1),        -- none of the following
+                   direct(2),       -- no intermediate header
+                   gre(3),          -- GRE encapsulation
+                   minimal(4),      -- Minimal encapsulation
+                   l2tp(5),         -- L2TP encapsulation
+                   pptp(6),         -- PPTP encapsulation
+                   l2f(7),          -- L2F encapsulation
+                   udp(8),          -- UDP encapsulation
+                   atmp(9),         -- ATMP encapsulation
+                   msdp(10),        -- MSDP encapsulation
+                   sixToFour(11),   -- 6to4 encapsulation
+                   sixOverFour(12), -- 6over4 encapsulation
+                   isatap(13),      -- ISATAP encapsulation
+                   teredo(14),      -- Teredo encapsulation
+                   ipHttps(15)      -- IPHTTPS
+               }
 
    END
+

--- a/mibs/junos/mib-IPV6-FLOW-LABEL-MIB.txt
+++ b/mibs/junos/mib-IPV6-FLOW-LABEL-MIB.txt
@@ -1,0 +1,66 @@
+
+-- WinAgents MIB Extraction Wizard
+-- Extracted from rfc3595.txt 16.03.2005 20:22:00
+
+IPV6-FLOW-LABEL-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+
+    MODULE-IDENTITY, mib-2, Integer32           FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION                          FROM SNMPv2-TC;
+
+ipv6FlowLabelMIB   MODULE-IDENTITY
+
+    LAST-UPDATED  "200308280000Z"  -- 28 August 2003
+    ORGANIZATION  "IETF Operations and Management Area"
+    CONTACT-INFO  "Bert Wijnen (Editor)
+                   Lucent Technologies
+                   Schagen 33
+                   3461 GL Linschoten
+                   Netherlands
+
+
+
+                   Phone: +31 348-407-775
+                   EMail: bwijnen@lucent.com
+
+                   Send comments to <mibs@ops.ietf.org>.
+                  "
+    DESCRIPTION   "This MIB module provides commonly used textual
+                   conventions for IPv6 Flow Labels.
+
+                   Copyright (C) The Internet Society (2003).  This
+                   version of this MIB module is part of RFC 3595,
+                   see the RFC itself for full legal notices.
+                  "
+    -- Revision History
+
+    REVISION      "200308280000Z"  -- 28 August 2003
+    DESCRIPTION   "Initial version, published as RFC 3595."
+
+    ::= { mib-2 103 }
+
+IPv6FlowLabel      ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT  "d"
+    STATUS         current
+    DESCRIPTION   "The flow identifier or Flow Label in an IPv6
+                   packet header that may be used to discriminate
+                   traffic flows.
+                  "
+    REFERENCE     "Internet Protocol, Version 6 (IPv6) specification,
+                   section 6.  RFC 2460.
+                  "
+    SYNTAX         Integer32 (0..1048575)
+
+IPv6FlowLabelOrAny ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT  "d"
+    STATUS         current
+    DESCRIPTION   "The flow identifier or Flow Label in an IPv6
+                   packet header that may be used to discriminate
+                   traffic flows.  The value of -1 is used to
+                   indicate a wildcard, i.e. any value.
+                  "
+    SYNTAX         Integer32 (-1 | 0..1048575)
+
+END
+

--- a/mibs/junos/mib-alarmmib.txt
+++ b/mibs/junos/mib-alarmmib.txt
@@ -1,0 +1,1191 @@
+ALARM-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    Integer32, Unsigned32, Gauge32,
+    TimeTicks, Counter32, Counter64,
+    IpAddress, Opaque, mib-2,
+    zeroDotZero
+    FROM SNMPv2-SMI                 -- [RFC2578]
+    DateAndTime,
+    RowStatus, RowPointer,
+    TEXTUAL-CONVENTION
+    FROM SNMPv2-TC                  -- [RFC2579]
+    SnmpAdminString
+    FROM SNMP-FRAMEWORK-MIB         -- [RFC3411]
+    InetAddressType, InetAddress
+    FROM INET-ADDRESS-MIB           -- [RFC3291]
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP
+    FROM SNMPv2-CONF                -- [RFC2580]
+    ZeroBasedCounter32
+    FROM RMON2-MIB;                 -- [RFC2021]
+
+    alarmMIB MODULE-IDENTITY
+    LAST-UPDATED "200409090000Z"  -- September 09, 2004
+    ORGANIZATION "IETF Distributed Management Working Group"
+    CONTACT-INFO
+    "WG EMail: disman@ietf.org
+    Subscribe: disman-request@ietf.org
+    http://www.ietf.org/html.charters/disman-charter.html
+
+
+
+Chair:     Randy Presuhn
+randy_presuhn@mindspring.com
+
+Editors:   Sharon Chisholm
+Nortel Networks
+PO Box 3511 Station C
+Ottawa, Ont.  K1Y 4H7
+Canada
+schishol@nortelnetworks.com
+
+Dan Romascanu
+Avaya
+Atidim Technology Park, Bldg. #3
+Tel Aviv, 61131
+Israel
+Tel: +972-3-645-8414
+Email: dromasca@avaya.com"
+DESCRIPTION
+"The MIB module describes a generic solution
+to model alarms and to store the current list
+of active alarms.
+
+Copyright (C) The Internet Society (2004).  The
+initial version of this MIB module was published
+in RFC 3877.  For full legal notices see the RFC
+itself.  Supplementary information may be available on:
+http://www.ietf.org/copyrights/ianamib.html"
+REVISION    "200409090000Z"  -- September 09, 2004
+DESCRIPTION
+"Initial version, published as RFC 3877."
+::= { mib-2 118 }
+
+alarmObjects OBJECT IDENTIFIER ::= { alarmMIB 1 }
+
+alarmNotifications OBJECT IDENTIFIER ::= { alarmMIB 0 }
+
+alarmModel OBJECT IDENTIFIER ::= { alarmObjects 1 }
+
+alarmActive  OBJECT IDENTIFIER ::= { alarmObjects 2 }
+
+alarmClear OBJECT IDENTIFIER ::= { alarmObjects 3 }
+
+-- Textual Conventions
+
+-- ResourceId is intended to be a general textual convention
+-- that can be used outside of the set of MIBs related to
+-- Alarm Management.
+
+
+
+
+ResourceId ::= TEXTUAL-CONVENTION
+STATUS current
+DESCRIPTION
+"A unique identifier for this resource.
+
+The type of the resource can be determined by looking
+at the OID that describes the resource.
+
+Resources must be identified in a consistent manner.
+For example, if this resource is an interface, this
+object MUST point to an ifIndex and if this resource
+is a physical entity [RFC2737], then this MUST point
+to an entPhysicalDescr, given that entPhysicalIndex
+is not accessible.  In general, the value is the
+name of the instance of the first accessible columnar
+object in the conceptual row of a table that is
+meaningful for this resource type, which SHOULD
+be defined in an IETF standard MIB."
+SYNTAX         OBJECT IDENTIFIER
+
+-- LocalSnmpEngineOrZeroLenStr is intended to be a general
+-- textual convention that can be used outside of the set of
+-- MIBs related to Alarm Management.
+
+LocalSnmpEngineOrZeroLenStr ::= TEXTUAL-CONVENTION
+STATUS current
+DESCRIPTION
+"An SNMP Engine ID or a zero-length string.  The
+instantiation of this textual convention will provide
+guidance on when this will be an SNMP Engine ID and
+    when it will be a zero lengths string"
+SYNTAX         OCTET STRING (SIZE(0 | 5..32))
+
+    -- Alarm Model
+
+    alarmModelLastChanged  OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value of sysUpTime at the time of the last
+    creation, deletion or modification of an entry in
+    the alarmModelTable.
+
+    If the number and content of entries has been unchanged
+    since the last re-initialization of the local network
+    management subsystem, then the value of this object
+    MUST be zero."
+
+
+
+    ::= { alarmModel 1 }
+
+    alarmModelTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF AlarmModelEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "A table of information about possible alarms on the system,
+    and how they have been modelled."
+    ::= { alarmModel 2 }
+
+    alarmModelEntry OBJECT-TYPE
+    SYNTAX      AlarmModelEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "Entries appear in this table for each possible alarm state.
+    This table MUST be persistent across system reboots."
+    INDEX       { alarmListName, alarmModelIndex, alarmModelState }
+    ::= { alarmModelTable 1 }
+
+    AlarmModelEntry ::= SEQUENCE {
+	alarmModelIndex                 Unsigned32,
+					alarmModelState                 Unsigned32,
+					alarmModelNotificationId        OBJECT IDENTIFIER,
+					alarmModelVarbindIndex          Unsigned32,
+					alarmModelVarbindValue          Integer32,
+					alarmModelDescription           SnmpAdminString,
+					alarmModelSpecificPointer       RowPointer,
+					alarmModelVarbindSubtree        OBJECT IDENTIFIER,
+					alarmModelResourcePrefix        OBJECT IDENTIFIER,
+					alarmModelRowStatus             RowStatus
+    }
+
+    alarmModelIndex OBJECT-TYPE
+SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+    "An integer that acts as an alarm Id
+    to uniquely identify each alarm
+    within the named alarm list. "
+    ::= { alarmModelEntry 1 }
+
+    alarmModelState OBJECT-TYPE
+SYNTAX  Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS       current
+
+
+
+    DESCRIPTION
+    "A value of 1 MUST indicate a clear alarm state.
+    The value of this object MUST be less than the
+    alarmModelState of more severe alarm states for
+    this alarm.  The value of this object MUST be more
+    than the alarmModelState of less severe alarm states
+    for this alarm."
+    ::= { alarmModelEntry 2 }
+
+    alarmModelNotificationId OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+    "The NOTIFICATION-TYPE object identifier of this alarm
+    state transition.  If there is no notification associated
+    with this alarm state, the value of this object MUST be
+    '0.0'"
+    DEFVAL { zeroDotZero }
+    ::= { alarmModelEntry 3 }
+
+    alarmModelVarbindIndex  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+    "The index into the varbind listing of the notification
+    indicated by alarmModelNotificationId which helps
+    signal that the given alarm has changed state.
+    If there is no applicable varbind, the value of this
+    object MUST be zero.
+
+    Note that the value of alarmModelVarbindIndex acknowledges
+    the existence of the first two obligatory varbinds in
+    the InformRequest-PDU and SNMPv2-Trap-PDU (sysUpTime.0
+					       and snmpTrapOID.0).  That is, a value of 2 refers to
+    the snmpTrapOID.0.
+
+    If the incoming notification is instead an SNMPv1 Trap-PDU,
+    then an appropriate value for sysUpTime.0 or snmpTrapOID.0
+    shall be determined by using the rules in section 3.1 of
+    [RFC3584]"
+    DEFVAL { 0 }
+    ::= { alarmModelEntry 4 }
+
+    alarmModelVarbindValue OBJECT-TYPE
+    SYNTAX  Integer32
+    MAX-ACCESS   read-create
+
+
+
+    STATUS       current
+    DESCRIPTION
+    "The value that the varbind indicated by
+    alarmModelVarbindIndex takes to indicate
+    that the alarm has entered this state.
+
+    If alarmModelVarbindIndex has a value of 0, so
+    MUST alarmModelVarbindValue.
+    "
+    DEFVAL { 0 }
+    ::= { alarmModelEntry 5 }
+
+    alarmModelDescription OBJECT-TYPE
+    SYNTAX SnmpAdminString
+    MAX-ACCESS read-create
+    STATUS current
+    DESCRIPTION
+    "A brief description of this alarm and state suitable
+    to display to operators."
+    DEFVAL { "" }
+    ::= { alarmModelEntry 6 }
+
+    alarmModelSpecificPointer OBJECT-TYPE
+    SYNTAX     RowPointer
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+    "If no additional, model-specific Alarm MIB is supported by
+    the system the value of this object is `0.0'and attempts
+    to set it to any other value MUST be rejected appropriately.
+
+    When a model-specific Alarm MIB is supported, this object
+    MUST refer to the first accessible object in a corresponding
+    row of the model definition in one of these model-specific
+    MIB and attempts to set this object to { 0 0 } or any other
+    value MUST be rejected appropriately."
+    DEFVAL { zeroDotZero }
+    ::= { alarmModelEntry 7 }
+
+    alarmModelVarbindSubtree  OBJECT-TYPE
+    SYNTAX  OBJECT IDENTIFIER
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+    "The name portion of each VarBind in the notification,
+    in order, is compared to the value of this object.
+    If the name is equal to or a subtree of the value
+    of this object, for purposes of computing the value
+
+
+
+    of AlarmActiveResourceID the 'prefix' will be the
+    matching portion, and the 'indexes' will be any
+    remainder.  The examination of varbinds ends with
+    the first match.  If the value of this object is 0.0,
+    then the first varbind, or in the case of v2, the
+    first varbind after the timestamp and the trap
+    OID, will always be matched.
+    "
+    DEFVAL { zeroDotZero }
+    ::= { alarmModelEntry 8 }
+
+    alarmModelResourcePrefix  OBJECT-TYPE
+    SYNTAX  OBJECT IDENTIFIER
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+    "The value of AlarmActiveResourceId is computed
+    by appending any indexes extracted in accordance
+    with the description of alarmModelVarbindSubtree
+    onto the value of this object.  If this object's
+    value is 0.0, then the 'prefix' extracted is used
+    instead.
+    "
+    DEFVAL { zeroDotZero }
+    ::= { alarmModelEntry 9 }
+
+    alarmModelRowStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+    "Control for creating and deleting entries.  Entries may be
+    modified while active.  Alarms whose alarmModelRowStatus is
+    not active will not appear in either the alarmActiveTable
+    or the alarmClearTable.  Setting this object to notInService
+    cannot be used as an alarm suppression mechanism.  Entries
+    that are notInService will disappear as described in RFC2579.
+
+    This row can not be modified while it is being
+    referenced by a value of alarmActiveModelPointer.  In these
+    cases, an error of `inconsistentValue' will be returned to
+    the manager.
+
+    This entry may be deleted while it is being
+    referenced by a value of alarmActiveModelPointer.  This results
+    in the deletion of this entry and entries in the active alarms
+    referencing this entry via an alarmActiveModelPointer.
+
+
+
+
+    As all read-create objects in this table have a DEFVAL clause,
+    there is no requirement that any object be explicitly set
+    before this row can become active.  Note that a row consisting
+    only of default values is not very meaningful."
+    ::= { alarmModelEntry 10 }
+
+    -- Active Alarm Table --
+
+    alarmActiveLastChanged  OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value of sysUpTime at the time of the last
+    creation or deletion of an entry in the alarmActiveTable.
+    If the number of entries has been unchanged since the
+    last re-initialization of the local network management
+    subsystem, then this object contains a zero value."
+    ::= { alarmActive 1 }
+
+    alarmActiveOverflow  OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "active alarms"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The number of active alarms that have not been put into
+    the alarmActiveTable since system restart as a result
+    of extreme resource constraints."
+    ::= { alarmActive 5 }
+
+    alarmActiveTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF AlarmActiveEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "A table of Active Alarms entries."
+    ::= { alarmActive 2 }
+
+    alarmActiveEntry OBJECT-TYPE
+    SYNTAX      AlarmActiveEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "Entries appear in this table when alarms are raised.  They
+    are removed when the alarm is cleared.
+
+    If under extreme resource constraint the system is unable to
+
+
+
+    add any more entries into this table, then the
+    alarmActiveOverflow statistic will be increased by one."
+    INDEX       { alarmListName, alarmActiveDateAndTime,
+	alarmActiveIndex }
+	::= { alarmActiveTable 1 }
+
+	AlarmActiveEntry ::= SEQUENCE {
+	    alarmListName                    SnmpAdminString,
+					     alarmActiveDateAndTime           DateAndTime,
+					     alarmActiveIndex                 Unsigned32,
+					     alarmActiveEngineID              LocalSnmpEngineOrZeroLenStr,
+					     alarmActiveEngineAddressType     InetAddressType,
+					     alarmActiveEngineAddress         InetAddress,
+					     alarmActiveContextName           SnmpAdminString,
+					     alarmActiveVariables             Unsigned32,
+					     alarmActiveNotificationID        OBJECT IDENTIFIER,
+					     alarmActiveResourceId            ResourceId,
+					     alarmActiveDescription           SnmpAdminString,
+					     alarmActiveLogPointer            RowPointer,
+					     alarmActiveModelPointer          RowPointer,
+					     alarmActiveSpecificPointer       RowPointer }
+
+    alarmListName OBJECT-TYPE
+SYNTAX     SnmpAdminString (SIZE(0..32))
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+    "The name of the list of alarms.  This SHOULD be the same as
+    nlmLogName if the Notification Log MIB [RFC3014] is supported.
+    This SHOULD be the same as, or contain as a prefix, the
+    applicable snmpNotifyFilterProfileName if the
+    SNMP-NOTIFICATION-MIB DEFINITIONS [RFC3413] is supported.
+
+    An implementation may allow multiple named alarm lists, up to
+    some implementation-specific limit (which may be none).  A
+    zero-length list name is reserved for creation and deletion
+    by the managed system, and MUST be used as the default log
+    name by systems that do not support named alarm lists."
+    ::= { alarmActiveEntry 1 }
+
+    alarmActiveDateAndTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "The local date and time when the error occurred.
+
+    This object facilitates retrieving all instances of
+
+
+
+    alarms that have been raised or have changed state
+    since a given point in time.
+
+    Implementations MUST include the offset from UTC,
+    if available.  Implementation in environments in which
+    the UTC offset is not available is NOT RECOMMENDED."
+    ::= { alarmActiveEntry 2 }
+
+    alarmActiveIndex OBJECT-TYPE
+SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+    "A strictly monotonically increasing integer which
+    acts as the index of entries within the named alarm
+    list.  It wraps back to 1 after it reaches its
+    maximum value."
+    ::= { alarmActiveEntry 3 }
+
+    alarmActiveEngineID OBJECT-TYPE
+    SYNTAX      LocalSnmpEngineOrZeroLenStr
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The identification of the SNMP engine at which the alarm
+    originated.  If the alarm is from an SNMPv1 system this
+    object is a zero length string."
+    ::= { alarmActiveEntry 4 }
+
+    alarmActiveEngineAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "This object indicates what type of address is stored in
+    the alarmActiveEngineAddress object - IPv4, IPv6, DNS, etc."
+    ::= { alarmActiveEntry 5 }
+
+    alarmActiveEngineAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The address of the SNMP engine on which the alarm is
+    occurring.
+
+    This object MUST always be instantiated, even if the list
+    can contain alarms from only one engine."
+
+
+
+    ::= { alarmActiveEntry 6 }
+
+    alarmActiveContextName OBJECT-TYPE
+SYNTAX      SnmpAdminString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The name of the SNMP MIB context from which the alarm came.
+    For SNMPv1 alarms this is the community string from the Trap.
+    Note that care MUST be taken when selecting community
+    strings to ensure that these can be represented as a
+    well-formed SnmpAdminString.  Community or Context names
+    that are not well-formed SnmpAdminStrings will be mapped
+    to zero length strings.
+
+    If the alarm's source SNMP engine is known not to support
+    multiple contexts, this object is a zero length string."
+    ::= { alarmActiveEntry 7 }
+
+    alarmActiveVariables OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The number of variables in alarmActiveVariableTable for this
+    alarm."
+    ::= { alarmActiveEntry 8 }
+
+    alarmActiveNotificationID OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The NOTIFICATION-TYPE object identifier of the alarm
+    state transition that is occurring."
+    ::= { alarmActiveEntry 9 }
+
+    alarmActiveResourceId    OBJECT-TYPE
+    SYNTAX      ResourceId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "This object identifies the resource under alarm.
+
+    If there is no corresponding resource, then
+    the value of this object MUST be 0.0."
+    ::= { alarmActiveEntry 10 }
+
+
+
+
+    alarmActiveDescription    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "This object provides a textual description of the
+    active alarm.  This text is generated dynamically by the
+    notification generator to provide useful information
+    to the human operator.  This information SHOULD
+    provide information allowing the operator to locate
+    the resource for which this alarm is being generated.
+    This information is not intended for consumption by
+    automated tools."
+    ::= { alarmActiveEntry 11 }
+
+    alarmActiveLogPointer OBJECT-TYPE
+    SYNTAX     RowPointer
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+    "A pointer to the corresponding row in a
+    notification logging MIB where the state change
+    notification for this active alarm is logged.
+    If no log entry applies to this active alarm,
+    then this object MUST have the value of 0.0"
+    ::= { alarmActiveEntry 12 }
+
+    alarmActiveModelPointer OBJECT-TYPE
+    SYNTAX     RowPointer
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+    "A pointer to the corresponding row in the
+    alarmModelTable for this active alarm.  This
+    points not only to the alarm model being
+    instantiated, but also to the specific alarm
+    state that is active."
+    ::= { alarmActiveEntry 13 }
+
+    alarmActiveSpecificPointer OBJECT-TYPE
+    SYNTAX     RowPointer
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+    "If no additional, model-specific, Alarm MIB is supported by
+    the system this object is `0.0'.  When a model-specific Alarm
+    MIB is supported, this object is the instance pointer to the
+    specific model-specific active alarm list."
+
+
+
+    ::= { alarmActiveEntry 14 }
+
+    -- Active Alarm Variable Table --
+
+    alarmActiveVariableTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF AlarmActiveVariableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "A table of variables to go with active alarm entries."
+    ::= { alarmActive 3 }
+
+    alarmActiveVariableEntry OBJECT-TYPE
+    SYNTAX      AlarmActiveVariableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "Entries appear in this table when there are variables in
+    the varbind list of a corresponding alarm in
+    alarmActiveTable.
+
+    Entries appear in this table as though
+    the trap/notification had been transported using a
+    SNMPv2-Trap-PDU, as defined in [RFC3416] - i.e., the
+    alarmActiveVariableIndex 1 will always be sysUpTime
+    and alarmActiveVariableIndex 2 will always be
+    snmpTrapOID.
+
+    If the incoming notification is instead an SNMPv1 Trap-PDU and
+    the value of alarmModelVarbindIndex is 1 or 2, an appropriate
+    value for sysUpTime.0 or snmpTrapOID.0 shall be determined
+    by using the rules in section 3.1 of [RFC3584]."
+    INDEX   {  alarmListName, alarmActiveIndex,
+	alarmActiveVariableIndex }
+	::= { alarmActiveVariableTable 1 }
+
+	AlarmActiveVariableEntry ::= SEQUENCE {
+	    alarmActiveVariableIndex                 Unsigned32,
+						     alarmActiveVariableID                    OBJECT IDENTIFIER,
+						     alarmActiveVariableValueType             INTEGER,
+						     alarmActiveVariableCounter32Val          Counter32,
+						     alarmActiveVariableUnsigned32Val         Unsigned32,
+						     alarmActiveVariableTimeTicksVal          TimeTicks,
+						     alarmActiveVariableInteger32Val          Integer32,
+						     alarmActiveVariableOctetStringVal        OCTET STRING,
+						     alarmActiveVariableIpAddressVal          IpAddress,
+						     alarmActiveVariableOidVal                OBJECT IDENTIFIER,
+						     alarmActiveVariableCounter64Val          Counter64,
+
+
+
+						     alarmActiveVariableOpaqueVal             Opaque }
+
+    alarmActiveVariableIndex OBJECT-TYPE
+SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+    "A strictly monotonically increasing integer, starting at
+    1 for a given alarmActiveIndex, for indexing variables
+    within the active alarm variable list. "
+    ::= { alarmActiveVariableEntry 1 }
+
+    alarmActiveVariableID OBJECT-TYPE
+    SYNTAX     OBJECT IDENTIFIER
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+    "The alarm variable's object identifier."
+    ::= { alarmActiveVariableEntry 2 }
+
+    alarmActiveVariableValueType OBJECT-TYPE
+    SYNTAX      INTEGER {
+	counter32(1),
+	    unsigned32(2),
+	    timeTicks(3),
+	    integer32(4),
+	    ipAddress(5),
+	    octetString(6),
+	    objectId(7),
+	    counter64(8),
+	    opaque(9)
+    }
+MAX-ACCESS  read-only
+STATUS      current
+DESCRIPTION
+"The type of the value.  One and only one of the value
+objects that follow is used for a given row in this table,
+	based on this type."
+	::= { alarmActiveVariableEntry 3 }
+
+	alarmActiveVariableCounter32Val OBJECT-TYPE
+	SYNTAX      Counter32
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	"The value when alarmActiveVariableType is 'counter32'."
+	::= { alarmActiveVariableEntry 4 }
+
+
+
+
+	alarmActiveVariableUnsigned32Val OBJECT-TYPE
+	SYNTAX      Unsigned32
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	"The value when alarmActiveVariableType is 'unsigned32'."
+	::= { alarmActiveVariableEntry 5 }
+
+	alarmActiveVariableTimeTicksVal OBJECT-TYPE
+	SYNTAX      TimeTicks
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	"The value when alarmActiveVariableType is 'timeTicks'."
+	::= { alarmActiveVariableEntry 6 }
+
+	alarmActiveVariableInteger32Val OBJECT-TYPE
+	SYNTAX      Integer32
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	"The value when alarmActiveVariableType is 'integer32'."
+	::= { alarmActiveVariableEntry 7 }
+
+    alarmActiveVariableOctetStringVal OBJECT-TYPE
+SYNTAX      OCTET STRING (SIZE(0..65535))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value when alarmActiveVariableType is 'octetString'."
+    ::= { alarmActiveVariableEntry 8 }
+
+    alarmActiveVariableIpAddressVal OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value when alarmActiveVariableType is 'ipAddress'."
+    ::= { alarmActiveVariableEntry 9 }
+
+    alarmActiveVariableOidVal OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value when alarmActiveVariableType is 'objectId'."
+    ::= { alarmActiveVariableEntry 10 }
+
+
+
+
+    alarmActiveVariableCounter64Val OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value when alarmActiveVariableType is 'counter64'."
+    ::= { alarmActiveVariableEntry 11 }
+
+    alarmActiveVariableOpaqueVal OBJECT-TYPE
+SYNTAX      Opaque (SIZE(0..65535))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The value when alarmActiveVariableType is 'opaque'.
+
+    Note that although RFC2578 [RFC2578] forbids the use
+    of Opaque in 'standard' MIB modules, this particular
+    usage is driven by the need to be able to accurately
+    represent any well-formed notification, and justified
+    by the need for backward compatibility."
+    ::= { alarmActiveVariableEntry 12 }
+
+    -- Statistics --
+
+    alarmActiveStatsTable  OBJECT-TYPE
+    SYNTAX  SEQUENCE OF AlarmActiveStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+    "This table represents the alarm statistics
+    information."
+    ::= { alarmActive 4 }
+
+    alarmActiveStatsEntry OBJECT-TYPE
+    SYNTAX  AlarmActiveStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+    "Statistics on the current active alarms."
+    INDEX   { alarmListName }
+
+    ::= {  alarmActiveStatsTable 1 }
+
+    AlarmActiveStatsEntry ::=
+    SEQUENCE {
+	alarmActiveStatsActiveCurrent  Gauge32,
+	alarmActiveStatsActives        ZeroBasedCounter32,
+	alarmActiveStatsLastRaise      TimeTicks,
+
+
+
+	alarmActiveStatsLastClear      TimeTicks
+    }
+
+alarmActiveStatsActiveCurrent OBJECT-TYPE
+SYNTAX Gauge32
+MAX-ACCESS read-only
+STATUS  current
+DESCRIPTION
+"The total number of currently active alarms on the system."
+::= { alarmActiveStatsEntry 1 }
+
+alarmActiveStatsActives OBJECT-TYPE
+SYNTAX ZeroBasedCounter32
+MAX-ACCESS read-only
+STATUS  current
+DESCRIPTION
+"The total number of active alarms since system restarted."
+::= { alarmActiveStatsEntry 2 }
+
+alarmActiveStatsLastRaise  OBJECT-TYPE
+SYNTAX      TimeTicks
+MAX-ACCESS  read-only
+STATUS      current
+DESCRIPTION
+"The value of sysUpTime at the time of the last
+alarm raise for this alarm list.
+If no alarm raises have occurred since the
+last re-initialization of the local network management
+subsystem, then this object contains a zero value."
+::= { alarmActiveStatsEntry 3 }
+
+alarmActiveStatsLastClear  OBJECT-TYPE
+SYNTAX      TimeTicks
+MAX-ACCESS  read-only
+STATUS      current
+DESCRIPTION
+"The value of sysUpTime at the time of the last
+alarm clear for this alarm list.
+If no alarm clears have occurred since the
+last re-initialization of the local network management
+subsystem, then this object contains a zero value."
+::= { alarmActiveStatsEntry 4 }
+
+-- Alarm Clear
+
+alarmClearMaximum OBJECT-TYPE
+SYNTAX Unsigned32
+MAX-ACCESS read-write
+
+
+
+STATUS current
+DESCRIPTION
+"This object specifies the maximum number of cleared
+alarms to store in the alarmClearTable.  When this
+number is reached, the cleared alarms with the
+earliest clear time will be removed from the table."
+::= { alarmClear 1 }
+
+alarmClearTable  OBJECT-TYPE
+SYNTAX  SEQUENCE OF AlarmClearEntry
+MAX-ACCESS  not-accessible
+STATUS  current
+DESCRIPTION
+"This table contains information on
+cleared alarms."
+::= { alarmClear 2 }
+
+alarmClearEntry OBJECT-TYPE
+SYNTAX  AlarmClearEntry
+MAX-ACCESS  not-accessible
+STATUS  current
+DESCRIPTION
+"Information on a cleared alarm."
+INDEX   { alarmListName, alarmClearDateAndTime,
+    alarmClearIndex }
+
+    ::= {  alarmClearTable 1 }
+
+    AlarmClearEntry ::=
+    SEQUENCE {
+	alarmClearIndex                 Unsigned32,
+	alarmClearDateAndTime           DateAndTime,
+	alarmClearEngineID              LocalSnmpEngineOrZeroLenStr,
+	alarmClearEngineAddressType     InetAddressType,
+	alarmClearEngineAddress         InetAddress,
+	alarmClearContextName           SnmpAdminString,
+	alarmClearNotificationID        OBJECT IDENTIFIER,
+	alarmClearResourceId            ResourceId,
+	alarmClearLogIndex              Unsigned32,
+	alarmClearModelPointer          RowPointer
+    }
+
+    alarmClearIndex OBJECT-TYPE
+SYNTAX     Unsigned32 (1..4294967295)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+    "An integer which acts as the index of entries within
+
+
+
+    the named alarm list.  It wraps back to 1 after it
+    reaches its maximum value.
+
+    This object has the same value as the alarmActiveIndex that
+    this alarm instance had when it was active."
+    ::= { alarmClearEntry 1 }
+
+    alarmClearDateAndTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "The local date and time when the alarm cleared.
+
+    This object facilitates retrieving all instances of
+    alarms that have been cleared since a given point in time.
+
+    Implementations MUST include the offset from UTC,
+    if available.  Implementation in environments in which
+    the UTC offset is not available is NOT RECOMMENDED."
+    ::= { alarmClearEntry 2 }
+
+    alarmClearEngineID OBJECT-TYPE
+    SYNTAX      LocalSnmpEngineOrZeroLenStr
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The identification of the SNMP engine at which the alarm
+    originated.  If the alarm is from an SNMPv1 system this
+    object is a zero length string."
+    ::= { alarmClearEntry 3 }
+
+    alarmClearEngineAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "This object indicates what type of address is stored in
+    the alarmActiveEngineAddress object - IPv4, IPv6, DNS, etc."
+    ::= { alarmClearEntry 4 }
+
+    alarmClearEngineAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The Address of the SNMP engine on which the alarm was
+    occurring.  This is used to identify the source of an SNMPv1
+
+
+
+    trap, since an alarmActiveEngineId cannot be extracted from the
+    SNMPv1 trap PDU.
+
+    This object MUST always be instantiated, even if the list
+    can contain alarms from only one engine."
+    ::= { alarmClearEntry 5 }
+
+    alarmClearContextName OBJECT-TYPE
+SYNTAX      SnmpAdminString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The name of the SNMP MIB context from which the alarm came.
+    For SNMPv1 traps this is the community string from the Trap.
+    Note that care needs to be taken when selecting community
+    strings to ensure that these can be represented as a
+    well-formed SnmpAdminString.  Community or Context names
+    that are not well-formed SnmpAdminStrings will be mapped
+    to zero length strings.
+
+    If the alarm's source SNMP engine is known not to support
+    multiple contexts, this object is a zero length string."
+    ::= { alarmClearEntry 6 }
+
+    alarmClearNotificationID OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "The NOTIFICATION-TYPE object identifier of the alarm
+    clear."
+    ::= { alarmClearEntry 7 }
+
+    alarmClearResourceId    OBJECT-TYPE
+    SYNTAX      ResourceId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "This object identifies the resource that was under alarm.
+
+    If there is no corresponding resource, then
+    the value of this object MUST be 0.0."
+    ::= { alarmClearEntry 8 }
+
+    alarmClearLogIndex OBJECT-TYPE
+SYNTAX     Unsigned32 (0..4294967295)
+    MAX-ACCESS read-only
+    STATUS     current
+
+
+
+    DESCRIPTION
+    "This number MUST be the same as the log index of the
+    applicable row in the notification log MIB, if it exists.
+    If no log index applies to the trap, then this object
+    MUST have the value of 0."
+    ::= { alarmClearEntry 9 }
+
+    alarmClearModelPointer OBJECT-TYPE
+    SYNTAX     RowPointer
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+    "A pointer to the corresponding row in the
+    alarmModelTable for this cleared alarm."
+    ::= { alarmClearEntry 10 }
+
+    -- Notifications
+
+    alarmActiveState NOTIFICATION-TYPE
+    OBJECTS     { alarmActiveModelPointer,
+	alarmActiveResourceId }
+	STATUS      current
+	DESCRIPTION
+	"An instance of the alarm indicated by
+	alarmActiveModelPointer has been raised
+	against the entity indicated by
+	alarmActiveResourceId.
+
+	The agent must throttle the generation of
+	consecutive alarmActiveState traps so that there is at
+	least a two-second gap between traps of this
+	type against the same alarmActiveModelPointer and
+	alarmActiveResourceId.  When traps are throttled,
+	they are dropped, not queued for sending at a future time.
+
+	A management application should periodically check
+	the value of alarmActiveLastChanged to detect any
+	missed alarmActiveState notification-events, e.g.,
+	due to throttling or transmission loss."
+	::= { alarmNotifications 2 }
+
+	alarmClearState NOTIFICATION-TYPE
+	OBJECTS     { alarmActiveModelPointer,
+	    alarmActiveResourceId }
+	    STATUS      current
+	    DESCRIPTION
+	    "An instance of the alarm indicated by
+	    alarmActiveModelPointer has been cleared against
+
+
+
+	    the entity indicated by alarmActiveResourceId.
+
+	    The agent must throttle the generation of
+	    consecutive alarmActiveClear traps so that there is at
+	    least a two-second gap between traps of this
+	    type against the same alarmActiveModelPointer and
+	    alarmActiveResourceId.  When traps are throttled,
+	    they are dropped, not queued for sending at a future time.
+
+	    A management application should periodically check
+	    the value of alarmActiveLastChanged to detect any
+	    missed alarmClearState notification-events, e.g.,
+	    due to throttling or transmission loss."
+	    ::= { alarmNotifications 3 }
+
+	    -- Conformance
+
+	    alarmConformance OBJECT IDENTIFIER ::= { alarmMIB 2 }
+
+	    alarmCompliances OBJECT IDENTIFIER ::= { alarmConformance 1 }
+
+	    alarmCompliance MODULE-COMPLIANCE
+	    STATUS  current
+	    DESCRIPTION
+	    "The compliance statement for systems supporting
+	    the Alarm MIB."
+	    MODULE -- this module
+	    MANDATORY-GROUPS {
+		alarmActiveGroup,
+		    alarmModelGroup
+	    }
+GROUP       alarmActiveStatsGroup
+DESCRIPTION
+"This group is optional."
+GROUP       alarmClearGroup
+DESCRIPTION
+"This group is optional."
+GROUP       alarmNotificationsGroup
+DESCRIPTION
+"This group is optional."
+::= { alarmCompliances 1 }
+
+alarmGroups OBJECT IDENTIFIER ::= { alarmConformance 2 }
+
+alarmModelGroup OBJECT-GROUP
+OBJECTS {
+    alarmModelLastChanged,
+	alarmModelNotificationId,
+
+
+
+	alarmModelVarbindIndex,
+	alarmModelVarbindValue,
+	alarmModelDescription,
+	alarmModelSpecificPointer,
+	alarmModelVarbindSubtree,
+	alarmModelResourcePrefix,
+	alarmModelRowStatus
+}
+STATUS   current
+DESCRIPTION
+"Alarm model group."
+::= { alarmGroups 1}
+
+alarmActiveGroup OBJECT-GROUP
+OBJECTS {
+    alarmActiveLastChanged,
+	alarmActiveOverflow,
+	alarmActiveEngineID,
+	alarmActiveEngineAddressType,
+	alarmActiveEngineAddress,
+	alarmActiveContextName,
+	alarmActiveVariables,
+	alarmActiveNotificationID,
+	alarmActiveResourceId,
+	alarmActiveDescription,
+	alarmActiveLogPointer,
+	alarmActiveModelPointer,
+	alarmActiveSpecificPointer,
+	alarmActiveVariableID,
+	alarmActiveVariableValueType,
+	alarmActiveVariableCounter32Val,
+	alarmActiveVariableUnsigned32Val,
+	alarmActiveVariableTimeTicksVal,
+	alarmActiveVariableInteger32Val,
+	alarmActiveVariableOctetStringVal,
+	alarmActiveVariableIpAddressVal,
+	alarmActiveVariableOidVal,
+	alarmActiveVariableCounter64Val,
+	alarmActiveVariableOpaqueVal
+}
+STATUS   current
+DESCRIPTION
+"Active Alarm list group."
+::= { alarmGroups 2}
+
+alarmActiveStatsGroup  OBJECT-GROUP
+OBJECTS  {
+    alarmActiveStatsActives,
+
+
+
+	alarmActiveStatsActiveCurrent,
+	alarmActiveStatsLastRaise,
+	alarmActiveStatsLastClear
+}
+STATUS   current
+DESCRIPTION
+"Active alarm summary group."
+::= { alarmGroups 3}
+
+alarmClearGroup  OBJECT-GROUP
+OBJECTS  {
+    alarmClearMaximum,
+	alarmClearEngineID,
+	alarmClearEngineAddressType,
+	alarmClearEngineAddress,
+	alarmClearContextName,
+	alarmClearNotificationID,
+	alarmClearResourceId,
+	alarmClearLogIndex,
+	alarmClearModelPointer
+}
+STATUS   current
+DESCRIPTION
+"Cleared alarm group."
+::= { alarmGroups 4}
+
+alarmNotificationsGroup NOTIFICATION-GROUP
+NOTIFICATIONS { alarmActiveState, alarmClearState }
+STATUS        current
+DESCRIPTION
+"The collection of notifications that can be used to
+model alarms for faults lacking pre-existing
+notification definitions."
+::= { alarmGroups 6 }
+
+END

--- a/mibs/junos/mib-entityStateTc.txt
+++ b/mibs/junos/mib-entityStateTc.txt
@@ -1,0 +1,169 @@
+ENTITY-STATE-TC-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+      MODULE-IDENTITY, mib-2       FROM SNMPv2-SMI
+      TEXTUAL-CONVENTION           FROM SNMPv2-TC;
+
+    entityStateTc MODULE-IDENTITY
+        LAST-UPDATED "200511220000Z"
+        ORGANIZATION "IETF Entity MIB Working Group"
+        CONTACT-INFO
+                "General Discussion: entmib@ietf.org
+                 To Subscribe:
+                 http://www.ietf.org/mailman/listinfo/entmib
+
+                 http://www.ietf.org/html.charters/entmib-charter.html
+
+                 Sharon Chisholm
+                 Nortel Networks
+                 PO Box 3511 Station C
+                 Ottawa, Ont.  K1Y 4H7
+                 Canada
+                 schishol@nortel.com
+
+                 David T. Perkins
+                 548 Qualbrook Ct
+                 San Jose, CA 95110
+                 USA
+                 Phone: 408 394-8702
+                 dperkins@snmpinfo.com"
+         DESCRIPTION
+                "This MIB defines state textual conventions.
+
+                 Copyright (C) The Internet Society 2005.  This version
+                 of this MIB module is part of RFC 4268;  see the RFC
+                 itself for full legal notices."
+         REVISION    "200511220000Z"
+         DESCRIPTION
+             "Initial version, published as RFC 4268."
+        ::= { mib-2 130 }
+
+     EntityAdminState  ::=  TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION
+            " Represents the various possible administrative states.
+              A value of 'locked' means the resource is administratively
+              prohibited from use.  A value of 'shuttingDown' means that
+              usage is administratively limited to current instances of
+              use.  A value of 'unlocked' means the resource is not
+              administratively prohibited from use.  A value of
+              'unknown' means that this resource is unable to
+              report administrative state."
+       SYNTAX         INTEGER
+                 {
+                 unknown (1),
+                 locked (2),
+                 shuttingDown (3),
+                 unlocked (4)
+                 }
+
+     EntityOperState  ::=  TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION
+            " Represents the possible values of operational states.
+
+              A value of 'disabled' means the resource is totally
+              inoperable.  A value of 'enabled' means the resource
+              is partially or fully operable.  A value of 'testing'
+              means the resource is currently being tested
+              and cannot therefore report whether it is operational
+              or not.  A value of 'unknown' means that this
+              resource is unable to report operational state."
+       SYNTAX         INTEGER
+                 {
+                 unknown (1),
+                 disabled (2),
+                 enabled (3),
+                 testing (4)
+                 }
+
+     EntityUsageState  ::=  TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION
+            " Represents the possible values of usage states.
+              A value of 'idle' means the resource is servicing no
+              users.  A value of 'active' means the resource is
+              currently in use and it has sufficient spare capacity
+              to provide for additional users.  A value of 'busy'
+              means the resource is currently in use, but it
+              currently has no spare capacity to provide for
+              additional users.  A value of 'unknown' means
+              that this resource is unable to report usage state."
+       SYNTAX         INTEGER
+                 {
+                 unknown (1),
+                 idle (2),
+                 active (3),
+                 busy (4)
+                 }
+
+
+    EntityAlarmStatus  ::=  TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION
+          " Represents the possible values of alarm status.
+            An Alarm [RFC3877] is a persistent indication
+            of an error or warning condition.
+
+            When no bits of this attribute are set, then no active
+            alarms are known against this entity and it is not under
+            repair.
+
+            When the 'value of underRepair' is set, the resource is
+            currently being repaired, which, depending on the
+            implementation, may make the other values in this bit
+            string not meaningful.
+
+            When the value of 'critical' is set, one or more critical
+            alarms are active against the resource.  When the value
+            of 'major' is set, one or more major alarms are active
+            against the resource.  When the value of 'minor' is set,
+            one or more minor alarms are active against the resource.
+            When the value of 'warning' is set, one or more warning
+            alarms are active against the resource.  When the value
+            of 'indeterminate' is set, one or more alarms of whose
+            perceived severity cannot be determined are active
+            against this resource.
+
+            A value of 'unknown' means that this resource is
+            unable to report alarm state."
+             SYNTAX         BITS
+                {
+                unknown (0),
+                underRepair (1),
+                critical(2),
+                major(3),
+                minor(4),
+                -- The following are not defined in X.733
+                warning (5),
+                indeterminate (6)
+                              }
+     EntityStandbyStatus  ::=  TEXTUAL-CONVENTION
+       STATUS         current
+       DESCRIPTION
+            " Represents the possible values of standby status.
+
+              A value of 'hotStandby' means the resource is not
+              providing service, but it will be immediately able to
+              take over the role of the resource to be backed up,
+              without the need for initialization activity, and will
+              contain the same information as the resource to be
+              backed up.  A value of 'coldStandy' means that the
+              resource is to back up another resource, but will not
+              be immediately able to take over the role of a resource
+              to be backed up, and will require some initialization
+              activity.  A value of 'providingService' means the
+              resource is providing service.  A value of
+              'unknown' means that this resource is unable to
+              report standby state."
+             SYNTAX         INTEGER
+               {
+               unknown (1),
+               hotStandby (2),
+               coldStandby (3),
+               providingService (4)
+               }
+
+END
+
+

--- a/mibs/junos/mib-ggsn.txt
+++ b/mibs/junos/mib-ggsn.txt
@@ -1,0 +1,8062 @@
+--
+-- GGSN MIB
+--
+-- Copyright (c) 2001-2003, Ericsson-Juniper Networks  MobileIP AB.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change
+-- without notice.
+--
+
+
+GGSN-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    enterprises, Integer32, Unsigned32, Gauge32, Counter64, IpAddress
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString, TimeStamp
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF;
+
+ggsnMIB MODULE-IDENTITY
+    LAST-UPDATED "200407221546Z" -- date is 22 July 2004
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+        "The MIB module for GPRS Gateway Support Node
+         Application"
+    ::= { ejnxMibs 1 }
+
+
+--
+-- Until we have the mechanism in place to "include" the
+-- definition of juniperMIB, we replicate it here.
+--
+
+ejnmobileipABmib     OBJECT IDENTIFIER ::= { enterprises 10923 }
+ejnxMibs             OBJECT IDENTIFIER ::= { ejnmobileipABmib 1 }
+
+
+--
+-- ggsnMIB tree structure
+--
+
+ggsnMibs       OBJECT IDENTIFIER ::= { ggsnMIB 1 }
+ggsnTraps      OBJECT IDENTIFIER ::= { ggsnMIB 2 }
+ggsnMIBObjects  OBJECT IDENTIFIER ::= { ggsnMibs 1 }
+
+
+--
+-- Top-level groups in ggsnMibs. For RADIUS group, standard
+-- MIBs defined in RFC2618 and RFC2620 are supported.
+--
+
+ggsnGeneralInfo  OBJECT IDENTIFIER ::= { ggsnMIBObjects 1 }
+ggsnGtpcInfo     OBJECT IDENTIFIER ::= { ggsnMIBObjects 2 }
+ggsnChargingInfo OBJECT IDENTIFIER ::= { ggsnMIBObjects 3 }
+ggsnDhcpInfo     OBJECT IDENTIFIER ::= { ggsnMIBObjects 4 }
+ggsnAlarmInfo    OBJECT IDENTIFIER ::= { ggsnMIBObjects 5 }
+ggsnGtpuInfo     OBJECT IDENTIFIER ::= { ggsnMIBObjects 6 }
+ggsnFbcInfo	 OBJECT IDENTIFIER ::= { ggsnMIBObjects 7 }
+ggsnMbmsInfo	 OBJECT IDENTIFIER ::= { ggsnMIBObjects 8 }
+ggsnGtptInfo     OBJECT IDENTIFIER ::= { ggsnMIBObjects 9 }
+ggsnRadiusInfo   OBJECT IDENTIFIER ::= { ggsnMIBObjects 10 }
+
+--
+--PGW Shared-ip-pool statistics
+--
+pgwSharedIpPoolStatsTable       OBJECT-TYPE
+   SYNTAX        SEQUENCE OF SharedIpPoolStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the statistics for all shared IP pools which
+          are served by the PGW."
+   ::= { ggsnMIBObjects  11 }
+
+pgwSharedIpPoolStatsEntry OBJECT-TYPE
+   SYNTAX        SharedIpPoolStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          shared IP pool which is served by the PGW."
+   INDEX         { pgwSharedIpPoolIndex }
+   ::= { pgwSharedIpPoolStatsTable 1 }
+
+SharedIpPoolStats ::= SEQUENCE {
+   pgwSharedIpPoolIndex                      Integer32,
+   pgwSharedIpPoolName                       DisplayString,
+   pgwAvailableAddressesInSharedIpPool       Gauge32,
+   pgwAddressesInQuarantineInSharedIpPool    Gauge32
+}
+
+pgwSharedIpPoolIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number representing each shared IP pool whose statistics
+          are generated."
+   ::= { pgwSharedIpPoolStatsEntry 1 }
+
+pgwSharedIpPoolName OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The identifier of a shared IP pool."
+   ::= { pgwSharedIpPoolStatsEntry 2 }
+
+pgwAvailableAddressesInSharedIpPool  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of available IP addresses
+          in a shared IP pool."
+   ::= { pgwSharedIpPoolStatsEntry 3 }
+
+pgwAddressesInQuarantineInSharedIpPool  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of IP addresses that are in quarantine in a shared IP pool"
+   ::= { pgwSharedIpPoolStatsEntry 4 }
+
+
+--
+-- GGSN service-based charging (FBC) statistics
+--
+
+ggsnFbcStats			OBJECT IDENTIFIER ::= { ggsnFbcInfo 1 }
+ggsnFbcAuthorizationStats	OBJECT IDENTIFIER ::= { ggsnFbcInfo 2 }
+
+ggsnFbcInitiatedDeactivation		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+	"The number of bearer deactivations initiated by the SACC functionality."
+    ::= { ggsnFbcStats 1 }
+
+ggsnFbcApplicationTransactionPps	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of transactions toward pre-paid server."
+    ::= { ggsnFbcStats 2 }
+
+ggsnFbcApplicationTransactionPrs	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of transactions toward policy/rate server."
+    ::= { ggsnFbcStats 3 }
+
+
+--
+-- GGSN system group
+--
+
+ggsnVersion OBJECT-TYPE
+   SYNTAX        DisplayString (SIZE (0..255))
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The revision of this application, blank if unknown
+          or unavailable."
+   ::= { ggsnGeneralInfo 1 }
+
+ggsnInstalled OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The value of sysUpTime when the application was
+          last restarted. Zero if unknown."
+   ::= { ggsnGeneralInfo 2 }
+
+
+--
+-- GGSN Global statistics
+--
+
+ggsnGlobalStats OBJECT IDENTIFIER ::= { ggsnGeneralInfo 3 }
+
+ggsnStatReportTime OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The value of sysUpTime when the global statistics report is
+          generated."
+   ::= { ggsnGlobalStats 1 }
+
+ggsnNbrOfActivePdpContexts OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active PDP contexts on this GGSN.
+         
+          Incremented when a PDP context is activated and a
+          GTP response has been sent to the SGSN. Decremented
+          when a PDP context is deactivated."
+   ::= { ggsnGlobalStats 2 }
+
+ggsnNbrOfSubscribers OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of subscribers, uniquely identified by IMSI,
+          currently serviced by this GGSN.
+          Incremented on transmission of a PDP context response with
+          request accepted for an IMSI (which previously did not have
+          a PDP context active). Decremented when the last PDP context
+          for that IMSI has been deleted.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 20 }
+
+ggsnNbrOfSubscribersMean OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The mean number of subscribers serviced by this GGSN.
+          Incremented on transmission of a PDP context response with
+          request accepted for an IMSI (which previously did not have a
+          PDP context active). Decremented when the last PDP context for
+          that IMSI has been deleted.
+          The mean number of subscribers is calculated over five samples
+          taken over a 15 minute period.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 21 }
+
+ggsnNbrOfTftFilters OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Traffic Flow Template filters on this GGSN."
+   ::= { ggsnGlobalStats 22 }
+
+ggsnControlLoad OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Weighted PDP context load in control."
+   ::= { ggsnGlobalStats 25 }
+
+ggsnPayloadLoad OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "This gauge keeps track of the weighted load on the node for the
+          payload part. The gauge is used for the new load balancing scheme.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 26 }
+
+ggsnNbrOfActivePdpContextsIpv6 OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv6 PDP contexts on this GGSN."
+   ::= { ggsnGlobalStats 27 }
+
+ggsnNeighborSolicitationRcv  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of neighbor solicitation requests
+          received by GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 28 }
+
+ggsnNeighborSolicitationRsp  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of neighbor solicitation responses
+          from GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 29 }
+
+ggsnRouterSolicitationRcv  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of router solicitation requests received by GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 30 }
+
+ggsnRouterSolicitationRsp  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of router solicitation responses from GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 31 }
+
+ggsnL2tpActiveTunnels OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of currently active L2TP tunnels."
+   ::= { ggsnGlobalStats 32 }
+
+ggsnL2tpMaxActiveTunnels OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The max number of active L2TP tunnels since last restart."
+   ::= { ggsnGlobalStats 33 }
+
+ggsnL2tpActiveSessions OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of currently active L2TP sessions."
+   ::= { ggsnGlobalStats 34 }
+
+ggsnL2tpMaxActiveSessions OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The max number of active L2TP sessions since last restart."
+   ::= { ggsnGlobalStats 35 }
+
+ggsnChgEncodedCdrs OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of successfully encoded CDRs on this GGSN."
+   ::= { ggsnGlobalStats 36 }
+
+ggsnChgFailedEncodedCdrs OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of unsuccessfully encoded CDRs on this GGSN."
+   ::= { ggsnGlobalStats 37 }
+
+ggsnChgGeneratedFtpCdrs OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of CDRs generated for FTP."
+   ::= { ggsnGlobalStats 38 }
+
+ggsnChgGeneratedGtppCdrs OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of CDRs generated for GTP prime."
+   ::= { ggsnGlobalStats 39 }
+
+ggsnChgGtppLogCdrs OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of GTP prime CDRs stored in the charging log."
+   ::= { ggsnGlobalStats 40 }
+
+ggsnChgGtppAttemptedCdrsSend OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number sending attempts of CDRs generated for GTP prime."
+   ::= { ggsnGlobalStats 41 }
+
+ggsnChgGtppCdrsSendFailure OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number sending failures of CDRs generated for GTP prime."
+   ::= { ggsnGlobalStats 42 }
+
+ggsnNbActivePdpPerTrafficClassConversational OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of active PDP contexts per Traffic Class, conversational."
+   ::= { ggsnGlobalStats 43 }
+
+ggsnNbActivePdpPerTrafficClassStreaming   OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of active PDP contexts per Traffic Class, streaming."
+   ::= { ggsnGlobalStats 44 }
+
+ggsnNbActivePdpPerTrafficClassInteractive   OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of active PDP contexts per Traffic Class, interactive."
+   ::= { ggsnGlobalStats 45 }
+
+ggsnNbActivePdpPerTrafficClassBackground   OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of active PDP contexts per Traffic Class, background."
+   ::= { ggsnGlobalStats 46 }
+
+ggsnRadiusAuthenticationFailure   OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of failed RADIUS Authentication procedures."
+   ::= { ggsnGlobalStats 47 }
+
+ggsnRadiusAccountingFailure   OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+	 "The number of failed RADIUS Accounting procedures."
+   ::= { ggsnGlobalStats 48 }
+
+ggsnNbrOfActivePdpContextsWlan   OBJECT-TYPE
+   SYNTAX	 Gauge32
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+     "The number of active WLAN PDP contexts on this GGSN.
+      
+      Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGlobalStats 49 }
+
+ggsn3gdtActiveContexts   OBJECT-TYPE
+   SYNTAX     Gauge32
+   MAX-ACCESS     read-only
+   STATUS     current
+   DESCRIPTION
+     "The number of active 3GDT PDP contexts on this GGSN."
+   ::= { ggsnGlobalStats 50 }
+
+ggsn3gdtTotalCompletedEstablishment   OBJECT-TYPE
+   SYNTAX     Gauge32
+   MAX-ACCESS     read-only
+   STATUS     deprecated
+   DESCRIPTION
+     "The number of total completed 3GDT PDP context establishments on this GGSN."
+   ::= { ggsnGlobalStats 51 }
+
+ggsn3gdtTotalAttemptedEstablishment   OBJECT-TYPE
+   SYNTAX     Gauge32
+   MAX-ACCESS     read-only
+   STATUS     deprecated
+   DESCRIPTION
+     "The number of total attempted 3GDT PDP context establishments on this GGSN."
+   ::= { ggsnGlobalStats 52 }
+
+ggsn3gdtErrorHandling   OBJECT-TYPE
+   SYNTAX     Gauge32
+   MAX-ACCESS     read-only
+   STATUS     deprecated
+   DESCRIPTION
+     "The number error indications from RNC."
+   ::= { ggsnGlobalStats 53 }
+
+gn3gdtTotalCompletedEstablishment   OBJECT-TYPE
+   SYNTAX     Counter32
+   MAX-ACCESS     read-only
+   STATUS     current
+   DESCRIPTION
+     "The number of total completed 3GDT PDP context establishments on this GGSN."
+   ::= { ggsnGlobalStats 54 }
+
+gn3gdtTotalAttemptedEstablishment   OBJECT-TYPE
+   SYNTAX     Counter32
+   MAX-ACCESS     read-only
+   STATUS     current
+   DESCRIPTION
+     "The number of total attempted 3GDT PDP context establishments on this GGSN."
+   ::= { ggsnGlobalStats 55 }
+
+gn3gdtErrorHandling   OBJECT-TYPE
+   SYNTAX     Counter32
+   MAX-ACCESS     read-only
+   STATUS     current
+   DESCRIPTION
+     "The number error indications from RNC."
+   ::= { ggsnGlobalStats 56 }
+
+ggsnNbrOfActivePdpContextsIpv4v6 OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv4v6 PDP contexts on this GGSN."
+   ::= { ggsnGlobalStats 57 }
+
+
+ggsnPdpContextsStatsAttempted
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 3 }
+ggsnPdpContextsStatsCompleted
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 4 }
+ggsnPdpContextsStatsFailed
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 5 }
+ggsnGtpStats
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 6 }
+ggsnGtpErrorStats
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 7 }
+ggsnGtpPrStats
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 8 }
+ggsnGtpPrErrorStats
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 9 }
+
+ggsnAttemptedActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of PDP context activation procedures
+          initiated by the MS on this GGSN.
+          
+          Incremented each time a Create PDP Context Request
+          that is not silently discarded is received by the GGSN.
+          This means the SNMP counter incremented each time a
+          Create PDP Context Response is sent back to the SGSN with
+          cause value Request Accepted or Request Rejected.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 1 }
+
+ggsnAttemptedDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of PDP context deactivation procedures
+          initiated by the MS on this GGSN.
+          
+          Incremented each time a Delete PDP Context Request
+          is received at this GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 2 }
+
+ggsnAttemptedSelfDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of PDP context deactivation procedures
+          initiated by this GGSN.
+          
+          Incremented each time this GGSN attempts to delete a context.
+          Increases for all types of internal deletes.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 3 }
+
+ggsnAttemptedUpdate OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of PDP context updates attempted on
+          this GGSN.
+          
+          Incremented each time an Update PDP Context Request
+          is received at this GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 4 }
+
+ggsnAttemptedTimeDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The number of PDP context deactivation procedures
+          initiated by this GGSN due to the idle supervision
+          function."
+   ::= { ggsnPdpContextsStatsAttempted 5 }
+
+ggsnAttemptedManualDeactivation OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+         "The number of PDP context deactivation procedures
+          initiated by this GGSN due to manual user command.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 6 }
+
+ggsnAttemptedSecondaryActivation OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+         "The number of secondary PDP context activation
+          procedures initiated by the MS on this GGSN.
+          
+          All GPRS session management statistics except
+          ggsnAttemptedSecondaryActivation, ggsnCompletedSecondaryActivation,
+          ggsnAttemptedSecondaryActivationIpv6, and ggsnCompletedSecondaryActivationIpv6
+          will accumulate all pdp contexts, that is both secondary and
+          primary. 
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 7 }
+
+ggsnAttemptedActivationIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of IPv6 PDP context activation procedures
+          initiated by the MS on this GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 8 }
+
+ggsnAttemptedSecondaryActivationIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of secondary IPv6 PDP context activation procedures
+          initiated by the MS on this GGSN.
+          
+          All GPRS session management statistics except
+          ggsnAttemptedSecondaryActivation, ggsnCompletedSecondaryActivation,
+          ggsnAttemptedSecondaryActivationIpv6, and
+          ggsnCompletedSecondaryActivationIpv6 will accumulate all 
+          pdp contexts, that is both secondary and primary.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 9 }
+
+ggsnAttemptedActivationWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of WLAN PDP context activation procedures
+          initiated by the MS on this GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 10 }
+
+ggsnAttemptedActivationConversational OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted primary and secondary PDP context activation procedures 
+          with traffic class conversational on this GGSN.
+
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 11 }
+
+ggsnAttemptedActivationStreaming OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted primary and secondary PDP context activation procedures 
+          with traffic class streaming on this GGSN.
+
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 12 }
+
+ggsnAttemptedActivationInteractive OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted primary and secondary PDP context activation procedures 
+          with traffic class interactive on this GGSN.
+
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 13 }
+
+ggsnAttemptedActivationBackground OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted primary and secondary PDP context activation procedures 
+          with traffic class background on this GGSN.
+
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 14 }
+
+ggsnAttemptedActivationDiscarded OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted primary and secondary PDP context activations
+          that are discarded on this GGSN.
+
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 15 }
+
+ggsnAttemptedActivationIpv4v6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of IPv4v6 PDP context activation procedures
+          initiated by the MS on this GGSN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsAttempted 16 }
+
+ggsnCompletedActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed
+          PDP context activation procedures initiated by an MS.
+          
+          Incremented each time a Create PDP Context Response is sent back
+          to an SGSN with cause value Request Accepted."
+   ::= { ggsnPdpContextsStatsCompleted 1 }
+
+ggsnCompletedDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed
+          PDP context deactivation procedures initiated by an MS. 
+          
+          Note: This counter can not be retrieved by CLI. "
+   ::= { ggsnPdpContextsStatsCompleted 2 }
+
+ggsnCompletedSelfDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed
+          PDP context deactivation procedures initiated by the GGSN.
+          
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 3 }
+
+ggsnCompletedUpdate OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed
+          PDP context update procedures initiated by an MS.
+          
+          Incremented each time an Update PDP Context Response is sent back
+          to an SGSN with cause value Request Accepted."
+   ::= { ggsnPdpContextsStatsCompleted 4 }
+
+ggsnIdleTimeoutDeactivation OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+         "The number of successfully completed
+          PDP context deactivation procedures initiated by the GGSN 
+          due to the idle supervision function.
+          
+          Note: The PDP context is supervised for the time it has been idle,
+          without actual payload." 
+   ::= { ggsnPdpContextsStatsCompleted 5 }
+
+ggsnCompletedManualDeactivation OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+         "The number of successfully completed
+          PDP context deactivation procedures initiated by the GGSN 
+          due to manual user command."
+   ::= { ggsnPdpContextsStatsCompleted 6 }
+
+ggsnCompletedSecondaryActivation OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+         "The number of successfully completed
+          secondary PDP context activation procedures initiated by an MS.
+          
+          Note: All GPRS session management statistics except
+          ggsnAttemptedSecondaryActivation, ggsnCompletedSecondaryActivation,
+          ggsnAttemptedSecondaryActivationIpv6, and
+          ggsnCompletedSecondaryActivationIpv6 count all PDP
+          contexts, both secondary and primary." 
+   ::= { ggsnPdpContextsStatsCompleted 7 }
+
+ggsnSessionTimeoutDeactivation OBJECT-TYPE
+   SYNTAX	 Counter64
+   MAX-ACCESS	 read-only
+   STATUS	 current
+   DESCRIPTION
+     "The number of successfully completed
+      PDP context deactivation procedures initiated by the GGSN
+      due to the duration supervision function.
+      
+      Note: The PDP context is supervised for the time it has been active,
+      irrespective of the actual payload."
+   ::= { ggsnPdpContextsStatsCompleted 8 }
+
+ggsnCompletedActivationIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed
+          IPv6 PDP context activation procedures initiated by an MS."
+   ::= { ggsnPdpContextsStatsCompleted 9 }
+
+ggsnCompletedSecondaryActivationIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed secondary IPv6 PDP context
+         activation procedures initiated by an MS.
+         
+         Note: All GPRS session management statistics except
+         ggsnAttemptedSecondaryActivation, ggsnCompletedSecondaryActivation,
+         ggsnAttemptedSecondaryActivationIpv6, and
+         ggsnCompletedSecondaryActivationIpv6 count all
+         PDP contexts, both secondary and primary."
+   ::= { ggsnPdpContextsStatsCompleted 10 }
+
+ggsnCompletedActivationWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed WLAN PDP context activation
+          procedures initiated by an MS.
+          
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 11 }
+
+ggsnCompletedActivationConversational OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed primary and secondary PDP context 
+          activation procedures with traffic class conversational.
+
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 12 }
+
+ggsnCompletedActivationStreaming OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed primary and secondary PDP context 
+          activation procedures with traffic class streaming.
+
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 13 }
+
+ggsnCompletedActivationInteractive OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed primary and secondary PDP context 
+          activation procedures with traffic class interactive.
+
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 14 }
+
+ggsnCompletedActivationBackground OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed primary and secondary PDP context 
+          activation procedures with traffic class background.
+
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 15 }
+
+ggsnCompletedActivationIpv4v6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed
+          IPv4v6 PDP context activation procedures initiated by an MS.
+          
+          Note: This counter can not be retrieved by CLI."
+   ::= { ggsnPdpContextsStatsCompleted 16 }
+
+ggsnFailedActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed PDP context activation
+          procedures initiated by an MS.
+          
+          Incremented each time a Create PDP Context Response is sent back
+          to an SGSN with cause value Request Rejected."         
+   ::= { ggsnPdpContextsStatsFailed 1 }
+
+
+
+--
+-- GGSN GTP statistics
+--
+
+ggsnGtpUplinkPackets	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "Total number of uplink control plane GTP packets processed by the GGSN or PGW.
+     Incremented when an uplink GTP packet is received over the Gn control plane."
+    
+    ::= { ggsnGtpStats 1 }
+
+
+ggsnGtpUplinkBytes	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "Total number of bytes for the uplink control plane GTP packets processed by the GGSN or PGW.
+     Incremented when an uplink GTP packet is received over the Gn control plane."
+
+    ::= { ggsnGtpStats 2 }
+
+
+ggsnGtpDownlinkPackets	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "Total number of downlink control plane GTP packets processed by the GGSN or PGW.
+     Incremented when a downlink packet is sent over the Gn control plane."
+
+    ::= { ggsnGtpStats 3 }
+
+
+ggsnGtpDownlinkBytes	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "Total number of bytes for the downlink control plane GTP packets processed by the GGSN or PGW.
+     Incremented when a downlink packet is sent over the Gn control plane."
+
+    ::= { ggsnGtpStats 4 }
+
+
+ggsnGtpControlPacketDrops	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The total number of GTP-C control packets that have been
+	 dropped by the node."
+    ::= { ggsnGtpStats 5 }
+
+
+ggsnGtpVerUnsupPacketsReceived		OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of Version Unsupported responses received by the GGSN."
+    ::= { ggsnGtpStats 6 }
+
+
+ggsnGtpVerUnsupPacketsSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of Version Unsupported responses sent by the GGSN."
+    ::= { ggsnGtpStats 7 }
+
+
+ggsnGtpEchoReqReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP echo requests received by the GGSN."
+    ::= { ggsnGtpStats 8 }
+
+
+ggsnGtpEchoReqSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP echo requests sent by the GGSN."
+    ::= { ggsnGtpStats 9 }
+
+
+ggsnGtpEchoRespReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP echo responses received by the GGSN."
+    ::= { ggsnGtpStats 10 }
+
+
+ggsnGtpEchoRespSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP echo responses sent by the GGSN."
+    ::= { ggsnGtpStats 11 }
+
+
+ggsnGtpPdpCreateReqReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP Create requests received by the GGSN."
+    ::= { ggsnGtpStats 12 }
+
+ggsnGtpPdpCreateRespSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP Create responses sent by the GGSN."
+    ::= { ggsnGtpStats 13 }
+
+
+ggsnGtpPdpUpdateReqReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP update requests received by the GGSN."
+    ::= { ggsnGtpStats 14 }
+
+
+ggsnGtpPdpUpdateReqSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP update requests sent by the GGSN."
+    ::= { ggsnGtpStats 15 }
+
+
+ggsnGtpPdpUpdateRespReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP update responses received by the GGSN."
+    ::= { ggsnGtpStats 16 }
+
+
+ggsnGtpPdpUpdateRespSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP update responses sent by the GGSN."
+    ::= { ggsnGtpStats 17 }
+
+
+ggsnGtpPdpDeleteReqReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP delete requests received by the GGSN."
+    ::= { ggsnGtpStats 18 }
+
+
+ggsnGtpPdpDeleteReqSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP delete requests sent by the GGSN."
+    ::= { ggsnGtpStats 19 }
+
+
+ggsnGtpPdpDeleteRespReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP delete responses received by the GGSN."
+    ::= { ggsnGtpStats 20 }
+
+
+ggsnGtpPdpDeleteRespSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of PDP delete responses sent by the GGSN."
+    ::= { ggsnGtpStats 21 }
+
+
+ggsnGtpRequestsAccepted	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP requests accepted by the GGSN.
+
+         Incremented each time a Create PDP Context Response,
+         Update PDP Context Response or Delete PDP Context Response
+         is sent back to an SGSN with cause value Request Accepted."
+    ::= { ggsnGtpStats 22 }
+
+ggsnGtpNbrOfTunnels OBJECT-TYPE
+    SYNTAX              Gauge32
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of currently active GTP tunnels on the GGSN.
+         Each primary PDP context is counted twice for
+         signaling tunnel and payload tunnel,
+         and each secondary PDP context is counted once for
+         payload tunnel only,
+         as they share signaling tunnels with their primary PDP contexts."         
+    ::= { ggsnGtpStats 23 }
+
+ggsnGtpNbrOfCreatedTunnels OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The total number of GTP tunnels that have been created on the GGSN.
+         Each primary PDP context is counted twice for
+         signaling tunnel and payload tunnel,
+         and each secondary PDP context is counted once for
+         payload tunnel only,
+         as they share signaling tunnels with their primary PDP contexts."         
+    ::= { ggsnGtpStats 24 }
+
+ggsnGtpPdpInitiateContextActivationRespReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of Initiate PDP Context Activation Responses received by the GGSN from an SGSN."
+    ::= { ggsnGtpStats 25 }
+    
+ggsnGtpPdpInitiateContextActivationReqSent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of Initiate PDP Context Activation Requests sent by the GGSN to an SGSN."
+    ::= { ggsnGtpStats 26 }
+
+ggsnGtpv0PdpCreateReqReceived	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GtpV0 PDP Create requests received by the GGSN."
+    ::= { ggsnGtpStats 27 }
+--
+-- GGSN GTP error statistics
+--
+
+
+ggsnGtpErrorIndicationReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of Error Indications received by the
+	 node (aggregate of error indications received by the GTP-U)."
+    ::= { ggsnGtpErrorStats 1 }
+
+ggsnGtpErrorIndicationSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of Error Indications sent by the
+	 node (aggregate of error indications sent by the GTP-U).
+	 The GGSN may send an Error Indication to the SGSN or RNC 
+	 if no PDP context exists or the PDP context is inactive 
+	 for a received GTP Packet Data Unit (G-PDU)."
+    ::= { ggsnGtpErrorStats 2 }
+
+ggsnGtpErrorInvalidRequestFormat	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP invalid request format errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 3 }
+
+ggsnGtpErrorResourcesUnavailable	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP resources unavailable errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 4 }
+
+ggsnGtpErrorDynAddrUnavailable		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP dynamic address unavailable errors
+	 sent by the GGSN."
+    ::= { ggsnGtpErrorStats 5 }
+
+ggsnGtpErrorMemoryUnavailable		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP memory not available errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 6 }
+
+ggsnGtpErrorApnUnknown			OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of GTP APN invalid errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 7 }
+
+ggsnGtpErrorPdpAddrUnknown		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP PDP address unknown errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 8 }
+
+ggsnGtpErrorAuthenticationFailed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP authentication failed errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 9 }
+
+ggsnGtpErrorSystemFailure		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP system failure errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 10 }
+
+ggsnGtpErrorTftSemanticError		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP TFT semantic errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 11 }
+
+ggsnGtpErrorTftSyntaxError		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP TFT syntax errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 12 }
+
+ggsnGtpErrorPackFiltSemantError		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of semantic packet filter errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 13 }
+
+ggsnGtpErrorPackFiltSyntaxError		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of packet filter syntax errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 14 }
+
+ggsnGtpErrorMandatoryIEMissing		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of errors sent by the GGSN indicating that
+	 a mandatory information element was missing."
+    ::= { ggsnGtpErrorStats 15 }
+
+ggsnGtpErrorMandatoryIEInvalid		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of errors sent by the GGSN indicating that a mandatory information element was invalid."
+    ::= { ggsnGtpErrorStats 16 }
+
+ggsnGtpErrorOptionalIEInvalid		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of errors sent by the GGSN indicating that an optional information element was invalid."
+    ::= { ggsnGtpErrorStats 17 }
+
+ggsnGtpErrorReferenceInexistent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of cause codes 'Context Not Found' and 'Non Existent' sent
+     as response to the following operations:
+     -Create PDP context
+     -Update PDP context
+     -Delete PDP context"
+    ::= { ggsnGtpErrorStats 18 }
+
+ggsnGtpErrorServiceUnsupported		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of service unsupported errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 19 }
+
+ggsnGtpErrorInvalidRequestFormatUpd	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP invalid update request format errors
+         sent by the GGSN."
+    ::= { ggsnGtpErrorStats 20 }
+
+ggsnGtpErrorInvalidRequestFormatDel	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP invalid delete request format errors
+         sent by the GGSN."
+    ::= { ggsnGtpErrorStats 21 }
+
+ggsnGtpErrorSystemFailureUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP system update failure errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 22 }
+
+ggsnGtpErrorTftSemanticErrorUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP TFT update semantic errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 23 }
+
+ggsnGtpErrorTftSyntaxErrorUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP TFT update syntax errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 24 }
+
+ggsnGtpErrorPackFiltSemantErrorUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of semantic update packet filter errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 25 }
+
+ggsnGtpErrorPackFiltSyntaxErrorUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of packet update filter syntax errors sent by the GGSN."
+    ::= { ggsnGtpErrorStats 26 }
+
+ggsnGtpErrorMandatoryIEMissingUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of errors sent by the GGSN indicating that
+     a mandatory information element was missing in an update request."
+    ::= { ggsnGtpErrorStats 27 }
+
+ggsnGtpErrorMandatoryIEMissingDel		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of errors sent by the GGSN indicating that
+     a mandatory information element was missing in a delete request."
+    ::= { ggsnGtpErrorStats 28 }
+
+ggsnGtpErrorMandatoryIEInvalidUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of errors sent by the GGSN indicating that
+     a mandatory information element was invalid in an update request."
+    ::= { ggsnGtpErrorStats 29 }
+
+ggsnGtpErrorMandatoryIEInvalidDel		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of errors sent by the GGSN indicating that
+     a mandatory information element was invalid in a delete request."
+    ::= { ggsnGtpErrorStats 30 }
+
+ggsnGtpErrorOptionalIEInvalidUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of errors sent by the GGSN indicating that an optional information element was invalid in an update request."
+    ::= { ggsnGtpErrorStats 31 }
+
+ggsnGtpErrorOptionalIEInvalidDel		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of errors sent by the GGSN indicating that an optional information element was invalid in a delete request."
+    ::= { ggsnGtpErrorStats 32 }
+
+ggsnGtpErrorReferenceInexistentUpd		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of cause codes 'Context Not Found' and 'Non Existent' sent
+     as response to update PDP context requests"
+    ::= { ggsnGtpErrorStats 33 }
+
+ggsnGtpErrorReferenceInexistentDel		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    "The number of cause codes 'Context Not Found' and 'Non Existent' sent
+     as response to delete PDP context requests"
+    ::= { ggsnGtpErrorStats 34 }
+
+ggsnGtpErrorPdpWithoutTft			OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of pdp context errors without TFT already activated."
+    ::= { ggsnGtpErrorStats 35 }
+
+ggsnGtpErrorApnAccessDenied			OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP apn access denied errors with no subscription."
+    ::= { ggsnGtpErrorStats 36 }
+
+ggsnGtpNewPdpTypeNwPreference         OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS      read-only
+    STATUS      current
+    DESCRIPTION
+    "The number of new PDP type due to network preference sent by the GGSN."
+    ::= { ggsnGtpErrorStats 37 }
+
+ggsnGtpNewPdpTypeSingleAddressBearerOnly         OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS      read-only
+    STATUS      current
+    DESCRIPTION
+    "The number of new PDP type due to single address bearer only sent by the GGSN."
+    ::= { ggsnGtpErrorStats 38 }
+
+--
+-- GGSN GTP Prime statistics
+--
+
+
+ggsnGtpPrEchoReqReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime echo requests received by the GGSN."
+    ::= { ggsnGtpPrStats 1 }
+
+ggsnGtpPrEchoRequestsSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime echo requests sent by the GGSN."
+    ::= { ggsnGtpPrStats 2 }
+
+ggsnGtpPrEchoRespReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime echo responses received by the GGSN."
+    ::= { ggsnGtpPrStats 3 }
+
+ggsnGtpPrEchoRespSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime echo responses sent by the GGSN."
+    ::= { ggsnGtpPrStats 4 }
+
+ggsnGtpPrVerUnsupPacketsReceived	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime version unsupported packets received by the GGSN."
+    ::= { ggsnGtpPrStats 5 }
+
+ggsnGtpPrVerUnsupPacketsSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime version unsupported packets sent by the GGSN."
+    ::= { ggsnGtpPrStats 6 }
+
+ggsnGtpPrNodeAliveReqReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime Node Alive request packets received by the GGSN."
+    ::= { ggsnGtpPrStats 7 }
+
+ggsnGtpPrNodeAliveReqSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime Node Alive request packets sent by the GGSN."
+    ::= { ggsnGtpPrStats 8 }
+
+ggsnGtpPrNodeAliveRespReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime Node Alive response packets received by the GGSN."
+    ::= { ggsnGtpPrStats 9 }
+
+ggsnGtpPrNodeAliveRespSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime Node Alive response packets sent by the GGSN."
+    ::= { ggsnGtpPrStats 10 }
+
+ggsnGtpPrRedirectReqReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime redirect requests received by the GGSN."
+    ::= { ggsnGtpPrStats 11 }
+
+ggsnGtpPrRedirectReqSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime redirect requests sent by the GGSN."
+    ::= { ggsnGtpPrStats 12 }
+
+ggsnGtpPrRedirectRespReceived		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime redirect responses received by the GGSN."
+    ::= { ggsnGtpPrStats 13 }
+
+ggsnGtpPrRedirectRespSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime redirect responses sent by the GGSN."
+    ::= { ggsnGtpPrStats 14 }
+
+ggsnGtpPrDataRecTransferReceived	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime data record transfer responses received
+	 by the GGSN."
+    ::= { ggsnGtpPrStats 15 }
+
+ggsnGtpPrDataRecTransferSent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime data record transfers sent by the GGSN."
+    ::= { ggsnGtpPrStats 16 }
+
+ggsnGtpPrSndDataRecordPackets		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer request Send
+	 Data Record packets sent by the GGSN."
+    ::= { ggsnGtpPrStats 17 }
+
+-- { ggsnGtpPrStats 18-20 } are not assigned
+
+ggsnGtpPrRequestAccepted		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+	 Request Accepted received by the GGSN."
+    ::= { ggsnGtpPrStats 21 }
+
+ggsnGtpPrNoResource			OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         No Resource received by the GGSN."
+    ::= { ggsnGtpPrStats 22 }
+
+ggsnGtpPrServiceUnsupported		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Service Unsupported received by the GGSN."
+    ::= { ggsnGtpPrStats 23 }
+
+ggsnGtpPrSystemFailure			OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         System Failure received by the GGSN."
+    ::= { ggsnGtpPrStats 24 }
+
+ggsnGtpPrInvalidMessageFormat		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Invalid Message Format received by the GGSN."
+    ::= { ggsnGtpPrStats 25 }
+
+ggsnGtpPrVersionUnsupported		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Version Unsupported received by the GGSN."
+    ::= { ggsnGtpPrStats 26 }
+
+ggsnGtpPrRequestUnfulfilled		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Request Unfulfilled received by the GGSN."
+    ::= { ggsnGtpPrStats 27 }
+
+ggsnGtpPrDecodingError			OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Decoding Error received by the GGSN."
+    ::= { ggsnGtpPrStats 28 }
+
+ggsnGtpPrAlreadyFulfilled		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Request Already Fulfilled received by the GGSN."
+    ::= { ggsnGtpPrStats 29 }
+
+ggsnGtpPrDupPacketFulfilled		OBJECT-TYPE
+    SYNTAX              Counter64
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The number of GTP Prime data record transfer response
+         Request Duplicate Packet Fulfilled received by the GGSN."
+    ::= { ggsnGtpPrStats 30 }
+
+
+--
+-- GGSN GTP Prime Error statistics
+--
+
+
+ggsnGtpPrErrorMandatoryIEMissing	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime mandatory information element
+	 missing errors received by the GGSN."
+    ::= { ggsnGtpPrErrorStats 1 }
+
+ggsnGtpPrErrorMandatoryIEInvalid	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime mandatory information element invalid
+	 errors received by the GGSN."
+    ::= { ggsnGtpPrErrorStats 2 }
+
+ggsnGtpPrErrorOptionalIEInvalid		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime optional information element invalid
+	 errors received by the GGSN."
+    ::= { ggsnGtpPrErrorStats 3 }
+
+ggsnGtpPrErrorRefInexistent		OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	"The number of GTP Prime reference inexistent errors
+	 received by the GGSN."
+    ::= { ggsnGtpPrErrorStats 4 }
+
+
+--
+-- Link traffic information
+--
+
+
+ggsnUplinkTrafficInfo
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 11 }
+ggsnDownlinkTrafficInfo
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 12 }
+pdnConnectionsGgsn
+   OBJECT IDENTIFIER ::= { ggsnGlobalStats 13 }
+
+ggsnUplinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv4 and IPv6 packets processed by the GGSN or PGW. Incremented when an uplink packet, received over the Gn or S5 user plane interface, is sent over Gi or SGi interface."   
+   ::= { ggsnUplinkTrafficInfo 1 }
+
+ggsnUplinkBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv4 and IPv6 bytes processed by the GGSN or PGW. Incremented when an uplink packet, received over the Gn or S5 user plane interface, is sent over Gi or SGi interface."
+   ::= { ggsnUplinkTrafficInfo 2 }
+
+ggsnUplinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv4 and IPv6 packets dropped by this GGSN or PGW. Incremented when an uplink packet, received over the Gn or S5 user plane interface, is dropped."
+   ::= { ggsnUplinkTrafficInfo 3 }
+
+ggsnUplinkDropsBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv4 and IPv6 bytes dropped by this GGSN or PGW. Incremented when an uplink packet received over the Gn or S5 user plane interface is dropped."
+   ::= { ggsnUplinkTrafficInfo 4 }
+
+ggsnUplinkPacketsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv6 packets processed by the GGSN or PGW. Incremented when an uplink IPv6 packet, received over the Gn or S5 user plane interface is sent over Gi or SGi interface."
+   ::= { ggsnUplinkTrafficInfo 5 }
+
+ggsnUplinkBytesIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv6 bytes processed by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the Gn or S5 user plane interface is sent over Gi or SGi interface."
+   ::= { ggsnUplinkTrafficInfo 6 }
+
+ggsnUplinkDropsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv6 packets dropped by this GGSN or PGW. Incremented when an uplink IPv6 packet received over the Gn or S5 user plane interface is dropped."
+   ::= { ggsnUplinkTrafficInfo 7 }
+
+ggsnUplinkBytesWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total bytes for all processed uplink WLAN packets via this GGSN."
+   ::= { ggsnUplinkTrafficInfo 8 }
+
+ggsnUplinkDropsWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "The number of uplink WLAN packets dropped by this GGSN."
+   ::= { ggsnUplinkTrafficInfo 9 }
+
+ggsnUplinkPacketsWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total uplink WLAN packets processed by this GGSN."
+   ::= { ggsnUplinkTrafficInfo 10 }
+
+ggsnDownlinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv4 and IPv6 packets processed by the GGSN or PGW. Incremented when a downlink packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnDownlinkTrafficInfo 1 }
+
+ggsnDownlinkBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv4 and IPv6 bytes processed by the GGSN or PGW. Incremented when a downlink packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnDownlinkTrafficInfo 2 }
+
+ggsnDownlinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv4 and IPv6 packets dropped by the GGSN or PGW. Incremented when a downlink packet received over the Gi or SGi user plane interface is dropped."
+   ::= { ggsnDownlinkTrafficInfo 3 }
+
+ggsnDownlinkDropsBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv4 and IPv6 bytes dropped by the GGSN or PGW. Incremented when a downlink packet received over the Gi or SGi user plane interface is dropped."
+   ::= { ggsnDownlinkTrafficInfo 4 }
+
+ggsnDownlinkPacketsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv6 packets processed by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnDownlinkTrafficInfo 5 }
+
+ggsnDownlinkBytesIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv6 bytes processed by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnDownlinkTrafficInfo 6 }
+
+ggsnDownlinkDropsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv6 bytes dropped by the GGSN or PGW. Incremented when a downlink IPv6 packet received over the Gi or SGi user plane interface is dropped."
+
+   ::= { ggsnDownlinkTrafficInfo 7 }
+
+ggsnDownlinkBytesWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total bytes for all processed downlink WLAN packets via this GGSN."
+   ::= { ggsnDownlinkTrafficInfo 8 }
+
+ggsnDownlinkDropsWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "The number of downlink WLAN packets dropped by this GGSN."
+   ::= { ggsnDownlinkTrafficInfo 9 }
+
+ggsnDownlinkPacketsWlan OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total downlink WLAN packets processed by this GGSN."
+   ::= { ggsnDownlinkTrafficInfo 10 }
+
+--
+-- PDN Connections GGSN
+--
+
+nbrOfGgsnPdnConnections OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Number of PDN connections to a non-PGW-enabled APN."
+   ::= { pdnConnectionsGgsn 1 }
+
+--
+-- GGSN Pic statistics
+--
+
+
+ggsnPicStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GgsnPicStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "A table listing the statistics for all GTP PICs."
+   ::= { ggsnGeneralInfo 4 }
+
+ggsnPicStatsEntry OBJECT-TYPE
+   SYNTAX        GgsnPicStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          GTP PICs on this GGSN."
+   INDEX         { ggsnPicIndex }
+   ::= { ggsnPicStatsTable 1 }
+
+
+GgsnPicStatsEntry ::= SEQUENCE {
+   ggsnPicIndex                  Integer32,
+   ggsnPicAddress                IpAddress,
+   ggsnPicNbrOfActivePdpContexts Gauge32
+}
+
+ggsnPicIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "A number representing each GTP PIC whose statistics
+          is being generated."
+   ::= { ggsnPicStatsEntry 1 }
+
+ggsnPicAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The IP address of this GTP PIC."
+   ::= { ggsnPicStatsEntry 2 }
+
+ggsnPicNbrOfActivePdpContexts OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The number of active PDP contexts on a per PIC
+          of this GGSN."
+   ::= { ggsnPicStatsEntry 3 }
+
+
+
+--
+-- GGSN APN statistics
+--
+
+
+ggsnApnStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF ApnStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the statistics for all APNs which
+          are served by this GGSN."
+   ::= { ggsnGeneralInfo 5 }
+
+ggsnApnStatsEntry OBJECT-TYPE
+   SYNTAX        ApnStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          APN which is served by this GGSN."
+   INDEX         { ggsnApnIndex }
+   ::= { ggsnApnStatsTable 1 }
+
+ApnStats ::= SEQUENCE {
+   ggsnApnIndex                     Integer32,
+   ggsnApnName                      DisplayString,
+   ggsnApnActivePdpContextCount     Gauge32,
+   ggsnApnAttemptedActivation	    Counter64,
+   ggsnApnAttemptedDynActivation    Counter64,
+   ggsnApnAttemptedDeactivation     Counter64,
+   ggsnApnAttemptedSelfDeactivation Counter64,
+   ggsnApnCompletedActivation	    Counter64,
+   ggsnApnCompletedDynActivation    Counter64,
+   ggsnApnCompletedDeactivation     Counter64,
+   ggsnApnCompletedSelfDeactivation Counter64,
+   ggsnApnUplinkPackets             Counter64,
+   ggsnApnUplinkBytes               Counter64,
+   ggsnApnUplinkDrops               Counter64,
+   ggsnApnDownlinkPackets           Counter64,
+   ggsnApnDownlinkBytes             Counter64,
+   ggsnApnDownlinkDrops             Counter64,
+   ggsnApnAttemptedMSActivation     Counter64,
+   ggsnApnCompletedMSActivation     Counter64,
+   ggsnApnAttemptedMSDeactivation   Counter64,
+   ggsnApnCompletedMSDeactivation   Counter64,
+   ggsnApnActivePdpContextMax	    Gauge32,
+   ggsnApnActivePdpContextMean	    Gauge32,
+   ggsnApnAttemptedAuthActivation   Counter64,
+   ggsnApnFailedAuthActivation      Counter64,
+   ggsnApnAttemptedUpdateMsAndSgsn  Counter64,
+   ggsnApnCompletedUpdateMsAndSgsn  Counter64,
+   ggsnApnNbrOfTftFilters	        Gauge32,
+   ggsnApnSessTimeoutDeactivation   Counter64,
+   ggsnApnIdleTimeoutDeactivation   Counter64,
+   ggsnApnGiSignalingInPackets      Counter64,
+   ggsnApnGiSignalingInBytes        Counter64,
+   ggsnApnGiSignalingOutPackets     Counter64,
+   ggsnApnGiSignalingOutBytes       Counter64,
+   ggsnApnActivePdpContextCountIpv6 Gauge32,
+   ggsnApnAttemptedActivationIpv6   Counter64,
+   ggsnApnCompletedActivationIpv6   Counter64,
+   ggsnApnAvailableIpAddressesInInternalPool Gauge32,
+   ggsnApnIpAddressesInQuarantineInInternalPool Gauge32,
+   ggsnApnUplinkPacketsIpv6         Counter64,
+   ggsnApnUplinkBytesIpv6           Counter64,
+   ggsnApnUplinkDropsIpv6           Counter64,
+   ggsnApnDownlinkPacketsIpv6       Counter64,
+   ggsnApnDownlinkBytesIpv6         Counter64,
+   ggsnApnDownlinkDropsIpv6         Counter64,
+   ggsnApnNeighborSolicitationRcv   Counter64,
+   ggsnApnNeighborSolicitationRsp   Counter64,
+   ggsnApnRouterSolicitationRcv     Counter64,
+   ggsnApnRouterSolicitationRsp     Counter64,
+   ggsnNbApnActivePdpPerTrafficClassConversational  Gauge32,
+   ggsnNbApnActivePdpPerTrafficClassStreaming       Gauge32,
+   ggsnNbApnActivePdpPerTrafficClassInteractive     Gauge32,
+   ggsnNbApnActivePdpPerTrafficClassBackground      Gauge32,
+   ggsnApnImsDedicatedCompletedActivation           Counter64,
+   ggsnApnImsDedicatedNotConfiguredActivationFailed Counter64,
+   ggsnApnImsGeneralPurposeCompletedActivation      Counter64,
+   ggsnApnImsGeneralNotConfiguredActivationFailed   Counter64,
+   ggsnApnActivationFailedDuetoGeneralPurposeNotConfigured Counter64,
+   ggsnApnUnauthorizedImsPackets                           Counter64,
+   ggsnApnRadiusAccountingFailure                          Counter64,
+   ggsnApnRadiusAuthenticationFailure                      Counter64,
+   ggsnApnSaccRsInstalledDynRules                          Gauge32,
+   ggsnApnSaccRsActivePredefinedChargingRules              Gauge32,
+   ggsnApnSaccRsActivePredefinedChargingRuleBases          Gauge32,
+   ggsnApn3gdtActiveContexts                               Gauge32,
+   ggsnApn3gdtTotalCompletedEstablishment                  Gauge32,
+   ggsnApn3gdtTotalAttemptedEstablishment                  Gauge32,
+   ggsnApn3gdtErrorHandling                                Gauge32,
+   ggsnApnAttemptedUpdateGgsn                              Counter64,
+   ggsnApnCompletedUpdateGgsn                              Counter64,
+   ggsnApnAttemptedActivationNonDuplicated                 Counter64,
+   ggsnApnActivePdpContextMaxDuringLastPeriod              Gauge32,
+   pgwApnActiveEpsBearer                                   Gauge32,
+   pgwApnActiveIpv6EpsBearer                               Gauge32,
+   pgwApnAttemptedEpsBearerActivation                      Counter64,
+   pgwApnCompletedEpsBearerActivation                      Counter64,
+   pgwApnAttemptedIpv6EpsBearerActivation                  Counter64,
+   pgwApnCompletedIpv6EpsBearerActivation                  Counter64,
+   pgwApnAttemptedEpsBearerDeactivation                    Counter64,
+   pgwApnCompletedEpsBearerDeactivation                    Counter64,
+   pgwApnAttemptedS5NetworkDeactivation                    Counter64,
+   pgwApnCompletedS5NetworkDeactivation                    Counter64,
+   pgwApnAttemptedS5UeSgwModification                      Counter64,
+   pgwApnCompletedS5UeSgwModification                      Counter64,
+   pgwApnAttemptedS5SgwSgsnModification                    Counter64,
+   pgwApnCompletedS5SgwSgsnModification                    Counter64,
+   pgwApnAttemptedS5SgsnSgwModification                    Counter64,
+   pgwApnCompletedS5SgsnSgwModification                    Counter64,
+   pgwApnAttemptedS5NetworkModification                    Counter64,
+   pgwApnCompletedS5NetworkModification                    Counter64,
+   pgwApnAttemptedS5UeSgwDeactivation                      Counter64,
+   pgwApnCompletedS5UeSgwDeactivation                      Counter64,
+   gnApnUplinkPackets                                      Counter64,
+   gnApnUplinkBytes                                        Counter64,
+   gnApnUplinkPacketsIpv6                                  Counter64,
+   gnApnUplinkBytesIpv6                                    Counter64,
+   gnApnDownlinkPackets                                    Counter64,
+   gnApnDownlinkBytes                                      Counter64,
+   gnApnDownlinkPacketsIpv6                                Counter64,
+   gnApnDownlinkBytesIpv6                                  Counter64,
+   s5ApnUplinkPackets                                      Counter64,
+   s5ApnUplinkBytes                                        Counter64,
+   s5ApnUplinkPacketsIpv6                                  Counter64,
+   s5ApnUplinkBytesIpv6                                    Counter64,
+   s5ApnDownlinkPackets                                    Counter64,
+   s5ApnDownlinkBytes                                      Counter64,
+   s5ApnDownlinkPacketsIpv6                                Counter64,
+   s5ApnDownlinkBytesIpv6                                  Counter64,
+   s2aApnUplinkPackets                                     Counter64,  
+   s2aApnUplinkBytes                                       Counter64,
+   s2aApnUplinkPacketsIpv6                                 Counter64,
+   s2aApnUplinkBytesIpv6                                   Counter64,
+   s2aApnDownlinkPackets                                   Counter64,
+   s2aApnDownlinkBytes                                     Counter64,
+   s2aApnDownlinkPacketsIpv6                               Counter64,
+   s2aApnDownlinkBytesIpv6                                 Counter64,
+   pgwApnActiveDedicatedEpsBearer                          Gauge32,
+   pgwApnAttemptedDedicatedEpsBearerActivation	           Counter64,
+   pgwApnCompletedDedicatedEpsBearerActivation  	       Counter64,
+   pgwApnAttemptedIpv6DedicatedEpsBearerActivation  	   Counter64,
+   pgwApnCompletedIpv6DedicatedEpsBearerActivation  	   Counter64,
+   pgwApnAttemptedS5NetworkDedicatedEpsBearerDeactivation  Counter64,
+   pgwApnCompletedS5NetworkDedicatedEpsBearerDeactivation  Counter64,
+   pgwApnAttemptedS5NetworkDedicatedEpsBearerModification  Counter64,
+   pgwApnCompletedS5NetworkDedicatedEpsBearerModification  Counter64,
+   pgwApnAttemptedS5UeSgwDedicatedEpsBearerDeactivation    Counter64,
+   pgwApnCompletedS5UeSgwDedicatedEpsBearerDeactivation	   Counter64,
+   gnApn3gdtUplinkBytes                                    Counter64,
+   gnApn3gdtUplinkBytesIpv6                                Counter64,
+   gnApn3gdtUplinkPackets                                  Counter64,
+   gnApn3gdtUplinkPacketsIpv6                              Counter64,
+   gnApn3gdtDownlinkBytes                                  Counter64,
+   gnApn3gdtDownlinkBytesIpv6                              Counter64,
+   gnApn3gdtDownlinkPackets                                Counter64,
+   gnApn3gdtDownlinkPacketsIpv6                            Counter64,
+   gnApn3gdtDownlinkDropsErrorHandling                     Counter64,
+   ggsnApn3gdtGtpError                                     Counter64,
+   gnApn3gdtTotalCompletedEstablishment                    Counter32,
+   gnApn3gdtTotalAttemptedEstablishment                    Counter32,
+   gnApn3gdtErrorHandling                                  Counter32,
+   ggsnApnActivePdpContextCountIpv4v6                      Gauge32,
+   pgwApnActiveIpv4v6EpsBearer                             Gauge32,
+   ggsnApnAttemptedActivationIpv4v6                        Counter64,
+   ggsnApnCompletedActivationIpv4v6                        Counter64,
+   pgwApnAttemptedIpv4v6EpsBearerActivation                Counter64,
+   pgwApnCompletedIpv4v6EpsBearerActivation                Counter64,
+   pgwApnActiveWlanEpsBearer                               Gauge32 
+}
+
+ggsnApnIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number representing each APN whose statistics
+          is being generated."
+   ::= { ggsnApnStatsEntry 1 }
+
+ggsnApnName OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The identifier of the subject APN."
+   ::= { ggsnApnStatsEntry 2 }
+
+ggsnApnActivePdpContextCount  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active PDP contexts associated with
+          the APN."
+   ::= { ggsnApnStatsEntry 3 }
+
+ggsnApnAttemptedActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted PDP context activations for this APN.
+          Opposite to ggsnAttemptedActivation, the ggsnApnAttemptedActivation is incremented
+          even when a Create PDP Context Request is silently discarded.
+          
+          Note1: If logical APN selection or RADIUS Assisted APN Selection (RAAS), or both are used, 
+          the counter is incremented on the chosen physical APN. 
+          If RAAS is used, and the RADIUS server does not reply or replies with an incorrect answer, 
+          the counter is incremented on the APN, using RAAS.
+                    
+          Note2: When the SGSN resends the activation request, it is counted as two attempts
+          on APN level but as only one attempt on node level. (This happens when the
+          primary RADIUS server is unavailable.)"
+   ::= { ggsnApnStatsEntry 4 }
+
+ggsnApnAttemptedDynActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of dynamic PDP context activation
+          procedures initiated by the MS where a dynamic
+          PDP address is requested on a per APN basis of the GGSN."
+   ::= { ggsnApnStatsEntry 5 }
+
+ggsnApnAttemptedDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted PDP context
+          deactivations on a per APN basis.
+
+          Note: When the SGSN resends the deactivation request, 
+          it is counted as two attempts on APN level but as 
+          only one attempt on node level. (This happens when 
+          the primary RADIUS server is unavailable.)"
+   ::= { ggsnApnStatsEntry 6 }
+
+ggsnApnAttemptedSelfDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of PDP context deactivation procedures
+          initiated by the GGSN on a per APN basis.
+           
+           Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 7 }
+
+ggsnApnCompletedActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of completed PDP context
+          activations per APN. Number of completed activations doesn't
+          necessarily match the number of attempts for the same APN.
+          The APN may have changed after the attempt was made due to logical APN
+          or RADIUS-assisted APN selection. The sum of all ggsnApnAttemptedActivation
+          should match the sum of ggsnApnCompletedActivation (and failed) over all APNs."
+   ::= { ggsnApnStatsEntry 8 }
+
+ggsnApnCompletedDynActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully attempted dynamic PDP
+          context activation procedures initiated by the MS
+          where a dynamic PDP address is requested on a per
+          APN basis of the GGSN."
+   ::= { ggsnApnStatsEntry 9 }
+
+ggsnApnCompletedDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of completed PDP context
+          deactivations on a per APN basis."
+   ::= { ggsnApnStatsEntry 10 }
+
+ggsnApnCompletedSelfDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed deactivation
+          PDP context procedures initiated by the GGSN on a
+          per APN basis.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 11 }
+
+ggsnApnUplinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane packets processed on a per APN basis by the GGSN or PGW. Incremented when an uplink packet received over the Gn or S5 user plane interface is sent over the Gi or SGi interface."
+   ::= { ggsnApnStatsEntry 12 }
+
+ggsnApnUplinkBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane bytes processed on a per APN basis by the GGSN or PGW. Incremented when an uplink packet received over the Gn or S5 user plane interface is sent over the Gi or SGi interface."
+   ::= { ggsnApnStatsEntry 13 }
+
+ggsnApnUplinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane packets dropped on a per APN basis by the GGSN or PGW. Incremented when an uplink packet received over the Gn or S5 user plane interface is dropped."
+   ::= { ggsnApnStatsEntry 14 }
+
+ggsnApnDownlinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane packets processed on a per APN basis by the GGSN or PGW. Incremented when a downlink packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnApnStatsEntry 15 }
+
+ggsnApnDownlinkBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane bytes processed on a per APN basis by the GGSN or PGW. Incremented when a downlink packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnApnStatsEntry 16 }
+
+ggsnApnDownlinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane packets dropped on a per APN basis by the GGSN or PGW. Incremented when a downlink packet received over the Gi or SGi user plane interface is dropped."
+   ::= { ggsnApnStatsEntry 17 }
+
+ggsnApnAttemptedMSActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The number of PDP context activation procedures
+          initiated by the MS on a per APN basis of the GGSN.
+
+          Note: When the SGSN resends the activation request, 
+          it is counted as two attempts on APN level but as 
+          only one attempt on node level. (This happens when 
+          the primary RADIUS server is unavailable.)"
+   ::= { ggsnApnStatsEntry 18 }
+
+ggsnApnCompletedMSActivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The number of successfully completed activation
+          PDP context procedures initiated by the MS on a
+          per APN basis of the GGSN."
+   ::= { ggsnApnStatsEntry 19 }
+
+ggsnApnAttemptedMSDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of PDP context deactivation procedures
+          initiated by the MS on a per APN basis of the GGSN.
+          
+          Note: When the SGSN resends the deactivation request, 
+          it is counted as two attempts on APN level but as 
+          only one attempt on node level. (This happens when 
+          the primary RADIUS server is unavailable.)"
+   ::= { ggsnApnStatsEntry 20 }
+
+ggsnApnCompletedMSDeactivation OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successfully completed deactivation
+          PDP context procedures initiated by the MS on a
+          per APN basis of the GGSN."
+   ::= { ggsnApnStatsEntry 21 }
+
+ggsnApnActivePdpContextMax  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The maximum number of PDP contexts that has been active at
+          the same time for the APN."
+   ::= { ggsnApnStatsEntry 22 }
+
+ggsnApnActivePdpContextMean  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The mean number of active PDP contexts active for the APN.
+          The mean number is calculated with five samples taken over a 15 minute period."
+   ::= { ggsnApnStatsEntry 23 }
+
+ggsnApnAttemptedAuthActivation  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted session establishment with
+	  user authentication required per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 24 }
+
+ggsnApnFailedAuthActivation  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of failed session establishment due to
+	  user authentication failure, per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 25 }
+
+ggsnApnAttemptedUpdateMsAndSgsn  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted PDP context updates, 
+          initiated by a Mobile Station or an SGSN, per APN of this GGSN.
+          
+          Note: In some cases the information in the GTP message is not
+          enough (missing or incorrect IE) to detect which APN the
+          update is related to. If so, this update will fail and
+          ggsnApnAttemptedUpdateMsAndSgsn will not be updated."
+   ::= { ggsnApnStatsEntry 26 }
+
+ggsnApnCompletedUpdateMsAndSgsn  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of successfully completed PDP context
+	  update initiated by MS or SGSN per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 27 }
+
+ggsnApnNbrOfTftFilters  OBJECT-TYPE
+    SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The current number of TFT filters in use per APN of this GGSN.
+         
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 28 }
+
+ggsnApnSessTimeoutDeactivation  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of PDP contexts deactivated per APN due to
+          duration limit."
+   ::= { ggsnApnStatsEntry 29 }
+
+ggsnApnIdleTimeoutDeactivation  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of PDP contexts deactivated per APN due to
+          continuous idle time limit."
+   ::= { ggsnApnStatsEntry 30 }
+
+ggsnApnGiSignalingInPackets  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of incoming packets used for signaling purpose
+	  on the Gi interface per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 31 }
+
+ggsnApnGiSignalingInBytes  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of bytes for incoming signaling packets
+	  on the Gi interface per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 32 }
+
+ggsnApnGiSignalingOutPackets  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of outgoing packets used for signaling purpose
+	  on the Gi interface per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 33 }
+
+ggsnApnGiSignalingOutBytes  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of bytes for outgoing signaling packets
+          on the Gi interface per APN of this GGSN."
+   ::= { ggsnApnStatsEntry 34 }
+
+ggsnApnActivePdpContextCountIpv6  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv6 PDP contexts associated with
+          the APN."
+   ::= { ggsnApnStatsEntry 35 }
+
+ggsnApnAttemptedActivationIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted IPv6 PDP context
+          activations on a per APN basis."
+   ::= { ggsnApnStatsEntry 36 }
+
+ggsnApnCompletedActivationIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of completed IPv6 PDP context
+          activations on a per APN basis."
+   ::= { ggsnApnStatsEntry 37 }
+
+ggsnApnUplinkPacketsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv6 packets processed on a per APN basis processed by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the Gn or S5 user plane interface is sent over Gi or SGi interface."
+   ::= { ggsnApnStatsEntry 38 }
+
+ggsnApnUplinkBytesIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv6 bytes processed on a per APN basis by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the Gn or S5 user plane interface is sent over Gi or SGi interface."
+   ::= { ggsnApnStatsEntry 39 }
+
+ggsnApnUplinkDropsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of uplink Gn and S5 user plane IPv6 packets dropped on a per APN basis by the GGSN or PGW. Incremented when an uplink packet received over the Gn or S5 user plane interface is dropped."
+   ::= { ggsnApnStatsEntry 40 }
+
+ggsnApnDownlinkPacketsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv6 bytes processed on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnApnStatsEntry 41 }
+
+ggsnApnDownlinkBytesIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv6 bytes dropped on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the Gn or S5 user plane interface."
+   ::= { ggsnApnStatsEntry 42 }
+
+ggsnApnDownlinkDropsIpv6 OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of downlink Gn and S5 user plane IPv6 bytes dropped on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet received over the Gi or SGi user plane interface is dropped."
+   ::= { ggsnApnStatsEntry 43 }
+
+ggsnApnNeighborSolicitationRcv  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of neighbor solicitation requests
+          received by GGSN, per APN."
+   ::= { ggsnApnStatsEntry 44 }
+
+ggsnApnNeighborSolicitationRsp  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of neighbor solicitation responses
+          from GGSN, per APN."
+   ::= { ggsnApnStatsEntry 45 }
+
+ggsnApnRouterSolicitationRcv  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of router solicitation requests
+          received by GGSN, per APN."
+   ::= { ggsnApnStatsEntry 46 }
+
+ggsnApnRouterSolicitationRsp  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of router solicitation responses
+          from GGSN, per APN."
+   ::= { ggsnApnStatsEntry 47 }
+
+ggsnNbApnActivePdpPerTrafficClassConversational  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active PDP contexts using traffic class conversational, per APN."
+   ::= { ggsnApnStatsEntry 48 }
+
+ggsnNbApnActivePdpPerTrafficClassStreaming  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active PDP contexts using traffic class streaming, per APN."
+   ::= { ggsnApnStatsEntry 49 }
+
+ggsnNbApnActivePdpPerTrafficClassInteractive  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active PDP contexts using traffic class interactive, per APN."
+   ::= { ggsnApnStatsEntry 50 }
+
+ggsnNbApnActivePdpPerTrafficClassBackground  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active PDP contexts using traffic class background, per APN."
+   ::= { ggsnApnStatsEntry 51 }
+
+ggsnApnImsDedicatedCompletedActivation  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successful dedicated Signaling PDP-Context Activation requests per APN.
+         
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 52 }
+
+ggsnApnImsDedicatedNotConfiguredActivationFailed  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed dedicated signaling PDP-Context Activation requests,
+          due to the APN is turned OFF for Signaling PDP context Activation, per APN.
+         
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 53 }
+
+ ggsnApnImsGeneralPurposeCompletedActivation  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of successful general purpose PDP-Context Activation requests per APN.
+         
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 54 }
+
+ggsnApnImsGeneralNotConfiguredActivationFailed  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed general purpose PDP-Context Activation requests,
+          due to the APN is turned OFF for general purpose PDP context Activation, per APN.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 55 }
+
+
+ggsnApnActivationFailedDuetoGeneralPurposeNotConfigured  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed general purpose PDP-Context Activation requests where a normal PDP-Context is created, due to the APN is turned OFF for general purpose PDP context Activation."
+   ::= { ggsnApnStatsEntry 56 }
+
+ggsnApnUnauthorizedImsPackets  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of dropped unauthorized IMS signaling packets per APN."
+   ::= { ggsnApnStatsEntry 57 }
+
+ggsnApnRadiusAccountingFailure  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed RADIUS Accounting procedures per APN."
+   ::= { ggsnApnStatsEntry 58 }
+
+ggsnApnRadiusAuthenticationFailure  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed RADIUS Authentication procedures per APN."
+   ::= { ggsnApnStatsEntry 59 }
+
+ggsnApnSaccRsInstalledDynRules  OBJECT-TYPE
+    SYNTAX       Gauge32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+		"Simultaneously installed dynamic charging rules."
+    ::= { ggsnApnStatsEntry 60 }
+
+ggsnApnSaccRsActivePredefinedChargingRules  OBJECT-TYPE
+    SYNTAX       Gauge32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+		"Number of active pre-defined charging rules per APN."
+    ::= { ggsnApnStatsEntry 61 }
+
+ggsnApnSaccRsActivePredefinedChargingRuleBases  OBJECT-TYPE
+    SYNTAX       Gauge32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+		"Number of active predefined charging rule bases per APN."
+    ::= { ggsnApnStatsEntry 62 }
+
+ggsnApnAvailableIpAddressesInInternalPool OBJECT-TYPE
+    SYNTAX        Gauge32
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "Available IP-addresses in the Internal GGSN IP-address pool."
+    ::= { ggsnApnStatsEntry 63 }
+
+ggsnApnIpAddressesInQuarantineInInternalPool OBJECT-TYPE
+    SYNTAX        Gauge32
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "IP-addresses in quarantine in Internal GGSN IP-address pool."
+    ::= { ggsnApnStatsEntry 64 }
+
+ggsnApn3gdtActiveContexts OBJECT-TYPE
+    SYNTAX        Gauge32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The current active 3GDT PDP contexts active in APN."
+    ::= { ggsnApnStatsEntry 65}
+
+ggsnApn3gdtTotalCompletedEstablishment OBJECT-TYPE
+    SYNTAX        Gauge32
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "The total completed 3GDT active PDP contexts requests in APN."
+    ::= { ggsnApnStatsEntry 66}
+
+ggsnApn3gdtTotalAttemptedEstablishment OBJECT-TYPE
+    SYNTAX        Gauge32
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "The total attempted 3GDT active PDP contexts requests in APN."
+    ::= { ggsnApnStatsEntry 67}
+
+ggsnApn3gdtErrorHandling OBJECT-TYPE
+    SYNTAX        Gauge32
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "The number of error indications from RNC."
+    ::= { ggsnApnStatsEntry 68}
+
+ggsnApnAttemptedUpdateGgsn OBJECT-TYPE
+    SYNTAX        Counter64
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The total number of attempted PDP context updates initiated by this GGSN on a per APN basis."
+    ::= { ggsnApnStatsEntry 69}
+
+ggsnApnCompletedUpdateGgsn OBJECT-TYPE
+    SYNTAX        Counter64
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The total number of successful PDP context updates initiated by this GGSN on a per APN basis."
+    ::= { ggsnApnStatsEntry 70}
+
+ggsnApnAttemptedActivationNonDuplicated OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of non-duplicated PDP context activations on a per APN basis.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 71}
+
+ggsnApnActivePdpContextMaxDuringLastPeriod OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The maximum number of PDP contexts that has been active at
+          the same time for the APN during the last measurement period.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnApnStatsEntry 72}
+
+pgwApnActiveEpsBearer  OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 EPS bearers associated with the APN by the PGW. Incremented when an EPS bearer is activated on this APN and a GTP response has been sent to the SGW. Decremented when entering the delete sequence."
+    ::= { ggsnApnStatsEntry 73 }
+
+pgwApnActiveIpv6EpsBearer  OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv6 EPS bearers associated with the APN by the PGW. Incremented when an EPS bearer is activated on this APN and a GTP response has been sent to the SGW. Decremented when entering the delete sequence."
+    ::= { ggsnApnStatsEntry 74 }
+
+pgwApnAttemptedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted IPv4 and IPv6 EPS Bearer activations for this APN. Incremented each time a Create EPS Bearer request is received by the PGW, even when the request is silently discarded."
+    ::= { ggsnApnStatsEntry 75 }
+
+pgwApnCompletedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of completed IPv4 and IPv6 EPS Bearer activations for this APN. Incremented when an EPS bearer is successfully activated."
+    ::= { ggsnApnStatsEntry 76 }
+
+pgwApnAttemptedIpv6EpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of EPS bearer activation attempts with the APN by the PGW. Incremented each time a Create EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value."
+    ::= { ggsnApnStatsEntry 77 }
+
+pgwApnCompletedIpv6EpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv6 EPS bearers associated with the APN by the PGW.  Incremented when an EPS bearer is successfully activated."
+    ::= { ggsnApnStatsEntry 78 }
+
+pgwApnAttemptedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted IPv4 and IPv6 EPS Bearer deactivations for this APN. Incremented when a deactivation is triggered by the PGW, triggered by the UE/SGW, rejected deactivation requests and silently discarded deactivation requests."
+    ::= { ggsnApnStatsEntry 79 }
+
+pgwApnCompletedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 EPS bearer deactivations associated with the APN by the PGW. Incremented both for successful PGW triggered deactivations and successful UE/SGW triggered deactivations."
+    ::= { ggsnApnStatsEntry 80 }
+
+pgwApnAttemptedS5NetworkDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted IPv4 and IPv6 EPS bearer deactivations for this APN. Incremented when a deactivation is triggered by the PGW."
+    ::= { ggsnApnStatsEntry 81 }
+
+pgwApnCompletedS5NetworkDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of completed IPv4 and IPv6 EPS bearer deactivations for this APN. Incremented for successful PGW triggered deactivations over the S5 interface"
+    ::= { ggsnApnStatsEntry 82 }
+
+pgwApnAttemptedS5UeSgwModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted UE/SGW initiated EPS bearer modifications (excluding modifications due to IRAT mobility from GERAN/UTRAN via SGSN using Gn/Gp to E-UTRAN)  including IPv6 EPS bearers. Attempted EPS bearer modifications include silently discarded modifications and retries of attempted modifications. Incremented at attempted UE/SGW initiated EPS bearer modifications including silently discarded modifications and retries of modifications."
+    ::= { ggsnApnStatsEntry 83 }
+
+pgwApnCompletedS5UeSgwModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful UE/SGW initiated EPS bearer modifications (excluding modifications due to IRAT mobility from GERAN/UTRAN via SGSN using Gn/Gp to E-UTRAN) including IPv6 EPS bearers. Incremented when an UE/SGW initiated EPS bearer modification is successful."
+    ::= { ggsnApnStatsEntry 84 }
+
+pgwApnAttemptedS5SgwSgsnModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted SGW to SGSN initiated EPS bearer modifications including IPv6 EPS bearers. Attempted EPS bearer modifications include silently discarded modifications and retries of attempted modifications. Incremented at attempted SGW to SGSN initiated EPS bearer modifications including silently discarded modifications and retries of modifications."
+    ::= { ggsnApnStatsEntry 85 }
+
+pgwApnCompletedS5SgwSgsnModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful SGW to SGSN initiated EPS bearer modifications including IPv6 EPS bearers. Incremented when an SGW to SGSN initiated EPS bearer modification is successful."
+    ::= { ggsnApnStatsEntry 86 }
+
+pgwApnAttemptedS5SgsnSgwModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted SGSN to SGW initiated EPS bearer modifications including IPv6 EPS bearers. Incremented at attempted SGSN to SGW initiated EPS bearer modifications including silently discarded modifications and retries of modifications."
+    ::= { ggsnApnStatsEntry 87 }
+
+pgwApnCompletedS5SgsnSgwModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful SGSN to SGW initiated EPS bearer modifications including IPv6 EPS bearers. Incremented when an SGSN to SGW initiated EPS bearer modification is successful."
+    ::= { ggsnApnStatsEntry 88 }
+
+pgwApnAttemptedS5NetworkModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted network initiated EPS bearer modifications over the S5 interface including IPv6 EPS bearers. Incremented at attempted network initiated EPS bearer modifications over the S5 interface including silently discarded modifications and retries of modifications."
+    ::= { ggsnApnStatsEntry 89 }
+
+pgwApnCompletedS5NetworkModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful network initiated EPS bearer modifications over the S5 interface including IPv6 EPS bearers. Incremented when a network initiated EPS bearer modification over the S5 interface is successful."
+    ::= { ggsnApnStatsEntry 90 }
+
+pgwApnAttemptedS5UeSgwDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted UE/SGW triggered EPS bearer deactivations including IPv6 EPS bearers over the S5 interface associated with this APN. Incremented when an UE/SGW triggered EPS bearer is deactivated over the S5 interface."
+    ::= { ggsnApnStatsEntry 91 }
+
+pgwApnCompletedS5UeSgwDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful UE/SGW triggered EPS bearer deactivations including IPv6 EPS bearers over the S5 interface associated with this APN. Incremented when an UE/SGW triggered EPS bearer is successfully deactivated over the S5 interface."
+    ::= { ggsnApnStatsEntry 92 }
+
+gnApnUplinkPackets  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane packets processed on a per APN basis by the GGSN or PGW. Incremented when an uplink packet received over the Gn user plane interface is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 93 }
+
+gnApnUplinkBytes  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane bytes processed on a per APN basis by the GGSN or PGW. Incremented when an uplink packet received over the Gn user plane interface is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 94 }
+
+gnApnUplinkPacketsIpv6   OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane IPv6 packets processed on a per APN basis by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the Gn user plane interface is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 95 }
+
+gnApnUplinkBytesIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane IPv6 bytes processed on a per APN basis by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the Gn user plane interface is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 96 }
+
+gnApnDownlinkPackets  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane packets processed on a per APN basis by the GGSN or PGW. Incremented when a downlink packet is sent over the Gn user plane interface."
+    ::= { ggsnApnStatsEntry 97 }
+
+gnApnDownlinkBytes  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane bytes processed on a per APN basis by the GGSN or PGW. Incremented when a downlink packet is sent over the Gn user plane interface."
+    ::= { ggsnApnStatsEntry 98 }
+
+gnApnDownlinkPacketsIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane IPv6 packets processed on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the Gn user plane interface."
+    ::= { ggsnApnStatsEntry 99 }
+
+gnApnDownlinkBytesIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane IPv6 bytes processed on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the Gn user plane interface."
+    ::= { ggsnApnStatsEntry 100 }
+
+s5ApnUplinkPackets  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink S5 user plane packets processed on a per APN basis by the GGSN or PGW. Incremented when an uplink packet, received over the S5 user plane interface, is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 101 }
+
+s5ApnUplinkBytes  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink S5 user plane bytes processed on a per APN basis by the GGSN or PGW. Incremented when an uplink packet, received over the S5 user plane interface, is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 102 }
+
+s5ApnUplinkPacketsIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink S5 user plane IPv6 packets processed on a per APN basis by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the S5 user plane interface is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 103 }
+
+s5ApnUplinkBytesIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink S5 user plane IPv6 bytes processed on a per APN basis by the GGSN or PGW. Incremented when an uplink IPv6 packet received over the S5 user plane interface is sent over Gi or SGi interface."
+    ::= { ggsnApnStatsEntry 104 }
+
+s5ApnDownlinkPackets  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink S5 user plane packets processed on a per APN basis by the GGSN or PGW. Incremented when a downlink packet is sent over the S5 user plane interface."
+    ::= { ggsnApnStatsEntry 105 }
+
+s5ApnDownlinkBytes  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink S5 user plane bytes processed on a per APN basis by the GGSN or PGW. Incremented when a downlink packet is sent over the S5 user plane interface."
+    ::= { ggsnApnStatsEntry 106 }
+
+s5ApnDownlinkPacketsIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink S5 user plane IPv6 packets processed on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the S5 user plane interface."
+    ::= { ggsnApnStatsEntry 107 }
+
+s5ApnDownlinkBytesIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink S5 user plane IPv6 bytes processed on a per APN basis by the GGSN or PGW. Incremented when a downlink IPv6 packet is sent over the S5 user plane interface."
+    ::= { ggsnApnStatsEntry 108 }
+
+gnApn3gdtUplinkBytes  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane IPv4 and IPv6 bytes that are contained in packets which are associated with 3GDT contexts. Incremented by the GGSN or PGW per APN when these packets are received from the RNC."
+    ::= { ggsnApnStatsEntry 109 }
+
+gnApn3gdtUplinkBytesIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane IPv6 bytes that are contained in packets which are associated with 3GDT contexts. Incremented by the GGSN or PGW per APN when these packets are received from the RNC."
+    ::= { ggsnApnStatsEntry 110 }
+
+gnApn3gdtUplinkPackets  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane IPv4 and IPv6 packets that are associated with 3GDT contexts. Incremented by 1 by the GGSN or PGW per APN when each of these packets is received from the RNC."
+    ::= { ggsnApnStatsEntry 111 }
+
+gnApn3gdtUplinkPacketsIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of uplink Gn user plane IPv6 packets that are associated with 3GDT contexts. Incremented by 1 by the GGSN or PGW per APN when each of these packets is received from the RNC."
+    ::= { ggsnApnStatsEntry 112 }
+
+gnApn3gdtDownlinkBytes  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane IPv4 and IPv6 bytes that are contained in packets which are associated with 3GDT contexts. Incremented by the GGSN or PGW per APN when these packets are received from the PDN."
+    ::= { ggsnApnStatsEntry 113 }
+
+gnApn3gdtDownlinkBytesIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane IPv6 bytes that are contained in packets which are associated with 3GDT contexts. Incremented by the GGSN or PGW per APN when these packets are received from the PDN."
+    ::= { ggsnApnStatsEntry 114 }
+
+gnApn3gdtDownlinkPackets  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane IPv4 and IPv6 packets that are associated with 3GDT contexts. Incremented by 1 by the GGSN or PGW per APN when each of these packets is received from the PDN."
+    ::= { ggsnApnStatsEntry 115 }
+
+gnApn3gdtDownlinkPacketsIpv6  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of downlink Gn user plane IPv6 packets that are associated with 3GDT contexts. Incremented by 1 by the GGSN or PGW per APN when each of these packets is received from the PDN."
+    ::= { ggsnApnStatsEntry 116 }
+
+gnApn3gdtDownlinkDropsErrorHandling  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "The total number of downlink Gn user plane IPv4 and IPv6 packets that are dropped after the RNC sends to the GGSN an error indication message that is associated with a 3GDT tunnel. Incremented by 1 when each of these packets is dropped."
+    ::= { ggsnApnStatsEntry 117 }
+
+ggsnApn3gdtGtpError  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "The number of occurrences when Update PDP Context Request/Response messages contain missing or incorrect IE values during a change of tunnel type from GTP to DT or vice versa. Specifically, the values for the SGSN-U or the TEID IEs."
+    ::= { ggsnApnStatsEntry 118 }
+
+gnApn3gdtTotalCompletedEstablishment OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The total completed 3GDT active PDP contexts requests in APN."
+    ::= { ggsnApnStatsEntry 119}
+
+gnApn3gdtTotalAttemptedEstablishment OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The total attempted 3GDT active PDP contexts requests in APN."
+    ::= { ggsnApnStatsEntry 120}
+
+gnApn3gdtErrorHandling OBJECT-TYPE
+    SYNTAX        Counter32
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of error indications from RNC."
+    ::= { ggsnApnStatsEntry 121}
+
+pgwApnActiveDedicatedEpsBearer  OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 dedicated EPS bearers associated with the APN by the PGW. Incremented when a dedicated EPS bearer is activated on this APN and a GTP response has been sent to the SGW. Decremented when entering the delete sequence."
+    ::= { ggsnApnStatsEntry 122 }
+
+pgwApnAttemptedDedicatedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted IPv4 and IPv6 dedicated EPS Bearer activations for this APN. Incremented each time a Create dedicated EPS Bearer request is received by the PGW, even when the request is silently discarded."
+    ::= { ggsnApnStatsEntry 123 }
+
+pgwApnCompletedDedicatedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of completed IPv4 and IPv6 dedicated EPS Bearer activations for this APN. Incremented when a dedicated EPS bearer is successfully activated."
+    ::= { ggsnApnStatsEntry 124 }
+
+pgwApnAttemptedIpv6DedicatedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of dedicated EPS bearer activation attempts with the APN by the PGW. Incremented each time a Create dedicated EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create dedicated EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value."
+    ::= { ggsnApnStatsEntry 125 }
+
+pgwApnCompletedIpv6DedicatedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv6 dedicated EPS bearers associated with the APN by the PGW. Incremented when a dedicated EPS bearer is successfully activated."
+    ::= { ggsnApnStatsEntry 126 }
+
+pgwApnAttemptedS5NetworkDedicatedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted IPv4 and IPv6 EPS dedicated bearer deactivations for this APN. Incremented when a dedicated EPS bearer is deactivated over the S5 interface."
+    ::= { ggsnApnStatsEntry 127 }
+
+pgwApnCompletedS5NetworkDedicatedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of completed IPv4 and IPv6 dedicated EPS bearer deactivations for this APN. Incremented when a dedicated EPS bearer is successfully deactivated over the S5 interface."
+    ::= { ggsnApnStatsEntry 128 }
+
+pgwApnAttemptedS5NetworkDedicatedEpsBearerModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted network initiated dedicated EPS bearer modifications over the S5 interface including IPv6 EPS bearers. Incremented at attempted network initiated dedicated EPS bearer modifications over the S5 interface including silently discarded modifications and retries of modifications."
+    ::= { ggsnApnStatsEntry 129 }
+
+pgwApnCompletedS5NetworkDedicatedEpsBearerModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful network initiated dedicated EPS bearer modifications over the S5 interface including IPv6 EPS bearers. Incremented when a network initiated dedicated EPS bearer modification over the S5 interface is successful."
+    ::= { ggsnApnStatsEntry 130 }
+
+pgwApnAttemptedS5UeSgwDedicatedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of attempted UE/SGW triggered dedicated EPS bearer deactivations including IPv6 EPS bearers over the S5 interface associated with this APN. Incremented when an UE/SGW triggered dedicated EPS bearer is deactivated over the S5 interface."
+    ::= { ggsnApnStatsEntry 131 }
+
+pgwApnCompletedS5UeSgwDedicatedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of successful UE/SGW triggered dedicated EPS bearer deactivations including IPv6 EPS bearers over the S5 interface associated with this APN. Incremented when an UE/SGW triggered dedicated EPS bearer is successfully deactivated over the S5 interface."
+    ::= { ggsnApnStatsEntry 132 }
+
+ggsnApnActivePdpContextCountIpv4v6  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv4v6 PDP contexts associated with
+          the APN."
+   ::= { ggsnApnStatsEntry 133 }
+
+pgwApnActiveIpv4v6EpsBearer  OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4v6 EPS bearers associated with the APN by the PGW. Incremented when an EPS bearer is activated on this APN and a GTP response has been sent to the SGW. Decremented when entering the delete sequence."
+    ::= { ggsnApnStatsEntry 134 }
+
+ggsnApnAttemptedActivationIpv4v6  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of attempted IPv4v6 PDP context
+          activations on a per APN basis."
+   ::= { ggsnApnStatsEntry 135 }
+
+ggsnApnCompletedActivationIpv4v6  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The total number of completed IPv4v6 PDP context
+          activations on a per APN basis."
+   ::= { ggsnApnStatsEntry 136 }
+
+pgwApnAttemptedIpv4v6EpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of attempted IPv4v6 EPS Bearer activations for this APN. Incremented each time a Create EPS Bearer request is received by the PGW, even when the request is silently discarded."
+
+    ::= { ggsnApnStatsEntry 137 }
+
+pgwApnCompletedIpv4v6EpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of completed IPv4v6 EPS Bearer activations for this APN. Incremented when an EPS bearer is successfully activated."
+    ::= { ggsnApnStatsEntry 138 }
+
+pgwApnActiveWlanEpsBearer OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of EPS bearers for WLAN associated with this APN on this PGW."
+    ::= { ggsnApnStatsEntry 139 }
+
+s2aApnUplinkPackets OBJECT-TYPE
+    SYNTAX     Counter64 
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of uplink user plane packets processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 140 }    
+                 
+s2aApnUplinkBytes OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of uplink user plane bytes processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 141 }  
+                                      
+s2aApnDownlinkPackets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of downlink user plane packets processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 142 }  
+                                  
+s2aApnDownlinkBytes OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of downlink user plane bytes processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 143 }  
+
+s2aApnUplinkPacketsIpv6 OBJECT-TYPE
+    SYNTAX     Counter64 
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+        "Total number of uplink user plane packets processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 144 }    
+                 
+s2aApnUplinkBytesIpv6 OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+        "Total number of uplink user plane bytes processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 145 }  
+                                      
+s2aApnDownlinkPacketsIpv6 OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+        "Total number of downlink user plane packets processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 146 }  
+                                  
+s2aApnDownlinkBytesIpv6 OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+        "Total number of downlink user plane bytes processed by PGW over S2a interface on the APN."
+    ::= { ggsnApnStatsEntry 147 }  
+
+--
+-- GGSN APN RADIUS AUTH SERVER Statistics
+--
+
+ggsnApnRadiusAuthServersStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GgsnApnRadiusAuthServersStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the statistics for all RADIUS servers for this APN."
+   ::= { ggsnRadiusInfo 1 }
+
+ggsnApnRadiusAuthServersStatsEntry OBJECT-TYPE
+   SYNTAX        GgsnApnRadiusAuthServersStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          APN which is served by this GGSN."
+   INDEX         { ggsnApnIndex, ggsnApnRadiusAuthServerIndex }
+   ::= { ggsnApnRadiusAuthServersStatsTable 1 }
+
+GgsnApnRadiusAuthServersStatsEntry ::= SEQUENCE {
+   ggsnApnRadiusAuthServerIndex                         Integer32,
+   ggsnApnRadiusAuthServerIpAddress                     IpAddress,
+   ggsnApnRadiusAuthServerAccessRequests                Counter64,
+   ggsnApnRadiusAuthServerAccessAccepts                 Counter64,
+   ggsnApnRadiusAuthServerAccessRejects                 Counter64,
+   ggsnApnRadiusAuthServerAccessRequestTimeouts         Counter64,
+   ggsnApnRadiusAuthServerAccessRequestRetransmits      Counter64,
+   ggsnApnRadiusAuthServerInvalidAuthenticators         Counter64
+}
+
+ggsnApnRadiusAuthServerIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number representing each RADIUS authentication server."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 1 }
+
+ggsnApnRadiusAuthServerIpAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "RADIUS authentication server IP-address."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 2 }
+
+ggsnApnRadiusAuthServerAccessRequests OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCESS REQUESTS sent to the RADIUS authentication server for this APN."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 3 }
+
+ggsnApnRadiusAuthServerAccessAccepts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCESS ACCEPTS received from the RADIUS authentication server for this APN."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 4 }
+
+ggsnApnRadiusAuthServerAccessRejects OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCESS REJECTS received from the RADIUS authentication server for this APN."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 5 }
+
+ggsnApnRadiusAuthServerAccessRequestTimeouts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of timed out ACCESS REQUESTS sent to the RADIUS authentication server for this APN."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 6 }
+
+ggsnApnRadiusAuthServerAccessRequestRetransmits OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCESS REQUESTS retransmitted to the RADIUS authentication server for this APN."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 7 }
+
+ggsnApnRadiusAuthServerInvalidAuthenticators OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of invalid authenticators received from the RADIUS authentication server for this APN."
+   ::= { ggsnApnRadiusAuthServersStatsEntry 8 }
+
+--
+-- GGSN APN RADIUS ACCT SERVER Statistics
+--
+
+ggsnApnRadiusAcctServersStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GgsnApnRadiusAcctServersStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the statistics for all RADIUS servers for this APN."
+   ::= { ggsnRadiusInfo 2 }
+
+ggsnApnRadiusAcctServersStatsEntry OBJECT-TYPE
+   SYNTAX        GgsnApnRadiusAcctServersStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          APN which is served by this GGSN."
+   INDEX         { ggsnApnIndex, ggsnApnRadiusAcctServerIndex }
+   ::= { ggsnApnRadiusAcctServersStatsTable 1 }
+
+GgsnApnRadiusAcctServersStatsEntry ::= SEQUENCE {
+   ggsnApnRadiusAcctServerIndex                         Integer32,
+   ggsnApnRadiusAcctServerIpAddress                     IpAddress,
+   ggsnApnRadiusAcctServerAccountingRequests            Counter64,
+   ggsnApnRadiusAcctServerAccountingResponses           Counter64,
+   ggsnApnRadiusAcctServerAccountingRequestTimeouts     Counter64,
+   ggsnApnRadiusAcctServerAccountingRequestRetransmits  Counter64,
+   ggsnApnRadiusAcctServerInvalidAuthenticators         Counter64
+}
+
+ggsnApnRadiusAcctServerIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number representing each RADIUS accounting server."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 1 }
+
+ggsnApnRadiusAcctServerIpAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "RADIUS accounting server IP-address."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 2 }
+
+ggsnApnRadiusAcctServerAccountingRequests OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCOUNTING REQUESTS sent to the RADIUS accounting server for this APN."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 3 }
+
+ggsnApnRadiusAcctServerAccountingResponses OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCOUNTING RESPONSES received from the RADIUS accounting server for this APN."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 4 }
+
+ggsnApnRadiusAcctServerAccountingRequestTimeouts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of timed out ACCOUNTING REQUESTS sent to the RADIUS accounting server for this APN."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 5 }
+
+ggsnApnRadiusAcctServerAccountingRequestRetransmits OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of ACCOUNTING REQUESTS retransmitted to the RADIUS accounting server for this APN."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 6 }
+
+ggsnApnRadiusAcctServerInvalidAuthenticators OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Number of invalid authenticators received from the RADIUS accounting server for this APN."
+   ::= { ggsnApnRadiusAcctServersStatsEntry 7 }
+
+--
+-- GGSN SGSN statistics
+--
+
+
+ggsnSgsnStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF SgsnStats
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+         "A table listing the statistics for all SGSNs with
+          which this GGSN communicates."
+   ::= { ggsnGeneralInfo 6 }
+
+ggsnSgsnStatsEntry OBJECT-TYPE
+   SYNTAX        SgsnStats
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          SGSN with which this GGSN communicates."
+   INDEX        { ggsnSgsnIndex }
+   ::= { ggsnSgsnStatsTable 1 }
+
+SgsnStats ::= SEQUENCE {
+    ggsnSgsnIndex		Integer32,
+    ggsnSgsnAddress		IpAddress,
+    ggsnSgsnUplinkPackets	Counter64,
+    ggsnSgsnUplinkBytes		Counter64,
+    ggsnSgsnUplinkDrops		Counter64,
+    ggsnSgsnDownlinkPackets	Counter64,
+    ggsnSgsnDownlinkBytes	Counter64,
+    ggsnSgsnDownlinkDrops	Counter64
+}
+
+ggsnSgsnIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+         "A number representing each SGSN whose statistics
+          is being generated."
+   ::= { ggsnSgsnStatsEntry 1 }
+
+ggsnSgsnAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "The IP address of the SGSN whose statistics
+          is being generated."
+   ::= { ggsnSgsnStatsEntry 2 }
+
+ggsnSgsnUplinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total uplink packets processed on a per SGSN basis."
+   ::= { ggsnSgsnStatsEntry 3 }
+
+ggsnSgsnUplinkBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total bytes for all processed uplink packets
+          on a per SGSN basis."
+   ::= { ggsnSgsnStatsEntry 4 }
+
+ggsnSgsnUplinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Number of uplink GTP-U packets dropped in the GGSN for 
+          this specific SGSN, that is, the number of packets dropped
+          in this GGSN that were sent from this SGSN."
+   ::= { ggsnSgsnStatsEntry 5 }
+
+ggsnSgsnDownlinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total downlink packets processed on a per SGSN basis."
+   ::= { ggsnSgsnStatsEntry 6 }
+
+ggsnSgsnDownlinkBytes OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Total bytes for all processed downlink packets
+          on a per SGSN basis."
+   ::= { ggsnSgsnStatsEntry 7 }
+
+ggsnSgsnDownlinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "Number of downlink GTP-U packets dropped in this GGSN
+          for this specific SGSN, that is, the number of packets dropped
+          by this GGSN before they were sent to this specific SGSN)."
+   ::= { ggsnSgsnStatsEntry 8 }
+
+
+--
+-- GGSN L2TP statistics
+--
+
+
+ggsnL2tpTunnelStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF L2tpTunnelStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the statistics for all L2TP tunnels which
+          are served by this GGSN."
+   ::= { ggsnGeneralInfo 7 }
+
+ggsnL2tpTunnelStatsEntry OBJECT-TYPE
+   SYNTAX        L2tpTunnelStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the statistics for each
+          L2TP tunnel which is served by this GGSN."
+   INDEX         { ggsnL2tpTunnelIndex }
+   ::= { ggsnL2tpTunnelStatsTable 1 }
+
+L2tpTunnelStats ::= SEQUENCE {
+   ggsnL2tpTunnelIndex              Integer32,
+   ggsnL2tpTunnelLocalTID           Integer32,
+   ggsnL2tpTunnelRemoteTID          Integer32,
+   ggsnL2tpTunnelLocalIp            IpAddress,
+   ggsnL2tpTunnelRemoteIp           IpAddress,
+   ggsnL2tpTunnelActiveSessions     Gauge32,
+   ggsnL2tpTunnelControlTxPackets   Counter64,
+   ggsnL2tpTunnelControlRxPackets   Counter64,
+   ggsnL2tpTunnelDataTxPackets      Counter64,
+   ggsnL2tpTunnelDataRxPackets      Counter64,
+   ggsnL2tpTunnelDiscardedTxPackets Counter64,
+   ggsnL2tpTunnelDiscardedRxPackets Counter64
+}
+
+ggsnL2tpTunnelIndex OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number representing each tunnel whose statistics
+          is being generated."
+   ::= { ggsnL2tpTunnelStatsEntry 1 }
+
+ggsnL2tpTunnelLocalTID OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The local tunnel identifier."
+   ::= { ggsnL2tpTunnelStatsEntry 2 }
+
+ggsnL2tpTunnelRemoteTID OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The remote tunnel identifier."
+   ::= { ggsnL2tpTunnelStatsEntry 3 }
+
+ggsnL2tpTunnelLocalIp OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The local IP this tunnel is bound to."
+   ::= { ggsnL2tpTunnelStatsEntry 4 }
+
+ggsnL2tpTunnelRemoteIp OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The remote IP this tunnel is bound to."
+   ::= { ggsnL2tpTunnelStatsEntry 5 }
+
+ ggsnL2tpTunnelActiveSessions OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of sessions that are currently active for this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 6 }
+
+ ggsnL2tpTunnelControlTxPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of control packets transmitted for this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 7 }
+
+ ggsnL2tpTunnelControlRxPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of control packets received for this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 8 }
+
+ ggsnL2tpTunnelDataTxPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of data packets transmitted for this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 9 }
+
+ ggsnL2tpTunnelDataRxPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of data packets received for this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 10 }
+
+ ggsnL2tpTunnelDiscardedTxPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of (attempted) transmitted packets that were discarded by this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 11 }
+
+ ggsnL2tpTunnelDiscardedRxPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+	 "The number of received packets that were discarded by this tunnel."
+   ::= { ggsnL2tpTunnelStatsEntry 12 }
+
+--
+-- PGW Global
+--
+pgwGlobalStats OBJECT IDENTIFIER ::= { ggsnGeneralInfo 8 }
+
+pgwAttemptedEpsBearerStats
+   OBJECT IDENTIFIER ::= { pgwGlobalStats 1 }
+pgwCompletedEpsBearerStats
+   OBJECT IDENTIFIER ::= { pgwGlobalStats 2 }
+
+pgwNbrOfActiveEpsBearer  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Total number of active IPv4 and IPv6 EPS bearers on this PGW. Incremented when successful create response has been sent to SGW. Decremented when entering the delete sequence."
+	::= { pgwGlobalStats 3 }
+
+pgwNbrOfActiveIpv6EpsBearer  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Total number of active IPv6 EPS bearer on this PGW. Incremented when successful create response has been sent to SGW. Decremented when entering the delete sequence."
+	::= { pgwGlobalStats 4 }
+
+pgwNbrOfActiveIpv4v6EpsBearer  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Total number of active IPv4v6 EPS bearer on this PGW. Incremented when successful create response has been sent to SGW. Decremented when entering the delete sequence."
+	::= { pgwGlobalStats 5 }
+
+pgwWlanNbrOfActiveEpsBearer  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Total number of active EPS bearers for WLAN on this PGW"
+	::= { pgwGlobalStats 6 }
+
+s6bInterface
+   OBJECT IDENTIFIER ::= { pgwGlobalStats 7 }
+
+--
+-- PDN Connections PGW
+--
+	
+pdnConnectionsPgw
+   OBJECT IDENTIFIER ::= { pgwGlobalStats 50 }	
+   
+nbrOfPgwPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections to a PGW-enabled APN."
+	::= { pdnConnectionsPgw 1 }
+
+nbrOfPiscPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections using PISC."
+	::= { pdnConnectionsPgw 2 }
+
+nbrOfOnlineChargingPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections using online charging."
+	::= { pdnConnectionsPgw 3 }
+
+nbrOfDynamicPolicyControlPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections using dynamic policy control."
+	::= { pdnConnectionsPgw 4 }
+
+nbrOfWlanPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections with RAT type WLAN."
+	::= { pdnConnectionsPgw 5 }
+
+nbrOfGeranPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections with RAT type GERAN."
+	::= { pdnConnectionsPgw 6 }
+
+nbrOfUtranPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections with RAT type UTRAN."
+	::= { pdnConnectionsPgw 7 }
+
+nbrOfHspaEvolutionPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections with RAT type HSPA Evolution."
+	::= { pdnConnectionsPgw 8 }
+
+nbrOfEutranPdnConnections  OBJECT-TYPE
+	SYNTAX     Gauge32
+	MAX-ACCESS read-only
+	STATUS     current
+	DESCRIPTION 
+		"Number of PDN connections with RAT type EUTRAN."
+	::= { pdnConnectionsPgw 9 }
+ 
+ggsnNodeName OBJECT-TYPE
+   SYNTAX        DisplayString 
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The node name of this ggsn."
+   ::= { ggsnGeneralInfo 9 }
+
+pgwRRreroutedStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF PgwRRreroutedStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the Scalable Gi Routing Redundancy statistics for each routing instance."
+   ::= { ggsnGeneralInfo  11 }
+
+pgwRRreroutedStatsEntry OBJECT-TYPE
+   SYNTAX        PgwRRreroutedStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the GIRR statistics for each Routing Instance on this GGSN."
+   INDEX     { pgwRoutingInstanceId }
+   ::= { pgwRRreroutedStatsTable 1 }
+
+
+PgwRRreroutedStatsEntry ::= SEQUENCE {
+   pgwRoutingInstanceId Integer32,
+   pgwRoutingInstanceName DisplayString,
+   pgwRRreroutedDataDownlinkPkts Counter64,
+   pgwRRreroutedDataRxPkts Counter64,
+   pgwRRreroutedDataTxPkts Counter64,
+   pgwRRreroutedDataIpv6DownlinkPkts Counter64,
+   pgwRRreroutedDataIpv6RxPkts Counter64,
+   pgwRRreroutedDataIpv6TxPkts Counter64
+}
+
+pgwRoutingInstanceId OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "Id of Routing Instance configured as GiRR instance."
+   ::= { pgwRRreroutedStatsEntry 1 }
+
+pgwRoutingInstanceName OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Name of Routing Instance configured as GiRR instance."
+   ::= { pgwRRreroutedStatsEntry 2 }
+
+pgwRRreroutedDataDownlinkPkts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Number of packets sent downlink"
+   ::= { pgwRRreroutedStatsEntry 3 }
+
+pgwRRreroutedDataRxPkts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of packets rerouted to peer by the GGSN."
+   ::= { pgwRRreroutedStatsEntry 4 }
+pgwRRreroutedDataTxPkts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of packets rerouted to the peer."
+   ::= { pgwRRreroutedStatsEntry 5 }
+
+pgwRRreroutedDataIpv6DownlinkPkts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Number of Ipv6 packets sent downlink"
+   ::= { pgwRRreroutedStatsEntry 6 }
+
+pgwRRreroutedDataIpv6RxPkts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Ipv6 packets rerouted to peer by the GGSN."
+   ::= { pgwRRreroutedStatsEntry 7 }
+
+pgwRRreroutedDataIpv6TxPkts OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Ipv6 packets rerouted to the peer."
+   ::= { pgwRRreroutedStatsEntry 8 }
+
+pgwAttemptedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of Active IPv4 and IPv6 EPS bearer creation attempts. Incremented each time a Create EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value."
+    ::= { pgwAttemptedEpsBearerStats 1 }
+
+pgwAttemptedEpsBearerIpv6Activation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of Ipv6 EPS bearer creation attempts. Incremented each time a Create EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value. Note: Counter not updated for bearers having the possibility to use either IPv4 or IPv6. Which address type that will be used is not known at this early stage."
+    ::= { pgwAttemptedEpsBearerStats 2 }
+
+pgwAttemptedEpsBearerModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of attempted IPv4 and IPv6 EPS bearer modifications. Incremented at attempted EPS bearer modifications including retries of modifications."
+    ::= { pgwAttemptedEpsBearerStats 3 }
+
+pgwAttemptedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 EPS bearer deactivation attempts. Incremented when a deactivation is triggered by the PGW, triggered by the UE/SGW, rejected deactivation requests and silently discarded deactivation requests."
+    ::= { pgwAttemptedEpsBearerStats 4 }
+
+pgwAttemptedDedicatedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of Active IPv4 and IPv6 EPS bearer creation attempts. Incremented each time a Create EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value."
+    ::= { pgwAttemptedEpsBearerStats 5 }
+
+pgwAttemptedDedicatedEpsBearerIpv6Activation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of Ipv6 dedicated EPS bearer creation attempts. Incremented each time a Create dedicated EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create dedicated EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value. Note: Counter not updated for bearers having the possibility to use either IPv4 or IPv6. Which address type that will be used is not known at this early stage."
+    ::= { pgwAttemptedEpsBearerStats 6 }
+
+pgwAttemptedEpsBearerIpv4v6Activation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of Ipv4v6 EPS bearer creation attempts. Incremented each time a Create EPS Bearer request that is not silently discarded is received by the PGW. This means the counter is incremented each time a create EPS Bearer response is sent back to the SGW with cause value Request Accepted or with a reject value. Note: Counter not updated for bearers having the possibility to use either IPv4 or IPv6. Which address type that will be used is not known at this early stage."
+    ::= { pgwAttemptedEpsBearerStats 7 }
+
+pgwAttempteds2aEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of attempted EPS bearer activations over the S2a interface, silently-discarded activations and activation retries also included."
+    ::= { pgwAttemptedEpsBearerStats 8 }
+
+pgwCompletedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 EPS bearer creations completed. Incremented when an EPS bearer is successfully activated."
+    ::= { pgwCompletedEpsBearerStats 1 }
+
+pgwCompletedEpsBearerIpv6Activation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of Ipv6 EPS bearer creations completed. Incremented when an EPS bearer is successfully activated."
+    ::= { pgwCompletedEpsBearerStats 2 }
+
+pgwCompletedEpsBearerModification  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 EPS bearer modifications completed. Incremented both for successful network and SGW initiated updates."
+    ::= { pgwCompletedEpsBearerStats 3 }
+
+pgwCompletedEpsBearerDeactivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 EPS bearer deactivations completed. Incremented both for successful PGW triggered deactivations and successful UE/SGW triggered deactivations."
+    ::= { pgwCompletedEpsBearerStats 4 }
+
+pgwCompletedDedicatedEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of IPv4 and IPv6 dedicated EPS bearer creations completed. Incremented when a dedicated EPS bearer is successfully activated."
+    ::= { pgwCompletedEpsBearerStats 5 }
+
+pgwCompletedDedicatedEpsBearerIpv6Activation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION 
+        "Total number of Ipv6 dedicated EPS bearer creations completed. Incremented when a dedicated EPS bearer is successfully activated."
+    ::= { pgwCompletedEpsBearerStats 6 }
+
+pgwCompletedEpsBearerIpv4v6Activation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of Ipv4v6 EPS bearer creations completed. Incremented when an EPS bearer is successfully activated."
+    ::= { pgwCompletedEpsBearerStats 7 }
+
+pgwCompleteds2aEpsBearerActivation  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of EPS bearer creations over the S2a interface completed."
+    ::= { pgwCompletedEpsBearerStats 8 }
+
+s6bAarSent  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of Authentication and Authorization Request (AAR) messages sent by the PGW over the S6b interface."
+    ::= { s6bInterface 1 }
+
+s6bAaaSuccRcvd  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of AAA messages with acceptance response cause values received by the PGW over the S6b interface."
+    ::= { s6bInterface 2 }
+
+s6bAaaFailRcvd  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of Authentication and Authorization Answer (AAA) messages with rejection response cause values received by the PGW over the S6b interface."
+    ::= { s6bInterface 3 }
+
+s6bAaaInvalidRcvd  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of AAA messages with invalid content received by the PGW over the S6b interface."
+    ::= { s6bInterface 4 }
+
+s6bStrSent  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of Session Termination Request (STR) messages sent by the PGW over the S6b interface."
+    ::= { s6bInterface 5 }
+
+s6bStaSuccRcvd  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of STA messages with acceptance response cause values received by the PGW over the S6b interface."
+    ::= { s6bInterface 6 }
+
+s6bStaFailRcvd  OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "Total number of Session Termination Answer (STA) messages with rejection response cause values received by the PGW over the S6b interface."
+    ::= { s6bInterface 7 }
+--
+-- GTP-C group
+--
+
+
+ggsnGtpcTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GtpcEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "The table listing GGSN-C PICs (also known as GTP-C PICs)"
+   ::= { ggsnGtpcInfo 1 }
+
+ggsnGtpcEntry OBJECT-TYPE
+   SYNTAX        GtpcEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "An entry representing a GGSN-C (GTP-C) PIC."
+   INDEX         { ggsnGtpcIndex }
+   ::= { ggsnGtpcTable 1 }
+
+GtpcEntry ::= SEQUENCE {
+   ggsnGtpcIndex       Integer32,
+   ggsnGtpcVersion     DisplayString,
+   ggsnGtpcAddress     IpAddress,
+   ggsnGtpcPdpCapacity Integer32,
+   ggsnGtpcRole        INTEGER,
+   ggsnGtpcStatus      DisplayString,
+   ggsnGtpcControlPacketDrops Counter64,
+   ggsnGtpcNbrOfActivePdpContexts Gauge32,
+   ggsnGtpcMemory	Integer32,
+   ggsnGtpcMemoryUsed	Integer32,
+   ggsnGtpcCpuUsage	Gauge32,
+   ggsnGtpcTftFilterDepthMax Gauge32,
+   ggsnGtpcTftFilterDepthMean Gauge32,
+   ggsnGtpcControlLoad  Gauge32,
+   ggsnGtpcNbrOfActivePdpContextsIpv6 Gauge32,
+   ggsnGtpcPeakCpuUsage  Gauge32,
+   ggsnGtpcNbrOfActivePdpContextsIpv4v6 Gauge32
+}
+
+ggsnGtpcIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number uniquely identifying each GGSN-C (GTP-C) PIC
+          in the GGSN."
+   ::= { ggsnGtpcEntry 1 }
+
+ggsnGtpcVersion OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Software version running on the GGSN-C (GTP-C) PIC."
+   ::= { ggsnGtpcEntry 2 }
+
+ggsnGtpcAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The external IP address of the GGSN-C (GTP-C) PIC."
+   ::= { ggsnGtpcEntry 3 }
+
+ggsnGtpcPdpCapacity OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The capacity of the GGSN-C (GTP-C) PIC."
+   ::= { ggsnGtpcEntry 4 }
+
+ggsnGtpcRole OBJECT-TYPE
+   SYNTAX        INTEGER {
+                     unknown(1),
+                     master(2),
+                     slave(3),
+                     standby(4)
+                 }
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The current role of the GGSN-C (GTP-C) PIC. 
+         1. unknown 
+         2. master = node controller 
+         3. slave = session controller 
+         4. standby"
+   ::= { ggsnGtpcEntry 5 }
+
+ggsnGtpcStatus OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The current status of the GGSN-C (GTP-C) PIC, 
+         for example BLOCK, READY, STANDBY or NOT READY."
+   ::= { ggsnGtpcEntry 6 }
+
+ggsnGtpcControlPacketDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of control packets that have
+          been dropped by this GGSN-C (GTP-C) PIC. 
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpcEntry 7 }
+
+ggsnGtpcNbrOfActivePdpContexts OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active bearers on this C-PIC."
+   ::= { ggsnGtpcEntry 8 }
+
+ggsnGtpcMemory OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The amount of memory on the GGSN-C PIC, in kilobytes."
+   ::= { ggsnGtpcEntry 9 }
+
+ggsnGtpcMemoryUsed OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The amount of used memory on the GGSN-C PIC, in kilobytes."
+   ::= { ggsnGtpcEntry 10 }
+
+ggsnGtpcCpuUsage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "This counter shows the average CPU utilization percentage
+         over all cores sampled every 5 seconds 
+         in case of a Node Controller C-PIC,
+         or shows the highest value from the Proxy CPU's utilization
+         and the average Slave CPU's utilization sampled every 5 seconds
+         in case of a Session Controller C-PIC." 
+   ::= { ggsnGtpcEntry 11 }
+
+ggsnGtpcTftFilterDepthMax OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The maximum number of TFT filters per user on this GGSN-C PIC,
+          in the last statistics update period."
+   ::= { ggsnGtpcEntry 12 }
+
+ggsnGtpcTftFilterDepthMean OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The mean number of TFT filters per user on this GGSN-C PIC,
+          in the last statistics update period."
+   ::= { ggsnGtpcEntry 13 }
+
+ggsnGtpcControlLoad OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Weighted PDP context load in control of the GGSN-C PIC."
+   ::= { ggsnGtpcEntry 14 }
+
+ggsnGtpcNbrOfActivePdpContextsIpv6 OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv6 bearers on this C-PIC. 
+         
+         Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpcEntry 15 }
+
+ggsnGtpcPeakCpuUsage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "This counter shows the highest CPU utilization percentage
+          over all cores of the C-PIC sampled every 5 seconds."
+   ::= { ggsnGtpcEntry 16 }
+
+ggsnGtpcNbrOfActivePdpContextsIpv4v6 OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv4v6 bearers on this C-PIC.
+
+         Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpcEntry 17 }
+
+--
+-- GTP-U group
+--
+
+ggsnGtpuTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GtpuEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "The table listing GGSN-U PICs."
+   ::= { ggsnGtpuInfo 1 }
+
+ggsnGtpuEntry OBJECT-TYPE
+   SYNTAX        GtpuEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "An entry representing a GGSN-U PIC."
+   INDEX         { ggsnGtpuIndex }
+   ::= { ggsnGtpuTable 1 }
+
+GtpuEntry ::= SEQUENCE {
+   ggsnGtpuIndex       Integer32,
+   ggsnGtpuVersion     DisplayString,
+   ggsnGtpuAddress     IpAddress,
+   ggsnGtpuPdpCapacity Integer32,
+   ggsnGtpuRole        INTEGER,
+   ggsnGtpuStatus      DisplayString,
+   ggsnGtpuUserUplinkDrops Counter64,
+   ggsnGtpuUserDownlinkDrops Counter64,
+   ggsnGtpuNbrOfActivePdpContexts Gauge32,
+   ggsnGtpuMemory	Integer32,
+   ggsnGtpuMemoryUsed	Integer32,
+   ggsnGtpuCpuUsage	Gauge32,
+   ggsnGtpuPayloadLoad  Gauge32,
+   ggsnGtpuNbrOfActivePdpContextsIpv6 Gauge32,
+   ggsnGtpuPeakCpuUsage	Gauge32,
+   ggsnGtpuUplinkPackets Counter64,
+   ggsnGtpuDownlinkPackets Counter64,
+   ggsnGtpuNbrOfActivePdpContextsIpv4v6 Gauge32
+}
+
+ggsnGtpuIndex OBJECT-TYPE
+   SYNTAX        Integer32 (0..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number uniquely identifying each GGSN-U PIC. Its value
+	  is calculated using formula 16 * (1 + FPC) + PIC."
+   ::= { ggsnGtpuEntry 1 }
+
+ggsnGtpuVersion OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Software version running on the GGSN-U PIC."
+   ::= { ggsnGtpuEntry 2 }
+
+ggsnGtpuAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The Gn network IP address of the GGSN-U PIC."
+   ::= { ggsnGtpuEntry 3 }
+
+ggsnGtpuPdpCapacity OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The capacity of the GGSN-U PIC."
+   ::= { ggsnGtpuEntry 4 }
+
+ggsnGtpuRole OBJECT-TYPE
+   SYNTAX        INTEGER {
+                     unknown(1),
+                     active(2),
+                     standby(4)
+                 }
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The current role of the GGSN-U PIC.
+          1. unknown
+          2. active
+          4. standby"
+   ::= { ggsnGtpuEntry 5 }
+
+ggsnGtpuStatus OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The current status of the GGSN-U PIC,
+          for example BLOCK, READY, STANDBY or NOT READY."
+   ::= { ggsnGtpuEntry 6 }
+
+ggsnGtpuUserUplinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of uplink (GTP-U) packets dropped by this GGSN-U PIC. Note: This counter cannot be retrieved by CLI.
+          Packets can be dropped for a number of reasons, including the following:
+          The packet is classified as unauthorized after packet inspection
+          The packet is an IPv6 link-local packet
+          There are errors in the GTP header
+          There is no PDP context
+          There are general IP header faults
+          No SGSN entry is found
+          IP-in-IP encapsulation is missing for packet inspection
+          IP-in-IP encapsulation provides wrong packet length
+          The IP version is other than IPv4 or IPv6
+          No GGSN-U/I application is available
+          The packet cannot be forwarded to an GGSN-U/I application for classification
+          The packet cannot be sent
+          A certain type of IP traffic (IPv4/IPv6) is not allowed
+          A bandwidth limitation is defined for the APN, and the limit is exceeded
+          The packet is a broadcast message from an MS
+          The IP packet source address does not match the IP address assigned to the MS by the GGSN 
+          There is no free memory left in U-PIC"
+   ::= { ggsnGtpuEntry 7 }
+
+ggsnGtpuUserDownlinkDrops OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of downlink (GTP-U) packets dropped by
+          this GGSN-U PIC.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpuEntry 8 }
+
+ggsnGtpuNbrOfActivePdpContexts OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active bearers on this U-PIC."
+   ::= { ggsnGtpuEntry 9 }
+
+ggsnGtpuMemory OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The amount of memory on the GGSN-U PIC, in kilobytes."
+   ::= { ggsnGtpuEntry 10 }
+
+ggsnGtpuMemoryUsed OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The amount of used memory on the GGSN-U PIC, in kilobytes."
+   ::= { ggsnGtpuEntry 11 }
+
+ggsnGtpuCpuUsage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "This counter shows the average CPU utilization percentage
+          over all Slave CPUs of the U-PIC sampled every 5 seconds."
+   ::= { ggsnGtpuEntry 12 }
+
+ggsnGtpuPayloadLoad OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Weighted PDP context load in payload of the GGSN-U PIC."
+   ::= { ggsnGtpuEntry 13 }
+
+ggsnGtpuNbrOfActivePdpContextsIpv6 OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv6 bearers on this U-PIC.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpuEntry 14 }
+
+ggsnGtpuPeakCpuUsage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "This counter shows the highest CPU utilization percentage
+          over all cores of the U-PIC sampled every 5 seconds."
+   ::= { ggsnGtpuEntry 15 }
+
+ggsnGtpuUplinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of uplink (GTP-U) packets processed by
+          this GGSN-U PIC.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpuEntry 16 }
+
+ggsnGtpuDownlinkPackets OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of downlink (GTP-U) packets processed by
+          this GGSN-U PIC.
+          
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpuEntry 17 }
+
+ggsnGtpuNbrOfActivePdpContextsIpv4v6 OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active IPv4v6 bearers on this U-PIC.
+
+          Note: This counter cannot be retrieved by CLI."
+   ::= { ggsnGtpuEntry 18 }
+
+--
+-- T-PIC group
+--
+
+ggsnGtptTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GtptEntry
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "The table listing GGSN-T PICs."
+   ::= { ggsnGtptInfo 1 }
+
+ggsnGtptEntry OBJECT-TYPE
+   SYNTAX        GtptEntry
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "An entry representing a GGSN-T PIC."
+   INDEX         { ggsnGtptIndex }
+   ::= { ggsnGtptTable 1 }
+
+GtptEntry ::= SEQUENCE {
+   ggsnGtptIndex       Integer32,
+   ggsnGtptVersion     DisplayString,
+   ggsnGtptAddress     IpAddress,
+   ggsnGtptCapacity	   Integer32,
+   ggsnGtptRole        INTEGER,
+   ggsnGtptStatus      DisplayString,
+   ggsnGtptMemory	   Integer32,
+   ggsnGtptMemoryUsed  Integer32,
+   ggsnGtptCpuUsage	   Gauge32,
+   ggsnGtptPeakCpuUsage	   Gauge32
+}
+
+ggsnGtptIndex OBJECT-TYPE
+   SYNTAX        Integer32 (0..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated 
+   DESCRIPTION
+         "A number uniquely identifying each GGSN-T PIC. Its value
+	  is calculated using formula 16 * (1 + FPC) + PIC."
+   ::= { ggsnGtptEntry 1 }
+
+ggsnGtptVersion OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        deprecated 
+   DESCRIPTION
+         "Software version running on the GGSN-T PIC."
+   ::= { ggsnGtptEntry 2 }
+
+ggsnGtptAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The Gn network IP address of the GGSN-T PIC."
+   ::= { ggsnGtptEntry 3 }
+
+ggsnGtptCapacity OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The capacity of the GGSN-T PIC."
+   ::= { ggsnGtptEntry 4 }
+
+ggsnGtptRole OBJECT-TYPE
+   SYNTAX        INTEGER {
+                     unknown(1),
+                     active(2),
+                     standby(4)
+                 }
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The current role of the GGSN-T PIC."
+   ::= { ggsnGtptEntry 5 }
+
+ggsnGtptStatus OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        deprecated 
+   DESCRIPTION
+         "The current status of the GGSN-T PIC, example BLOCK."
+   ::= { ggsnGtptEntry 6 }
+
+ggsnGtptMemory OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The amount of memory on the GGSN-T PIC, in kilobytes."
+   ::= { ggsnGtptEntry 7 }
+
+ggsnGtptMemoryUsed OBJECT-TYPE
+   SYNTAX        Integer32
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The amount of used memory on the GGSN-T PIC, in kilobytes."
+   ::= { ggsnGtptEntry 8 }
+
+ggsnGtptCpuUsage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "This counter describes the average CPU utilization in 
+         percentage of the GGSN-T PIC calculated over 5 seconds. 
+         The GGSN-T PIC contains multiple CPUs. The counter is 
+         calculated as the max of(proxy, average of all the 
+         slave CPUs load) of the GGSN-T PIC."
+   ::= { ggsnGtptEntry 9 }
+
+ggsnGtptPeakCpuUsage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The counter describes the maximum CPU load of a GGSN-T PIC
+          in percentage. A GGSN-T PIC contains multiple CPUs. The 
+          counter is the CPU utilization of the CPU with the highest 
+          value calculated over a 5 second average of a GGSN-T PIC."
+   ::= { ggsnGtptEntry 10 }
+--
+-- Charging group
+--
+
+
+ggsnAcctPartialRecordGenerated OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of partial Call Data Records
+          generated."
+   ::= { ggsnChargingInfo 1 }
+
+ggsnAcctBillingGatewayTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF BillingGatewayEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "The table listing the Charging Gateway Functions with
+          which the GGSN communicates."
+   ::= { ggsnChargingInfo 2 }
+
+ggsnAcctBillingGatewayEntry OBJECT-TYPE
+   SYNTAX        BillingGatewayEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "An entry representing a Charging Gateway Functions."
+   INDEX         { ggsnAcctBillingGatewayIndex }
+   ::= { ggsnAcctBillingGatewayTable 1 }
+
+BillingGatewayEntry ::= SEQUENCE {
+   ggsnAcctBillingGatewayIndex       Integer32,
+   ggsnAcctBillingGatewayAddress     IpAddress,
+   ggsnAcctDataRecTransReqSent       Counter64,
+   ggsnAcctDataRecTransReqSentDup    Counter64,
+   ggsnAcctDataRecTransReqCancelled  Counter64,
+   ggsnAcctDataRecTransRespReceived  Counter64,
+   ggsnAcctRedirectionReqReceived    Counter64,
+   ggsnAcctRedirectionRespSent       Counter64
+}
+
+ggsnAcctBillingGatewayIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number uniquely identifying each Charging Gateway Functions
+          with which the GGSN communicates."
+   ::= { ggsnAcctBillingGatewayEntry 1 }
+
+ggsnAcctBillingGatewayAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The address of the Charging Gateway Functions referred to
+          in this table entry."
+   ::= { ggsnAcctBillingGatewayEntry 2 }
+
+ggsnAcctDataRecTransReqSent OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Data Record Transfer Request
+         messages that are sent from the GGSN to 
+         the Charging Gateway Function."   
+   ::= { ggsnAcctBillingGatewayEntry 3 }
+
+ggsnAcctDataRecTransReqSentDup OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Data Record Transfer Request
+          messages that are sent from the GGSN to 
+          the Charging Gateway Function when the 
+          Packet Transfer Command IE has the 
+          'Send possibly duplicated Data Record Packet'
+          value.
+          
+          Note: This counter is applicable 
+          only when using GTP Prime version 2." 
+   ::= { ggsnAcctBillingGatewayEntry 4 }
+
+ggsnAcctDataRecTransReqCancelled OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The number of Data Record Transfer Requests
+          sent with indication to cancel CDR packets
+          related to previously unacknowledged sequence
+          number."
+   ::= { ggsnAcctBillingGatewayEntry 5 }
+
+ggsnAcctDataRecTransRespReceived OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Data Record Transfer Response
+         messages that are received from the
+         Charging Gateway Function." 
+   ::= { ggsnAcctBillingGatewayEntry 6 }
+
+ggsnAcctRedirectionReqReceived OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Redirection Request
+         messages that are received from the
+         Charging Gateway Function."
+   ::= { ggsnAcctBillingGatewayEntry 7 }
+
+ggsnAcctRedirectionRespSent OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Redirection Response
+         messages that are sent from the GGSN
+         to the Charging Gateway Function."
+   ::= { ggsnAcctBillingGatewayEntry 8 }
+
+
+--
+-- DHCP group
+--
+
+
+ggsnDhcpClientAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The Address of the DHCP client of the GGSN."
+   ::= { ggsnDhcpInfo 1 }
+
+ggsnDhcpServerTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF DhcpServerEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "The table listing the DHCP servers with
+          which the GGSN communicates."
+   ::= { ggsnDhcpInfo 2 }
+
+ggsnDhcpServerEntry OBJECT-TYPE
+   SYNTAX        DhcpServerEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "An entry representing a GGSN DHCP server."
+   INDEX         { ggsnDhcpServerIndex }
+   ::= { ggsnDhcpServerTable 1 }
+
+DhcpServerEntry ::= SEQUENCE {
+   ggsnDhcpServerIndex            Integer32,
+   ggsnDhcpServerAddress          IpAddress,
+   ggsnDhcpServerName             DisplayString,
+   ggsnDhcpClientYiaddr           IpAddress,
+   ggsnDhcpClientState            DisplayString,
+   ggsnDhcpClientRequestsSent     Counter64,
+   ggsnDhcpClientRepliesReceived  Counter64,
+   ggsnDhcpClientRepliesDiscarded Counter64,
+   ggsnDhcpClientDiscoversSent    Counter64,
+   ggsnDhcpClientDeclinesSent     Counter64,
+   ggsnDhcpClientReleasesSent     Counter64,
+   ggsnDhcpClientOffersReceived   Counter64,
+   ggsnDhcpClientAcksReceived     Counter64,
+   ggsnDhcpClientNaksReceived     Counter64,
+   ggsnDhcpClientSendErrors       Counter64,
+   ggsnDhcpServerRoutingInstance  DisplayString
+}
+
+ggsnDhcpServerIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number uniquely identifying each DHCP server with
+          which this client communicates."
+   ::= { ggsnDhcpServerEntry 1 }
+
+ggsnDhcpServerAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The IP address of the DHCP server (siaddr)
+          referred to in this table entry."
+   ::= { ggsnDhcpServerEntry 2 }
+
+ggsnDhcpServerName OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The host name of the DHCP server (sname)."
+   ::= { ggsnDhcpServerEntry 3 }
+
+ggsnDhcpClientYiaddr OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The IP address of the 'your' client (yiaddr)."
+   ::= { ggsnDhcpServerEntry 4 }
+
+ggsnDhcpClientState OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The state of the DHCP client such as RENEWING."
+   ::= { ggsnDhcpServerEntry 5 }
+
+ggsnDhcpClientRequestsSent     OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of requests sent by the GGSN to this DHCP server. "
+   ::= { ggsnDhcpServerEntry 6 }
+
+ggsnDhcpClientRepliesReceived  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of replies received by the GGSN from this DHCP server."
+   ::= { ggsnDhcpServerEntry 7 }
+
+ggsnDhcpClientRepliesDiscarded OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of replies received and dropped by the GGSN from this DHCP server."
+   ::= { ggsnDhcpServerEntry 8 }
+
+ggsnDhcpClientDiscoversSent OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Specifies the number of DHCPDISCOVER messages sent by the GGSN to a DHCP server."
+   ::= { ggsnDhcpServerEntry 9 }
+
+ggsnDhcpClientDeclinesSent OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of DHCPRELEASE messages sent by GGSN to this DHCP server.
+          This counter is only incremented when a duplicate ip-address has been
+          received from a DHCP server."
+   ::= { ggsnDhcpServerEntry 10 }
+
+ggsnDhcpClientReleasesSent OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of releases sent to this server."
+   ::= { ggsnDhcpServerEntry 11 }
+
+ggsnDhcpClientOffersReceived OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of offers received from this server."
+   ::= { ggsnDhcpServerEntry 12 }
+
+ggsnDhcpClientAcksReceived OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of acks received from this server."
+   ::= { ggsnDhcpServerEntry 13 }
+
+ggsnDhcpClientNaksReceived OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of naks received from this server."
+   ::= { ggsnDhcpServerEntry 14 }
+
+ggsnDhcpClientSendErrors OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of client send errors."
+   ::= { ggsnDhcpServerEntry 15 }
+
+ggsnDhcpServerRoutingInstance OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The routing instance of the DHCP server."
+   ::= { ggsnDhcpServerEntry 16 }
+
+--
+-- GGSN APN service-based charging (FBC) statistics
+--
+-- Per U PIC, per APN service-based charging (FBC) statistics
+--
+
+ggsnApnFbcStatsTable 		OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnFbcStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "SACC statistics per APN."
+    ::= { ggsnFbcStats 4 }
+
+ggsnApnFbcStatsEntry 		OBJECT-TYPE
+    SYNTAX			ApnFbcStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+	"SACC statistics per APN."
+    INDEX         		{ ggsnGtpuIndex, ggsnApnIndex }
+    ::= { ggsnApnFbcStatsTable 1 }
+
+ApnFbcStats ::= SEQUENCE {
+    ggsnApnFbcNbrOfPpsUsers		Gauge32,
+    ggsnApnFbcNbrOfPpsPdpContexts	Gauge32,
+    ggsnApnFbcPpsCreate			Counter64,
+    ggsnApnFbcPpsReject			Counter64,
+    ggsnApnFbcInitiatedDeactivation	Counter64,
+    ggsnApnFbcInitialPrsReq		Counter64,
+    ggsnApnFbcInitialPrsReqFailed	Counter64,
+    ggsnApnFbcUpdPrsReq			Counter64,
+    ggsnApnFbcUpdPrsReqFailed		Counter64,
+    ggsnApnFbcStartCredReq		Counter64,
+    ggsnApnFbcStartCredReqFailed	Counter64,
+    ggsnApnFbcUpdCredReq		Counter64,
+    ggsnApnFbcUpdCredReqFailed		Counter64,
+    ggsnApnFbcStopCredReq		Counter64,
+    ggsnApnFbcStopCredReqFailed		Counter64,
+    ggsnApnFbcExtPrsUpd			Counter64,
+    ggsnApnFbcExtCreditUpd		Counter64,
+    ggsnApnFbcDurationTime		Counter64,
+    ggsnApnFbcActivationBearerCtrlAccept		Counter64,
+    ggsnApnFbcActivationBearerCtrlReject		Counter64,
+    ggsnApnFbcActivationBearerCtrlUpgrade		Counter64,
+    ggsnApnFbcActivationBearerCtrlDowngrade		Counter64,
+    ggsnApnFbcModificationBearerCtrlAccept		Counter64,
+    ggsnApnFbcModificationBearerCtrlDeactivate		Counter64,
+    ggsnApnFbcModificationBearerCtrlUpgrade		Counter64,
+    ggsnApnFbcModificationBearerCtrlDowngrade		Counter64,
+    ggsnApnFbcActivationNoBearerCtrlAccept		Counter64,
+    ggsnApnFbcActivationNoBearerCtrlReject		Counter64,
+    ggsnApnFbcActivationNoBearerCtrlDowngrade		Counter64,
+    ggsnApnFbcModificationNoBearerCtrlAccept		Counter64,
+    ggsnApnFbcModificationNoBearerCtrlDeactivate	Counter64,
+    ggsnApnFbcModificationNoBearerCtrlDowngrade	Counter64,
+    ggsnApnSaccAttemptedServiceInitiatedQoSModification	Counter64
+}
+
+ggsnApnFbcNbrOfPpsUsers		OBJECT-TYPE
+    SYNTAX			Gauge32
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "The number of user sessions with online charging per APN."
+    ::= { ggsnApnFbcStatsEntry 2 }
+
+ggsnApnFbcNbrOfPpsPdpContexts		OBJECT-TYPE
+    SYNTAX			Gauge32
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+    "The number of user sessions with online charging per APN."
+    ::= { ggsnApnFbcStatsEntry 3 }
+
+ggsnApnFbcPpsCreate		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "The number of user session activations with online charging per APN."
+    ::= { ggsnApnFbcStatsEntry 4 }
+
+ggsnApnFbcPpsReject		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "The number of user session activations with online charging rejected per APN."
+    ::= { ggsnApnFbcStatsEntry 5 }
+
+ggsnApnFbcInitiatedDeactivation	OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "The number of bearer deactivations initiated by the SACC functionality per APN."
+    ::= { ggsnApnFbcStatsEntry 6 }
+
+ggsnApnFbcInitialPrsReq		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of service-based charging (FBC) initial policy/rate requests."
+    ::= { ggsnApnFbcStatsEntry 7 }
+
+ggsnApnFbcInitialPrsReqFailed	OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of failed service-based charging (FBC) initial
+	 policy/rate requests."
+    ::= { ggsnApnFbcStatsEntry 8 }
+
+ggsnApnFbcUpdPrsReq		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of service-based charging (FBC) policy/rate
+	 updates/interim requests."
+    ::= { ggsnApnFbcStatsEntry 9 }
+
+ggsnApnFbcUpdPrsReqFailed	OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of failed service-based charging (FBC) policy/rate
+	 updates/interim requests."
+    ::= { ggsnApnFbcStatsEntry 10 }
+
+ggsnApnFbcStartCredReq		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of service-based charging (FBC) start credit requests
+	 to pre-paid server."
+    ::= { ggsnApnFbcStatsEntry 11 }
+
+ggsnApnFbcStartCredReqFailed	OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of failed service-based charging (FBC) start credit requests
+	 to pre-paid server."
+    ::= { ggsnApnFbcStatsEntry 12 }
+
+ggsnApnFbcUpdCredReq		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of service-based charging (FBC) interim credit requests
+	 to pre-paid server."
+    ::= { ggsnApnFbcStatsEntry 13 }
+
+ggsnApnFbcUpdCredReqFailed	OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of failed service-based charging (FBC) interim credit requests to
+	 pre-paid server."
+    ::= { ggsnApnFbcStatsEntry 14 }
+
+ggsnApnFbcStopCredReq		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of stop credit requests (bucket request / renewals)."
+    ::= { ggsnApnFbcStatsEntry 15 }
+
+ggsnApnFbcStopCredReqFailed	OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+	"Number of failed stop credit requests
+	 (bucket request / renewals)."
+    ::= { ggsnApnFbcStatsEntry 16 }
+
+ggsnApnFbcExtPrsUpd		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "The number of externally initiated updates due to RAR and ASR from the PCRF per APN."
+    ::= { ggsnApnFbcStatsEntry 17 }
+
+ggsnApnFbcExtCreditUpd		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "The number of externally initiated updates due to RAR and ASR from the OCS per APN."
+    ::= { ggsnApnFbcStatsEntry 18 }
+
+ggsnApnFbcDurationTime		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+    "Number of seconds measured for duration time.
+     
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnApnFbcStatsEntry 19 }
+
+ggsnApnFbcActivationBearerCtrlAccept		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS accepts at PDP Context activation with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 20 }
+
+ggsnApnFbcActivationBearerCtrlReject		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+    "Number of PDP Context rejects at activation with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 21 }
+
+ggsnApnFbcActivationBearerCtrlUpgrade		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS upgrades at PDP Context activation with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 22 }
+
+ggsnApnFbcActivationBearerCtrlDowngrade		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS downgrades at PDP Context activation with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 23 }
+
+ggsnApnFbcModificationBearerCtrlAccept		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS accepts at PDP Context modification with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 24 }
+
+ggsnApnFbcModificationBearerCtrlDeactivate		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of PDP Context deactivates at modification with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 25 }
+
+ggsnApnFbcModificationBearerCtrlUpgrade		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS upgrades at PDP Context modification with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 26 }
+
+ggsnApnFbcModificationBearerCtrlDowngrade		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS downgrades at PDP Context modification with SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 27 }
+
+ggsnApnFbcActivationNoBearerCtrlAccept		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS accepts at PDP Context activation without SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 28 }
+
+ggsnApnFbcActivationNoBearerCtrlReject		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of PDP Context rejects at activation without SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 29 }
+
+ggsnApnFbcActivationNoBearerCtrlDowngrade		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS downgrades at PDP Context activation without SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 30 }
+
+ggsnApnFbcModificationNoBearerCtrlAccept		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS accepts at PDP Context modification without SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 31 }
+
+ggsnApnFbcModificationNoBearerCtrlDeactivate		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of PDP Context deactivates at modification without SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 32 }
+
+ggsnApnFbcModificationNoBearerCtrlDowngrade		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of QoS downgrades at PDP Context modification without SGSN bearer control support."
+    ::= { ggsnApnFbcStatsEntry 33 }
+
+ggsnApnSaccAttemptedServiceInitiatedQoSModification		OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			current
+    DESCRIPTION
+	"Number of attempted service initiated QoS modifications for default bearer."
+    ::= { ggsnApnFbcStatsEntry 34 }
+
+--
+-- GGSN service-based charging (FBC) Authorization statistics
+--
+-- Per node
+--
+
+ggsnFbcAuthStats	OBJECT IDENTIFIER ::= { ggsnFbcAuthorizationStats 1 }
+
+ggsnFbcUserAuthPacketsDropped		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of packets discarded by authorization for
+     service classes originating from the policy server list.
+     Only dropped downlink packets result in incrementation of the counter.
+     
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcAuthStats 2 }
+
+ggsnFbcDefaultAuthPacketsDropped	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of packets discarded by authorization for service
+     classes originating from the policy server communication
+     error fallback list (default list).
+     Only dropped downlink packets result in incrementation of the counter.
+     
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcAuthStats 3 }
+
+ggsnFbcEmptyBucketPacketsDropped	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of packets discarded by authorization for service
+     classes originating from the empty-bucket based service
+     class list. Only dropped downlink packets result in incrementation
+     of the counter.
+     
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcAuthStats 4 }
+
+ggsnFbcComFailAuthPacketsDropped	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of packets discarded by authorization for service
+     classes originating from the prepaid server communication
+     error fallback list (default list). Only dropped downlink 
+     packets result in incrementation of the counter.
+     
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcAuthStats 5 }
+
+ggsnFbcIdentErrorPacketsDropped		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of packets discarded by authorization due to a
+     service identification error. Only dropped downlink packets
+     result in incrementation of the counter.
+     
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcAuthStats 6 }
+
+
+--
+-- GGSN APN service-based charging (FBC) SID statistics
+--
+-- Per U PIC, per APN, per SID
+--
+
+ggsnApnFbcServIdentStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnFbcServIdentStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "Service data flow statistics per APN."
+    ::= { ggsnFbcStats 5 }
+
+ggsnApnFbcServIdentStatsEntry		OBJECT-TYPE
+    SYNTAX			ApnFbcServIdentStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+	"Service data flow statistics per APN."
+    INDEX { ggsnGtpuIndex, ggsnApnIndex, ggsnServIdentIndex }
+    ::= { ggsnApnFbcServIdentStatsTable 1 }
+
+ApnFbcServIdentStats ::= SEQUENCE {
+    ggsnServIdentIndex		Integer32,
+    ggsnApnFbcServIdentUplinkBytes	Counter64,
+    ggsnApnFbcServIdentDownlinkBytes	Counter64,
+    ggsnApnFbcServIdentEventTrans	Counter64,
+    ggsnApnFbcServIdentEventTransFail	Counter64,
+    ggsnApnFbcServIdentEventStartTrans	Counter64,
+    ggsnApnFbcServIdentEventSuccessTrans	Counter64
+}
+
+ggsnServIdentIndex		OBJECT-TYPE
+   SYNTAX			Integer32 (1..4096)
+   MAX-ACCESS			not-accessible
+   STATUS			current
+   DESCRIPTION
+   "The service data flow identifier."
+   ::= { ggsnApnFbcServIdentStatsEntry 1 }
+
+ggsnApnFbcServIdentUplinkBytes		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of uplink bytes on service data flow per APN."
+    ::= { ggsnApnFbcServIdentStatsEntry 2 }
+
+ggsnApnFbcServIdentDownlinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of downlink bytes on service data flow per APN."
+    ::= { ggsnApnFbcServIdentStatsEntry 4 }
+
+ggsnApnFbcServIdentEventTrans	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of transactions per service identifier for which event charging applies."
+    ::= { ggsnApnFbcServIdentStatsEntry 5 }
+
+ggsnApnFbcServIdentEventTransFail	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of failed transactions (error response or abnormal termination)
+	 per service identifier for which event charging applies."
+    ::= { ggsnApnFbcServIdentStatsEntry 6 }
+
+ggsnApnFbcServIdentEventStartTrans	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of start transaction events per service identifier for which event charging applies."
+    ::= { ggsnApnFbcServIdentStatsEntry 7 }
+
+ggsnApnFbcServIdentEventSuccessTrans	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of successful transaction events per service identifier for which event charging applies."
+    ::= { ggsnApnFbcServIdentStatsEntry 8 }
+
+--
+-- GGSN APN service-based charging (FBC) SCID statistics
+--
+-- Per U PIC, per APN, per SCID
+--
+
+ggsnApnFbcServClassStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnFbcServClassStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		deprecated
+    DESCRIPTION
+         "Service-based charging (FBC) service ID statistics for an APN."
+    ::= { ggsnFbcStats 6 }
+
+ggsnApnFbcServClassStatsEntry		OBJECT-TYPE
+    SYNTAX			ApnFbcServClassStats
+    MAX-ACCESS			not-accessible
+    STATUS			deprecated
+    DESCRIPTION
+	"A conceptual row listing the service-based charging (FBC) service ID
+	 statistics for each APN."
+    INDEX { ggsnGtpuIndex, ggsnApnIndex, ggsnServClassIndex }
+    ::= { ggsnApnFbcServClassStatsTable 1 }
+
+ApnFbcServClassStats ::= SEQUENCE {
+    ggsnServClassIndex		Integer32,
+    ggsnApnFbcServClassUplinkBytes	Counter64,
+    ggsnApnFbcServClassDownlinkBytes	Counter64,
+    ggsnApnFbcServClassActiveTime	Counter64
+}
+
+ggsnServClassIndex		OBJECT-TYPE
+   SYNTAX			Integer32 (1..4096)
+   MAX-ACCESS			not-accessible
+   STATUS			deprecated
+   DESCRIPTION
+         "The service ID for the statistics."
+   ::= { ggsnApnFbcServClassStatsEntry 1 }
+
+ggsnApnFbcServClassUplinkBytes		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of uplink bytes marked with rating group (RG)."
+    ::= { ggsnApnFbcServClassStatsEntry 2 }
+
+ggsnApnFbcServClassDownlinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of downlink bytes marked with rating group (RG)."
+    ::= { ggsnApnFbcServClassStatsEntry 4 }
+
+ggsnApnFbcServClassActiveTime	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of seconds measured for active time for service class.
+    
+     Note: Only valid for SACC 2.0."
+    ::= { ggsnApnFbcServClassStatsEntry 6 }
+
+ggsnFbcExtPrsUpdReqNoMatch      OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+         "Number of externally initiated URT updates for users
+          without PDP context.
+          
+          Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcStats 7 }
+
+ggsnFbcExtCreditUpdReqNoMatch   OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+         "Number of externally initiated quota updates for users
+          without PDP context.
+
+          Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcStats 8 }
+
+ggsnFbcExtUpdReqFailure         OBJECT-TYPE
+    SYNTAX			Counter64
+    MAX-ACCESS			read-only
+    STATUS			deprecated
+    DESCRIPTION
+         "Number of unidentified messages including messages with
+          authentication id failure.
+          
+          Note: Only valid for SACC 2.0."
+    ::= { ggsnFbcStats 9 }
+
+
+
+--
+-- GGSN APN service-based charging (FBC) PR-AS statistics
+--
+-- Per APN, per PR-AS ID
+--
+
+ggsnApnFbcPrasStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnFbcPrasStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "Policy control application system statistics per APN."
+    ::= { ggsnFbcStats 10 }
+
+ggsnApnFbcPrasStatsEntry		OBJECT-TYPE
+    SYNTAX			ApnFbcPrasStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+	"Policy control application system statistics per APN."
+    INDEX { ggsnApnIndex, ggsnPrasIndex }
+    ::= { ggsnApnFbcPrasStatsTable 1 }
+
+ApnFbcPrasStats ::= SEQUENCE {
+    ggsnPrasIndex		Integer32,
+    ggsnApnFbcPrasName		DisplayString,
+    ggsnApnFbcPrasStartReq	Counter64,
+    ggsnApnFbcPrasStartReqFail	Counter64,
+    ggsnApnFbcPrasUpdateReq	Counter64,
+    ggsnApnFbcPrasUpdateReqFail	Counter64,
+    ggsnApnFbcPrasStopReq	Counter64,
+    ggsnApnFbcPrasStopReqFail	Counter64,
+    ggsnApnFbcPrasUserServiceDenied	Counter64,
+    ggsnApnFbcPrasUserUnknown	Counter64
+}
+
+ggsnPrasIndex		OBJECT-TYPE
+   SYNTAX			Integer32
+   MAX-ACCESS			not-accessible
+   STATUS			current
+   DESCRIPTION
+   "The PCRF index."
+   ::= { ggsnApnFbcPrasStatsEntry 1 }
+
+ggsnApnFbcPrasName OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+   "The PCRF identifier."
+   ::= { ggsnApnFbcPrasStatsEntry 2 }
+
+ggsnApnFbcPrasStartReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of initial requests towards the PCRF per APN."
+    ::= { ggsnApnFbcPrasStatsEntry 3 }
+
+ggsnApnFbcPrasStartReqFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of failed initial requests towards the PCRF per APN."
+    ::= { ggsnApnFbcPrasStatsEntry 4 }
+
+ggsnApnFbcPrasUpdateReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of update requests towards the PCRF per APN."
+    ::= { ggsnApnFbcPrasStatsEntry 5 }
+
+ggsnApnFbcPrasUpdateReqFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of failed update requests towards the PCRF per APN."
+    ::= { ggsnApnFbcPrasStatsEntry 6 }
+
+ggsnApnFbcPrasStopReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of termination requests towards the PCRF per APN."
+    ::= { ggsnApnFbcPrasStatsEntry 7 }
+
+ggsnApnFbcPrasStopReqFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of failed termination requests towards the PCRF per APN."
+    ::= { ggsnApnFbcPrasStatsEntry 8 }
+
+ggsnApnFbcPrasUserServiceDenied		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+	"The number of requests towards the PCRF per APN that failed with result code User Service Denied."
+    ::= { ggsnApnFbcPrasStatsEntry 9 }
+
+ggsnApnFbcPrasUserUnknown		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+	"The number of requests towards the PCRF per APN that failed with result code User Unknown."
+    ::= { ggsnApnFbcPrasStatsEntry 10 }
+
+
+
+--
+-- GGSN APN service-based charging (FBC) CC-AS statistics
+--
+-- Per APN, per CC-AS ID
+--
+
+ggsnApnFbcCcasStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnFbcCcasStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "Online charging application system statistics per APN."
+    ::= { ggsnFbcStats 11 }
+
+ggsnApnFbcCcasStatsEntry		OBJECT-TYPE
+    SYNTAX			ApnFbcCcasStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "Online charging application system statistics per APN."
+    INDEX { ggsnApnIndex, ggsnCcasIndex }
+    ::= { ggsnApnFbcCcasStatsTable 1 }
+
+ApnFbcCcasStats ::= SEQUENCE {
+    ggsnCcasIndex		Integer32,
+    ggsnApnFbcCcasName		DisplayString,
+    ggsnApnFbcCcasStartReq	Counter64,
+    ggsnApnFbcCcasStartReqFail	Counter64,
+    ggsnApnFbcCcasUpdateReq	Counter64,
+    ggsnApnFbcCcasUpdateReqFail	Counter64,
+    ggsnApnFbcCcasStopReq	Counter64,
+    ggsnApnFbcCcasStopReqFail	Counter64,
+    ggsnApnFbcCcasUserServiceDenied	Counter64,
+    ggsnApnFbcCcasUserUnknown	Counter64,
+    ggsnApnSaccCcasAuthReject	Counter64,
+    ggsnApnSaccCcasCcNotApplicable	Counter64
+}
+
+ggsnCcasIndex		OBJECT-TYPE
+    SYNTAX			Integer32
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "The OCS index."
+    ::= { ggsnApnFbcCcasStatsEntry 1 }
+
+ggsnApnFbcCcasName OBJECT-TYPE
+    SYNTAX        DisplayString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+    "The OCS identifier."
+    ::= { ggsnApnFbcCcasStatsEntry 2 }
+
+ggsnApnFbcCcasStartReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of initial requests towards the OCS per APN."
+    ::= { ggsnApnFbcCcasStatsEntry 3 }
+
+ggsnApnFbcCcasStartReqFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of failed initial requests towards the OCS per APN."
+    ::= { ggsnApnFbcCcasStatsEntry 4 }
+
+ggsnApnFbcCcasUpdateReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of update requests towards the OCS per APN."
+    ::= { ggsnApnFbcCcasStatsEntry 5 }
+
+ggsnApnFbcCcasUpdateReqFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of failed update requests towards the OCS per APN."
+    ::= { ggsnApnFbcCcasStatsEntry 6 }
+
+ggsnApnFbcCcasStopReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of termination requests towards the OCS per APN."
+    ::= { ggsnApnFbcCcasStatsEntry 7 }
+
+ggsnApnFbcCcasStopReqFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of failed termination requests towards the OCS per APN."
+    ::= { ggsnApnFbcCcasStatsEntry 8 }
+
+ggsnApnFbcCcasUserServiceDenied		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the OCS per APN that failed with result code User Service Denied."
+    ::= { ggsnApnFbcCcasStatsEntry 9 }
+
+ggsnApnFbcCcasUserUnknown		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the OCS per APN that failed with result code User Unknown."
+    ::= { ggsnApnFbcCcasStatsEntry 10 }
+
+ggsnApnSaccCcasAuthReject		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the OCS per APN that failed with result code Authorization Rejected."
+    ::= { ggsnApnFbcCcasStatsEntry 11 }
+
+ggsnApnSaccCcasCcNotApplicable		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the OCS per APN that failed with result code Credit Control Not Applicable."
+    ::= { ggsnApnFbcCcasStatsEntry 12 }
+
+
+
+--
+-- GGSN service-based charging (FBC) DAS statistics
+--
+-- Per DAS ID
+--
+
+ggsnFbcDiamApplSysStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF FbcDiamApplSysStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "Diameter application system statistics."
+    ::= { ggsnFbcStats 12 }
+
+ggsnFbcDiamApplSysStatsEntry		OBJECT-TYPE
+    SYNTAX			FbcDiamApplSysStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "Diameter application system statistics."
+    INDEX { ggsnDiamApplSysIndex }
+    ::= { ggsnFbcDiamApplSysStatsTable 1 }
+
+FbcDiamApplSysStats ::= SEQUENCE {
+    ggsnDiamApplSysIndex		Integer32,
+    ggsnFbcDiamApplSysName		DisplayString,
+    ggsnFbcDiamApplSysReq	Counter64
+}
+
+ggsnDiamApplSysIndex		OBJECT-TYPE
+    SYNTAX			Integer32
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "The diamater application system index."
+    ::= { ggsnFbcDiamApplSysStatsEntry 1 }
+
+ggsnFbcDiamApplSysName OBJECT-TYPE
+    SYNTAX        DisplayString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+    "The diameter application system identifier."
+    ::= { ggsnFbcDiamApplSysStatsEntry 2 }
+
+ggsnFbcDiamApplSysReq		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the diameter application system."
+    ::= { ggsnFbcDiamApplSysStatsEntry 3 }
+
+--
+-- GGSN APN service-based charging (FBC) Rate Group statistics
+--
+-- Per APN, per RG
+--
+
+ggsnApnFbcRateGroupStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnFbcRateGroupStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		obsolete
+    DESCRIPTION
+         "Service-based charging (FBC) rate group statistics for an APN."
+    ::= { ggsnFbcStats 13 }
+
+ggsnApnFbcRateGroupStatsEntry		OBJECT-TYPE
+    SYNTAX			ApnFbcRateGroupStats
+    MAX-ACCESS			not-accessible
+    STATUS			obsolete
+    DESCRIPTION
+	"A conceptual row listing the service-based charging (FBC) rate group statistics for each APN."
+    INDEX { ggsnApnIndex, ggsnRateGroupIndex }
+    ::= { ggsnApnFbcRateGroupStatsTable 1 }
+
+ApnFbcRateGroupStats ::= SEQUENCE {
+    ggsnRateGroupIndex		Integer32,
+    ggsnApnFbcRateGroupEventStartTrans Counter64,
+    ggsnApnFbcRateGroupEventSuccessTrans Counter64
+}
+
+ggsnRateGroupIndex		OBJECT-TYPE
+   SYNTAX			Integer32 (1..65535)
+   MAX-ACCESS			not-accessible
+   STATUS			obsolete
+   DESCRIPTION
+         "The rate group for the statistics."
+   ::= { ggsnApnFbcRateGroupStatsEntry 1 }
+
+ggsnApnFbcRateGroupEventStartTrans 	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				obsolete
+    DESCRIPTION
+	"Number of start transaction events per rate group."
+    ::= { ggsnApnFbcRateGroupStatsEntry 2 }
+
+ggsnApnFbcRateGroupEventSuccessTrans  OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				obsolete
+    DESCRIPTION
+	"Number of successful transaction events per rate group."
+    ::= { ggsnApnFbcRateGroupStatsEntry 3 }
+
+
+--
+-- GGSN APN service-based charging PCRF statistics
+--
+-- Per APN, per PCRF
+--
+
+ggsnApnSaccPcrfStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnSaccPcrfStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "PCRF statistics per APN."
+    ::= { ggsnFbcStats 14 }
+
+ggsnApnSaccPcrfStatsEntry	OBJECT-TYPE
+    SYNTAX			ApnSaccPcrfStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "PCRF statistics per APN."
+    INDEX				{ ggsnApnIndex, ggsnPcrfIndex }
+    ::= { ggsnApnSaccPcrfStatsTable 1 }
+
+ApnSaccPcrfStats ::= SEQUENCE {
+    ggsnPcrfIndex				Integer32,
+    ggsnApnSaccPcrfName  			DisplayString,
+    ggsnApnSaccPcrfAuthorFail			Counter64,
+    ggsnApnSaccPcrfAuthenFail			Counter64,
+    ggsnApnSaccPcrfUpdCcReqSessIdNoMatch	Counter64,
+    ggsnApnSaccPcrfActivePdpContextUsageReporting  Gauge32,
+    ggsnApnSaccPcrfActiveIPcanSessions		Gauge32,
+    ggsnApnSaccPcrfActiveDedicatedIPcanBearers		Gauge32
+}
+
+ggsnPcrfIndex			OBJECT-TYPE
+    SYNTAX			Integer32
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "The PCRF index."
+    ::= { ggsnApnSaccPcrfStatsEntry 1 }
+
+ggsnApnSaccPcrfName 		OBJECT-TYPE
+    SYNTAX        		DisplayString
+    MAX-ACCESS    		read-only
+    STATUS        		current
+    DESCRIPTION
+    "The PCRF identifier."
+    ::= { ggsnApnSaccPcrfStatsEntry 2 }
+
+ggsnApnSaccPcrfAuthorFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the PCRF per APN that failed with result code Authorization Rejected."
+    ::= { ggsnApnSaccPcrfStatsEntry 3 }
+
+ggsnApnSaccPcrfAuthenFail		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the OCS per APN that failed with result code Authentication Rejected."
+    ::= { ggsnApnSaccPcrfStatsEntry 4 }
+
+ggsnApnSaccPcrfUpdCcReqSessIdNoMatch	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of requests towards the OCS per APN that failed with result code Unknown Session ID."
+    ::= { ggsnApnSaccPcrfStatsEntry 5 }
+
+ggsnApnSaccPcrfActivePdpContextUsageReporting	OBJECT-TYPE
+    SYNTAX				Gauge32
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of IP-CAN sessions with usage monitoring or usage reporting over Gx per APN."
+    ::= { ggsnApnSaccPcrfStatsEntry 6 }
+
+ggsnApnSaccPcrfActiveIPcanSessions	OBJECT-TYPE
+    SYNTAX				Gauge32
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of active IP-CAN sessions with policy control over Gx per APN."
+    ::= { ggsnApnSaccPcrfStatsEntry 7 }
+
+ggsnApnSaccPcrfActiveDedicatedIPcanBearers	OBJECT-TYPE
+    SYNTAX				Gauge32
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of active dedicated IP-CAN bearers with policy control over Gx per APN."
+    ::= { ggsnApnSaccPcrfStatsEntry 8 }
+
+--
+-- GGSN APN service-based charging RS statistics
+--
+-- Per APN, per RS
+--
+
+ggsnApnSaccRsStatsTable 	OBJECT-TYPE
+    SYNTAX        		SEQUENCE OF ApnSaccRsStats
+    MAX-ACCESS    		not-accessible
+    STATUS        		current
+    DESCRIPTION
+    "Rule space statistics per APN."
+    ::= { ggsnFbcStats 15 }
+
+ggsnApnSaccRsStatsEntry 	OBJECT-TYPE
+    SYNTAX			ApnSaccRsStats
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "Rule space statistics per APN."
+    INDEX				{ ggsnApnIndex, ggsnRsIndex }
+    ::= { ggsnApnSaccRsStatsTable 1 }
+
+ApnSaccRsStats ::= SEQUENCE {
+    ggsnRsIndex 				Integer32,
+    ggsnApnSaccRsName				DisplayString,
+    ggsnApnSaccRsUplinkBytes			Counter64,
+    ggsnApnSaccRsDownlinkBytes			Counter64,
+    ggsnApnSaccRsServiceInstances		Counter64,
+    ggsnApnSaccRsAuthDownlinkPacketsDropped	Counter64,
+    ggsnApnSaccRsAuthUplinkPacketsDropped	Counter64,
+    ggsnApnSaccRsGateDownlinkPacketsDropped	Counter64,
+    ggsnApnSaccRsGateUplinkPacketsDropped	Counter64
+}
+
+ggsnRsIndex			OBJECT-TYPE
+    SYNTAX			Integer32
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+    "The rule space index."
+    ::= { ggsnApnSaccRsStatsEntry 1 }
+
+ggsnApnSaccRsName 		OBJECT-TYPE
+    SYNTAX        		DisplayString
+    MAX-ACCESS    		read-only
+    STATUS        		current
+    DESCRIPTION
+    "The rule space identifier."
+    ::= { ggsnApnSaccRsStatsEntry 2 }
+
+ggsnApnSaccRsUplinkBytes		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of uplink bytes on rule space per APN."
+    ::= { ggsnApnSaccRsStatsEntry 3 }
+
+ggsnApnSaccRsDownlinkBytes		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of downlink bytes on rule space per APN."
+    ::= { ggsnApnSaccRsStatsEntry 4 }
+
+ggsnApnSaccRsServiceInstances		OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+    "Number of service instances identified per APN and Rule Space."
+    ::= { ggsnApnSaccRsStatsEntry 5 }
+
+ggsnApnSaccRsAuthDownlinkPacketsDropped 	OBJECT-TYPE
+    SYNTAX					Counter64
+    MAX-ACCESS					read-only
+    STATUS					current
+    DESCRIPTION
+    "The number of discarded downlink packets due to authorization based on policy and credit control."
+    ::= { ggsnApnSaccRsStatsEntry 6 }
+
+ggsnApnSaccRsAuthUplinkPacketsDropped		OBJECT-TYPE
+    SYNTAX					Counter64
+    MAX-ACCESS					read-only
+    STATUS					current
+    DESCRIPTION
+    "The number of discarded uplink packets due to authorization based on policy and credit control."
+    ::= { ggsnApnSaccRsStatsEntry 7 }
+
+ggsnApnSaccRsGateDownlinkPacketsDropped		OBJECT-TYPE
+    SYNTAX					Counter64
+    MAX-ACCESS				read-only
+    STATUS					current
+    DESCRIPTION
+    "The number of discarded downlink packets due to closed gate."
+    ::= { ggsnApnSaccRsStatsEntry 8 }
+
+ggsnApnSaccRsGateUplinkPacketsDropped		OBJECT-TYPE
+    SYNTAX					Counter64
+    MAX-ACCESS				read-only
+    STATUS					current
+    DESCRIPTION
+    "The number of discarded uplink packets due to closed gate."
+    ::= { ggsnApnSaccRsStatsEntry 9 }
+
+--
+-- GGSN APN service-based charging (SACC 2) SID statistics
+--
+-- Per U PIC, per APN, per SID
+--
+
+ggsnApnSacc2ServIdentStatsTable	OBJECT-TYPE
+    SYNTAX                      SEQUENCE OF ApnSacc2ServIdentStats
+    MAX-ACCESS                  not-accessible
+    STATUS                      deprecated
+    DESCRIPTION
+         "Service-based charging (SACC 2) service ID statistics for an APN."
+    ::= { ggsnFbcStats 16 }
+
+ggsnApnSacc2ServIdentStatsEntry OBJECT-TYPE
+    SYNTAX                      ApnSacc2ServIdentStats
+    MAX-ACCESS                  not-accessible
+    STATUS                      deprecated
+    DESCRIPTION
+        "A conceptual row listing the service-based charging (SACC 2) service ID
+         statistics for each APN."
+    INDEX { ggsnGtpuIndex, ggsnApnIndex, ggsnSacc2ServIdentIndex }
+    ::= { ggsnApnSacc2ServIdentStatsTable 1 }
+
+ApnSacc2ServIdentStats ::= SEQUENCE {
+    ggsnSacc2ServIdentIndex			Unsigned32,
+    ggsnApnSacc2ServIdentUplinkBytes    	Counter64,
+    ggsnApnSacc2ServIdentDownlinkBytes  	Counter64,
+    ggsnApnSacc2ServIdentEventTrans     	Counter64,
+    ggsnApnSacc2ServIdentEventTransFail 	Counter64,
+    ggsnApnSacc2ServIdentEventStartTrans	Counter64,
+    ggsnApnSacc2ServIdentEventSuccessTrans	Counter64
+}
+
+ggsnSacc2ServIdentIndex		OBJECT-TYPE
+   SYNTAX                       Unsigned32
+   MAX-ACCESS                   not-accessible
+   STATUS                       deprecated
+   DESCRIPTION
+         "The service ID for the statistics."
+   ::= { ggsnApnSacc2ServIdentStatsEntry 1 }
+
+ggsnApnSacc2ServIdentUplinkBytes        OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of uplink bytes marked with service identifier."
+    ::= { ggsnApnSacc2ServIdentStatsEntry 2 }
+
+ggsnApnSacc2ServIdentDownlinkBytes      OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of downlink bytes marked with service identifier."
+    ::= { ggsnApnSacc2ServIdentStatsEntry 4 }
+
+ggsnApnSacc2ServIdentEventTrans	   	OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of transactions per service identifier for which event charging applies."
+    ::= { ggsnApnSacc2ServIdentStatsEntry 5 }
+
+ggsnApnSacc2ServIdentEventTransFail   	OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of failed transactions (error response or abnormal termination)
+         per service identifier for which event charging applies."
+    ::= { ggsnApnSacc2ServIdentStatsEntry 6 }
+
+ggsnApnSacc2ServIdentEventStartTrans    OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of start transaction events per service identifier for which event charging applies."
+    ::= { ggsnApnSacc2ServIdentStatsEntry 7 }
+
+ggsnApnSacc2ServIdentEventSuccessTrans	OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of successful transaction events per service identifier for which event charging applies."
+    ::= { ggsnApnSacc2ServIdentStatsEntry 8 }
+
+--
+-- GGSN APN service-based charging (SACC 2) SCID statistics
+--
+-- Per U PIC, per APN, per SCID
+--
+
+ggsnApnSacc2ServClassStatsTable	OBJECT-TYPE
+    SYNTAX                      SEQUENCE OF ApnSacc2ServClassStats
+    MAX-ACCESS                  not-accessible
+    STATUS                      deprecated
+    DESCRIPTION
+         "Service-based charging (SACC 2) service ID statistics for an APN."
+    ::= { ggsnFbcStats 17 }
+
+ggsnApnSacc2ServClassStatsEntry OBJECT-TYPE
+    SYNTAX                      ApnSacc2ServClassStats
+    MAX-ACCESS                  not-accessible
+    STATUS                      deprecated
+    DESCRIPTION
+        "A conceptual row listing the service-based charging (SACC 2) service class ID
+         statistics for each APN."
+    INDEX { ggsnGtpuIndex, ggsnApnIndex, ggsnSacc2ServClassIndex }
+    ::= { ggsnApnSacc2ServClassStatsTable 1 }
+
+ApnSacc2ServClassStats ::= SEQUENCE {
+    ggsnSacc2ServClassIndex		Unsigned32,
+    ggsnApnSacc2ServClassUplinkBytes    Counter64,
+    ggsnApnSacc2ServClassDownlinkBytes  Counter64,
+    ggsnApnSacc2ServClassActiveTime     Counter64
+}
+
+ggsnSacc2ServClassIndex		OBJECT-TYPE
+   SYNTAX                       Unsigned32
+   MAX-ACCESS                   not-accessible
+   STATUS                       deprecated
+   DESCRIPTION
+         "The service class ID for the statistics."
+   ::= { ggsnApnSacc2ServClassStatsEntry 1 }
+
+ggsnApnSacc2ServClassUplinkBytes        OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of uplink bytes marked with service class."
+    ::= { ggsnApnSacc2ServClassStatsEntry 2 }
+
+ggsnApnSacc2ServClassDownlinkBytes	OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of downlink bytes marked with service class."
+    ::= { ggsnApnSacc2ServClassStatsEntry 4 }
+
+ggsnApnSacc2ServClassActiveTime		OBJECT-TYPE
+    SYNTAX                              Counter64
+    MAX-ACCESS                          read-only
+    STATUS                              deprecated
+    DESCRIPTION
+        "Number of seconds measured for active time for service class."
+    ::= { ggsnApnSacc2ServClassStatsEntry 6 }
+
+--
+-- GGSN APN service-based charging (SACC 3) SID statistics
+--
+-- Per U PIC, per APN, per SID
+--
+
+ggsnApnSacc3ServIdentStatsTable 	OBJECT-TYPE
+    SYNTAX        			SEQUENCE OF ApnSacc3ServIdentStats
+    MAX-ACCESS    			not-accessible
+    STATUS        			deprecated
+    DESCRIPTION
+         "Service-based charging (SACC 3) service ID statistics for an APN."
+    ::= { ggsnFbcStats 18 }
+
+ggsnApnSacc3ServIdentStatsEntry		OBJECT-TYPE
+    SYNTAX				ApnSacc3ServIdentStats
+    MAX-ACCESS				not-accessible
+    STATUS				deprecated
+    DESCRIPTION
+	"A conceptual row listing the service-based charging (SACC 3) service ID
+	 statistics for each APN."
+    INDEX { ggsnGtpuIndex, ggsnApnIndex, ggsnSacc3ServIdentIndex }
+    ::= { ggsnApnSacc3ServIdentStatsTable 1 }
+
+ApnSacc3ServIdentStats ::= SEQUENCE {
+    ggsnSacc3ServIdentIndex			Unsigned32,
+    ggsnApnSacc3ServIdentUplinkBytes		Counter64,
+    ggsnApnSacc3ServIdentDownlinkBytes		Counter64
+}
+
+ggsnSacc3ServIdentIndex		OBJECT-TYPE
+   SYNTAX			Unsigned32
+   MAX-ACCESS			not-accessible
+   STATUS			deprecated
+   DESCRIPTION
+         "The service ID for SACC 3 statistics."
+   ::= { ggsnApnSacc3ServIdentStatsEntry 1 }
+
+ggsnApnSacc3ServIdentUplinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of uplink bytes marked with service data flow ID."
+    ::= { ggsnApnSacc3ServIdentStatsEntry 2 }
+
+ggsnApnSacc3ServIdentDownlinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of downlink bytes marked with service data flow ID."
+    ::= { ggsnApnSacc3ServIdentStatsEntry 4 }
+
+--
+-- GGSN APN service-based charging (SACC 3) Rating Group statistics
+--
+-- Per APN, per RG
+--
+
+ggsnApnSacc3RatingGroupStatsTable 	OBJECT-TYPE
+    SYNTAX        			SEQUENCE OF ApnSacc3RatingGroupStats
+    MAX-ACCESS    			not-accessible
+    STATUS        			deprecated
+    DESCRIPTION
+         "Service-based charging (SACC 3) rating group statistics for an APN."
+    ::= { ggsnFbcStats 19 }
+
+ggsnApnSacc3RatingGroupStatsEntry		OBJECT-TYPE
+    SYNTAX					ApnSacc3RatingGroupStats
+    MAX-ACCESS					not-accessible
+    STATUS					deprecated
+    DESCRIPTION
+	"A conceptual row listing the service-based charging (SACC 3) rating group statistics for each APN."
+    INDEX { ggsnApnIndex, ggsnRatingGroupIndex }
+    ::= { ggsnApnSacc3RatingGroupStatsTable 1 }
+
+ApnSacc3RatingGroupStats ::= SEQUENCE {
+    ggsnRatingGroupIndex			Unsigned32,
+    ggsnApnSacc3RatingGroupUplinkBytes		Counter64,
+    ggsnApnSacc3RatingGroupDownlinkBytes	Counter64
+}
+
+ggsnRatingGroupIndex		OBJECT-TYPE
+   SYNTAX			Unsigned32
+   MAX-ACCESS			not-accessible
+   STATUS			deprecated
+   DESCRIPTION
+         "The rating group for the statistics."
+   ::= { ggsnApnSacc3RatingGroupStatsEntry 1 }
+
+ggsnApnSacc3RatingGroupUplinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of uplink bytes marked with rating group."
+    ::= { ggsnApnSacc3RatingGroupStatsEntry 2 }
+
+ggsnApnSacc3RatingGroupDownlinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS				read-only
+    STATUS				deprecated
+    DESCRIPTION
+	"Number of downlink bytes marked with rating group."
+    ::= { ggsnApnSacc3RatingGroupStatsEntry 3 }
+
+--
+-- GGSN APN service-based charging (SACC 3) Rating Group statistics
+--
+-- Per U PIC, APN, per RG
+--
+
+pgwApnSaccRatingGroupStatsTable 	OBJECT-TYPE
+    SYNTAX        			SEQUENCE OF pgwApnSaccRatingGroupStats
+    MAX-ACCESS    			not-accessible
+    STATUS        			current
+    DESCRIPTION
+    "Rating group statistics per APN."
+    ::= { ggsnFbcStats 20 }
+
+pgwApnSaccRatingGroupStatsEntry		OBJECT-TYPE
+    SYNTAX					pgwApnSaccRatingGroupStats
+    MAX-ACCESS				not-accessible
+    STATUS					current
+    DESCRIPTION
+    "Rating group statistics per APN."
+    INDEX { ggsnGtpuIndex, ggsnApnIndex, pgwRatingGroupIndex }
+    ::= { pgwApnSaccRatingGroupStatsTable 1 }
+    
+pgwApnSaccRatingGroupStats ::= SEQUENCE {
+    pgwRatingGroupIndex			Unsigned32,
+    pgwApnSaccRatingGroupUplinkBytes	Counter64,
+    pgwApnSaccRatingGroupDownlinkBytes	Counter64
+}
+
+pgwRatingGroupIndex	OBJECT-TYPE
+    SYNTAX			Unsigned32
+    MAX-ACCESS		not-accessible
+    STATUS			current
+    DESCRIPTION
+    "The rating group identifier."
+    ::= { pgwApnSaccRatingGroupStatsEntry 1 }
+
+pgwApnSaccRatingGroupUplinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS			read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of uplink bytes on rating group per APN."
+    ::= { pgwApnSaccRatingGroupStatsEntry 2 }
+
+pgwApnSaccRatingGroupDownlinkBytes	OBJECT-TYPE
+    SYNTAX				Counter64
+    MAX-ACCESS			read-only
+    STATUS				current
+    DESCRIPTION
+    "The number of downlink bytes on rating group per APN."
+    ::= { pgwApnSaccRatingGroupStatsEntry 3 }
+
+--
+-- MBMS information group
+--
+
+ggsnMbmsGmbSessionStartAttempts  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of MBMS activation procedures initiated on this GGSN"
+   ::= { ggsnMbmsInfo 1 }
+
+ggsnMbmsGmbSessionStartFailures  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed MBMS activation procedures initiated on this GGSN."
+   ::= { ggsnMbmsInfo 2 }
+
+ggsnMbmsCurrentNbrOfSessions  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of active MBMS sessions on this GGSN."
+   ::= { ggsnMbmsInfo 3 }
+
+ggsnMbmsCurrentAggregatedMbr  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The aggregated maximum bitrate for MBMS sessions on this GGSN."
+   ::= { ggsnMbmsInfo 4 }
+
+ggsnMbmsGiIncomingPackets  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total downlink MBMS packets processed by this GGSN."
+   ::= { ggsnMbmsInfo 5 }
+
+ggsnMbmsDiscardedPackets  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total Downlink MBMS packets dropped by this GGSN"
+   ::= { ggsnMbmsInfo 6 }
+
+ggsnMbmsSgsnUserPlaneTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MbmsSgsnUStats
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "A table listing MBMS payload statistics for all SGSNs with
+          which this GGSN communicates."
+   ::= { ggsnMbmsInfo 7 }
+
+ggsnMbmsSgsnUserPlaneEntry OBJECT-TYPE
+   SYNTAX        MbmsSgsnUStats
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "A conceptual row listing the MBMS payload statistics for each
+          SGSN with which this GGSN communicates."
+   INDEX        { ggsnMbmsSgsnUIndex }
+   ::= { ggsnMbmsSgsnUserPlaneTable 1 }
+
+MbmsSgsnUStats ::= SEQUENCE {
+    ggsnMbmsSgsnUIndex		Integer32,
+    ggsnMbmsSgsnUAddress		IpAddress,
+    ggsnMbmsSgsnForwardedPackets	Counter64
+}
+
+ggsnMbmsSgsnUIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        deprecated
+   DESCRIPTION
+         "A number representing each SGSN whose statistics
+          is being generated."
+   ::= { ggsnMbmsSgsnUserPlaneEntry 1 }
+
+ggsnMbmsSgsnUAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "The IP address of the SGSN whose statistics
+          is being generated."
+   ::= { ggsnMbmsSgsnUserPlaneEntry 2 }
+
+ggsnMbmsSgsnForwardedPackets  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        deprecated
+   DESCRIPTION
+         "Total outgoing MBMS data packets processed on a per SGSN"
+   ::= { ggsnMbmsSgsnUserPlaneEntry 3 }
+
+
+ggsnMbmsSgsnControlPlaneTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MbmsSgsnCStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing MBMS signaling statistics for all SGSNs with
+          which this GGSN communicates."
+   ::= { ggsnMbmsInfo 8 }
+
+ggsnMbmsSgsnControlPlaneEntry OBJECT-TYPE
+   SYNTAX        MbmsSgsnCStats
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A conceptual row listing the MBMS signaling statistics for each
+          SGSN with which this GGSN communicates."
+   INDEX        { ggsnMbmsSgsnCIndex }
+   ::= { ggsnMbmsSgsnControlPlaneTable 1 }
+
+MbmsSgsnCStats ::= SEQUENCE {
+    ggsnMbmsSgsnCIndex		Integer32,
+    ggsnMbmsSgsnCAddress		IpAddress,
+    ggsnMbmsGnSessionStartAttempts	Counter64,
+    ggsnMbmsGnSessionStartFailures	Counter64
+}
+
+ggsnMbmsSgsnCIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A number representing each SGSN whose statistics
+          is being generated."
+   ::= { ggsnMbmsSgsnControlPlaneEntry 1 }
+
+ggsnMbmsSgsnCAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The IP address of the SGSN whose statistics
+          is being generated."
+   ::= { ggsnMbmsSgsnControlPlaneEntry 2 }
+
+ggsnMbmsGnSessionStartAttempts  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of MBMS activation procedures initiated per SGSN."
+   ::= { ggsnMbmsSgsnControlPlaneEntry 3 }
+
+ggsnMbmsGnSessionStartFailures  OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of failed MBMS activation procedures initiated per SGSN."
+   ::= { ggsnMbmsSgsnControlPlaneEntry 4 }
+
+--
+-- Alarm information group
+--
+
+PerceivedSeverity ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+       "Perceived severity of an event or alarm."
+   SYNTAX      INTEGER {
+       unknown       (1),
+       critical      (2),
+       major         (3),
+       minor         (4),
+       warning       (5),
+       cleared       (6),
+       informational (7)
+   }
+
+ggsnAlarmNumber  OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total number of active alarms, that is, the total number
+          of entries in the alarm table"
+   ::= { ggsnAlarmInfo 1 }
+
+ggsnAlarmCriticalNumber OBJECT-TYPE
+   SYNTAX       Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total number of critical alarms."
+   ::= { ggsnAlarmInfo 2 }
+
+ggsnAlarmMajorNumber OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total number of major alarms."
+   ::= { ggsnAlarmInfo 3 }
+
+ggsnAlarmMinorNumber OBJECT-TYPE
+   SYNTAX       Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total number of minor alarms."
+   ::= { ggsnAlarmInfo 4 }
+
+ggsnAlarmWarningNumber OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total number of warnings."
+   ::= { ggsnAlarmInfo 5 }
+
+ggsnAlarmUnknownNumber OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "Total number of unknown alarms."
+   ::= { ggsnAlarmInfo 6 }
+
+ggsnAlarmTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF GgsnAlarm
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the current active alarms in the
+          system."
+   ::= { ggsnAlarmInfo 7 }
+
+ggsnAlarmEntry OBJECT-TYPE
+   SYNTAX        GgsnAlarm
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table entry holding one current alarm."
+   INDEX         { ggsnAlarmId }
+   ::= { ggsnAlarmTable 1 }
+
+GgsnAlarm ::= SEQUENCE {
+   ggsnAlarmId             Integer32,
+   ggsnAlarmName           DisplayString,
+   ggsnAlarmTime           TimeStamp,
+   ggsnAlarmSourceId       DisplayString,
+   ggsnAlarmObjectClass    DisplayString,
+   ggsnAlarmObjectInstance DisplayString,
+   ggsnAlarmSeverity       PerceivedSeverity,
+   ggsnAlarmDescription    DisplayString
+}
+
+ggsnAlarmId OBJECT-TYPE
+   SYNTAX        Integer32 (1..2147483647)
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "A number uniquely identifying each event or alarm
+          in the Alarm Table."
+   ::= { ggsnAlarmEntry 1 }
+
+ggsnAlarmName OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The name of the event or alarm."
+   ::= { ggsnAlarmEntry 2 }
+
+ggsnAlarmTime OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The value of sysUpTime when the event or alarm was sent."
+   ::= { ggsnAlarmEntry 3 }
+
+ggsnAlarmSourceId OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The name of the event or alarm's originator."
+   ::= { ggsnAlarmEntry 4 }
+
+ggsnAlarmObjectClass OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The class of the network resources associated
+          with the event or alarm."
+   ::= { ggsnAlarmEntry 5 }
+
+ggsnAlarmObjectInstance OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The instance (of a class) of the network resource
+          associated with the event or alarm."
+   ::= { ggsnAlarmEntry 6 }
+
+ggsnAlarmSeverity OBJECT-TYPE
+   SYNTAX        PerceivedSeverity
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The perceived severity of the event. The value
+          unknown (0) is not recommended to be used."
+   ::= { ggsnAlarmEntry 7 }
+
+ggsnAlarmDescription OBJECT-TYPE
+   SYNTAX        DisplayString
+   MAX-ACCESS     read-only
+   STATUS        current
+   DESCRIPTION
+         "A short textual explanation of the event or
+          alarm instance."
+   ::= { ggsnAlarmEntry 8 }
+
+
+--
+-- Alarm History
+--
+
+
+AlarmEventCause ::= TEXTUAL-CONVENTION
+    STATUS      	current
+    DESCRIPTION
+	"Cause for the alarm event appearing in the alarm history table."
+    SYNTAX      INTEGER {
+	new		(1),
+	changed		(2),
+	cleared		(3),
+	notification	(4),
+	mibcleared	(5),
+	usercleared	(6)
+    }
+
+ggsnAlarmHistTable 			OBJECT-TYPE
+    SYNTAX        			SEQUENCE OF GgsnAlarmHistEntry
+    MAX-ACCESS    			not-accessible
+    STATUS        			current
+    DESCRIPTION
+	"The alarm history table is a limited size table
+	that contains recent alarms and alarm events.
+
+	A number of events cause an entry to be added to the
+	alarm history table:
+
+	'new'          - a trap was sent and an alarm added to the alarm
+	                 table
+	'changed'      - an existing alarm was updated and a changed trap sent
+	'cleared'      - an existing alarm was removed and a clear trap sent
+	'notification' - only a trap was sent
+	'mibcleared'   - the entire MIB statistics were cleared
+	'usercleared'  - a user requested a clear of the alarm history table
+
+	Only a fixed maximum of alarm events are stored in
+	this table at once and events are aged out of this
+	table over time. "
+    ::= { ggsnAlarmInfo 8 }
+
+ggsnAlarmHistEntry OBJECT-TYPE
+    SYNTAX        			GgsnAlarmHistEntry
+    MAX-ACCESS    			not-accessible
+    STATUS        			current
+    DESCRIPTION
+	"A table entry holding one alarm history event."
+    INDEX         		{ ggsnAlarmHistTime }
+    ::= { ggsnAlarmHistTable 1 }
+
+GgsnAlarmHistEntry ::= SEQUENCE {
+    ggsnAlarmHistTime    		TimeStamp,
+    ggsnAlarmHistEventCause 		AlarmEventCause,
+    ggsnAlarmHistAlarmId    	   	Integer32,
+    ggsnAlarmHistAlarmName          	DisplayString,
+    ggsnAlarmHistAlarmTime          	TimeStamp,
+    ggsnAlarmHistAlarmSourceId      	DisplayString,
+    ggsnAlarmHistAlarmObjInstance	DisplayString,
+    ggsnAlarmHistAlarmSeverity      	PerceivedSeverity,
+    ggsnAlarmHistAlarmDescription   	DisplayString
+}
+
+ggsnAlarmHistTime			OBJECT-TYPE
+    SYNTAX        			TimeStamp
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+     "The value of sysUpTime when the alarm event occurred."
+    ::= { ggsnAlarmHistEntry 1 }
+
+ggsnAlarmHistEventCause			OBJECT-TYPE
+    SYNTAX        			AlarmEventCause
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"The event documented by this alarm history event entry."
+    ::= { ggsnAlarmHistEntry 2 }
+
+ggsnAlarmHistAlarmId 			OBJECT-TYPE
+    SYNTAX        			Integer32 (1..2147483647)
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"A number uniquely identifying each event or alarm
+	in the Alarm Table."
+    ::= { ggsnAlarmHistEntry 3 }
+
+ggsnAlarmHistAlarmName 			OBJECT-TYPE
+    SYNTAX        			DisplayString
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"The name of the event or alarm."
+    ::= { ggsnAlarmHistEntry 4 }
+
+ggsnAlarmHistAlarmTime 			OBJECT-TYPE
+    SYNTAX        			TimeStamp
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"The value of sysUpTime when the event or alarm was sent."
+    ::= { ggsnAlarmHistEntry 5 }
+
+ggsnAlarmHistAlarmSourceId 		OBJECT-TYPE
+    SYNTAX        			DisplayString
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"The name of the event or alarm's originator."
+    ::= { ggsnAlarmHistEntry 6 }
+
+ggsnAlarmHistAlarmObjInstance 		OBJECT-TYPE
+    SYNTAX        			DisplayString
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"The instance (of a class) of the network resource
+	    associated with the event or alarm."
+    ::= { ggsnAlarmHistEntry 7 }
+
+ggsnAlarmHistAlarmSeverity 		OBJECT-TYPE
+    SYNTAX        			PerceivedSeverity
+    MAX-ACCESS    			read-only
+    STATUS        			current
+    DESCRIPTION
+	"The perceived severity of the event. The value
+	unknown (0) is not recommended to be used."
+    ::= { ggsnAlarmHistEntry 8 }
+
+ggsnAlarmHistAlarmDescription 		OBJECT-TYPE
+    SYNTAX        			DisplayString
+    MAX-ACCESS     			read-only
+    STATUS        			current
+    DESCRIPTION
+	"A short textual explanation of the event or
+	alarm instance."
+    ::= { ggsnAlarmHistEntry 9 }
+
+
+
+--
+-- GGSN enterprise traps
+--
+
+
+ggsnTrapNew NOTIFICATION-TYPE
+   OBJECTS { ggsnAlarmId,
+             ggsnAlarmName,
+             ggsnAlarmTime,
+             ggsnAlarmSourceId,
+             ggsnAlarmObjectClass,
+             ggsnAlarmObjectInstance,
+             ggsnAlarmSeverity,
+             ggsnAlarmDescription }
+   STATUS    current
+   DESCRIPTION
+         "A trap describing the newly generated event or
+          alarm. The text in ggsnTrapDescription indicates
+          the nature of the problem."
+   ::= { ggsnTraps 1 }
+
+ggsnTrapChanged NOTIFICATION-TYPE
+   OBJECTS { ggsnAlarmId,
+             ggsnAlarmName,
+             ggsnAlarmTime,
+             ggsnAlarmSourceId,
+             ggsnAlarmObjectClass,
+             ggsnAlarmObjectInstance,
+             ggsnAlarmSeverity,
+             ggsnAlarmDescription }
+   STATUS    current
+   DESCRIPTION
+         "A trap indicating a change has occurred in the attributes of the alarm or event. 
+          The text in ggsnTrapDescription indicates the nature of the change."
+   ::= { ggsnTraps 2 }
+
+ggsnTrapCleared NOTIFICATION-TYPE
+   OBJECTS { ggsnAlarmId,
+             ggsnAlarmName,
+             ggsnAlarmTime,
+             ggsnAlarmSourceId,
+             ggsnAlarmObjectClass,
+             ggsnAlarmObjectInstance,
+             ggsnAlarmSeverity,
+             ggsnAlarmDescription }
+   STATUS    current
+   DESCRIPTION
+         "A trap indicating the clear of the event or alarm."
+   ::= { ggsnTraps 3 }
+
+
+--
+-- Conformance information
+--
+
+ggsnMIBConformance
+         OBJECT IDENTIFIER ::= { ggsnMibs 2 }
+ggsnMIBCompliances
+         OBJECT IDENTIFIER ::= { ggsnMIBConformance 1 }
+ggsnMIBGroups
+         OBJECT IDENTIFIER ::= { ggsnMIBConformance 2 }
+
+
+-- Compliance statements
+
+ggsnMIBCompliance MODULE-COMPLIANCE
+   STATUS        current
+   DESCRIPTION
+         "The compliance statement for the box implementing
+          the ggsn MIB."
+   MODULE -- this module
+   MANDATORY-GROUPS {
+	ggsnSystemGroup,
+	ggsnGlobalStatisticsGroup,
+	ggsnApnStatisticsGroup,
+	ggsnSgsnStatisticsGroup,
+	ggsnAcctClientStatisticsGroup,
+	ggsnDhcpStatisticsGroup,
+	ggsnAlarmsGroup,
+	ggsnAlarmsEntryGroup,
+	ggsnNotificationsGroup,
+	ggsnAlarmHistEntryGroup,
+	ggsnApnFbcStatisticsGroup,
+	ggsnFbcAuthStatisticsGroup,
+	ggsnApnFbcServIdentStatsGroup,
+	ggsnApnFbcServClassStatsGroup,
+    ggsnApnSacc2ServIdentStatsGroup,
+    ggsnApnSacc2ServClassStatsGroup,
+    ggsnApnSacc3ServIdentStatsGroup,
+	ggsnApnSacc3RatingGroupStatsGroup,
+	ggsnFbcStatsGroup,
+	pgwApnSaccRatingGroupStatsGroup
+   }
+   ::= { ggsnMIBCompliances 1 }
+
+
+-- Unit of conformance
+
+ggsnSystemGroup OBJECT-GROUP
+   OBJECTS { ggsnVersion,
+             ggsnInstalled,
+             ggsnGtpcVersion,
+             ggsnGtpcAddress,
+             ggsnGtpcPdpCapacity,
+             ggsnGtpcRole,
+             ggsnGtpcStatus,
+             ggsnGtpcControlPacketDrops,
+             ggsnGtpcNbrOfActivePdpContexts,
+             ggsnGtpcMemory,
+             ggsnGtpcMemoryUsed,
+             ggsnGtpcCpuUsage,
+             ggsnGtpcTftFilterDepthMax,
+             ggsnGtpcTftFilterDepthMean,
+             ggsnGtpcControlLoad,
+             ggsnGtpuVersion,
+             ggsnGtpuAddress,
+             ggsnGtpuPdpCapacity,
+             ggsnGtpuRole,
+             ggsnGtpuStatus,
+             ggsnGtpuUserUplinkDrops,
+             ggsnGtpuUserDownlinkDrops,
+             ggsnGtpuNbrOfActivePdpContexts,
+             ggsnGtpuMemory,
+             ggsnGtpuMemoryUsed,
+             ggsnGtpuCpuUsage,
+             ggsnGtpuPayloadLoad,
+             ggsnGtpuNbrOfActivePdpContextsIpv6,
+             ggsnGtpuNbrOfActivePdpContextsIpv4v6,
+             ggsnGtpcNbrOfActivePdpContextsIpv6,
+             ggsnGtpcNbrOfActivePdpContextsIpv4v6,
+			 ggsnGtpuUplinkPackets,
+			 ggsnGtpuDownlinkPackets
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing system
+          management of the ggsn application."
+   ::= { ggsnMIBGroups 1 }
+
+ggsnGlobalStatisticsGroup OBJECT-GROUP
+   OBJECTS { 	ggsnStatReportTime,
+		ggsnNbrOfActivePdpContexts,
+		ggsnNbrOfSubscribers,
+		ggsnNbrOfSubscribersMean,
+		ggsnNbrOfTftFilters,
+		ggsnControlLoad,
+		ggsnPayloadLoad,
+		ggsnAttemptedActivation,
+		ggsnAttemptedDeactivation,
+		ggsnAttemptedSelfDeactivation,
+		ggsnAttemptedUpdate,
+		ggsnAttemptedManualDeactivation,
+		ggsnAttemptedSecondaryActivation,
+		ggsnCompletedActivation,
+		ggsnCompletedDeactivation,
+		ggsnCompletedSelfDeactivation,
+		ggsnCompletedUpdate,
+		ggsnIdleTimeoutDeactivation,
+		ggsnCompletedManualDeactivation,
+		ggsnCompletedSecondaryActivation,
+	        ggsnSessionTimeoutDeactivation,
+		ggsnFailedActivation,
+		ggsnGtpUplinkPackets,
+		ggsnGtpUplinkBytes,
+		ggsnGtpDownlinkPackets,
+		ggsnGtpDownlinkBytes,
+		ggsnGtpControlPacketDrops,
+		ggsnGtpVerUnsupPacketsReceived,
+		ggsnGtpVerUnsupPacketsSent,
+		ggsnGtpEchoReqReceived,
+		ggsnGtpEchoReqSent,
+		ggsnGtpEchoRespReceived,
+		ggsnGtpEchoRespSent,
+		ggsnGtpPdpCreateReqReceived,
+                ggsnGtpv0PdpCreateReqReceived,
+		ggsnGtpPdpCreateRespSent,
+		ggsnGtpPdpUpdateReqReceived,
+		ggsnGtpPdpUpdateReqSent,
+		ggsnGtpPdpUpdateRespReceived,
+		ggsnGtpPdpUpdateRespSent,
+		ggsnGtpPdpDeleteReqReceived,
+		ggsnGtpPdpDeleteReqSent,
+		ggsnGtpPdpDeleteRespReceived,
+		ggsnGtpPdpDeleteRespSent,
+		ggsnGtpPdpInitiateContextActivationRespReceived,
+		ggsnGtpPdpInitiateContextActivationReqSent,
+		ggsnGtpRequestsAccepted,
+		ggsnGtpNbrOfTunnels,
+		ggsnGtpNbrOfCreatedTunnels,
+		ggsnGtpErrorIndicationReceived,
+		ggsnGtpErrorIndicationSent,
+		ggsnGtpErrorInvalidRequestFormat,
+		ggsnGtpErrorResourcesUnavailable,
+		ggsnGtpErrorDynAddrUnavailable,
+		ggsnGtpErrorMemoryUnavailable,
+		ggsnGtpErrorApnUnknown,
+		ggsnGtpErrorPdpAddrUnknown,
+		ggsnGtpErrorAuthenticationFailed,
+		ggsnGtpErrorSystemFailure,
+		ggsnGtpErrorTftSemanticError,
+		ggsnGtpErrorTftSyntaxError,
+		ggsnGtpErrorPackFiltSemantError,
+		ggsnGtpErrorPackFiltSyntaxError,
+		ggsnGtpErrorMandatoryIEMissing,
+		ggsnGtpErrorMandatoryIEInvalid,
+		ggsnGtpErrorOptionalIEInvalid,
+		ggsnGtpErrorReferenceInexistent,
+		ggsnGtpErrorServiceUnsupported,
+		ggsnGtpPrEchoReqReceived,
+		ggsnGtpPrEchoRequestsSent,
+		ggsnGtpPrEchoRespReceived,
+		ggsnGtpPrEchoRespSent,
+		ggsnGtpPrVerUnsupPacketsReceived,
+		ggsnGtpPrVerUnsupPacketsSent,
+		ggsnGtpPrNodeAliveReqReceived,
+		ggsnGtpPrNodeAliveReqSent,
+		ggsnGtpPrNodeAliveRespReceived,
+		ggsnGtpPrNodeAliveRespSent,
+		ggsnGtpPrRedirectReqReceived,
+		ggsnGtpPrRedirectReqSent,
+		ggsnGtpPrRedirectRespReceived,
+		ggsnGtpPrRedirectRespSent,
+		ggsnGtpPrDataRecTransferReceived,
+		ggsnGtpPrDataRecTransferSent,
+		ggsnGtpPrSndDataRecordPackets,
+		ggsnGtpPrRequestAccepted,
+		ggsnGtpPrNoResource,
+		ggsnGtpPrServiceUnsupported,
+		ggsnGtpPrSystemFailure,
+		ggsnGtpPrInvalidMessageFormat,
+		ggsnGtpPrVersionUnsupported,
+		ggsnGtpPrRequestUnfulfilled,
+		ggsnGtpPrDecodingError,
+		ggsnGtpPrAlreadyFulfilled,
+		ggsnGtpPrDupPacketFulfilled,
+		ggsnGtpPrErrorMandatoryIEMissing,
+		ggsnGtpPrErrorMandatoryIEInvalid,
+		ggsnGtpPrErrorOptionalIEInvalid,
+		ggsnGtpPrErrorRefInexistent,
+		ggsnUplinkPackets,
+		ggsnUplinkBytes,
+		ggsnUplinkDrops,
+		ggsnUplinkDropsBytes,
+		ggsnDownlinkPackets,
+		ggsnDownlinkBytes,
+		ggsnDownlinkDrops,
+		ggsnDownlinkDropsBytes,
+		ggsnNbrOfActivePdpContextsIpv6,
+		ggsnAttemptedActivationIpv6,
+		ggsnAttemptedSecondaryActivationIpv6,
+		ggsnCompletedActivationIpv6,
+		ggsnCompletedSecondaryActivationIpv6,
+		ggsnUplinkPacketsIpv6,
+		ggsnUplinkBytesIpv6,
+		ggsnUplinkDropsIpv6,
+		ggsnDownlinkPacketsIpv6,
+		ggsnDownlinkBytesIpv6,
+		ggsnDownlinkDropsIpv6,
+		ggsnNbrOfActivePdpContextsWlan,
+		ggsnAttemptedActivationWlan,
+		ggsnCompletedActivationWlan,
+		ggsnAttemptedActivationConversational,
+		ggsnAttemptedActivationStreaming,
+ 		ggsnAttemptedActivationInteractive,
+		ggsnAttemptedActivationBackground,
+		ggsnAttemptedActivationDiscarded,
+		ggsnCompletedActivationConversational,
+		ggsnCompletedActivationStreaming,
+		ggsnCompletedActivationInteractive,
+		ggsnCompletedActivationBackground,
+		ggsnAttemptedActivationIpv4v6,
+		ggsnCompletedActivationIpv4v6,
+		ggsnUplinkBytesWlan,
+		ggsnUplinkDropsWlan,
+		ggsnUplinkPacketsWlan,
+		ggsnDownlinkBytesWlan,
+		ggsnDownlinkDropsWlan,
+		ggsnDownlinkPacketsWlan,
+		ggsnNeighborSolicitationRcv,
+		ggsnNeighborSolicitationRsp,
+		ggsnRouterSolicitationRcv,
+		ggsnRouterSolicitationRsp,
+		ggsnL2tpActiveTunnels,
+		ggsnL2tpMaxActiveTunnels,
+		ggsnL2tpActiveSessions,
+		ggsnL2tpMaxActiveSessions,
+		ggsnChgEncodedCdrs,
+		ggsnChgFailedEncodedCdrs,
+		ggsnChgGeneratedFtpCdrs,
+		ggsnChgGeneratedGtppCdrs,
+		ggsnChgGtppLogCdrs,
+		ggsnChgGtppAttemptedCdrsSend,
+		ggsnChgGtppCdrsSendFailure,
+		ggsnNbActivePdpPerTrafficClassConversational,
+		ggsnNbActivePdpPerTrafficClassStreaming,
+		ggsnNbActivePdpPerTrafficClassInteractive,
+		ggsnNbActivePdpPerTrafficClassBackground,
+		ggsnRadiusAuthenticationFailure,
+        ggsnRadiusAccountingFailure,
+        ggsn3gdtActiveContexts,
+        ggsn3gdtTotalCompletedEstablishment,
+        ggsn3gdtTotalAttemptedEstablishment,
+        ggsn3gdtErrorHandling,
+        gn3gdtTotalCompletedEstablishment,
+	    gn3gdtTotalAttemptedEstablishment,
+	    gn3gdtErrorHandling,
+        ggsnNbrOfActivePdpContextsIpv4v6
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing global
+          measurements for the ggsn node."
+   ::= { ggsnMIBGroups 2 }
+
+ggsnApnStatisticsGroup OBJECT-GROUP
+   OBJECTS { ggsnApnName,
+             ggsnApnActivePdpContextCount,
+             ggsnApnAttemptedActivation,
+             ggsnApnAttemptedDynActivation,
+             ggsnApnAttemptedDeactivation,
+             ggsnApnAttemptedSelfDeactivation,
+             ggsnApnCompletedActivation,
+             ggsnApnCompletedDynActivation,
+             ggsnApnCompletedDeactivation,
+             ggsnApnCompletedSelfDeactivation,
+             ggsnApnAvailableIpAddressesInInternalPool,
+             ggsnApnIpAddressesInQuarantineInInternalPool,
+             ggsnApnUplinkPackets,
+             ggsnApnUplinkBytes,
+             ggsnApnUplinkDrops,
+             ggsnApnDownlinkPackets,
+             ggsnApnDownlinkBytes,
+             ggsnApnDownlinkDrops,
+             ggsnApnAttemptedMSActivation,
+             ggsnApnCompletedMSActivation,
+             ggsnApnAttemptedMSDeactivation,
+             ggsnApnCompletedMSDeactivation,
+             ggsnApnActivePdpContextMax,
+             ggsnApnActivePdpContextMean,
+             ggsnApnAttemptedAuthActivation,
+             ggsnApnFailedAuthActivation,
+             ggsnApnAttemptedUpdateMsAndSgsn,
+             ggsnApnCompletedUpdateMsAndSgsn,
+             ggsnApnNbrOfTftFilters,
+             ggsnApnSessTimeoutDeactivation,
+             ggsnApnIdleTimeoutDeactivation,
+             ggsnApnGiSignalingInPackets,
+             ggsnApnGiSignalingInBytes,
+             ggsnApnGiSignalingOutPackets,
+             ggsnApnGiSignalingOutBytes,
+	         ggsnApnActivePdpContextCountIpv6,
+	         ggsnApnAttemptedActivationIpv6,
+	         ggsnApnCompletedActivationIpv6,
+	         ggsnApnUplinkPacketsIpv6,
+             ggsnApnUplinkBytesIpv6,
+             ggsnApnUplinkDropsIpv6,
+	         ggsnApnDownlinkPacketsIpv6,
+             ggsnApnDownlinkBytesIpv6,
+             ggsnApnDownlinkDropsIpv6,
+	         ggsnApnNeighborSolicitationRcv,
+             ggsnApnNeighborSolicitationRsp,
+	         ggsnApnRouterSolicitationRcv,
+             ggsnApnRouterSolicitationRsp,
+             ggsnNbApnActivePdpPerTrafficClassConversational,
+             ggsnNbApnActivePdpPerTrafficClassStreaming,
+             ggsnNbApnActivePdpPerTrafficClassInteractive,
+             ggsnNbApnActivePdpPerTrafficClassBackground,
+             ggsnApnImsDedicatedCompletedActivation,
+             ggsnApnImsDedicatedNotConfiguredActivationFailed,
+             ggsnApnImsGeneralPurposeCompletedActivation,
+             ggsnApnImsGeneralNotConfiguredActivationFailed,
+             ggsnApnActivationFailedDuetoGeneralPurposeNotConfigured,
+             ggsnApnUnauthorizedImsPackets,
+             ggsnApnRadiusAccountingFailure,
+             ggsnApnRadiusAuthenticationFailure,
+             ggsnApnSaccRsInstalledDynRules,
+             ggsnApnSaccRsActivePredefinedChargingRules,
+             ggsnApnSaccRsActivePredefinedChargingRuleBases,
+             ggsnApn3gdtActiveContexts,
+             ggsnApn3gdtTotalCompletedEstablishment,
+             ggsnApn3gdtTotalAttemptedEstablishment,
+             ggsnApn3gdtErrorHandling,
+             ggsnApnAttemptedUpdateGgsn,
+             ggsnApnCompletedUpdateGgsn,
+             ggsnApnAttemptedActivationNonDuplicated,
+             ggsnApnActivePdpContextMaxDuringLastPeriod,
+             pgwApnActiveEpsBearer,
+             pgwApnActiveIpv6EpsBearer,
+             pgwApnAttemptedEpsBearerActivation,
+             pgwApnCompletedEpsBearerActivation,
+             pgwApnAttemptedIpv6EpsBearerActivation,
+             pgwApnCompletedIpv6EpsBearerActivation,
+             pgwApnAttemptedEpsBearerDeactivation,
+             pgwApnCompletedEpsBearerDeactivation,
+             pgwApnAttemptedS5NetworkDeactivation,
+             pgwApnCompletedS5NetworkDeactivation,
+             pgwApnAttemptedS5UeSgwModification,
+             pgwApnCompletedS5UeSgwModification,
+             pgwApnAttemptedS5SgwSgsnModification,
+             pgwApnCompletedS5SgwSgsnModification,
+             pgwApnAttemptedS5SgsnSgwModification,
+             pgwApnCompletedS5SgsnSgwModification,
+             pgwApnAttemptedS5NetworkModification,
+             pgwApnCompletedS5NetworkModification,
+             pgwApnAttemptedS5UeSgwDeactivation,
+             pgwApnCompletedS5UeSgwDeactivation,
+             gnApnUplinkPackets,
+             gnApnUplinkBytes,
+             gnApnUplinkPacketsIpv6,
+             gnApnUplinkBytesIpv6,
+             gnApnDownlinkPackets,
+             gnApnDownlinkBytes,
+             gnApnDownlinkPacketsIpv6,
+             gnApnDownlinkBytesIpv6,
+             s5ApnUplinkPackets,
+             s5ApnUplinkBytes,
+             s5ApnUplinkPacketsIpv6,
+             s5ApnUplinkBytesIpv6,
+             s5ApnDownlinkPackets,
+             s5ApnDownlinkBytes,
+             s5ApnDownlinkPacketsIpv6,
+             s5ApnDownlinkBytesIpv6,
+             gnApn3gdtUplinkBytes,
+             gnApn3gdtUplinkBytesIpv6,
+             gnApn3gdtUplinkPackets,
+             gnApn3gdtUplinkPacketsIpv6,
+             gnApn3gdtDownlinkBytes,
+             gnApn3gdtDownlinkBytesIpv6,
+             gnApn3gdtDownlinkPackets,
+             gnApn3gdtDownlinkPacketsIpv6,
+             gnApn3gdtDownlinkDropsErrorHandling,
+             ggsnApn3gdtGtpError,
+             pgwApnActiveDedicatedEpsBearer,
+	         pgwApnAttemptedDedicatedEpsBearerActivation,  
+		     pgwApnCompletedDedicatedEpsBearerActivation,  
+		     pgwApnAttemptedIpv6DedicatedEpsBearerActivation,  
+		     pgwApnCompletedIpv6DedicatedEpsBearerActivation,  
+		     pgwApnAttemptedS5NetworkDedicatedEpsBearerDeactivation, 
+		     pgwApnCompletedS5NetworkDedicatedEpsBearerDeactivation,  
+		     pgwApnAttemptedS5NetworkDedicatedEpsBearerModification,  
+		     pgwApnCompletedS5NetworkDedicatedEpsBearerModification,  
+		     pgwApnAttemptedS5UeSgwDedicatedEpsBearerDeactivation,  
+		     pgwApnCompletedS5UeSgwDedicatedEpsBearerDeactivation,
+             ggsnApnActivePdpContextCountIpv4v6,
+             pgwApnActiveIpv4v6EpsBearer,
+             ggsnApnAttemptedActivationIpv4v6,
+             ggsnApnCompletedActivationIpv4v6,
+             pgwApnAttemptedIpv4v6EpsBearerActivation,
+             pgwApnCompletedIpv4v6EpsBearerActivation,
+             pgwApnActiveWlanEpsBearer,
+             s2aApnUplinkPackets,
+             s2aApnUplinkBytes,
+             s2aApnDownlinkPackets,
+             s2aApnDownlinkBytes,
+             s2aApnUplinkPacketsIpv6,
+             s2aApnUplinkBytesIpv6,
+             s2aApnDownlinkPacketsIpv6,
+             s2aApnDownlinkBytesIpv6
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing
+          measurements on a per APN of the ggsn node."
+   ::= { ggsnMIBGroups 3 }
+
+ggsnSgsnStatisticsGroup OBJECT-GROUP
+   OBJECTS { ggsnSgsnAddress,
+             ggsnSgsnUplinkPackets,
+             ggsnSgsnUplinkBytes,
+             ggsnSgsnUplinkDrops,
+             ggsnSgsnDownlinkPackets,
+             ggsnSgsnDownlinkBytes,
+             ggsnSgsnDownlinkDrops
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing
+          measurements on a per SGSN of the ggsn node."
+   ::= { ggsnMIBGroups 4 }
+
+ggsnAcctClientStatisticsGroup OBJECT-GROUP
+   OBJECTS { ggsnAcctPartialRecordGenerated,
+       	     ggsnAcctBillingGatewayIndex,
+             ggsnAcctBillingGatewayAddress,
+             ggsnAcctDataRecTransReqSent,
+             ggsnAcctDataRecTransReqSentDup,
+             ggsnAcctDataRecTransReqCancelled,
+             ggsnAcctDataRecTransRespReceived,
+             ggsnAcctRedirectionReqReceived,
+             ggsnAcctRedirectionRespSent
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing
+          measurements on a per Billing Gateway with
+          which the ggsn node communicates."
+   ::= { ggsnMIBGroups 5 }
+
+ggsnDhcpStatisticsGroup OBJECT-GROUP
+   OBJECTS { ggsnDhcpClientAddress,
+             ggsnDhcpServerAddress,
+             ggsnDhcpServerName,
+             ggsnDhcpClientYiaddr,
+             ggsnDhcpClientState,
+             ggsnDhcpClientRequestsSent,
+             ggsnDhcpClientRepliesReceived,
+             ggsnDhcpClientRepliesDiscarded,
+             ggsnDhcpClientDiscoversSent,
+             ggsnDhcpClientDeclinesSent,
+             ggsnDhcpClientReleasesSent,
+             ggsnDhcpClientOffersReceived,
+             ggsnDhcpClientAcksReceived,
+             ggsnDhcpClientNaksReceived,
+             ggsnDhcpClientSendErrors,
+             ggsnDhcpServerRoutingInstance
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing
+          measurements on a per DHCP server with
+          which the ggsn node communicates."
+   ::= { ggsnMIBGroups 6 }
+
+ggsnAlarmsGroup OBJECT-GROUP
+   OBJECTS { ggsnAlarmNumber,
+             ggsnAlarmCriticalNumber,
+             ggsnAlarmMajorNumber,
+             ggsnAlarmMinorNumber,
+             ggsnAlarmWarningNumber,
+             ggsnAlarmUnknownNumber
+   }
+   STATUS current
+   DESCRIPTION
+         "The alarms objects implemented for the GGSN node."
+   ::= {ggsnMIBGroups 7}
+
+ggsnAlarmsEntryGroup OBJECT-GROUP
+   OBJECTS { ggsnAlarmId,
+             ggsnAlarmName,
+             ggsnAlarmTime,
+             ggsnAlarmSourceId,
+             ggsnAlarmObjectClass,
+             ggsnAlarmObjectInstance,
+             ggsnAlarmSeverity,
+             ggsnAlarmDescription
+   }
+   STATUS current
+   DESCRIPTION
+         "The alarm entry objects implemented for the GGSN node."
+   ::= {ggsnMIBGroups 8}
+
+
+ggsnNotificationsGroup NOTIFICATION-GROUP
+   NOTIFICATIONS { ggsnTrapNew,
+                   ggsnTrapChanged,
+                   ggsnTrapCleared
+   }
+   STATUS current
+   DESCRIPTION
+         "The notifications which are implemented by the
+          GGSN node."
+   ::= {ggsnMIBGroups 9}
+
+
+ggsnAlarmHistEntryGroup OBJECT-GROUP
+   OBJECTS {
+	ggsnAlarmHistTime,
+	ggsnAlarmHistEventCause,
+	ggsnAlarmHistAlarmId,
+	ggsnAlarmHistAlarmName,
+	ggsnAlarmHistAlarmTime,
+	ggsnAlarmHistAlarmSourceId,
+	ggsnAlarmHistAlarmObjInstance,
+	ggsnAlarmHistAlarmSeverity,
+	ggsnAlarmHistAlarmDescription
+   }
+   STATUS current
+   DESCRIPTION
+   	"The alarm history objects implemented for the GGSN node."
+   ::= { ggsnMIBGroups 10 }
+
+
+-- { ggsnMIBGroups 11 } is not assigned
+
+ggsnOldObjectsGroup    OBJECT-GROUP
+    OBJECTS {
+	ggsnPicAddress,
+        ggsnPicNbrOfActivePdpContexts,
+	ggsnAttemptedTimeDeactivation,
+	ggsnFbcApplicationTransactionPps,
+	ggsnFbcApplicationTransactionPrs,
+	ggsnApnFbcInitialPrsReq,
+	ggsnApnFbcInitialPrsReqFailed,
+	ggsnApnFbcUpdPrsReq,
+	ggsnApnFbcUpdPrsReqFailed,
+	ggsnApnFbcStartCredReq,
+	ggsnApnFbcStartCredReqFailed,
+	ggsnApnFbcUpdCredReq,
+	ggsnApnFbcUpdCredReqFailed,
+	ggsnApnFbcStopCredReq,
+	ggsnApnFbcStopCredReqFailed
+    }
+    STATUS  deprecated
+    DESCRIPTION
+            "The collection of objects deprecated from
+             the original GGSN MIB."
+    ::= { ggsnMIBGroups 12 }
+
+ggsnApnFbcStatisticsGroup	OBJECT-GROUP
+   OBJECTS {
+	ggsnApnFbcNbrOfPpsUsers,
+	ggsnApnFbcNbrOfPpsPdpContexts,
+	ggsnApnFbcPpsCreate,
+	ggsnApnFbcPpsReject,
+	ggsnApnFbcInitiatedDeactivation,
+        ggsnApnFbcExtPrsUpd,
+	ggsnApnFbcExtCreditUpd,
+	ggsnApnFbcDurationTime,
+	ggsnApnFbcActivationBearerCtrlAccept,
+	ggsnApnFbcActivationBearerCtrlReject,
+	ggsnApnFbcActivationBearerCtrlUpgrade,
+	ggsnApnFbcActivationBearerCtrlDowngrade,
+	ggsnApnFbcModificationBearerCtrlAccept,
+	ggsnApnFbcModificationBearerCtrlDeactivate,
+	ggsnApnFbcModificationBearerCtrlUpgrade,
+	ggsnApnFbcModificationBearerCtrlDowngrade,
+	ggsnApnFbcActivationNoBearerCtrlAccept,
+	ggsnApnFbcActivationNoBearerCtrlReject,
+	ggsnApnFbcActivationNoBearerCtrlDowngrade,
+	ggsnApnFbcModificationNoBearerCtrlAccept,
+	ggsnApnFbcModificationNoBearerCtrlDeactivate,
+	ggsnApnFbcModificationNoBearerCtrlDowngrade,
+	ggsnApnSaccAttemptedServiceInitiatedQoSModification
+   }
+   STATUS current
+   DESCRIPTION
+   "SACC statistics per APN."
+   ::= { ggsnMIBGroups 13 }
+
+ggsnFbcAuthStatisticsGroup	OBJECT-GROUP
+   OBJECTS {
+	ggsnFbcUserAuthPacketsDropped,
+	ggsnFbcDefaultAuthPacketsDropped,
+	ggsnFbcEmptyBucketPacketsDropped,
+	ggsnFbcComFailAuthPacketsDropped,
+	ggsnFbcIdentErrorPacketsDropped
+   }
+   STATUS deprecated
+   DESCRIPTION
+         "Service-based charging (FBC) authorization statistics per node."
+   ::= { ggsnMIBGroups 14 }
+
+ggsnApnFbcServIdentStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnFbcServIdentUplinkBytes,
+	ggsnApnFbcServIdentDownlinkBytes,
+	ggsnApnFbcServIdentEventTrans,
+	ggsnApnFbcServIdentEventTransFail,
+	ggsnApnFbcServIdentEventStartTrans,
+	ggsnApnFbcServIdentEventSuccessTrans
+    }
+    STATUS current
+    DESCRIPTION
+    "Service data flow statistics per APN."
+    ::= { ggsnMIBGroups 15 }
+
+ggsnApnFbcServClassStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnFbcServClassUplinkBytes,
+	ggsnApnFbcServClassDownlinkBytes,
+	ggsnApnFbcServClassActiveTime
+    }
+    STATUS deprecated
+    DESCRIPTION
+	"Service-based charging (FBC) service class statistics per APN."
+    ::= { ggsnMIBGroups 16 }
+
+ggsnFbcStatsGroup		OBJECT-GROUP
+    OBJECTS {
+	ggsnFbcInitiatedDeactivation,
+        ggsnFbcExtPrsUpdReqNoMatch,
+        ggsnFbcExtCreditUpdReqNoMatch,
+        ggsnFbcExtUpdReqFailure
+    }
+    STATUS current
+    DESCRIPTION
+	"SACC statistics."
+    ::= { ggsnMIBGroups 17 }
+
+ggsnApnFbcPrasStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnFbcPrasName,
+	ggsnApnFbcPrasStartReq,
+	ggsnApnFbcPrasStartReqFail,
+	ggsnApnFbcPrasUpdateReq,
+	ggsnApnFbcPrasUpdateReqFail,
+	ggsnApnFbcPrasStopReq,
+	ggsnApnFbcPrasStopReqFail,
+	ggsnApnFbcPrasUserServiceDenied,
+	ggsnApnFbcPrasUserUnknown
+    }
+    STATUS current
+    DESCRIPTION
+    "Policy control application system statistics per APN."
+    ::= { ggsnMIBGroups 18 }
+
+ggsnApnFbcCcasStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnFbcCcasName,
+	ggsnApnFbcCcasStartReq,
+	ggsnApnFbcCcasStartReqFail,
+	ggsnApnFbcCcasUpdateReq,
+	ggsnApnFbcCcasUpdateReqFail,
+	ggsnApnFbcCcasStopReq,
+	ggsnApnFbcCcasStopReqFail,
+	ggsnApnFbcCcasUserServiceDenied,
+	ggsnApnFbcCcasUserUnknown,
+	ggsnApnSaccCcasAuthReject,
+	ggsnApnSaccCcasCcNotApplicable
+    }
+    STATUS current
+    DESCRIPTION
+    "Online charging application system statistics per APN."
+    ::= { ggsnMIBGroups 19 }
+
+ggsnFbcDiamApplSysStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnFbcDiamApplSysName,
+	ggsnFbcDiamApplSysReq
+    }
+    STATUS current
+    DESCRIPTION
+    "Diameter application system statistics."
+    ::= { ggsnMIBGroups 20 }
+
+ggsnApnFbcRateGroupStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnFbcRateGroupEventStartTrans,
+	ggsnApnFbcRateGroupEventSuccessTrans
+    }
+    STATUS obsolete
+    DESCRIPTION
+	"Service-based charging (FBC) rate group statistics per APN."
+    ::= { ggsnMIBGroups 21 }
+
+ggsnL2tpTunnelStatsGroup OBJECT-GROUP
+   OBJECTS { ggsnL2tpTunnelLocalTID,
+             ggsnL2tpTunnelRemoteTID,
+             ggsnL2tpTunnelLocalIp,
+             ggsnL2tpTunnelRemoteIp,
+             ggsnL2tpTunnelActiveSessions,
+             ggsnL2tpTunnelControlTxPackets,
+             ggsnL2tpTunnelControlRxPackets,
+             ggsnL2tpTunnelDataTxPackets,
+             ggsnL2tpTunnelDataRxPackets,
+             ggsnL2tpTunnelDiscardedTxPackets,
+             ggsnL2tpTunnelDiscardedRxPackets
+   }
+   STATUS current
+   DESCRIPTION
+         "The basic collection of objects providing
+          measurements on a per L2TP tunnel of the ggsn node."
+   ::= { ggsnMIBGroups 22 }
+
+ggsnApnSaccPcrfStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnSaccPcrfName,
+	ggsnApnSaccPcrfAuthorFail,
+	ggsnApnSaccPcrfAuthenFail,
+	ggsnApnSaccPcrfUpdCcReqSessIdNoMatch,
+	ggsnApnSaccPcrfActivePdpContextUsageReporting,
+	ggsnApnSaccPcrfActiveIPcanSessions,
+	ggsnApnSaccPcrfActiveDedicatedIPcanBearers
+    }
+    STATUS current
+    DESCRIPTION
+    "PCRF statistics per APN."
+    ::= { ggsnMIBGroups 23 }
+
+ggsnApnSaccRsStatsGroup	OBJECT-GROUP
+    OBJECTS {
+	ggsnApnSaccRsName,
+	ggsnApnSaccRsUplinkBytes,
+	ggsnApnSaccRsDownlinkBytes,
+	ggsnApnSaccRsServiceInstances,
+	ggsnApnSaccRsAuthDownlinkPacketsDropped,
+	ggsnApnSaccRsAuthUplinkPacketsDropped,
+	ggsnApnSaccRsGateDownlinkPacketsDropped,
+	ggsnApnSaccRsGateUplinkPacketsDropped
+    }
+    STATUS current
+    DESCRIPTION
+    "Rule space statistics per APN."
+    ::= { ggsnMIBGroups 24 }
+
+ggsnApnSacc2ServIdentStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        ggsnApnSacc2ServIdentUplinkBytes,
+        ggsnApnSacc2ServIdentDownlinkBytes,
+        ggsnApnSacc2ServIdentEventTrans,
+        ggsnApnSacc2ServIdentEventTransFail,
+        ggsnApnSacc2ServIdentEventStartTrans,
+        ggsnApnSacc2ServIdentEventSuccessTrans
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "Service-based charging (SACC 2) service identifier statistics per APN."
+    ::= { ggsnMIBGroups 25 }
+
+ggsnApnSacc2ServClassStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        ggsnApnSacc2ServClassUplinkBytes,
+        ggsnApnSacc2ServClassDownlinkBytes,
+        ggsnApnSacc2ServClassActiveTime
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "Service-based charging (SACC 2) service class statistics per APN."
+    ::= { ggsnMIBGroups 26 }
+
+ggsnApnSacc3ServIdentStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        ggsnApnFbcServIdentUplinkBytes,
+        ggsnApnFbcServIdentDownlinkBytes
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "Service-based charging (SACC 3) service identifier statistics per APN."
+    ::= { ggsnMIBGroups 27 }
+
+ggsnApnSacc3RatingGroupStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        ggsnApnSacc3RatingGroupUplinkBytes,
+        ggsnApnSacc3RatingGroupDownlinkBytes
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "Service-based charging (SACC 3) rating group statistics per APN."
+    ::= { ggsnMIBGroups 28 }
+
+pgwGlobalStatisticsGroup   OBJECT-GROUP
+    OBJECTS {
+        pgwNbrOfActiveEpsBearer,
+        pgwNbrOfActiveIpv6EpsBearer,
+        pgwNbrOfActiveIpv4v6EpsBearer,
+        pgwWlanNbrOfActiveEpsBearer
+    }
+    STATUS current
+    DESCRIPTION
+        "Global statistics for EPS bearers"
+    ::= { ggsnMIBGroups 29 }
+
+pgwAttemptedEpsBearerStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        pgwAttemptedEpsBearerActivation,
+        pgwAttemptedEpsBearerIpv6Activation,
+        pgwAttemptedEpsBearerModification,
+        pgwAttemptedEpsBearerDeactivation,       
+        pgwAttemptedDedicatedEpsBearerActivation,
+        pgwAttemptedDedicatedEpsBearerIpv6Activation,
+        pgwAttemptedEpsBearerIpv4v6Activation,
+        pgwAttempteds2aEpsBearerActivation 
+    }
+    STATUS current
+    DESCRIPTION
+        "Global statistics for EPS bearer attempts"
+    ::= { ggsnMIBGroups 30 }
+
+pgwCompletedEpsBearerStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        pgwCompletedEpsBearerActivation,
+        pgwCompletedEpsBearerIpv6Activation,
+        pgwCompletedEpsBearerModification,
+        pgwCompletedEpsBearerDeactivation,
+        pgwCompletedDedicatedEpsBearerActivation,
+		pgwCompletedDedicatedEpsBearerIpv6Activation,
+        pgwCompletedEpsBearerIpv4v6Activation,
+        pgwCompleteds2aEpsBearerActivation
+    }
+    STATUS current
+    DESCRIPTION
+        "Global statistics for EPS bearer completions"
+    ::= { ggsnMIBGroups 31 }
+    
+pgwApnSaccRatingGroupStatsGroup   OBJECT-GROUP
+    OBJECTS {
+        pgwApnSaccRatingGroupUplinkBytes,
+        pgwApnSaccRatingGroupDownlinkBytes
+    }
+    STATUS current
+    DESCRIPTION
+    "Rating group statistics per APN."
+    ::= { ggsnMIBGroups 32 }
+
+s6bInterfaceGroup   OBJECT-GROUP
+    OBJECTS {
+        s6bAarSent,
+        s6bAaaSuccRcvd,
+        s6bAaaFailRcvd,
+        s6bAaaInvalidRcvd,
+        s6bStrSent,
+	s6bStaSuccRcvd,
+        s6bStaFailRcvd
+    }
+    STATUS current
+    DESCRIPTION
+        "S6b statistics."
+    ::= { ggsnMIBGroups 33 }
+
+
+END

--- a/mibs/junos/mib-jnx-alarm.txt
+++ b/mibs/junos/mib-jnx-alarm.txt
@@ -1,0 +1,89 @@
+--
+-- Juniper Enterprise Specific MIB: Ping MIB
+-- 
+-- Copyright (c) 2001-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-ALARM-EXT-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE 
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DateAndTime
+	FROM SNMPv2-TC                  -- [RFC2579]
+    alarmClearEntry
+	FROM ALARM-MIB
+    jnxMibs, jnxAlarmExtMibRoot
+        FROM JUNIPER-SMI;
+
+jnxAlarmMIB MODULE-IDENTITY
+    LAST-UPDATED "201209041502Z" -- Tue Sept 2 15:02:46 2012 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This is Juniper Networks' implementation of enterprise
+	     specific MIB for alarms from the router chassis box."
+    ::= { jnxAlarmExtMibRoot 1 }
+
+jnxAlarmObjects	OBJECT IDENTIFIER ::= { jnxAlarmMIB 1 }
+
+--  Extension to Clear table.     
+--  Some systems may have a requirement that information
+--  on alarms that are no longer active be available. 
+--  This memo provides a clear table to support this 
+--  requirement. Though Clear table provides the history 
+--  of alarms raised, it doesn't the datAndTime when the 
+--  alarm was rasied. This information is critical. 
+--  A new table is deined that extends the alarmClearTable
+--  by AUGENTING it. This table will provide dateAndTime 
+--  a particular which is no longer active was raised.
+--
+-- Alarm Clear Table Extensions
+--
+
+
+jnxAlarmClearTable    OBJECT-TYPE
+    SYNTAX	    SEQUENCE OF JnxAlarmClearEntry
+    MAX-ACCESS	    not-accessible
+    STATUS	    current
+    DESCRIPTION	    
+	" This table augments alarmClearTable. This table
+	contains additional object needed to indicate 
+	DateAndTime when a particular alarm was raised."
+    ::= { jnxAlarmObjects 1}
+
+jnxAlarmClearEntry    OBJECT-TYPE
+    SYNTAX	    JnxAlarmClearEntry
+    MAX-ACCESS	    not-accessible
+    STATUS	    current
+    DESCRIPTION	    
+	" An entry containing additional information 
+	applicable to a particular entry in alarm
+	ClearTable."
+    AUGMENTS	    { alarmClearEntry }
+    ::= { jnxAlarmClearTable 1 }
+
+JnxAlarmClearEntry    ::=
+    SEQUENCE {
+	    jnxAlarmClearActiveDateAndTime    DateAndTime	
+	}
+
+jnxAlarmClearActiveDateAndTime	OBJECT-TYPE
+    SYNTAX	    DateAndTime
+    MAX-ACCESS	    read-only
+    STATUS	    current
+    DESCRIPTION
+	" This object indicates DateAndTime, when 
+	current alarm was raised."
+    ::=	{ jnxAlarmClearEntry 1 }
+
+END

--- a/mibs/junos/mib-jnx-analyzer.txt
+++ b/mibs/junos/mib-jnx-analyzer.txt
@@ -9,7 +9,7 @@ IMPORTS
 	FROM JUNIPER-EX-SMI;
 
 jnxAnalyzerMIB MODULE-IDENTITY
-    LAST-UPDATED "200705221000Z"
+    LAST-UPDATED "201407170000Z"
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -37,6 +37,18 @@ jnxAnalyzerMIB MODULE-IDENTITY
     DESCRIPTION
         "Marking jnxAnalyzerStatus as deprecated"
 
+    REVISION
+        "201007300000Z" -- Fri July 30 00:00:00 2009 UTC
+
+    DESCRIPTION
+        "Marking deprecated OIDs as obsolete"
+
+    REVISION
+        "201407170000Z" -- THU July 17  00:00:00 2014 UTC
+
+    DESCRIPTION
+        "Rectifying typo errors from 'Anlayzer' to 'Analyzer'"
+
     ::= { jnxExAnalyzer 1 }
 
 jnxAnalyzerMIBObjects      OBJECT IDENTIFIER ::= { jnxAnalyzerMIB 1 }
@@ -58,7 +70,7 @@ jnxAnalyzerEntry OBJECT-TYPE
     MAX-ACCESS	not-accessible
     STATUS	current
     DESCRIPTION
-	"A row instance contains the Anlayzer Name, Analyzer Status, Mirroring 
+	"A row instance contains the Analyzer Name, Analyzer Status, Mirroring 
 	Ratio, Loss Priority."
     INDEX { jnxAnalyzerName }
     ::= { jnxAnalyzerTable 1 }
@@ -76,13 +88,13 @@ jnxAnalyzerName OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION
-        "This object identifies a unique Anlayzer configured on the switch." 
+        "This object identifies a unique Analyzer configured on the switch." 
     ::= { jnxAnalyzerEntry 1 }
 
 jnxAnalyzerStatus OBJECT-TYPE
     SYNTAX 	TruthValue
     MAX-ACCESS	read-only
-    STATUS	deprecated
+    STATUS	obsolete
     DESCRIPTION
 	"This object identifies whether the mirroring associated with a 
 	particular analyzer is enabled or disabled."
@@ -121,9 +133,9 @@ jnxLossPriority OBJECT-TYPE
 jnxAnalyzerInputTable OBJECT-TYPE
     SYNTAX	SEQUENCE OF JnxAnalyzerInputEntry
     MAX-ACCESS	not-accessible
-    STATUS 	deprecated
+    STATUS 	obsolete
     DESCRIPTION
-	"An anlayzer Session is an association of several source ports to 
+	"An analyzer Session is an association of several source ports to 
 	a destination port.A range or series of ports can be mirrored in
 	a session."
     ::= { jnxAnalyzerMIBObjects 2 }
@@ -131,7 +143,7 @@ jnxAnalyzerInputTable OBJECT-TYPE
 jnxAnalyzerInputEntry OBJECT-TYPE
     SYNTAX	JnxAnalyzerInputEntry
     MAX-ACCESS	not-accessible
-    STATUS	deprecated
+    STATUS	obsolete
     DESCRIPTION	
 	"An Entry is created for each Input Source port."
     INDEX { jnxAnalyzerName, jnxAnalyzerInputValue } 
@@ -147,7 +159,7 @@ JnxAnalyzerInputEntry ::=
 jnxAnalyzerInputValue OBJECT-TYPE
     SYNTAX	DisplayString (SIZE(0..255))
     MAX-ACCESS	not-accessible
-    STATUS	deprecated
+    STATUS	obsolete
     DESCRIPTION
 	"This identifies each different analyzer input source.
 	
@@ -164,7 +176,7 @@ jnxAnalyzerInputOption	OBJECT-TYPE
 	egress	(2) 
     }
     MAX-ACCESS	read-only
-    STATUS	deprecated
+    STATUS	obsolete
     DESCRIPTION
 	"A source port is a switch port that is been mirrored. It can be 
 	mirrored based either on Ingress(received) traffic or egress
@@ -176,7 +188,7 @@ jnxAnalyzerInputOption	OBJECT-TYPE
 	mirroring ratio. A series or range of ingress ports can be mirrored 
 	in an analyzer session.
 	
-	The goal of transmit (or egress) anlayzer is to monitor as much as 
+	The goal of transmit (or egress) analyzer is to monitor as much as 
 	possible all the packets sent by the source interface. The amount 
 	of egress packets mirrored to the destination port depends on the 
 	mirroring ratio.The copy is provided after the packet is modified. 
@@ -191,7 +203,7 @@ jnxAnalyzerInputType OBJECT-TYPE
 	vlanname  (2)
     }
     MAX-ACCESS	read-only
-    STATUS	deprecated
+    STATUS	obsolete
     DESCRIPTION
 	"This specifies whether interfaces or VLANs is mirrored. 
         
@@ -284,7 +296,7 @@ jnxAnalyzerOutputType OBJECT-TYPE
 	Value  2 specifies  that the traffic from all the source ports is 
 	copied into the Remote Analyzer vlan specified by the vlan name.
 
-        In the source switch the anlayzer session destination is given 
+        In the source switch the analyzer session destination is given 
 	as the analyzer vlan. In the intermediate switches the analyzer 
 	sessions have the source and the destination as the analyzer vlan. 
 	The packet will reach the destination ports as it will be a part 
@@ -298,7 +310,7 @@ jnxExAnalyzerInputTable OBJECT-TYPE
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION
-        "An anlayzer Session is an association of several source ports to
+        "An analyzer Session is an association of several source ports to
         a destination port.A range or series of ports can be mirrored in
         a session."
     ::= { jnxAnalyzerMIBObjects 4 }
@@ -321,9 +333,10 @@ JnxExAnalyzerInputEntry ::=
 
 jnxExAnalyzerInputOption  OBJECT-TYPE
     SYNTAX      INTEGER {
-        ingress (1),
-        egress  (2),
-        vlan    (3)
+        ingress        (1),
+        egress         (2),
+        vlan           (3),
+        egress-vlan    (4)
     }
     MAX-ACCESS  not-accessible
     STATUS      current
@@ -338,14 +351,15 @@ jnxExAnalyzerInputOption  OBJECT-TYPE
         mirroring ratio. A series or range of ingress ports can be mirrored
         in an analyzer session.
 
-        The goal of transmit (or egress) anlayzer is to monitor as much as
+        The goal of transmit (or egress) analyzer is to monitor as much as
         possible all the packets sent by the source interface. The amount
         of egress packets mirrored to the destination port depends on the
         mirroring ratio.The copy is provided after the packet is modified.
         A range of egress ports can be mirrored in an analyzer session.
         The value 1 corresponds to mirroring ingress traffic. The value 2
         corresponds to mirroring egress traffic. The value 3 corresponds to
-        mirroring vlan ingress traffic."
+        mirroring vlan ingress traffic. The value 4 corresponds to mirroring 
+        vlan egress traffic."
     ::= { jnxExAnalyzerInputEntry 1 }
 
 jnxExAnalyzerInputValue OBJECT-TYPE

--- a/mibs/junos/mib-jnx-bfd-exp.txt
+++ b/mibs/junos/mib-jnx-bfd-exp.txt
@@ -758,7 +758,11 @@ BFD-STD-MIB DEFINITIONS ::= BEGIN
 --                   the notifications contained in this group." 
 --    
       OBJECT       bfdSessAddrType 
-      SYNTAX       InetAddressType { unknown(0), ipv4(1), ipv6(2) } 
+      SYNTAX       InetAddressType {
+                                    unknown(0),
+                                    ipv4(1),
+                                    ipv6(2)
+                                    }
       DESCRIPTION "Only unknown(0), ipv4(1) and ipv6(2) support  
                    is required." 
     

--- a/mibs/junos/mib-jnx-bfd.txt
+++ b/mibs/junos/mib-jnx-bfd.txt
@@ -7,6 +7,9 @@ JUNIPER-BFD-MIB DEFINITIONS ::= BEGIN
       bfdSessIndex 
          FROM BFD-STD-MIB                       -- [jnx-bfd-exp]
 
+      DisplayString, TimeStamp, TruthValue
+         FROM SNMPv2-TC
+
       jnxBfdMibRoot                             -- [jnx-smi] 
          FROM JUNIPER-SMI
    ; 
@@ -37,6 +40,8 @@ JUNIPER-BFD-MIB DEFINITIONS ::= BEGIN
 
    jnxBfdObjects       OBJECT IDENTIFIER ::= { jnxBfdMib 1 }
 
+   jnxBfdNotifyObjects OBJECT IDENTIFIER ::= { jnxBfdMib 2 }
+
    --  BFD Session Extn Table
    --  This table is a juniper extn to jnxSessTable
 
@@ -64,7 +69,8 @@ JUNIPER-BFD-MIB DEFINITIONS ::= BEGIN
          jnxBfdSessThreshTxInterval        Unsigned32,
          jnxBfdSessCurrTxInterval          Unsigned32,
          jnxBfdSessThreshDectTime          Unsigned32,
-         jnxBfdSessCurrDectTime            Unsigned32
+         jnxBfdSessCurrDectTime            Unsigned32,
+         jnxBfdSessIntfName                DisplayString
       }
 
    jnxBfdSessThreshTxInterval OBJECT-TYPE
@@ -108,6 +114,28 @@ JUNIPER-BFD-MIB DEFINITIONS ::= BEGIN
       DESCRIPTION
           "The actual value of detection time for the session."
       ::= { jnxBfdSessEntry 4} 
+
+   jnxBfdSessIntfName OBJECT-TYPE
+      SYNTAX      DisplayString
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object specifies the interface associated with 
+         the bfd session"
+      ::= { jnxBfdSessEntry 5}
+
+      -- Notification Objects 
+
+   jnxBfdSessifName OBJECT-TYPE
+      SYNTAX      DisplayString
+      MAX-ACCESS  accessible-for-notify
+      STATUS      current
+      DESCRIPTION
+         "This object gives the Interface Name in the bfdSessUp and 
+	  bfdSessDown trap. Even though this object doesnt appear in 
+	  the OBJECTS list of these traps, but the agent relay this 
+	  information as an extra parameter in the trap."
+      ::= { jnxBfdNotifyObjects 1}
 
    -- Notification Configuration
   

--- a/mibs/junos/mib-jnx-bgpmib2.txt
+++ b/mibs/junos/mib-jnx-bgpmib2.txt
@@ -2,7 +2,7 @@
 -- draft-ietf-idr-bgp4-mibv2-03.txt
 --
 -- Copyright (c) 2002 The Internet Society.
--- Copyright (c) 2003, 2006, Juniper Networks, Inc.
+-- Copyright (c) 2003-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- Juniper Networks edits to this MIB:                               *** JNX ***
@@ -11,6 +11,11 @@
 --             Added bgpM2PeerRoutingInstance to bgpM2PeerTable.
 --             Added REVISION clause to MODULE-IDENTITY.
 --             Fixed conformance clauses.
+--   12/12/17  Redefines the value for jnxBgpM2PrefixesInPrefixesRejected
+--             so that it conforms to the definition.
+--             Add a new counter in the same sequence to return the number
+--             of activeprefixes received from the peer
+--             jnxBgpM2PrefixInPrefixesActive.
 -- *****************************************************************************
 
 BGP4-V2-MIB-JUNIPER DEFINITIONS ::= BEGIN
@@ -51,6 +56,14 @@ BGP4-V2-MIB-JUNIPER DEFINITIONS ::= BEGIN
         DESCRIPTION
             "This MIB module defines management objects for
              the Border Gateway Protocol, Version 4."
+        REVISION    "201212170000Z"                               -- *** JNX ***
+        DESCRIPTION                                               -- *** JNX ***
+            "This change redefines the value returned for the     -- *** JNX ***
+            variable jnxBgpM2PrefixesInPrefixesRejected so that   -- *** JNX ***
+            it conforms to the definition.                        -- *** JNX ***
+            It also adds a new counter in the same sequence to    -- *** JNX ***
+            return the number of active prefixes received from    -- *** JNX ***
+            the peer:  jnxBgpM2PrefixInPrefixesActive"            -- *** JNX ***
         REVISION    "200309091508Z"  -- 09-Sep-03 11:08 AM EDT       *** JNX ***
         DESCRIPTION                                               -- *** JNX ***
             "This is a proprietary implementation of the          -- *** JNX ***
@@ -1688,6 +1701,8 @@ BGP4-V2-MIB-JUNIPER DEFINITIONS ::= BEGIN
         jnxBgpM2PrefixInPrefixesRejected
             Gauge32,
         jnxBgpM2PrefixOutPrefixes
+            Gauge32,
+        jnxBgpM2PrefixInPrefixesActive
             Gauge32
     }
 
@@ -1741,6 +1756,7 @@ BGP4-V2-MIB-JUNIPER DEFINITIONS ::= BEGIN
              in the Adj-Ribs-In and are NOT eligible to become active
              in the Loc-Rib."
         ::= { jnxBgpM2PrefixCountersEntry 9 }
+
     jnxBgpM2PrefixOutPrefixes OBJECT-TYPE
         SYNTAX     Gauge32
         MAX-ACCESS read-only
@@ -1750,6 +1766,15 @@ BGP4-V2-MIB-JUNIPER DEFINITIONS ::= BEGIN
              in that peers Adj-Ribs-Out."
         ::= { jnxBgpM2PrefixCountersEntry 10 }
 
+    jnxBgpM2PrefixInPrefixesActive OBJECT-TYPE
+        SYNTAX     Gauge32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The number of prefixes for a peer that are installed
+             in the Adj-Ribs-In and are the active route
+             in the Loc-Rib."
+        ::= { jnxBgpM2PrefixCountersEntry 11 }
 
 
     jnxBgpM2PeerExtensions

--- a/mibs/junos/mib-jnx-bl.txt
+++ b/mibs/junos/mib-jnx-bl.txt
@@ -1,0 +1,3031 @@
+JNX-OPT-IF-EXT-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+           MODULE-IDENTITY,
+           OBJECT-TYPE,
+           Gauge32,
+           Integer32,
+           Unsigned32,
+           Counter64,
+           transmission,
+           NOTIFICATION-TYPE
+                   FROM SNMPv2-SMI
+           TEXTUAL-CONVENTION,
+           RowPointer,
+           RowStatus,
+           TruthValue,
+           DisplayString,
+           DateAndTime
+                   FROM SNMPv2-TC
+           SnmpAdminString
+                   FROM SNMP-FRAMEWORK-MIB
+           MODULE-COMPLIANCE, OBJECT-GROUP
+                   FROM SNMPv2-CONF
+           ifIndex
+                   FROM IF-MIB
+           JnxoptIfDirectionality,
+           jnxoptIfOChConfigEntry,
+           jnxoptIfOChSinkCurrentEntry,
+           jnxoptIfMibModule
+                  FROM JNX-OPT-IF-MIB;
+
+
+
+--  This is the MIB module for the optical parameters associated with the
+--    black link end points.
+
+jnxoptIfExtMibModule MODULE-IDENTITY
+    LAST-UPDATED "201204250000Z"
+    ORGANIZATION "IETF Ops/Camp MIB Working Group"
+    CONTACT-INFO
+       " Email:      Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+    DESCRIPTION
+       "The MIB module to describe Black Link extension to rfc3591.
+        It is the enterprise version of the draft
+        draft-galikunze-ccamp-g-698-2-snmp-mib-02 "
+    REVISION  "201204250000Z"
+    DESCRIPTION
+       "Draft version 1.0"
+    REVISION  "201301250000Z"
+    DESCRIPTION
+       "Draft version 2.0"
+    REVISION  "201302270000Z"
+    DESCRIPTION
+       "Update FEC error count to Counter64"
+    REVISION  "201311010000Z"
+    DESCRIPTION
+       "Enhancement for OTN PM 24 hour TCA thresholds"
+    ::={ jnxoptIfMibModule 3 }
+
+
+JnxoptIfChannelSpacing ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Channel spacing
+           1 - 100  GHz
+           2 - 50   GHz
+           3 - 25   GHz
+           4 - 12.5 GHz
+           5 - 6.25 GHz "
+    SYNTAX  INTEGER {
+        spacing100Ghz(1),
+        spacing50Ghz(2),
+        spacing25Ghz(3),
+        spacing12point5Ghz(4),
+        spacing6point5Ghz(5)
+        }
+
+
+JnxoptIfBitRateLineCoding ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Optical tributary signal class
+           1 - NRZ 2.5G (from nominally 622 Mbit/s to nominally 2.67 Gbit/s)
+           2 - NRZ 10G nominally 2.4 Gbit/s to nominally 10.71 Gbit/s.
+           3 - 40  Gbits/s
+           4 - 100 Gbits/s
+           5 - 400 Gbits/s
+        40 Gbits/s and above are under study."
+    SYNTAX  INTEGER {
+        rate2point5G(1),
+        rate10G(2),
+        rate40G(3),
+        rate100G(4),
+        rate400G(5)
+        }
+
+JnxoptIfFiberTypeRecommendation ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Fiber Types - ITU-T Recs G.652, G.653, G.654 and G.655
+            One for recommendation and one for category.
+            G.652 A, B, C, D
+            G.653 A, B
+            G.654 A, B, C
+            G.655 C, D, E
+            G.656
+            G.657 A, B "
+    SYNTAX  INTEGER {
+        g652(1),
+        g653(2),
+        g654(3),
+        g655(4),
+        g656(5),
+        g657(6)
+    }
+
+JnxoptIfFiberTypeCategory  ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Fiber Types - ITU-T Recs G.652, G.653, G.654 and G.655
+            G.652 A, B, C, D
+            G.653 A, B
+            G.654 A, B, C
+            G.655 C, D, E
+            G.656
+            G.657 A, B
+            Categories - A, B, C, D and E "
+    SYNTAX  INTEGER {
+        categoryA(1),
+        categoryB(2),
+        categoryC(3),
+        categoryD(4),
+        categoryE(5)
+        }
+
+JnxoptIfOTNType     ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for
+          the Near End or Far End performance data.
+            1 - Near End
+            2 - Far End "
+    SYNTAX INTEGER {
+        nearEnd(1),
+        farEnd(2)
+    }
+
+JnxoptIfOTNDirection  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Indicates the direction as Rx/Tx or bi-directional."
+    SYNTAX       INTEGER {
+                    jnxTxDir(1),
+                    jnxRxDir(2),
+                    jnxBiDir(3)
+                 }
+
+JnxoptIfOTNLayer   ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for OTUk,
+          ODUk, TCM performance data.
+            1 - OTUk
+            2 - ODUk
+            3 - TCM
+         The ODUk layer and TCM sublayer PM is not related to the black link PM
+         management, but since this could be a common PM model for the ODUk
+         layer and TCM layers, we include it here so it may be used for simple
+         scenarios where only lower order ODUk or higher order ODUk is present.
+         For scenarios where both lower order ODUk and higher order ODUk are
+         present, further extension to the MIB model is required, in particular
+         for the indexing for these layers."
+    SYNTAX INTEGER {
+        jnxoptIfOTUkLayer(1),
+        jnxoptIfODUkLayer(2),
+        jnxoptIfTCMSubLayer(3)
+    }
+
+--
+-- Alarm for the OCh and OTUk sublayer
+--
+JnxoptIfOTNOChAlarms  ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "This is the possible alarms from the OCh and OTUk layer."
+    SYNTAX INTEGER {
+        -- No alarm
+        jnxoptIfOtnNoAlarm(0),
+        -- OTN Loss of signal alarm
+        jnxoptIfOtnLosAlarm(1),
+        -- OTN Loss of frame alarm
+        jnxoptIfOtnLofAlarm(2),
+        -- OTN Loss of multi framealarm
+        jnxoptIfOtnLomAlarm(3),
+        -- OTN SSF alarm
+        jnxoptIfOtuSsfAlarm(4),
+        -- OTN OTU BDI alarm
+        jnxoptIfOtuBdiAlarm(5),
+        -- OTN OTU Trail Trace mismatch alarm
+        jnxoptIfOtuTimAlarm(6),
+        -- OTN OTU IAE alarm
+        jnxoptIfOtuIaeAlarm(7),
+        -- OTN OTU BIAE alarm,
+        jnxoptIfOtuBiaeAlarm(8),
+        -- OTN TSF alarm
+        jnxoptIfOtuTsfAlarm(9),
+        -- OTN OTU Degraded alarm,
+        jnxoptIfOtuDegAlarm(10),
+        -- OTN OTU Fec ExcessiveErrors alarm
+        jnxoptIfOtuFecExcessiveErrsAlarm(11),
+        -- OTN OTU BBE Thresholdalarm
+        jnxoptIf15MinThreshBBETCA(12),
+        -- OTN OTU ES Thresholdalarm
+        jnxoptIf15MinThreshESTCA(13),
+        -- OTN OTU SES Threshold alarm
+        jnxoptIf15MinThreshSESTCA(14),
+        -- OTN OTU UAS Threshold alarm
+        jnxoptIf15MinThreshUASTCA(15),
+        -- OTN OTU Bip8 Thresholdalarm alarm
+        jnxoptIf15MinThreshBip8TCA(16),
+        -- OTN  FEC uncorrectedwords TCA
+        jnxoptIf15MinThUnCorrectedWordsTCA(17),
+        -- OTN  Pre FEC BER TCA
+        jnxoptIf15MinThreshPreFECBERTCA(18),
+        -- OTN OTU 24 hour BBE Thresholdalarm
+        jnxoptIf24HourThreshBBETCA(19),
+        -- OTN OTU 24 hour  ES Thresholdalarm
+        jnxoptIf24HourThreshESTCA(20),
+        -- OTN OTU 24 hour SES Threshold alarm
+        jnxoptIf24HourThreshSESTCA(21),
+        -- OTN OTU 24 hour UAS Threshold alarm
+        jnxoptIf24HourThreshUASTCA(22),
+        -- OTN OTU 24 hour Bip8 Thresholdalarm alarm
+        jnxoptIf24HourThreshBip8TCA(23),
+        -- OTN  Pre FEC BER 24 hour TCA
+        jnxoptIf24HourThreshPreFECBERTCA(24),
+        -- OTN OTU AIS alarm
+        jnxoptIfOtuAisAlarm(25)
+    }
+
+JnxoptIfOTNODUkTcmAlarms  ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "This is the alarms from the ODUk and TCM layer."
+    SYNTAX INTEGER {
+        -- No alarm
+        jnxoptIfOtnOdukTcmNoAlarm(0),
+        -- OTN ODU/TCM OCI alarm
+        jnxoptIfOdukTcmOciAlarm(1),
+        -- OTN ODU/TCM LCK alarm
+        jnxoptIfOdukTcmLckAlarm(2),
+        -- OTN ODU/TCM BDI alarm
+        jnxoptIfOdukTcmBdiAlarm(3),
+        -- OTN ODU/TCM Trail Trace mismatch alarm
+        jnxoptIfOdukTcmTimAlarm(4),
+        -- OTN ODU/TCM Degraded alarm,
+        jnxoptIfOdukTcmDegAlarm(5),
+        -- OTN ODU IAE alarm
+        jnxoptIfOdukTcmIaeAlarm(6),
+        -- OTN ODU/TCM Loss of Tandem Connection
+        jnxoptIfOdukTcmLTCAlarm(7),
+        -- OTN ODU/TCM CSF alarm,
+        jnxoptIfOdukTcmCSfAlarm(8),
+        -- OTN ODU/TCM SSF alarm,
+        jnxoptIfOdukTcmSSfAlarm(9),
+        -- OTN ODU/TCM TSF alarm,
+        jnxoptIfOdukTcmTSfAlarm(10),
+        -- OTN ODU BBE Threshold alarm
+        jnxoptIfOdukTcm15MinThreshBBETCA(11),
+        -- OTN ODU ES Threshold alarm
+        jnxoptIfOdukTcm15MinThreshESTCA(12),
+        -- OTN ODU SES Threshold alarm
+        jnxoptIfOdukTcm15MinThreshSESTCA(13),
+        -- OTN ODU UAS Threshold alarm
+        jnxoptIfOdukTcm15MinThreshUASTCA(14),
+        -- OTN ODU Bip8 Threshold alarm
+        jnxoptIfOdukTcm15MinThreshBip8TCA(15),
+        -- OTN ODU Ais 
+        jnxoptIfOdukTcmAisAlarm(16), 
+        -- OTN ODU PTM - payload type mismatch 
+        jnxoptIfOdukPtmAlarm(17),
+        -- OTN ODU 24 hour BBE Threshold alarm
+        jnxoptIfOdukTcm24HourThreshBBETCA(18),
+        -- OTN ODU 24 hour ES Threshold alarm
+        jnxoptIfOdukTcm24HourThreshESTCA(19),
+        -- OTN ODU SES Threshold alarm
+        jnxoptIfOdukTcm24HourThreshSESTCA(20),
+        -- OTN ODU 24 hour UAS Threshold alarm
+        jnxoptIfOdukTcm24HourThreshUASTCA(21),
+        -- OTN ODU 24 hour bip8 Threshold alarm
+        jnxoptIfOdukTcm24HourThreshBip8TCA(22) 
+     }
+
+JnxoptIfOTNAlarmSeverity  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Severity of the Notification"
+    SYNTAX       INTEGER {
+        jnxCritical(1),
+        jnxMajor(2),
+        jnxMinor(3),
+        jnxInfo(4)
+    }
+
+-- Addition to the RFC 3591 objects
+jnxoptIfOTNNotifications    OBJECT IDENTIFIER   ::= { jnxoptIfExtMibModule 0 }
+jnxoptIfOPSmEntry           OBJECT IDENTIFIER   ::= { jnxoptIfExtMibModule 1 }
+jnxoptIfOChSrcSinkGroup     OBJECT IDENTIFIER   ::= { jnxoptIfExtMibModule 2 }
+jnxoptIfOTNPMGroup          OBJECT IDENTIFIER   ::= { jnxoptIfExtMibModule 3 }
+jnxoptIfOTNAlarm            OBJECT IDENTIFIER   ::= { jnxoptIfExtMibModule 4 }
+
+-- OPS - Optical Phyical Section
+jnxoptIfOPSmConfigTable  OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOPSmConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of OPS General config  parameters."
+    ::= { jnxoptIfOPSmEntry 1 }
+
+jnxoptIfOPSmConfigEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOPSmConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "An conceptual row of OPS General config parameters."
+    INDEX  { ifIndex  }
+    ::= { jnxoptIfOPSmConfigTable 1 }
+
+    JnxoptIfOPSmConfigEntry  ::=
+        SEQUENCE {
+            jnxoptIfOPSmDirectionality        
+                                      JnxoptIfDirectionality,
+            jnxoptIfOPSmFiberTypeRecommendation
+                                      JnxoptIfFiberTypeRecommendation,
+            jnxoptIfOPSmFiberTypeCategory  
+                                      JnxoptIfFiberTypeCategory
+        }
+
+jnxoptIfOPSmDirectionality  OBJECT-TYPE
+    SYNTAX    JnxoptIfDirectionality
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Indicates the directionality of the entity."
+    ::= { jnxoptIfOPSmConfigEntry  1 }
+
+jnxoptIfOPSmFiberTypeRecommendation  OBJECT-TYPE
+    SYNTAX    JnxoptIfFiberTypeRecommendation
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Fiber type as per fibre types are chosen from those defined in
+         ITU-T Recs G.652, G.653, G.654, G.655, G.656 and G.657."
+    ::= { jnxoptIfOPSmConfigEntry  2 }
+
+jnxoptIfOPSmFiberTypeCategory  OBJECT-TYPE
+    SYNTAX    JnxoptIfFiberTypeCategory
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Fiber type as per fibre types are chosen from those defined in
+         ITU-T Recs G.652, G.653, and G.655.
+         The categories are A, B, C, D and E."
+    ::= { jnxoptIfOPSmConfigEntry  3 }
+
+
+-- OCh config table
+-- modified the OCh Table group
+-- General parameters for the Black Link Ss-Rs will be added to
+-- the OchConfigTable
+
+jnxoptIfOChConfigExtTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOChConfigExtEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of Och General config extension parameters"
+    ::= {  jnxoptIfOChSrcSinkGroup 1 }
+
+jnxoptIfOChConfigExtEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOChConfigExtEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual row that contains OCh configuration extension
+         information of an interface."
+    AUGMENTS { jnxoptIfOChConfigEntry }
+    ::= { jnxoptIfOChConfigExtTable 1 }
+
+
+JnxoptIfOChConfigExtEntry ::=
+    SEQUENCE {
+        jnxoptIfOChMiminumChannelSpacing                JnxoptIfChannelSpacing,
+        jnxoptIfOChBitRateLineCoding                    JnxoptIfBitRateLineCoding,
+        jnxoptIfOChFEC                                  Unsigned32,
+        jnxoptIfOChSinkMaximumBERMantissa               Unsigned32,
+        jnxoptIfOChSinkMaximumBERExponent               Unsigned32,
+        jnxoptIfOChMinWavelength                        Unsigned32,
+        jnxoptIfOChMaxWavelength                        Unsigned32,
+        jnxoptIfOChWavelength                           Unsigned32,
+        jnxoptIfOChVendorTransceiverClass               DisplayString,
+        jnxoptIfOChOpticalInterfaceApplicationCode      DisplayString,
+        jnxoptIfOChLaserAdminState                      INTEGER,
+        jnxoptIfOChLaserOperationalState                INTEGER,
+        jnxoptIfOChAdminState                           INTEGER,
+        jnxoptIfOChOperationalState                     INTEGER
+     }
+
+jnxoptIfOChMiminumChannelSpacing  OBJECT-TYPE
+    SYNTAX      JnxoptIfChannelSpacing
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A minimum nominal difference in frequency (GHz) between two adjacent
+         channels."
+    ::= { jnxoptIfOChConfigExtEntry 1 }
+
+jnxoptIfOChBitRateLineCoding  OBJECT-TYPE
+    SYNTAX  JnxoptIfBitRateLineCoding
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Optical tributary signal class
+          NRZ 2.5G (from nominally 622 Mbit/s  to nominally  2.67 Gbit/s)
+          NRZ 10G  (nominally 2.4 Gbit/s to nominally 10.71 Gbit/s) "
+    ::= { jnxoptIfOChConfigExtEntry 2 }
+
+jnxoptIfOChFEC  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates what Forward Error Correction (FEC) code
+         is used at Source and Sink.
+         GFEC (from G709) and the I.x EFEC's
+         (G.975 - Table I.1 super FEC).
+           1 - No FEC
+           2 - GFEC
+           3 - I.2 EFEC
+           4 - I.3 EFEC
+           5 - I.4 EFEC
+           6 - I.5 EFEC
+           7 - I.6 EFEC
+           8 - I.7 EFEC
+           9 - I.8 EFEC
+          10 - I.9 EFEC
+          11 - 100G FEC (for new applications)
+          12 - 100G EFEC (for new applications)
+          99 - Vendor Specific "
+    ::= { jnxoptIfOChConfigExtEntry 3 }
+
+jnxoptIfOChSinkMaximumBERMantissa  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicate the maximum Bit(mantissa) error rate can be
+         supported by the application at the Receiver.  In case of FEC
+         applications it is intended after the FEC correction."
+    ::= { jnxoptIfOChConfigExtEntry  4 }
+
+jnxoptIfOChSinkMaximumBERExponent  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicate the maximum Bit(exponent) error rate can be
+         supported by the application at the Receiver.  In case of FEC
+         applications it is intended after the FEC correction."
+    ::= { jnxoptIfOChConfigExtEntry  5 }
+
+jnxoptIfOChMinWavelength  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS "0.01 nm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "This parameter indicate minimum wavelength spectrum in a
+        definite wavelength Band (L, C and S) "
+    ::= { jnxoptIfOChConfigExtEntry  6 }
+
+jnxoptIfOChMaxWavelength  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS "0.01 nm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "This parameter indicate maximum wavelength spectrum in a
+        definite wavelength Band (L, C and S) "
+    ::= { jnxoptIfOChConfigExtEntry  7 }
+
+jnxoptIfOChWavelength  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS "0.01 nm"
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the wavelength value."
+    ::= { jnxoptIfOChConfigExtEntry  8 }
+
+jnxoptIfOChVendorTransceiverClass  OBJECT-TYPE
+    SYNTAX  DisplayString (SIZE (1..64))
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "As defined in G.698
+        Vendors can summarize a set of parameters in a
+        single proprietary parameter: the Class of transceiver.  The
+        Transceiver classification will be based on the Vendor Name and
+        the main TX and RX parameters (i.e.  Trunk Mode, Framing, Bit
+        rate, Trunk Type etc).
+        If this parameter is used, the MIB parameters
+        specifying the Transceiver characteristics may not be significant
+        and the vendor will be responsible to specify the Class contents
+        and values.  The Vendor can publish the parameters of its Classes
+        or declare to be compatible with published Classes.(G) Optional
+        for compliance. (not mentioned in G.698) "
+    ::= { jnxoptIfOChConfigExtEntry  9 }
+
+jnxoptIfOChOpticalInterfaceApplicationCode  OBJECT-TYPE
+    SYNTAX  DisplayString (SIZE (1..64))
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the transceiver application code at Ss
+         and Rs as defined in [ITU.G698.2] Chapter 5.3 "
+    ::= { jnxoptIfOChConfigExtEntry  10 }
+
+jnxoptIfOChLaserAdminState  OBJECT-TYPE
+    SYNTAX  INTEGER {
+                disabled(0),
+                enabled(1)
+            }
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The configured State of the laser:
+            0 - disabled
+            1 - enabled "
+    ::= { jnxoptIfOChConfigExtEntry  11 }
+
+jnxoptIfOChLaserOperationalState  OBJECT-TYPE
+    SYNTAX  INTEGER {
+                disabled(0),
+                enabled(1),
+                fault(2),
+                degraded(3)
+            }
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The Operational Status of Laser:
+            0 - disabled
+            1 - Enabled 
+            2 - fault
+            3 - degraded"
+    ::= {  jnxoptIfOChConfigExtEntry  12 }
+
+jnxoptIfOChAdminState  OBJECT-TYPE
+    SYNTAX  INTEGER {
+                disable(0),
+                enable(1)
+            }
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The Administrative Status of an Interface:
+            0 - Out of Service
+            1 - In Service
+        "
+    ::= {  jnxoptIfOChConfigExtEntry  13 }
+
+jnxoptIfOChOperationalState  OBJECT-TYPE
+    SYNTAX   INTEGER {
+                 disabled(0),
+                 enabled(1),
+                 fault(2),
+                 degraded(3)
+             }
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The Operational Status of an Interface:
+            0 - disabled
+            1 - enabled
+            2 - Fault 
+            3 - Degraded"
+    ::= {  jnxoptIfOChConfigExtEntry  14 }
+
+
+
+-- Parameters at OCh Src (Ss)
+--  OptIfOChSrcConfigEntry
+
+jnxoptIfOChSrcConfigTable  OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOChSrcConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A configuration table of OCh Src (Ss) parameters."
+    ::= { jnxoptIfOChSrcSinkGroup 2 }
+
+jnxoptIfOChSrcConfigEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOChSrcConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual row that contains the Src (Ss) configuration
+         parameters for a given interface."
+    INDEX  { ifIndex  }
+    ::= { jnxoptIfOChSrcConfigTable 1 }
+
+JnxoptIfOChSrcConfigEntry ::=
+    SEQUENCE {
+        jnxoptIfOChMinimumMeanChannelOutputPower               Integer32,
+        jnxoptIfOChMaximumMeanChannelOutputPower               Integer32,
+        jnxoptIfOChMinimumCentralFrequency                     Unsigned32,
+        jnxoptIfOChMaximumCentralFrequency                     Unsigned32,
+        jnxoptIfOChMaximumSpectralExcursion                    Unsigned32,
+        jnxoptIfOChMaximumTxDispersionOSNRPenalty              Integer32
+     }
+
+jnxoptIfOChMinimumMeanChannelOutputPower  OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.01 dbm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimum mean launched power at Ss is the average power (in dbm)
+         of a pseudo-random data sequence coupled into the DWDM link."
+    ::= { jnxoptIfOChSrcConfigEntry  1}
+
+jnxoptIfOChMaximumMeanChannelOutputPower  OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.01 dbm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximum mean launched power at Ss is the average power (in dbm)
+         of a pseudo-random data sequence coupled into the DWDM link."
+    ::= { jnxoptIfOChSrcConfigEntry  2}
+
+jnxoptIfOChMinimumCentralFrequency  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS      "0.01 THz"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimum central frequency is the nominal single-channel frequency
+         (in THz) on which the digital coded information of the particular
+         optical channel is modulated by use of the NRZ line code.
+         Eg 191.5THz will be represented as 19150 "
+    ::= { jnxoptIfOChSrcConfigEntry  3}
+
+jnxoptIfOChMaximumCentralFrequency  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS      "0.01 THz"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximum central frequency is the nominal single-channel frequency
+         (in THz) on which the digital coded information of the particular
+         optical channel is modulated by use of the NRZ line code.
+         Eg 191.5THz will be represented as 19150 "
+    ::= { jnxoptIfOChSrcConfigEntry  4}
+
+jnxoptIfOChMaximumSpectralExcursion  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS      "0.1 GHz"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "This is the maximum acceptable difference between the nominal
+         central frequency (in GHz) of the channel and the minus 15 dB
+         points of the transmitter spectrum furthest from the nominal
+         central frequency measured at point Ss."
+    ::= { jnxoptIfOChSrcConfigEntry  5}
+
+
+jnxoptIfOChMaximumTxDispersionOSNRPenalty OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Defines a reference receiver that this penalty is measured with.
+         Lowest OSNR at Ss with worst case (residual) dispersion minus the
+         Lowest OSNR at Ss with no dispersion. Lowest OSNR at Ss with no
+         dispersion "
+    ::= { jnxoptIfOChSrcConfigEntry  6}
+
+--  Optical Path from Point Src (Ss) to Sink (Rs)
+--  Alternatively this can be jnxoptIfOChSsRsTable
+
+jnxoptIfOChSrcSinkConfigTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOChSrcSinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of paramters for the optical path from Src to Sink
+        (Ss to Rs)."
+    ::= { jnxoptIfOChSrcSinkGroup 3 }
+
+jnxoptIfOChSrcSinkConfigEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOChSrcSinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual row that contains the optical path Src-Sink (Ss-Rs)
+         configuration parameters for a given interface."
+    INDEX  { ifIndex  }
+    ::= { jnxoptIfOChSrcSinkConfigTable 1 }
+
+JnxoptIfOChSrcSinkConfigEntry ::=
+     SEQUENCE {
+         jnxoptIfOChSrcSinkMinimumChromaticDispersion              Integer32,
+         jnxoptIfOChSrcSinkMaximumChromaticDispersion              Integer32,
+         jnxoptIfOChSrcSinkMinimumSrcOpticalReturnLoss             Integer32,
+         jnxoptIfOChSrcSinkMaximumDiscreteReflectanceSrcToSink     Integer32,
+         jnxoptIfOChSrcSinkMaximumDifferentialGroupDelay           Integer32,
+         jnxoptIfOChSrcSinkMaximumPolarisationDependentLoss        Integer32,
+         jnxoptIfOChSrcSinkMaximumInterChannelCrosstalk            Integer32,
+         jnxoptIfOChSrcSinkInterFerometricCrosstalk                Integer32,
+         jnxoptIfOChSrcSinkOpticalPathOSNRPenalty                  Integer32
+     }
+
+jnxoptIfOChSrcSinkMinimumChromaticDispersion OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "ps/nm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "These parameters define the minimum value of the
+         optical path 'end to end chromatic dispersion' (in ps/nm) that the
+         system shall be able to tolerate."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  1}
+
+jnxoptIfOChSrcSinkMaximumChromaticDispersion OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "ps/nm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "These parameters define the maximum value of the
+         optical path 'end to end chromatic dispersion' (in ps/nm) that the
+         system shall be able to tolerate."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  2 }
+
+jnxoptIfOChSrcSinkMinimumSrcOpticalReturnLoss    OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "These parameter defines minimum optical return loss (in dB) of the
+         cable plant at the source reference point (Src/Ss), including any
+         connectors."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  3 }
+
+
+jnxoptIfOChSrcSinkMaximumDiscreteReflectanceSrcToSink   OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Optical reflectance is defined to be the ratio of the reflected
+         optical power pre.sent at a point, to the optical power incident to
+         that point.  Control of reflections is discussed extensively in
+         ITU-T Rec. G.957."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  4}
+
+jnxoptIfOChSrcSinkMaximumDifferentialGroupDelay   OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "ps"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Differential group delay (DGD) is the time difference between the
+         fractions of a pulse that are transmitted in the two principal
+         states of polarization of an optical signal.  For distances
+         greater than several kilometres, and assuming random (strong)
+         polarization mode coupling, DGD in a fibre can be statistically
+         modelled as having a Maxwellian distribution."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  5}
+
+
+jnxoptIfOChSrcSinkMaximumPolarisationDependentLoss   OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The polarisation dependent loss (PDL) is the difference (in dB)
+         between the maximum and minimum values of the channel insertion
+         loss (or gain) of the black-link from point SS to RS due to a
+         variation of the state of polarization (SOP) over all SOPs."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  6}
+
+jnxoptIfOChSrcSinkMaximumInterChannelCrosstalk   OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Inter-channel crosstalk is defined as the ratio of total power in
+         all of the disturbing channels to that in the wanted channel,
+         where the wanted and disturbing channels are at different
+         wavelengths.  The parameter specify the isolation of a link
+         conforming to the 'black-link' approach such that under the worst-
+         case operating conditions the inter-channel crosstalk at any
+         reference point RS is less than the maximum inter-channel
+         crosstalk value."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  7}
+
+
+jnxoptIfOChSrcSinkInterFerometricCrosstalk   OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "This parameter places a requirement on the isolation of a link
+         conforming to the 'black-link' approach such that under the worst
+         case operating conditions the interferometric crosstalk at any
+         reference point RS is less than the maximum interferometric
+         crosstalk value.."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  8}
+
+jnxoptIfOChSrcSinkOpticalPathOSNRPenalty  OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The optical path OSNR penalty is defined as the difference between
+         the Lowest OSNR at Rs and Lowest OSNR at Ss that meets the BER
+         requirement."
+    ::= { jnxoptIfOChSrcSinkConfigEntry  9}
+
+-- Parameters at Sink (Rs)
+-- jnxoptIfOChSinkConfigTable
+jnxoptIfOChSinkConfigTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOChSinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of OCh Sink (Rs) configuration parameters."
+    ::= { jnxoptIfOChSrcSinkGroup  4 }
+
+jnxoptIfOChSinkConfigEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOChSinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual row that contains the Sink (Rs) configuration
+         parameters for a given interface."
+    INDEX  { ifIndex  }
+    ::= { jnxoptIfOChSinkConfigTable 1 }
+
+JnxoptIfOChSinkConfigEntry ::=
+    SEQUENCE {
+        jnxoptIfOChSinkMinimumMeanIntputPower            Integer32,
+        jnxoptIfOChSinkMaximumMeanIntputPower            Integer32,
+        jnxoptIfOChSinkMinimumOSNR                       Integer32,
+        jnxoptIfOChSinkOSNRTolerance                     Integer32
+    }
+
+jnxoptIfOChSinkMinimumMeanIntputPower OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.01 dbm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        " The minimum values of the average received power (in dbm
+          at point the Sink (Rs)."
+    ::= { jnxoptIfOChSinkConfigEntry  1}
+
+jnxoptIfOChSinkMaximumMeanIntputPower OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.01 dbm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximum values of the average received power (in dbm)
+         at point the Sink (Rs)."
+    ::= { jnxoptIfOChSinkConfigEntry  2}
+
+jnxoptIfOChSinkMinimumOSNR OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimum optical signal-to-noise ratio (OSNR) is the minimum
+         value of the ratio of the signal power in the wanted channel to
+         the highest noise power density in the range of the central
+         frequency plus and minus the maximum spectral excursion."
+    ::= { jnxoptIfOChSinkConfigEntry  3}
+
+jnxoptIfOChSinkOSNRTolerance OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The receiver OSNR tolerance is defined as the minimum value of
+         OSNR at point Sink (Rs) that can be tolerated while maintaining the
+         maximum BER of the application. Sink (Rs)."
+    ::= { jnxoptIfOChSinkConfigEntry  4}
+
+
+
+
+
+-- Performance Monitoring
+
+-- The OptIfOChSinkCurrentExtEntry table is an extension to the
+-- jnxoptIfOChSinkCurrentExtEntry
+-- following optional parameters for current status
+-- OptIfOChSinkCurrentExtEntry
+
+jnxoptIfOChSinkCurrentExtTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOChSinkCurrentExtEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of OCh sink etxension to the performance monitoring
+         information for the current 15-minute interval."
+    ::= { jnxoptIfOTNPMGroup 1 }
+
+
+jnxoptIfOChSinkCurrentExtEntry OBJECT-TYPE
+    SYNTAX  JnxoptIfOChSinkCurrentExtEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual row that contains OCh sink performance
+         monitoring information for an interface for the current
+         15-minute interval."
+    AUGMENTS { jnxoptIfOChSinkCurrentEntry }
+    ::= { jnxoptIfOChSinkCurrentExtTable 1 }
+
+
+
+JnxoptIfOChSinkCurrentExtEntry ::=
+    SEQUENCE {
+        jnxoptIfOChSinkCurrentChromaticDispersion        Integer32,
+        jnxoptIfOChSinkCurrentOSNR                       Integer32,
+        jnxoptIfOChSinkCurrentQ                          Integer32
+    }
+
+jnxoptIfOChSinkCurrentChromaticDispersion OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "ps/nm"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Residual Chromatic Dispersion measured at Rx Transceiver port."
+    ::= { jnxoptIfOChSinkCurrentExtEntry  1}
+
+jnxoptIfOChSinkCurrentOSNR OBJECT-TYPE
+    SYNTAX  Integer32
+    UNITS      "0.1 dB"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Current Optical Signal to Noise Ratio (OSNR) estimated at Rx
+            Transceiver port ."
+    ::= { jnxoptIfOChSinkCurrentExtEntry  2}
+
+jnxoptIfOChSinkCurrentQ  OBJECT-TYPE
+    SYNTAX  Integer32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "'Q' factor estimated at Rx Transceiver port."
+    ::= { jnxoptIfOChSinkCurrentExtEntry  3}
+
+-- Performance Monitoring
+-- OTN  PM Config Table
+--
+
+--
+
+jnxoptIfOTNPMConfigTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of performance monitoring configuration for the type
+         'jnxoptIfOTNPMConfigLayer' layer."
+    ::= { jnxoptIfOTNPMGroup 2 }
+
+jnxoptIfOTNPMConfigEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the performance monitoring configuration
+         for the type 'jnxoptIfOTNPMConfigLayer' layer."
+    INDEX  { ifIndex, jnxoptIfOTNPMConfigType, jnxoptIfOTNPMConfigLayer,
+             jnxoptIfOTNPMConfigTCMLevel  }
+    ::= { jnxoptIfOTNPMConfigTable 1 }
+
+JnxoptIfOTNPMConfigEntry ::=
+    SEQUENCE {
+        jnxoptIfOTNPMConfigType                   JnxoptIfOTNType,
+        jnxoptIfOTNPMConfigLayer                  JnxoptIfOTNLayer,
+        jnxoptIfOTNPMConfigTCMLevel               Unsigned32,
+        jnxoptIfOTNPMESRInterval                  Unsigned32,
+        jnxoptIfOTNPMSESRInterval                 Unsigned32,
+        jnxoptIfOTNPMValidIntervals               Unsigned32,
+        jnxoptIfOTNPM15MinBip8Threshold           Unsigned32,
+        jnxoptIfOTNPM15MinESsThreshold            Unsigned32,
+        jnxoptIfOTNPM15MinSESsThreshold           Unsigned32,
+        jnxoptIfOTNPM15MinUASsThreshold           Unsigned32,
+        jnxoptIfOTNPM15MinBBEsThreshold           Unsigned32,
+        jnxoptIfOTNPM24HourBip8Threshold          Unsigned32,
+        jnxoptIfOTNPM24HourESsThreshold           Unsigned32,
+        jnxoptIfOTNPM24HourSESsThreshold          Unsigned32,
+        jnxoptIfOTNPM24HourUASsThreshold          Unsigned32,
+        jnxoptIfOTNPM24HourBBEsThreshold          Unsigned32,
+        jnxoptIfOTNPMBip8EnableTCA                TruthValue,
+        jnxoptIfOTNPMESsEnableTCA                 TruthValue,
+        jnxoptIfOTNPMSESsEnableTCA                TruthValue,
+        jnxoptIfOTNPMUASsEnableTCA                TruthValue,
+        jnxoptIfOTNPMBBEsEnableTCA                TruthValue
+    }
+
+jnxoptIfOTNPMConfigType       OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS not-accessible 
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMConfigEntry  1}
+
+jnxoptIfOTNPMConfigLayer   OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNLayer
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for OTUk,
+         ODUk, TCMn performance data.
+         1 - OTUk
+         2 - ODUk
+         3 - TCM
+         The ODUk/TCM sublayer PM is not related to the black link PM
+         management, but since this is a common PM model for the ODU/TCM layer,
+         we may include it here."
+    ::= { jnxoptIfOTNPMConfigEntry  2}
+
+jnxoptIfOTNPMConfigTCMLevel   OBJECT-TYPE
+    SYNTAX  Unsigned32 (0..6)
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the TCM level (1-6)
+         if the PM is of the type TCM. This will be 0 for OTUK/ODUK."
+    ::= { jnxoptIfOTNPMConfigEntry  3}
+
+jnxoptIfOTNPMESRInterval  OBJECT-TYPE
+    SYNTAX  Unsigned32 (1..96)
+    UNITS "seconds"
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the measurement interval
+         for error seconds ratio."
+    ::= {jnxoptIfOTNPMConfigEntry  4}
+
+jnxoptIfOTNPMSESRInterval  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS "seconds"
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the measurement interval
+         for severely error seconds ratio."
+    ::= {jnxoptIfOTNPMConfigEntry  5}
+
+jnxoptIfOTNPMValidIntervals OBJECT-TYPE
+    SYNTAX          Unsigned32
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "The number of contiguous 15 minute intervals for which valid
+         PM data is available for the particular interface."
+    ::= { jnxoptIfOTNPMConfigEntry 6 }
+
+jnxoptIfOTNPM15MinBip8Threshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of Bip8 encountered by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshBip8TCA. One notification will be
+         sent per interval per interface. A value of `0' will disable the
+         notification."
+    ::= { jnxoptIfOTNPMConfigEntry  7 }
+
+jnxoptIfOTNPM15MinESsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of ES encountered by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshEsTCA. One notification will be
+         sent per interval per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry 8 }
+
+jnxoptIfOTNPM15MinSESsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of SES encountered by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshSESTCA. One notification will be
+         sent per interval per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry 9 }
+
+
+jnxoptIfOTNPM15MinUASsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of UAS encountered by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshUASTCA. One notification will be
+         sent per interval per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry  10 }
+
+jnxoptIfOTNPM15MinBBEsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of UAS encountered by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshBBETCA. One notification will be
+         sent per interval per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry  11 }
+
+jnxoptIfOTNPM24HourBip8Threshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of Bip8 encountered by the interface within any
+         given 24 Hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshBip8TCA. One notification will be
+         sent per interval per interface. A value of `0' will disable the
+         notification."
+    ::= { jnxoptIfOTNPMConfigEntry  12 }
+
+jnxoptIfOTNPM24HourESsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of ES encountered by the interface within any
+         given 24 hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf24HourThreshEsTCA. One notification will be
+         sent per 24 hour per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry 13 }
+
+jnxoptIfOTNPM24HourSESsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of SES encountered by the interface within any
+         given 24 hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf24HourThreshSESsTCA. One notification will be
+         sent per 24 hour per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry 14 }
+
+jnxoptIfOTNPM24HourUASsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of SES encountered by the interface within any
+         given 24 hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf24HourThreshUASsTCA. One notification will be
+         sent per 24 hour per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry 15 }
+
+jnxoptIfOTNPM24HourBBEsThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The number of BBE encountered by the interface within any
+         given 24 hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf24HourThreshBBEsTCA. One notification will be
+         sent per 24 hour per interface. A value of `0' will disable the
+         notification."
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry 16 }
+
+jnxoptIfOTNPMBip8EnableTCA  OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        " Enable TCA's - 15minute and 24hr for Bip8 "
+    ::= { jnxoptIfOTNPMConfigEntry  17 }
+
+jnxoptIfOTNPMESsEnableTCA  OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        " Enable TCA's - 15minute and 24hr for ESs "
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry  18 }
+
+jnxoptIfOTNPMSESsEnableTCA  OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        " Enable TCA's - 15minute and 24hr for SESs "
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry  19 }
+
+jnxoptIfOTNPMUASsEnableTCA  OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        " Enable TCA's - 15minute and 24hr for UASs "
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry  20 }
+
+jnxoptIfOTNPMBBEsEnableTCA  OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        " Enable TCA's - 15minute and 24hr for BBEs "
+    --
+    --
+    --
+    ::= { jnxoptIfOTNPMConfigEntry  21 }
+
+
+--
+-- PM Current Entry  at either the OTU/ODUk/TCM
+--
+jnxoptIfOTNPMCurrentTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table for the Performance monitoring Current Table."
+    ::= {jnxoptIfOTNPMGroup 3}
+
+jnxoptIfOTNPMCurrentEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "A conceptual entry in the Near end or Far End performance monitoring
+        Current table for the type 'jnxoptIfOTNPMCurrentLayer' layer."
+    INDEX  { ifIndex, jnxoptIfOTNPMCurrentType ,
+             jnxoptIfOTNPMCurrentLayer, jnxoptIfOTNPMCurrentTCMLevel  }
+    ::= { jnxoptIfOTNPMCurrentTable 1 }
+
+JnxoptIfOTNPMCurrentEntry ::=
+    SEQUENCE {
+        jnxoptIfOTNPMCurrentType                        JnxoptIfOTNType,
+        jnxoptIfOTNPMCurrentLayer                       JnxoptIfOTNLayer,
+        jnxoptIfOTNPMCurrentTCMLevel                    Unsigned32,
+        jnxoptIfOTNPMCurrentSuspectedFlag               TruthValue,
+        jnxoptIfOTNPMCurrentBip8                        Unsigned32,
+        jnxoptIfOTNPMCurrentESs                         Unsigned32,
+        jnxoptIfOTNPMCurrentSESs                        Unsigned32,
+        jnxoptIfOTNPMCurrentUASs                        Unsigned32,
+        jnxoptIfOTNPMCurrentBBEs                        Unsigned32,
+        jnxoptIfOTNPMCurrentESR                         Unsigned32,
+        jnxoptIfOTNPMCurrentSESR                        Unsigned32,
+        jnxoptIfOTNPMCurrentBBER                        Unsigned32,
+        jnxoptIfOTNPMCurrentElapsedTime                 Unsigned32,
+        jnxoptIfOTNPMCurSuspectReason                   Integer32
+    }
+
+jnxoptIfOTNPMCurrentType           OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the Near
+         End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMCurrentEntry  1}
+
+jnxoptIfOTNPMCurrentLayer   OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNLayer
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for OTUk,
+         ODUk, TCMn performance data.
+         1 - OTUk (OCh which is used for the black link)
+         2 - ODUk
+         3 - TCM
+         The ODUk/TCM sublayer PM is not related to the black link PM
+         management, but since this is a common PM model for the ODU/TCM layer,
+         we may include it here."
+    ::= { jnxoptIfOTNPMCurrentEntry  2}
+
+jnxoptIfOTNPMCurrentTCMLevel   OBJECT-TYPE
+    SYNTAX  Unsigned32 (0..6)
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the TCM level (1-6)
+         if the PM is of the type TCM. This will be 0 for OTUK/ODUK."
+    ::= { jnxoptIfOTNPMCurrentEntry  3}
+
+
+jnxoptIfOTNPMCurrentSuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+    ::= { jnxoptIfOTNPMCurrentEntry  4}
+
+jnxoptIfOTNPMCurrentBip8   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Number of Failures occurred in an observation period."
+    ::= { jnxoptIfOTNPMCurrentEntry  5}
+
+jnxoptIfOTNPMCurrentESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "This is the number of seconds in which one or more bits are in
+         error or during which Loss of Signal (LOS) or Alarm Indication
+         Signal (AIS) is detected."
+    ::= { jnxoptIfOTNPMCurrentEntry  6}
+
+jnxoptIfOTNPMCurrentSESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of seconds which have a severe error.
+         This is the number of seconds in which the bit-error ratio =
+         1x10Eminus3 or during which Loss of Signal (LOS) or Alarm
+         Indication Signal (AIS) is detected."
+    ::= { jnxoptIfOTNPMCurrentEntry  7}
+
+jnxoptIfOTNPMCurrentUASs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "It is the number of unavailable seconds.
+         A period of unavailable time begins at the onset of ten
+         consecutive SES events.  These ten seconds are considered to be
+         part of unavailable time.  A new period of available time begins
+         at the onset of ten consecutive non-SES events.  These ten seconds
+         are considered to be part of available time."
+    ::= { jnxoptIfOTNPMCurrentEntry  8}
+
+jnxoptIfOTNPMCurrentBBEs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "An errored block not occurring as part of an SES."
+    ::= { jnxoptIfOTNPMCurrentEntry  9}
+ 
+jnxoptIfOTNPMCurrentESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of ES in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMCurrentEntry  10}
+
+
+jnxoptIfOTNPMCurrentSESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of SES in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMCurrentEntry  11}
+
+jnxoptIfOTNPMCurrentBBER OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of BER in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMCurrentEntry 12 }
+
+jnxoptIfOTNPMCurrentElapsedTime OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  "seconds"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Time elapsed for this 15 minute interval"
+    ::= { jnxoptIfOTNPMCurrentEntry 13 }
+
+jnxoptIfOTNPMCurSuspectReason OBJECT-TYPE
+    SYNTAX  Integer32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - interface disabled
+          4 - clock shift detected
+          5 - cleared by user
+          6 - interval too short secs < 890
+          7 - interval too long secs > 910
+          8 - near end unavailable
+          9 - far end unavailable
+         10 - partial data
+         11 - missing intervals due to restarts
+        "
+    ::= { jnxoptIfOTNPMCurrentEntry 14 }
+
+--
+-- OTN PM Interval Table
+-- Upto 96 15-minute intervals
+--
+jnxoptIfOTNPMIntervalTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMIntervalEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring Interval Table."
+    ::= { jnxoptIfOTNPMGroup 4 }
+
+jnxoptIfOTNPMIntervalEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMIntervalEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance monitoring
+         Interval table for the type 'jnxoptIfOTNPMIntervalLayer' layer."
+    INDEX  { ifIndex, jnxoptIfOTNPMIntervalType, jnxoptIfOTNPMIntervalLayer,
+             jnxoptIfOTNPMIntervalTCMLevel, jnxoptIfOTNPMIntervalNumber  }
+    ::= { jnxoptIfOTNPMIntervalTable 1 }
+
+JnxoptIfOTNPMIntervalEntry  ::=
+    SEQUENCE {
+        jnxoptIfOTNPMIntervalType                      JnxoptIfOTNType,
+        jnxoptIfOTNPMIntervalLayer                     JnxoptIfOTNLayer,
+        jnxoptIfOTNPMIntervalTCMLevel                  Unsigned32,
+        jnxoptIfOTNPMIntervalNumber                    Unsigned32,
+        jnxoptIfOTNPMIntervalSuspectedFlag             TruthValue,
+        jnxoptIfOTNPMIntervalBip8                      Unsigned32,
+        jnxoptIfOTNPMIntervalESs                       Unsigned32,
+        jnxoptIfOTNPMIntervalSESs                      Unsigned32,
+        jnxoptIfOTNPMIntervalUASs                      Unsigned32,
+        jnxoptIfOTNPMIntervalBBEs                      Unsigned32,
+        jnxoptIfOTNPMIntervalESR                       Unsigned32,
+        jnxoptIfOTNPMIntervalSESR                      Unsigned32,
+        jnxoptIfOTNPMIntervalBBER                      Unsigned32,
+        jnxoptIfOTNPMIntervalTimeStamp                 DateAndTime,
+        jnxoptIfOTNPMIntSuspectReason                  Integer32
+    }
+
+jnxoptIfOTNPMIntervalType         OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMIntervalEntry  1}
+
+jnxoptIfOTNPMIntervalLayer   OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNLayer
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for OTUk,
+         ODUk, TCMn performance data.
+         1 - OTUk
+         2  - ODUk
+         3 - TCM
+         The ODUk/TCM sublayer PM is not related to the black link PM
+         management, but since this is a common  PM model for the ODU/TCM
+         layer, we may include it here."
+    ::= { jnxoptIfOTNPMIntervalEntry  2}
+
+jnxoptIfOTNPMIntervalTCMLevel   OBJECT-TYPE
+    SYNTAX  Unsigned32 (0..6)
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the TCM level (1-6)
+         if the PM is of the type TCM. This will be 0 for OTUK/ODUK."
+    ::= { jnxoptIfOTNPMIntervalEntry  3}
+
+jnxoptIfOTNPMIntervalNumber   OBJECT-TYPE
+    SYNTAX  Unsigned32 (1..96)
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A number between 1 and 96, where 1 is the most
+         recently completed 15 minute interval and 96 is
+         the 15 minutes interval completed 23 hours and 45
+         minutes prior to interval 1."
+    ::= { jnxoptIfOTNPMIntervalEntry  4}
+
+jnxoptIfOTNPMIntervalSuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+    ::= { jnxoptIfOTNPMIntervalEntry  5}
+ 
+jnxoptIfOTNPMIntervalBip8   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Number of Failures occurred in an observation period."
+    ::= { jnxoptIfOTNPMIntervalEntry  6}
+
+jnxoptIfOTNPMIntervalESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "It is a one-second period in which one or more bits are in error
+         or during which Loss of Signal (LOS) or Alarm Indication Signal
+         (AIS) is detected."
+    ::= { jnxoptIfOTNPMIntervalEntry  7}
+
+
+jnxoptIfOTNPMIntervalSESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of seconds which have a severe error.
+         It is a one-second period which has a bit-error ratio =
+         1x10Eminus3 or during which Loss of Signal (LOS) or Alarm
+         Indication Signal (AIS) is detected."
+    ::= { jnxoptIfOTNPMIntervalEntry  8}
+
+jnxoptIfOTNPMIntervalUASs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "It is the number of unavailable seconds in this 15 minute interval.
+         A period of unavailable time begins at the onset of ten
+         consecutive SES events.  These ten seconds are considered to be
+         part of unavailable time.  A new period of available time begins
+         at the onset of ten consecutive non-SES events.  These ten seconds
+         are considered to be part of available time."
+    ::= { jnxoptIfOTNPMIntervalEntry  9}
+
+jnxoptIfOTNPMIntervalBBEs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "An errored block not occurring as part of an SES."
+    ::= { jnxoptIfOTNPMIntervalEntry  10}
+
+jnxoptIfOTNPMIntervalESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of ES in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMIntervalEntry  11}
+ 
+jnxoptIfOTNPMIntervalSESR   OBJECT-TYPE
+    SYNTAX Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of SES in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMIntervalEntry  12}
+
+jnxoptIfOTNPMIntervalBBER   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of BBE in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMIntervalEntry  13}
+
+jnxoptIfOTNPMIntervalTimeStamp  OBJECT-TYPE
+    SYNTAX  DateAndTime
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Time stamp of this interval."
+    ::= { jnxoptIfOTNPMIntervalEntry  14}
+  
+jnxoptIfOTNPMIntSuspectReason  OBJECT-TYPE
+    SYNTAX  Integer32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - interface disabled
+          4 - clock shift detected
+          5 - cleared by user
+          6 - interval too short secs < 890
+          7 - interval too long secs > 910
+          8 - near end unavailable
+          9 - far end unavailable
+         10 - partial data
+         11 - missing intervals due to restarts
+
+        "
+    ::= { jnxoptIfOTNPMIntervalEntry  15}
+--
+-- PM Current Day Entry
+--
+jnxoptIfOTNPMCurrentDayTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMCurrentDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring Current Day Table."
+    ::= { jnxoptIfOTNPMGroup  5 }
+ 
+
+jnxoptIfOTNPMCurrentDayEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMCurrentDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance
+         monitoring Current day table for the type
+         'jnxoptIfOTNPMCurrentDayLayer'  layer."
+    INDEX { ifIndex, jnxoptIfOTNPMCurrentDayType, jnxoptIfOTNPMCurrentDayLayer,
+            jnxoptIfOTNPMCurrentDayTCMLevel  }
+    ::= { jnxoptIfOTNPMCurrentDayTable 1 }
+
+JnxoptIfOTNPMCurrentDayEntry  ::=
+    SEQUENCE {
+        jnxoptIfOTNPMCurrentDayType                   JnxoptIfOTNType,
+        jnxoptIfOTNPMCurrentDayLayer                  JnxoptIfOTNLayer,
+        jnxoptIfOTNPMCurrentDayTCMLevel               Unsigned32,
+        jnxoptIfOTNPMCurrentDaySuspectedFlag          TruthValue,
+        jnxoptIfOTNPMCurrentDayBip8                   Unsigned32,
+        jnxoptIfOTNPMCurrentDayESs                    Unsigned32,
+        jnxoptIfOTNPMCurrentDaySESs                   Unsigned32,
+        jnxoptIfOTNPMCurrentDayUASs                   Unsigned32,
+        jnxoptIfOTNPMCurrentDayBBEs                   Unsigned32,
+        jnxoptIfOTNPMCurrentDayESR                    Unsigned32,
+        jnxoptIfOTNPMCurrentDaySESR                   Unsigned32,
+        jnxoptIfOTNPMCurrentDayBBER                   Unsigned32,
+        jnxoptIfOTNPMCurrentDayElapsedTime            Unsigned32,
+        jnxoptIfOTNPMCurDaySuspectReason              Integer32
+    }
+
+jnxoptIfOTNPMCurrentDayType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for
+         the Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMCurrentDayEntry  1}
+
+jnxoptIfOTNPMCurrentDayLayer   OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNLayer
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for OTUk,
+         ODUk, TCMn performance data.
+         1 - OTUk
+         2 - ODUk
+         3 - TCM
+         The ODUk/TCM sublayer PM is not related to the black link PM
+         management, but since this is a common PM model for the ODU/TCM layer,
+         we may include it here."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  2}
+
+jnxoptIfOTNPMCurrentDayTCMLevel   OBJECT-TYPE
+    SYNTAX  Unsigned32 (0..6)
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the TCM level (1-6)
+         if the PM is of the type TCM. This will be 0 for OTUK/ODUK."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  3}
+
+
+jnxoptIfOTNPMCurrentDaySuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+  ::= { jnxoptIfOTNPMCurrentDayEntry  4}
+
+jnxoptIfOTNPMCurrentDayBip8   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Number of Failures occurred in an observation period."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  5}
+
+
+
+jnxoptIfOTNPMCurrentDayESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of seconds which have an error.
+         It is a one-second period in which one or more bits are in error
+         or during which Loss of Signal (LOS) or Alarm Indication Signal
+         (AIS) is detected."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  6}
+
+jnxoptIfOTNPMCurrentDaySESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of seconds which have a severe error.
+         It is a one-second period which has a bit-error ratio =
+         1x10Eminus3 or during which Loss of Signal (LOS) or Alarm
+         Indication Signal (AIS) is detected."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  7}
+
+jnxoptIfOTNPMCurrentDayUASs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "It is the number of unavailable seconds in the cunrrent day.
+         A period of unavailable time begins at the onset of ten
+         consecutive SES events.  These ten seconds are considered to be
+         part of unavailable time.  A new period of available time begins
+         at the onset of ten consecutive non-SES events. These ten seconds
+         are considered to be part of available time."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  8}
+
+jnxoptIfOTNPMCurrentDayBBEs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "An errored block not occurring as part of an SES."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  9}
+
+jnxoptIfOTNPMCurrentDayESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of ES in available time to total seconds in available
+        time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  10}
+
+jnxoptIfOTNPMCurrentDaySESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of SES in available time to total seconds in available
+        time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  11}
+ 
+jnxoptIfOTNPMCurrentDayBBER   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of BBE in available time to total seconds in available
+        time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMCurrentDayEntry  12}
+
+jnxoptIfOTNPMCurrentDayElapsedTime  OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "seconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Time elapsed for current day"
+    ::= { jnxoptIfOTNPMCurrentDayEntry  13 }
+
+jnxoptIfOTNPMCurDaySuspectReason  OBJECT-TYPE
+    SYNTAX  Integer32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - interface disabled
+          4 - clock shift detected
+          5 - cleared by user
+          6 - partial data
+          7 - one or more intervals are invaild
+        "
+    ::= { jnxoptIfOTNPMCurrentDayEntry  14 }
+
+--
+-- PM Prev Day Entry
+--
+jnxoptIfOTNPMPrevDayTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMPrevDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring Previous Day Table."
+    ::= { jnxoptIfOTNPMGroup 6 }
+
+jnxoptIfOTNPMPrevDayEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMPrevDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance
+         monitoring previous day table for the type
+         'jnxoptIfOTNPMPrevDayLayer' layer."
+    INDEX  { ifIndex, jnxoptIfOTNPMPrevDayType     ,
+             jnxoptIfOTNPMPrevDayLayer, jnxoptIfOTNPMPrevDayTCMLevel  }
+    ::= { jnxoptIfOTNPMPrevDayTable 1 }
+
+JnxoptIfOTNPMPrevDayEntry  ::=
+    SEQUENCE {
+        jnxoptIfOTNPMPrevDayType                      JnxoptIfOTNType,
+        jnxoptIfOTNPMPrevDayLayer                     JnxoptIfOTNLayer,
+        jnxoptIfOTNPMPrevDayTCMLevel                  Unsigned32,
+        jnxoptIfOTNPMPrevDaySuspectedFlag             TruthValue,
+        jnxoptIfOTNPMPrevDayBip8                      Unsigned32,
+        jnxoptIfOTNPMPrevDayESs                       Unsigned32,
+        jnxoptIfOTNPMPrevDaySESs                      Unsigned32,
+        jnxoptIfOTNPMPrevDayUASs                      Unsigned32,
+        jnxoptIfOTNPMPrevDayBBEs                      Unsigned32,
+        jnxoptIfOTNPMPrevDayESR                       Unsigned32,
+        jnxoptIfOTNPMPrevDaySESR                      Unsigned32,
+        jnxoptIfOTNPMPrevDayBBER                      Unsigned32,
+        jnxoptIfOTNPMPrevDayTimeStamp                 DateAndTime,
+        jnxoptIfOTNPMPrevDaySuspectReason             Integer32
+
+    }
+
+jnxoptIfOTNPMPrevDayType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMPrevDayEntry  1}
+
+jnxoptIfOTNPMPrevDayLayer   OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNLayer
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for OTUk,
+         ODUk, TCMn performance data.
+         1 - OTUk
+         2 - ODUk
+         3 - TCM
+         The ODUk/TCM sublayer PM is not related to the black link PM
+         management, but since this is a common PM model for the ODU/TCM
+         layer, we may include it here."
+    ::= { jnxoptIfOTNPMPrevDayEntry  2}
+
+jnxoptIfOTNPMPrevDayTCMLevel   OBJECT-TYPE
+    SYNTAX  Unsigned32 (0..6)
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the TCM level (1-6)
+         if the PM is of the type TCM."
+    ::= { jnxoptIfOTNPMPrevDayEntry  3}
+
+
+jnxoptIfOTNPMPrevDaySuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+  ::= { jnxoptIfOTNPMPrevDayEntry  4}
+
+jnxoptIfOTNPMPrevDayBip8   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Number of pre FEC failures occurred in an observation period."
+    ::= { jnxoptIfOTNPMPrevDayEntry  5}
+
+jnxoptIfOTNPMPrevDayESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of seconds which have an error.
+         It is a one-second period in which one or more bits are in error
+         or during which Loss of Signal (LOS) or Alarm Indication Signal
+         (AIS) is detected."
+    ::= { jnxoptIfOTNPMPrevDayEntry  6}
+
+jnxoptIfOTNPMPrevDaySESs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of seconds which have a severe error.
+         A severely errored second, is a one-second period which has
+         a bit-error ratio = 1x10Eminus3 or during which Loss of Signal (LOS)
+         or Alarm Indication Signal (AIS) is detected."
+    ::= { jnxoptIfOTNPMPrevDayEntry  7}
+
+jnxoptIfOTNPMPrevDayUASs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "It is the number of unavailable seconds in the previous day.
+         A period of unavailable time begins at the onset of ten
+         consecutive SES events.  These ten seconds are considered to be
+         part of unavailable time.  A new period of available time begins
+         at the onset of ten consecutive non-SES events.  These ten seconds
+         are considered to be part of available time."
+    ::= { jnxoptIfOTNPMPrevDayEntry  8}
+
+jnxoptIfOTNPMPrevDayBBEs   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "An errored block not occurring as part of an SES."
+    ::= { jnxoptIfOTNPMPrevDayEntry  9}
+
+jnxoptIfOTNPMPrevDayESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of ES in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMPrevDayEntry  10}
+
+jnxoptIfOTNPMPrevDaySESR   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of SES in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMPrevDayEntry  11}
+
+jnxoptIfOTNPMPrevDayBBER   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    UNITS  ".001"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The ratio of BBE in available time to total seconds in available
+         time during a fixed measurement interval."
+    ::= { jnxoptIfOTNPMPrevDayEntry  12}
+
+jnxoptIfOTNPMPrevDayTimeStamp  OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Time stamp of this interval."
+    ::= { jnxoptIfOTNPMPrevDayEntry  13}
+
+jnxoptIfOTNPMPrevDaySuspectReason  OBJECT-TYPE
+    SYNTAX  Integer32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - clock shift detected
+          4 - cleared by user
+          5 - partial data
+          6 - missing intervals due to restarts
+          7 - one or more intervals are invaild
+        "
+    ::= { jnxoptIfOTNPMPrevDayEntry  14 }
+
+--
+-- OTN FEC PM Config Table
+--
+jnxoptIfOTNPMFECConfigTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMFECConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A table of performance monitoring  FEC configuration."
+    ::= { jnxoptIfOTNPMGroup 7 }
+
+jnxoptIfOTNPMFECConfigEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMFECConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the performance monitoring FEC configuration
+         layer."
+    INDEX  { ifIndex, jnxoptIfOTNPMFECConfigType }
+    ::= { jnxoptIfOTNPMFECConfigTable 1 }
+
+JnxoptIfOTNPMFECConfigEntry  ::=
+    SEQUENCE {
+        jnxoptIfOTNPMFECConfigType                      JnxoptIfOTNType,
+        jnxoptIfOTNPMFECValidIntervals                  Unsigned32,
+        jnxoptIfOTNPM15MinPreFECBERMantissaThreshold    Unsigned32,
+        jnxoptIfOTNPM15MinPreFECBERExponentThreshold    Unsigned32,
+        jnxoptIfOTNPM24HourPreFECBERMantissaThreshold   Unsigned32,
+        jnxoptIfOTNPM24HourPreFECBERExponentThreshold   Unsigned32,
+        jnxoptIfOTNPMFECBEREnableTCA                    TruthValue
+    }
+
+jnxoptIfOTNPMFECConfigType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMFECConfigEntry  1}
+
+jnxoptIfOTNPMFECValidIntervals  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of contiguous 15 minute intervals for which valid FEC
+         PM data is available for the particular interface."
+    ::= {jnxoptIfOTNPMFECConfigEntry  2}
+
+jnxoptIfOTNPM15MinPreFECBERMantissaThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "BER (mantissa) by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshPreFECBERTCA. One notification
+         will be sent per interval per interface. A value of `0' will disable
+         the notification."
+    ::= {jnxoptIfOTNPMFECConfigEntry  3}
+
+jnxoptIfOTNPM15MinPreFECBERExponentThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The Pre FEC BER (exponent) by the interface within any
+         given 15 minutes performance data collection period, which causes the
+         SNMP agent to send jnxoptIf15MinThreshPreFECBERTCA. One notification
+         will be sent per interval per interface. A value of `0' will disable
+         the notification."
+    ::= {jnxoptIfOTNPMFECConfigEntry  4}
+
+jnxoptIfOTNPM24HourPreFECBERMantissaThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "BER (mantissa) by the interface within any
+         given 24 Hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf5s24Hour15MinThreshPreFECBERTCA. 
+         One notification will be sent per 24 hour period per interface. 
+         A value of `0' will disable the notification."
+    ::= {jnxoptIfOTNPMFECConfigEntry  5}
+
+jnxoptIfOTNPM24HourPreFECBERExponentThreshold  OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        "The Pre FEC BER (exponent) by the interface within any
+         given 24 Hour performance data collection period, which causes the
+         SNMP agent to send jnxoptIf5s24Hour15MinThreshPreFECBERTCA.
+         One notification will be sent per 24 hour period per interface.
+         A value of `0' will disable the notification."
+    ::= {jnxoptIfOTNPMFECConfigEntry  6}
+
+jnxoptIfOTNPMFECBEREnableTCA  OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+        " Enable TCA's - 15minute and 24hr for FEC BER "
+    ::= { jnxoptIfOTNPMFECConfigEntry 7 }
+
+--
+-- FEC PM Table
+--
+jnxoptIfOTNPMFECCurrentTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMFECCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring FEC Current Table."
+    ::= { jnxoptIfOTNPMGroup 8 }
+
+jnxoptIfOTNPMFECCurrentEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMFECCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance
+         monitoring FEC current table."
+    INDEX  { ifIndex, jnxoptIfOTNPMFECCurrentType}
+    ::= { jnxoptIfOTNPMFECCurrentTable  1 }
+
+JnxoptIfOTNPMFECCurrentEntry  ::=
+    SEQUENCE {
+        jnxoptIfOTNPMFECCurrentType                     JnxoptIfOTNType,
+        jnxoptIfOTNPMFECCurrentSuspectedFlag            TruthValue,
+        jnxoptIfOTNPMCurrentFECCorrectedErr             Counter64,
+        jnxoptIfOTNPMCurrentFECUncorrectedWords         Counter64,
+        jnxoptIfOTNPMCurrentFECBERMantissa              Unsigned32,
+        jnxoptIfOTNPMCurrentFECBERExponent              Unsigned32,
+        jnxoptIfOTNPMCurrentFECMinBERMantissa           Unsigned32,
+        jnxoptIfOTNPMCurrentFECMinBERExponent           Unsigned32,
+        jnxoptIfOTNPMCurrentFECMaxBERMantissa           Unsigned32,
+        jnxoptIfOTNPMCurrentFECMaxBERExponent           Unsigned32,
+        jnxoptIfOTNPMCurrentFECAvgBERMantissa           Unsigned32,
+        jnxoptIfOTNPMCurrentFECAvgBERExponent           Unsigned32,
+        jnxoptIfOTNPMCurrentFECElapsedTime              Unsigned32,
+        jnxoptIfOTNPMFECCurSuspectReason                Integer32
+    }
+
+jnxoptIfOTNPMFECCurrentType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMFECCurrentEntry  1}
+
+
+jnxoptIfOTNPMFECCurrentSuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  2}
+
+jnxoptIfOTNPMCurrentFECCorrectedErr   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of bits corrected by the FEC are counted in the
+         interval."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  3}
+
+jnxoptIfOTNPMCurrentFECUncorrectedWords   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of un-corrected words by the FEC are counted over the
+         interval."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  4}
+
+jnxoptIfOTNPMCurrentFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of Errored bits at receiving side before the FEC
+         function counted over one second .. mantissa."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  5}
+
+jnxoptIfOTNPMCurrentFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of Errored bits at receiving side before the FEC
+         function counted over one second .. exponent (eg -1)."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  6}
+
+jnxoptIfOTNPMCurrentFECMinBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimum number of Errored bits at receiving side before the FEC
+         function counted over one second .. mantissa."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  7}
+
+jnxoptIfOTNPMCurrentFECMinBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimum number of Errored bits at receiving side before the FEC
+         function counted over one second .. exponent (eg -1)."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  8}
+
+jnxoptIfOTNPMCurrentFECMaxBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximum number of Errored bits at receiving side before the FEC
+         function counted over one second .. mantissa."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  9}
+
+jnxoptIfOTNPMCurrentFECMaxBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximum number of Errored bits at receiving side before the FEC
+         function counted over one second .. exponent (eg -1)."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  10}
+
+jnxoptIfOTNPMCurrentFECAvgBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average number of Errored bits at receiving side before the FEC
+         function counted over one second .. mantissa."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  11}
+
+jnxoptIfOTNPMCurrentFECAvgBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average number of Errored bits at receiving side before the FEC
+         function counted over one second .. exponent (eg -1)."
+    ::= { jnxoptIfOTNPMFECCurrentEntry  12}
+
+jnxoptIfOTNPMCurrentFECElapsedTime    OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "seconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Time elapsed for this 15 minute interval."
+    ::= { jnxoptIfOTNPMFECCurrentEntry 13 }
+
+jnxoptIfOTNPMFECCurSuspectReason OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - interface disabled
+          4 - clock shift detected
+          5 - cleared by user
+          6 - interval too short secs < 890
+          7 - interval too long secs > 910
+          8 - near end unavailable
+          9 - far end unavailable
+         10 - partial data
+         11 - missing intervals due to restarts
+        "
+    ::= { jnxoptIfOTNPMFECCurrentEntry 14 }
+--
+-- FEC PM  Interval Table
+--
+jnxoptIfOTNPMFECIntervalTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMFECIntervalEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring FEC Interval Table."
+    ::= { jnxoptIfOTNPMGroup 9 }
+ 
+jnxoptIfOTNPMFECIntervalEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMFECIntervalEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance
+         monitoring FEC interval table."
+    INDEX  { ifIndex, jnxoptIfOTNPMFECIntervalType,
+             jnxoptIfOTNPMFECIntervalNumber }
+    ::= { jnxoptIfOTNPMFECIntervalTable 1 }
+
+JnxoptIfOTNPMFECIntervalEntry ::=
+    SEQUENCE {
+        jnxoptIfOTNPMFECIntervalType                   JnxoptIfOTNType,
+        jnxoptIfOTNPMFECIntervalNumber                 Unsigned32,
+        jnxoptIfOTNPMFECIntervalSuspectedFlag          TruthValue,
+        jnxoptIfOTNPMIntervalFECCorrectedErr           Counter64,
+        jnxoptIfOTNPMIntervalFECUncorrectedWords       Counter64,
+        jnxoptIfOTNPMIntervalMinFECBERMantissa         Unsigned32,
+        jnxoptIfOTNPMIntervalMinFECBERExponent         Unsigned32,
+        jnxoptIfOTNPMIntervalMaxFECBERMantissa         Unsigned32,
+        jnxoptIfOTNPMIntervalMaxFECBERExponent         Unsigned32,
+        jnxoptIfOTNPMIntervalAvgFECBERMantissa         Unsigned32,
+        jnxoptIfOTNPMIntervalAvgFECBERExponent         Unsigned32,
+        jnxoptIfOTNPMFECIntervalTimeStamp              DateAndTime,
+        jnxoptIfOTNPMFECIntSuspectReason               Integer32
+    }
+
+jnxoptIfOTNPMFECIntervalType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMFECIntervalEntry  1}
+
+jnxoptIfOTNPMFECIntervalNumber   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS not-accessible 
+    STATUS  current
+    DESCRIPTION
+        "A number between 1 and 96, where 1 is the most
+         recently completed 15 minute interval and 96 is
+         the 15 minutes interval completed 23 hours and 45
+         minutes prior to interval 1."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  2}
+
+jnxoptIfOTNPMFECIntervalSuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  3}
+
+jnxoptIfOTNPMIntervalFECCorrectedErr   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of bits corrected by the FEC are counted in the
+         interval."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  4}
+
+jnxoptIfOTNPMIntervalFECUncorrectedWords   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of words un-corrected words by the FEC are counted over
+         the interval."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  5}
+
+jnxoptIfOTNPMIntervalMinFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimun bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the minimum Pre
+         FEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  6}
+
+jnxoptIfOTNPMIntervalMinFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimun bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the minimum Pre
+         FEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  7}
+
+jnxoptIfOTNPMIntervalMaxFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the maximum Pre
+         FEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  8}
+
+jnxoptIfOTNPMIntervalMaxFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the maximum Pre
+         FEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  9}
+
+jnxoptIfOTNPMIntervalAvgFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the average Pre
+         FEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  10}
+
+jnxoptIfOTNPMIntervalAvgFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the average Pre
+         FEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECIntervalEntry  11}
+
+jnxoptIfOTNPMFECIntervalTimeStamp  OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Time stamp of this interval."
+    ::= { jnxoptIfOTNPMFECIntervalEntry 12 }
+
+jnxoptIfOTNPMFECIntSuspectReason  OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - interface disabled
+          4 - clock shift detected
+          5 - cleared by user
+          6 - interval too short secs < 890
+          7 - interval too long secs > 910
+          8 - near end unavailable
+          9 - far end unavailable
+         10 - partial data
+         11 - missing intervals due to restarts
+        "
+    ::= { jnxoptIfOTNPMFECIntervalEntry 13 }
+
+--
+-- FEC PM  Current Day day Table
+--
+jnxoptIfOTNPMFECCurrentDayTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMFECCurrentDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring FEC current day table."
+    ::= { jnxoptIfOTNPMGroup 10 }
+
+jnxoptIfOTNPMFECCurrentDayEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMFECCurrentDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance
+         monitoring FEC current day table."
+    INDEX  { ifIndex, jnxoptIfOTNPMFECCurrentDayType }
+    ::= { jnxoptIfOTNPMFECCurrentDayTable 1 }
+
+JnxoptIfOTNPMFECCurrentDayEntry ::=
+    SEQUENCE {
+        jnxoptIfOTNPMFECCurrentDayType                     JnxoptIfOTNType,
+        jnxoptIfOTNPMFECCurrentDaySuspectedFlag            TruthValue,
+        jnxoptIfOTNPMCurrentDayFECCorrectedErr             Counter64,
+        jnxoptIfOTNPMCurrentDayFECUncorrectedWords         Counter64,
+        jnxoptIfOTNPMCurrentDayMinFECBERMantissa           Unsigned32,
+        jnxoptIfOTNPMCurrentDayMinFECBERExponent           Unsigned32,
+        jnxoptIfOTNPMCurrentDayMaxFECBERMantissa           Unsigned32,
+        jnxoptIfOTNPMCurrentDayMaxFECBERExponent           Unsigned32,
+        jnxoptIfOTNPMCurrentDayAvgFECBERMantissa           Unsigned32,
+        jnxoptIfOTNPMCurrentDayAvgFECBERExponent           Unsigned32,
+        jnxoptIfOTNPMFECCurrentDayElapsedTime              Unsigned32,
+        jnxoptIfOTNPMFECCurDaySuspectReason                Integer32
+    }
+
+jnxoptIfOTNPMFECCurrentDayType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  1}
+
+
+jnxoptIfOTNPMFECCurrentDaySuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  2}
+
+jnxoptIfOTNPMCurrentDayFECCorrectedErr   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of bits corrected by the FEC are counted in the
+         interval."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  3}
+
+jnxoptIfOTNPMCurrentDayFECUncorrectedWords   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of words un-corrected by the FEC are counted over the
+         Day."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  4}
+
+jnxoptIfOTNPMCurrentDayMinFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimun bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the minimum
+         PreFEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  5}
+
+jnxoptIfOTNPMCurrentDayMinFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimun bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the minimum
+         PreFEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  6}
+
+jnxoptIfOTNPMCurrentDayMaxFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the maximum
+         PreFEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  7}
+
+jnxoptIfOTNPMCurrentDayMaxFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the maximum
+         PreFEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  8}
+
+jnxoptIfOTNPMCurrentDayAvgFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the average
+         PreFEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  9}
+
+jnxoptIfOTNPMCurrentDayAvgFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the average
+         PreFEC BER in the current 24hour period."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  10}
+
+jnxoptIfOTNPMFECCurrentDayElapsedTime    OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "seconds"
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Time elapsed for current day."
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  11}
+
+jnxoptIfOTNPMFECCurDaySuspectReason  OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - clock shift detected
+          4 - cleared by user
+          5 - partial data
+          6 - missing intervals due to restarts
+          7 - one or more intervals are invaild
+        "
+    ::= { jnxoptIfOTNPMFECCurrentDayEntry  12}
+
+--
+-- FEC PM  Prev day Table
+--
+jnxoptIfOTNPMFECPrevDayTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxoptIfOTNPMFECPrevDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A Performance monitoring FEC previous day table."
+    ::= { jnxoptIfOTNPMGroup 11 }
+
+jnxoptIfOTNPMFECPrevDayEntry OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNPMFECPrevDayEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "A conceptual entry in the Near end or Far End performance
+         monitoring FEC previous day table."
+    INDEX  { ifIndex, jnxoptIfOTNPMFECPrevDayType }
+    ::= { jnxoptIfOTNPMFECPrevDayTable 1 }
+
+JnxoptIfOTNPMFECPrevDayEntry ::=
+    SEQUENCE {
+        jnxoptIfOTNPMFECPrevDayType                     JnxoptIfOTNType,
+        jnxoptIfOTNPMFECPrevDaySuspectedFlag            TruthValue,
+        jnxoptIfOTNPMPrevDayFECCorrectedErr             Counter64,
+        jnxoptIfOTNPMPrevDayFECUncorrectedWords         Counter64,
+        jnxoptIfOTNPMPrevDayMinFECBERMantissa           Unsigned32,
+        jnxoptIfOTNPMPrevDayMinFECBERExponent           Unsigned32,
+        jnxoptIfOTNPMPrevDayMaxFECBERMantissa           Unsigned32,
+        jnxoptIfOTNPMPrevDayMaxFECBERExponent           Unsigned32,
+        jnxoptIfOTNPMPrevDayAvgFECBERMantissa           Unsigned32,
+        jnxoptIfOTNPMPrevDayAvgFECBERExponent           Unsigned32,
+        jnxoptIfOTNPMFECPrevDayTimeStamp                DateAndTime,
+        jnxoptIfOTNPMFECPrevDaySuspectReason            Integer32
+    }
+
+jnxoptIfOTNPMFECPrevDayType        OBJECT-TYPE
+    SYNTAX  JnxoptIfOTNType
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+        "This parameter indicates the parameters for the table are for the
+         Near End or Far End performance data.
+         1 - Near End
+         2 - Far End "
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  1}
+
+
+jnxoptIfOTNPMFECPrevDaySuspectedFlag   OBJECT-TYPE
+    SYNTAX  TruthValue
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "If true, the data in this entry may be unreliable."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  2}
+
+jnxoptIfOTNPMPrevDayFECCorrectedErr   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of bits corrected by the FEC are counted in the
+         previous day."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  3}
+
+jnxoptIfOTNPMPrevDayFECUncorrectedWords   OBJECT-TYPE
+    SYNTAX  Counter64
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The number of un-corrected words by the FEC are counted over the
+         previous Day."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  4}
+
+jnxoptIfOTNPMPrevDayMinFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the maximum Pre
+         FEC BER in the previous 24hour period."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  5}
+
+jnxoptIfOTNPMPrevDayMinFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The minimun bit error rate at receiving side before the FEC
+         function counted over one second .. exponent. This is the maximum Pre
+         FEC BER in the previous 24hour period."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  6}
+
+jnxoptIfOTNPMPrevDayMaxFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the maximum Pre
+         FEC BER in the previous 24hour period (mantissa)."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  7}
+
+jnxoptIfOTNPMPrevDayMaxFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The maximun bit error rate at receiving side before the FEC
+         function counted over one second .. exponent (eg -3).
+         This is the maximum Pre FEC BER in the previous 24hour period."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  8}
+
+jnxoptIfOTNPMPrevDayAvgFECBERMantissa   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average bit error rate at receiving side before the FEC
+         function counted over one second .. mantissa. This is the average Pre
+         FEC BER during the previous 24hour period (mantissa)."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  9}
+
+jnxoptIfOTNPMPrevDayAvgFECBERExponent   OBJECT-TYPE
+    SYNTAX  Unsigned32
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "The average bit error rate at receiving side before the FEC
+         function counted over one second .. exponent (eg -3).
+         This is the average Pre FEC BER during the previous 24hour period."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  10}
+
+jnxoptIfOTNPMFECPrevDayTimeStamp OBJECT-TYPE
+    SYNTAX  DateAndTime
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+        "Time stamp for the Prev day."
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  11}
+
+jnxoptIfOTNPMFECPrevDaySuspectReason  OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "If SuspectedFlag is true, the reson for the PM data being suspect.
+          0 - not applicable
+          1 - unknown
+          2 - new object
+          3 - clock shift detected
+          4 - cleared by user
+          5 - partial data
+          6 - missing intervals due to restarts
+          7 - one or more intervals are invaild
+        "
+    ::= { jnxoptIfOTNPMFECPrevDayEntry  12}
+
+--
+-- OTN Alarm Table
+--
+jnxoptIfOTNAlarmTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF JnxoptIfOTNAlarmEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "A table of alarm entries."
+
+    ::= { jnxoptIfOTNAlarm 1 }
+
+jnxoptIfOTNAlarmEntry OBJECT-TYPE
+    SYNTAX     JnxoptIfOTNAlarmEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "A conceptual entry in the alarm table."
+    INDEX { ifIndex }
+    ::= { jnxoptIfOTNAlarmTable 1 }
+
+JnxoptIfOTNAlarmEntry ::= SEQUENCE {
+    jnxoptIfOTNAlarmLocation                 JnxoptIfOTNType,
+    jnxoptIfOTNAlarmDirection                JnxoptIfOTNDirection,
+    jnxoptIfOTNAlarmLayer                    JnxoptIfOTNLayer,
+    jnxoptIfOTNAlarmTCMLevel                 Unsigned32,
+    jnxoptIfOTNOChOTUkAlarmType              JnxoptIfOTNOChAlarms,
+    jnxoptIfOTNAlarmSeverity                 JnxoptIfOTNAlarmSeverity,
+    jnxoptIfOTNAlarmDate                     DateAndTime,
+    jnxoptIfOTNODUkTcmAlarmType              JnxoptIfOTNODUkTcmAlarms
+}
+
+jnxoptIfOTNAlarmLocation OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNType
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The object identifies indicates if this entry was for
+         Near end/Far end."
+    ::= { jnxoptIfOTNAlarmEntry 1 }
+
+jnxoptIfOTNAlarmDirection OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNDirection
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The object identifies indicates if this entry was for
+         for the Tx/Rx or both."
+    ::= { jnxoptIfOTNAlarmEntry 2 }
+
+jnxoptIfOTNAlarmLayer OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNLayer
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This specifies which sublayer this alarm is for."
+    ::= { jnxoptIfOTNAlarmEntry 3 }
+
+jnxoptIfOTNAlarmTCMLevel   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "TCM level 1-6 of the alarm. It will be 0 if alarm sublayer is
+         OCh, OTUk or ODUk."
+    ::= { jnxoptIfOTNAlarmEntry 4 }
+
+jnxoptIfOTNOChOTUkAlarmType OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNOChAlarms
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This specifies the type of alarm of the sublayer
+         'jnxoptIfOTNAlarmLayer' for OCh/OTUk ."
+    ::= { jnxoptIfOTNAlarmEntry 5 }
+
+jnxoptIfOTNAlarmSeverity  OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNAlarmSeverity
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The object identifies the severity of the last alarm/alert
+         that most recently was set or cleared."
+    ::= { jnxoptIfOTNAlarmEntry 6 }
+
+jnxoptIfOTNAlarmDate OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This specifies the date and time when this alarm occurred."
+    ::= { jnxoptIfOTNAlarmEntry 7 }
+
+jnxoptIfOTNODUkTcmAlarmType OBJECT-TYPE
+    SYNTAX      JnxoptIfOTNODUkTcmAlarms
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This specifies the type of alarm of the sublayer
+         'jnxoptIfOTNAlarmLayer' for ODUk/TCM ."
+    ::= { jnxoptIfOTNAlarmEntry 8 }
+
+
+ --
+ -- OTN Notifications
+ --
+
+jnxoptIfOTNOChOTUkAlarmSet NOTIFICATION-TYPE
+    OBJECTS { jnxoptIfOTNAlarmLocation,
+              jnxoptIfOTNAlarmDirection,
+              jnxoptIfOTNAlarmLayer,
+              jnxoptIfOTNAlarmTCMLevel,
+              jnxoptIfOTNOChOTUkAlarmType,
+              jnxoptIfOTNAlarmSeverity,
+              jnxoptIfOTNAlarmDate }
+    STATUS  current
+    DESCRIPTION
+        "Notification of a recently set OTN alarm of Layer
+         and Type."
+    ::= { jnxoptIfOTNNotifications 1 }
+
+jnxoptIfOTNOChOTUkAlarmClear NOTIFICATION-TYPE
+    OBJECTS { jnxoptIfOTNAlarmLocation,
+              jnxoptIfOTNAlarmDirection,
+              jnxoptIfOTNAlarmLayer,
+              jnxoptIfOTNAlarmTCMLevel,
+              jnxoptIfOTNOChOTUkAlarmType,
+              jnxoptIfOTNAlarmSeverity,
+              jnxoptIfOTNAlarmDate }
+    STATUS  current
+    DESCRIPTION
+        "Notification of a recently clear OTN alarm of Layer
+         and Type."
+    ::= { jnxoptIfOTNNotifications 2 }
+
+jnxoptIfOTNODUkTcmAlarmSet NOTIFICATION-TYPE
+    OBJECTS { jnxoptIfOTNAlarmLocation,
+              jnxoptIfOTNAlarmDirection,
+              jnxoptIfOTNAlarmLayer,
+              jnxoptIfOTNAlarmTCMLevel,
+              jnxoptIfOTNODUkTcmAlarmType,
+              jnxoptIfOTNAlarmSeverity,
+              jnxoptIfOTNAlarmDate }
+    STATUS  current
+    DESCRIPTION
+        "Notification of a recently set OTN alarm of Layer
+         and Type."
+    ::= { jnxoptIfOTNNotifications 3 }
+
+jnxoptIfOTNODUkTcmAlarmClear NOTIFICATION-TYPE
+    OBJECTS { jnxoptIfOTNAlarmLocation,
+              jnxoptIfOTNAlarmDirection,
+              jnxoptIfOTNAlarmLayer,
+              jnxoptIfOTNAlarmTCMLevel,
+              jnxoptIfOTNODUkTcmAlarmType,
+              jnxoptIfOTNAlarmSeverity,
+              jnxoptIfOTNAlarmDate }
+    STATUS  current
+    DESCRIPTION
+        "Notification of a recently clear OTN alarm of Layer
+         and Type."
+    ::= { jnxoptIfOTNNotifications 4 }
+
+
+END

--- a/mibs/junos/mib-jnx-chas-defines.txt
+++ b/mibs/junos/mib-jnx-chas-defines.txt
@@ -1,8 +1,9 @@
+
 --
 -- Juniper chassis mib definitions:
 -- OIDs used to identify various platforms and chassis components.
 -- 
--- Copyright (c) 1998-2009, Juniper Networks, Inc.
+-- Copyright (c) 1998-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -19,7 +20,7 @@ IMPORTS
 
 jnxChassisDefines MODULE-IDENTITY
 
-    LAST-UPDATED "200312100000Z" -- Wed Dec 10 00:00:00 2003 UTC
+    LAST-UPDATED "201404010000Z" -- Thu Apr 1 00:00:00 2014 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -30,7 +31,42 @@ jnxChassisDefines MODULE-IDENTITY
 
     DESCRIPTION
             "The MIB modules defines OIDs used by chassis mib to
-            identify platform and chassis components." 
+            identify platform and chassis components."
+    REVISION
+            "201002010000Z" -- Mon Feb 01 00:00:00 2010 UTC
+    DESCRIPTION
+            "PIC object for EX8200 PICS 36XS and 40XS are added."
+    REVISION    "201102070000Z" -- 07-Feb-11
+    DESCRIPTION
+            "Added Quantum Fabric Series 3000 and 5000."
+    REVISION
+            "201207180000Z" -- 18-Jul-12
+    DESCRIPTION
+            "Added Altius-1 / MX104 chassis."
+    REVISION    "201209130000Z" -- 13-Sept-12
+    DESCRIPTION
+            "Added QFX3100."
+    REVISION    "201209130000Z" -- 13-Sep-12
+    DESCRIPTION
+            "Added EX4300 product."
+    REVISION    "201301100000Z" -- 10-Jan-13
+    DESCRIPTION
+            "Added EX9206/EX9208/EX9204 chassis info"
+    REVISION    "201310170000Z" -- 17-Oct-13
+    DESCRIPTION
+            "Added QFX5100 products.
+             Added 96x10GE + 8x40GE PIC object(Cakebread).
+             Added 48x10GBASET + 6x40GE PIC object(Nirvana)."
+    REVISION    "201401270000Z" -- 27-Jan-14
+    DESCRIPTION
+            "Added EX4600 product (Ridge)."
+    REVISION    "201404010000Z" -- 01-Apr-14
+    DESCRIPTION
+            "Added STOUT/CHIVAS/SRX5K/FORTIUS product"
+    REVISION    "201406170000Z" -- 17-JUN-14
+    DESCRIPTION
+            "Added POLARIS MLC 24x10GE PIC"
+
     ::= { jnxMibs 25 }
 
 
@@ -926,6 +962,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
 
   jnxMediaCardSpaceM320      OBJECT IDENTIFIER ::= { jnxMediaCardSpace     9 }
     jnxM320MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceM320 1 }
+    jnxM320MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceM320 2 }
 
   jnxMidplaneM320         OBJECT IDENTIFIER ::= { jnxBackplane  9 }
 
@@ -1235,6 +1272,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
 
   jnxMidplaneMX960         OBJECT IDENTIFIER ::= { jnxBackplane        21 }
 
+
 --
 -- J4320
 --
@@ -1498,6 +1536,8 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
     jnxProductEX4200port48T    OBJECT IDENTIFIER ::= { jnxProductVariationEX4200 3 }
     jnxProductEX4200port48P    OBJECT IDENTIFIER ::= { jnxProductVariationEX4200 4 }
     jnxProductEX4200port24F    OBJECT IDENTIFIER ::= { jnxProductVariationEX4200 5 }
+    jnxProductEX4200port24PX   OBJECT IDENTIFIER ::= { jnxProductVariationEX4200 6 }
+    jnxProductEX4200port48PX   OBJECT IDENTIFIER ::= { jnxProductVariationEX4200 7 }
 
   jnxChassisEX4200          OBJECT IDENTIFIER ::= { jnxChassis          31 }
     jnxEX4200RE0            OBJECT IDENTIFIER ::= { jnxChassisEX4200 1  }
@@ -1786,22 +1826,22 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
 --
 -- ESR1000V
 --
-  jnxProductLineESR1000V      OBJECT IDENTIFIER ::= { jnxProductLine 42 }
-  jnxProductNameESR1000V      OBJECT IDENTIFIER ::= { jnxProductName 42 }
-  jnxProductModelESR1000V     OBJECT IDENTIFIER ::= { jnxProductModel 42 }
-  jnxProductVariationESR1000V OBJECT IDENTIFIER ::= { jnxProductVariation 42 }
-  jnxChassisESR1000V          OBJECT IDENTIFIER ::= { jnxChassis 42 }
+  jnxProductLineLN1000V      OBJECT IDENTIFIER ::= { jnxProductLine 42 }
+  jnxProductNameLN1000V      OBJECT IDENTIFIER ::= { jnxProductName 42 }
+  jnxProductModelLN1000V     OBJECT IDENTIFIER ::= { jnxProductModel 42 }
+  jnxProductVariationLN1000V OBJECT IDENTIFIER ::= { jnxProductVariation 42 }
+  jnxChassisLN1000V          OBJECT IDENTIFIER ::= { jnxChassis 42 }
 
-  jnxMediaCardSpaceESR1000V   OBJECT IDENTIFIER ::= { jnxMediaCardSpace 42 }
-    jnxESR1000VMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceESR1000V 1 }
+  jnxMediaCardSpaceLN1000V   OBJECT IDENTIFIER ::= { jnxMediaCardSpace 42 }
+    jnxLN1000VMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceLN1000V 1 }
 
-  jnxMidplaneESR1000V         OBJECT IDENTIFIER ::= { jnxBackplane 42 }
+  jnxMidplaneLN1000V         OBJECT IDENTIFIER ::= { jnxBackplane 42 }
 
-  jnxSlotESR1000V             OBJECT IDENTIFIER ::= { jnxSlot 42 }
-    jnxESR1000VSlotFPC        OBJECT IDENTIFIER ::= { jnxSlotESR1000V  1  }
-    jnxESR1000VSlotRE         OBJECT IDENTIFIER ::= { jnxSlotESR1000V  2  }
-    jnxESR1000VSlotPower      OBJECT IDENTIFIER ::= { jnxSlotESR1000V  3  }
-    jnxESR1000VSlotFan        OBJECT IDENTIFIER ::= { jnxSlotESR1000V  4  }
+  jnxSlotLN1000V             OBJECT IDENTIFIER ::= { jnxSlot 42 }
+    jnxLN1000VSlotFPC        OBJECT IDENTIFIER ::= { jnxSlotLN1000V  1  }
+    jnxLN1000VSlotRE         OBJECT IDENTIFIER ::= { jnxSlotLN1000V  2  }
+    jnxLN1000VSlotPower      OBJECT IDENTIFIER ::= { jnxSlotLN1000V  3  }
+    jnxLN1000VSlotFan        OBJECT IDENTIFIER ::= { jnxSlotLN1000V  4  }
 
 --
 --EX2200 (Jasmine)
@@ -1814,6 +1854,9 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
     jnxProductEX2200port24P    OBJECT IDENTIFIER ::= { jnxProductVariationEX2200 2 }
     jnxProductEX2200port48T    OBJECT IDENTIFIER ::= { jnxProductVariationEX2200 3 }
     jnxProductEX2200port48P    OBJECT IDENTIFIER ::= { jnxProductVariationEX2200 4 }
+    jnxProductEX2200Cport12T   OBJECT IDENTIFIER ::= { jnxProductVariationEX2200 5 }
+    jnxProductEX2200Cport12P   OBJECT IDENTIFIER ::= { jnxProductVariationEX2200 6 }
+    jnxProductEX2200port24TDC    OBJECT IDENTIFIER ::= { jnxProductVariationEX2200 7 }
 
   jnxChassisEX2200          OBJECT IDENTIFIER ::= { jnxChassis          43 }
 
@@ -1862,7 +1905,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
       jnxEX4500RE            OBJECT IDENTIFIER ::= { jnxEX4500FPC 3 }
 
 --
---DCF 
+--DCF (not used; see QFXInterconnect and QFXNode)
 --
 
    jnxProductLineFXSeries       OBJECT IDENTIFIER ::= { jnxProductLine      45 }
@@ -1957,7 +2000,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
    jnxSlotSRX1400             OBJECT IDENTIFIER ::= { jnxSlot             49 }
      jnxSRX1400SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotSRX1400 1  }
      jnxSRX1400SlotHM         OBJECT IDENTIFIER ::= { jnxSlotSRX1400 2  }
-     jnxSRX3100SlotPower      OBJECT IDENTIFIER ::= { jnxSlotSRX1400 3  }
+     jnxSRX1400SlotPower      OBJECT IDENTIFIER ::= { jnxSlotSRX1400 3  }
      jnxSRX1400SlotFan        OBJECT IDENTIFIER ::= { jnxSlotSRX1400 4  }
      jnxSRX1400SlotCB         OBJECT IDENTIFIER ::= { jnxSlotSRX1400 5  }
      jnxSRX1400SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotSRX1400 6  }
@@ -1968,7 +2011,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
    jnxMidplaneSRX1400         OBJECT IDENTIFIER ::= { jnxBackplane        49 }
 
 --
--- IBM4274S58J58S (A40 OEM)
+-- IBM4274S58J58S (A40 IBM OEM)
 --
 
   jnxProductLineIBM4274S58J58S      OBJECT IDENTIFIER ::= { jnxProductLine      50 }
@@ -1991,7 +2034,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
   jnxMidplaneIBM4274S58J58S         OBJECT IDENTIFIER ::= { jnxBackplane        50 }
 
 --
--- IBM4274S56J56S (A20 OEM)
+-- IBM4274S56J56S (A20 IBM OEM)
 --
 
   jnxProductLineIBM4274S56J56S      OBJECT IDENTIFIER ::= { jnxProductLine      51 }
@@ -2014,7 +2057,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
   jnxMidplaneIBM4274S56J56S         OBJECT IDENTIFIER ::= { jnxBackplane        51 }
 
 --             
--- IBM4274S36J36S (A10 OEM)
+-- IBM4274S36J36S (A10 IBM OEM)
 --
 
   jnxProductLineIBM4274S36J36S      OBJECT IDENTIFIER ::= { jnxProductLine      52 }
@@ -2037,7 +2080,7 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
   jnxMidplaneIBM4274S36J36S         OBJECT IDENTIFIER ::= { jnxBackplane        52 }
 
 --
--- IBM4274S34J34S (A2 OEM)
+-- IBM4274S34J34S (A2 IBM OEM)
 --
 
   jnxProductLineIBM4274S34J34S      OBJECT IDENTIFIER ::= { jnxProductLine      53 }
@@ -2160,6 +2203,8 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
   jnxProductVariationMX80 OBJECT IDENTIFIER ::= { jnxProductVariation 57 }
     jnxProductMX80        OBJECT IDENTIFIER ::= { jnxProductVariationMX80 1 }
     jnxProductMX80-48T    OBJECT IDENTIFIER ::= { jnxProductVariationMX80 2 }
+    jnxProductMX80-T      OBJECT IDENTIFIER ::= { jnxProductVariationMX80 3 }
+    jnxProductMX80-P      OBJECT IDENTIFIER ::= { jnxProductVariationMX80 4 }
   jnxChassisMX80          OBJECT IDENTIFIER ::= { jnxChassis          57 }
 
   jnxSlotMX80             OBJECT IDENTIFIER ::= { jnxSlot     57 }
@@ -2182,9 +2227,1495 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
     jnxMX80Power          OBJECT IDENTIFIER ::= { jnxModuleMX80 4  }
     jnxMX80PowerAC        OBJECT IDENTIFIER ::= { jnxModuleMX80 5  }
     jnxMX80Fan            OBJECT IDENTIFIER ::= { jnxModuleMX80 6  }
+      
+
+--
+-- SRX220 (VALI)
+--
+  jnxProductLineSRX220       OBJECT IDENTIFIER ::= { jnxProductLine      58 }
+  jnxProductNameSRX220       OBJECT IDENTIFIER ::= { jnxProductName      58 }
+  jnxChassisSRX220           OBJECT IDENTIFIER ::= { jnxChassis          58 }
+
+  jnxSlotSRX220              OBJECT IDENTIFIER ::= { jnxSlot    58 }
+    jnxSRX220SlotFPC         OBJECT IDENTIFIER ::= { jnxSlotSRX220  1  }
+    jnxSRX220SlotRE          OBJECT IDENTIFIER ::= { jnxSlotSRX220  2  }
+    jnxSRX220SlotPower       OBJECT IDENTIFIER ::= { jnxSlotSRX220  3  }
+    jnxSRX220SlotFan         OBJECT IDENTIFIER ::= { jnxSlotSRX220  4  }
+
+  jnxMediaCardSpaceSRX220    OBJECT IDENTIFIER ::= { jnxMediaCardSpace       58 }
+    jnxSRX220MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceSRX220  1 }
+
+  jnxMidplaneSRX220         OBJECT IDENTIFIER ::= { jnxBackplane 58 }
+
+  jnxModuleSRX220            OBJECT IDENTIFIER ::= { jnxModule    58 }
+    jnxSRX220FPC             OBJECT IDENTIFIER ::= { jnxModuleSRX220 1  }
+    jnxSRX220RE              OBJECT IDENTIFIER ::= { jnxModuleSRX220 2  }
+    jnxSRX220Power           OBJECT IDENTIFIER ::= { jnxModuleSRX220 3  }
+    jnxSRX220Fan             OBJECT IDENTIFIER ::= { jnxModuleSRX220 4  }    
+
+
+
+
+--
+-- EX_XRE
+--
+
+  jnxProductLineEXXRE      OBJECT IDENTIFIER ::= { jnxProductLine      59 }
+  jnxProductNameEXXRE      OBJECT IDENTIFIER ::= { jnxProductName      59 }
+  jnxProductModelEXXRE     OBJECT IDENTIFIER ::= { jnxProductModel     59 }
+  jnxProductVariationEXXRE OBJECT IDENTIFIER ::= { jnxProductVariation 59 }
+    jnxProductEXXRE        OBJECT IDENTIFIER ::= { jnxProductVariationEXXRE 1 } 
+  jnxChassisEXXRE          OBJECT IDENTIFIER ::= { jnxChassis          59 }
+    jnxEXXRERE0            OBJECT IDENTIFIER ::= { jnxChassisEXXRE 1  }
+    jnxEXXRERE1            OBJECT IDENTIFIER ::= { jnxChassisEXXRE 2  }
+  jnxSlotEXXRE             OBJECT IDENTIFIER ::= { jnxSlot             59 }
+    jnxEXXRESlotPower      OBJECT IDENTIFIER ::= { jnxSlotEXXRE 1 }
+    jnxEXXRESlotFan        OBJECT IDENTIFIER ::= { jnxSlotEXXRE 2 }
+    jnxEXXRESlotHM         OBJECT IDENTIFIER ::= { jnxSlotEXXRE 3 }
+    jnxEXXRESlotLCC        OBJECT IDENTIFIER ::= { jnxSlotEXXRE 4 }
+
+  jnxMediaCardSpaceEXXRE      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    59 }
+    jnxEXXREMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEXXRE 1 }
+
+  jnxBackplaneEXXRE           OBJECT IDENTIFIER ::= { jnxBackplane 59 }
+
+  jnxModuleEXXRE         OBJECT IDENTIFIER    ::=   { jnxModule    59 }
+    jnxEXXREPower        OBJECT IDENTIFIER    ::=   { jnxModuleEXXRE 1 }
+    jnxEXXREFan          OBJECT IDENTIFIER    ::=   { jnxModuleEXXRE 2 }
+    jnxEXXREHM           OBJECT IDENTIFIER    ::=   { jnxModuleEXXRE 3 }
+    jnxEXXRELCC          OBJECT IDENTIFIER    ::=   { jnxModuleEXXRE 4 } 
+      
+--
+-- QFXInterconnect
+--
+
+  jnxProductLineQFXInterconnect OBJECT IDENTIFIER ::= { jnxProductLine      60 }
+  jnxProductNameQFXInterconnect OBJECT IDENTIFIER ::= { jnxProductName      60 }
+  jnxProductModelQFXInterconnect OBJECT IDENTIFIER ::= { jnxProductModel     60 }
+  jnxProductVariationQFXInterconnect  OBJECT IDENTIFIER ::= { jnxProductVariation 60 }
+    jnxProductQFX3008           OBJECT IDENTIFIER ::= { jnxProductVariationQFXInterconnect 1 }
+    jnxProductQFXC083008        OBJECT IDENTIFIER ::= { jnxProductVariationQFXInterconnect 2 }
+    jnxProductQFX3008I          OBJECT IDENTIFIER ::= { jnxProductVariationQFXInterconnect 3 }
+
+  jnxChassisQFXInterconnect     OBJECT IDENTIFIER ::= { jnxChassis          60 }
+
+  jnxSlotQFXInterconnect        OBJECT IDENTIFIER ::= { jnxSlot             60 }
+    jnxQFXInterconnectSlotFPC   OBJECT IDENTIFIER ::= { jnxSlotQFXInterconnect   1 }
+    jnxQFXInterconnectSlotHM    OBJECT IDENTIFIER ::= { jnxSlotQFXInterconnect   2 }
+    jnxQFXInterconnectSlotPower OBJECT IDENTIFIER ::= { jnxSlotQFXInterconnect   3 }
+    jnxQFXInterconnectSlotFan   OBJECT IDENTIFIER ::= { jnxSlotQFXInterconnect   4 }
+    jnxQFXInterconnectSlotCBD   OBJECT IDENTIFIER ::= { jnxSlotQFXInterconnect   5 }
+    jnxQFXInterconnectSlotFPB   OBJECT IDENTIFIER ::= { jnxSlotQFXInterconnect   6 }
+
+  jnxMediaCardSpaceQFXInterconnect    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   60 }
+    jnxQFXInterconnectMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceQFXInterconnect 1 }
+
+  jnxMidplaneQFXInterconnect    OBJECT IDENTIFIER ::= { jnxBackplane        60 }
+
+--
+-- QFXNode
+--
+
+  jnxProductLineQFXNode       OBJECT IDENTIFIER ::= { jnxProductLine      61 }
+  jnxProductNameQFXNode       OBJECT IDENTIFIER ::= { jnxProductName      61 }
+  jnxProductModelQFXNode      OBJECT IDENTIFIER ::= { jnxProductModel     61 }
+  jnxProductVariationQFXNode  OBJECT IDENTIFIER ::= { jnxProductVariation 61 }
+    jnxProductQFX3500         OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 1 }
+    jnxProductQFX5500         OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 2 }
+    jnxProductQFX360016Q      OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 3 }
+    jnxProductQFX350048T4Q    OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 4 }
+    jnxProductQFX510024QF     OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 5 }
+    jnxProductQFX510048S6QF   OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 6 }
+    jnxProductQFX510096S6QF   OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 7 }
+    jnxProductQFX510048C6QF   OBJECT IDENTIFIER ::= { jnxProductVariationQFXNode 8 }
+
+  jnxChassisQFXNode           OBJECT IDENTIFIER ::= { jnxChassis          61 }
+
+  jnxSlotQFXNode              OBJECT IDENTIFIER ::= { jnxSlot             61 }
+    jnxQFXNodeSlotFPC         OBJECT IDENTIFIER ::= { jnxSlotQFXNode   1 }
+    jnxQFXNodeSlotHM          OBJECT IDENTIFIER ::= { jnxSlotQFXNode   2 }
+    jnxQFXNodeSlotPower       OBJECT IDENTIFIER ::= { jnxSlotQFXNode   3 }
+    jnxQFXNodeSlotFan         OBJECT IDENTIFIER ::= { jnxSlotQFXNode   4 }
+    jnxQFXNodeSlotFPB         OBJECT IDENTIFIER ::= { jnxSlotQFXNode   5 }
+
+  jnxMediaCardSpaceQFXNode    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   61 }
+    jnxQFXNodeMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceQFXNode 1 }
+
+--
+-- QFXJVRE
+--
+
+   jnxProductLineQFXJVRE      OBJECT IDENTIFIER ::= { jnxProductLine      62 }
+   jnxProductNameQFXJVRE      OBJECT IDENTIFIER ::= { jnxProductName      62 }
+   jnxProductModelQFXJVRE     OBJECT IDENTIFIER ::= { jnxProductModel     62 }
+   jnxChassisQFXJVRE          OBJECT IDENTIFIER ::= { jnxChassis          62 }
+
+   jnxSlotQFXJVRE             OBJECT IDENTIFIER ::= { jnxSlot             62 }
+    jnxQFXJVRESlotFPC         OBJECT IDENTIFIER ::= { jnxSlotQFXJVRE   1 }
+    jnxQFXJVRESlotHM          OBJECT IDENTIFIER ::= { jnxSlotQFXJVRE   2 }
+    jnxQFXJVRESlotPower       OBJECT IDENTIFIER ::= { jnxSlotQFXJVRE   3 }
+    jnxQFXJVRESlotFan         OBJECT IDENTIFIER ::= { jnxSlotQFXJVRE   4 }
+    jnxQFXJVRESlotFPB         OBJECT IDENTIFIER ::= { jnxSlotQFXJVRE   5 }
+
+  jnxMediaCardSpaceQFXJVRE    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   62 }
+    jnxQFXJVREMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceQFXJVRE 1 }
+
+--
+-- EX4300
+--
+
+  jnxProductLineEX4300      OBJECT IDENTIFIER ::= { jnxProductLine      63 }
+  jnxProductNameEX4300      OBJECT IDENTIFIER ::= { jnxProductName      63 }
+  jnxProductModelEX4300     OBJECT IDENTIFIER ::= { jnxProductModel     63 }
+  jnxProductVariationEX4300 OBJECT IDENTIFIER ::= { jnxProductVariation 63 }
+    jnxProductEX4300port24T    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 1 }
+    jnxProductEX4300port48T    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 2 }
+    jnxProductEX4300port48TBF    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 3 }
+    jnxProductEX4300port48TDC    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 4 }
+    jnxProductEX4300port48TDCBF    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 5 }
+    jnxProductEX4300port24P   OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 6 }
+    jnxProductEX4300port48P   OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 7 }
+
+  jnxChassisEX4300          OBJECT IDENTIFIER ::= { jnxChassis          63 }
+    jnxEX4300RE0            OBJECT IDENTIFIER ::= { jnxChassisEX4300 1  }
+    jnxEX4300RE1            OBJECT IDENTIFIER ::= { jnxChassisEX4300 2  }
+  jnxSlotEX4300             OBJECT IDENTIFIER ::= { jnxSlot             63 }
+    jnxEX4300SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotEX4300 1 }
+      jnxEX4300SlotPower    OBJECT IDENTIFIER ::= { jnxEX4300SlotFPC 1 }
+      jnxEX4300SlotFan      OBJECT IDENTIFIER ::= { jnxEX4300SlotFPC 2 }
+
+  jnxMediaCardSpaceEX4300      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    63 }
+    jnxEX4300MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX4300 1 }
+
+ jnxModuleEX4300            OBJECT IDENTIFIER ::= { jnxModule    63 }
+    jnxEX4300FPC            OBJECT IDENTIFIER ::= { jnxModuleEX4300 1 }
+      jnxEX4300Power        OBJECT IDENTIFIER ::= { jnxEX4300FPC 1 }
+      jnxEX4300Fan          OBJECT IDENTIFIER ::= { jnxEX4300FPC 2 }
+
+
+-- EX4300 Fiber switch MICs
+--
+    jnxProductEX4300port32F    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 8 }
+
+--
+-- SRX110
+--
+  jnxProductLineSRX110       OBJECT IDENTIFIER ::= { jnxProductLine      64 }
+  jnxProductNameSRX110       OBJECT IDENTIFIER ::= { jnxProductName      64 }
+  jnxChassisSRX110           OBJECT IDENTIFIER ::= { jnxChassis          64 }
+
+  jnxSlotSRX110              OBJECT IDENTIFIER ::= { jnxSlot    64 }
+    jnxSRX110SlotFPC         OBJECT IDENTIFIER ::= { jnxSlotSRX110  1  }
+    jnxSRX110SlotRE          OBJECT IDENTIFIER ::= { jnxSlotSRX110  2  }
+    jnxSRX110SlotPower       OBJECT IDENTIFIER ::= { jnxSlotSRX110  3  }
+    jnxSRX110SlotFan         OBJECT IDENTIFIER ::= { jnxSlotSRX110  4  }
+
+  jnxMediaCardSpaceSRX110    OBJECT IDENTIFIER ::= { jnxMediaCardSpace       64 }
+    jnxSRX110MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceSRX110  1 }
+
+  jnxMidplaneSRX110          OBJECT IDENTIFIER ::= { jnxBackplane 64 }
+
+  jnxModuleSRX110            OBJECT IDENTIFIER ::= { jnxModule    64 }
+    jnxSRX110FPC             OBJECT IDENTIFIER ::= { jnxModuleSRX110 1  }
+    jnxSRX110RE              OBJECT IDENTIFIER ::= { jnxModuleSRX110 2  }
+    jnxSRX110Power           OBJECT IDENTIFIER ::= { jnxModuleSRX110 3  }
+    jnxSRX110Fan             OBJECT IDENTIFIER ::= { jnxModuleSRX110 4  }
+
+--
+-- SRX120
+--
+-- NOTE:  These platforms no longer exist. The definitions below are being
+--        retained since the index number 65 has already been allocated to it
+--
+  jnxProductLineSRX120       OBJECT IDENTIFIER ::= { jnxProductLine      65 }
+  jnxProductNameSRX120       OBJECT IDENTIFIER ::= { jnxProductName      65 }
+  jnxChassisSRX120           OBJECT IDENTIFIER ::= { jnxChassis          65 }
+
+  jnxSlotSRX120              OBJECT IDENTIFIER ::= { jnxSlot    65 }
+    jnxSRX120SlotFPC         OBJECT IDENTIFIER ::= { jnxSlotSRX120  1  }
+    jnxSRX120SlotRE          OBJECT IDENTIFIER ::= { jnxSlotSRX120  2  }
+    jnxSRX120SlotPower       OBJECT IDENTIFIER ::= { jnxSlotSRX120  3  }
+    jnxSRX120SlotFan         OBJECT IDENTIFIER ::= { jnxSlotSRX120  4  }
+
+  jnxMediaCardSpaceSRX120    OBJECT IDENTIFIER ::= { jnxMediaCardSpace       65 }
+    jnxSRX120MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceSRX120  1 }
+
+  jnxMidplaneSRX120          OBJECT IDENTIFIER ::= { jnxBackplane 65 }
+
+  jnxModuleSRX120            OBJECT IDENTIFIER ::= { jnxModule    65 }
+    jnxSRX120FPC             OBJECT IDENTIFIER ::= { jnxModuleSRX120 1  }
+    jnxSRX120RE              OBJECT IDENTIFIER ::= { jnxModuleSRX120 2  }
+    jnxSRX120Power           OBJECT IDENTIFIER ::= { jnxModuleSRX120 3  }
+    jnxSRX120Fan             OBJECT IDENTIFIER ::= { jnxModuleSRX120 4  }
+
+
+--
+-- MAG8600 (Agent00)
+-- 
+  jnxProductLineMAG8600      OBJECT IDENTIFIER ::= { jnxProductLine      66 }
+  jnxProductNameMAG8600      OBJECT IDENTIFIER ::= { jnxProductName      66 }
+  jnxProductModelMAG8600     OBJECT IDENTIFIER ::= { jnxProductModel     66 }
+  jnxProductVariationMAG8600 OBJECT IDENTIFIER ::= { jnxProductVariation 66 }
+  jnxChassisMAG8600          OBJECT IDENTIFIER ::= { jnxChassis          66 }
+
+  jnxSlotMAG8600             OBJECT IDENTIFIER ::= { jnxSlot             66 }
+    jnxMAG8600SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMAG8600 1  }
+    jnxMAG8600SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMAG8600 2  }
+    jnxMAG8600SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMAG8600 3  }
+    jnxMAG8600SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMAG8600 4  }
+    jnxMAG8600SlotCB         OBJECT IDENTIFIER ::= { jnxSlotMAG8600 5  }
+
+  jnxMediaCardSpaceMAG8600   OBJECT IDENTIFIER ::= { jnxMediaCardSpace   66 }
+  jnxMAG8600MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMAG8600 1 }
+
+  jnxMidplaneMAG8600         OBJECT IDENTIFIER ::= { jnxBackplane        66 }
+
+
+--
+-- MAG6611 (Habanero)
+--
+  
+  jnxProductLineMAG6611      OBJECT IDENTIFIER ::= { jnxProductLine      67 }
+  jnxProductNameMAG6611      OBJECT IDENTIFIER ::= { jnxProductName      67 }
+  jnxProductModelMAG6611     OBJECT IDENTIFIER ::= { jnxProductModel     67 }
+  jnxProductVariationMAG6611 OBJECT IDENTIFIER ::= { jnxProductVariation 67 }
+  jnxChassisMAG6611          OBJECT IDENTIFIER ::= { jnxChassis          67 }
+
+  jnxSlotMAG6611             OBJECT IDENTIFIER ::= { jnxSlot             67 }
+    jnxMAG6611SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMAG6611 1  }
+    jnxMAG6611SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMAG6611 2  }
+    jnxMAG6611SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMAG6611 3  }
+    jnxMAG6611SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMAG6611 4  }
+    jnxMAG6611SlotCB         OBJECT IDENTIFIER ::= { jnxSlotMAG6611 5  }
+
+  jnxMediaCardSpaceMAG6611   OBJECT IDENTIFIER ::= { jnxMediaCardSpace   67 }
+  jnxMAG6611MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMAG6611 1 }
+
+  jnxMidplaneMAG6611         OBJECT IDENTIFIER ::= { jnxBackplane        67 }
+
+--
+-- MAG6610 (Cayenne)
+--
+  
+  jnxProductLineMAG6610      OBJECT IDENTIFIER ::= { jnxProductLine      68 }
+  jnxProductNameMAG6610      OBJECT IDENTIFIER ::= { jnxProductName      68 }
+  jnxProductModelMAG6610     OBJECT IDENTIFIER ::= { jnxProductModel     68 }
+  jnxProductVariationMAG6610 OBJECT IDENTIFIER ::= { jnxProductVariation 68 }
+  jnxChassisMAG6610          OBJECT IDENTIFIER ::= { jnxChassis          68 }
+
+  jnxSlotMAG6610             OBJECT IDENTIFIER ::= { jnxSlot             68 }
+    jnxMAG6610SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMAG6610 1  }
+    jnxMAG6610SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMAG6610 2  }
+    jnxMAG6610SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMAG6610 3  }
+    jnxMAG6610SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMAG6610 4  }
+    jnxMAG6610SlotCB         OBJECT IDENTIFIER ::= { jnxSlotMAG6610 5  }
+
+  jnxMediaCardSpaceMAG6610   OBJECT IDENTIFIER ::= { jnxMediaCardSpace   68 }
+  jnxMAG6610MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMAG6610 1 }
+
+  jnxMidplaneMAG6610         OBJECT IDENTIFIER ::= { jnxBackplane        68 }
+
+
+--
+-- PTX5000 - Sangria 8 Slot 
+--
+
+  jnxProductLinePTX5000      OBJECT IDENTIFIER ::= { jnxProductLine      69 }
+  jnxProductNamePTX5000      OBJECT IDENTIFIER ::= { jnxProductName      69 }
+  jnxProductModelPTX5000     OBJECT IDENTIFIER ::= { jnxProductModel     69 }
+  jnxProductVariationPTX5000 OBJECT IDENTIFIER ::= { jnxProductVariation 69 }
+  jnxChassisPTX5000          OBJECT IDENTIFIER ::= { jnxChassis          69 }
+
+  jnxSlotPTX5000             OBJECT IDENTIFIER ::= { jnxSlot             69 }
+    jnxPTX5000SlotSIB        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 1  }
+    jnxPTX5000SlotHM         OBJECT IDENTIFIER ::= { jnxSlotPTX5000 2  }
+    jnxPTX5000SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 3  }
+    jnxPTX5000SlotFan        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 4  }
+    jnxPTX5000SlotCB         OBJECT IDENTIFIER ::= { jnxSlotPTX5000 5  }
+    jnxPTX5000SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 6  }
+    jnxPTX5000SlotSPMB       OBJECT IDENTIFIER ::= { jnxSlotPTX5000 7  }
+    jnxPTX5000SlotPDU        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 8  }
+    jnxPTX5000SlotPSM        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 9  }
+    jnxPTX5000SlotCCG        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 10 }
+    jnxPTX5000SlotPIC        OBJECT IDENTIFIER ::= { jnxSlotPTX5000 11 }
+
+  jnxMediaCardSpacePTX5000      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    69 }
+    jnxPTX5000MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpacePTX5000 1 }
+
+  jnxMidplanePTX5000         OBJECT IDENTIFIER ::= { jnxBackplane        69 }
+
+  jnxModulePTX5000           OBJECT IDENTIFIER ::= { jnxModule    69 }
+    jnxPTX5000SIB            OBJECT IDENTIFIER ::= { jnxModulePTX5000 1  }
+    jnxPTX5000HM             OBJECT IDENTIFIER ::= { jnxModulePTX5000 2  }
+    jnxPTX5000FPC            OBJECT IDENTIFIER ::= { jnxModulePTX5000 3  }
+    jnxPTX5000Fan            OBJECT IDENTIFIER ::= { jnxModulePTX5000 4  }
+    jnxPTX5000CB             OBJECT IDENTIFIER ::= { jnxModulePTX5000 5  }
+    jnxPTX5000FPB            OBJECT IDENTIFIER ::= { jnxModulePTX5000 6  }
+    jnxPTX5000SPMB           OBJECT IDENTIFIER ::= { jnxModulePTX5000 7  }
+    jnxPTX5000PDU            OBJECT IDENTIFIER ::= { jnxModulePTX5000 8  }
+    jnxPTX5000PSM            OBJECT IDENTIFIER ::= { jnxModulePTX5000 9  }
+    jnxPTX5000CCG            OBJECT IDENTIFIER ::= { jnxModulePTX5000 10 }
+    jnxPTX5000PIC            OBJECT IDENTIFIER ::= { jnxModulePTX5000 11 }
+
+--
+-- PTX9000 - Sangria 16 Slot
+--
+
+  jnxProductLinePTX9000      OBJECT IDENTIFIER ::= { jnxProductLine      70 }
+  jnxProductNamePTX9000      OBJECT IDENTIFIER ::= { jnxProductName      70 }
+  jnxProductModelPTX9000     OBJECT IDENTIFIER ::= { jnxProductModel     70 }
+  jnxProductVariationPTX9000 OBJECT IDENTIFIER ::= { jnxProductVariation 70 }
+  jnxChassisPTX9000          OBJECT IDENTIFIER ::= { jnxChassis          70 }
+
+  jnxSlotPTX9000             OBJECT IDENTIFIER ::= { jnxSlot             70 }
+    jnxPTX9000SlotSIB        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 1  }
+    jnxPTX9000SlotHM         OBJECT IDENTIFIER ::= { jnxSlotPTX9000 2  }
+    jnxPTX9000SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 3  }
+    jnxPTX9000SlotFan        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 4  }
+    jnxPTX9000SlotCB         OBJECT IDENTIFIER ::= { jnxSlotPTX9000 5  }
+    jnxPTX9000SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 6  }
+    jnxPTX9000SlotSPMB       OBJECT IDENTIFIER ::= { jnxSlotPTX9000 7  }
+    jnxPTX9000SlotPDU        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 8  }
+    jnxPTX9000SlotPSM        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 9  }
+    jnxPTX9000SlotCCG        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 10 }
+    jnxPTX9000SlotPIC        OBJECT IDENTIFIER ::= { jnxSlotPTX9000 11 }
+
+  jnxMediaCardSpacePTX9000      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    70 }
+    jnxPTX9000MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpacePTX9000 1 }
+
+  jnxMidplanePTX9000         OBJECT IDENTIFIER ::= { jnxBackplane        70 }
+
+  jnxModulePTX9000           OBJECT IDENTIFIER ::= { jnxModule    70 }
+    jnxPTX9000SIB            OBJECT IDENTIFIER ::= { jnxModulePTX9000 1  }
+    jnxPTX9000HM             OBJECT IDENTIFIER ::= { jnxModulePTX9000 2  }
+    jnxPTX9000FPC            OBJECT IDENTIFIER ::= { jnxModulePTX9000 3  }
+    jnxPTX9000Fan            OBJECT IDENTIFIER ::= { jnxModulePTX9000 4  }
+    jnxPTX9000CB             OBJECT IDENTIFIER ::= { jnxModulePTX9000 5  }
+    jnxPTX9000FPB            OBJECT IDENTIFIER ::= { jnxModulePTX9000 6  }
+    jnxPTX9000SPMB           OBJECT IDENTIFIER ::= { jnxModulePTX9000 7  }
+    jnxPTX9000PDU            OBJECT IDENTIFIER ::= { jnxModulePTX9000 8  }
+    jnxPTX9000PSM            OBJECT IDENTIFIER ::= { jnxModulePTX9000 9  }
+    jnxPTX9000CCG            OBJECT IDENTIFIER ::= { jnxModulePTX9000 10 }
+    jnxPTX9000PIC            OBJECT IDENTIFIER ::= { jnxModulePTX9000 11 }
+
+
+-- Release 10.4 
+--
+-- IBM EX 4500 
+--
+
+   jnxProductLineIBM0719J45E      OBJECT IDENTIFIER ::= { jnxProductLine      71 }
+   jnxProductNameIBM0719J45E      OBJECT IDENTIFIER ::= { jnxProductName      71 }
+   jnxProductModelIBM0719J45E     OBJECT IDENTIFIER ::= { jnxProductModel     71 }
+   jnxProductVariationIBM0719J45E OBJECT IDENTIFIER ::= { jnxProductVariation 71 }
+     jnxProductIBM0719J45Eport40F    OBJECT IDENTIFIER ::= { jnxProductVariationIBM0719J45E 1 }
+     jnxProductIBM0719J45Eport20F    OBJECT IDENTIFIER ::= { jnxProductVariationIBM0719J45E 2 }
+
+   jnxChassisIBM0719J45E          OBJECT IDENTIFIER ::= { jnxChassis          71 }
+     jnxIBM0719J45ERE0            OBJECT IDENTIFIER ::= { jnxChassisIBM0719J45E 1  }
+     jnxIBM0719J45ERE1            OBJECT IDENTIFIER ::= { jnxChassisIBM0719J45E 2  }
+   jnxSlotIBM0719J45E             OBJECT IDENTIFIER ::= { jnxSlot             71 }
+     jnxIBM0719J45ESlotFPC        OBJECT IDENTIFIER ::= { jnxSlotIBM0719J45E 1 }
+       jnxIBM0719J45ESlotPower    OBJECT IDENTIFIER ::= { jnxIBM0719J45ESlotFPC 1 }
+       jnxIBM0719J45ESlotFan      OBJECT IDENTIFIER ::= { jnxIBM0719J45ESlotFPC 2 }
+       jnxIBM0719J45ESlotRE       OBJECT IDENTIFIER ::= { jnxIBM0719J45ESlotFPC 3 }
+
+   jnxMediaCardSpaceIBM0719J45E      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    71 }
+     jnxIBM0719J45EMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceIBM0719J45E 1 }
+
+   jnxModuleIBM0719J45E            OBJECT IDENTIFIER ::= { jnxModule    71 }
+     jnxIBM0719J45EFPC             OBJECT IDENTIFIER ::= { jnxModuleIBM0719J45E 1 }
+       jnxIBM0719J45EPower         OBJECT IDENTIFIER ::= { jnxIBM0719J45EFPC 1 }
+       jnxIBM0719J45EFan           OBJECT IDENTIFIER ::= { jnxIBM0719J45EFPC 2 }
+       jnxIBM0719J45ERE            OBJECT IDENTIFIER ::= { jnxIBM0719J45EFPC 3 }
+
+
+--
+-- IBM Converged Switch J08F (QFXC08 3008)
+--
+
+  jnxProductLineIBMJ08F OBJECT IDENTIFIER ::= { jnxProductLine      72 }
+  jnxProductNameIBMJ08F OBJECT IDENTIFIER ::= { jnxProductName      72 }
+  jnxProductModelIBMJ08F OBJECT IDENTIFIER ::= { jnxProductModel     72 }
+  jnxProductVariationIBMJ08F  OBJECT IDENTIFIER ::= { jnxProductVariation 72 }
+    jnxProductIBM2413F08J08F  OBJECT IDENTIFIER ::= { jnxProductVariationIBMJ08F 1 }
+
+  jnxChassisIBMJ08F     OBJECT IDENTIFIER ::= { jnxChassis          72 }
+
+  jnxSlotIBMJ08F        OBJECT IDENTIFIER ::= { jnxSlot             72 }
+    jnxIBMJ08FSlotFPC   OBJECT IDENTIFIER ::= { jnxSlotIBMJ08F   1 }
+    jnxIBMJ08FSlotHM    OBJECT IDENTIFIER ::= { jnxSlotIBMJ08F   2 }
+    jnxIBMJ08FSlotPower OBJECT IDENTIFIER ::= { jnxSlotIBMJ08F   3 }
+    jnxIBMJ08FSlotFan   OBJECT IDENTIFIER ::= { jnxSlotIBMJ08F   4 }
+    jnxIBMJ08FSlotCBD   OBJECT IDENTIFIER ::= { jnxSlotIBMJ08F   5 }
+    jnxIBMJ08FSlotFPB   OBJECT IDENTIFIER ::= { jnxSlotIBMJ08F   6 }
+
+  jnxMediaCardSpaceIBMJ08F    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   72 }
+    jnxIBMJ08FMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceIBMJ08F 1 }
+
+  jnxMidplaneIBMJ08F    OBJECT IDENTIFIER ::= { jnxBackplane        72 }
+
+--
+-- IBM Converged Switch J52F (QFX 3500)
+--
+
+  jnxProductLineIBMJ52F       OBJECT IDENTIFIER ::= { jnxProductLine      73 }
+  jnxProductNameIBMJ52F       OBJECT IDENTIFIER ::= { jnxProductName      73 }
+  jnxProductModelIBMJ52F      OBJECT IDENTIFIER ::= { jnxProductModel     73 }
+  jnxProductVariationIBMJ52F  OBJECT IDENTIFIER ::= { jnxProductVariation 73 }
+    jnxProductIBM2409F52J52F  OBJECT IDENTIFIER ::= { jnxProductVariationIBMJ52F 1 }
+    jnxProductIBM8729HC1J52F  OBJECT IDENTIFIER ::= { jnxProductVariationIBMJ52F 2 }
+
+  jnxChassisIBMJ52F           OBJECT IDENTIFIER ::= { jnxChassis          73 }
+
+  jnxSlotIBMJ52F              OBJECT IDENTIFIER ::= { jnxSlot             73 }
+    jnxIBMJ52FSlotFPC         OBJECT IDENTIFIER ::= { jnxSlotIBMJ52F   1 }
+    jnxIBMJ52FSlotHM          OBJECT IDENTIFIER ::= { jnxSlotIBMJ52F   2 }
+    jnxIBMJ52FSlotPower       OBJECT IDENTIFIER ::= { jnxSlotIBMJ52F   3 }
+    jnxIBMJ52FSlotFan         OBJECT IDENTIFIER ::= { jnxSlotIBMJ52F   4 }
+    jnxIBMJ52FSlotFPB         OBJECT IDENTIFIER ::= { jnxSlotIBMJ52F   5 }
+
+  jnxMediaCardSpaceIBMJ52F    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   73 }
+    jnxIBMJ52FMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceIBMJ52F 1 }
+
+--
+-- EX6210 
+--
+
+  jnxProductLineEX6210       OBJECT IDENTIFIER ::= { jnxProductLine      74 }
+  jnxProductNameEX6210       OBJECT IDENTIFIER ::= { jnxProductName      74 }
+  jnxProductModelEX6210      OBJECT IDENTIFIER ::= { jnxProductModel     74 }
+  jnxProductVariationEX6210  OBJECT IDENTIFIER ::= { jnxProductVariation 74 }
+  jnxChassisEX6210           OBJECT IDENTIFIER ::= { jnxChassis          74 }
+
+  jnxSlotEX6210              OBJECT IDENTIFIER ::= { jnxSlot             74 }
+    jnxEX6210SlotFPC         OBJECT IDENTIFIER ::= { jnxSlotEX6210  1 }
+                            -- Flexible Port Concentrator
+      jnxEX6210Slot48P       OBJECT IDENTIFIER ::= { jnxEX6210SlotFPC  1 }
+      jnxEX6210Slot48T       OBJECT IDENTIFIER ::= { jnxEX6210SlotFPC  2 }
+    jnxEX6210HM              OBJECT IDENTIFIER ::= { jnxSlotEX6210  3 }
+                            -- Host Module (also called Routing Engine)
+    jnxEX6210SlotPower       OBJECT IDENTIFIER ::= { jnxSlotEX6210  4 }
+    jnxEX6210SlotFan         OBJECT IDENTIFIER ::= { jnxSlotEX6210  5 }
+      jnxEX6210SlotFT        OBJECT IDENTIFIER ::= { jnxEX6210SlotFan  1 }
+    jnxEX6210SlotCBD         OBJECT IDENTIFIER ::= { jnxSlotEX6210  6 }
+                            -- Control Board
+
+  jnxMediaCardSpaceEX6210    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   74 }
+    jnxEX6210MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX6210 1 }
+
+  jnxBackplaneEX6210         OBJECT IDENTIFIER ::= { jnxBackplane        74 }
+  
+
+--
+-- DELL PowerConnect J-Series FX3500 (QFX 3500)
+--
+
+  jnxProductLineDellJFX3500   OBJECT IDENTIFIER ::= { jnxProductLine      75 }
+  jnxProductNameDellJFX3500   OBJECT IDENTIFIER ::= { jnxProductName      75 }
+  jnxProductModelDellJFX3500  OBJECT IDENTIFIER ::= { jnxProductModel     75 }
+  jnxProductVariationDellJFX3500  OBJECT IDENTIFIER ::= { jnxProductVariation 75 }
+
+  jnxChassisDellJFX3500       OBJECT IDENTIFIER ::= { jnxChassis          75 }
+
+  jnxSlotDellJFX3500          OBJECT IDENTIFIER ::= { jnxSlot             75 }
+    jnxDellJFX3500SlotFPC     OBJECT IDENTIFIER ::= { jnxSlotDellJFX3500   1 }
+    jnxDellJFX3500SlotHM      OBJECT IDENTIFIER ::= { jnxSlotDellJFX3500   2 }
+    jnxDellJFX3500SlotPower   OBJECT IDENTIFIER ::= { jnxSlotDellJFX3500   3 }
+    jnxDellJFX3500SlotFan     OBJECT IDENTIFIER ::= { jnxSlotDellJFX3500   4 }
+    jnxDellJFX3500SlotFPB     OBJECT IDENTIFIER ::= { jnxSlotDellJFX3500   5 }
+
+  jnxMediaCardSpaceDellJFX3500 OBJECT IDENTIFIER ::= { jnxMediaCardSpace   75 }
+    jnxDellJFX3500MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDellJFX3500 1 }
+
+--
+-- EX3300 (Dragon-VC)
+--
+
+  jnxProductLineEX3300      OBJECT IDENTIFIER ::= { jnxProductLine      76 }
+  jnxProductNameEX3300      OBJECT IDENTIFIER ::= { jnxProductName      76 }
+  jnxProductModelEX3300     OBJECT IDENTIFIER ::= { jnxProductModel     76 }
+  jnxProductVariationEX3300 OBJECT IDENTIFIER ::= { jnxProductVariation 76 }
+    jnxProductEX3300port24T    OBJECT IDENTIFIER ::= { jnxProductVariationEX3300 1 }
+    jnxProductEX3300port24P    OBJECT IDENTIFIER ::= { jnxProductVariationEX3300 2 }
+    jnxProductEX3300port48T    OBJECT IDENTIFIER ::= { jnxProductVariationEX3300 3 }
+    jnxProductEX3300port48P    OBJECT IDENTIFIER ::= { jnxProductVariationEX3300 4 }
+    jnxProductEX3300port24TDC  OBJECT IDENTIFIER ::= { jnxProductVariationEX3300 5 }
+    jnxProductEX3300port48TBF  OBJECT IDENTIFIER ::= { jnxProductVariationEX3300 6 }
+
+  jnxChassisEX3300          OBJECT IDENTIFIER ::= { jnxChassis          76 }
+    jnxEX3300RE0            OBJECT IDENTIFIER ::= { jnxChassisEX3300 1  }
+    jnxEX3300RE1            OBJECT IDENTIFIER ::= { jnxChassisEX3300 2  }
+
+  jnxSlotEX3300             OBJECT IDENTIFIER ::= { jnxSlot             76 }
+    jnxEX3300SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotEX3300 1 }
+      jnxEX3300SlotPower    OBJECT IDENTIFIER ::= { jnxEX3300SlotFPC 1 }
+      jnxEX3300SlotFan      OBJECT IDENTIFIER ::= { jnxEX3300SlotFPC 2 }
+  
+  jnxMediaCardSpaceEX3300      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    76 }
+    jnxEX3300MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX3300 1 }
+
+  jnxModuleEX3300            OBJECT IDENTIFIER ::= { jnxModule    76 }
+    jnxEX3300FPC             OBJECT IDENTIFIER ::= { jnxModuleEX3300 1 }
+      jnxEX3300Power         OBJECT IDENTIFIER ::= { jnxEX3300FPC 1 }
+      jnxEX3300Fan           OBJECT IDENTIFIER ::= { jnxEX3300FPC 2 }
+      jnxEX3300RE            OBJECT IDENTIFIER ::= { jnxEX3300FPC 3 }
+
+
+--
+-- DELLJSRX3600 (A10 DELL OEM)
+--
+
+  jnxProductLineDELLJSRX3600      OBJECT IDENTIFIER ::= { jnxProductLine      77 }
+  jnxProductNameDELLJSRX3600      OBJECT IDENTIFIER ::= { jnxProductName      77 }
+  jnxProductModelDELLJSRX3600     OBJECT IDENTIFIER ::= { jnxProductModel     77 }
+  jnxProductVariationDELLJSRX3600 OBJECT IDENTIFIER ::= { jnxProductVariation 77 }
+  jnxChassisDELLJSRX3600          OBJECT IDENTIFIER ::= { jnxChassis          77 }
+
+  jnxSlotDELLJSRX3600             OBJECT IDENTIFIER ::= { jnxSlot             77 }
+    jnxDELLJSRX3600SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3600 1  }
+    jnxDELLJSRX3600SlotHM         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3600 2  }
+    jnxDELLJSRX3600SlotPower      OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3600 3  }
+    jnxDELLJSRX3600SlotFan        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3600 4  }
+    jnxDELLJSRX3600SlotCB         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3600 5  }
+    jnxDELLJSRX3600SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3600 6  }
+
+  jnxMediaCardSpaceDELLJSRX3600   OBJECT IDENTIFIER ::= { jnxMediaCardSpace    77 }
+  jnxDELLJSRX3600MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDELLJSRX3600 1 }
+
+  jnxMidplaneDELLJSRX3600         OBJECT IDENTIFIER ::= { jnxBackplane        77 }
+
+--
+-- DELLJSRX3400 (A2 DELL OEM)
+--
+
+  jnxProductLineDELLJSRX3400      OBJECT IDENTIFIER ::= { jnxProductLine      78 }
+  jnxProductNameDELLJSRX3400      OBJECT IDENTIFIER ::= { jnxProductName      78 }
+  jnxProductModelDELLJSRX3400     OBJECT IDENTIFIER ::= { jnxProductModel     78 }
+  jnxProductVariationDELLJSRX3400 OBJECT IDENTIFIER ::= { jnxProductVariation 78 }
+  jnxChassisDELLJSRX3400          OBJECT IDENTIFIER ::= { jnxChassis          78 }
+
+  jnxSlotDELLJSRX3400             OBJECT IDENTIFIER ::= { jnxSlot             78 }
+    jnxDELLJSRX3400SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3400 1  }
+    jnxDELLJSRX3400SlotHM         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3400 2  }
+    jnxDELLJSRX3400SlotPower      OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3400 3  }
+    jnxDELLJSRX3400SlotFan        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3400 4  }
+    jnxDELLJSRX3400SlotCB         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3400 5  }
+    jnxDELLJSRX3400SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX3400 6  }
+
+  jnxMediaCardSpaceDELLJSRX3400   OBJECT IDENTIFIER ::= { jnxMediaCardSpace    78 }
+  jnxDELLJSRX3400MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDELLJSRX3400 1 }
+
+  jnxMidplaneDELLJSRX3400         OBJECT IDENTIFIER ::= { jnxBackplane        78 }
+
+--
+-- DELLJSRX1400 (A1 DELL OEM)
+--
+
+  jnxProductLineDELLJSRX1400      OBJECT IDENTIFIER ::= { jnxProductLine      79 }
+  jnxProductNameDELLJSRX1400      OBJECT IDENTIFIER ::= { jnxProductName      79 }
+  jnxProductModelDELLJSRX1400     OBJECT IDENTIFIER ::= { jnxProductModel     79 }
+  jnxProductVariationDELLJSRX1400 OBJECT IDENTIFIER ::= { jnxProductVariation 79 }
+  jnxChassisDELLJSRX1400          OBJECT IDENTIFIER ::= { jnxChassis          79 }
+
+  jnxSlotDELLJSRX1400             OBJECT IDENTIFIER ::= { jnxSlot             79 }
+    jnxDELLJSRX1400SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX1400 1  }
+    jnxDELLJSRX1400SlotHM         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX1400 2  }
+    jnxDELLJSRX1400SlotPower      OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX1400 3  }
+    jnxDELLJSRX1400SlotFan        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX1400 4  }
+    jnxDELLJSRX1400SlotCB         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX1400 5  }
+    jnxDELLJSRX1400SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX1400 6  }
+
+  jnxMediaCardSpaceDELLJSRX1400   OBJECT IDENTIFIER ::= { jnxMediaCardSpace    79 }
+  jnxDELLJSRX1400MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDELLJSRX1400 1 }
+
+  jnxMidplaneDELLJSRX1400         OBJECT IDENTIFIER ::= { jnxBackplane        79 }
+
+--
+-- DELLJSRX5800 (A40 DELL OEM)
+--
+
+  jnxProductLineDELLJSRX5800      OBJECT IDENTIFIER ::= { jnxProductLine      80 }
+  jnxProductNameDELLJSRX5800      OBJECT IDENTIFIER ::= { jnxProductName      80 }
+  jnxProductModelDELLJSRX5800     OBJECT IDENTIFIER ::= { jnxProductModel     80 }
+  jnxProductVariationDELLJSRX5800 OBJECT IDENTIFIER ::= { jnxProductVariation 80 }
+  jnxChassisDELLJSRX5800          OBJECT IDENTIFIER ::= { jnxChassis          80 }
+
+  jnxSlotDELLJSRX5800             OBJECT IDENTIFIER ::= { jnxSlot             80 }
+    jnxDELLJSRX5800SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5800 1  }
+    jnxDELLJSRX5800SlotHM         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5800 2  }
+    jnxDELLJSRX5800SlotPower      OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5800 3  }
+    jnxDELLJSRX5800SlotFan        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5800 4  }
+    jnxDELLJSRX5800SlotCB         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5800 5  }
+    jnxDELLJSRX5800SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5800 6  }
+
+  jnxMediaCardSpaceDELLJSRX5800      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    80 }
+    jnxDELLJSRX5800MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDELLJSRX5800 1 }
+
+  jnxMidplaneDELLJSRX5800         OBJECT IDENTIFIER ::= { jnxBackplane        80 }
+
+--
+-- DELLJSRX5600 (A20 DELL OEM)
+--
+
+  jnxProductLineDELLJSRX5600      OBJECT IDENTIFIER ::= { jnxProductLine      81 }
+  jnxProductNameDELLJSRX5600      OBJECT IDENTIFIER ::= { jnxProductName      81 }
+  jnxProductModelDELLJSRX5600     OBJECT IDENTIFIER ::= { jnxProductModel     81 }
+  jnxProductVariationDELLJSRX5600 OBJECT IDENTIFIER ::= { jnxProductVariation 81 }
+  jnxChassisDELLJSRX5600          OBJECT IDENTIFIER ::= { jnxChassis          81 }
+
+  jnxSlotDELLJSRX5600             OBJECT IDENTIFIER ::= { jnxSlot             81 }
+    jnxDELLJSRX5600SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5600 1  }
+    jnxDELLJSRX5600SlotHM         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5600 2  }
+    jnxDELLJSRX5600SlotPower      OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5600 3  }
+    jnxDELLJSRX5600SlotFan        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5600 4  }
+    jnxDELLJSRX5600SlotCB         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5600 5  }
+    jnxDELLJSRX5600SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5600 6  }
+
+  jnxMediaCardSpaceDELLJSRX5600      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    81 }
+  jnxDELLJSRX5600MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDELLJSRX5600 1 }
+
+  jnxMidplaneDELLJSRX5600         OBJECT IDENTIFIER ::= { jnxBackplane        81 }
+
+--
+-- QFXSwitch
+--
+
+  jnxProductLineQFXSwitch       OBJECT IDENTIFIER ::= { jnxProductLine      82 }
+  jnxProductNameQFXSwitch       OBJECT IDENTIFIER ::= { jnxProductName      82 }
+  jnxProductModelQFXSwitch      OBJECT IDENTIFIER ::= { jnxProductModel     82 }
+  jnxProductVariationQFXSwitch  OBJECT IDENTIFIER ::= { jnxProductVariation 82 }
+    jnxProductQFX3500s          OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 1 }
+    jnxProductQFX360016QS       OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 2 }
+    jnxProductQFX350048T4QS     OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 3 }
+    jnxProductQFX510024Q        OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 4 }
+    jnxProductQFX510048S6Q      OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 5 }
+    jnxProductQFX510096S8Q      OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 6 }
+    jnxProductQFX510048C6Q      OBJECT IDENTIFIER ::= { jnxProductVariationQFXSwitch 7 }
+
+  jnxChassisQFXSwitch           OBJECT IDENTIFIER ::= { jnxChassis          82 }
+
+  jnxSlotQFXSwitch              OBJECT IDENTIFIER ::= { jnxSlot             82 }
+    jnxQFXSwitchSlotFPC         OBJECT IDENTIFIER ::= { jnxSlotQFXSwitch   1 }
+    jnxQFXSwitchSlotHM          OBJECT IDENTIFIER ::= { jnxSlotQFXSwitch   2 }
+    jnxQFXSwitchSlotPower       OBJECT IDENTIFIER ::= { jnxSlotQFXSwitch   3 }
+    jnxQFXSwitchSlotFan         OBJECT IDENTIFIER ::= { jnxSlotQFXSwitch   4 }
+    jnxQFXSwitchSlotFPB         OBJECT IDENTIFIER ::= { jnxSlotQFXSwitch   5 }
+
+  jnxMediaCardSpaceQFXSwitch    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   82 }
+    jnxQFXSwitchMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceQFXSwitch 1 }
+
+
+--
+-- T4000
+--
+
+
+  jnxProductLineT4000		OBJECT IDENTIFIER ::= { jnxProductLine		83 }
+  jnxProductNameT4000		OBJECT IDENTIFIER ::= { jnxProductName		83 }
+  jnxProductModelT4000		OBJECT IDENTIFIER ::= { jnxProductModel		83 }
+  jnxProductVariationT4000	OBJECT IDENTIFIER ::= { jnxProductVariation 	83 }
+  jnxChassisT4000		OBJECT IDENTIFIER ::= { jnxChassis		83 }
+  
+  jnxSlotT4000			OBJECT IDENTIFIER ::= { jnxSlot			83 }
+    jnxT4000SlotFPC		OBJECT IDENTIFIER ::= { jnxSlotT4000 1 }
+    			   	-- Flexible Port Concentrator slot
+    jnxT4000SlotSIB		OBJECT IDENTIFIER ::= { jnxSlotT4000 2 }
+				-- Switch Interface Board slot
+    jnxT4000SlotHM		OBJECT IDENTIFIER ::= { jnxSlotT4000 3 }
+				-- Host Module (also called Routing Engine) slot
+    jnxT4000SlotSCG		OBJECT IDENTIFIER ::= { jnxSlotT4000 4 }
+				-- SONET Clock Generator slot
+    jnxT4000SlotPower		OBJECT IDENTIFIER ::= { jnxSlotT4000 5 }
+    jnxT4000SlotFan		OBJECT IDENTIFIER ::= { jnxSlotT4000 6 }
+    jnxT4000SlotCB		OBJECT IDENTIFIER ::= { jnxSlotT4000 7 }
+				-- Control Board slot
+    jnxT4000SlotFPB		OBJECT IDENTIFIER ::= { jnxSlotT4000 8 }
+				-- Front Panel Board
+    jnxT4000SlotCIP		OBJECT IDENTIFIER ::= { jnxSlotT4000 9 }
+				-- Connector Interface Panel
+    jnxT4000SlotSPMB		OBJECT IDENTIFIER ::= { jnxSlotT4000 10 }
+				-- Processor Mezzanine Board for SIB
+    jnxT4000SlotPSD		OBJECT IDENTIFIER ::= { jnxSlotT4000 11 }
+				-- Protected System Domain slot
+
+  jnxMediaCardSpaceT4000	OBJECT IDENTIFIER ::= { jnxMediaCardSpace	83 }
+    jnxT4000MediaCardSpacePIC 	OBJECT IDENTIFIER ::= { jnxMediaCardSpaceT4000 1 }
+  
+  jnxMidplaneT4000		OBJECT IDENTIFIER ::= { jnxBackplane		83 }
+
+  jnxModuleT4000		OBJECT IDENTIFIER ::= { jnxModule 		83 }
+    jnxT4000SIB  		OBJECT IDENTIFIER ::= { jnxModuleT4000 1 }
+				-- Switch Interface Board
+    jnxT4000SCG  		OBJECT IDENTIFIER ::= { jnxModuleT4000 2 }
+				-- SONET Clock Generator
+    jnxT4000CB			OBJECT IDENTIFIER ::= { jnxModuleT4000 3 }
+				-- Control Board
+    jnxT4000SPMB		OBJECT IDENTIFIER ::= { jnxModuleT4000 4 }
+				-- Processor Mezzanine Board for SIB
+
+--
+-- Quantum Fabric Series 3000 (Staten Island)
+--
+ 
+  jnxProductLineQFX3000      OBJECT IDENTIFIER ::= { jnxProductLine 84 }
+  jnxProductNameQFX3000      OBJECT IDENTIFIER ::= { jnxProductName 84 }
+  jnxProductModelQFX3000     OBJECT IDENTIFIER ::= { jnxProductModel 84 }
+  jnxProductVariationQFX3000 OBJECT IDENTIFIER ::= { jnxProductVariation 84 }
+    jnxProductQFX3000-G      OBJECT IDENTIFIER ::= { jnxProductVariationQFX3000 1 }
+    jnxProductQFX3000-M      OBJECT IDENTIFIER ::= { jnxProductVariationQFX3000 2 }
+  jnxChassisQFX3000          OBJECT IDENTIFIER ::= { jnxChassis          84 }
+
+--
+-- Quantum Fabric Series 5000 (Wall Street)
+--
+
+  jnxProductLineQFX5000 	 OBJECT IDENTIFIER ::= { jnxProductLine 85 }
+  jnxProductNameQFX5000      OBJECT IDENTIFIER ::= { jnxProductName 85 }
+  jnxProductModelQFX5000     OBJECT IDENTIFIER ::= { jnxProductModel 85 }
+  jnxProductVariationQFX5000 OBJECT IDENTIFIER ::= { jnxProductVariation 85 }
+  jnxChassisQFX5000          OBJECT IDENTIFIER ::= { jnxChassis          85 }
 
 --
 --
+-- SRX550
+--
+  jnxProductLineSRX550       OBJECT IDENTIFIER ::= { jnxProductLine 86 }
+  jnxProductNameSRX550       OBJECT IDENTIFIER ::= { jnxProductName 86 }
+  jnxChassisSRX550           OBJECT IDENTIFIER ::= { jnxChassis     86 }
+    
+  jnxSlotSRX550              OBJECT IDENTIFIER ::= { jnxSlot 86 }
+    jnxSRX550SlotFPC         OBJECT IDENTIFIER ::= { jnxSlotSRX550  1  }
+    jnxSRX550SlotRE          OBJECT IDENTIFIER ::= { jnxSlotSRX550  2  }
+    jnxSRX550SlotPower       OBJECT IDENTIFIER ::= { jnxSlotSRX550  3  }
+    jnxSRX550SlotFan         OBJECT IDENTIFIER ::= { jnxSlotSRX550  4  }
+    
+  jnxMediaCardSpaceSRX550    OBJECT IDENTIFIER ::= { jnxMediaCardSpace 86 }
+    jnxSRX550MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceSRX550  1 }
+    
+  jnxMidplaneSRX550         OBJECT IDENTIFIER ::= { jnxBackplane 86 }
+    
+  jnxModuleSRX550            OBJECT IDENTIFIER ::= { jnxModule 86 }
+    jnxSRX550FPC             OBJECT IDENTIFIER ::= { jnxModuleSRX550 1  }
+    jnxSRX550RE              OBJECT IDENTIFIER ::= { jnxModuleSRX550 2  }
+    jnxSRX550Power           OBJECT IDENTIFIER ::= { jnxModuleSRX550 3  }
+    jnxSRX550Fan             OBJECT IDENTIFIER ::= { jnxModuleSRX550 4  }
+
+
+--
+-- ACX
+--
+  jnxProductLineACX      OBJECT IDENTIFIER ::= { jnxProductLine      87 }
+  jnxProductNameACX      OBJECT IDENTIFIER ::= { jnxProductName      87 }
+  jnxProductModelACX     OBJECT IDENTIFIER ::= { jnxProductModel     87 }
+  jnxProductVariationACX OBJECT IDENTIFIER ::= { jnxProductVariation 87 }
+    jnxProductACX1000        OBJECT IDENTIFIER ::= { jnxProductVariationACX 1 }
+    jnxProductACX2000    OBJECT IDENTIFIER ::= { jnxProductVariationACX 2 }
+    jnxProductACX4000    OBJECT IDENTIFIER ::= { jnxProductVariationACX 3 }
+    jnxProductACX2100    OBJECT IDENTIFIER ::= { jnxProductVariationACX 4 }
+    jnxProductACX2200    OBJECT IDENTIFIER ::= { jnxProductVariationACX 5 }
+    jnxProductACX1100    OBJECT IDENTIFIER ::= { jnxProductVariationACX 6 }
+jnxChassisACX          OBJECT IDENTIFIER ::= { jnxChassis          87 }
+
+  jnxSlotACX             OBJECT IDENTIFIER ::= { jnxSlot     87 }
+    jnxACXSlotFPC        OBJECT IDENTIFIER ::= { jnxSlotACX 1  }
+    jnxACXSlotFEB        OBJECT IDENTIFIER ::= { jnxSlotACX 2  }
+    jnxACXSlotRE         OBJECT IDENTIFIER ::= { jnxSlotACX 3  }
+    jnxACXSlotPower      OBJECT IDENTIFIER ::= { jnxSlotACX 4  }
+    jnxACXSlotFan        OBJECT IDENTIFIER ::= { jnxSlotACX 5  }
+
+  jnxMediaCardSpaceACX      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    87 }
+    jnxACXMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceACX 1 }
+    jnxACXMediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceACX 2 }
+
+  jnxMidplaneACX         OBJECT IDENTIFIER ::= { jnxBackplane        87 }
+
+  jnxModuleACX           OBJECT IDENTIFIER ::= { jnxModule     87 }
+    jnxACXFPC            OBJECT IDENTIFIER ::= { jnxModuleACX 1  }
+    jnxACXFEB            OBJECT IDENTIFIER ::= { jnxModuleACX 2  }
+    jnxACXRE             OBJECT IDENTIFIER ::= { jnxModuleACX 3  }
+    jnxACXPower          OBJECT IDENTIFIER ::= { jnxModuleACX 4  }
+       jnxACXPowerDC     OBJECT IDENTIFIER ::= { jnxACXPower 1  }
+       jnxACXPowerAC     OBJECT IDENTIFIER ::= { jnxACXPower 2  }
+    jnxACXFan            OBJECT IDENTIFIER ::= { jnxModuleACX 5  }
+
+
+--
+-- MX40
+--
+
+  jnxProductLineMX40      OBJECT IDENTIFIER ::= { jnxProductLine      88 }
+  jnxProductNameMX40      OBJECT IDENTIFIER ::= { jnxProductName      88 }
+  jnxProductModelMX40     OBJECT IDENTIFIER ::= { jnxProductModel     88 }
+  jnxProductVariationMX40 OBJECT IDENTIFIER ::= { jnxProductVariation 88 }
+    jnxProductMX40        OBJECT IDENTIFIER ::= { jnxProductVariationMX40 1 }
+  jnxChassisMX40          OBJECT IDENTIFIER ::= { jnxChassis          88 }
+
+  jnxSlotMX40             OBJECT IDENTIFIER ::= { jnxSlot     88 }
+    jnxMX40SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX40 1  }
+    jnxMX40SlotCFEB       OBJECT IDENTIFIER ::= { jnxSlotMX40 2  }
+    jnxMX40SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMX40 3  }
+    jnxMX40SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMX40 4  }
+    jnxMX40SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX40 5  }
+
+  jnxMediaCardSpaceMX40      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    88 }
+    jnxMX40MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX40 1 }
+    jnxMX40MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX40 2 }
+
+  jnxMidplaneMX40         OBJECT IDENTIFIER ::= { jnxBackplane        88 }
+
+  jnxModuleMX40           OBJECT IDENTIFIER ::= { jnxModule     88 }
+    jnxMX40FPC            OBJECT IDENTIFIER ::= { jnxModuleMX40 1  }
+    jnxMX40CFEB           OBJECT IDENTIFIER ::= { jnxModuleMX40 2  }
+    jnxMX40RE             OBJECT IDENTIFIER ::= { jnxModuleMX40 3  }
+    jnxMX40Power          OBJECT IDENTIFIER ::= { jnxModuleMX40 4  }
+    jnxMX40PowerAC        OBJECT IDENTIFIER ::= { jnxModuleMX40 5  }
+    jnxMX40Fan            OBJECT IDENTIFIER ::= { jnxModuleMX40 6  }
+
+--
+-- MX10
+--
+
+  jnxProductLineMX10      OBJECT IDENTIFIER ::= { jnxProductLine      89 }
+  jnxProductNameMX10      OBJECT IDENTIFIER ::= { jnxProductName      89 }
+  jnxProductModelMX10     OBJECT IDENTIFIER ::= { jnxProductModel     89 }
+  jnxProductVariationMX10 OBJECT IDENTIFIER ::= { jnxProductVariation 89 }
+    jnxProductMX10        OBJECT IDENTIFIER ::= { jnxProductVariationMX10 1 }
+  jnxChassisMX10          OBJECT IDENTIFIER ::= { jnxChassis          89 }
+
+  jnxSlotMX10             OBJECT IDENTIFIER ::= { jnxSlot     89 }
+    jnxMX10SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX10 1  }
+    jnxMX10SlotCFEB       OBJECT IDENTIFIER ::= { jnxSlotMX10 2  }
+    jnxMX10SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMX10 3  }
+    jnxMX10SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMX10 4  }
+    jnxMX10SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX10 5  }
+
+  jnxMediaCardSpaceMX10      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    89 }
+    jnxMX10MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX10 1 }
+    jnxMX10MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX10 2 }
+
+  jnxMidplaneMX10         OBJECT IDENTIFIER ::= { jnxBackplane        89 }
+
+  jnxModuleMX10           OBJECT IDENTIFIER ::= { jnxModule     89 }
+    jnxMX10FPC            OBJECT IDENTIFIER ::= { jnxModuleMX10 1  }
+    jnxMX10CFEB           OBJECT IDENTIFIER ::= { jnxModuleMX10 2  }
+    jnxMX10RE             OBJECT IDENTIFIER ::= { jnxModuleMX10 3  }
+    jnxMX10Power          OBJECT IDENTIFIER ::= { jnxModuleMX10 4  }
+    jnxMX10PowerAC        OBJECT IDENTIFIER ::= { jnxModuleMX10 5  }
+    jnxMX10Fan            OBJECT IDENTIFIER ::= { jnxModuleMX10 6  }
+ 
+
+--
+-- MX5
+--
+
+  jnxProductLineMX5      OBJECT IDENTIFIER ::= { jnxProductLine      90 }
+  jnxProductNameMX5      OBJECT IDENTIFIER ::= { jnxProductName      90 }
+  jnxProductModelMX5     OBJECT IDENTIFIER ::= { jnxProductModel     90 }
+  jnxProductVariationMX5 OBJECT IDENTIFIER ::= { jnxProductVariation 90 }
+    jnxProductMX5        OBJECT IDENTIFIER ::= { jnxProductVariationMX5 1 }
+  jnxChassisMX5          OBJECT IDENTIFIER ::= { jnxChassis          90 }
+
+  jnxSlotMX5             OBJECT IDENTIFIER ::= { jnxSlot     90 }
+    jnxMX5SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX5 1  }
+    jnxMX5SlotCFEB       OBJECT IDENTIFIER ::= { jnxSlotMX5 2  }
+    jnxMX5SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMX5 3  }
+    jnxMX5SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMX5 4  }
+    jnxMX5SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX5 5  }
+
+  jnxMediaCardSpaceMX5      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    90 }
+    jnxMX5MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX5 1 }
+    jnxMX5MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX5 2 }
+
+  jnxMidplaneMX5         OBJECT IDENTIFIER ::= { jnxBackplane        90 }
+
+  jnxModuleMX5           OBJECT IDENTIFIER ::= { jnxModule     90 }
+    jnxMX5FPC            OBJECT IDENTIFIER ::= { jnxModuleMX5 1  }
+    jnxMX5CFEB           OBJECT IDENTIFIER ::= { jnxModuleMX5 2  }
+    jnxMX5RE             OBJECT IDENTIFIER ::= { jnxModuleMX5 3  }
+    jnxMX5Power          OBJECT IDENTIFIER ::= { jnxModuleMX5 4  }
+    jnxMX5PowerAC        OBJECT IDENTIFIER ::= { jnxModuleMX5 5  }
+    jnxMX5Fan            OBJECT IDENTIFIER ::= { jnxModuleMX5 6  }
+ 
+
+--
+-- QFXMInterconnect
+--
+
+  jnxProductLineQFXMInterconnect OBJECT IDENTIFIER ::= { jnxProductLine      91 }
+  jnxProductNameQFXMInterconnect OBJECT IDENTIFIER ::= { jnxProductName      91 }
+  jnxProductModelQFXMInterconnect OBJECT IDENTIFIER ::= { jnxProductModel     91 }
+  jnxProductVariationQFXMInterconnect  OBJECT IDENTIFIER ::= { jnxProductVariation 91 }
+    jnxProductQFX3600I          OBJECT IDENTIFIER ::= { jnxProductVariationQFXMInterconnect 1 }
+
+  jnxChassisQFXMInterconnect     OBJECT IDENTIFIER ::= { jnxChassis          91 }
+
+  jnxSlotQFXMInterconnect        OBJECT IDENTIFIER ::= { jnxSlot             91 }
+    jnxQFXMInterconnectSlotFPC   OBJECT IDENTIFIER ::= { jnxSlotQFXMInterconnect   1 }
+    jnxQFXMInterconnectSlotHM    OBJECT IDENTIFIER ::= { jnxSlotQFXMInterconnect   2 }
+    jnxQFXMInterconnectSlotPower OBJECT IDENTIFIER ::= { jnxSlotQFXMInterconnect   3 }
+    jnxQFXMInterconnectSlotFan   OBJECT IDENTIFIER ::= { jnxSlotQFXMInterconnect   4 }
+    jnxQFXMInterconnectSlotFPB   OBJECT IDENTIFIER ::= { jnxSlotQFXMInterconnect   5 }
+
+  jnxMediaCardSpaceQFXMInterconnect    OBJECT IDENTIFIER ::= { jnxMediaCardSpace   91 }
+    jnxQFXMInterconnectMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceQFXMInterconnect 1 }
+
+
+--
+-- EX4550
+--
+  jnxProductLineEX4550      OBJECT IDENTIFIER ::= { jnxProductLine      92 }
+  jnxProductNameEX4550      OBJECT IDENTIFIER ::= { jnxProductName      92 }
+  jnxProductModelEX4550     OBJECT IDENTIFIER ::= { jnxProductModel     92 }
+  jnxProductVariationEX4550 OBJECT IDENTIFIER ::= { jnxProductVariation 92 }
+    jnxProductEX4550port32F    OBJECT IDENTIFIER ::= { jnxProductVariationEX4550 1 }
+    jnxProductEX4550port32T    OBJECT IDENTIFIER ::= { jnxProductVariationEX4550 2 }
+
+  jnxChassisEX4550          OBJECT IDENTIFIER ::= { jnxChassis          92 }
+    jnxEX4550RE0            OBJECT IDENTIFIER ::= { jnxChassisEX4550 1 }
+    jnxEX4550RE1            OBJECT IDENTIFIER ::= { jnxChassisEX4550 2 }
+  jnxSlotEX4550             OBJECT IDENTIFIER ::= { jnxSlot             92 }
+    jnxEX4550SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotEX4550 1 }
+      jnxEX4550SlotPower    OBJECT IDENTIFIER ::= { jnxEX4550SlotFPC 1 }
+      jnxEX4550SlotFan      OBJECT IDENTIFIER ::= { jnxEX4550SlotFPC 2 }
+      jnxEX4550SlotRE       OBJECT IDENTIFIER ::= { jnxEX4550SlotFPC 3 }
+  
+  jnxMediaCardSpaceEX4550      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    92 }
+    jnxEX4550MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX4550 1 }
+
+  jnxModuleEX4550            OBJECT IDENTIFIER ::= { jnxModule    92 }
+    jnxEX4550FPC             OBJECT IDENTIFIER ::= { jnxModuleEX4550 1 }
+      jnxEX4550Power         OBJECT IDENTIFIER ::= { jnxEX4550FPC 1 }
+      jnxEX4550Fan           OBJECT IDENTIFIER ::= { jnxEX4550FPC 2 }
+      jnxEX4550RE            OBJECT IDENTIFIER ::= { jnxEX4550FPC 3 }
+
+
+--
+-- MX2020
+--
+  jnxProductLineMX2020      OBJECT IDENTIFIER ::= { jnxProductLine      93 }
+  jnxProductNameMX2020      OBJECT IDENTIFIER ::= { jnxProductName      93 }
+  jnxProductModelMX2020     OBJECT IDENTIFIER ::= { jnxProductModel     93 }
+  jnxProductVariationMX2020 OBJECT IDENTIFIER ::= { jnxProductVariation 93 }
+  jnxChassisMX2020          OBJECT IDENTIFIER ::= { jnxChassis          93 }
+
+  jnxSlotMX2020             OBJECT IDENTIFIER ::= { jnxSlot             93 }
+    jnxMX2020SlotSFB        OBJECT IDENTIFIER ::= { jnxSlotMX2020 1  }
+                            -- Switch Fabric Board
+    jnxMX2020SlotHM         OBJECT IDENTIFIER ::= { jnxSlotMX2020 2  }
+                            -- Host Module (also called Routing Engine {RE})
+    jnxMX2020SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX2020 3  }
+                            -- Flexible Port Concentrator slot
+    jnxMX2020SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX2020 4  }
+    jnxMX2020SlotCB         OBJECT IDENTIFIER ::= { jnxSlotMX2020 5  }
+                            -- Control Board (hosts RE, SPMB)
+    jnxMX2020SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotMX2020 6  }
+                            -- Front Panel Board
+    jnxMX2020SlotSPMB       OBJECT IDENTIFIER ::= { jnxSlotMX2020 7  }
+                            -- Processor Mezzanine Board for SFB
+    jnxMX2020SlotPDM        OBJECT IDENTIFIER ::= { jnxSlotMX2020 8  }
+                            -- Power Distribution Module
+    jnxMX2020SlotPSM        OBJECT IDENTIFIER ::= { jnxSlotMX2020 9  }
+                            -- Power Supply Module
+    jnxMX2020SlotADC        OBJECT IDENTIFIER ::= { jnxSlotMX2020 10 }
+                            -- Adapter Card (connects FPC to backplane)
+
+  jnxMediaCardSpaceMX2020      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    93 }
+    jnxMX2020MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX2020 1 }
+    jnxMX2020MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX2020 2 }
+
+  jnxBackplaneMX2020         OBJECT IDENTIFIER ::= { jnxBackplane        93 }
+    jnxBackplaneLowerMX2020         OBJECT IDENTIFIER ::= { jnxBackplaneMX2020   1 }
+    jnxBackplaneUpperMX2020         OBJECT IDENTIFIER ::= { jnxBackplaneMX2020   2 }
+    jnxBackplaneLowerPowerMX2020    OBJECT IDENTIFIER ::= { jnxBackplaneMX2020   3 }
+    jnxBackplaneUpperPowerMX2020    OBJECT IDENTIFIER ::= { jnxBackplaneMX2020   4 }
+
+  jnxModuleMX2020           OBJECT IDENTIFIER ::= { jnxModule    93 }
+    jnxMX2020SFB            OBJECT IDENTIFIER ::= { jnxModuleMX2020 1  }
+    jnxMX2020HM             OBJECT IDENTIFIER ::= { jnxModuleMX2020 2  }
+    jnxMX2020FPC            OBJECT IDENTIFIER ::= { jnxModuleMX2020 3  }
+    jnxMX2020Fan            OBJECT IDENTIFIER ::= { jnxModuleMX2020 4  }
+    jnxMX2020CB             OBJECT IDENTIFIER ::= { jnxModuleMX2020 5  }
+    jnxMX2020FPB            OBJECT IDENTIFIER ::= { jnxModuleMX2020 6  }
+    jnxMX2020SPMB           OBJECT IDENTIFIER ::= { jnxModuleMX2020 7  }
+    jnxMX2020PDM            OBJECT IDENTIFIER ::= { jnxModuleMX2020 8  }
+    jnxMX2020PSM            OBJECT IDENTIFIER ::= { jnxModuleMX2020 9  }
+    jnxMX2020ADC            OBJECT IDENTIFIER ::= { jnxModuleMX2020 10 }
+
+
+
+
+--
+-- VJX
+--
+
+  jnxProductLineVseries      OBJECT IDENTIFIER ::= { jnxProductLine      94 }
+  jnxProductNameVseries      OBJECT IDENTIFIER ::= { jnxProductName      94 }
+  jnxChassisVseries          OBJECT IDENTIFIER ::= { jnxChassis          94 }
+  jnxSlotVseries             OBJECT IDENTIFIER ::= { jnxSlot    94 }    
+    jnxVseriesSlotFPC         OBJECT IDENTIFIER ::= { jnxSlotVseries  1  }
+    jnxVseriesSlotRE          OBJECT IDENTIFIER ::= { jnxSlotVseries  2  }
+    jnxVseriesSlotPower       OBJECT IDENTIFIER ::= { jnxSlotVseries  3  }
+    jnxVseriesSlotFan         OBJECT IDENTIFIER ::= { jnxSlotVseries  4  }
+
+  jnxMidplaneVseries         OBJECT IDENTIFIER ::= { jnxBackplane 94 }
+
+  jnxModuleVseries            OBJECT IDENTIFIER ::= { jnxModule    94}
+    jnxVseriesFPC             OBJECT IDENTIFIER ::= { jnxModuleVseries 1  }
+    jnxVseriesRE              OBJECT IDENTIFIER ::= { jnxModuleVseries 2  }
+    jnxVseriesPower           OBJECT IDENTIFIER ::= { jnxModuleVseries 3  }
+    jnxVseriesFan             OBJECT IDENTIFIER ::= { jnxModuleVseries 4  }
+
+
+--
+-- LN2600
+--
+  jnxProductLineLN2600      OBJECT IDENTIFIER ::= { jnxProductLine 95 }
+  jnxProductNameLN2600      OBJECT IDENTIFIER ::= { jnxProductName 95 }
+  jnxProductModelLN2600     OBJECT IDENTIFIER ::= { jnxProductModel 95 }
+  jnxProductVariationLN2600 OBJECT IDENTIFIER ::= { jnxProductVariation 95 }
+  jnxChassisLN2600          OBJECT IDENTIFIER ::= { jnxChassis 95 }
+
+  jnxMediaCardSpaceLN2600   OBJECT IDENTIFIER ::= { jnxMediaCardSpace 95 }
+    jnxLN2600MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceLN2600 1 }
+
+  jnxMidplaneLN2600         OBJECT IDENTIFIER ::= { jnxBackplane 95 }
+
+  jnxSlotLN2600             OBJECT IDENTIFIER ::= { jnxSlot 95 }
+    jnxLN2600SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotLN2600  1  }
+    jnxLN2600SlotRE         OBJECT IDENTIFIER ::= { jnxSlotLN2600  2  }
+    jnxLN2600SlotPower      OBJECT IDENTIFIER ::= { jnxSlotLN2600  3  }
+    jnxLN2600SlotFan        OBJECT IDENTIFIER ::= { jnxSlotLN2600  4  }
+
+
+
+-- 
+-- VSRX
+--
+
+  jnxProductLineFireflyPerimeter        OBJECT IDENTIFIER ::= { jnxProductLine  96 }
+  jnxProductNameFireflyPerimeter        OBJECT IDENTIFIER ::= { jnxProductName  96 }
+  jnxChassisFireflyPerimeter            OBJECT IDENTIFIER ::= { jnxChassis      96 }
+
+  jnxSlotFireflyPerimeter               OBJECT IDENTIFIER ::= { jnxSlot         96 }
+    jnxFireflyPerimeterSlotFPC          OBJECT IDENTIFIER ::= { jnxSlotFireflyPerimeter     1  }
+    jnxFireflyPerimeterSlotRE           OBJECT IDENTIFIER ::= { jnxSlotFireflyPerimeter     2  }
+    jnxFireflyPerimeterSlotPower        OBJECT IDENTIFIER ::= { jnxSlotFireflyPerimeter     3  }
+    jnxFireflyPerimeterSlotFan          OBJECT IDENTIFIER ::= { jnxSlotFireflyPerimeter     4  }
+
+  jnxMediaCardSpaceFireflyPerimeter      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    96 }
+    jnxFireflyPerimeterMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceFireflyPerimeter 1 }
+
+  jnxMidplaneFireflyPerimeter           OBJECT IDENTIFIER ::= { jnxBackplane    96 }
+
+  jnxModuleFireflyPerimeter             OBJECT IDENTIFIER ::= { jnxModule       96 }
+    jnxFireflyPerimeterFPC              OBJECT IDENTIFIER ::= { jnxModuleFireflyPerimeter   1  }
+    jnxFireflyPerimeterRE               OBJECT IDENTIFIER ::= { jnxModuleFireflyPerimeter   2  }
+    jnxFireflyPerimeterPower            OBJECT IDENTIFIER ::= { jnxModuleFireflyPerimeter   3  }
+    jnxFireflyPerimeterFan              OBJECT IDENTIFIER ::= { jnxModuleFireflyPerimeter   4  }
+
+
+--
+-- QFX3100
+--
+  jnxProductLineQFX3100      OBJECT IDENTIFIER ::= { jnxProductLine      100 }
+  jnxProductNameQFX3100      OBJECT IDENTIFIER ::= { jnxProductName      100 }
+  jnxProductModelQFX3100     OBJECT IDENTIFIER ::= { jnxProductModel     100 }
+  jnxProductVariationQFX3100 OBJECT IDENTIFIER ::= { jnxProductVariation 100 }
+  jnxChassisQFX3100          OBJECT IDENTIFIER ::= { jnxChassis          100 }
+--
+-- MX104 
+--
+  jnxProductLineMX104      OBJECT IDENTIFIER ::= { jnxProductLine      97 }
+  jnxProductNameMX104      OBJECT IDENTIFIER ::= { jnxProductName      97 }
+  jnxProductModelMX104     OBJECT IDENTIFIER ::= { jnxProductModel     97 }
+  jnxProductVariationMX104 OBJECT IDENTIFIER ::= { jnxProductVariation 97 }
+    jnxProductMX104   OBJECT IDENTIFIER ::= { jnxProductVariationMX104 1 }
+  jnxChassisMX104          OBJECT IDENTIFIER ::= { jnxChassis          97 }
+
+  jnxSlotMX104             OBJECT IDENTIFIER ::= { jnxSlot     97 }
+    jnxMX104SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX104 1  }
+    jnxMX104SlotAFEB       OBJECT IDENTIFIER ::= { jnxSlotMX104 2  }
+    jnxMX104SlotRE         OBJECT IDENTIFIER ::= { jnxSlotMX104 3  }
+    jnxMX104SlotPower      OBJECT IDENTIFIER ::= { jnxSlotMX104 4  }
+    jnxMX104SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX104 5  }
+
+  jnxMediaCardSpaceMX104      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    97 }
+    jnxMX104MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX104 1 }
+    jnxMX104MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX104 2 }
+
+  jnxMidplaneMX104         OBJECT IDENTIFIER ::= { jnxBackplane        97 }
+
+  jnxModuleMX104           OBJECT IDENTIFIER ::= { jnxModule     97 }
+    jnxMX104FPC            OBJECT IDENTIFIER ::= { jnxModuleMX104 1  }
+    jnxMX104FEB            OBJECT IDENTIFIER ::= { jnxModuleMX104 2  }
+    jnxMX104RE             OBJECT IDENTIFIER ::= { jnxModuleMX104 3  }
+    jnxMX104Power          OBJECT IDENTIFIER ::= { jnxModuleMX104 4  }
+    jnxMX104PowerAC        OBJECT IDENTIFIER ::= { jnxModuleMX104 5  }
+    jnxMX104Fan            OBJECT IDENTIFIER ::= { jnxModuleMX104 6  }
+
+
+--
+-- PTX3000 - Hendricks Chassis
+--
+
+  jnxProductLinePTX3000      OBJECT IDENTIFIER ::= { jnxProductLine      98 }
+  jnxProductNamePTX3000      OBJECT IDENTIFIER ::= { jnxProductName      98 }
+  jnxProductModelPTX3000     OBJECT IDENTIFIER ::= { jnxProductModel     98 }
+  jnxProductVariationPTX3000 OBJECT IDENTIFIER ::= { jnxProductVariation 98 }
+  jnxChassisPTX3000          OBJECT IDENTIFIER ::= { jnxChassis          98 }
+
+  jnxSlotPTX3000             OBJECT IDENTIFIER ::= { jnxSlot             98 }
+    jnxPTX3000SlotSIB        OBJECT IDENTIFIER ::= { jnxSlotPTX3000 1  }
+    jnxPTX3000SlotHM         OBJECT IDENTIFIER ::= { jnxSlotPTX3000 2  }
+    jnxPTX3000SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotPTX3000 3  }
+    jnxPTX3000SlotFan        OBJECT IDENTIFIER ::= { jnxSlotPTX3000 4  }
+    jnxPTX3000SlotCB         OBJECT IDENTIFIER ::= { jnxSlotPTX3000 5  }
+    jnxPTX3000SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotPTX3000 6  }
+    jnxPTX3000SlotPSM        OBJECT IDENTIFIER ::= { jnxSlotPTX3000 7  }
+    jnxPTX3000SlotPIC        OBJECT IDENTIFIER ::= { jnxSlotPTX3000 8  }
+
+  jnxMediaCardSpacePTX3000      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    98 }
+    jnxPTX3000MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpacePTX3000 1 }
+
+  jnxMidplanePTX3000         OBJECT IDENTIFIER ::= { jnxBackplane        98 }
+
+  jnxModulePTX3000           OBJECT IDENTIFIER ::= { jnxModule    98 }
+    jnxPTX3000SIB            OBJECT IDENTIFIER ::= { jnxModulePTX3000 1  }
+    jnxPTX3000HM             OBJECT IDENTIFIER ::= { jnxModulePTX3000 2  }
+    jnxPTX3000FPC            OBJECT IDENTIFIER ::= { jnxModulePTX3000 3  }
+    jnxPTX3000Fan            OBJECT IDENTIFIER ::= { jnxModulePTX3000 4  }
+    jnxPTX3000CB             OBJECT IDENTIFIER ::= { jnxModulePTX3000 5  }
+    jnxPTX3000FPB            OBJECT IDENTIFIER ::= { jnxModulePTX3000 6  }
+    jnxPTX3000PSM            OBJECT IDENTIFIER ::= { jnxModulePTX3000 7  }
+    jnxPTX3000PIC            OBJECT IDENTIFIER ::= { jnxModulePTX3000 8  }
+
+
+
+--
+-- MX2010
+--
+  jnxProductLineMX2010      OBJECT IDENTIFIER ::= { jnxProductLine      99 }
+  jnxProductNameMX2010      OBJECT IDENTIFIER ::= { jnxProductName      99 }
+  jnxProductModelMX2010     OBJECT IDENTIFIER ::= { jnxProductModel     99 }
+  jnxProductVariationMX2010 OBJECT IDENTIFIER ::= { jnxProductVariation 99 }
+  jnxChassisMX2010          OBJECT IDENTIFIER ::= { jnxChassis          99 }
+  jnxSlotMX2010             OBJECT IDENTIFIER ::= { jnxSlot             99 }
+    jnxMX2010SlotSFB        OBJECT IDENTIFIER ::= { jnxSlotMX2010 1  }
+                            -- Switch Fabric Board
+    jnxMX2010SlotHM         OBJECT IDENTIFIER ::= { jnxSlotMX2010 2  }
+                            -- Host Module (also called Routing Engine {RE})
+    jnxMX2010SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX2010 3  }
+                            -- Flexible Port Concentrator slot
+    jnxMX2010SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX2010 4  }
+    jnxMX2010SlotCB         OBJECT IDENTIFIER ::= { jnxSlotMX2010 5  }
+                            -- Control Board (hosts RE, SPMB)
+    jnxMX2010SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotMX2010 6  }
+                            -- Front Panel Board
+    jnxMX2010SlotSPMB       OBJECT IDENTIFIER ::= { jnxSlotMX2010 7  }
+                            -- Processor Mezzanine Board for SFB
+    jnxMX2010SlotPDM        OBJECT IDENTIFIER ::= { jnxSlotMX2010 8  }
+                            -- Power Distribution Module
+    jnxMX2010SlotPSM        OBJECT IDENTIFIER ::= { jnxSlotMX2010 9  }
+                            -- Power Supply Module
+    jnxMX2010SlotADC        OBJECT IDENTIFIER ::= { jnxSlotMX2010 10 }
+                            -- Adapter Card (connects FPC to backplane)
+
+  jnxSlotMX2010             OBJECT IDENTIFIER ::= { jnxSlot             99 }
+    jnxMX2010SlotSFB        OBJECT IDENTIFIER ::= { jnxSlotMX2010 1  }
+                            -- Switch Fabric Board
+    jnxMX2010SlotHM         OBJECT IDENTIFIER ::= { jnxSlotMX2010 2  }
+                            -- Host Module (also called Routing Engine {RE})
+    jnxMX2010SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotMX2010 3  }
+                            -- Flexible Port Concentrator slot
+    jnxMX2010SlotFan        OBJECT IDENTIFIER ::= { jnxSlotMX2010 4  }
+    jnxMX2010SlotCB         OBJECT IDENTIFIER ::= { jnxSlotMX2010 5  }
+                            -- Control Board (hosts RE, SPMB)
+    jnxMX2010SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotMX2010 6  }
+                            -- Front Panel Board
+    jnxMX2010SlotSPMB       OBJECT IDENTIFIER ::= { jnxSlotMX2010 7  }
+                            -- Processor Mezzanine Board for SFB
+    jnxMX2010SlotPDM        OBJECT IDENTIFIER ::= { jnxSlotMX2010 8  }
+                            -- Power Distribution Module
+    jnxMX2010SlotPSM        OBJECT IDENTIFIER ::= { jnxSlotMX2010 9  }
+                            -- Power Supply Module
+    jnxMX2010SlotADC        OBJECT IDENTIFIER ::= { jnxSlotMX2010 10 }
+                            -- Adapter Card (connects FPC to backplane)
+
+  jnxMediaCardSpaceMX2010      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    99 }
+    jnxMX2010MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX2010 1 }
+    jnxMX2010MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceMX2010 2 }
+
+  jnxBackplaneMX2010         OBJECT IDENTIFIER ::= { jnxBackplane        99 }
+    jnxBackplaneLowerMX2010    OBJECT IDENTIFIER ::= { jnxBackplaneMX2010   1 }
+    jnxBackplaneUpperMX2010    OBJECT IDENTIFIER ::= { jnxBackplaneMX2010   2 }
+    jnxBackplanePowerMX2010    OBJECT IDENTIFIER ::= { jnxBackplaneMX2010   3 }
+
+  jnxModuleMX2010           OBJECT IDENTIFIER ::= { jnxModule    99 }
+    jnxMX2010SFB            OBJECT IDENTIFIER ::= { jnxModuleMX2010 1  }
+    jnxMX2010HM             OBJECT IDENTIFIER ::= { jnxModuleMX2010 2  }
+    jnxMX2010FPC            OBJECT IDENTIFIER ::= { jnxModuleMX2010 3  }
+    jnxMX2010Fan            OBJECT IDENTIFIER ::= { jnxModuleMX2010 4  }
+    jnxMX2010CB             OBJECT IDENTIFIER ::= { jnxModuleMX2010 5  }
+    jnxMX2010FPB            OBJECT IDENTIFIER ::= { jnxModuleMX2010 6  }
+    jnxMX2010SPMB           OBJECT IDENTIFIER ::= { jnxModuleMX2010 7  }
+    jnxMX2010PDM            OBJECT IDENTIFIER ::= { jnxModuleMX2010 8  }
+    jnxMX2010PSM            OBJECT IDENTIFIER ::= { jnxModuleMX2010 9  }
+    jnxMX2010ADC            OBJECT IDENTIFIER ::= { jnxModuleMX2010 10 }
+
+
+--
+-- QFX3100
+--
+  jnxProductLineQFX3100      OBJECT IDENTIFIER ::= { jnxProductLine      100 }
+  jnxProductNameQFX3100      OBJECT IDENTIFIER ::= { jnxProductName      100 }
+  jnxProductModelQFX3100     OBJECT IDENTIFIER ::= { jnxProductModel     100 }
+  jnxProductVariationQFX3100 OBJECT IDENTIFIER ::= { jnxProductVariation 100 }
+  jnxChassisQFX3100          OBJECT IDENTIFIER ::= { jnxChassis          100 }
+
+  jnxSlotQFX3100              OBJECT IDENTIFIER ::= { jnxSlot            100 }
+    jnxQFX3100SlotCPU         OBJECT IDENTIFIER ::= { jnxSlotQFX3100   1 }
+    jnxQFX3100SlotMemory      OBJECT IDENTIFIER ::= { jnxSlotQFX3100   2 }
+    jnxQFX3100SlotPower       OBJECT IDENTIFIER ::= { jnxSlotQFX3100   3 }
+    jnxQFX3100SlotFan         OBJECT IDENTIFIER ::= { jnxSlotQFX3100   4 }
+    jnxQFX3100SlotHardDisk    OBJECT IDENTIFIER ::= { jnxSlotQFX3100   5 }
+    jnxQFX3100SlotNIC         OBJECT IDENTIFIER ::= { jnxSlotQFX3100   6 }
+
+
+-- LN2800 (Tesla_EU)
+--
+  jnxProductLineLN2800       OBJECT IDENTIFIER ::= { jnxProductLine 101 }
+  jnxProductNameLN2800       OBJECT IDENTIFIER ::= { jnxProductName 101 }
+  jnxChassisLN2800           OBJECT IDENTIFIER ::= { jnxChassis     101 }
+  jnxSlotLN2800              OBJECT IDENTIFIER ::= { jnxSlot 101 }
+    jnxLN2800SlotFPC         OBJECT IDENTIFIER ::= { jnxSlotLN2800  1  }
+    jnxLN2800SlotRE          OBJECT IDENTIFIER ::= { jnxSlotLN2800  2  }
+    jnxLN2800SlotPower       OBJECT IDENTIFIER ::= { jnxSlotLN2800  3  }
+    jnxLN2800SlotFan         OBJECT IDENTIFIER ::= { jnxSlotLN2800  4  }
+ 
+  jnxMediaCardSpaceLN2800    OBJECT IDENTIFIER ::= { jnxMediaCardSpace 101 }
+    jnxLN2800MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceLN2800  1 }
+
+  jnxMidplaneLN2800         OBJECT IDENTIFIER ::= { jnxBackplane 101 }
+
+  jnxModuleLN2800            OBJECT IDENTIFIER ::= { jnxModule 101 }
+    jnxLN2800FPC             OBJECT IDENTIFIER ::= { jnxModuleLN2800 1  }
+    jnxLN2800RE              OBJECT IDENTIFIER ::= { jnxModuleLN2800 2  }
+    jnxLN2800Power           OBJECT IDENTIFIER ::= { jnxModuleLN2800 3  }
+
+
+--
+-- EX9214
+--
+
+  jnxProductLineEX9214      OBJECT IDENTIFIER ::= { jnxProductLine      102 }
+  jnxProductNameEX9214      OBJECT IDENTIFIER ::= { jnxProductName      102 }
+  jnxProductModelEX9214     OBJECT IDENTIFIER ::= { jnxProductModel     102 }
+  jnxProductVariationEX9214 OBJECT IDENTIFIER ::= { jnxProductVariation 102 }
+  jnxChassisEX9214          OBJECT IDENTIFIER ::= { jnxChassis          102 }
+
+  jnxSlotEX9214             OBJECT IDENTIFIER ::= { jnxSlot             102 }
+    jnxEX9214SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotEX9214 1  }
+    jnxEX9214SlotHM         OBJECT IDENTIFIER ::= { jnxSlotEX9214 2  }
+    jnxEX9214SlotPower      OBJECT IDENTIFIER ::= { jnxSlotEX9214 3  }
+    jnxEX9214SlotFan        OBJECT IDENTIFIER ::= { jnxSlotEX9214 4  }
+    jnxEX9214SlotCB         OBJECT IDENTIFIER ::= { jnxSlotEX9214 5  }
+    jnxEX9214SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotEX9214 6  }
+
+  jnxMediaCardSpaceEX9214      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    102 }
+    jnxEX9214MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX9214 1 }
+    jnxEX9214MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX9214 2 }
+
+  jnxMidplaneEX9214         OBJECT IDENTIFIER ::= { jnxBackplane        102 }
+
+
+--
+-- EX9208
+--
+
+  jnxProductLineEX9208      OBJECT IDENTIFIER ::= { jnxProductLine      103 }
+  jnxProductNameEX9208      OBJECT IDENTIFIER ::= { jnxProductName      103 }
+  jnxProductModelEX9208     OBJECT IDENTIFIER ::= { jnxProductModel     103 }
+  jnxProductVariationEX9208 OBJECT IDENTIFIER ::= { jnxProductVariation 103 }
+  jnxChassisEX9208          OBJECT IDENTIFIER ::= { jnxChassis          103 }
+
+  jnxSlotEX9208             OBJECT IDENTIFIER ::= { jnxSlot             103 }
+    jnxEX9208SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotEX9208 1  }
+    jnxEX9208SlotHM         OBJECT IDENTIFIER ::= { jnxSlotEX9208 2  }
+    jnxEX9208SlotPower      OBJECT IDENTIFIER ::= { jnxSlotEX9208 3  }
+    jnxEX9208SlotFan        OBJECT IDENTIFIER ::= { jnxSlotEX9208 4  }
+    jnxEX9208SlotCB         OBJECT IDENTIFIER ::= { jnxSlotEX9208 5  }
+    jnxEX9208SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotEX9208 6  }
+
+  jnxMediaCardSpaceEX9208      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    103 }
+  jnxEX9208MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX9208 1 }
+  jnxEX9208MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX9208 2 }
+
+  jnxMidplaneEX9208         OBJECT IDENTIFIER ::= { jnxBackplane        103 }
+
+
+--
+-- EX9204
+--
+
+  jnxProductLineEX9204      OBJECT IDENTIFIER ::= { jnxProductLine      104 }
+  jnxProductNameEX9204      OBJECT IDENTIFIER ::= { jnxProductName      104 }
+  jnxProductModelEX9204     OBJECT IDENTIFIER ::= { jnxProductModel     104 }
+  jnxProductVariationEX9204 OBJECT IDENTIFIER ::= { jnxProductVariation 104 }
+  jnxChassisEX9204          OBJECT IDENTIFIER ::= { jnxChassis          104 }
+
+  jnxSlotEX9204             OBJECT IDENTIFIER ::= { jnxSlot             104 }
+  jnxEX9204SlotFPC          OBJECT IDENTIFIER ::= { jnxSlotEX9204 1  }
+  jnxEX9204SlotHM           OBJECT IDENTIFIER ::= { jnxSlotEX9204 2  }
+  jnxEX9204SlotPower        OBJECT IDENTIFIER ::= { jnxSlotEX9204 3  }
+  jnxEX9204SlotFan          OBJECT IDENTIFIER ::= { jnxSlotEX9204 4  }
+  jnxEX9204SlotCB           OBJECT IDENTIFIER ::= { jnxSlotEX9204 5  }
+  jnxEX9204SlotFPB          OBJECT IDENTIFIER ::= { jnxSlotEX9204 6  }
+  jnxMediaCardSpaceEX9204   OBJECT IDENTIFIER ::= { jnxMediaCardSpace    104 }
+  jnxEX9204MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX9204 1 }
+  jnxEX9204MediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX9204 2 }
+
+  jnxMidplaneEX9204         OBJECT IDENTIFIER ::= { jnxBackplane         104 }
+
+
+--
+-- A15 (SRX5400)
+--
+    
+  jnxProductLineSRX5400      OBJECT IDENTIFIER ::= { jnxProductLine      105 }
+  jnxProductNameSRX5400      OBJECT IDENTIFIER ::= { jnxProductName      105 }
+  jnxProductModelSRX5400     OBJECT IDENTIFIER ::= { jnxProductModel     105 }
+  jnxProductVariationSRX5400 OBJECT IDENTIFIER ::= { jnxProductVariation 105 }
+  jnxChassisSRX5400          OBJECT IDENTIFIER ::= { jnxChassis          105 }
+
+  jnxSlotSRX5400             OBJECT IDENTIFIER ::= { jnxSlot             105 }
+    jnxSRX5400SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotSRX5400 1  }
+    jnxSRX5400SlotHM         OBJECT IDENTIFIER ::= { jnxSlotSRX5400 2  }
+    jnxSRX5400SlotPower      OBJECT IDENTIFIER ::= { jnxSlotSRX5400 3  }
+    jnxSRX5400SlotFan        OBJECT IDENTIFIER ::= { jnxSlotSRX5400 4  }
+    jnxSRX5400SlotCB         OBJECT IDENTIFIER ::= { jnxSlotSRX5400 5  }
+    jnxSRX5400SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotSRX5400 6  }
+
+  jnxMediaCardSpaceSRX5400      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    105 }
+  jnxSRX5400MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceSRX5400 1 }
+
+
+  jnxMidplaneSRX5400         OBJECT IDENTIFIER ::= { jnxBackplane        105 }
+
+--
+-- IBM4274S54J54S (A15 IBM OEM)
+--
+
+  jnxProductLineIBM4274S54J54S      OBJECT IDENTIFIER ::= { jnxProductLine      106 }
+  jnxProductNameIBM4274S54J54S      OBJECT IDENTIFIER ::= { jnxProductName      106 }
+  jnxProductModelIBM4274S54J54S     OBJECT IDENTIFIER ::= { jnxProductModel     106 }
+  jnxProductVariationIBM4274S54J54S OBJECT IDENTIFIER ::= { jnxProductVariation 106 }
+  jnxChassisIBM4274S54J54S          OBJECT IDENTIFIER ::= { jnxChassis          106 }
+
+  jnxSlotIBM4274S54J54S             OBJECT IDENTIFIER ::= { jnxSlot             106 }
+    jnxIBM4274S54J54SSlotFPC        OBJECT IDENTIFIER ::= { jnxSlotIBM4274S54J54S 1  }
+    jnxIBM4274S54J54SSlotHM         OBJECT IDENTIFIER ::= { jnxSlotIBM4274S54J54S 2  }
+    jnxIBM4274S54J54SSlotPower      OBJECT IDENTIFIER ::= { jnxSlotIBM4274S54J54S 3  }
+    jnxIBM4274S54J54SSlotFan        OBJECT IDENTIFIER ::= { jnxSlotIBM4274S54J54S 4  }
+    jnxIBM4274S54J54SSlotCB         OBJECT IDENTIFIER ::= { jnxSlotIBM4274S54J54S 5  }
+    jnxIBM4274S54J54SSlotFPB        OBJECT IDENTIFIER ::= { jnxSlotIBM4274S54J54S 6  }
+
+  jnxMediaCardSpaceIBM4274S54J54S      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    106 }
+  jnxIBM4274S54J54SMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceIBM4274S54J54S 1 }
+
+  jnxMidplaneIBM4274S54J54S         OBJECT IDENTIFIER ::= { jnxBackplane        106 }
+
+--
+-- DELLJSRX5400 (A15 DELL OEM)
+--
+
+  jnxProductLineDELLJSRX5400      OBJECT IDENTIFIER ::= { jnxProductLine      107 }
+  jnxProductNameDELLJSRX5400      OBJECT IDENTIFIER ::= { jnxProductName      107 }
+  jnxProductModelDELLJSRX5400     OBJECT IDENTIFIER ::= { jnxProductModel     107 }
+  jnxProductVariationDELLJSRX5400 OBJECT IDENTIFIER ::= { jnxProductVariation 107 }
+  jnxChassisDELLJSRX5400          OBJECT IDENTIFIER ::= { jnxChassis          107 }
+
+  jnxSlotDELLJSRX5400             OBJECT IDENTIFIER ::= { jnxSlot             107 }
+    jnxDELLJSRX5400SlotFPC        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5400 1  }
+    jnxDELLJSRX5400SlotHM         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5400 2  }
+    jnxDELLJSRX5400SlotPower      OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5400 3  }
+    jnxDELLJSRX5400SlotFan        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5400 4  }
+    jnxDELLJSRX5400SlotCB         OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5400 5  }
+    jnxDELLJSRX5400SlotFPB        OBJECT IDENTIFIER ::= { jnxSlotDELLJSRX5400 6  }
+
+  jnxMediaCardSpaceDELLJSRX5400      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    107 }
+  jnxDELLJSRX5400MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceDELLJSRX5400 1 }
+
+  jnxMidplaneDELLJSRX5400         OBJECT IDENTIFIER ::= { jnxBackplane        107 }
+
+--
+-- VMX
+--
+
+  jnxProductLineVMX      OBJECT IDENTIFIER ::= { jnxProductLine      108 }
+  jnxProductNameVMX      OBJECT IDENTIFIER ::= { jnxProductName      108 }
+  jnxProductModelVMX     OBJECT IDENTIFIER ::= { jnxProductModel   108 }
+  jnxChassisVMX          OBJECT IDENTIFIER ::= { jnxChassis          108 }
+
+  jnxSlotVMX             OBJECT IDENTIFIER ::= { jnxSlot    108 }    
+    jnxVMXSlotFPC         OBJECT IDENTIFIER ::= { jnxSlotVMX  1  }
+    jnxVMxSlotPower       OBJECT IDENTIFIER ::= { jnxSlotVMX  2  }
+    jnxVMXSlotFan         OBJECT IDENTIFIER ::= { jnxSlotVMX  3  }
+    jnxVMXSlotCB          OBJECT IDENTIFIER ::= { jnxSlotVMX  4  }
+    jnxVMXSlotHM          OBJECT IDENTIFIER ::= { jnxSlotVMX  5  }
+
+  jnxMediaCardSpaceVMX      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    108 }
+    jnxVMXMediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceVMX 1 }
+    jnxVMXMediaCardSpaceMIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceVMX 2 }
+
+  jnxMidplaneVMX         OBJECT IDENTIFIER ::= { jnxBackplane 108 }
+
+
+--
+-- EX4600
+--
+
+  jnxProductLineEX4600      OBJECT IDENTIFIER ::= { jnxProductLine      109 }
+  jnxProductNameEX4600      OBJECT IDENTIFIER ::= { jnxProductName      109 }
+  jnxProductModelEX4600     OBJECT IDENTIFIER ::= { jnxProductModel     109 }
+  jnxProductVariationEX4600 OBJECT IDENTIFIER ::= { jnxProductVariation 109 }
+    jnxProductEX4600        OBJECT IDENTIFIER ::= { jnxProductVariationEX4600 1 }
+
+  jnxChassisEX4600          OBJECT IDENTIFIER ::= { jnxChassis          109 }
+
+  jnxSlotEX4600                 OBJECT IDENTIFIER ::= { jnxSlot             109 }
+    jnxEX4600SlotFPC            OBJECT IDENTIFIER ::= { jnxSlotEX4600      1 }
+    jnxEX4600HM                 OBJECT IDENTIFIER ::= { jnxSlotEX4600      2 }
+    jnxEX4600SlotPower          OBJECT IDENTIFIER ::= { jnxSlotEX4600      3 }
+    jnxEX4600SlotFan            OBJECT IDENTIFIER ::= { jnxSlotEX4600      4 }
+
+  jnxMediaCardSpaceEX4600      OBJECT IDENTIFIER ::= { jnxMediaCardSpace    109 }
+    jnxEX4600MediaCardSpacePIC OBJECT IDENTIFIER ::= { jnxMediaCardSpaceEX4600 1 }
+
+--
+-- VRR
+--
+    jnxProductLineVRR   OBJECT IDENTIFIER ::= { jnxProductLine  110 }
+    jnxProductModelVRR  OBJECT IDENTIFIER ::= { jnxProductModel 110 }
+    jnxProductNameVRR   OBJECT IDENTIFIER ::= { jnxProductName  110 }
+    jnxChassisVRR       OBJECT IDENTIFIER ::= { jnxChassis      110 }
+    jnxSlotVRR          OBJECT IDENTIFIER ::= { jnxSlot         110 }    
+      jnxVRRSlotFPC       OBJECT IDENTIFIER ::= { jnxSlotVRR      1 }  
+      jnxVRRSlotRE        OBJECT IDENTIFIER ::= { jnxSlotVRR      2 }  
+      jnxVRRSlotPower     OBJECT IDENTIFIER ::= { jnxSlotVRR      3 }  
+      jnxVRRSlotFan       OBJECT IDENTIFIER ::= { jnxSlotVRR      4 }  
+      jnxVRRSlotHM        OBJECT IDENTIFIER ::= { jnxSlotVRR      5 }  
+      jnxVRRSlotCB        OBJECT IDENTIFIER ::= { jnxSlotVRR      6 }  
+      jnxVRRSlotFPB       OBJECT IDENTIFIER ::= { jnxSlotVRR      7 }  
+    jnxMidplaneVRR      OBJECT IDENTIFIER ::= { jnxBackplane    110 }
+    jnxModuleVRR        OBJECT IDENTIFIER ::= { jnxModule       110 }
+      jnxVRRFPC         OBJECT IDENTIFIER ::= { jnxModuleVRR      1 }  
+      jnxVRRRE          OBJECT IDENTIFIER ::= { jnxModuleVRR      2 }  
+      jnxVRRPower       OBJECT IDENTIFIER ::= { jnxModuleVRR      3 }  
+      jnxVRRFan         OBJECT IDENTIFIER ::= { jnxModuleVRR      4 }  
+
+
+
 -- PLATFORM INDEPENDENT OIDs
 -- 
 -- As of release 6.0, all new Juniper routers will use the following
@@ -2448,16 +3979,18 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
       jnxPicEX4500M2Legacy OBJECT IDENTIFIER ::= { jnxPic 229 }
       jnxPicEX820036XS           OBJECT IDENTIFIER ::= { jnxPic 230 }
       jnxPicEX820040XS           OBJECT IDENTIFIER ::= { jnxPic 231 }
-
+      jnxPicEX820048PL           OBJECT IDENTIFIER ::= { jnxPic 232 }
+      jnxPicEX82002XS40P         OBJECT IDENTIFIER ::= { jnxPic 233 }
 -- 
--- OIDs 232 and 233 are not defined here as they have been reserved
--- for future use.
--- 
+-- OIDs 232 and 233 are not defined here as they have been used on 
+-- the DEV_EX_1001_DOUBLECAP_BRANCH development branch.  Leaving
+-- them undefined to prevent merge conflicts.
+--
 
-      jnxPicType1ASPCPrism       OBJECT IDENTIFIER ::= { jnxPic 234 }
-      jnxPicType2ASPCPrism       OBJECT IDENTIFIER ::= { jnxPic 235 }
-      jnxPicType3ASPCPrism       OBJECT IDENTIFIER ::= { jnxPic 236 }
-      jnxPicSPCPrismx1           OBJECT IDENTIFIER ::= { jnxPic 237 }
+      jnxPicType1ASPCXLP         OBJECT IDENTIFIER ::= { jnxPic 234 }
+      jnxPicType2ASPCXLP         OBJECT IDENTIFIER ::= { jnxPic 235 }
+      jnxPicType3ASPCXLP         OBJECT IDENTIFIER ::= { jnxPic 236 }
+      jnxPicSPCXLPx1             OBJECT IDENTIFIER ::= { jnxPic 237 }
       jnxPicStoli40GE            OBJECT IDENTIFIER ::= { jnxPic 238 }
       jnxPicHyp1X100GECFP        OBJECT IDENTIFIER ::= { jnxPic 239 }
       jnxPicHyp1X40GECFP         OBJECT IDENTIFIER ::= { jnxPic 240 }
@@ -2466,5 +3999,478 @@ jnxStatusSource	    OBJECT IDENTIFIER ::= { jnxClassStatus 1 }
       jnxPic12x10GE              OBJECT IDENTIFIER ::= { jnxPic 243 }
       jnxPic1x100GE              OBJECT IDENTIFIER ::= { jnxPic 244 }
       jnxPicHyp2X40GEQSFP        OBJECT IDENTIFIER ::= { jnxPic 245 }
+      jnxPicHercules24X10GE      OBJECT IDENTIFIER ::= { jnxPic 246 }
+      jnxPicCTPGluonSerialMS     OBJECT IDENTIFIER ::= { jnxPic 247 }
+      jnxPicAgent00SLC1X10GE     OBJECT IDENTIFIER ::= { jnxPic 248 }
+      jnxPicAgent00SLC4X1GE      OBJECT IDENTIFIER ::= { jnxPic 249 }
+      jnxPicQFXSFE16x40GEQSFP    OBJECT IDENTIFIER ::= { jnxPic 250 }
+      jnxPicQFXSFI16x40GE        OBJECT IDENTIFIER ::= { jnxPic 251 }
+      jnxPicQFXSRI16x40GE        OBJECT IDENTIFIER ::= { jnxPic 252 }
+      jnxPicQFX48x10GESFPPlus    OBJECT IDENTIFIER ::= { jnxPic 253 }
+      jnxPicQFX4x40GEQSFP        OBJECT IDENTIFIER ::= { jnxPic 254 }
+      jnxPicQFX2x80GEQCXP        OBJECT IDENTIFIER ::= { jnxPic 255 }
+      jnxPicType3IQECC4XOC48     OBJECT IDENTIFIER ::= { jnxPic 256 }
+      jnxPicSng2x40GE            OBJECT IDENTIFIER ::= { jnxPic 257 }
 
-END
+--
+-- pics added for IBM 4500
+--
+      jnxPicIBM0719J45EUplinkSFPPlus4Port OBJECT IDENTIFIER ::= { jnxPic 258 }
+      jnxPicIBM0719J45EUplinkXFP4Port     OBJECT IDENTIFIER ::= { jnxPic 259 }
+      jnxPicIBM0719J45EM2Optical          OBJECT IDENTIFIER ::= { jnxPic 260 }
+      jnxPicIBM0719J45EM2Legacy           OBJECT IDENTIFIER ::= { jnxPic 261 }
+
+--
+-- pics added for IBM & Dell for QFX series
+--
+      jnxPicIBMJ08FSFE16x40GEQSFP    OBJECT IDENTIFIER ::= { jnxPic 262 }
+      jnxPicIBMJ08FSFI16xFabric      OBJECT IDENTIFIER ::= { jnxPic 263 }
+      jnxPicIBMJ08FSRI16xFabric      OBJECT IDENTIFIER ::= { jnxPic 264 }
+      jnxPicIBMJ52F48x10GESFPPlus    OBJECT IDENTIFIER ::= { jnxPic 265 }
+      jnxPicIBMJ52F4x40GEQSFP        OBJECT IDENTIFIER ::= { jnxPic 266 }
+      jnxPicDellJFX350048x10GESFPPlus OBJECT IDENTIFIER ::= { jnxPic 267 }
+
+---
+--- #if REL11.1
+--- pics added for rapidshot
+
+      jnxPicEX820048TES         OBJECT IDENTIFIER ::= { jnxPic 268 }
+      jnxPicEX820048SES         OBJECT IDENTIFIER ::= { jnxPic 269 }
+      jnxPicEX82008XSES         OBJECT IDENTIFIER ::= { jnxPic 270 }
+      jnxPicEX820040XSES        OBJECT IDENTIFIER ::= { jnxPic 271 }
+      jnxPicEX820048TES4X       OBJECT IDENTIFIER ::= { jnxPic 272 }
+      jnxPicEX820048SES4X       OBJECT IDENTIFIER ::= { jnxPic 273 }
+      jnxPicEX82008XSES4X       OBJECT IDENTIFIER ::= { jnxPic 274 }
+      jnxPicEX820040XSES4X      OBJECT IDENTIFIER ::= { jnxPic 275 }
+
+--- #endif
+
+--
+-- pics added for EX62XX series
+--
+    jnxPicEX620048T                  OBJECT IDENTIFIER ::= { jnxPic 276 }
+    jnxPicEX620048P                  OBJECT IDENTIFIER ::= { jnxPic 277 }
+    jnxPicEX62004XS                  OBJECT IDENTIFIER ::= { jnxPic 278 }
+
+
+--
+-- pics added for DELL for QFX 3500
+--
+      jnxPicDellJFX35004x40GEQSFP     OBJECT IDENTIFIER ::= { jnxPic 279 }
+
+--
+-- pics added for EX82xx series
+--
+    jnxPicEX820048TL                 OBJECT IDENTIFIER ::= { jnxPic 280 }
+    jnxPicEX82002XS40T               OBJECT IDENTIFIER ::= { jnxPic 281 }
+
+
+    jnxPicType2MSPrism	             OBJECT IDENTIFIER ::= { jnxPic 282 }
+    jnxPicMicMSPrism       	     OBJECT IDENTIFIER ::= { jnxPic 283 }
+
+--
+-- pics added for QFX series 3500
+--
+      jnxPicQFX16x10GESFPPlus           OBJECT IDENTIFIER ::= { jnxPic 284 }
+      jnxPicIBMJ52F16x10GESFPPlus       OBJECT IDENTIFIER ::= { jnxPic 285 }
+      jnxPicDellJFX350016x10GESFPPlus   OBJECT IDENTIFIER ::= { jnxPic 286 }
+
+--
+-- pics added for QFX series Ptunnel ports
+--
+      jnxPicQFX10xPTunnel               OBJECT IDENTIFIER ::= { jnxPic 287 }
+      jnxPicIBMJ52F10xPTunnel           OBJECT IDENTIFIER ::= { jnxPic 288 }
+
+--
+-- pics added for Fortius platforms
+--
+      jnxPic16XT1E1CEMIC                OBJECT IDENTIFIER ::= { jnxPic 289 }
+      jnxPic8XT1E1CEMIC                 OBJECT IDENTIFIER ::= { jnxPic 290 }
+      jnxPic8xGERJ452xPOEMIC            OBJECT IDENTIFIER ::= { jnxPic 291 }
+      jnxPic2xGESFPMIC                  OBJECT IDENTIFIER ::= { jnxPic 292 }
+      jnxPic2x10GESFPPLUSMIC            OBJECT IDENTIFIER ::= { jnxPic 293 }
+      jnxPic4xGESFPRJ45COMBOMIC         OBJECT IDENTIFIER ::= { jnxPic 294 }
+
+      jnxPicUplinkDualMedia2port        OBJECT IDENTIFIER ::= { jnxPic 295 }
+
+--
+-- EX3300 (Dragon-VC)
+--
+
+      jnxPicEX3300UplinkSFPPlus4Port    OBJECT IDENTIFIER ::= { jnxPic 296 }
+
+
+--
+-- EX4500 (Tsunami)
+--
+      jnxPicEX4500UplinkSFP4Port        OBJECT IDENTIFIER ::= { jnxPic 297 }
+
+
+--
+-- EX4550
+--
+      jnxPicEX4550UplinkEm8XFP          OBJECT IDENTIFIER ::= { jnxPic 298 }
+      jnxPicEX4550UplinkEm8XT           OBJECT IDENTIFIER ::= { jnxPic 299 }
+      jnxPicEX4550UplinkEm2QSFP         OBJECT IDENTIFIER ::= { jnxPic 300 }
+      jnxPicEX4550VC128G                OBJECT IDENTIFIER ::= { jnxPic 301 }
+
+
+--
+-- PIC added for QFX5000
+--
+      jnxPicQFX16x80GCXP               OBJECT IDENTIFIER ::= { jnxPic 302 }
+
+
+-- pics added for QFX360016Q/QFX360016QS for QFX series
+      jnxPicQFX63x10GESFPPlus           OBJECT IDENTIFIER ::= { jnxPic 303 }
+      jnxPicQFX16x40GEQSFP              OBJECT IDENTIFIER ::= { jnxPic 304 }
+
+--
+-- Fortius MIC, MX MIC, and Hercules PIC
+--
+      jnxPic6xGESFPRJ45                OBJECT IDENTIFIER ::= { jnxPic 305 }
+      jnxPicMXPISA16xT1E1RJ48          OBJECT IDENTIFIER ::= { jnxPic 306 }
+      jnxPic6x40GEQSFPP                OBJECT IDENTIFIER ::= { jnxPic 307 }
+      jnxPicACX1xOC124xOC3SFP          OBJECT IDENTIFIER ::= { jnxPic 308 }
+
+
+--
+-- Fortius MIC
+--
+      jnxPicACXPISA16xT1E1RJ48         OBJECT IDENTIFIER ::= { jnxPic 309 }
+
+
+--
+-- Snorkel MICs
+--
+      jnxPic8x10GESFPPMIC              OBJECT IDENTIFIER ::= { jnxPic 310 }
+      jnxPic1x100GECFPMIC              OBJECT IDENTIFIER ::= { jnxPic 311 }
+      jnxPic4x10GESFPPMIC              OBJECT IDENTIFIER ::= { jnxPic 312 }
+
+
+--
+-- Sangria OTN PIC
+--
+      jnxPicPTX2x100GOTNPIC            OBJECT IDENTIFIER ::= { jnxPic 313 }
+
+
+--
+-- MX XLP MICs
+--
+      jnxPicMXXLPDPCPIC                OBJECT IDENTIFIER ::= { jnxPic 314 }
+      jnxPicMXXLP8GMIC                 OBJECT IDENTIFIER ::= { jnxPic 315 }
+      jnxPicMXXLP16GMIC                OBJECT IDENTIFIER ::= { jnxPic 316 }
+      jnxPicMXXLP8GFIPSMIC             OBJECT IDENTIFIER ::= { jnxPic 317 }
+      jnxPicMXXLP16GFIPSMIC            OBJECT IDENTIFIER ::= { jnxPic 318 }
+
+
+--
+-- EX4300 PICs
+--
+      jnxPicEX4300QSFP4Port             OBJECT IDENTIFIER ::= { jnxPic 319 }
+      jnxPicEX4300UplinkSFPPlus4Port    OBJECT IDENTIFIER ::= { jnxPic 320 }
+
+
+--
+-- Australia A10/A2/A1 PICs
+--
+      jnxPicNPIOC2x10GESFPPLUSPIC      OBJECT IDENTIFIER ::= { jnxPic 321 }
+
+
+--
+-- Twister 4 Port DS3/E3 MIC
+--
+      jnxPic4CHDS3E3MICSR              OBJECT IDENTIFIER ::= { jnxPic 322 }
+
+
+--
+-- Twister 4 Port CHOC3 - 1 Port CHOC12 MIC
+--
+      jnxPic4CHOC31CHOC12MICSR         OBJECT IDENTIFIER ::= { jnxPic 323 }
+
+
+--
+-- Sangria 24x10GE LAN/WAN/OTN PIC
+--
+      jnxPicSNG24x10GELWOPIC           OBJECT IDENTIFIER ::= { jnxPic 324 }
+
+
+--
+-- Fortius 8x GE RJ45/SFP MIC 
+--
+      jnxPic8xGESFPRJ45COMBOMIC        OBJECT IDENTIFIER ::= { jnxPic 325 }
+
+
+--
+-- Altius 4X10 SFP+ Builtin MIC 
+--
+      jnxPic4X10GESFPPLUSMIC        OBJECT IDENTIFIER ::= { jnxPic 326 }
+
+
+--
+-- Fortius 4x 1GE RJ45 MIC 
+--
+      jnxPic4xGERJ45MIC                OBJECT IDENTIFIER ::= { jnxPic 327 }
+
+
+--
+
+-- Scuba 12X10GE SFPP Pseudo PIC (VSC8248-based)
+-- Scuba 12X10GE SFPP OTN Pseudo PIC (VSC8496-based)
+-- Scuba 2X100GE CFP2 OTN Pseudo PIC
+-- Scuba 12X10GE SFPP Pseudo PIC (VSC8248-based)
+-- Scuba 12X10GE SFPP OTN Pseudo PIC (VSC8496-based)
+-- Scuba 2X100GE CFP2 OTN Pseudo PIC
+-- Windsurf 12X10GE SFPP Pseudo PIC (VSC8248-based)
+-- Windsurf NX10GE SFPP OTN Debug Pseudo PIC (VSC8494-based)
+-- Windsurf 12X10GE SFPP OTN Pseudo PIC (VSC8496-based)
+-- Windsurf 3X40GE QSFPP Pseudo PIC
+-- Windsurf 1X100GE CFP2 OTN Pseudo PIC
+
+      jnxPic24X10GESFPPMIC             OBJECT IDENTIFIER ::= { jnxPic 328 }
+      jnxPic24X10GESFPPOTNMIC          OBJECT IDENTIFIER ::= { jnxPic 329 }
+      jnxPic2X100GECFP2MIC             OBJECT IDENTIFIER ::= { jnxPic 330 }
+      jnxPic12X10GESFPPPIC             OBJECT IDENTIFIER ::= { jnxPic 331 }
+      jnxPic12X10GESFPPOTNPIC          OBJECT IDENTIFIER ::= { jnxPic 332 }
+      jnxPic2X100GECFP2PIC             OBJECT IDENTIFIER ::= { jnxPic 333 }
+      jnxPicWdSf12X10GESFPPPIC         OBJECT IDENTIFIER ::= { jnxPic 334 }
+      jnxPicNX10GESFPPOTNDEBUGPIC      OBJECT IDENTIFIER ::= { jnxPic 335 }
+      jnxPicWdSf12X10GESFPPOTNPIC      OBJECT IDENTIFIER ::= { jnxPic 336 }
+      jnxPic3X40GEQSFPPPIC             OBJECT IDENTIFIER ::= { jnxPic 337 }
+      jnxPic1X100GECFP2PIC             OBJECT IDENTIFIER ::= { jnxPic 338 }
+
+
+-- pics added for QFX3500-48T4Q/QFX3500-48T4QS for QFX series
+      jnxPicQFX48x10GESFP              OBJECT IDENTIFIER ::= { jnxPic 339 }
+
+
+--
+-- KingFisher Red IPC 16X10G pic 
+-- KingFisher Ultra 2X100G
+--
+      jnxPicKFIPCSFPPPIC                OBJECT IDENTIFIER ::= { jnxPic 341 }
+      jnxPicKFIPCCFP2PIC                OBJECT IDENTIFIER ::= { jnxPic 342 }
+
+
+--
+-- Java 4x1g or 2x10g MACsec capable uplink PIC 
+--
+      jnxPicJAVAxUplinkSFFPlusMACSEC4PORT  OBJECT IDENTIFIER ::= { jnxPic 343 }
+
+
+-- Platform: EX8200 Morpheus
+-- linecards:
+--          MLC-48XSO 48 port 10G  SFP+  oversubscribed line card
+--          MLC-12LQO 12 port 40G  QSFP+ oversubscribed line card
+--          MLC-2CF    2 port 100G CFP 
+      jnxPicEX8200M48XSO               OBJECT IDENTIFIER ::= { jnxPic 344 }
+      jnxPicEX8200M12LQO               OBJECT IDENTIFIER ::= { jnxPic 345 }
+      jnxPicEX8200M2CF                 OBJECT IDENTIFIER ::= { jnxPic 346 }
+
+--
+-- Opus Removable QIC for Opus TORs
+--
+      jnxPicOpusQic4X40G               OBJECT IDENTIFIER ::= { jnxPic 347 }
+
+
+--
+-- Altius 20x1G SFP  Hardened  Mic
+-- Altius 4xOC3/1xOC12 Channelized Hardened Mic
+-- Altius 16X T1/E1 RJ48 CE Hardened MIC
+--
+      jnxPic20XGESfpEHMIC            OBJECT IDENTIFIER ::= { jnxPic 348 }
+      jnxPic1XCOC124XCOC3CEHMIC      OBJECT IDENTIFIER ::= { jnxPic 349 }
+      jnxPicPISA16XT1E1HMIC          OBJECT IDENTIFIER ::= { jnxPic 350 }
+      jnxPic20XGESFPEMIC             OBJECT IDENTIFIER ::= { jnxPic 351 }
+
+
+
+-- Platform: EX42XX
+-- SFP+ MACsec Uplink Module  
+      jnxPicUplinkMacsecSFPplus1G4     OBJECT IDENTIFIER ::= { jnxPic 352 }
+      jnxPicUplinkMacsecSFPplus10G2    OBJECT IDENTIFIER ::= { jnxPic 353 }
+      jnxPicUplinkMacsecSFPplus4port   OBJECT IDENTIFIER ::= { jnxPic 354 }
+
+--
+-- VMX Virtual 10X1GE PIC
+--
+      jnxPicVMX10X1GEPIC                OBJECT IDENTIFIER ::= { jnxPic 355 }
+
+
+--
+-- Altius 10x1G SFP  Enhanced Hardened  Half Mic
+-- Altius 10x1G SFP  Enhanced Half Mic
+--
+      jnxPic10XGESFPHALFEHMIC          OBJECT IDENTIFIER ::= { jnxPic 356 }
+      jnxPic10XGESFPHALFEMIC           OBJECT IDENTIFIER ::= { jnxPic 357 }
+
+
+--
+-- pic added for MX platform
+--
+      jnxPic1xOC124xOC3SFP              OBJECT IDENTIFIER ::= { jnxPic 358 }
+
+
+-- Platform: EX42XX
+-- SFP+ MACsec Uplink Module  
+      jnxPicUplinkMacsecSFPplus1G4     OBJECT IDENTIFIER ::= { jnxPic 352 }
+      jnxPicUplinkMacsecSFPplus10G2    OBJECT IDENTIFIER ::= { jnxPic 353 }
+      jnxPicUplinkMacsecSFPplus4port   OBJECT IDENTIFIER ::= { jnxPic 354 }
+
+--
+-- VMX Virtual 10X1GE PIC
+--
+      jnxPicVMX10X1GEPIC                OBJECT IDENTIFIER ::= { jnxPic 355 }
+
+
+--
+-- pic added for MX platform
+--
+      jnxPic1xOC124xOC3SFP              OBJECT IDENTIFIER ::= { jnxPic 358 }
+
+-- Platform: EX9200
+-- MIC entries for 2x40GbE, 20x1GbE SFP and 40x1GbE Copper MICs
+      jnxPicEX920040x1GbERJ45            OBJECT IDENTIFIER ::= { jnxPic 359 }
+      jnxPicEX920020x1GbESFP             OBJECT IDENTIFIER ::= { jnxPic 360 }
+      jnxPicEX92002x40GbEQSFPP           OBJECT IDENTIFIER ::= { jnxPic 361 }
+
+--
+-- Scuba 4X100GE CXP MIC
+--
+      jnxPic4X100GECXPMIC              OBJECT IDENTIFIER ::= { jnxPic 362 }
+
+
+--
+-- Opus Removable QIC for Opus ODM TORs
+--
+      jnxPicQFXEM4Q          OBJECT IDENTIFIER ::= { jnxPic 363 }
+      jnxPicQFXEM8S          OBJECT IDENTIFIER ::= { jnxPic 364 }
+
+
+--
+-- Mics for SRX NG-IOC 
+--
+      jnxPicSRXIOC21X100GECFP          OBJECT IDENTIFIER ::= { jnxPic 365 }
+      jnxPicSRXIOC210X10GESFPP         OBJECT IDENTIFIER ::= { jnxPic 366 }
+      jnxPicSRXIOC22X40GEQSFP          OBJECT IDENTIFIER ::= { jnxPic 367 }
+
+ 
+-- Chivas 4X100G CFP2 Pic
+-- Chivas Load Pic
+--
+     jnxPicCHV4X100GCFP2            OBJECT IDENTIFIER ::= { jnxPic 368 }
+     jnxPicCHVLOAD                  OBJECT IDENTIFIER ::= { jnxPic 369 }
+
+-- EX4300 Fiber switch MICs
+--
+      jnxPicEX4300UplinkSFPPlus8Port          OBJECT IDENTIFIER ::= { jnxPic 370 }
+      jnxPicEX4300UplinkQSFP2Port             OBJECT IDENTIFIER ::= { jnxPic 371 }
+      jnxPicEX4300QSFP2Port                   OBJECT IDENTIFIER ::= { jnxPic 379 }
+
+-- EX4300 Fiber switch MICs
+--
+    jnxProductEX4300port32F    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 8 }
+
+-- EX4300 Fiber switch MICs
+--
+    jnxProductEX4300port32F    OBJECT IDENTIFIER ::= { jnxProductVariationEX4300 8 }
+
+-- I2C_ID_CHV_FAKE_4x100GE_PIC
+--
+      jnxPicCHVfake4X100GCFP2            OBJECT IDENTIFIER ::= { jnxPic 372 }
+
+
+--
+-- Platform: QFX5100
+-- 24x40GE PIC for Dominus/Central Park
+
+      jnxPicQFX510024Q        OBJECT IDENTIFIER ::= { jnxPic 373 }
+
+
+--
+-- Windsurf 2X10GE SFPP OTN Pseudo PIC
+--
+      jnxPicWdSf2X10GESFPPOTNPIC         OBJECT IDENTIFIER ::= { jnxPic 374 }
+
+
+-- EX9200 24x10GE+6x40GE PICs
+--
+    jnxPicEX920012X10GESFPPPIC           OBJECT IDENTIFIER ::= { jnxPic 375 }
+    jnxPicEX92003X40GEQSFPPPIC           OBJECT IDENTIFIER ::= { jnxPic 376 }
+
+-- EX9200 20X1GE MACSEC MIC/Half-MIC
+--
+    jnxPicEX920020X1GESFPMACSECMIC      OBJECT IDENTIFIER ::= { jnxPic 377 }
+    jnxPicEX920020X1GESFPMACSECHALFMIC  OBJECT IDENTIFIER ::= { jnxPic 378 }
+
+-- EX4300 Fiber switch MICs
+--
+      jnxPicEX4300QSFP2Port             OBJECT IDENTIFIER ::= { jnxPic 379 }
+
+-- I2C_ID_CHV_4X100G_OTN_PIC
+--
+      jnxPicCHV4X100GOTNCFP2              OBJECT IDENTIFIER ::= { jnxPic 380 }
+
+    
+-- I2C_ID_CHV_48X10G_12X40G_LWO_PIC
+--
+      jnxPicCHV48X10G12X40GLWOPIC         OBJECT IDENTIFIER ::= { jnxPic 381 }
+
+
+-- Platform: QFX5100
+--
+      jnxPicQFX24x40GEFQSFP       OBJECT IDENTIFIER ::= { jnxPic 382 }
+      jnxPicQFX48x10GEFSFP        OBJECT IDENTIFIER ::= { jnxPic 383 }
+      jnxPicQFX6x40GEFQSFP        OBJECT IDENTIFIER ::= { jnxPic 384 }
+      jnxPicQFX510048C6QF         OBJECT IDENTIFIER ::= { jnxPic 398 }
+      jnxPicQFX510048C6QFQSFP     OBJECT IDENTIFIER ::= { jnxPic 399 }
+
+      jnxPicQFX96X10GEFSFP8X40GEFQSFP        OBJECT IDENTIFIER ::= { jnxPic 385}
+      jnxPicQFX48X10GECSFP6X40GEFQSFP        OBJECT IDENTIFIER ::= { jnxPic 386}
+
+-- Platform: QFX5100
+-- 48x10GE+6x40GE PIC for Lenoxhill/Caymus
+-- 24x10GE+4x40GE PIC for Ridge
+-- 96x10GE+8x40GE PIC for Cakebread
+-- 48x10GBASET+6x40GE PIC for Nirvana
+-- 24x10GE+4x40GE PIC for Ridge - EX4600
+-- Opus Removable QIC for Ridge - EX4600
+--
+      jnxPicQFX510048S6Q           OBJECT IDENTIFIER ::= { jnxPic 387 }
+      jnxPicQFX510024S4Q           OBJECT IDENTIFIER ::= { jnxPic 388 }
+      jnxPicQFX510096S8Q           OBJECT IDENTIFIER ::= { jnxPic 389 }
+      jnxPicQFX510048C6Q           OBJECT IDENTIFIER ::= { jnxPic 390 }
+      jnxPicEX460024S4Q            OBJECT IDENTIFIER ::= { jnxPic 391 }
+      jnxPicEX4600EM8F             OBJECT IDENTIFIER ::= { jnxPic 392 }
+
+-- Platform: STOUT
+-- MIC8-100G-CFP4
+-- MIC8-40G-QSFPP
+-- MPC8E Load MIC
+-- MPC7E 6xQSFPP PIC
+-- MPC7E 20x10FE PIC
+--
+      jnxPic8X100GECFP4MIC         OBJECT IDENTIFIER ::= { jnxPic 393 }
+      jnxPic12X40GEQSFPPMIC        OBJECT IDENTIFIER ::= { jnxPic 394 }
+      jnxPicMPC8LOADMIC            OBJECT IDENTIFIER ::= { jnxPic 395 }
+      jnxPic6XQSFPP                OBJECT IDENTIFIER ::= { jnxPic 396 }
+      jnxPic20X10GE                OBJECT IDENTIFIER ::= { jnxPic 397 }
+
+
+-- Platform: CHIVAS
+      jnxPicCHV12X40GLWOPIC        OBJECT IDENTIFIER ::= { jnxPic 400 }
+
+-- Platform: SRX5K
+      jnxPicSRXIOC220X1GESFP       OBJECT IDENTIFIER ::= { jnxPic 401 }
+      jnxPicSRXIOC210X1GESFP       OBJECT IDENTIFIER ::= { jnxPic 402 }
+
+-- Platform: FORTIUS
+      jnxPic3xGERJ453xPOEMIC       OBJECT IDENTIFIER ::= { jnxPic 403 }
+      jnxPic3xGERJ45MIC            OBJECT IDENTIFIER ::= { jnxPic 404 }
+      jnxPic4xGESFPRJ453xPOEMIC    OBJECT IDENTIFIER ::= { jnxPic 405 }
+      jnxPic3xGESFP                OBJECT IDENTIFIER ::= { jnxPic 406 }
+      jnxPicMultiserviceBuiltin    OBJECT IDENTIFIER ::= { jnxPic 407 }
+
+
+
+ END

--- a/mibs/junos/mib-jnx-chassis.txt
+++ b/mibs/junos/mib-jnx-chassis.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Chassis MIB
 -- 
--- Copyright (c) 1998-2008, Juniper Networks, Inc.
+-- Copyright (c) 1998-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -21,7 +21,7 @@ IMPORTS
 
 jnxBoxAnatomy MODULE-IDENTITY
 
-    LAST-UPDATED "200812310000Z" -- Wed Dec 31 00:00:00 2008 UTC
+    LAST-UPDATED "201305220000Z" -- Wed May 22 00:00:00 2013 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -65,12 +65,82 @@ jnxBoxAnatomy MODULE-IDENTITY
                "Added new fru type PSD to jnxFruType enumeration and
                 added jcsX chassis IDs to JnxChassisId enumeration."
     REVISION     "200812310000Z"    -- Dec 31, 2008
-    DESCRIPTION "Added nodeX chassis IDs to JnxChassisId enumeration."
+    DESCRIPTION
+               "Added nodeX chassis IDs to JnxChassisId enumeration."
     REVISION     "200901090000Z"    -- Jan 09, 2009
     DESCRIPTION 
                "Added sfcX and lcc4-lcc15 chassis IDs to JnxChassisId
                 enumeration."
+    REVISION     "201010220000Z"    -- Oct 22, 2010
+    DESCRIPTION
+               "Added load average variables"
+    REVISION     "201109090000Z"    -- Sep 09, 2011
+    DESCRIPTION
+               "Added jnxBoxPersonality for MidRangius Boxes
+                namely MX40/MX10/MX5"
+    REVISION     "201202150000Z"    -- Feb 02, 2012
+    DESCRIPTION 
+               "Added new offline reason builtinPicBounce to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201202210000Z"    -- Feb 21, 2012
+    DESCRIPTION
+               "Added new jnxFruType: PDU and PSM,
+                and new traps: jnxFmLinkErr and jnxFmCellDropErr."
+    REVISION     "201208240000Z"    -- Aug 24, 2012
+    DESCRIPTION 
+               "Added new offline reason fruTypeConfigMismatch to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201208240000Z"    -- Aug 24, 2012
+    DESCRIPTION 
+               "Added new offline reason fruTypeConfigMismatch to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201210120000Z"    -- Oct 12, 2012
+    DESCRIPTION 
+               "Added new offline reason fruPICOfflineOnEccErrors to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201211070000Z"    -- Nov 07, 2012
+    DESCRIPTION 
+               "Added new offline reasons fruFpcIncompatible and
+                fruFpcFanTrayPEMIncompatible to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201301070000Z"    -- Jan 07, 2013
+    DESCRIPTION
+               "Added new offline reason openflowConfigChange to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201302280000Z"    -- Feb 28, 2013
+    DESCRIPTION
+               "Added new offline reasons fruFpcScbIncompatible to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201303220000Z"    -- Mar 22, 2013
+    DESCRIPTION
+               "Added new offline reason hwError
+                to jnxFruOfflineReason enumeration."
+    REVISION     "201305220000Z"    -- May 22, 2013
+    DESCRIPTION 
+               "Added new offline reasons fruReUnresponsive to
+                jnxFruOfflineReason enumeration."
+    REVISION     "201307170000Z"    -- Jul 17, 2013
+    DESCRIPTION 
+               "Added new Fabric plane offline/online/check traps
+                to trap fabric plane offline/online/fault events."
+    REVISION     "201309240000Z"    -- Sep 24, 2013
+    DESCRIPTION
+               "Added new offline reason hwError
+                to jnxFruOfflineReason enumeration."
+    REVISION     "201310150000Z"    -- Oct 15, 2013
+    DESCRIPTION
+               "Added new offline reason fruIncompatibleWithPEM,
+                fruIncompatibleWithSIB, and sibIncompatibleWithOtherSIB
+                to jnxFruOfflineReason enumeration."
+    REVISION     "201311190000Z"    -- Nov 19, 2013
+    DESCRIPTION
+               "Added new offline reason fruPfeErrors to
+                jnxFruOfflineReason enumeration."
 
+    REVISION     "201404080000Z"    -- Apr 08, 2014
+    DESCRIPTION
+               "Added new offline reason vpnLocalizationRoleChange to
+                jnxFruOfflineReason enumeration."
 
 
     ::= { jnxMibs 1 }
@@ -112,7 +182,19 @@ JnxChassisId ::= TEXTUAL-CONVENTION
                      lcc12         (27),
                      lcc13         (28),
                      lcc14         (29),
-                     lcc15         (30)
+                     lcc15         (30),
+                     member0       (31),
+                     member1       (32),
+                     member2       (33),
+                     member3       (34),
+                     member4       (35),
+                     member5       (36),
+                     member6       (37),
+                     member7       (38),
+                     nodeDevice    (39),
+                     interconnectDevice (40),
+                     controlPlaneDevice (41),
+                     directorDevice (42)
                  }
 
 
@@ -821,7 +903,10 @@ JnxChassisId ::= TEXTUAL-CONVENTION
             jnxOperatingStateOrdered    INTEGER,
             jnxOperatingChassisId       JnxChassisId,
             jnxOperatingChassisDescr    DisplayString,
-            jnxOperatingRestartTime     DateAndTime
+            jnxOperatingRestartTime     DateAndTime,
+            jnxOperating1MinLoadAvg     Gauge32,
+            jnxOperating5MinLoadAvg     Gauge32,
+            jnxOperating15MinLoadAvg     Gauge32
     }
 
     jnxOperatingContentsIndex OBJECT-TYPE
@@ -1020,6 +1105,35 @@ JnxChassisId ::= TEXTUAL-CONVENTION
                 last restarted."
         ::= { jnxOperatingEntry 19 }
 
+        jnxOperating1MinLoadAvg OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                    "The CPU Load Average over the last 1 minutes
+                     Here it will be shown as percentage value
+                     Zero if unavailable or inapplicable."
+            ::= { jnxOperatingEntry 20 }
+
+        jnxOperating5MinLoadAvg OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                    "The CPU Load Average over the last 5 minutes
+                     Here it will be shown as percentage value
+                     Zero if unavailable or inapplicable."
+            ::= { jnxOperatingEntry 21 }
+
+        jnxOperating15MinLoadAvg OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                    "The CPU Load Average over the last 15 minutes
+                     Here it will be shown as percentage value
+                     Zero if unavailable or inapplicable."
+            ::= { jnxOperatingEntry 22 }
 
 --
 -- Box Redundancy Information Table
@@ -1348,7 +1462,11 @@ JnxChassisId ::= TEXTUAL-CONVENTION
 		fan(13),                                -- fan
 		lineCardChassis(14),                    -- LCC
                 forwardingEngineBoard(15),              -- FEB
-                protectedSystemDomain(16)               -- PSD
+                protectedSystemDomain(16),              -- PSD
+		powerDistributionUnit(17),              -- PDU
+		powerSupplyModule(18),                  -- PSM
+		switchFabricBoard(19),                  -- SFB
+		adapterCard(20)                         -- ADC
 	}
 	MAX-ACCESS	read-only
 	STATUS		current
@@ -1455,7 +1573,46 @@ JnxChassisId ::= TEXTUAL-CONVENTION
                 spuIdpdCoreDumpComplete(57),    -- SPU idpd crash with complete core dump
                 spuCoreDumpIncomplete(58),      -- SPU kernel crash with incomplete core dump
                 spuIdpdDown(59),                -- SPU idpd down
-                fruPfeReset(60)                 -- PFE reset
+                fruPfeReset(60),                -- PFE reset
+                fruReconnectNotReady(61),       -- FPC not ready to reconnect
+                fruSfLinkDown(62),              -- FE - Fabric links down
+                fruFabricDown(63),              -- Fabric transitioned from up to down
+                fruAntiCounterfeitRetry(64),    -- FPC offlined due to Anti Counterfeit Retry
+                fruFPCChassisClusterDisable(65), -- FPC offlined due to Chassis Cluster Disable
+                spuFipsError(66),                -- SPU fips error
+                fruFPCFabricDownOffline(67),     -- FPC offlined due to Fabric down
+                febCfgChange(68),                -- FEB config change
+                routeLocalizationRoleChange(69), -- Route localization role change
+                fruFpcUnsupported(70),           -- FPC unsupported
+                psdVersionMismatch(71),          -- PSD version mismatch
+                fruResetThresholdExceeded(72),   -- FRU Reset Threshold Exceeded
+                picBounce(73),                   -- PIC Bounce
+                badVoltage(74),                  -- bad voltage
+                fruFPCReducedFabricBW(75),       -- FPC offlined due to Reduced Fabric Bandwidth
+                fruAutoheal(76),                 -- FRU offlined due to software autoheal action
+                builtinPicBounce(77),            -- Builtin PIC Bounce
+                fruFabricDegraded(78),           -- Fabric running in degraded state
+                fruFPCFabricDegradedOffline(79), -- FPC offlined due to degraded fabric action 
+                fruUnsupportedSlot(80),          -- FRU unsupported in the current slot
+                fruRouteLocalizationMisCfg(81),  -- Route Localization - FPC Misconfiguration
+                fruTypeConfigMismatch(82),       -- FRU Type configuration mismatch
+                lccModeChanged(83),              -- LCC mode changed on the SFC
+                hwFault(84),                     -- Hardware fault
+                fruPICOfflineOnEccErrors(85),    -- PIC offlined on ecc errors cross ceratins limit.
+                fruFpcIncompatible(86),          -- FPC imcompatible with other FPCs
+                fruFpcFanTrayPEMIncompatible(87),-- FPC incompatible with FAN-TRAYs ,PEMs
+                fruUnsupportedFirmware(88),      -- Firmware on this FRU not supported
+                openflowConfigChange(89),        -- Openflow config change offlines FPC
+                fruFpcScbIncompatible(90),       -- FPC incompatible with SCB
+                fruReUnresponsive(91),           -- Corresponding slot RE unresponsive
+                hwError(92),                     -- Hardware error
+                fruErrorManagerReqFPCReset(93),  -- Error manager requested FPC reset.
+                fruIncompatibleWithPEM(94),      -- FRU incompatible with power supply
+                fruIncompatibleWithSIB(95),      -- FRU incompatible with SIB
+                sibIncompatibleWithOtherSIB(96), -- FRU incompatible with other SIB
+                fruPfeErrors(97),                -- PIC offlined on PFE Errors cross limit.
+                vpnLocalizationRoleChange(98)    -- VPN localization core-facing-FPC role change
+
 	}
 	MAX-ACCESS	read-only
 	STATUS		current
@@ -1549,6 +1706,20 @@ JnxChassisId ::= TEXTUAL-CONVENTION
 		"The system domain type of this subject, notApplicable will
 		be returned if this feature is not supported."
 	::= { jnxBoxAnatomy 17 }
+
+
+--
+-- Applicable only for MidRangius Systems (MX5/10/40)
+--
+    jnxBoxPersonality OBJECT-TYPE 
+	SYNTAX          OBJECT IDENTIFIER
+	MAX-ACCESS      read-only
+	STATUS          current
+	DESCRIPTION
+	        "The personality of the box, indicating which product line it is currently acting as
+		 for example, 'MX40'."
+	::= { jnxBoxAnatomy 18 }
+
 
 
 --
@@ -1780,7 +1951,6 @@ JnxChassisId ::= TEXTUAL-CONVENTION
                 switched over."
         ::= { jnxChassisTraps 13 }
 
-
     jnxHardDiskFailed NOTIFICATION-TYPE
         OBJECTS         { jnxFruContentsIndex,
                           jnxFruL1Index,
@@ -1814,6 +1984,149 @@ JnxChassisId ::= TEXTUAL-CONVENTION
                 from boot device list."
         ::= { jnxChassisTraps 15 }
 
+    jnxBootFromBackup NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+         STATUS         current
+         DESCRIPTION
+                 "A jnxBootFromBackup trap signifies that the SNMP
+                 entity, acting in an agent role, has detected that
+                 the specified  routing-engine/member has booted from
+                 the back up root partition"
+         ::= { jnxChassisTraps 16 }     
+
+    jnxFmLinkErr NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A LinkErr trap signifies that the SNMP
+                entity, acting in an agent role, has detected
+                link errors."
+        ::= { jnxChassisTraps 17 }
+
+    jnxFmCellDropErr NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A CellDropErr trap signifies that the SNMP
+                entity, acting in an agent role, has detected 
+                cell drop errors."
+        ::= { jnxChassisTraps 18 }
+
+    jnxExtSrcLockLost NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A ExtSrcLockLost trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                a lock for an external clock source has been lost."
+        ::= { jnxChassisTraps 19 }
+    jnxPlaneOffline NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot,
+                          jnxFruOfflineReason,
+                          jnxFruLastPowerOff,
+                          jnxFruLastPowerOn }
+        STATUS          current
+        DESCRIPTION
+                "A jnxPlaneOffline trap signifies that the SNMP
+                entity, acting in an agent role, has detected
+                that the specified Fabric plane
+                has gone offline in the chassis."
+        ::= { jnxChassisTraps 20 }
+
+    jnxPlaneOnline NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxPlaneOnline trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified Fabric Plane has
+                gone online in the chassis."
+        ::= { jnxChassisTraps 21 }
+
+    jnxPlaneCheck NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxPlaneCheck trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified Fabric plane has
+                encountered some operational errors and gone into
+                check state in the chassis."
+        ::= { jnxChassisTraps 22 }   
+    
+    jnxPlaneFault NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxPlaneCheck trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified Fabric plane has
+                encountered some operational errors and gone into
+                fault state in the chassis."
+        ::= { jnxChassisTraps 23 }   
+
+    jnxPowerSupplyInputFailure NOTIFICATION-TYPE
+        OBJECTS         { jnxContentsContainerIndex,
+                          jnxContentsL1Index,
+                          jnxContentsL2Index,
+                          jnxContentsL3Index,
+                          jnxContentsDescr,
+                          jnxOperatingState }
+        STATUS          current
+        DESCRIPTION
+            "A jnxPowerSupplyInputFailure trap signifies that
+            the SNMP entity, acting in an agent role, has
+            detected that the specified power supply's input feed 
+            in the chassis has been in the failure condition."
+        ::= { jnxChassisTraps 24 }
 
 
     -- Traps for chassis alarm cleared conditions
@@ -1882,5 +2195,50 @@ JnxChassisId ::= TEXTUAL-CONVENTION
                 is in ok state in the chassis."
         ::= { jnxChassisOKTraps 4 }
 
+    jnxExtSrcLockAcquired NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A ExtSrcLockAcquired trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                a lock for an external clock source has been acquired."
+        ::= { jnxChassisOKTraps 5 }
+
+    jnxHardDiskOK NOTIFICATION-TYPE
+        OBJECTS         { jnxFruContentsIndex,
+                          jnxFruL1Index,
+                          jnxFruL2Index,
+                          jnxFruL3Index,
+                          jnxFruName,
+                          jnxFruType,
+                          jnxFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxHardDiskOK trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the Disk in the specified Routing Engine has
+                recovered from the failure condition."
+        ::= { jnxChassisOKTraps 6 }
+
+    jnxPowerSupplyInputOK NOTIFICATION-TYPE
+        OBJECTS     { jnxContentsContainerIndex,
+                      jnxContentsL1Index,
+                      jnxContentsL2Index,
+                      jnxContentsL3Index,
+                      jnxContentsDescr,
+                      jnxOperatingState }
+        STATUS      current
+        DESCRIPTION
+            "A jnxPowerSupplyInputOK trap signifies that the 
+            SNMP entity, acting in an agent role, has detected 
+            that the specified power supply's input feed in the
+            chassis has recovered from the failure condition."
+        ::= { jnxChassisOKTraps 7 }
 
 END

--- a/mibs/junos/mib-jnx-cos.txt
+++ b/mibs/junos/mib-jnx-cos.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper enterprise specific Class-Of-Service (COS) MIB. 
 --
--- Copyright (c) 2001-2006, Juniper Networks, Inc.
+-- Copyright (c) 2001-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -21,7 +21,7 @@
 
 
     jnxCos MODULE-IDENTITY
-        LAST-UPDATED "200912040000Z" -- Fri Dec 04 00:00:00 2009 UTC
+        LAST-UPDATED "201305200000Z" -- Mon May 20 00:00:00 2013 UTC
         ORGANIZATION "Juniper Networks, Inc."
         CONTACT-INFO
                 "Juniper Technical Assistance Center
@@ -40,6 +40,10 @@
                      RED  - Random Early Detection
                      PLP  - Packet Loss Priority
                      DSCP - Differential Service Code Point. "
+
+	REVISION     "201305200000Z"    -- May 20, 2013
+    	DESCRIPTION
+        "Modified the max range for JnxCosFcIdentifier from 7 to 15."
 
         REVISION     "200904310000Z"    -- Dec 04, 2009
         DESCRIPTION  "Added Rate Limit stats"
@@ -84,7 +88,7 @@
     JnxCosFcIdentifier ::= TEXTUAL-CONVENTION
         STATUS      current
         DESCRIPTION "A number identifying the forwarding class."
-        SYNTAX      Integer32(0..7)
+        SYNTAX      Integer32(0..15)
 
 
 
@@ -708,7 +712,13 @@
 
             -- Rate Limit dropped byte stats
             jnxCosQstatRateLimitDropBytes           Counter64,
-            jnxCosQstatRateLimitDropByteRate        CounterBasedGauge64
+            jnxCosQstatRateLimitDropByteRate        CounterBasedGauge64,
+         
+            -- Total drop packet/byte stats
+            jnxCosQstatTotalDropPkts               Counter64,       
+            jnxCosQstatTotalDropPktRate            CounterBasedGauge64,
+            jnxCosQstatTotalDropBytes              Counter64,
+            jnxCosQstatTotalDropByteRate           CounterBasedGauge64
     }
 
     jnxCosQstatIfIndex OBJECT-TYPE 
@@ -1185,6 +1195,40 @@
         "The rate (expressed in bytes per second) at which bytes
         are rate-limit dropped at the output on the given interface."
         ::= { jnxCosQstatEntry 52 }
+     
+    -- Total Drop packet/byte stats
+    jnxCosQstatTotalDropPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Total Number of packets dropped on the queue."    
+        ::= { jnxCosQstatEntry 53 }
+
+    jnxCosQstatTotalDropPktRate OBJECT-TYPE
+        SYNTAX      CounterBasedGauge64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The output queue's packet total drop rate, expressed in
+            packets per second."
+        ::= { jnxCosQstatEntry 54 }
+            
+    jnxCosQstatTotalDropBytes OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Total Number of bytes dropped on the queue."      
+        ::= { jnxCosQstatEntry 55 }
+
+    jnxCosQstatTotalDropByteRate OBJECT-TYPE
+        SYNTAX      CounterBasedGauge64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The queue's current total drop rate in bytes per second."
+        ::= { jnxCosQstatEntry 56 }
 
         -- ***************************************************************
         --  Per interface cos stats flags

--- a/mibs/junos/mib-jnx-dom.txt
+++ b/mibs/junos/mib-jnx-dom.txt
@@ -1,0 +1,406 @@
+--
+-- Juniper Enterprise Specific MIB: XFP Digital Optical Monitor MIB
+-- 
+-- Copyright (c) 2010, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-DOM-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+    DateAndTime, TEXTUAL-CONVENTION
+        FROM SNMPv2-TC
+    jnxDomMibRoot, jnxDomNotifications
+        FROM JUNIPER-SMI
+    ifIndex, ifDescr
+        FROM IF-MIB;
+
+-- DOM Alarm and Warning Type
+
+jnxDomMib MODULE-IDENTITY
+    LAST-UPDATED "200912230931Z" -- Wed Dec 23 09:30:00 2009 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This MIB module defines objects used for Digital Optical 
+             Monitor on XFP interface of Juniper products."
+    REVISION      "200912230000Z" 
+    DESCRIPTION
+            "Initial revision."
+    ::= { jnxDomMibRoot 1 }
+
+JnxDomAlarmId ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+            "Identifies specific DOM alarms that may exist on an
+             interface."
+    SYNTAX     BITS {
+        domRxLossSignalAlarm(0),               -- Input Loss of signal
+        domRxCDRLossLockAlarm(1),              -- Input Loss of Lock
+        domRxNotReadyAlarm(2),                 -- Input rx path
+        domRxLaserPowerHighAlarm(3),           -- Input laser power
+        domRxLaserPowerLowAlarm(4),            -- Input laser power
+        domTxLaserBiasCurrentHighAlarm(5),     -- Output laser bias current
+        domTxLaserBiasCurrentLowAlarm(6),      -- Output laser bias current
+        domTxLaserOutputPowerHighAlarm(7),     -- Output laser power
+        domTxLaserOutputPowerLowAlarm(8),      -- Output laser power
+        domTxDataNotReadyAlarm(9),             -- Output A/D data not ready
+        domTxNotReadyAlarm(10),                -- Output tx path
+        domTxLaserFaultAlarm(11),              -- Output laser safety
+        domTxCDRLossLockAlarm(12),             -- Output CDR
+        domModuleTemperatureHighAlarm(13),     -- Module temperature
+        domModuleTemperatureLowAlarm(14),      -- Module temperature
+        domModuleNotReadyAlarm(15),            -- Module MOD_NR
+        domModulePowerDownAlarm(16),           -- Module P_DOWN
+        domLinkDownAlarm(17),                  -- Wire Unplugged or Down
+        domModuleRemovedAlarm(18)              -- Module Unplugged or Down
+    }
+
+JnxDomWarningId ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+            "Identifies specific DOM warnings that may exist on an
+             interface."
+    SYNTAX     BITS {
+        domRxLaserPowerHighWarning(0),         -- Input laser power
+        domRxLaserPowerLowWarning(1),          -- Input laser power
+        domTxLaserBiasCurrentHighWarning(2),   -- Output laser bias current
+        domTxLaserBiasCurrentLowWarning(3),    -- Output laser bias current
+        domTxLaserOutputPowerHighWarning(4),   -- Output laser power
+        domTxLaserOutputPowerLowWarning(5),    -- Output laser power
+        domModuleTemperatureHighWarning(6),    -- Module temperature
+        domModuleTemperatureLowWarning(7)      -- Module temperature
+    }
+
+-- 
+-- Current DOM Statistics
+-- 
+
+jnxDomDigitalMonitoring OBJECT IDENTIFIER ::= { jnxDomMib 1 }
+
+jnxDomCurrentTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF JnxDomCurrentEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Information about Digital Optical Monitoring for this
+             interfaces on this router."
+    ::= { jnxDomDigitalMonitoring 1 }
+
+jnxDomCurrentEntry OBJECT-TYPE
+    SYNTAX     JnxDomCurrentEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "Information about Digital Optical Monitoring 
+             for this interfaces on this router."
+    INDEX    { ifIndex }
+    ::= { jnxDomCurrentTable 1 }
+
+JnxDomCurrentEntry ::=
+    SEQUENCE {
+        jnxDomCurrentAlarms
+              JnxDomAlarmId,
+        jnxDomCurrentAlarmDate
+              DateAndTime,
+        jnxDomLastAlarms
+              JnxDomAlarmId,
+        jnxDomCurrentWarnings
+              JnxDomWarningId,
+        jnxDomCurrentRxLaserPower
+              Integer32,
+        jnxDomCurrentTxLaserBiasCurrent
+              Integer32,
+        jnxDomCurrentTxLaserOutputPower
+              Integer32,
+        jnxDomCurrentModuleTemperature
+              Integer32,
+        jnxDomCurrentRxLaserPowerHighAlarmThreshold
+              Integer32,
+        jnxDomCurrentRxLaserPowerLowAlarmThreshold
+              Integer32,
+        jnxDomCurrentRxLaserPowerHighWarningThreshold
+              Integer32,
+        jnxDomCurrentRxLaserPowerLowWarningThreshold
+              Integer32,
+        jnxDomCurrentTxLaserBiasCurrentHighAlarmThreshold
+              Integer32,
+        jnxDomCurrentTxLaserBiasCurrentLowAlarmThreshold
+              Integer32,
+        jnxDomCurrentTxLaserBiasCurrentHighWarningThreshold
+              Integer32,
+        jnxDomCurrentTxLaserBiasCurrentLowWarningThreshold
+              Integer32,
+        jnxDomCurrentTxLaserOutputPowerHighAlarmThreshold
+              Integer32,
+        jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold
+              Integer32,
+        jnxDomCurrentTxLaserOutputPowerHighWarningThreshold
+              Integer32,
+        jnxDomCurrentTxLaserOutputPowerLowWarningThreshold
+              Integer32,
+        jnxDomCurrentModuleTemperatureHighAlarmThreshold
+              Integer32,
+        jnxDomCurrentModuleTemperatureLowAlarmThreshold
+              Integer32,
+        jnxDomCurrentModuleTemperatureHighWarningThreshold
+              Integer32,
+        jnxDomCurrentModuleTemperatureLowWarningThreshold
+              Integer32
+    }
+
+    jnxDomCurrentAlarms OBJECT-TYPE
+        SYNTAX      JnxDomAlarmId
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "This object identifies all the active DOM alarms 
+                 on a XFP physical interface on this router."
+        ::= { jnxDomCurrentEntry 1 }
+
+    jnxDomCurrentAlarmDate OBJECT-TYPE
+        SYNTAX      DateAndTime
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "The system date and time when the management subsystem learned
+                 of the current alarm event."
+        ::= { jnxDomCurrentEntry 2 }
+
+    jnxDomLastAlarms OBJECT-TYPE
+        SYNTAX      JnxDomAlarmId
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "This object identifies a copy of jnxDomCurrentAlarms 
+                 before last set or clear."
+        ::= { jnxDomCurrentEntry 3 }
+
+    jnxDomCurrentWarnings OBJECT-TYPE
+        SYNTAX      JnxDomWarningId
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "This object identifies all the active DOM warnings
+                 on a XFP physical interface on this router."
+        ::= { jnxDomCurrentEntry 4 }
+
+    jnxDomCurrentRxLaserPower OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Receiver laser power."
+        ::= { jnxDomCurrentEntry 5 }
+
+    jnxDomCurrentTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.001 mA"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Receiver laser bias current."
+        ::= { jnxDomCurrentEntry 6 }
+
+
+    jnxDomCurrentTxLaserOutputPower OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser output power."
+        ::= { jnxDomCurrentEntry 7 }
+
+    jnxDomCurrentModuleTemperature OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS  "Celsius (degrees C)"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Module temperature."
+        ::= { jnxDomCurrentEntry 8 }
+
+    jnxDomCurrentRxLaserPowerHighAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Receiver laser power high alarm threshold."
+        ::= { jnxDomCurrentEntry 9 }
+
+    jnxDomCurrentRxLaserPowerLowAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Receiver laser power low alarm threshold."
+        ::= { jnxDomCurrentEntry 10 }
+
+    jnxDomCurrentRxLaserPowerHighWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Receiver laser power high warning threshold."
+        ::= { jnxDomCurrentEntry 11 }
+
+    jnxDomCurrentRxLaserPowerLowWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Receiver laser power low warning threshold."
+        ::= { jnxDomCurrentEntry 12 }
+
+    jnxDomCurrentTxLaserBiasCurrentHighAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.001 mA"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser bias current high alarm threshold."
+        ::= { jnxDomCurrentEntry 13 }
+
+    jnxDomCurrentTxLaserBiasCurrentLowAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.001 mA"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser bias current low alarm threshold."
+        ::= { jnxDomCurrentEntry 14 }
+
+    jnxDomCurrentTxLaserBiasCurrentHighWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.001 mA"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser bias current high warning threshold."
+        ::= { jnxDomCurrentEntry 15 }
+
+    jnxDomCurrentTxLaserBiasCurrentLowWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.001 mA"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser bias current low warning threshold."
+        ::= { jnxDomCurrentEntry 16 }
+
+    jnxDomCurrentTxLaserOutputPowerHighAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser power high alarm threshold."
+        ::= { jnxDomCurrentEntry 17 }
+
+    jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser power low alarm threshold."
+        ::= { jnxDomCurrentEntry 18 }
+
+    jnxDomCurrentTxLaserOutputPowerHighWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser power high warning threshold."
+        ::= { jnxDomCurrentEntry 19 }
+
+    jnxDomCurrentTxLaserOutputPowerLowWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "0.01 dbm"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Transmitter laser power low warning threshold."
+        ::= { jnxDomCurrentEntry 20 }
+
+    jnxDomCurrentModuleTemperatureHighAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "Celsius (degrees C)"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Module temperature high alarm threshold."
+        ::= { jnxDomCurrentEntry 21 }
+
+    jnxDomCurrentModuleTemperatureLowAlarmThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "Celsius (degrees C)"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Module temperature low alarm threshold."
+        ::= { jnxDomCurrentEntry 22 }
+
+    jnxDomCurrentModuleTemperatureHighWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "Celsius (degrees C)"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Module temperature high warning threshold."
+        ::= { jnxDomCurrentEntry 23 }
+
+    jnxDomCurrentModuleTemperatureLowWarningThreshold OBJECT-TYPE
+        SYNTAX      Integer32
+        UNITS       "Celsius (degrees C)"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                " Module temperature low warning threshold."
+        ::= { jnxDomCurrentEntry 24 }
+
+--
+-- Configuration Management Notifications
+--
+
+jnxDomNotificationPrefix   OBJECT IDENTIFIER ::= { jnxDomNotifications 0 }
+
+    jnxDomAlarmSet NOTIFICATION-TYPE
+        OBJECTS { ifDescr,
+                  jnxDomLastAlarms,
+                  jnxDomCurrentAlarms,
+                  jnxDomCurrentAlarmDate }
+        STATUS  current
+        DESCRIPTION
+                "Notification of a recently set Dom alarm."
+        ::= { jnxDomNotificationPrefix 1 }
+
+    jnxDomAlarmCleared NOTIFICATION-TYPE
+        OBJECTS { ifDescr,
+                  jnxDomLastAlarms,
+                  jnxDomCurrentAlarms,
+                  jnxDomCurrentAlarmDate }
+        STATUS  current
+        DESCRIPTION
+                "Notification of a recently cleared Dom alarm."
+        ::= { jnxDomNotificationPrefix 2 }
+
+END
+

--- a/mibs/junos/mib-jnx-event.txt
+++ b/mibs/junos/mib-jnx-event.txt
@@ -75,7 +75,7 @@ jnxEvent MODULE-IDENTITY
       INDEX     { jnxEventAvIndex }
       ::= { jnxEventAvTable 1 }
 
-    JnxEventAvEntry::=
+    JnxEventAvEntry ::=
         SEQUENCE {
           jnxEventAvIndex       Unsigned32,
           jnxEventAvAttribute   DisplayString,

--- a/mibs/junos/mib-jnx-ex-mac-notification.txt
+++ b/mibs/junos/mib-jnx-ex-mac-notification.txt
@@ -1,7 +1,7 @@
 -- *****************************************************************
 -- Juniper Enterprise Specific MIB: EX-MAC-NOTIFICATION 
 --
--- Copyright (c) 2008-2009, Juniper Networks, Inc.
+-- Copyright (c) 2008-2010, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -19,7 +19,7 @@ IMPORTS
                 FROM JUNIPER-EX-SMI;
 
 jnxMacNotificationMIB MODULE-IDENTITY
-    LAST-UPDATED "200905270000Z"
+    LAST-UPDATED "201004280000Z"
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
         "Juniper Technical Assistance Center
@@ -42,6 +42,16 @@ jnxMacNotificationMIB MODULE-IDENTITY
     REVISION  "200905270000Z"
     DESCRIPTION
             "Updated the description of the Objects."
+    
+    REVISION  "201002090000Z"
+    DESCRIPTION
+            "Updated the description of jnxHistMacChangedMsg. When next hop gets
+            changed the port information gets updated and is logged."
+
+    REVISION  "201004280000Z"
+    DESCRIPTION
+            "Added new scalar jnxMacAddressesUpdated which increments for each
+            mac address updated."
 
     ::= { jnxMacNotificationRoot 1 }
 
@@ -215,6 +225,7 @@ jnxHistMacChangedMsg OBJECT-TYPE
           0 - End of MIB object.
           1 - MAC learnt.
           2 - MAC removed.
+          3 - MAC updated.
 
         <VLAN> is VLAN number of the VLAN which the MAC address is
         belonged to and has size of 2 octet.
@@ -235,6 +246,15 @@ jnxHistTimestamp  OBJECT-TYPE
         containing the information denoted by the jnxHistMacChangedMsg
         object in this entry was generated."
     ::= { jnxMacHistoryEntry 3 }
+
+jnxMacAddressesUpdated OBJECT-TYPE
+    SYNTAX        Counter64
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Indicates the number of MAC addresses updated by the
+        device."
+    ::= { jnxMacNotificationMIBGlobalObjects 9 }
 
 -- ***********************************************************
 

--- a/mibs/junos/mib-jnx-ex-smi.txt
+++ b/mibs/junos/mib-jnx-ex-smi.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Structure of Management Information
 --
--- Copyright (c) 2002-2007, Juniper Networks, Inc.
+-- Copyright (c) 2002-2009, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.

--- a/mibs/junos/mib-jnx-exp.txt
+++ b/mibs/junos/mib-jnx-exp.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Networks: SNMP Experimental MIB Registry
 -- 
--- Copyright (c) 2003, 2005-2008, Juniper Networks, Inc.
+-- Copyright (c) 2003-2010, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -97,5 +97,25 @@ jnxInternalMibRoot OBJECT-IDENTITY
         "This branch is reserved for internal use."
     ::= { jnxExperiment 6 }
 
+jnxP2mpExperiment OBJECT-IDENTITY
+    STATUS  current
+    DESCRIPTION
+        "The object identifier used to anchor the experimental IETF draft
+         for the P2MP MIB."
+    ::= { jnxExperiment 7 }
+
+jnxL2L3VpnMcastExperiment OBJECT-IDENTITY
+    STATUS  current
+    DESCRIPTION
+        "This branch anchors the experimental IETF draft for L2L3VpnMcast 
+         MIB."
+    ::= { jnxExperiment 11 }
+
+jnxMvpnExperiment OBJECT-IDENTITY
+    STATUS  current
+    DESCRIPTION
+        "This branch anchors the experimental IETF draft for Multicast
+         VPN MIB."
+    ::= { jnxExperiment 12 }
 
 END

--- a/mibs/junos/mib-jnx-fabric-chassis.txt
+++ b/mibs/junos/mib-jnx-fabric-chassis.txt
@@ -1,0 +1,1948 @@
+--
+-- Juniper Enterprise Specific MIB: Fabric Chassis MIB
+-- 
+-- Copyright (c) 2012, Juniper Networks, Inc.
+-- All rights reserved.
+--
+
+JUNIPER-FABRIC-CHASSIS DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    Integer32, Counter32, TimeTicks
+        FROM SNMPv2-SMI
+    DisplayString, TEXTUAL-CONVENTION, DateAndTime
+        FROM SNMPv2-TC
+    jnxDcfMibRoot, jnxFabricChassisTraps, jnxFabricChassisOKTraps
+        FROM JUNIPER-SMI
+    JnxChassisId
+        FROM JUNIPER-MIB;
+
+jnxFabricAnatomy MODULE-IDENTITY
+
+    LAST-UPDATED "201209130000Z" -- Thur Sept 13 00:00:00 2012 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                 Juniper Networks, Inc.
+                 1194 N. Mathilda Avenue
+                 Sunnyvale, CA 94089
+                 E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "The MIB modules representing Juniper Networks'
+          Quantum Fabric hardware components."
+
+    REVISION
+        "201209130000Z" -- Thur Sept 13 00:00:00 2012 UTC
+    DESCRIPTION
+        "Added director group device (DG) enum to JnxFabricContainersFamily."
+    REVISION
+        "201207260000Z" -- Thur July 26 00:00:00 2012 UTC
+    DESCRIPTION
+        "Modified the description for JnxFabricDeviceId. Added 
+         ufabric as part of JnxFabricContainersFamily."
+
+    ::= { jnxDcfMibRoot 2 }
+
+jnxFabricAnatomyScalars    OBJECT IDENTIFIER ::= { jnxFabricAnatomy 1 }
+jnxFabricAnatomyTables     OBJECT IDENTIFIER ::= { jnxFabricAnatomy 2 }
+
+
+--
+-- Textual Conventions
+--
+
+JnxFabricDeviceId ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+      "The device identifier assigned to the individual devices across the fabric by SFC. 
+       This shall be a unique index for each of the devices constituting the fabric."
+    SYNTAX	    Integer32 (1..2147483647)
+
+
+JnxFabricContainersFamily ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+      "The family of container that defines the device."
+    SYNTAX       INTEGER {
+            fabricChassis(1),
+            fabricNode(2),
+            ufabric(3),
+            directorGroupDevice(4)
+      }
+
+
+-- Juniper Fabric Anatomy MIB
+--
+
+-- Fabric Scalar Objects
+
+    jnxFabricClass OBJECT-TYPE 
+      SYNTAX	    OBJECT IDENTIFIER
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+              "The product line of the fabric switch."
+      ::= { jnxFabricAnatomyScalars 1 }
+
+    jnxFabricDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name, model, or detailed description of the fabric,
+            indicating which product the fabric is about."
+      ::= { jnxFabricAnatomyScalars 2 }
+
+    jnxFabricSerialNo OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The serial number of this subject, blank if unknown 
+            or unavailable."
+      ::= { jnxFabricAnatomyScalars 3 }
+
+    jnxFabricRevision OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The revision of this subject, blank if unknown or
+            unavailable."
+      ::= { jnxFabricAnatomyScalars 4 }
+
+    jnxFabricFirmwareRevision OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The firmware (u-boot) revision of this subject, blank if unknown or
+            unavailable."
+      ::= { jnxFabricAnatomyScalars 5 }
+
+    jnxFabricLastInstalled OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the subject was last
+            installed, up-and-running.  Zero if unknown or 
+            already up-and-running when the agent was up."
+      ::= { jnxFabricAnatomyScalars 6 }
+
+    jnxFabricContentsLastChange OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the fabric contents 
+            table last changed.  Zero if unknown or already 
+            existing when the agent was up."
+      ::= { jnxFabricAnatomyScalars 7 }
+
+    jnxFabricFilledLastChange OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the fabric filled 
+            status table last changed.  Zero if unknown or
+            already at that state when the agent was up."
+      ::= { jnxFabricAnatomyScalars 8 }
+      
+--
+-- Fabric Device Table
+--
+
+    jnxFabricDeviceTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricDeviceEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of fabric device entries."
+      ::= { jnxFabricAnatomyTables 1 }
+
+    jnxFabricDeviceEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricDeviceEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry of fabric device table."
+      INDEX       { jnxFabricDeviceIndex }
+      ::= { jnxFabricDeviceTable 1 }
+
+    JnxFabricDeviceEntry ::= SEQUENCE {
+          jnxFabricDeviceIndex		      JnxFabricDeviceId,
+          jnxFabricDeviceEntryContainersFamily JnxFabricContainersFamily,
+          jnxFabricDeviceEntryClass           OBJECT IDENTIFIER,
+          jnxFabricDeviceEntryModel           OBJECT IDENTIFIER,
+          jnxFabricDeviceEntryDescr           DisplayString,
+          jnxFabricDeviceEntrySerialNo        DisplayString,
+          jnxFabricDeviceEntryName            DisplayString,
+          jnxFabricDeviceEntryRevision        DisplayString,
+          jnxFabricDeviceEntryFirmwareRevision    DisplayString,
+          jnxFabricDeviceEntryInstalled       TimeTicks,
+          jnxFabricDeviceEntryContentsLastChange  TimeTicks,
+          jnxFabricDeviceEntryFilledLastChange    TimeTicks,
+          jnxFabricDeviceEntryKernelMemoryUsedPercent Integer32
+    }
+
+    jnxFabricDeviceIndex OBJECT-TYPE
+      SYNTAX	    JnxFabricDeviceId
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "Identifies the device on which the contents of this
+                row exists."
+      ::= { jnxFabricDeviceEntry 1 }
+
+    jnxFabricDeviceEntryContainersFamily OBJECT-TYPE
+      SYNTAX	    JnxFabricContainersFamily
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The family of container that defines this device."
+      ::= { jnxFabricDeviceEntry 2 }
+
+    jnxFabricDeviceEntryClass OBJECT-TYPE 
+      SYNTAX	    OBJECT IDENTIFIER
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+              "The productline of the device entry."
+      ::= { jnxFabricDeviceEntry 3 }
+
+    jnxFabricDeviceEntryModel OBJECT-TYPE 
+      SYNTAX	    OBJECT IDENTIFIER
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+              "The model object identifier of the device entry."
+      ::= { jnxFabricDeviceEntry 4 }
+
+    jnxFabricDeviceEntryDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of the device entry."
+      ::= { jnxFabricDeviceEntry 5 }
+
+    jnxFabricDeviceEntrySerialNo OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The serial number of this subject, blank if unknown 
+            or unavailable."
+      ::= { jnxFabricDeviceEntry 6 }
+
+    jnxFabricDeviceEntryName OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name of this subject which is same as the serial
+            number unless a device alias has been configured."
+      ::= { jnxFabricDeviceEntry 7 }
+
+    jnxFabricDeviceEntryRevision OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The revision of this subject, blank if unknown or
+            unavailable."
+      ::= { jnxFabricDeviceEntry 8 }
+
+    jnxFabricDeviceEntryFirmwareRevision OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The firmware (u-boot) revision of this subject, blank if unknown or
+            unavailable."
+      ::= { jnxFabricDeviceEntry 9 }
+
+    jnxFabricDeviceEntryInstalled OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the subject was last
+            installed, up-and-running.  Zero if unknown or 
+            already up-and-running when the agent was up."
+      ::= { jnxFabricDeviceEntry 10 }
+
+    jnxFabricDeviceEntryContentsLastChange OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the contents 
+            table last changed.  Zero if unknown or already 
+            existing when the agent was up."
+      ::= { jnxFabricDeviceEntry 11 }
+
+    jnxFabricDeviceEntryFilledLastChange OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the filled 
+            status table last changed.  Zero if unknown or
+            already at that state when the agent was up."
+      ::= { jnxFabricDeviceEntry 12 }
+
+    jnxFabricDeviceEntryKernelMemoryUsedPercent OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The percentage of kernel memory used
+            of this subject.  0 if unavailable or
+            inapplicable."
+      ::= { jnxFabricDeviceEntry 13 }
+
+--
+-- Fabric Containers Table
+--
+
+    jnxFabricContainersTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricContainersEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of containers entries."
+      ::= { jnxFabricAnatomyTables 2 }
+
+    jnxFabricContainersEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricContainersEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry of containers table. Each entry is
+             indexed by the container table type and
+             the container index."
+
+      INDEX { jnxFabricContainersFamily,
+              jnxFabricContainersIndex }
+      ::= { jnxFabricContainersTable 1 }
+
+    JnxFabricContainersEntry ::= SEQUENCE {
+          jnxFabricContainersFamily  JnxFabricContainersFamily,
+          jnxFabricContainersIndex  Integer32,
+          jnxFabricContainersView   BITS,
+          jnxFabricContainersLevel  INTEGER,
+          jnxFabricContainersWithin Integer32,
+          jnxFabricContainersType   OBJECT IDENTIFIER,
+          jnxFabricContainersDescr  DisplayString,
+          jnxFabricContainersCount  Integer32
+    }
+
+    jnxFabricContainersFamily OBJECT-TYPE
+      SYNTAX	    JnxFabricContainersFamily
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The family of container."
+      ::= { jnxFabricContainersEntry 1 }
+
+    jnxFabricContainersIndex OBJECT-TYPE
+      SYNTAX	    Integer32 (1..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The index for this entry."
+      ::= { jnxFabricContainersEntry 2 }
+
+    jnxFabricContainersView OBJECT-TYPE
+      SYNTAX	    BITS {
+			viewFront(0),
+			viewRear(1),
+			viewTop(2),
+			viewBottom(3),
+			viewLeftHandSide(4),
+			viewRightHandSide(5)
+      		    }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The view(s) from which the specific container
+            appears.
+
+            This variable indicates that the specific container
+            is embedded and accessible from the corresponding
+            view(s).
+
+            The value is a bit map represented as a sum.
+            If multiple bits are set, the specified
+            container(s) are located and accessible from 
+            that set of views.
+
+            The various values representing the bit positions
+            and its corresponding views are:
+                1   front
+                2   rear
+                4   top
+                8   bottom
+               16   leftHandSide
+               32   rightHandSide
+
+            Note 1: 
+            LefHandSide and rightHandSide are referred
+            to based on the view from the front.
+
+            Note 2: 
+            If the specified containers are scattered 
+            around various views, the numbering is according
+            to the following sequence:
+                front -> rear -> top -> bottom
+                    -> leftHandSide -> rightHandSide
+            For each view plane, the numbering sequence is
+            first from left to right, and then from up to down.
+
+            Note 3: 
+            Even though the value in chassis hardware (e.g. 
+            slot number) may be labelled from 0, 1, 2, and up,
+            all the indices in MIB start with 1 (not 0) 
+            according to network management convention."
+      ::= { jnxFabricContainersEntry 3 }
+
+    jnxFabricContainersLevel OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            level0(0),
+            level1(1),
+            level2(2),
+            level3(3)
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The abstraction level of the chassis or device.
+            It is enumerated from the outside to the inside, 
+            from the outer layer to the inner layer.
+            For example, top level (i.e. level 0) refers to 
+            chassis frame, level 1 FPC slot within chassis 
+            frame, level 2 PIC space within FPC slot."
+      ::= { jnxFabricContainersEntry 4 }
+
+    jnxFabricContainersWithin OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The index of its next higher level container 
+            housing     this entry.  The associated 
+            jnxFabricContainersIndex in the jnxFabricContainersTable 
+            represents its next higher level container."
+      ::= { jnxFabricContainersEntry 5 }
+
+    jnxFabricContainersType OBJECT-TYPE
+      SYNTAX	    OBJECT IDENTIFIER
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The type of this container."
+      ::= { jnxFabricContainersEntry 6 }
+
+    jnxFabricContainersDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of this
+            subject."
+      ::= { jnxFabricContainersEntry 7 }
+
+    jnxFabricContainersCount OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The maximum number of containers of this level
+            per container of the next higher level.  
+            e.g. if there are six level 2 containers in 
+            level 1 container, then jnxFabricContainersCount for
+            level 2 is six."
+      ::= { jnxFabricContainersEntry 8 }
+
+--
+-- Fabric Contents Table
+--
+
+    jnxFabricContentsTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricContentsEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of contents entries."
+      ::= { jnxFabricAnatomyTables 3 }
+
+    jnxFabricContentsEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricContentsEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry of contents table."
+      INDEX { jnxFabricDeviceIndex,
+              jnxFabricContentsContainerIndex,
+              jnxFabricContentsL1Index,
+              jnxFabricContentsL2Index,
+              jnxFabricContentsL3Index }
+      ::= { jnxFabricContentsTable 1 }
+
+    JnxFabricContentsEntry ::= SEQUENCE {
+          jnxFabricContentsContainerIndex Integer32,
+          jnxFabricContentsL1Index        Integer32,
+          jnxFabricContentsL2Index        Integer32,
+          jnxFabricContentsL3Index        Integer32,
+          jnxFabricContentsType           OBJECT IDENTIFIER,
+          jnxFabricContentsDescr          DisplayString,
+          jnxFabricContentsSerialNo       DisplayString,
+          jnxFabricContentsRevision       DisplayString,
+          jnxFabricContentsInstalled      TimeTicks,
+          jnxFabricContentsPartNo         DisplayString,
+          jnxFabricContentsChassisId      JnxChassisId,
+          jnxFabricContentsChassisDescr   DisplayString,
+          jnxFabricContentsChassisCleiCode DisplayString
+    }
+
+    jnxFabricContentsContainerIndex OBJECT-TYPE
+      SYNTAX	    Integer32 (1..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The associated jnxFabricContainersIndex in the 
+            jnxFabricContainersTable."
+      ::= { jnxFabricContentsEntry 1 }
+      
+    jnxFabricContentsL1Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level one index of the container
+            housing this subject.  Zero if unavailable
+            or inapplicable."
+      ::= { jnxFabricContentsEntry 2 }
+
+    jnxFabricContentsL2Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level two index of the container
+            housing this subject.  Zero if unavailable
+            or inapplicable."
+      ::= { jnxFabricContentsEntry 3 }
+
+    jnxFabricContentsL3Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level three index of the container
+            housing this subject.  Zero if unavailable
+            or inapplicable."
+      ::= { jnxFabricContentsEntry 4 }
+
+    jnxFabricContentsType OBJECT-TYPE
+      SYNTAX	    OBJECT IDENTIFIER
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The type of this subject.  zeroDotZero
+            if unknown."
+      ::= { jnxFabricContentsEntry 5 }
+
+    jnxFabricContentsDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of this
+            subject."
+      ::= { jnxFabricContentsEntry 6 }
+
+    jnxFabricContentsSerialNo OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The serial number of this subject, blank if 
+            unknown or unavailable."
+      ::= { jnxFabricContentsEntry 7 }
+
+    jnxFabricContentsRevision OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The revision of this subject, blank if unknown 
+            or unavailable."
+      ::= { jnxFabricContentsEntry 8 }
+
+    jnxFabricContentsInstalled OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the subject was last 
+            installed, up-and-running.  Zero if unknown
+            or already up-and-running when the agent was up."
+      ::= { jnxFabricContentsEntry 9 }
+
+    jnxFabricContentsPartNo OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The part number of this subject, blank if unknown 
+            or unavailable."
+      ::= { jnxFabricContentsEntry 10 }
+
+    jnxFabricContentsChassisId OBJECT-TYPE
+      SYNTAX	    JnxChassisId
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "Identifies the chassis on which the contents of this
+                row exists."
+        ::= { jnxFabricContentsEntry 11 }
+
+    jnxFabricContentsChassisDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "A textual description of the chassis on which the
+                contents of this row exists."
+        ::= { jnxFabricContentsEntry 12 }
+
+    jnxFabricContentsChassisCleiCode OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The clei code of this subject, blank if unknown
+                 or unavailable.
+
+                 A CLEI code is an intelligent code that consists of 10
+                 alphanumeric characters with 4 data elements.  The first data
+                 element is considered the basic code with the first 2 characters
+                 indicating the technology or equipment type, and the third and
+                 fourth characters denoting the functional sub-category.  The
+                 second data element represents the features, and its three
+                 characters denote functional capabilities or changes.  The third
+                 data element has one character and denotes a reference to a
+                 manufacturer, system ID, specification, or drawing.  The fourth
+                 data element consists of two characters and contains complementary
+                 data.  These two characters provide a means of differentiating or
+                 providing uniqueness between the eight character CLEI codes by
+                 identifying the manufacturing vintage of the product.  Names are
+                 assigned via procedures defined in [GR485].
+
+                 The assigned maintenance agent for the CLEI code, Telcordia
+                 Technologies, is responsible for assigning certain equipment and
+                 other identifiers (e.g., location, manufacturer/supplier) for the
+                 telecommunications industry."
+        ::= { jnxFabricContentsEntry 13 }
+
+--
+-- Fabric Filled Status Table
+--
+-- This table show the empty/filled status of the container in the 
+-- fabric containers table.
+--
+
+    jnxFabricFilledTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricFilledEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of filled status entries."
+      ::= { jnxFabricAnatomyTables 4 }
+
+    jnxFabricFilledEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricFilledEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry of filled status table."
+      INDEX { jnxFabricDeviceIndex,
+              jnxFabricFilledContainerIndex,
+              jnxFabricFilledL1Index,
+              jnxFabricFilledL2Index,
+              jnxFabricFilledL3Index }
+      ::= { jnxFabricFilledTable 1 }
+
+    JnxFabricFilledEntry ::= SEQUENCE {
+          jnxFabricFilledContainerIndex Integer32,
+          jnxFabricFilledL1Index        Integer32,
+          jnxFabricFilledL2Index        Integer32,
+          jnxFabricFilledL3Index        Integer32,
+          jnxFabricFilledDescr          DisplayString,
+          jnxFabricFilledState          INTEGER,
+          jnxFabricFilledChassisId      JnxChassisId,
+          jnxFabricFilledChassisDescr   DisplayString
+    }
+
+    jnxFabricFilledContainerIndex OBJECT-TYPE
+      SYNTAX	    Integer32 (1..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The associated jnxFabricContainersIndex in the 
+            jnxFabricContainersTable."
+      ::= { jnxFabricFilledEntry 1 }
+      
+    jnxFabricFilledL1Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level one index of the container
+            housing this subject.  Zero if unavailable
+            or inapplicable."
+      ::= { jnxFabricFilledEntry 2 }
+
+    jnxFabricFilledL2Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level two index of the container
+            housing this subject.  Zero if unavailable
+            or inapplicable."
+      ::= { jnxFabricFilledEntry 3 }
+
+    jnxFabricFilledL3Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level three index of the container
+            housing this subject.  Zero if unavailable
+            or inapplicable."
+      ::= { jnxFabricFilledEntry 4 }
+
+    jnxFabricFilledDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of this
+            subject."
+      ::= { jnxFabricFilledEntry 5 }
+
+    jnxFabricFilledState OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            unknown(1),
+            empty(2),
+            filled(3)
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The filled state of this subject."
+      ::= { jnxFabricFilledEntry 6 }
+
+    jnxFabricFilledChassisId OBJECT-TYPE
+      SYNTAX         JnxChassisId
+      MAX-ACCESS     read-only
+      STATUS         current
+      DESCRIPTION
+                "Identifies the chassis on which the contents of this
+                row exists."
+        ::= { jnxFabricFilledEntry 7 }
+
+    jnxFabricFilledChassisDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "A textual description of the chassis on which the
+                contents of this row exists."
+        ::= { jnxFabricFilledEntry 8 }
+
+
+--
+-- Fabric Operating Status Table
+--
+-- This table reveals the operating status of some subjects 
+-- of interest in the fabric contents table.
+--
+
+    jnxFabricOperatingTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricOperatingEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of operating status entries."
+      ::= { jnxFabricAnatomyTables 5 }
+
+    jnxFabricOperatingEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricOperatingEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry of operating status table."
+      INDEX { jnxFabricDeviceIndex,
+              jnxFabricOperatingContentsIndex,
+              jnxFabricOperatingL1Index,
+              jnxFabricOperatingL2Index,
+              jnxFabricOperatingL3Index }
+      ::= { jnxFabricOperatingTable 1 }
+
+    JnxFabricOperatingEntry ::= SEQUENCE {
+          jnxFabricOperatingContentsIndex Integer32,
+          jnxFabricOperatingL1Index     Integer32,
+          jnxFabricOperatingL2Index     Integer32,
+          jnxFabricOperatingL3Index     Integer32,
+          jnxFabricOperatingDescr       DisplayString,
+          jnxFabricOperatingState       INTEGER,
+          jnxFabricOperatingTemp        Integer32,
+          jnxFabricOperatingCPU         Integer32,
+          jnxFabricOperatingISR         Integer32,
+          jnxFabricOperatingDRAMSize    Integer32,
+          jnxFabricOperatingBuffer      Integer32,
+          jnxFabricOperatingHeap        Integer32,
+          jnxFabricOperatingUpTime      TimeTicks,
+          jnxFabricOperatingLastRestart TimeTicks,
+          jnxFabricOperatingMemory      Integer32,
+          jnxFabricOperatingStateOrdered  INTEGER,
+          jnxFabricOperatingChassisId   JnxChassisId,
+          jnxFabricOperatingChassisDescr  DisplayString,
+          jnxFabricOperatingRestartTime   DateAndTime,
+          jnxFabricOperating1MinLoadAvg   Integer32,
+          jnxFabricOperating5MinLoadAvg   Integer32,
+          jnxFabricOperating15MinLoadAvg  Integer32
+    }
+
+    jnxFabricOperatingContentsIndex OBJECT-TYPE
+      SYNTAX	    Integer32 (1..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The associated jnxFabricContentsContainerIndex in the 
+            jnxFabricContentsTable."
+      ::= { jnxFabricOperatingEntry 1 }
+      
+    jnxFabricOperatingL1Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level one index associated with this
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 2 }
+
+    jnxFabricOperatingL2Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level two index associated with this 
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 3 }
+
+    jnxFabricOperatingL3Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level three index associated with this
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 4 }
+
+    jnxFabricOperatingDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of this subject."
+      ::= { jnxFabricOperatingEntry 5 }
+
+    jnxFabricOperatingState OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            unknown(1),
+            running(2),   -- up and running,
+                          -- as a active primary
+            ready(3),     -- ready to run, not running yet
+            reset(4),     -- held in reset, not ready yet
+            runningAtFullSpeed(5),  
+                          -- valid for fans only
+            down(6),      -- down or off, for power supply
+            standby(7)    -- running as a standby backup
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The operating state of this subject."
+      ::= { jnxFabricOperatingEntry 6 }
+
+    jnxFabricOperatingTemp OBJECT-TYPE
+      SYNTAX	    Integer32
+      UNITS	    "Celsius (degrees C)"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The temperature in Celsius (degrees C) of this 
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 7 }
+
+    jnxFabricOperatingCPU OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The CPU utilization in percentage of this 
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 8 }
+      
+    jnxFabricOperatingISR OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The CPU utilization in percentage of this subject
+            spending in interrupt service routine (ISR).
+            Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 9 }
+      
+    jnxFabricOperatingDRAMSize OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    deprecated
+      DESCRIPTION
+                "The DRAM size in bytes of this subject.
+                Zero if unavailable or inapplicable."
+        ::= { jnxFabricOperatingEntry 10 }
+
+    jnxFabricOperatingBuffer OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The buffer pool utilization in percentage
+            of this subject.  Zero if unavailable or 
+            inapplicable."
+      ::= { jnxFabricOperatingEntry 11 }
+      
+    jnxFabricOperatingHeap OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The heap utilization in percentage of 
+            this subject.  Zero if unavailable or 
+            inapplicable."
+      ::= { jnxFabricOperatingEntry 12 }
+
+    jnxFabricOperatingUpTime OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The time interval in 10-millisecond period
+            that this subject has been up and running.  
+            Zero if unavailable or inapplicable."
+      ::= { jnxFabricOperatingEntry 13 }
+
+    jnxFabricOperatingLastRestart OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when this subject 
+            last restarted.  Zero if unavailable or 
+            inapplicable."
+      ::= { jnxFabricOperatingEntry 14 }
+
+    jnxFabricOperatingMemory OBJECT-TYPE
+      SYNTAX	    Integer32
+      UNITS	    "Megabytes"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The installed memory size in Megabytes 
+            of this subject.  Zero if unavailable or
+            inapplicable."
+      ::= { jnxFabricOperatingEntry 15 }
+
+    jnxFabricOperatingStateOrdered OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            running(1),   -- up and running,
+                          -- as a active primary
+            standby(2),   -- running as a standby backup
+            ready(3),     -- ready to run, not running yet
+              runningAtFullSpeed(4),  
+                          -- valid for fans only
+            reset(5),     -- held in reset, not ready yet
+            down(6),      -- down or off, for power supply
+            unknown(7)
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The operating state of this subject.  Identical to
+                 jnxFabricOperatingState, but with enums ordered from 'most
+                 operational' to 'least operational' states."
+      ::= { jnxFabricOperatingEntry 16 }
+
+    jnxFabricOperatingChassisId OBJECT-TYPE
+      SYNTAX	    JnxChassisId
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "Identifies the chassis on which the contents of this
+                row exists."
+        ::= { jnxFabricOperatingEntry 17 }
+
+    jnxFabricOperatingChassisDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "A textual description of the chassis on which the
+                contents of this row exists."
+        ::= { jnxFabricOperatingEntry 18 }
+
+    jnxFabricOperatingRestartTime OBJECT-TYPE
+      SYNTAX	    DateAndTime
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The time at which this entity
+                last restarted."
+        ::= { jnxFabricOperatingEntry 19 }
+
+    jnxFabricOperating1MinLoadAvg OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The CPU Load Average over the last 1 minutes
+                Here it will be shown as percentage value
+                Zero if unavailable or inapplicable."
+        ::= { jnxFabricOperatingEntry 20 }
+
+    jnxFabricOperating5MinLoadAvg OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The CPU Load Average over the last 5 minutes
+                Here it will be shown as percentage value
+                Zero if unavailable or inapplicable."
+        ::= { jnxFabricOperatingEntry 21 }
+
+    jnxFabricOperating15MinLoadAvg OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The CPU Load Average over the last 15 minutes
+                Here it will be shown as percentage value
+                Zero if unavailable or inapplicable."
+        ::= { jnxFabricOperatingEntry 22 }
+
+--
+-- Fabric Redundancy Information Table
+--
+-- This table shows the internal configuration setting for the 
+-- available redundant subsystems or components in the fabric.
+--
+
+    jnxFabricRedundancyTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricRedundancyEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of redundancy information entries."
+      ::= { jnxFabricAnatomyTables 6 }
+
+    jnxFabricRedundancyEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricRedundancyEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry in the redundancy information table."
+      INDEX { jnxFabricDeviceIndex,
+              jnxFabricRedundancyContentsIndex,
+              jnxFabricRedundancyL1Index,
+              jnxFabricRedundancyL2Index,
+              jnxFabricRedundancyL3Index }
+      ::= { jnxFabricRedundancyTable 1 }
+
+    JnxFabricRedundancyEntry ::= SEQUENCE {
+          jnxFabricRedundancyContentsIndex          Integer32,
+          jnxFabricRedundancyL1Index                Integer32,
+          jnxFabricRedundancyL2Index                Integer32,
+          jnxFabricRedundancyL3Index                Integer32,
+          jnxFabricRedundancyDescr		    DisplayString,
+          jnxFabricRedundancyConfig		    INTEGER,
+          jnxFabricRedundancyState		    INTEGER,
+          jnxFabricRedundancySwitchoverCount        Counter32,
+          jnxFabricRedundancySwitchoverTime         TimeTicks,
+          jnxFabricRedundancySwitchoverReason       INTEGER,
+          jnxFabricRedundancyKeepaliveHeartbeat	    Integer32,
+          jnxFabricRedundancyKeepaliveTimeout       Integer32,
+          jnxFabricRedundancyKeepaliveElapsed       Integer32,
+          jnxFabricRedundancyKeepaliveLoss	    Counter32,
+          jnxFabricRedundancyChassisId		    JnxChassisId,
+          jnxFabricRedundancyChassisDescr	    DisplayString
+    }
+
+    jnxFabricRedundancyContentsIndex OBJECT-TYPE
+      SYNTAX	    Integer32 (1..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The associated jnxFabricContentsContainerIndex in the 
+            jnxFabricContentsTable."
+      ::= { jnxFabricRedundancyEntry 1 }
+      
+    jnxFabricRedundancyL1Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level one index associated with this
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricRedundancyEntry 2 }
+
+    jnxFabricRedundancyL2Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level two index associated with this 
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricRedundancyEntry 3 }
+
+    jnxFabricRedundancyL3Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level three index associated with this
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricRedundancyEntry 4 }
+
+    jnxFabricRedundancyDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of this subject."
+      ::= { jnxFabricRedundancyEntry 5 }
+
+    jnxFabricRedundancyConfig OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            unknown(1),
+            master(2),    -- election priority set as a master
+            backup(3),    -- election priority set as a backup
+            disabled(4),  -- election disabled
+            notApplicable(5) -- any among the available can be master
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The election priority of redundancy configuration for
+            this subject.  The value 'notApplicable' means no
+            specific instance is configured to be master or
+            backup; whichever component boots up first becomes a
+            master."
+      ::= { jnxFabricRedundancyEntry 6 }
+
+    jnxFabricRedundancyState OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            unknown(1),
+            master(2),    -- master
+            backup(3),    -- backup
+            disabled(4)   -- disabled
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The current running state for this subject."
+      ::= { jnxFabricRedundancyEntry 7 }
+
+    jnxFabricRedundancySwitchoverCount OBJECT-TYPE
+      SYNTAX	    Counter32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The total number of switchover as perceived by
+            this subject since routing engine is up and running.
+            The switchover is defined as a change in state of
+            jnxFabricRedundancyState from master to backup or vice
+            versa.      Its value is reset when the routing engine
+            is reset or rebooted."
+      ::= { jnxFabricRedundancyEntry 8 }
+
+    jnxFabricRedundancySwitchoverTime OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when the jnxFabricRedundancyState
+            of this subject was last switched over from master
+            to backup or vice versa.  Zero if unknown or never
+            switched over since the routing engine is up and
+            running."
+      ::= { jnxFabricRedundancyEntry 9 }
+
+    jnxFabricRedundancySwitchoverReason OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            other(1),         -- others
+            neverSwitched(2), -- never switched
+            userSwitched(3),  -- user-initiated switchover
+            autoSwitched(4)   -- automatic switchover
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The reason of the last switchover for this subject."
+      ::= { jnxFabricRedundancyEntry 10 }
+
+    jnxFabricRedundancyKeepaliveHeartbeat OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The period of sending keepalive messages between
+            the master and backup subsystems.  It is a system-wide
+            preset value in seconds used by internal mastership
+            resolution.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricRedundancyEntry 11 }
+
+    jnxFabricRedundancyKeepaliveTimeout OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The timeout period in seconds, by the keepalive 
+            watchdog timer, before initiating a switch over to 
+            the backup subsystem.  Zero if unavailable or 
+            inapplicable."
+      ::= { jnxFabricRedundancyEntry 12 }
+
+    jnxFabricRedundancyKeepaliveElapsed OBJECT-TYPE
+      SYNTAX	    Integer32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The elapsed time in seconds by this subject since 
+            receiving the last keepalive message from the other
+            subsystems.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricRedundancyEntry 13 }
+
+    jnxFabricRedundancyKeepaliveLoss OBJECT-TYPE
+      SYNTAX	    Counter32
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The total number of losses on keepalive messages 
+            between the master and backup subsystems as perceived
+            by this subject since the system is up and running.  
+            Zero if unavailable or inapplicable."
+      ::= { jnxFabricRedundancyEntry 14 }
+
+    jnxFabricRedundancyChassisId OBJECT-TYPE
+      SYNTAX         JnxChassisId
+      MAX-ACCESS     read-only
+      STATUS         current
+      DESCRIPTION
+                "Identifies the chassis on which the contents of this
+                row exists."
+        ::= { jnxFabricRedundancyEntry 15 }
+
+    jnxFabricRedundancyChassisDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "A textual description of the chassis on which the
+                contents of this row exists."
+        ::= { jnxFabricRedundancyEntry 16 }
+
+      
+--
+-- FRU (Field Replaceable Unit) Status Table
+--
+-- This table shows the status of the FRUs in the chassis' within the fabric
+--
+
+    jnxFabricFruTable OBJECT-TYPE
+      SYNTAX	    SEQUENCE OF JnxFabricFruEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "A list of FRU status entries."
+      ::= { jnxFabricAnatomyTables 7 }
+
+    jnxFabricFruEntry OBJECT-TYPE
+      SYNTAX	    JnxFabricFruEntry
+      MAX-ACCESS    not-accessible
+      STATUS	    current
+      DESCRIPTION
+            "An entry in the FRU status table."
+      INDEX { jnxFabricDeviceIndex,
+              jnxFabricFruContentsIndex,
+              jnxFabricFruL1Index,
+              jnxFabricFruL2Index,
+              jnxFabricFruL3Index }
+      ::= { jnxFabricFruTable 1 }
+
+    JnxFabricFruEntry ::= SEQUENCE {
+          jnxFabricFruContentsIndex       Integer32,
+          jnxFabricFruL1Index             Integer32,
+          jnxFabricFruL2Index             Integer32,
+          jnxFabricFruL3Index             Integer32,
+          jnxFabricFruName                DisplayString,
+          jnxFabricFruType		  INTEGER,
+          jnxFabricFruSlot                Integer32,
+          jnxFabricFruState		  INTEGER,
+          jnxFabricFruTemp                Integer32,
+          jnxFabricFruOfflineReason       INTEGER,
+          jnxFabricFruLastPowerOff        TimeTicks,
+          jnxFabricFruLastPowerOn         TimeTicks,
+          jnxFabricFruPowerUpTime         TimeTicks,
+          jnxFabricFruChassisId           JnxChassisId,
+          jnxFabricFruChassisDescr        DisplayString,
+          jnxFabricFruPsdAssignment       Integer32
+    }
+
+    jnxFabricFruContentsIndex OBJECT-TYPE
+      SYNTAX	    Integer32 (1..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The associated jnxFabricContentsContainerIndex in the 
+            jnxFabricContentsTable."
+      ::= { jnxFabricFruEntry 1 }
+      
+    jnxFabricFruL1Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level one index associated with this
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 2 }
+
+    jnxFabricFruL2Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level two index associated with this 
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 3 }
+
+    jnxFabricFruL3Index OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The level three index associated with this
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 4 }
+
+    jnxFabricFruName OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The name or detailed description of this subject."
+      ::= { jnxFabricFruEntry 5 }
+
+    jnxFabricFruType OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            other(1),                               -- unknown or others
+            clockGenerator(2),                      -- CG
+            flexiblePicConcentrator(3),             -- FPC
+            switchingAndForwardingModule(4),        -- SFM
+            controlBoard(5),                        -- CBD, SCB
+            routingEngine(6),                       -- RE
+            powerEntryModule(7),                    -- PEM
+            frontPanelModule(8),                    -- FPM
+            switchInterfaceBoard(9),                -- SIB
+            processorMezzanineBoardForSIB(10),      -- SPMB
+            portInterfaceCard(11),                  -- PIC
+            craftInterfacePanel(12),                -- CIP
+            fan(13),                                -- fan
+            lineCardChassis(14),                    -- LCC
+            forwardingEngineBoard(15),              -- FEB
+            protectedSystemDomain(16)               -- PSD
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The FRU type for this subject."
+      ::= { jnxFabricFruEntry 6 }
+
+    jnxFabricFruSlot OBJECT-TYPE
+      SYNTAX	    Integer32 (0..2147483647)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The slot number of this subject.  This is equivalent
+            to jnxFabricFruL1Index in meaning.  Zero if unavailable or 
+            inapplicable."
+      ::= { jnxFabricFruEntry 7 }
+
+    jnxFabricFruState OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            unknown(1),
+            empty(2),
+            present(3),
+            ready(4),
+            announceOnline(5),
+            online(6),
+            anounceOffline(7),
+            offline(8),
+            diagnostic(9),
+            standby(10)
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The current state for this subject."
+      ::= { jnxFabricFruEntry 8 }
+
+    jnxFabricFruTemp OBJECT-TYPE
+      SYNTAX	    Integer32
+      UNITS	    "Celsius (degrees C)"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The temperature in Celsius (degrees C) of this 
+            subject.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 9 }
+
+    jnxFabricFruOfflineReason OBJECT-TYPE
+      SYNTAX	    INTEGER {
+            unknown(1),                 -- unknown or other
+            none(2),                    -- none 
+            error(3),                   -- error 
+            noPower(4),                 -- no power  
+            configPowerOff(5),              -- configured to power off
+            configHoldInReset(6),           -- configured to hold in reset
+            cliCommand(7),                  -- offlined by cli command
+            buttonPress(8),                 -- offlined by button press
+            cliRestart(9),                  -- restarted by cli command
+            overtempShutdown(10),           -- overtemperature shutdown
+            masterClockDown(11),            -- master clock down
+            singleSfmModeChange(12),        -- single SFM mode change
+            packetSchedulingModeChange(13), -- packet scheduling mode change
+            physicalRemoval(14),            -- physical removal
+            unresponsiveRestart(15),        -- restarting unresponsive board
+            sonetClockAbsent(16),           -- sonet out clock absent
+            rddPowerOff(17),                -- RDD power off
+            majorErrors(18),                -- major errors
+            minorErrors(19),                -- minor errors
+            lccHardRestart(20),             -- LCC hard restart
+            lccVersionMismatch(21),         -- LCC version mismatch
+            powerCycle(22),                 -- power cycle
+            reconnect(23),                  -- reconnect
+            overvoltage(24),                -- overvoltage
+            pfeVersionMismatch(25),         -- PFE version mismatch
+            febRddCfgChange(26),            -- FEB redundancy cfg changed
+            fpcMisconfig(27),               -- FPC is misconfigured
+            fruReconnectFail(28),           -- FRU did not reconnect
+            fruFwddReset(29),               -- FWDD reset the fru
+            fruFebSwitch(30),               -- FEB got switched
+            fruFebOffline(31),              -- FEB was offlined
+            fruInServSoftUpgradeError(32),  -- In Service Software Upgrade Error
+            fruChasdPowerRatingExceed(33),  -- Chassis power rating exceeded
+            fruConfigOffline(34),           -- Configured offline
+            fruServiceRestartRequest(35),   -- restarting request from a service
+            spuResetRequest(36),            -- SPU reset request
+            spuFlowdDown(37),               -- SPU flowd down
+            spuSpi4Down(38),                -- SPU SPI4 down
+            spuWatchdogTimeout(39),         -- SPU Watchdog timeout
+            spuCoreDump(40),                -- SPU kernel core dump
+            fpgaSpi4LinkDown(41),           -- FPGA SPI4 link down
+            i3Spi4LinkDown(42),             -- I3 SPI4 link down
+            cppDisconnect(43),              -- CPP disconnect
+            cpuNotBoot(44),                 -- CPU not boot
+            spuCoreDumpComplete(45),        -- SPU kernel core dump complete
+            rstOnSpcSpuFailure(46),         -- Rst on SPC SPU failure
+            softRstOnSpcSpuFailure(47),     -- Soft Reset on SPC SPU failure
+            hwAuthenticationFailure(48),    -- HW authentication failure
+            reconnectFpcFail(49),           -- Reconnect FPC fail
+            fpcAppFailed(50),               -- FPC app failed
+            fpcKernelCrash(51),             -- FPC kernel crash
+            spuFlowdDownNoCore(52),         -- SPU flowd down, no core dump
+            spuFlowdCoreDumpIncomplete(53), -- SPU flowd crash with incomplete core dump
+            spuFlowdCoreDumpComplete(54),   -- SPU flowd crash with complete core dump
+            spuIdpdDownNoCore(55),          -- SPU idpd down, no core dump
+            spuIdpdCoreDumpIncomplete(56),  -- SPU idpd crash with incomplete core dump
+            spuIdpdCoreDumpComplete(57),    -- SPU idpd crash with complete core dump
+            spuCoreDumpIncomplete(58),      -- SPU kernel crash with incomplete core dump
+            spuIdpdDown(59),                -- SPU idpd down
+            fruPfeReset(60),                -- PFE reset
+            fruReconnectNotReady(61),       -- FPC not ready to reconnect
+            fruSfLinkDown(62),              -- FE - Fabric links down
+            fruFabricDown(63),              -- Fabric transitioned from up to down
+            fruAntiCounterfeitRetry(64),    -- FPC offlined due to Anti Counterfeit Retry
+            fruFPCChassisClusterDisable(65), -- FPC offlined due to Chassis Cluster Disable
+            spuFipsError(66),                -- SPU fips error
+            fruFPCFabricDownOffline(67),     -- FPC offlined due to Fabric down
+            febCfgChange(68),                -- FEB config change
+            routeLocalizationRoleChange(69), -- Route localization role change
+            fruFpcUnsupported(70),           -- FPC unsupported
+            psdVersionMismatch(71),          -- PSD version mismatch
+            fruResetThresholdExceeded(72),   -- FRU Reset Threshold Exceeded
+            picBounce(73),                   -- PIC Bounce
+            badVoltage(74),                  -- bad voltage
+            fruFPCReducedFabricBW(75)        -- FPC offlined due to Reduced Fabric Bandwidth
+      }
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The offline reason of this subject."
+      ::= { jnxFabricFruEntry 10 }
+
+    jnxFabricFruLastPowerOff OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when this subject was last 
+            powered off.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 11 }
+
+    jnxFabricFruLastPowerOn OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The value of sysUpTime when this subject was last 
+            powered on.  Zero if unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 12 }
+
+    jnxFabricFruPowerUpTime OBJECT-TYPE
+      SYNTAX	    TimeTicks
+      UNITS	    "centi-seconds"
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+            "The time interval in 10-millisecond period
+            that this subject has been up and running
+            since the last power on time.  Zero if 
+            unavailable or inapplicable."
+      ::= { jnxFabricFruEntry 13 }
+
+    jnxFabricFruChassisId OBJECT-TYPE
+      SYNTAX	    JnxChassisId
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "Identifies the chassis on which the contents of this
+                row exists."
+        ::= { jnxFabricFruEntry 14 }
+
+    jnxFabricFruChassisDescr OBJECT-TYPE
+      SYNTAX	    DisplayString (SIZE (0..255))
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "A textual description of the chassis on which the
+                contents of this row exists."
+        ::= { jnxFabricFruEntry 15 }
+
+    jnxFabricFruPsdAssignment OBJECT-TYPE
+      SYNTAX	    Integer32 (0..31)
+      MAX-ACCESS    read-only
+      STATUS	    current
+      DESCRIPTION
+                "The PSD assignment of this subject. Zero if unavailable or
+                not applicable."
+        ::= { jnxFabricFruEntry 16 }
+
+--
+-- definition of chassis related traps
+--
+    -- Traps for chassis alarm conditions   
+
+    jnxFabricPowerSupplyFailure NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricContentsContainerIndex,
+                    jnxFabricContentsL1Index,
+                    jnxFabricContentsL2Index,
+                    jnxFabricContentsL3Index,
+                    jnxFabricContentsDescr,
+                    jnxFabricOperatingState }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricPowerSupplyFailure trap signifies that
+            the SNMP entity, acting in an agent role, has
+            detected that the specified power supply in the
+            chassis has been in the failure (bad DC output) 
+            condition."
+      ::= { jnxFabricChassisTraps 1 }
+
+    jnxFabricFanFailure NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricContentsContainerIndex,
+                    jnxFabricContentsL1Index,
+                    jnxFabricContentsL2Index,
+                    jnxFabricContentsL3Index,
+                    jnxFabricContentsDescr,
+                    jnxFabricOperatingState }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricFanFailure trap signifies that the SNMP
+            entity, acting in an agent role, has detected
+            that the specified cooling fan or impeller in 
+            the chassis has been in the failure (not spinning) 
+            condition."
+      ::= { jnxFabricChassisTraps 2 }
+
+    jnxFabricOverTemperature NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricContentsContainerIndex,
+                    jnxFabricContentsL1Index,
+                    jnxFabricContentsL2Index,
+                    jnxFabricContentsL3Index,
+                    jnxFabricContentsDescr,
+                    jnxFabricOperatingTemp }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricOverTemperature trap signifies that the 
+            SNMP entity, acting in an agent role, has 
+            detected that the specified hardware component
+            in the chassis has experienced over temperature
+            condition."
+      ::= { jnxFabricChassisTraps 3 }
+
+    jnxFabricRedundancySwitchover NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricRedundancyContentsIndex,
+                    jnxFabricRedundancyL1Index,
+                    jnxFabricRedundancyL2Index,
+                    jnxFabricRedundancyL3Index,
+                    jnxFabricRedundancyDescr,
+                    jnxFabricRedundancyConfig,
+                    jnxFabricRedundancyState,
+                    jnxFabricRedundancySwitchoverCount,
+                    jnxFabricRedundancySwitchoverTime,
+                    jnxFabricRedundancySwitchoverReason }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricRedundancySwitchover trap signifies that 
+            the SNMP entity, acting in an agent role, has 
+            detected that the specified hardware component
+            in the chassis has experienced a redundancy 
+            switchover event defined as a change in state
+            of jnxFabricRedundancyState from master to backup or
+            vice versa."
+      ::= { jnxFabricChassisTraps 4 }
+
+    jnxFabricFruRemoval NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricFruContentsIndex,
+                    jnxFabricFruL1Index,
+                    jnxFabricFruL2Index,
+                    jnxFabricFruL3Index,
+                    jnxFabricFruName,
+                    jnxFabricFruType,
+                    jnxFabricFruSlot }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricFruRemoval trap signifies that the SNMP 
+            entity, acting in an agent role, has detected 
+            that the specified FRU (Field Replaceable Unit)
+            has been removed from the chassis."
+      ::= { jnxFabricChassisTraps 5 }
+
+    jnxFabricFruInsertion NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricFruContentsIndex,
+                    jnxFabricFruL1Index,
+                    jnxFabricFruL2Index,
+                    jnxFabricFruL3Index,
+                    jnxFabricFruName,
+                    jnxFabricFruType,
+                    jnxFabricFruSlot }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricFruInsertion trap signifies that the SNMP 
+            entity,     acting in an agent role, has detected that
+            the specified FRU (Field Replaceable Unit) has been 
+            inserted into the chassis."
+      ::= { jnxFabricChassisTraps 6 }
+
+    jnxFabricFruPowerOff NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricFruContentsIndex,
+                    jnxFabricFruL1Index,
+                    jnxFabricFruL2Index,
+                    jnxFabricFruL3Index,
+                    jnxFabricFruName,
+                    jnxFabricFruType,
+                    jnxFabricFruSlot,
+                    jnxFabricFruOfflineReason,
+                    jnxFabricFruLastPowerOff,
+                    jnxFabricFruLastPowerOn }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricFruPowerOff trap signifies that the SNMP 
+            entity, acting in an agent role, has detected 
+            that the specified FRU (Field Replaceable Unit)
+            has been powered off in the chassis."
+      ::= { jnxFabricChassisTraps 7 }
+
+    jnxFabricFruPowerOn NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricFruContentsIndex,
+                    jnxFabricFruL1Index,
+                    jnxFabricFruL2Index,
+                    jnxFabricFruL3Index,
+                    jnxFabricFruName,
+                    jnxFabricFruType,
+                    jnxFabricFruSlot,
+                    jnxFabricFruOfflineReason,
+                    jnxFabricFruLastPowerOff,
+                    jnxFabricFruLastPowerOn }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricFruPowerOn trap signifies that the SNMP 
+            entity,     acting in an agent role, has detected that
+            the specified FRU (Field Replaceable Unit) has been 
+            powered on in the chassis."
+      ::= { jnxFabricChassisTraps 8 }
+
+    jnxFabricFruFailed NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "This indicates the specified FRU (Field Replaceable Unit)
+                 has failed in the chassis. Most probably this is due toi
+                 some hard error such as fru is not powering up or not
+                 able to load ukernel. In these cases, fru is replaced."
+        ::= { jnxFabricChassisTraps 9 }
+
+    jnxFabricFruOffline NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot,
+                          jnxFabricFruOfflineReason,
+                          jnxFabricFruLastPowerOff,
+                          jnxFabricFruLastPowerOn }
+        STATUS          current
+        DESCRIPTION
+                "A jnxFabricFruOffline trap signifies that the SNMP
+                entity, acting in an agent role, has detected
+                that the specified FRU (Field Replaceable Unit)
+                has gone offline in the chassis."
+        ::= { jnxFabricChassisTraps 10 }
+
+    jnxFabricFruOnline NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxFabricFruOnline trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified FRU (Field Replaceable Unit) has
+                gone online in the chassis."
+        ::= { jnxFabricChassisTraps 11 }
+
+    jnxFabricFruCheck NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxFabricFruCheck trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified FRU (Field Replaceable Unit) has
+                encountered some operational errors and gone into
+                check state in the chassis."
+        ::= { jnxFabricChassisTraps 12 }   
+
+    jnxFabricFEBSwitchover NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxFabricFEBSwitchover trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified FEB (Forwarding Engine Board) has
+                switched over."
+        ::= { jnxFabricChassisTraps 13 }
+
+
+    jnxFabricHardDiskFailed NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxHardDiskFailed trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the Disk in the specified Routing Engine has
+                encountered some operational errors and gone into
+                failed state in the chassis."
+        ::= { jnxFabricChassisTraps 14 }
+
+    jnxFabricHardDiskMissing NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A DiskMissing trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                hard disk in the specified outing Engine is missing
+                from boot device list."
+        ::= { jnxFabricChassisTraps 15 }
+
+    jnxFabricBootFromBackup NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+         STATUS         current
+         DESCRIPTION
+                 "A jnxBootFromBackup trap signifies that the SNMP
+                 entity, acting in an agent role, has detected that
+                 the specified  routing-engine/member has booted from
+                 the back up root partition"
+         ::= { jnxFabricChassisTraps 16 }     
+
+
+    -- Traps for chassis alarm cleared conditions
+
+    jnxFabricPowerSupplyOK NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricContentsContainerIndex,
+                    jnxFabricContentsL1Index,
+                    jnxFabricContentsL2Index,
+                    jnxFabricContentsL3Index,
+                    jnxFabricContentsDescr,
+                    jnxFabricOperatingState }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricPowerSupplyOK trap signifies that the 
+            SNMP entity, acting in an agent role, has
+            detected that the specified power supply in the
+            chassis has recovered from the failure (bad DC output) 
+            condition."
+      ::= { jnxFabricChassisOKTraps 1 }
+
+    jnxFabricFanOK NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricContentsContainerIndex,
+                    jnxFabricContentsL1Index,
+                    jnxFabricContentsL2Index,
+                    jnxFabricContentsL3Index,
+                    jnxFabricContentsDescr,
+                    jnxFabricOperatingState }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricFanOK trap signifies that the SNMP
+            entity, acting in an agent role, has detected that
+            the specified cooling fan or impeller in the chassis
+            has recovered from the failure (not spinning) condition."
+      ::= { jnxFabricChassisOKTraps 2 }
+
+    jnxFabricTemperatureOK NOTIFICATION-TYPE
+      OBJECTS     { jnxFabricDeviceIndex,
+                    jnxFabricContentsContainerIndex,
+                    jnxFabricContentsL1Index,
+                    jnxFabricContentsL2Index,
+                    jnxFabricContentsL3Index,
+                    jnxFabricContentsDescr,
+                    jnxFabricOperatingTemp }
+      STATUS            current
+      DESCRIPTION
+            "A jnxFabricTemperatureOK trap signifies that the 
+            SNMP entity, acting in an agent role, has 
+            detected that the specified hardware component
+            in the chassis has recovered from over temperature
+            condition." 
+      ::= { jnxFabricChassisOKTraps 3 }
+
+    jnxFabricFruOK NOTIFICATION-TYPE
+        OBJECTS         { jnxFabricDeviceIndex,
+                          jnxFabricFruContentsIndex,
+                          jnxFabricFruL1Index,
+                          jnxFabricFruL2Index,
+                          jnxFabricFruL3Index,
+                          jnxFabricFruName,
+                          jnxFabricFruType,
+                          jnxFabricFruSlot }
+        STATUS          current
+        DESCRIPTION
+                "A jnxFabricFabricFruOK trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified FRU (Field Replaceable Unit) has
+                recovered from previous operational errors and it
+                is in ok state in the chassis."
+        ::= { jnxFabricChassisOKTraps 4 }
+
+END
+

--- a/mibs/junos/mib-jnx-firewall.txt
+++ b/mibs/junos/mib-jnx-firewall.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Firewalls MIB
 -- 
--- Copyright (c) 2000-2003, Juniper Networks, Inc.
+-- Copyright (c) 2000-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -240,4 +240,84 @@ jnxFirewalls MODULE-IDENTITY
 		to have two counters of the same name and different type."
 	::= { jnxFirewallCounterEntry 8 }
 
+    jnxFWCntrXTable   OBJECT-TYPE
+	SYNTAX      SEQUENCE OF JnxFWCntrXEntry
+	MAX-ACCESS  not-accessible
+	STATUS      current
+	DESCRIPTION
+	    "An extended list of firewall filter counters.
+	    This table maintains the additional statistics
+	    for the additional policer counters and is only
+	    supported on MX platform for now."
+
+
+	::= { jnxFirewalls 3 }
+
+    jnxFWCntrXEntry      OBJECT-TYPE
+	SYNTAX      JnxFWCntrXEntry
+	MAX-ACCESS  not-accessible
+	STATUS      current
+	DESCRIPTION
+	    "An entry of extended firewall table."
+	AUGMENTS    { jnxFirewallCounterEntry }
+	::= { jnxFWCntrXTable 1 }
+
+    JnxFWCntrXEntry ::=
+    SEQUENCE {
+           jnxFWCntrPolicerOfferedPktCount          Counter64,
+           jnxFWCntrPolicerOfferedByteCount         Counter64,
+           jnxFWCntrPolicerOutSpecPktCount          Counter64,
+           jnxFWCntrPolicerOutSpecByteCount         Counter64,
+           jnxFWCntrPolicerTxPktCount               Counter64,
+           jnxFWCntrPolicerTxByteCount              Counter64
+    }
+
+    jnxFWCntrPolicerOfferedPktCount OBJECT-TYPE
+	SYNTAX      Counter64
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	    "  "
+	::= { jnxFWCntrXEntry 1 }
+
+    jnxFWCntrPolicerOfferedByteCount OBJECT-TYPE
+	SYNTAX      Counter64
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	    "  "
+	::= { jnxFWCntrXEntry 2 }
+
+    jnxFWCntrPolicerOutSpecPktCount OBJECT-TYPE
+	SYNTAX      Counter64
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	    "  "
+	::= { jnxFWCntrXEntry 3 }
+
+    jnxFWCntrPolicerOutSpecByteCount OBJECT-TYPE
+	SYNTAX      Counter64
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	    "  "
+	::= { jnxFWCntrXEntry 4 }
+
+    jnxFWCntrPolicerTxPktCount OBJECT-TYPE
+	SYNTAX      Counter64
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	    "  "
+	::= { jnxFWCntrXEntry 5 }
+
+    jnxFWCntrPolicerTxByteCount OBJECT-TYPE
+	SYNTAX      Counter64
+	MAX-ACCESS  read-only
+	STATUS      current
+	DESCRIPTION
+	    "  "
+	::= { jnxFWCntrXEntry 6 }
+    
 END

--- a/mibs/junos/mib-jnx-fru.txt
+++ b/mibs/junos/mib-jnx-fru.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: FRU management for OTN Equipments
+-- 
+-- Copyright (c) 2012-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-FRU-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    Integer32
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION
+        FROM SNMPv2-TC
+    jnxFruMibRoot, jnxFruTraps
+        FROM JUNIPER-SMI;
+
+
+jnxFruMib MODULE-IDENTITY
+    LAST-UPDATED "201211131414Z" -- Tue Nov 13 14:14:51 PST 2012
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This MIB module defines objects used for managing the
+             OTN FRU's for Juniper products."
+    REVISION      "201201260000Z"
+    DESCRIPTION
+               "Initial revision."
+    ::= { jnxFruMibRoot 1 }
+
+--
+-- Textual Conventions
+--
+JnxFruAdminStates ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Admin states for a FRU"
+    SYNTAX       INTEGER {
+                    inService(1),
+                    outOfService(2)
+                 }
+JnxFruOperStates ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Operation states for a FRU"
+    SYNTAX       INTEGER {
+                     unEquipped(1),  -- no FRU
+                     init(2),        -- init state
+                     normal(3),      -- normal state
+                     mismatched(4),  -- does not match configured FRU
+                     fault(5),       -- fru is in fault state
+                     swul(6)         -- ISSU Software upload state
+                 }
+
+jnxFruCfg           OBJECT IDENTIFIER ::= { jnxFruMib 1 }
+
+
+jnxFruCfgTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxFruCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the otn FRU's. "
+        ::= { jnxFruCfg 1 }
+
+jnxFruCfgEntry OBJECT-TYPE
+        SYNTAX     JnxFruCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "Information about the otn FRU's."
+        INDEX   { jnxFruCfgContentsIndex, jnxFruCfgL1Index,
+                  jnxFruCfgL2Index, jnxFruCfgL3Index }
+        ::= { jnxFruCfgTable 1 }
+
+JnxFruCfgEntry ::=
+    SEQUENCE {
+        jnxFruCfgContentsIndex         Integer32,
+        jnxFruCfgL1Index               Integer32,
+        jnxFruCfgL2Index               Integer32,
+        jnxFruCfgL3Index               Integer32,
+        jnxFruCfgType                  OBJECT IDENTIFIER,
+        jnxFruCfgAdminState            JnxFruAdminStates,
+        jnxFruCfgOperState             JnxFruOperStates
+    }
+
+    jnxFruCfgContentsIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..'7fffffff'h)
+        MAX-ACCESS      accessible-for-notify
+        STATUS          current
+        DESCRIPTION
+                "The associated jnxContentsContainerIndex in the 
+                jnxContentsTable."
+        ::= { jnxFruCfgEntry 1 }
+
+    jnxFruCfgL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (0..'7fffffff'h)
+        MAX-ACCESS      accessible-for-notify
+        STATUS          current
+        DESCRIPTION
+                "The level one index associated with this
+                subject.  Zero if unavailable or inapplicable."
+        ::= { jnxFruCfgEntry 2 }
+
+    jnxFruCfgL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (0..'7fffffff'h)
+        MAX-ACCESS      accessible-for-notify
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this 
+                subject.  Zero if unavailable or inapplicable."
+        ::= { jnxFruCfgEntry 3 }
+
+    jnxFruCfgL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (0..'7fffffff'h)
+        MAX-ACCESS      accessible-for-notify
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this
+                subject.  Zero if unavailable or inapplicable."
+        ::= { jnxFruCfgEntry 4 }
+
+    jnxFruCfgType OBJECT-TYPE
+        SYNTAX           OBJECT IDENTIFIER
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "The object ID for this FRU"
+        ::= { jnxFruCfgEntry 5 }
+ 
+    jnxFruCfgAdminState OBJECT-TYPE
+        SYNTAX          JnxFruAdminStates
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "The Administrative state of this FRU"
+        ::= { jnxFruCfgEntry 6 }
+
+    jnxFruCfgOperState OBJECT-TYPE
+        SYNTAX          JnxFruOperStates
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The Operational state of this FRU"
+        ::= { jnxFruCfgEntry 7 }
+
+
+--
+-- Traps for FRU config
+--
+-- This can be moved to jnx-chassis.mib
+jnxFruNotifMismatch NOTIFICATION-TYPE
+        OBJECTS         { jnxFruCfgContentsIndex,
+                          jnxFruCfgL1Index,
+                          jnxFruCfgL2Index,
+                          jnxFruCfgL3Index,
+                          jnxFruCfgType
+                          }
+        STATUS          current
+        DESCRIPTION
+                "A jnxFruInsertion trap signifies that the SNMP
+                entity, acting in an agent role, has detected that
+                the specified FRU (Field Replaceable Unit)  
+                inserted into the chassis does not match what was
+                configured."
+        ::= { jnxFruTraps 1 }
+
+jnxFruNotifAdminStatus NOTIFICATION-TYPE
+        OBJECTS         { jnxFruCfgContentsIndex,
+                          jnxFruCfgL1Index,
+                          jnxFruCfgL2Index,
+                          jnxFruCfgL3Index,
+                          jnxFruCfgAdminState
+                        }
+        STATUS  current
+        DESCRIPTION
+                "Notification of the Administrative state of the otn interface"
+        ::= { jnxFruTraps 2 }
+
+jnxFruNotifOperStatus NOTIFICATION-TYPE
+        OBJECTS         { jnxFruCfgContentsIndex,
+                          jnxFruCfgL1Index,
+                          jnxFruCfgL2Index,
+                          jnxFruCfgL3Index, 
+                          jnxFruCfgOperState
+                        }
+        STATUS  current
+        DESCRIPTION
+                "Notification of Operational state of the otn interface"
+        ::= { jnxFruTraps 3 }
+
+END

--- a/mibs/junos/mib-jnx-gen-set.txt
+++ b/mibs/junos/mib-jnx-gen-set.txt
@@ -1,0 +1,138 @@
+--
+-- Juniper Enterprise Specific MIB: General  traps and information 
+--    to support SET 
+--
+-- Copyright (c) 2012-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-SNMP-SET-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+    DisplayString
+        FROM SNMPv2-TC
+    jnxSnmpSetMibRoot, jnxSnmpSetTraps
+        FROM JUNIPER-SMI;
+
+jnxSnmpSetMib MODULE-IDENTITY
+    LAST-UPDATED "201201271000Z" -- Thu Jan 27 10:00:00 PST 2012
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This MIB module defines objects used for managing 
+             SNMP sets for Juniper products."
+    REVISION      "201311260000Z"
+    DESCRIPTION
+               "Added General  trap for SNMP set failure."
+    ::= { jnxSnmpSetMibRoot 1 }
+
+jnxSnmpSet              OBJECT IDENTIFIER ::=     { jnxSnmpSetMib 1 }
+jnxSnmpSetNotifications OBJECT IDENTIFIER ::=     {  jnxSnmpSetTraps 1 }
+
+--
+-- Error returned for the commit failure
+--
+jnxCommitSetFailureReason OBJECT-TYPE
+    SYNTAX          DisplayString 
+    MAX-ACCESS      accessible-for-notify
+    STATUS          current
+    DESCRIPTION
+            " This is the reason for the failure ... Text information
+              about the failure "
+
+    ::= { jnxSnmpSet 1 }
+
+--
+-- Traps
+--
+jnxSnmpSetFailure NOTIFICATION-TYPE
+        OBJECTS {
+                  jnxCommitSetFailureReason
+                }
+        STATUS  current
+        DESCRIPTION
+                "Notification for a snmp set commit error."
+        ::= { jnxSnmpSetNotifications 1 }
+
+
+END
+
+--
+-- Juniper Enterprise Specific MIB: General  traps and information 
+--    to support SET 
+--
+-- Copyright (c) 2012-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-SNMP-SET-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+    DisplayString
+        FROM SNMPv2-TC
+    jnxSnmpSetMibRoot, jnxSnmpSetTraps
+        FROM JUNIPER-SMI;
+
+jnxSnmpSetMib MODULE-IDENTITY
+    LAST-UPDATED "201201271000Z" -- Thu Jan 27 10:00:00 PST 2012
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This MIB module defines objects used for managing 
+             SNMP sets for Juniper products."
+    REVISION      "201311260000Z"
+    DESCRIPTION
+               "Added General  trap for SNMP set failure."
+    ::= { jnxSnmpSetMibRoot 1 }
+
+jnxSnmpSet              OBJECT IDENTIFIER ::=     { jnxSnmpSetMib 1 }
+jnxSnmpSetNotifications OBJECT IDENTIFIER ::=     {  jnxSnmpSetTraps 1 }
+
+--
+-- Error returned for the commit failure
+--
+jnxCommitSetFailureReason OBJECT-TYPE
+    SYNTAX          DisplayString 
+    MAX-ACCESS      accessible-for-notify
+    STATUS          current
+    DESCRIPTION
+            " This is the reason for the failure ... Text information
+              about the failure "
+
+    ::= { jnxSnmpSet 1 }
+
+--
+-- Traps
+--
+jnxSnmpSetFailure NOTIFICATION-TYPE
+        OBJECTS {
+                  jnxCommitSetFailureReason
+                }
+        STATUS  current
+        DESCRIPTION
+                "Notification for a snmp set commit error."
+        ::= { jnxSnmpSetNotifications 1 }
+
+
+END
+

--- a/mibs/junos/mib-jnx-if-accounting.txt
+++ b/mibs/junos/mib-jnx-if-accounting.txt
@@ -1,0 +1,197 @@
+-- *******************************************************************
+-- Juniper enterprise specific QoS based Interface Accounting MIB. 
+--
+-- Copyright (c) 2001-2006, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- *******************************************************************
+
+JUNIPER-IF-ACCOUNTING-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, 
+    Integer32, Counter64
+        FROM SNMPv2-SMI
+    InterfaceIndex                       
+        FROM IF-MIB
+    JnxCosFcIdentifier
+        FROM JUNIPER-COS-MIB   
+    ifJnx
+        FROM JUNIPER-IF-MIB;
+        
+jnxIfAccountingStats        MODULE-IDENTITY
+    LAST-UPDATED "201305151223Z"                -- Wed May 25 12:23:51 2013 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+                 "Juniper Technical Assistance Center
+                      Juniper Networks, Inc.
+                      1194 N. Mathilda Avenue
+                      Sunnyvale, CA 94089
+                      E-mail: support@juniper.net"
+
+    DESCRIPTION  "MIB module to define Forwarding Class based Interface statistics.
+                    The statistics will provide protocol specific statistics value
+                    which includes L2 overhead bytes. The mib is currently supported 
+                    only on MX platforms."
+    
+    REVISION     	"201305151223Z"             -- Wed May 25 12:23:51 2013 UTC
+    DESCRIPTION		"MIB module to define QoS based Interface accounting." 
+   
+    
+    ::= { ifJnx 10 }    
+    
+-- ***************************************************************
+--  Per Forwarding-class stats table
+-- ***************************************************************
+    jnxIfFcAccountStatTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxIfFcAccountStatEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table presents the per forwarding-class and 
+             per protocol type statistics."
+        ::= { jnxIfAccountingStats 1 }
+
+
+    jnxIfFcAccountStatEntry OBJECT-TYPE
+        SYNTAX      JnxIfFcAccountStatEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table presents the per forwarding-class and 
+             per protocol type statistics. The indices of the 
+             table are Interface Index, Forwarding class Index
+             and Protocol type"
+        INDEX       { jnxIfFcIfIndex, jnxIfFcFcIndex, jnxIfFcProtocol }
+        ::= { jnxIfFcAccountStatTable 1 }
+        
+
+    JnxIfFcAccountStatEntry ::=
+        SEQUENCE {
+            jnxIfFcIfIndex              InterfaceIndex,
+            jnxIfFcFcIndex              JnxCosFcIdentifier,
+            jnxIfFcProtocol             INTEGER,
+
+            -- input packet/byte stats for unicast traffic
+            jnxIfFcHCInUcastPkts          Counter64,
+            jnxIfFcHCInUcastOctets        Counter64,
+
+            -- output packet/byte stats for unicast traffic
+            jnxIfFcHCOutUcastPkts         Counter64,
+            jnxIfFcHCOutUcastOctets       Counter64,
+
+            -- input packet/byte stats for multicast traffic
+            jnxIfFcHCInMcastPkts        Counter64,
+            jnxIfFcHCInMcastOctets      Counter64,
+
+            -- output packet/byte stats for multicast traffic
+            jnxIfFcHCOutMcastPkts       Counter64,
+            jnxIfFcHCOutMcastOctets     Counter64
+    }
+
+    jnxIfFcIfIndex OBJECT-TYPE 
+        SYNTAX      InterfaceIndex 
+        MAX-ACCESS  not-accessible 
+        STATUS      current
+        DESCRIPTION
+            "The ifIndex of the interface." 
+        ::= { jnxIfFcAccountStatEntry 1 }
+        
+        
+    jnxIfFcFcIndex OBJECT-TYPE 
+        SYNTAX      JnxCosFcIdentifier 
+        MAX-ACCESS  not-accessible 
+        STATUS      current
+        DESCRIPTION
+            "The Forwarding Class Index of the interface." 
+        ::= { jnxIfFcAccountStatEntry 2 }
+                
+            
+    --Protocol family for accounting all is aggregate of all types
+    jnxIfFcProtocol OBJECT-TYPE
+        SYNTAX      INTEGER {
+                        all (1),
+                        ipv4 (2),
+                        ipv6 (3)
+        }
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "The protocol type of the entry's traffic."
+        ::= { jnxIfFcAccountStatEntry 3 }
+        
+    --input packet/byte stats for unicast traffic
+    jnxIfFcHCInUcastPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of unicast packets ingressed."
+        ::= { jnxIfFcAccountStatEntry 4 }
+
+    --input packet/byte stats for unicast traffic
+    jnxIfFcHCInUcastOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of unicast bytes ingressed."
+        ::= { jnxIfFcAccountStatEntry 5 }
+
+    --output packet/byte stats for unicast traffic
+    jnxIfFcHCOutUcastPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of unicast packets egressed."
+        ::= { jnxIfFcAccountStatEntry 6 }
+
+    --output packet/byte stats for unicast traffic
+    jnxIfFcHCOutUcastOctets  OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of unicast bytes egressed."
+        ::= { jnxIfFcAccountStatEntry 7 }
+
+    --input packet/byte stats for multicast traffic
+    jnxIfFcHCInMcastPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of multicast packets ingressed."
+        ::= { jnxIfFcAccountStatEntry 8 }
+
+    --input packet/byte stats for multicast traffic
+    jnxIfFcHCInMcastOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of multicast bytes ingressed."
+        ::= { jnxIfFcAccountStatEntry 9 }
+
+    --output packet/byte stats for multicast traffic
+    jnxIfFcHCOutMcastPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of multicast packets egressed."
+        ::= { jnxIfFcAccountStatEntry 10 }
+
+    --output packet/byte stats for multicast traffic
+    jnxIfFcHCOutMcastOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The total number of multicast bytes egressed."
+        ::= { jnxIfFcAccountStatEntry 11 }
+
+
+END

--- a/mibs/junos/mib-jnx-if-extensions.txt
+++ b/mibs/junos/mib-jnx-if-extensions.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Interface MIB Extension
 -- 
--- Copyright (c) 1999-2003, 2007, Juniper Networks, Inc.
+-- Copyright (c) 1999-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -10,7 +10,8 @@
 JUNIPER-IF-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
-    MODULE-IDENTITY, OBJECT-TYPE, Gauge32, Integer32, Counter64, Counter32
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+    Gauge32, Integer32, Counter64, Counter32
         FROM SNMPv2-SMI
     CounterBasedGauge64
         FROM HCNUM-TC
@@ -22,7 +23,7 @@ IMPORTS
         FROM JUNIPER-SMI;
 
 ifJnx MODULE-IDENTITY
-    LAST-UPDATED "200307182153Z" -- Fri Jul 18 21:53:51 2003 UTC
+    LAST-UPDATED "201109221523Z" -- Thu Sept 22 15:23:51 2011 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -33,7 +34,14 @@ ifJnx MODULE-IDENTITY
 
     DESCRIPTION
             "The MIB modules extends the ifTable as
-             defined in IF-MIB."     
+             defined in IF-MIB." 
+    REVISION     "201105100000Z"       -- 10 May, 2011
+    DESCRIPTION
+            "New Layer2 Policer Counters Added to ifJnxTable for MX Series only"     
+    REVISION      "201109220000Z"
+    DESCRIPTION
+               "Added new OIDs Crc and Fcs Erros.
+                Added new Trap ifJnxErrors"
     REVISION     "200706050000Z"       -- 05 June, 2007
     DESCRIPTION
             "New Time Domain Reflectometery Added" 
@@ -112,7 +120,9 @@ ifJnx MODULE-IDENTITY
         ifJnxOutAgedErrors     Counter64,
         ifJnxOutFifoErrors     Counter32,
         ifJnxOutHslFifoUnderFlows Counter64,
-        ifJnxOutHslCrcErrors   Counter32
+        ifJnxOutHslCrcErrors   Counter32,
+        ifJnxCrcErrors         Counter64,
+        ifJnxFcsErrors         Counter64
 	}
 
     ifIn1SecRate OBJECT-TYPE
@@ -402,6 +412,23 @@ ifJnx MODULE-IDENTITY
                 the router interfaces while transmitting packets."
     ::= { ifJnxEntry 31 }
 
+    ifJnxCrcErrors OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "CRC Errors: The number of CRC errors" 
+    ::= { ifJnxEntry 32 }
+
+    ifJnxFcsErrors OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "FCS Errors: The number of FCS errors" 
+    ::= { ifJnxEntry 33 }
+    
+
 
 
 --
@@ -545,6 +572,352 @@ ifJnx MODULE-IDENTITY
 		real and physical PIC cards.  Otherwise, it returns 
 		an octet string	of four zeros '0.0.0.0.'"
 	::= { ifChassisEntry 6 }
+
+    --
+    -- This branch contains all Interface Level PFE Notifications data.
+    --
+    ifJnxNotification   OBJECT IDENTIFIER ::= { ifJnx 3 }
+
+    ifJnxNotificationPrefix OBJECT IDENTIFIER ::= { ifJnxNotification 0}
+
+    ifJnxErrors NOTIFICATION-TYPE
+    OBJECTS {
+         ifJnxCrcErrors,
+         ifJnxFcsErrors
+    }
+    STATUS current
+    DESCRIPTION
+         "A ifJnxErrors notification is sent when the value
+         of ifJnxCrcErrors or ifJnxFcsErrors increases."
+
+    ::= { ifJnxNotificationPrefix 1 } 
       
+--
+-- This table augments ifTable
+--
+    ifJnxPolTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF IfJnxPolEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "A list of Juniper's extension to the interface entries.
+                The number of entries is given by the value of ifNumber.
+                This table contains additional objects for the interface
+                table."
+
+
+        ::= { ifJnx 4 }
+
+    ifJnxPolEntry      OBJECT-TYPE
+        SYNTAX      IfJnxPolEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "An entry containing additional management information
+                applicable to a particular interface."
+        INDEX  { ifIndex }
+        ::= { ifJnxPolTable 1 }
+
+    IfJnxPolEntry ::=
+        SEQUENCE {
+
+        ifJnxInPolLowOctets         Counter64,
+        ifJnxInPolLowPkts           Counter64,
+        ifJnxInPolLow1SecRate       Counter64,
+        ifJnxInPolMLowOctets        Counter64,
+        ifJnxInPolMLowPkts          Counter64,
+        ifJnxInPolMLow1SecRate      Counter64,
+        ifJnxInPolMHighOctets       Counter64,
+        ifJnxInPolMHighPkts         Counter64,
+        ifJnxInPolMHigh1SecRate     Counter64,
+        ifJnxInPolHighOctets        Counter64,
+        ifJnxInPolHighPkts          Counter64,
+        ifJnxInPolHigh1SecRate      Counter64,
+        ifJnxInPolDropOctets        Counter64,
+        ifJnxInPolDropPkts          Counter64,
+        ifJnxInPolDrop1SecRate      Counter64,
+        ifJnxOutPolLowOctets        Counter64,
+        ifJnxOutPolLowPkts          Counter64,
+        ifJnxOutPolLow1SecRate      Counter64,
+        ifJnxOutPolMLowOctets       Counter64,
+        ifJnxOutPolMLowPkts         Counter64,
+        ifJnxOutPolMLow1SecRate     Counter64,
+        ifJnxOutPolMHighOctets      Counter64,
+        ifJnxOutPolMHighPkts        Counter64,
+        ifJnxOutPolMHigh1SecRate    Counter64,
+        ifJnxOutPolHighOctets       Counter64,
+        ifJnxOutPolHighPkts         Counter64,
+        ifJnxOutPolHigh1SecRate     Counter64,
+        ifJnxOutPolDropOctets       Counter64,
+        ifJnxOutPolDropPkts         Counter64,
+        ifJnxOutPolDrop1SecRate     Counter64
+
+        }
+
+    ifJnxInPolLowOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Low Bytes"
+    ::= { ifJnxPolEntry 1 }
+
+
+    ifJnxInPolLowPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Low Pkts"
+    ::= { ifJnxPolEntry 2 }
+
+
+    ifJnxInPolLow1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Low 1 Sec Rate"
+    ::= { ifJnxPolEntry 3 }
+
+
+    ifJnxInPolMLowOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium Low Bytes"
+    ::= { ifJnxPolEntry 4 }
+
+
+    ifJnxInPolMLowPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium Low Pkts"
+    ::= { ifJnxPolEntry 5 }
+
+
+    ifJnxInPolMLow1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium Low 1 Sec Rate"
+    ::= { ifJnxPolEntry 6 }
+
+
+    ifJnxInPolMHighOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium High Bytes"
+    ::= { ifJnxPolEntry 7 }
+
+
+    ifJnxInPolMHighPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium High Pkts"
+    ::= { ifJnxPolEntry 8 }
+
+
+    ifJnxInPolMHigh1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium High 1 Sec Rate"
+    ::= { ifJnxPolEntry 9 }
+
+
+    ifJnxInPolHighOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input High Bytes"
+    ::= { ifJnxPolEntry 10 }
+
+
+    ifJnxInPolHighPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input High Pkts"
+    ::= { ifJnxPolEntry 11 }
+
+
+    ifJnxInPolHigh1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input High 1 Sec Rate"
+    ::= { ifJnxPolEntry 12 }
+
+    ifJnxInPolDropOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Drop Bytes"
+    ::= { ifJnxPolEntry 13 }
+
+
+    ifJnxInPolDropPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Drop Pkts"
+    ::= { ifJnxPolEntry 14 }
+
+
+    ifJnxInPolDrop1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Drop 1 Sec Rate"
+    ::= { ifJnxPolEntry 15 }
+
+    ifJnxOutPolLowOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Low Bytes"
+    ::= { ifJnxPolEntry 16 }
+
+
+    ifJnxOutPolLowPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Low Pkts"
+    ::= { ifJnxPolEntry 17 }
+
+
+    ifJnxOutPolLow1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Low 1 Sec Rate"
+    ::= { ifJnxPolEntry 18 }
+
+
+    ifJnxOutPolMLowOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Medium Low Bytes"
+    ::= { ifJnxPolEntry 19 }
+
+
+    ifJnxOutPolMLowPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Input Medium Low Pkts"
+    ::= { ifJnxPolEntry 20 }
+
+
+    ifJnxOutPolMLow1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Medium Low 1 Sec Rate"
+    ::= { ifJnxPolEntry 21 }
+
+
+    ifJnxOutPolMHighOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Medium High Bytes"
+    ::= { ifJnxPolEntry 22 }
+
+
+    ifJnxOutPolMHighPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Medium High Pkts"
+    ::= { ifJnxPolEntry 23 }
+
+
+    ifJnxOutPolMHigh1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Medium High 1 Sec Rate"
+    ::= { ifJnxPolEntry 24 }
+
+
+    ifJnxOutPolHighOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output High Bytes"
+    ::= { ifJnxPolEntry 25 }
+
+
+    ifJnxOutPolHighPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output High Pkts"
+    ::= { ifJnxPolEntry 26 }
+
+
+    ifJnxOutPolHigh1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output High 1 Sec Rate"
+    ::= { ifJnxPolEntry 27 }
+
+
+    ifJnxOutPolDropOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Drop Bytes"
+    ::= { ifJnxPolEntry 28 }
+
+    ifJnxOutPolDropPkts OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Drop Pkts"
+    ::= { ifJnxPolEntry 29 }
+
+
+    ifJnxOutPolDrop1SecRate OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Logical Interface Policer Output Drop 1 Sec Rate"
+    ::= { ifJnxPolEntry 30 }
 
 END

--- a/mibs/junos/mib-jnx-ifotn.txt
+++ b/mibs/junos/mib-jnx-ifotn.txt
@@ -1,0 +1,1560 @@
+--
+-- Juniper Enterprise Specific MIB: OTN interface management
+--
+-- Copyright (c) 2012-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-IFOTN-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, TimeTicks, NOTIFICATION-TYPE,
+    Unsigned32, Counter32, Integer32
+        FROM SNMPv2-SMI
+    DateAndTime, TEXTUAL-CONVENTION, RowStatus, TruthValue
+        FROM SNMPv2-TC
+    jnxIfOtnMibRoot, jnxIfOtnNotifications
+        FROM JUNIPER-SMI
+    ifIndex, ifDescr
+        FROM IF-MIB
+    JnxoptIfOTNOChAlarms, JnxoptIfOTNODUkTcmAlarms
+        FROM JNX-OPT-IF-EXT-MIB;
+
+jnxIfOtnMib MODULE-IDENTITY
+    LAST-UPDATED "201201271000Z" -- Thu Jan 27 10:00:00 PST 2012
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This MIB module defines objects used for managing the
+             OTN interface for Juniper products."
+    REVISION      "201201270000Z"
+    DESCRIPTION
+               "Added OTN Alarms and PM data."
+    REVISION      "201201270000Z"
+    DESCRIPTION
+               "Initial revision."
+    ::= { jnxIfOtnMibRoot 1 }
+
+--
+-- Textual Conventions
+--
+JnxIfAdminStates ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Admin states for an interface"
+    SYNTAX       INTEGER {
+                      jnxAdminStateInService(1), 
+                                      -- In service
+                      jnxAdminStateInServiceMA(2),
+                                      -- In service maintenance, the link is in
+                                      -- service, but alarms are suppressed
+                      jnxAdminStateOutofService(3), 
+                                      -- Out of service due to a fault
+                      jnxAdminStateOutofServiceMA(4)
+                                      -- OOS maintenance as configured by the
+                                      -- user, may or may not have alarms`
+                 }
+JnxIfOperStates ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Operational states for an interface"
+    SYNTAX       INTEGER {
+                       jnxOperStateInit(1),
+                                     -- Starting state of the interface
+                       jnxOperStateNormal(2),
+                                     -- The interface is working normally
+                       jnxOperStateFault(3),
+                                     -- There is some traffic affecting fault
+                                     -- on the interface eg LOS
+                       jnxOperStateDegraded(4)
+                                     -- There is some function affecting 
+                                     -- degrading the performance on the
+                                     --  interface for eg  BER
+                 }
+
+JnxIfOtnRate ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Rates for an interface "
+    SYNTAX       INTEGER {
+                   otu0(1),
+                   otu1(2),
+                   otu2(3),
+                   otu2e(4),
+                   otu3(5),
+                   otu4(6), 
+                   otu1e(7),
+                   otu5(8)
+                 }
+
+JnxIfOtnFecType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "fec modes of an interface "
+    SYNTAX       INTEGER {
+                     nofec(0),
+                     gfec(1),
+                     efecI2(2),
+                     efecI3(3),
+                     efecI4(4),
+                     efecI5(5),
+                     efecI6(6),
+                     efecI7(7),
+                     efecI8(8),
+                     efecI9(9),
+                     gfecandsdfec(10)
+                 }
+
+JnxIfOtnLayer  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Layer which describes the table"
+    SYNTAX       INTEGER {
+                    jnxOch(1),
+                    jnxOTUk(2),
+                    jnxODUk(3),
+                    jnxTCM(4)
+                 }
+
+JnxIfOtnType  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Near End or Far End "
+    SYNTAX       INTEGER {
+                    jnxNearEnd(1),
+                    jnxFarEnd(2)      
+                 }
+
+JnxIfOtnDirection  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Direction for the entities in the table"
+    SYNTAX       INTEGER {
+                    jnxTxDir(1),
+                    jnxRxDir(2),
+                    jnxBiDir(3)
+                 }
+
+
+JnxIfOtnSeverity  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Severity of the Notification"
+    SYNTAX       INTEGER {
+                     jnxCritical(1),
+                     jnxMajor(2),
+                     jnxMinor(3),
+                     jnxInfo(4)
+                 }
+
+JnxIfOtnServiceStateAction  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Notification's action on the service state"
+    SYNTAX       INTEGER {
+                     jnxNotSupported(0),
+                     jnxNonServiceAffecting(1),
+                     jnxServiceAffecting(2)
+                 }
+
+
+
+jnxIfOtn               OBJECT IDENTIFIER ::= { jnxIfOtnMib 1 }
+
+
+--
+-- Otn OCh options
+jnxIfOtnOChCfgTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnOChCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the Otn OCh Config Table. "
+        ::= { jnxIfOtn 1 }
+
+jnxIfOtnOChCfgEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnOChCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains of the Otn OCh Config Table."
+        INDEX   { jnxIfOtnOChCfgContainerIndex, jnxIfOtnOChCfgL1Index,
+                  jnxIfOtnOChCfgL2Index, jnxIfOtnOChCfgL3Index }
+        ::= { jnxIfOtnOChCfgTable 1 }
+
+JnxIfOtnOChCfgEntry ::=
+    SEQUENCE {
+            jnxIfOtnOChCfgContainerIndex
+                             Integer32,
+            jnxIfOtnOChCfgL1Index       
+                             Integer32,
+            jnxIfOtnOChCfgL2Index       
+                             Integer32,
+            jnxIfOtnOChCfgL3Index       
+                             Integer32,
+            jnxIfOtnLocalLoopback       
+                             TruthValue,
+            jnxIfOtnLineLoopback       
+                             TruthValue,
+            jnxIfOtnPayloadLoopback       
+                             TruthValue,
+            jnxIfOtnAdminState          
+                             JnxIfAdminStates,
+            jnxIfOtnOperState           
+                             JnxIfOperStates,
+            jnxIfOtnIndex              
+                             Unsigned32,
+            jnxIfOtnOChStatus         
+                             BITS,
+            jnxIfOtnOChPortMode
+                             Unsigned32
+    }
+
+    jnxIfOtnOChCfgContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+               "The associated jnxContentsContainerIndex  - eg shelf.."
+        ::= { jnxIfOtnOChCfgEntry 1 }
+
+    jnxIfOtnOChCfgL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level one index associated with this subject ... eg fpc
+                 slot."
+        ::= { jnxIfOtnOChCfgEntry 2 }
+
+    jnxIfOtnOChCfgL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this subject .. eg pic
+                 slot."
+        ::= { jnxIfOtnOChCfgEntry 3 }
+
+    jnxIfOtnOChCfgL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this subject..
+                 eg port.
+                "
+        ::= { jnxIfOtnOChCfgEntry 4 }
+
+    jnxIfOtnLocalLoopback OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "This is the local loopback at the Line (after the optics)."
+        ::= { jnxIfOtnOChCfgEntry 5 }
+
+    jnxIfOtnLineLoopback OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "This is the line loopback at the Line."
+        ::= { jnxIfOtnOChCfgEntry 6 }
+
+    jnxIfOtnPayloadLoopback OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "This is the Payload loopback before the optics."
+        ::= { jnxIfOtnOChCfgEntry 7 }
+
+    jnxIfOtnAdminState OBJECT-TYPE
+        SYNTAX          JnxIfAdminStates
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "The Admin state of this interface"
+        ::= { jnxIfOtnOChCfgEntry 8 }
+
+    jnxIfOtnOperState OBJECT-TYPE
+        SYNTAX          JnxIfOperStates
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The operational state of this interface"
+        ::= { jnxIfOtnOChCfgEntry 9 }
+
+    jnxIfOtnIndex OBJECT-TYPE
+        SYNTAX          Unsigned32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The interface ifIndex of this interface"
+        ::= { jnxIfOtnOChCfgEntry 10 }
+
+    jnxIfOtnOChStatus OBJECT-TYPE
+        SYNTAX          BITS {
+                            los(0),
+                            lof(1),
+                            lom(2),
+                            wavelengthlockerr(3)
+                        }
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The interface status at the OCh layer."
+        ::= { jnxIfOtnOChCfgEntry 11 }
+
+    jnxIfOtnOChPortMode OBJECT-TYPE
+        SYNTAX          Unsigned32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The Port Mode for this interface
+                 0  -  default (not applicable)
+                 1  -  lan
+                 2  -  wan 
+                 3  -  gfp
+                "
+        ::= { jnxIfOtnOChCfgEntry 12 }
+
+
+
+
+-- otn interface options 
+--
+jnxIfOtnOTUkCfgTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnOTUkCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the Otn OTUk config table. "
+        ::= { jnxIfOtn 2 }
+
+jnxIfOtnOTUkCfgEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnOTUkCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains the Otn OTUk config table.
+                 "
+        INDEX   { jnxIfOtnOTUkCfgContainerIndex, jnxIfOtnOTUkCfgL1Index,
+                  jnxIfOtnOTUkCfgL2Index, jnxIfOtnOTUkCfgL3Index }
+        ::= { jnxIfOtnOTUkCfgTable 1 }
+
+JnxIfOtnOTUkCfgEntry ::=
+    SEQUENCE {
+            jnxIfOtnOTUkCfgContainerIndex         
+                                  Integer32,
+            jnxIfOtnOTUkCfgL1Index         
+                                  Integer32,
+            jnxIfOtnOTUkCfgL2Index       
+                                  Integer32,
+            jnxIfOtnOTUkCfgL3Index    
+                                  Integer32,
+            jnxIfOtnOTUkCfgRate 
+                                  JnxIfOtnRate,
+            jnxIfOtnOTUkCfgFecMode
+                                  JnxIfOtnFecType,
+            jnxIfOtnOTUkEnableAutoFrrByteInsert
+                                  TruthValue,
+            jnxIfOtnOTUkEnableBERFrrSupport
+                                  TruthValue,
+            jnxIfOtnOTUkPreFecBERThresholdMantissa
+                                  Integer32,
+            jnxIfOtnOTUkPreFecBERThresholdExponent
+                                  Integer32,
+            jnxIfOtnOTUkPreFecBERThresholdTime    
+                                  Integer32,
+            jnxIfOtnOTUkTIMActEnabled
+                                  TruthValue,
+            jnxIfOtnOTUkTxTTI
+                                  OCTET STRING,
+            jnxIfOtnOTUkRxTTI
+                                  OCTET STRING,
+            jnxIfOtnOTUkExpectedRxSapi
+                                  OCTET STRING,
+            jnxIfOtnOTUkExpectedRxDapi
+                                  OCTET STRING,
+            jnxIfOtnOTUkStatus
+                                  BITS,
+            jnxIfOtnOTUkPreFecBERThresholdClearMantissa
+                                  Integer32,
+            jnxIfOtnOTUkPreFecBERThresholdClearExponent
+                                  Integer32
+    }
+
+    jnxIfOtnOTUkCfgContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The associated jnxContentsContainerIndex  - eg shelf."
+        ::= { jnxIfOtnOTUkCfgEntry 1 }
+
+    jnxIfOtnOTUkCfgL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level one index associated with this subject ... eg fpc
+                 slot."
+        ::= { jnxIfOtnOTUkCfgEntry 2 }
+
+    jnxIfOtnOTUkCfgL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this subject .. eg pic
+                 slot."
+        ::= { jnxIfOtnOTUkCfgEntry 3 }
+
+    jnxIfOtnOTUkCfgL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this subject.. 
+                 eg port.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 4 }
+
+
+    jnxIfOtnOTUkCfgRate OBJECT-TYPE
+        SYNTAX          JnxIfOtnRate
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This is the rate for the interface and the rates depend
+                  on the interface/fru type. 
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 5 }
+
+    jnxIfOtnOTUkCfgFecMode OBJECT-TYPE
+        SYNTAX          JnxIfOtnFecType
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This is the Fec type in the OTU frame and the selection
+                  depends on the interface/fru type.  "
+        ::= { jnxIfOtnOTUkCfgEntry 6 }
+
+    jnxIfOtnOTUkEnableAutoFrrByteInsert OBJECT-TYPE
+        SYNTAX          TruthValue 
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This will enable/disable the automatic insertion of 
+                  the frr SF/SD byte in the overhead bytes(RES) "
+        ::= { jnxIfOtnOTUkCfgEntry 7 }
+
+    jnxIfOtnOTUkEnableBERFrrSupport OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This will enable/disable the FRR support for BER "
+        ::= { jnxIfOtnOTUkCfgEntry 8 }
+
+    jnxIfOtnOTUkPreFecBERThresholdMantissa OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This will set the BER threshold(mantissa), which when
+                  crossed will trigger Signal Degrade.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 9 }
+
+    jnxIfOtnOTUkPreFecBERThresholdExponent OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This will set the BER threshold(exponent), which when
+                  crossed will trigger Signal Degrade.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 10 }
+
+    jnxIfOtnOTUkPreFecBERThresholdTime OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ms"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " 
+                  The collection times (1ms - 1sec) to calculate the BER.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 11 }
+
+    jnxIfOtnOTUkTIMActEnabled OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                 Indicates whether the Trace Identifier Mismatch (TIM)
+                 Consequent Action function is enabled.
+                 The default value of this object is false(2).
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 12 }
+
+    jnxIfOtnOTUkTxTTI OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..64))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " 
+                  The Trace TTI  SAPI 0..15, DAPI 16..31
+                  32 ..63 user defined  
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 13 }
+
+    jnxIfOtnOTUkRxTTI OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(64))
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                  The Receive Trace TTI  SAPI 0..15, DAPI 16..31
+                  32 ..63 user defined
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 14 }
+
+    jnxIfOtnOTUkExpectedRxSapi OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..16))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Expected receive SAPI.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 15 }
+
+    jnxIfOtnOTUkExpectedRxDapi OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..16))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Expected receive DAPI. 
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 16 }
+
+    jnxIfOtnOTUkStatus OBJECT-TYPE
+        SYNTAX          BITS {
+                            ais(0),
+                            bdi(1),
+                            iae(2),
+                            ttim(3),
+                            sf(4),
+                            sd(5),
+                            biae(6),
+                            tsf(7),
+                            ssf(8),
+                            fecexcessive(9),
+                            fecdegrade(10)
+                        }
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The interface status at the OTUk layer."
+        ::= { jnxIfOtnOTUkCfgEntry 17 }
+
+    jnxIfOtnOTUkPreFecBERThresholdClearMantissa OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This will set the BER threshold(mantissa) for clear signal
+                  degrade condition, which signal degrade condition will be
+                  cleared when Pre-Fec error count is below the clear
+                  threshold error count.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 18 }
+
+    jnxIfOtnOTUkPreFecBERThresholdClearExponent OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                " This will set the BER threshold(exponent) for clear signal
+                  degrade condition, which signal degrade condition will be
+                  cleared when Pre-Fec error count is below the clear threshold
+                  error count.
+                "
+        ::= { jnxIfOtnOTUkCfgEntry 19 }
+
+--
+-- ODUk config table
+--
+
+jnxIfOtnODUkCfgTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnODUkCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the Otn ODUk config table. "
+        ::= { jnxIfOtn 3 }
+
+jnxIfOtnODUkCfgEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnODUkCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains information about the 
+                  Otn ODUk config.
+                 "
+        INDEX   { jnxIfOtnODUkCfgContainerIndex, jnxIfOtnODUkCfgL1Index,
+                  jnxIfOtnODUkCfgL2Index, jnxIfOtnODUkCfgL3Index
+                 }
+        ::= { jnxIfOtnODUkCfgTable 1 }
+
+JnxIfOtnODUkCfgEntry ::=
+    SEQUENCE {
+            jnxIfOtnODUkCfgContainerIndex
+                                  Integer32,
+            jnxIfOtnODUkCfgL1Index       
+                                  Integer32,
+            jnxIfOtnODUkCfgL2Index       
+                                  Integer32,
+            jnxIfOtnODUkCfgL3Index       
+                                  Integer32,
+            jnxIfOtnODUkAPSPCC0          
+                                  Integer32,
+            jnxIfOtnODUkAPSPCC1          
+                                  Integer32,
+            jnxIfOtnODUkAPSPCC2          
+                                  Integer32,
+            jnxIfOtnODUkAPSPCC3          
+                                  Integer32,
+            jnxIfOtnODUkPayloadType      
+                                  Integer32,
+            jnxIfOtnODUkTIMActEnabled
+                                  TruthValue,
+            jnxIfOtnODUkTxTTI
+                                  OCTET STRING,
+            jnxIfOtnODUkRxTTI
+                                  OCTET STRING,
+            jnxIfOtnODUkExpectedRxSapi
+                                  OCTET STRING,
+            jnxIfOtnODUkExpectedRxDapi
+                                  OCTET STRING,
+            jnxIfOtnODUkStatus
+                                  BITS,
+            jnxIfOtnODUkRxPayloadType      
+                                  Integer32
+     }
+
+    jnxIfOtnODUkCfgContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+               "The associated jnxContentsContainerIndex  - eg shelf.."
+        ::= { jnxIfOtnODUkCfgEntry 1 }
+
+    jnxIfOtnODUkCfgL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level one index associated with this subject ... eg fpc
+                 slot."
+        ::= { jnxIfOtnODUkCfgEntry 2 }
+
+    jnxIfOtnODUkCfgL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this subject .. eg 
+                 pic slot."
+        ::= { jnxIfOtnODUkCfgEntry 3 }
+
+    jnxIfOtnODUkCfgL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this subject..
+                  eg port.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 4 }
+
+
+     jnxIfOtnODUkAPSPCC0 OBJECT-TYPE
+        SYNTAX          Integer32(0..255)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Read/Write APS PCC byte 0 for this ODUk only.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 5 }
+
+     jnxIfOtnODUkAPSPCC1 OBJECT-TYPE
+        SYNTAX          Integer32(0..255)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Read/Write APS PCC byte 1 for this ODUk only.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 6 }
+
+     jnxIfOtnODUkAPSPCC2 OBJECT-TYPE
+        SYNTAX          Integer32(0..255)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Read/Write APS PCC byte 2 for this ODUk only.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 7 }
+
+     jnxIfOtnODUkAPSPCC3 OBJECT-TYPE
+        SYNTAX          Integer32(0..255)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Read/Write APS PCC byte 3 for this ODUk only.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 8 }
+
+     jnxIfOtnODUkPayloadType OBJECT-TYPE
+        SYNTAX          Integer32(0..255)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Read/Write Payload Type for ODUk only.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 9 }
+
+    jnxIfOtnODUkTIMActEnabled OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                 Indicates whether the Trace Identifier Mismatch (TIM)
+                 Consequent Action function is enabled.
+                 The default value of this object is false(2).
+                "
+        ::= { jnxIfOtnODUkCfgEntry 10 }
+
+    jnxIfOtnODUkTxTTI OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..64))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  The Trace TTI  SAPI 0..15, DAPI 16..31
+                  32 ..63 user defined for this layer.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 11 }
+
+    jnxIfOtnODUkRxTTI OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(64))
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                  The Receive Trace TTI  SAPI 0..15, DAPI 16..31
+                  32 ..63 user defined for this layer.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 12 }
+
+    jnxIfOtnODUkExpectedRxSapi OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..16))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION     
+                "
+                  Expected receive SAPI for this layer.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 13 }
+
+    jnxIfOtnODUkExpectedRxDapi OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..16))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Expected receive DAPI for this layer.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 14 }
+
+    jnxIfOtnODUkStatus OBJECT-TYPE
+        SYNTAX          BITS {
+                            ais(0),
+                            bdi(1),
+                            iae(2),
+                            ttim(3),
+                            sf(4),
+                            sd(5),
+                            biae(6),
+                            tsf(7),
+                            ssf(8),
+                            csf(9),
+                            oci(10),
+                            lck(11),
+                            ltc(12),
+                            ptm(13)
+                        }
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "The  status at the ODUk layer
+                 Only some of these alarms are valid for the TCM layer
+                "
+        ::= { jnxIfOtnODUkCfgEntry 15 }
+
+     jnxIfOtnODUkRxPayloadType OBJECT-TYPE
+        SYNTAX          Integer32(0..255)
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                  Receive  Payload Type for ODUk only.
+                "
+        ::= { jnxIfOtnODUkCfgEntry 16 }
+
+--
+-- TCM Config Table
+--
+
+
+jnxIfOtnTcmCfgTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnTcmCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the Otn TCM config table. "
+        ::= { jnxIfOtn 4 }
+
+jnxIfOtnTcmCfgEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnTcmCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains information about the
+                  Otn Tcm config.
+                 "
+        INDEX   { jnxIfOtnTcmCfgContainerIndex, jnxIfOtnTcmCfgL1Index,
+                  jnxIfOtnTcmCfgL2Index, jnxIfOtnTcmCfgL3Index,
+                  jnxIfOtnTcmCfgLevel
+                 }
+        ::= { jnxIfOtnTcmCfgTable 1 }
+
+
+JnxIfOtnTcmCfgEntry ::=
+    SEQUENCE {
+            jnxIfOtnTcmCfgContainerIndex
+                                  Integer32,
+            jnxIfOtnTcmCfgL1Index
+                                  Integer32,
+            jnxIfOtnTcmCfgL2Index
+                                  Integer32,
+            jnxIfOtnTcmCfgL3Index
+                                  Integer32,
+            jnxIfOtnTcmCfgLevel
+                                  Integer32,
+            jnxIfOtnTCMEnable
+                                  TruthValue,
+            jnxIfOtnTcmTxTTI
+                                  OCTET STRING,
+            jnxIfOtnTcmRxTTI
+                                  OCTET STRING,
+            jnxIfOtnTcmExpectedRxSapi
+                                  OCTET STRING,
+            jnxIfOtnTcmExpectedRxDapi
+                                  OCTET STRING,
+            jnxIfOtnTcmStatus
+                                  BITS
+     }
+
+    jnxIfOtnTcmCfgContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The associated jnxContentsContainerIndex  - eg shelf."
+        ::= { jnxIfOtnTcmCfgEntry 1 }
+
+    jnxIfOtnTcmCfgL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+               "The level one index associated with this subject ... eg fpc
+                slot."
+        ::= { jnxIfOtnTcmCfgEntry 2 }
+
+    jnxIfOtnTcmCfgL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this subject .. eg pic
+                 slot."
+        ::= { jnxIfOtnTcmCfgEntry 3 }
+
+    jnxIfOtnTcmCfgL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this subject..
+                 eg port.
+                "
+        ::= { jnxIfOtnTcmCfgEntry 4 }
+
+
+     jnxIfOtnTcmCfgLevel OBJECT-TYPE
+        SYNTAX          Integer32 (1..6)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    The TCM level for the Table
+                "
+        ::= { jnxIfOtnTcmCfgEntry 5 }
+
+     jnxIfOtnTCMEnable OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   Enable this TCM layer (only for TCM layers)
+                "
+        ::= { jnxIfOtnTcmCfgEntry 6 }
+
+
+    jnxIfOtnTcmTxTTI OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..64))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  The Trace TTI  SAPI 0..15, DAPI 16..31
+                  32 ..63 user defined for this layer.
+                "
+        ::= { jnxIfOtnTcmCfgEntry 7 }
+
+    jnxIfOtnTcmRxTTI OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(64))
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                  The Receive Trace TTI  SAPI 0..15, DAPI 16..31
+                  32 ..63 user defined for this layer.
+                "
+        ::= { jnxIfOtnTcmCfgEntry 8 }
+
+
+    jnxIfOtnTcmExpectedRxSapi OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..16))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Expected receive SAPI for this layer.
+                "
+        ::= { jnxIfOtnTcmCfgEntry 9 }
+
+    jnxIfOtnTcmExpectedRxDapi OBJECT-TYPE
+        SYNTAX          OCTET STRING (SIZE(0..16))
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Expected receive DAPI for this layer.
+                "
+        ::= { jnxIfOtnTcmCfgEntry 10 }
+
+
+    jnxIfOtnTcmStatus OBJECT-TYPE
+        SYNTAX          BITS {
+                            ais(0),
+                            bdi(1),
+                            iae(2),
+                            ttim(3),
+                            biae(6),
+                            tsf(7),
+                            ssf(8),
+                            ltc(9)
+                        }
+
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                 The  status at the TCM layer.
+                "
+        ::= { jnxIfOtnTcmCfgEntry 11 }
+
+
+
+
+--
+-- ODUK Maintainenance/Test table
+--
+jnxIfOtnODUkTcmTestTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnODUkTcmTestEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the Otn ODUk Test function table. "
+        ::= { jnxIfOtn 5 }
+
+jnxIfOtnODUkTcmTestEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnODUkTcmTestEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains information about the
+                  Otn ODUk Test function.
+                 "
+        INDEX   { ifIndex, jnxIfOtnODUkTcmTestLayer,
+                  jnxIfOtnODUkTcmTestTCMLevel }
+        ::= { jnxIfOtnODUkTcmTestTable 1 }
+
+JnxIfOtnODUkTcmTestEntry ::=
+    SEQUENCE {
+            jnxIfOtnODUkTcmTestLayer
+                                  JnxIfOtnLayer,
+            jnxIfOtnODUkTcmTestTCMLevel
+                                  Integer32,
+            jnxIfOtnODUkTcmInsertAis
+                                  TruthValue,
+            jnxIfOtnODUkTcmInsertLck
+                                  TruthValue,
+            jnxIfOtnODUkTcmInsertOci
+                                  TruthValue,
+            jnxIfOtnODUkPayloadPRBS
+                                  TruthValue,
+            jnxIfOtnODUkPayloadPRBSResult 
+                                  OCTET STRING
+      }
+
+    jnxIfOtnODUkTcmTestLayer OBJECT-TYPE
+        SYNTAX          JnxIfOtnLayer
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    The layer OTU/ODU/TCM layer for the alarm
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 1 }
+
+    jnxIfOtnODUkTcmTestTCMLevel OBJECT-TYPE
+        SYNTAX          Integer32(0..6)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    For ODUk will be this will be 0
+                    If layer is TCM then this will give the TCM
+                    level 1..6.
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 2 }
+
+     jnxIfOtnODUkTcmInsertAis OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                    Insert ODU Ais into OTN stream.
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 3 }
+
+     jnxIfOtnODUkTcmInsertLck OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                    Insert ODU Lck into OTN stream.
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 4 }
+
+     jnxIfOtnODUkTcmInsertOci OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                    Insert ODU Oci into OTN stream.
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 5 }
+
+     jnxIfOtnODUkPayloadPRBS OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                    Insert Payload PRBS, For ODUK layer and TCM level is 0.
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 6 }
+
+     jnxIfOtnODUkPayloadPRBSResult OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                  Result of the Payload PRBS .
+                "
+        ::= { jnxIfOtnODUkTcmTestEntry 7 }
+
+--
+-- ODUK/TCM Delay Measurement Table
+--
+
+jnxIfOtnODUkTcmDMTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnODUkTcmDMEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Table for Otn ODUk/TCM  Delay Measurement config table. "
+        ::= { jnxIfOtn 6 }
+
+jnxIfOtnODUkTcmDMEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnODUkTcmDMEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains information about the
+                  Delay Measurement test table. 
+                 "
+        INDEX   { ifIndex, jnxIfOtnODUkTcmDMLayer,
+                  jnxIfOtnODUkTcmDMLevel
+                }
+        ::= { jnxIfOtnODUkTcmDMTable 1 }
+
+JnxIfOtnODUkTcmDMEntry ::=
+    SEQUENCE {
+        jnxIfOtnODUkTcmDMLayer
+                     Integer32,
+        jnxIfOtnODUkTcmDMLevel
+                     Integer32,
+        jnxIfOtnDMConnectionMonitoringEndpoint
+                     TruthValue,
+        jnxIfOtnDMBypass
+                     TruthValue,
+        jnxIfOtnDMPersistFrames
+                     Integer32,
+        jnxIfOtnDMEnable
+                     TruthValue
+    }
+
+    jnxIfOtnODUkTcmDMLayer OBJECT-TYPE
+        SYNTAX          JnxIfOtnLayer
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    The layer OTU/ODU/TCM layer for the alarm
+                "
+        ::= { jnxIfOtnODUkTcmDMEntry 1 }
+
+    jnxIfOtnODUkTcmDMLevel OBJECT-TYPE
+        SYNTAX          Integer32(0..6)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    For ODUk will be this will be 0
+                    If layer is TCM then this will give the TCM
+                    level 1..6.
+                "
+        ::= { jnxIfOtnODUkTcmDMEntry 2 }
+
+    jnxIfOtnDMConnectionMonitoringEndpoint OBJECT-TYPE
+        SYNTAX          TruthValue 
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   Originate Connection Monitoring Endpoint for the Delay 
+                   Measurement
+                "
+        ::= { jnxIfOtnODUkTcmDMEntry 3 }
+
+    jnxIfOtnDMBypass OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   Act as tandem, passing Dm value through node
+                "
+        ::= { jnxIfOtnODUkTcmDMEntry 4 }
+
+    jnxIfOtnDMPersistFrames OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Number of consequtive frames required to declare Dm Complete 
+                "
+        ::= { jnxIfOtnODUkTcmDMEntry 5 }
+
+    jnxIfOtnDMEnable OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                  Start/Stop the DM measurement 
+                "
+        ::= { jnxIfOtnODUkTcmDMEntry 6 }
+
+
+
+
+--
+-- Notification Trigger Table
+-- 
+
+jnxIfOtnNotificationTrigDefaultHoldtimeUp OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect to
+                   persist before it is declared an alarm.
+                "
+       ::= { jnxIfOtn 7 } 
+
+jnxIfOtnNotificationTrigDefaultHoldtimeDown OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect to
+                   absent before the alarm is cleared.
+                "
+       ::= { jnxIfOtn 8 }
+
+jnxIfOtnNotificationTrigTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxIfOtnNotificationTrigEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the otn Alarm/Alart/Info trigger table. "
+        ::= { jnxIfOtn 9 }
+
+jnxIfOtnNotificationTrigEntry OBJECT-TYPE
+        SYNTAX     JnxIfOtnNotificationTrigEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains information about the Otn
+                  Alarm Trigger Table.
+                 "
+        INDEX   { jnxIfOtnNotificationTrigContainerIndex,
+                  jnxIfOtnNotificationTrigL1Index,
+                  jnxIfOtnNotificationTrigL2Index,
+                  jnxIfOtnNotificationTrigL3Index,
+                  jnxIfOtnNotificationTrigLayer,
+                  jnxIfOtnNotificationTrigTCMLevel,
+                  jnxIfOtnNotificationTrigAlmId }
+        ::= { jnxIfOtnNotificationTrigTable 1 }
+
+JnxIfOtnNotificationTrigEntry ::=
+    SEQUENCE {
+            jnxIfOtnNotificationTrigContainerIndex
+                                Integer32,
+            jnxIfOtnNotificationTrigL1Index
+                                Integer32,
+            jnxIfOtnNotificationTrigL2Index       
+                                Integer32,
+            jnxIfOtnNotificationTrigL3Index       
+                                Integer32,
+            jnxIfOtnNotificationTrigLayer         
+                                JnxIfOtnLayer,
+            jnxIfOtnNotificationTrigTCMLevel      
+                                Integer32,
+            jnxIfOtnNotificationTrigAlmId           
+                                Integer32,
+            jnxIfOtnNotificationTrigSeverity       
+                                JnxIfOtnSeverity,
+            jnxIfOtnNotificationTrigIgnore         
+                                TruthValue,
+            jnxIfOtnNotificationTrigHoldtimeUp    
+                                Integer32,
+            jnxIfOtnNotificationTrigHoldtimeDown     
+                                Integer32,
+            jnxIfOtnTrigServiceStateAction       
+                                JnxIfOtnServiceStateAction
+    }
+
+    jnxIfOtnNotificationTrigContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The associated jnxContentsContainerIndex  - eg shelf."
+        ::= { jnxIfOtnNotificationTrigEntry 1 }
+
+    jnxIfOtnNotificationTrigL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level one index associated with this subject ... eg fpc
+                 slot."
+        ::= { jnxIfOtnNotificationTrigEntry 2 }
+
+    jnxIfOtnNotificationTrigL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this subject .. eg pic
+                 slot."
+        ::= { jnxIfOtnNotificationTrigEntry 3 }
+
+    jnxIfOtnNotificationTrigL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this subject..
+                 eg port.
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 4 }
+
+    jnxIfOtnNotificationTrigLayer OBJECT-TYPE
+        SYNTAX          JnxIfOtnLayer 
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    The layer OTU/ODU/TCM layer for the alarm
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 5 }
+
+    jnxIfOtnNotificationTrigTCMLevel OBJECT-TYPE
+        SYNTAX          Integer32(0..6)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    For OCh/OTUk/ODUk will be this will be 0
+                    If layer is TCM then this will give the TCM
+                    level 1..6. 
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 6 }
+
+    jnxIfOtnNotificationTrigAlmId OBJECT-TYPE
+        SYNTAX          Integer32(0..255) 
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                    This will be the ID of Alarm for that layer 
+                    'JnxoptIfOTNOChAlarms'/'JnxoptIfOTNODUkTcmAlarms'.
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 7 }
+
+    jnxIfOtnNotificationTrigSeverity OBJECT-TYPE
+        SYNTAX          JnxIfOtnSeverity
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                 This will be the Severity of the Notification for that layer.
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 8 }
+
+    jnxIfOtnNotificationTrigIgnore OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will ignore the alarm when set. 
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 9 }
+
+
+    jnxIfOtnNotificationTrigHoldtimeUp OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect to 
+                   persist before it is declared an alarm.
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 10 }
+
+    jnxIfOtnNotificationTrigHoldtimeDown OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect is
+                   absent before the alarm is cleared.
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 11 }
+
+    jnxIfOtnTrigServiceStateAction OBJECT-TYPE
+        SYNTAX          JnxIfOtnServiceStateAction
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                   This will indicate whether this alarm is service affecting
+                   or not .
+                "
+        ::= { jnxIfOtnNotificationTrigEntry 12 }
+
+
+
+-- Clear for all Performance monitoring counters on this interface
+--
+jnxOtnClearAllPMs OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+                " To clear all Performance monitoring counters on OTN
+                  interfaces "
+        ::= { jnxIfOtn  10 }
+
+jnxOtnClearInterfacePMs OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+                " To clear all Performance monitoring counters on this OTN
+                  interfaces "
+        INDEX       { ifIndex }
+        ::= { jnxIfOtn  11 }
+
+jnxOtnClearInterfaceCurrentPM OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+                " To clear the current Performance monitoring counters on 
+                  this OTN interfaces "
+        INDEX       { ifIndex }
+        ::= { jnxIfOtn  12 }
+
+
+-- Clear PM's for Interfaces
+jnxOtnClearIfPMsTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxOtnClearIfPMsEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                " To clear OTN Performance monitoring counters on this OTN
+                  interfaces "
+        INDEX       { ifIndex }
+        ::= { jnxIfOtn  13 }
+
+jnxOtnClearIfPMsEntry OBJECT-TYPE
+        SYNTAX     JnxOtnClearIfPMsEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that s used to clear the OTN PM Table."
+        INDEX   { ifIndex }
+        ::= { jnxOtnClearIfPMsTable 1 }
+
+JnxOtnClearIfPMsEntry ::=
+    SEQUENCE {
+            jnxOtnClearCurrent
+                             TruthValue,
+            jnxOtnClearInterfaceInterval
+                             TruthValue,
+            jnxOtnClearInterfaceDay
+                             TruthValue,
+            jnxOtnClearInterfaceAll
+                             TruthValue
+    }
+
+    jnxOtnClearCurrent OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1- to clear all the current OTN PM's for this interface
+               "
+        ::= { jnxOtnClearIfPMsEntry 1 }
+
+    jnxOtnClearInterfaceInterval OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1- to clear all the OTN PM's intervals(1-96) for this
+                 interface
+               "
+        ::= { jnxOtnClearIfPMsEntry 2 }
+
+    jnxOtnClearInterfaceDay OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1 - to clear all the Current Day and Previous Day OTN PM's
+                     for this interface
+               "
+        ::= { jnxOtnClearIfPMsEntry 3 }
+
+    jnxOtnClearInterfaceAll OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1 - to clear all the OTN PM's for this interface
+               "
+        ::= { jnxOtnClearIfPMsEntry 4 }
+
+
+
+--
+-- Configuration Management Notifications
+--
+
+jnxIfOtnNotificationPrefix   OBJECT IDENTIFIER ::= { jnxIfOtnNotifications 0 }
+
+jnxIfOtnNotificationAdminStatus NOTIFICATION-TYPE
+        OBJECTS {
+                  ifDescr,
+                  jnxIfOtnAdminState
+                }
+        STATUS  current
+        DESCRIPTION
+                "Notification of the admin state of the otn interface."
+        ::= { jnxIfOtnNotificationPrefix 1 }
+
+jnxIfOtnNotificationOperStatus NOTIFICATION-TYPE
+        OBJECTS {
+                  ifDescr,
+                  jnxIfOtnOperState
+                }
+        STATUS  current
+        DESCRIPTION
+                "Notification of operational state of the otn interface"
+        ::= { jnxIfOtnNotificationPrefix 2 }
+
+END

--- a/mibs/junos/mib-jnx-ipforward.txt
+++ b/mibs/junos/mib-jnx-ipforward.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: ipForward
 -- 
--- Copyright (c) 2006, Juniper Networks, Inc.
+-- Copyright (c) 2006-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -16,11 +16,13 @@ IMPORTS
 	FROM SNMP-FRAMEWORK-MIB      -- RFC2571 
     ipCidrRouteEntry
 	FROM IP-FORWARD-MIB          -- RFC2096
+    inetCidrRouteEntry
+        FROM IP-FORWARD-MIB          -- RFC4292
     jnxMibs
         FROM JUNIPER-SMI;
 
 jnxIpForwardMIB MODULE-IDENTITY
-    LAST-UPDATED "200608210000Z" -- Aug 21 00:00:00 2006 UTC
+    LAST-UPDATED "201111130000Z" -- Nov 13 00:00:00 2011 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -35,9 +37,9 @@ jnxIpForwardMIB MODULE-IDENTITY
 	     has directly related entries in mib-2,  ipForward MIB."
 
     -- revision history
-    REVISION "200505010000Z" -- May 1 00:00:00 2005 UTC
+    REVISION "201111130000Z" -- Nov 13 00:00:00 2011 UTC
     DESCRIPTION
-            "Initial implementation."
+            "jnxInetCidrRouteTunnelName deprecates jnxIpCidrRouteTunnelName."
     ::= { jnxMibs 38 }
 
 
@@ -49,7 +51,7 @@ jnxIpForwardMIB MODULE-IDENTITY
 jnxIpCidrRouteTable OBJECT-TYPE
     SYNTAX      SEQUENCE OF JnxIpCidrRouteEntry
     MAX-ACCESS  not-accessible
-    STATUS      current
+    STATUS      deprecated
     DESCRIPTION
         "Augments the ipCidrRouteTable with additional data."
    ::= { jnxIpForwardMIB 1 }
@@ -57,7 +59,7 @@ jnxIpCidrRouteTable OBJECT-TYPE
 jnxIpCidrRouteEntry OBJECT-TYPE
     SYNTAX      JnxIpCidrRouteEntry
     MAX-ACCESS  not-accessible
-    STATUS      current
+    STATUS      deprecated
     DESCRIPTION
         "Each entry provides additional CIDR forwarding information."
     AUGMENTS { ipCidrRouteEntry }
@@ -72,12 +74,45 @@ jnxIpCidrRouteTunnelName OBJECT-TYPE
      SYNTAX        SnmpAdminString
      -- MAX-ACCESS    read-create
      MAX-ACCESS    read-only
-     STATUS        current
+     STATUS        deprecated
      DESCRIPTION
            "The canonical name assigned to the tunnel. The router
 	    will forward traffic bound for the destination defined
 	    by the INDEX through this tunnel." 
       DEFVAL {""}
       ::= { jnxIpCidrRouteEntry 1 }
+
+jnxInetCidrRouteTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxInetCidrRouteEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Augments the inetCidrRouteTable with additional data."
+   ::= { jnxIpForwardMIB 2 }
+
+jnxInetCidrRouteEntry OBJECT-TYPE
+    SYNTAX      JnxInetCidrRouteEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry provides additional CIDR forwarding information."
+    AUGMENTS { inetCidrRouteEntry }
+    ::= { jnxInetCidrRouteTable 1 }
+
+JnxInetCidrRouteEntry ::=
+    SEQUENCE {
+        jnxInetCidrRouteTunnelName        SnmpAdminString
+     }
+
+jnxInetCidrRouteTunnelName OBJECT-TYPE
+     SYNTAX        SnmpAdminString
+     MAX-ACCESS    read-only
+     STATUS        current
+     DESCRIPTION
+           "The canonical name assigned to the tunnel. The router
+            will forward traffic bound for the destination defined
+            by the INDEX through this tunnel."
+      DEFVAL {""}
+      ::= { jnxInetCidrRouteEntry 1 }
 
 END

--- a/mibs/junos/mib-jnx-ipsec-flow-mon.txt
+++ b/mibs/junos/mib-jnx-ipsec-flow-mon.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper Networks IPSEC Generic Flow Monitoring object mibs 
 --
--- Copyright (c) 2001-2007, Juniper Networks, Inc.
+-- Copyright (c) 2001-2011, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -99,7 +99,8 @@ JUNIPER-IPSEC-FLOW-MON-MIB DEFINITIONS ::= BEGIN
             "The hash algorithm used in IPsec Phase-1 IKE negotiations."
          SYNTAX INTEGER {
                    md5(1),
-                   sha(2)
+                   sha(2),
+                   sha256(3)
          }
 
     JnxIkeAuthMethod ::= TEXTUAL-CONVENTION
@@ -196,7 +197,9 @@ JUNIPER-IPSEC-FLOW-MON-MIB DEFINITIONS ::= BEGIN
          SYNTAX INTEGER{
                    unknown            (0),
                    hmacMd5            (1),
-                   hmacSha            (2)
+                   hmacSha            (2),
+                   hmacSha256         (3)
+
          }
 
     JnxRemotePeerType  ::= TEXTUAL-CONVENTION
@@ -586,10 +589,10 @@ JUNIPER-IPSEC-FLOW-MON-MIB DEFINITIONS ::= BEGIN
          SYNTAX         Counter32
          UNITS          "Packets"
          MAX-ACCESS     read-only
-         STATUS         current
+         STATUS         obsolete 
          DESCRIPTION
             "The number of times that the remote peer is detected 
-             in a dead (or down) state."   
+             in a dead (or down) state. This attribute is obsolete"   
          ::= { jnxIkeTunnelMonEntry 27 }
 
 
@@ -664,7 +667,7 @@ JUNIPER-IPSEC-FLOW-MON-MIB DEFINITIONS ::= BEGIN
          jnxIpSecTunMonDecryptFails         Counter64,
          jnxIpSecTunMonBadHeaders           Counter64,
          jnxIpSecTunMonBadTrailers          Counter64,
-         jnxIpSecTunMonDroppedPkts          Counter64        
+         jnxIpSecTunMonDroppedPkts          Counter64   -- obsolete        
       }											
 
       jnxIpSecTunMonRemoteGwAddrType OBJECT-TYPE
@@ -889,9 +892,10 @@ JUNIPER-IPSEC-FLOW-MON-MIB DEFINITIONS ::= BEGIN
       jnxIpSecTunMonDroppedPkts  OBJECT-TYPE
          SYNTAX         Counter64
          MAX-ACCESS 	read-only 
-         STATUS         current 
+         STATUS         obsolete
          DESCRIPTION
-            "Total number of dropped packets for this Phase-2 tunnel."
+            "Total number of dropped packets for this Phase-2 tunnel. 
+             This attribute is obsolete."
          ::= { jnxIpSecTunnelMonEntry 26 }
 
 
@@ -1069,7 +1073,7 @@ JUNIPER-IPSEC-FLOW-MON-MIB DEFINITIONS ::= BEGIN
          STATUS     current
          DESCRIPTION
             "The algorithm used for authentication of packets which
-			 can be hmac-md5-96 or hmac-sha1-96"
+			 can be hmac-md5-96 or hmac-sha1-96 or hmac-sha-256-128"
          ::= { jnxIpSecSaMonEntry 13 }
 
       jnxIpSecSaMonState OBJECT-TYPE

--- a/mibs/junos/mib-jnx-ipsec-monitor-asp.txt
+++ b/mibs/junos/mib-jnx-ipsec-monitor-asp.txt
@@ -12,7 +12,7 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
         jnxSpSvcSetName 
            FROM JUNIPER-SP-MIB;
       jnxIpSecMonitorMIB MODULE-IDENTITY
-         LAST-UPDATED "200508312153Z" --  2005 UTC      
+         LAST-UPDATED "201202102100Z" --  2012 UTC      
          ORGANIZATION "Juniper Networks, Inc."
          CONTACT-INFO
                 "Juniper Technical Assistance Center
@@ -21,7 +21,7 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
                       Sunnyvale, CA 94089
                       E-mail: support@juniper.net"
 	     DESCRIPTION " "
-         REVISION "200508312153Z"
+         REVISION "201202102100Z"
          DESCRIPTION
                    "Initial version implements only the following
                     tables:
@@ -57,7 +57,8 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
             "The IPsec Phase-1 IKE negotiation mode."
          SYNTAX INTEGER {
                    main(1),
-                   aggressive(2)
+                   aggressive(2),
+                   ikev2(3)
          }
 
       JnxIkeHashAlgo   ::= TEXTUAL-CONVENTION
@@ -67,7 +68,9 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
             IKE negotiations."
          SYNTAX INTEGER {
                    md5(1),
-                   sha(2)
+                   sha(2),
+                   sha256(3),
+                   sha384(4)
          }
 
       JnxIkeAuthMethod ::= TEXTUAL-CONVENTION
@@ -109,11 +112,19 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
             "The Diffie Hellman Group used in negotiations.
                    modp768        -- 768-bit MODP
                    modp1024       -- 1024-bit MODP
+                   modp1536       -- 1536-bit MODP
+                   modp2048       -- 2048-bit MODP
+                   ec-modp256     -- 256-bit EC-MODP
+                   ec-modp384     -- 384-bit EC-MODP
             "
          SYNTAX INTEGER {
                    unknown(0),
                    modp768(1),
-                   modp1024(2)
+                   modp1024(2),
+                   modp1536(5),
+                   modp2048(14),
+                   ecmodp256(19),
+                   ecmodp384(20)
          }
 
       JnxKeyType    ::= TEXTUAL-CONVENTION
@@ -144,7 +155,10 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
          SYNTAX INTEGER {
                    espDes(1),
                    esp3des(2),
-                   espNull(3)
+                   espNull(3),
+                   espAes128 (4),  
+                   espAes192 (5),
+                   espAes256 (6)
          }
 
       JnxSpi  ::= TEXTUAL-CONVENTION
@@ -163,7 +177,8 @@ JNX-IPSEC-MONITOR-MIB DEFINITIONS ::= BEGIN
          SYNTAX INTEGER{
                    unknown(0),
                    hmacMd5(2),
-                   hmacSha(3)
+                   hmacSha(3),
+                   hmacSha256(4)
          }
 
       JnxRemotePeerType  ::= TEXTUAL-CONVENTION

--- a/mibs/junos/mib-jnx-ipv6.txt
+++ b/mibs/junos/mib-jnx-ipv6.txt
@@ -2,7 +2,7 @@
 -- $Id: jnx-ipv6.mib,v 1.3 2003-07-18 22:57:37 dchuang Exp $
 -- Juniper Enterprise Specific MIB: ipv6 MIB Extension
 -- 
--- Copyright (c) 2001-2003, Juniper Networks, Inc.
+-- Copyright (c) 2001-2011, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -13,6 +13,8 @@ JUNIPER-IPv6-MIB DEFINITIONS ::= BEGIN
 IMPORTS
     MODULE-IDENTITY, OBJECT-TYPE, Counter64
         FROM SNMPv2-SMI
+   ipv6IfEntry 
+        FROM IPV6-MIB
     jnxMibs
         FROM JUNIPER-SMI;
 
@@ -42,6 +44,7 @@ jnxIpv6 MODULE-IDENTITY
 jnxIpv6Stats         OBJECT IDENTIFIER ::= { jnxIpv6 1 }
 jnxIpv6GlobalStats   OBJECT IDENTIFIER ::= { jnxIpv6Stats 1 }
 jnxIcmpv6GlobalStats OBJECT IDENTIFIER ::= { jnxIpv6Stats 2 }
+jnxIpv6IfStats       OBJECT IDENTIFIER ::= { jnxIpv6Stats 3 }
 
 --
 -- Ipv6 Global Stats
@@ -944,5 +947,46 @@ jnxIcmpv6GlobalStats OBJECT IDENTIFIER ::= { jnxIpv6Stats 2 }
          DESCRIPTION
             "The total number of Node Information Report messages transmitted."
          ::= { jnxIcmpv6GlobalStats 56 }
+
+    jnxIpv6IfStatsTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxIpv6IfStatsEntry 
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "The (conceptual) table containing 
+                 IPv6 statistics of an interface"
+        ::= { jnxIpv6IfStats 1 }
+
+    jnxIpv6IfStatsEntry OBJECT-TYPE
+        SYNTAX      JnxIpv6IfStatsEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "An entry (conceptual row) containing 
+                 IPv6 statistics entry of an interface"
+        AUGMENTS      { ipv6IfEntry }
+        ::= { jnxIpv6IfStatsTable 1 }
+
+    JnxIpv6IfStatsEntry ::= SEQUENCE {
+            jnxIpv6IfInOctets   Counter64,
+            jnxIpv6IfOutOctets  Counter64
+        }
+
+    jnxIpv6IfInOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "The total number of octets received on the interface"
+        ::= { jnxIpv6IfStatsEntry 1 }
+
+    jnxIpv6IfOutOctets OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "The total number of octets transmitted out of the
+                 interface"
+        ::= { jnxIpv6IfStatsEntry 2 }
 
 END

--- a/mibs/junos/mib-jnx-jdhcp.txt
+++ b/mibs/junos/mib-jnx-jdhcp.txt
@@ -1,0 +1,1635 @@
+-- *******************************************************************
+-- Juniper enterprise specific DHCP MIB.
+--
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- *******************************************************************
+
+JUNIPER-JDHCP-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, IpAddress, 
+    Counter32, NOTIFICATION-TYPE, Unsigned32
+        FROM SNMPv2-SMI
+    ifIndex,InterfaceIndex
+        FROM IF-MIB
+    TEXTUAL-CONVENTION, DisplayString, DateAndTime, MacAddress
+        FROM SNMPv2-TC 
+    jnxJdhcpMibRoot
+        FROM JUNIPER-SMI;
+
+jnxJdhcpMIB  MODULE-IDENTITY
+    LAST-UPDATED "201107090000Z" --  July 9, 2011
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+    DESCRIPTION
+        "The JUNOS DHCP MIB for the Juniper Networks enterprise."
+
+    -- revision history
+    REVISION      "201107090000Z"
+    DESCRIPTION   "Add scalar for pkts dropped due to recovery in progress"
+    REVISION      "201103150000Z"
+    DESCRIPTION   "Add OIDs to the Interface Statistics Table"
+    REVISION      "201101250000Z"
+    DESCRIPTION   "Add Interface Statistics Table"
+    REVISION      "201004190000Z"
+    DESCRIPTION   "Creation Date"
+    ::= { jnxJdhcpMibRoot 61 }
+    
+
+-- Managed object groups
+jnxJdhcpLocalServerObjects   OBJECT IDENTIFIER ::= { jnxJdhcpMIB 1 }
+jnxJdhcpRelayObjects         OBJECT IDENTIFIER ::= { jnxJdhcpMIB 2 }
+
+-- Managed objects for DHCP Local Server
+jnxJdhcpLocalServerStatistics OBJECT IDENTIFIER
+    ::= { jnxJdhcpLocalServerObjects 1 }
+jnxJdhcpLocalServerBindings   OBJECT IDENTIFIER
+    ::= { jnxJdhcpLocalServerObjects 2 }
+jnxJdhcpLocalServerTraps    OBJECT IDENTIFIER
+    ::= { jnxJdhcpLocalServerObjects 3 }
+jnxJdhcpLocalServerTrapVars   OBJECT IDENTIFIER 
+    ::= { jnxJdhcpLocalServerObjects 4 }
+jnxJdhcpLocalServerIfcStats   OBJECT IDENTIFIER
+    ::= { jnxJdhcpLocalServerObjects 5 }
+
+-- DHCP Local Server Statistics
+jnxJdhcpLocalServerTotalDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped."
+    ::= { jnxJdhcpLocalServerStatistics 1}
+
+jnxJdhcpLocalServerBadHardwareDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped due to bad hardware address."
+    ::= { jnxJdhcpLocalServerStatistics 2}
+
+jnxJdhcpLocalServerBadBootpOpcodeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to not BOOTP message."
+    ::= { jnxJdhcpLocalServerStatistics 3}
+
+jnxJdhcpLocalServerBadOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad options in the packet."
+    ::= { jnxJdhcpLocalServerStatistics 4}
+
+jnxJdhcpLocalServerBadAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to invalid server address."
+    ::= { jnxJdhcpLocalServerStatistics 5}
+
+jnxJdhcpLocalServerNoAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no available addresses."
+    ::= { jnxJdhcpLocalServerStatistics 6}
+
+jnxJdhcpLocalServerNoInterfaceDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no interface match."
+    ::= { jnxJdhcpLocalServerStatistics 7}
+
+jnxJdhcpLocalServerNoRoutingInstanceDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no routing instance match."
+    ::= { jnxJdhcpLocalServerStatistics 8}
+
+jnxJdhcpLocalServerNoLocalAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no valid local address."
+    ::= {  jnxJdhcpLocalServerStatistics 9}
+
+jnxJdhcpLocalServerShortPacketDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to packet too short."
+    ::= { jnxJdhcpLocalServerStatistics 10}
+
+jnxJdhcpLocalServerBadReadDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to send error."
+    ::= { jnxJdhcpLocalServerStatistics 11}
+
+jnxJdhcpLocalServerBadSendDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to send error."
+    ::= { jnxJdhcpLocalServerStatistics 12}
+
+jnxJdhcpLocalServerAuthenticationDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to authentication failure."
+    ::= { jnxJdhcpLocalServerStatistics 13}
+
+jnxJdhcpLocalServerDynamicProfileDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to dynamic profile error."
+    ::= { jnxJdhcpLocalServerStatistics 14}
+
+jnxJdhcpLocalServerLicenseDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to license error."
+    ::= { jnxJdhcpLocalServerStatistics 15}
+
+jnxJdhcpLocalServerBootRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Boot Request packets received."
+    ::= { jnxJdhcpLocalServerStatistics 16}
+
+jnxJdhcpLocalServerDhcpDeclineReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Decline packets received."
+    ::= { jnxJdhcpLocalServerStatistics 17}
+
+jnxJdhcpLocalServerDhcpDiscoverReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Discover packets received."
+    ::= { jnxJdhcpLocalServerStatistics 18}
+
+jnxJdhcpLocalServerDhcpInformReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP inform packets received."
+    ::= { jnxJdhcpLocalServerStatistics 19}
+
+jnxJdhcpLocalServerDhcpReleaseReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP release packets received."
+    ::= { jnxJdhcpLocalServerStatistics 20}
+
+jnxJdhcpLocalServerDhcpRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP request packets received."
+    ::= { jnxJdhcpLocalServerStatistics 21}
+
+jnxJdhcpLocalServerDhcpBootReplySent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Boot Reply packets sent."
+    ::= { jnxJdhcpLocalServerStatistics 22}
+
+jnxJdhcpLocalServerDhcpOfferSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Offer packets sent."
+    ::= { jnxJdhcpLocalServerStatistics 23}
+
+jnxJdhcpLocalServerDhcpAckSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Ack packets sent."
+    ::= { jnxJdhcpLocalServerStatistics 24}
+
+jnxJdhcpLocalServerDhcpNakSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Nak packets sent."
+    ::= { jnxJdhcpLocalServerStatistics 25}
+
+jnxJdhcpLocalServerForceRenewSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Force Renew packets sent."
+    ::= { jnxJdhcpLocalServerStatistics 26}
+
+jnxJdhcpLocalServerTotalLeaseCount OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Bound DHCP Clients."
+    ::= { jnxJdhcpLocalServerStatistics 27}
+
+jnxJdhcpLocalServerSwitchDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to switchover recovery in progress."
+    ::= { jnxJdhcpLocalServerStatistics 28}
+
+
+-- DHCP Local Server Bindings Table
+
+jnxJdhcpLocalServerBindingsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJdhcpLocalServerBindingsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of address bindings maintained by this JUNOS DHCP Local Server."
+    ::= { jnxJdhcpLocalServerBindings 1 }
+
+jnxJdhcpLocalServerBindingsEntry OBJECT-TYPE
+    SYNTAX      JnxJdhcpLocalServerBindingsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry (conceptual row) representing an address binding (client) maintained by
+        this JUNOS DHCP Local Server."
+    INDEX     { jnxJdhcpLocalServerBindingsIpAddress }
+    ::= { jnxJdhcpLocalServerBindingsTable 1 }
+
+JnxJdhcpLocalServerBindingsEntry ::= SEQUENCE {
+    jnxJdhcpLocalServerBindingsIpAddress                    IpAddress,
+    jnxJdhcpLocalServerBindingsMacAddress                   MacAddress,
+    jnxJdhcpLocalServerBindingsState                        INTEGER,
+    jnxJdhcpLocalServerBindingsLeaseEndTime                 DateAndTime,
+    jnxJdhcpLocalServerBindingsLeaseExpireTime              Unsigned32,
+    jnxJdhcpLocalServerBindingsLeaseStartTime               DateAndTime,
+    jnxJdhcpLocalServerBindingsIncomingClientInterface      DisplayString,
+    jnxJdhcpLocalServerBindingsClientInterfaceVlanId        Unsigned32,
+    jnxJdhcpLocalServerBindingsDemuxInterfaceName           DisplayString,
+    jnxJdhcpLocalServerBindingsServerIpAddress              IpAddress,
+    jnxJdhcpLocalServerBindingsBootpRelayAddress            IpAddress,
+    jnxJdhcpLocalServerBindingsPreviousBootpRelayAddress    IpAddress,
+    jnxJdhcpLocalServerBindingsClientPoolName               DisplayString,
+    jnxJdhcpLocalServerBindingsClientProfileName            DisplayString
+    }
+
+jnxJdhcpLocalServerBindingsIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with this entry in the bindings table."
+    ::= { jnxJdhcpLocalServerBindingsEntry 1 }
+
+jnxJdhcpLocalServerBindingsMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The MAC Address associated with this entry in the bindings
+        table and corresponding to the IP Address denoted by the table index."
+    ::= { jnxJdhcpLocalServerBindingsEntry 2 }
+
+jnxJdhcpLocalServerBindingsState OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    init(1),
+                    selecting(2),
+                    requesting(3),
+                    release(4),
+                    bound(5),
+                    renewing(6),
+                    rebinding(7)  }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The state associated with this entry in the bindings table."
+    ::= { jnxJdhcpLocalServerBindingsEntry 3 }
+
+jnxJdhcpLocalServerBindingsLeaseEndTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time the lease expires on this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 4 }
+
+jnxJdhcpLocalServerBindingsLeaseExpireTime OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time remaining until the lease expires for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 5 }
+
+jnxJdhcpLocalServerBindingsLeaseStartTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time the lease was started for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 6 }
+
+jnxJdhcpLocalServerBindingsIncomingClientInterface OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The incoming interface for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 7 }
+
+jnxJdhcpLocalServerBindingsClientInterfaceVlanId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The VLAN ID for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 8 }
+
+jnxJdhcpLocalServerBindingsDemuxInterfaceName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The demux interface for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 9 }
+
+jnxJdhcpLocalServerBindingsServerIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpLocalServerBindingsEntry 10 }
+
+jnxJdhcpLocalServerBindingsBootpRelayAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The BOOTP relay Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpLocalServerBindingsEntry 11 }
+
+jnxJdhcpLocalServerBindingsPreviousBootpRelayAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Previous BOOTP relay Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpLocalServerBindingsEntry 12 }
+
+jnxJdhcpLocalServerBindingsClientPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The client pool name for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 13 }
+
+jnxJdhcpLocalServerBindingsClientProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The client pool name for this binding."
+    ::= { jnxJdhcpLocalServerBindingsEntry 14 }
+
+-- DHCP Local Server Interface Statistics Table
+
+jnxJdhcpLocalServerIfcStatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJdhcpLocalServerIfcStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of interface statistics maintained by this JUNOS DHCP Local Server."
+    ::= { jnxJdhcpLocalServerIfcStats 1 }
+
+jnxJdhcpLocalServerIfcStatsEntry OBJECT-TYPE
+    SYNTAX      JnxJdhcpLocalServerIfcStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry (conceptual row) representing an address binding (client) maintained by
+        this JUNOS DHCP Local Server."
+    INDEX     { jnxJdhcpLocalServerIfcStatsIfIndex }
+    ::= { jnxJdhcpLocalServerIfcStatsTable 1 }
+
+JnxJdhcpLocalServerIfcStatsEntry ::= SEQUENCE {
+    jnxJdhcpLocalServerIfcStatsIfIndex                     InterfaceIndex,
+    jnxJdhcpLocalServerIfcStatsTotalDropped                Counter32,
+    jnxJdhcpLocalServerIfcStatsBadHardwareDropped          Counter32,
+    jnxJdhcpLocalServerIfcStatsBadBootpOpcodeDropped       Counter32,
+    jnxJdhcpLocalServerIfcStatsBadOptionsDropped           Counter32,
+    jnxJdhcpLocalServerIfcStatsBadAddressDropped           Counter32,
+    jnxJdhcpLocalServerIfcStatsNoAddressDropped            Counter32,
+    jnxJdhcpLocalServerIfcStatsNoInterfaceCfgDropped       Counter32,
+    jnxJdhcpLocalServerIfcStatsNoLocalAddressDropped       Counter32,
+    jnxJdhcpLocalServerIfcStatsShortPacketDropped          Counter32,
+    jnxJdhcpLocalServerIfcStatsBadSendDropped              Counter32,
+    jnxJdhcpLocalServerIfcStatsAuthenticationDropped       Counter32,
+    jnxJdhcpLocalServerIfcStatsDynamicProfileDropped       Counter32,
+    jnxJdhcpLocalServerIfcStatsLicenseDropped              Counter32,
+    jnxJdhcpLocalServerIfcStatsBootRequestReceived         Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpDeclineReceived         Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpDiscoverReceived        Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpInformReceived          Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpReleaseReceived         Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpRequestReceived         Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpBootReplySent           Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpOfferSent               Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpAckSent                 Counter32,
+    jnxJdhcpLocalServerIfcStatsDhcpNakSent                 Counter32,
+    jnxJdhcpLocalServerIfcStatsForceRenewSent              Counter32,
+    jnxJdhcpLocalServerIfcStatsTotalLeaseCount             Counter32,
+    jnxJdhcpLocalServerIfcStatsBadDhcpOpcodeDropped        Counter32,
+    jnxJdhcpLocalServerIfcStatsNoOptionsDropped            Counter32,
+    jnxJdhcpLocalServerIfcStatsHopLimitDropped             Counter32,
+    jnxJdhcpLocalServerIfcStatsTtlExpiredDropped           Counter32,
+    jnxJdhcpLocalServerIfcStatsBadUdpCksumDropped          Counter32,
+    jnxJdhcpLocalServerIfcStatsOption60Dropped             Counter32
+    }
+
+-- According to IF-MIB.txt and interface index is an Integer 32 (1 - 2147483647) 
+-- This will correlate with an IFL in DHCP
+
+jnxJdhcpLocalServerIfcStatsIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of the interface for which this entry
+            contains information."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 1}
+
+jnxJdhcpLocalServerIfcStatsTotalDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 2}
+
+jnxJdhcpLocalServerIfcStatsBadHardwareDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped due to bad hardware address."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 3}
+
+jnxJdhcpLocalServerIfcStatsBadBootpOpcodeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to not BOOTP message."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 4}
+
+jnxJdhcpLocalServerIfcStatsBadOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad options in the packet."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 5}
+
+jnxJdhcpLocalServerIfcStatsBadAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to invalid server address."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 6}
+
+jnxJdhcpLocalServerIfcStatsNoAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no available addresses."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 7}
+
+jnxJdhcpLocalServerIfcStatsNoInterfaceCfgDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no interface match."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 8}
+
+jnxJdhcpLocalServerIfcStatsNoLocalAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no valid local address."
+    ::= {  jnxJdhcpLocalServerIfcStatsEntry 9}
+
+jnxJdhcpLocalServerIfcStatsShortPacketDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to packet too short."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 10}
+
+jnxJdhcpLocalServerIfcStatsBadSendDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to send error."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 11}
+
+jnxJdhcpLocalServerIfcStatsAuthenticationDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to authentication failure."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 12}
+
+jnxJdhcpLocalServerIfcStatsDynamicProfileDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to dynamic profile error."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 13}
+
+jnxJdhcpLocalServerIfcStatsLicenseDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to license error."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 14}
+
+jnxJdhcpLocalServerIfcStatsBootRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Boot Request packets received."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 15}
+
+jnxJdhcpLocalServerIfcStatsDhcpDeclineReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Decline packets received."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 16}
+
+jnxJdhcpLocalServerIfcStatsDhcpDiscoverReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Discover packets received."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 17}
+
+jnxJdhcpLocalServerIfcStatsDhcpInformReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP inform packets received."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 18}
+
+jnxJdhcpLocalServerIfcStatsDhcpReleaseReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP release packets received."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 19}
+
+jnxJdhcpLocalServerIfcStatsDhcpRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP request packets received."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 20}
+
+jnxJdhcpLocalServerIfcStatsDhcpBootReplySent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Boot Reply packets sent."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 21}
+
+jnxJdhcpLocalServerIfcStatsDhcpOfferSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Offer packets sent."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 22}
+
+jnxJdhcpLocalServerIfcStatsDhcpAckSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Ack packets sent."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 23}
+
+jnxJdhcpLocalServerIfcStatsDhcpNakSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Nak packets sent."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 24}
+
+jnxJdhcpLocalServerIfcStatsForceRenewSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Force Renew packets sent."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 25}
+
+jnxJdhcpLocalServerIfcStatsTotalLeaseCount OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Bound DHCP Clients."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 26}
+
+jnxJdhcpLocalServerIfcStatsBadDhcpOpcodeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped with bad DHCP opcode."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 27}
+
+jnxJdhcpLocalServerIfcStatsNoOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped with no options."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 28}
+
+jnxJdhcpLocalServerIfcStatsHopLimitDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to hop limit violation."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 29}
+
+jnxJdhcpLocalServerIfcStatsTtlExpiredDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to ttl expiration."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 30}
+
+jnxJdhcpLocalServerIfcStatsBadUdpCksumDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad UDP checksum."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 31}
+
+jnxJdhcpLocalServerIfcStatsOption60Dropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad option 60."
+    ::= { jnxJdhcpLocalServerIfcStatsEntry 32}
+
+
+-- Managed objects for DHCP Relay
+jnxJdhcpRelayStatistics OBJECT IDENTIFIER
+    ::= { jnxJdhcpRelayObjects 1 }
+jnxJdhcpRelayBindings   OBJECT IDENTIFIER
+    ::= { jnxJdhcpRelayObjects 2 }
+jnxJdhcpRelayTraps    OBJECT IDENTIFIER
+    ::= { jnxJdhcpRelayObjects 3 }
+jnxJdhcpRelayTrapVars   OBJECT IDENTIFIER 
+    ::= { jnxJdhcpRelayObjects 4 }
+jnxJdhcpRelayIfcStats   OBJECT IDENTIFIER
+    ::= { jnxJdhcpRelayObjects 5 }
+
+-- DHCP RelayStatistics
+jnxJdhcpRelayTotalDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped."
+    ::= { jnxJdhcpRelayStatistics 1}
+
+jnxJdhcpRelayBadHardwareDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped due to bad hardware address."
+    ::= { jnxJdhcpRelayStatistics 2}
+
+jnxJdhcpRelayBadBootpOpcodeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to not BOOTP message."
+    ::= { jnxJdhcpRelayStatistics 3}
+
+jnxJdhcpRelayBadOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad options in the packet."
+    ::= { jnxJdhcpRelayStatistics 4}
+
+jnxJdhcpRelayBadAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to invalid server address."
+    ::= { jnxJdhcpRelayStatistics 5}
+
+jnxJdhcpRelayNoAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no available addresses."
+    ::= { jnxJdhcpRelayStatistics 6}
+
+jnxJdhcpRelayNoInterfaceDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no interface match."
+    ::= { jnxJdhcpRelayStatistics 7}
+
+jnxJdhcpRelayNoRoutingInstanceDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no routing instance match."
+    ::= { jnxJdhcpRelayStatistics 8}
+
+jnxJdhcpRelayNoLocalAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no valid local address."
+    ::= {  jnxJdhcpRelayStatistics 9}
+
+jnxJdhcpRelayShortPacketDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to packet too short."
+    ::= { jnxJdhcpRelayStatistics 10}
+
+jnxJdhcpRelayBadReadDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to read error."
+    ::= { jnxJdhcpRelayStatistics 11}
+
+jnxJdhcpRelayBadSendDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to send error."
+    ::= { jnxJdhcpRelayStatistics 12}
+
+jnxJdhcpRelayOption82Dropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to failure to add Option 82."
+    ::= { jnxJdhcpRelayStatistics 13}
+
+jnxJdhcpRelayOption60Dropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to configure to drop."
+    ::= { jnxJdhcpRelayStatistics 14}
+
+jnxJdhcpRelayAuthenticationDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to authentication failure."
+    ::= { jnxJdhcpRelayStatistics 15}
+
+jnxJdhcpRelayDynamicProfileDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to dynamic profile error."
+    ::= { jnxJdhcpRelayStatistics 16}
+
+jnxJdhcpRelayLicenseDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to license error."
+    ::= { jnxJdhcpRelayStatistics 17}
+
+jnxJdhcpRelayBootRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Boot Request packets received."
+    ::= { jnxJdhcpRelayStatistics 18}
+
+jnxJdhcpRelayDhcpDeclineReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Decline packets received."
+    ::= { jnxJdhcpRelayStatistics 19}
+
+jnxJdhcpRelayDhcpDiscoverReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Discover packets received."
+    ::= { jnxJdhcpRelayStatistics 20}
+
+jnxJdhcpRelayDhcpInformReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP inform packets received."
+    ::= { jnxJdhcpRelayStatistics 21}
+
+jnxJdhcpRelayDhcpReleaseReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP release packets received."
+    ::= { jnxJdhcpRelayStatistics 22}
+
+jnxJdhcpRelayDhcpRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP request packets received."
+    ::= { jnxJdhcpRelayStatistics 23}
+
+jnxJdhcpRelayDhcpBootReplySent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Boot Reply packets sent."
+    ::= { jnxJdhcpRelayStatistics 24}
+
+jnxJdhcpRelayDhcpOfferSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Offer packets sent."
+    ::= { jnxJdhcpRelayStatistics 25}
+
+jnxJdhcpRelayDhcpAckSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Ack packets sent."
+    ::= { jnxJdhcpRelayStatistics 26}
+
+jnxJdhcpRelayDhcpNakSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Nak packets sent."
+    ::= { jnxJdhcpRelayStatistics 27}
+
+jnxJdhcpRelayForceRenewSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Force Renew packets sent."
+    ::= { jnxJdhcpRelayStatistics 28}
+
+jnxJdhcpRelayTotalLeaseCount OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Bound DHCP Clients."
+    ::= { jnxJdhcpRelayStatistics 29}
+
+jnxJdhcpRelaySwitchDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to switchover recovery in progress."
+    ::= { jnxJdhcpRelayStatistics 30}
+
+-- DHCP Relay Bindings Table
+
+jnxJdhcpRelayBindingsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJdhcpRelayBindingsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of address bindings maintained by this JUNOS DHCP Relay."
+    ::= { jnxJdhcpRelayBindings 1 }
+
+jnxJdhcpRelayBindingsEntry OBJECT-TYPE
+    SYNTAX      JnxJdhcpRelayBindingsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry (conceptual row) representing an address binding (client) maintained by
+        this JUNOS DHCP Relay."
+    INDEX     { jnxJdhcpRelayBindingsIpAddress }
+    ::= { jnxJdhcpRelayBindingsTable 1 }
+
+JnxJdhcpRelayBindingsEntry ::= SEQUENCE {
+    jnxJdhcpRelayBindingsIpAddress                    IpAddress,
+    jnxJdhcpRelayBindingsLeaseState                   INTEGER,
+    jnxJdhcpRelayBindingsLeaseEndTime                 DateAndTime,
+    jnxJdhcpRelayBindingsLeaseExpireTime              Unsigned32,
+    jnxJdhcpRelayBindingsLeaseStartTime               DateAndTime,
+    jnxJdhcpRelayBindingsIncomingClientInterface      DisplayString,
+    jnxJdhcpRelayBindingsClientInterfaceVlanId        Unsigned32,
+    jnxJdhcpRelayBindingsDemuxInterfaceName           DisplayString,
+    jnxJdhcpRelayBindingsServerIpAddress              IpAddress,
+    jnxJdhcpRelayBindingsServerInterface              DisplayString,
+    jnxJdhcpRelayBindingsBootpRelayAddress            IpAddress,
+    jnxJdhcpRelayBindingsPreviousBootpRelayAddress    IpAddress,
+    jnxJdhcpRelayBindingsClientProfileName            DisplayString
+    }
+
+jnxJdhcpRelayBindingsIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with this entry in the bindings table."
+    ::= { jnxJdhcpRelayBindingsEntry 1 }
+
+jnxJdhcpRelayBindingsLeaseState OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    init(1),
+                    selecting(2),
+                    requesting(3),
+                    release(4),
+                    bound(5),
+                    renewing(6),
+                    rebinding(7)  }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The state associated with this entry in the bindings table."
+    ::= { jnxJdhcpRelayBindingsEntry 2 }
+
+jnxJdhcpRelayBindingsLeaseEndTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time the lease expires on this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 3 }
+
+jnxJdhcpRelayBindingsLeaseExpireTime OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time remaining until the lease expires for this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 4 }
+
+jnxJdhcpRelayBindingsLeaseStartTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time the lease was started for this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 5 }
+
+jnxJdhcpRelayBindingsIncomingClientInterface OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The incoming interface or this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 6 }
+
+jnxJdhcpRelayBindingsClientInterfaceVlanId  OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The VLAN ID for this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 7 }
+
+jnxJdhcpRelayBindingsDemuxInterfaceName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The demux interface for this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 8 }
+
+jnxJdhcpRelayBindingsServerIpAddress  OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpRelayBindingsEntry 9 }
+
+jnxJdhcpRelayBindingsServerInterface  OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The demux interface for this binding."
+    ::= { jnxJdhcpRelayBindingsEntry 10 }
+
+jnxJdhcpRelayBindingsBootpRelayAddress  OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with the Bootp Relay for this entry in the bindings table."
+    ::= { jnxJdhcpRelayBindingsEntry 11 }
+
+jnxJdhcpRelayBindingsPreviousBootpRelayAddress  OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with the Previous Bootp Relay for this entry in the bindings table."
+    ::= { jnxJdhcpRelayBindingsEntry 12 }
+
+jnxJdhcpRelayBindingsClientProfileName  OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The display client profile name."
+    ::= { jnxJdhcpRelayBindingsEntry 13 }
+
+-- DHCP Relay Interface Statistics Table
+
+jnxJdhcpRelayIfcStatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJdhcpRelayIfcStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of interface statistics maintained by this JUNOS DHCP Relay."
+    ::= { jnxJdhcpRelayIfcStats 1 }
+
+jnxJdhcpRelayIfcStatsEntry OBJECT-TYPE
+    SYNTAX      JnxJdhcpRelayIfcStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry (conceptual row) representing an address binding (client) maintained by
+        this JUNOS DHCP Relay."
+    INDEX     { jnxJdhcpRelayIfcStatsIfIndex }
+    ::= { jnxJdhcpRelayIfcStatsTable 1 }
+
+JnxJdhcpRelayIfcStatsEntry ::= SEQUENCE {
+    jnxJdhcpRelayIfcStatsIfIndex                     InterfaceIndex,
+    jnxJdhcpRelayIfcStatsTotalDropped                Counter32,
+    jnxJdhcpRelayIfcStatsBadHardwareDropped          Counter32,
+    jnxJdhcpRelayIfcStatsBadBootpOpcodeDropped       Counter32,
+    jnxJdhcpRelayIfcStatsBadOptionsDropped           Counter32,
+    jnxJdhcpRelayIfcStatsBadAddressDropped           Counter32,
+    jnxJdhcpRelayIfcStatsNoAddressDropped            Counter32,
+    jnxJdhcpRelayIfcStatsNoInterfaceCfgDropped       Counter32,
+    jnxJdhcpRelayIfcStatsNoLocalAddressDropped       Counter32,
+    jnxJdhcpRelayIfcStatsShortPacketDropped          Counter32,
+    jnxJdhcpRelayIfcStatsBadSendDropped              Counter32,
+    jnxJdhcpRelayIfcStatsAuthenticationDropped       Counter32,
+    jnxJdhcpRelayIfcStatsDynamicProfileDropped       Counter32,
+    jnxJdhcpRelayIfcStatsLicenseDropped              Counter32,
+    jnxJdhcpRelayIfcStatsBootRequestReceived         Counter32,
+    jnxJdhcpRelayIfcStatsDhcpDeclineReceived         Counter32,
+    jnxJdhcpRelayIfcStatsDhcpDiscoverReceived        Counter32,
+    jnxJdhcpRelayIfcStatsDhcpInformReceived          Counter32,
+    jnxJdhcpRelayIfcStatsDhcpReleaseReceived         Counter32,
+    jnxJdhcpRelayIfcStatsDhcpRequestReceived         Counter32,
+    jnxJdhcpRelayIfcStatsDhcpBootReplySent           Counter32,
+    jnxJdhcpRelayIfcStatsDhcpOfferSent               Counter32,
+    jnxJdhcpRelayIfcStatsDhcpAckSent                 Counter32,
+    jnxJdhcpRelayIfcStatsDhcpNakSent                 Counter32,
+    jnxJdhcpRelayIfcStatsForceRenewSent              Counter32,
+    jnxJdhcpRelayIfcStatsTotalLeaseCount             Counter32,
+    jnxJdhcpRelayIfcStatsBadDhcpOpcodeDropped        Counter32,
+    jnxJdhcpRelayIfcStatsNoOptionsDropped            Counter32,
+    jnxJdhcpRelayIfcStatsHopLimitDropped             Counter32,
+    jnxJdhcpRelayIfcStatsTtlExpiredDropped           Counter32,
+    jnxJdhcpRelayIfcStatsBadUdpCksumDropped          Counter32,
+    jnxJdhcpRelayIfcStatsOption82Dropped             Counter32
+    }
+
+jnxJdhcpRelayIfcStatsIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of the interface for which this entry
+            contains information."
+    ::= { jnxJdhcpRelayIfcStatsEntry 1}
+
+jnxJdhcpRelayIfcStatsTotalDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped."
+    ::= { jnxJdhcpRelayIfcStatsEntry 2}
+
+jnxJdhcpRelayIfcStatsBadHardwareDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of packets dropped due to bad hardware address."
+    ::= { jnxJdhcpRelayIfcStatsEntry 3}
+
+jnxJdhcpRelayIfcStatsBadBootpOpcodeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to not BOOTP message."
+    ::= { jnxJdhcpRelayIfcStatsEntry 4}
+
+jnxJdhcpRelayIfcStatsBadOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad options in the packet."
+    ::= { jnxJdhcpRelayIfcStatsEntry 5}
+
+jnxJdhcpRelayIfcStatsBadAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to invalid server address."
+    ::= { jnxJdhcpRelayIfcStatsEntry 6}
+
+jnxJdhcpRelayIfcStatsNoAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no available addresses."
+    ::= { jnxJdhcpRelayIfcStatsEntry 7}
+
+jnxJdhcpRelayIfcStatsNoInterfaceCfgDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no interface match."
+    ::= { jnxJdhcpRelayIfcStatsEntry 8}
+
+jnxJdhcpRelayIfcStatsNoLocalAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to no valid local address."
+    ::= {  jnxJdhcpRelayIfcStatsEntry 9}
+
+jnxJdhcpRelayIfcStatsShortPacketDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to packet too short."
+    ::= { jnxJdhcpRelayIfcStatsEntry 10}
+
+jnxJdhcpRelayIfcStatsBadSendDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to send error."
+    ::= { jnxJdhcpRelayIfcStatsEntry 11}
+
+jnxJdhcpRelayIfcStatsAuthenticationDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to authentication failure."
+    ::= { jnxJdhcpRelayIfcStatsEntry 12}
+
+jnxJdhcpRelayIfcStatsDynamicProfileDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to dynamic profile error."
+    ::= { jnxJdhcpRelayIfcStatsEntry 13}
+
+jnxJdhcpRelayIfcStatsLicenseDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to license error."
+    ::= { jnxJdhcpRelayIfcStatsEntry 14}
+
+jnxJdhcpRelayIfcStatsBootRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Boot Request packets received."
+    ::= { jnxJdhcpRelayIfcStatsEntry 15}
+
+jnxJdhcpRelayIfcStatsDhcpDeclineReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Decline packets received."
+    ::= { jnxJdhcpRelayIfcStatsEntry 16}
+
+jnxJdhcpRelayIfcStatsDhcpDiscoverReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Discover packets received."
+    ::= { jnxJdhcpRelayIfcStatsEntry 17}
+
+jnxJdhcpRelayIfcStatsDhcpInformReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP inform packets received."
+    ::= { jnxJdhcpRelayIfcStatsEntry 18}
+
+jnxJdhcpRelayIfcStatsDhcpReleaseReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP release packets received."
+    ::= { jnxJdhcpRelayIfcStatsEntry 19}
+
+jnxJdhcpRelayIfcStatsDhcpRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP request packets received."
+    ::= { jnxJdhcpRelayIfcStatsEntry 20}
+
+jnxJdhcpRelayIfcStatsDhcpBootReplySent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Boot Reply packets sent."
+    ::= { jnxJdhcpRelayIfcStatsEntry 21}
+
+jnxJdhcpRelayIfcStatsDhcpOfferSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Offer packets sent."
+    ::= { jnxJdhcpRelayIfcStatsEntry 22}
+
+jnxJdhcpRelayIfcStatsDhcpAckSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Ack packets sent."
+    ::= { jnxJdhcpRelayIfcStatsEntry 23}
+
+jnxJdhcpRelayIfcStatsDhcpNakSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Nak packets sent."
+    ::= { jnxJdhcpRelayIfcStatsEntry 24}
+
+jnxJdhcpRelayIfcStatsForceRenewSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCP Force Renew packets sent."
+    ::= { jnxJdhcpRelayIfcStatsEntry 25}
+
+jnxJdhcpRelayIfcStatsTotalLeaseCount OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Bound DHCP Clients."
+    ::= { jnxJdhcpRelayIfcStatsEntry 26}
+
+jnxJdhcpRelayIfcStatsBadDhcpOpcodeDropped  OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped with bad DHCP opcode."
+    ::= { jnxJdhcpRelayIfcStatsEntry 27}
+
+jnxJdhcpRelayIfcStatsNoOptionsDropped  OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped with no options."
+    ::= { jnxJdhcpRelayIfcStatsEntry 28}
+
+jnxJdhcpRelayIfcStatsHopLimitDropped  OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to hop limit violation."
+    ::= { jnxJdhcpRelayIfcStatsEntry 29}
+
+jnxJdhcpRelayIfcStatsTtlExpiredDropped  OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to ttl expiration."
+    ::= { jnxJdhcpRelayIfcStatsEntry 30}
+
+jnxJdhcpRelayIfcStatsBadUdpCksumDropped  OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to bad UDP checksum."
+    ::= { jnxJdhcpRelayIfcStatsEntry 31}
+
+jnxJdhcpRelayIfcStatsOption82Dropped  OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to failure to add Option 82."
+    ::= { jnxJdhcpRelayIfcStatsEntry 32}
+
+-- Objects used for traps
+jnxJdhcpLocalServerLastDetected  OBJECT-TYPE
+    SYNTAX       DateAndTime
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The time the duplicate client was last detected"
+    ::= { jnxJdhcpLocalServerTrapVars 1 }
+
+jnxJdhcpRouterName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..257))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The VRF ID in JUNOS. Represented as the Logical Router (LR)
+         Name followed by the Router Instance (RI) Name."
+    ::= { jnxJdhcpLocalServerTrapVars 2 }
+
+jnxJdhcpLocalServerMacAddress  OBJECT-TYPE
+    SYNTAX       MacAddress
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The MAC address of the client that changed interfaces."
+    ::= { jnxJdhcpLocalServerTrapVars 3 }
+
+jnxJdhcpLocalServerInterfaceName  OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The interface where the DHCP client was detected"
+    ::= { jnxJdhcpLocalServerTrapVars 4 }
+
+jnxJdhcpLocalServerInterfaceLimit  OBJECT-TYPE
+    SYNTAX       Unsigned32
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The number of clients supported on this interface."
+    ::= { jnxJdhcpLocalServerTrapVars 5 }
+
+jnxJdhcpLocalServerEventSeverity OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    debug(0),
+                    warning(1),
+                    critical(2)
+                }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The level of error. "
+    ::= { jnxJdhcpLocalServerTrapVars 6 }
+
+jnxJdhcpLocalServerEventString  OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The text of the event string associated with the health event."
+    ::= { jnxJdhcpLocalServerTrapVars 7 }
+
+jnxJdhcpRelayRouterName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..257))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The VRF ID in JUNOS. Represented as the Logical Router (LR)
+         Name followed by the Router Instance (RI) Name."
+    ::= { jnxJdhcpRelayTrapVars 1 }
+
+jnxJdhcpRelayInterfaceName  OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The interface where the DHCP client was detected"
+    ::= { jnxJdhcpRelayTrapVars 2 }
+
+jnxJdhcpRelayInterfaceLimit  OBJECT-TYPE
+    SYNTAX       Unsigned32
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The number of clients supported on this interface."
+    ::= { jnxJdhcpRelayTrapVars 3 }
+
+
+-- Notifications
+
+jnxJdhcpLocalServerDuplicateClient  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpRouterName,
+        jnxJdhcpLocalServerMacAddress,
+        jnxJdhcpLocalServerInterfaceName,
+        jnxJdhcpLocalServerLastDetected }
+    STATUS      current
+    DESCRIPTION
+        "Reports the first occurance of detection of a DHCP client that
+         changed interfaces."
+    ::= { jnxJdhcpLocalServerTraps 1 }
+
+jnxJdhcpLocalServerInterfaceLimitExceeded  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpRouterName,
+        jnxJdhcpLocalServerInterfaceName,
+        jnxJdhcpLocalServerInterfaceLimit }
+    STATUS      current
+    DESCRIPTION
+        "Reports when the limit of clients has been exceeded on an interface."
+    ::= { jnxJdhcpLocalServerTraps 2 }
+
+jnxJdhcpLocalServerInterfaceLimitAbated  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpRouterName,
+        jnxJdhcpLocalServerInterfaceName,
+        jnxJdhcpLocalServerInterfaceLimit }
+    STATUS      current
+    DESCRIPTION
+        "Reports when the number of clients on an interface has fallen
+        below the limit allowed on that interface."
+    ::= { jnxJdhcpLocalServerTraps 3 }
+
+jnxJdhcpLocalServerHealth NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpRouterName,
+        jnxJdhcpLocalServerEventSeverity,
+        jnxJdhcpLocalServerEventString }
+    STATUS      current
+    DESCRIPTION
+        "Reports when a health event occurs in the Local Server 
+         application."
+    ::= { jnxJdhcpLocalServerTraps 4 }
+
+-- Relay Notifications
+
+jnxJdhcpRelayInterfaceLimitExceeded  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpRelayRouterName,
+        jnxJdhcpRelayInterfaceName,
+        jnxJdhcpRelayInterfaceLimit }
+    STATUS      current
+    DESCRIPTION
+        "Reports when the limit of clients has been exceeded on an interface."
+    ::= { jnxJdhcpRelayTraps 1 }
+
+jnxJdhcpRelayInterfaceLimitAbated  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpRelayRouterName,
+        jnxJdhcpRelayInterfaceName,
+        jnxJdhcpRelayInterfaceLimit }
+    STATUS      current
+    DESCRIPTION
+        "Reports when the number of clients on an interface has fallen
+        below the limit allowed on that interface."
+    ::= { jnxJdhcpRelayTraps 2 }
+
+
+END
+
+

--- a/mibs/junos/mib-jnx-jdhcpv6.txt
+++ b/mibs/junos/mib-jnx-jdhcpv6.txt
@@ -1,0 +1,757 @@
+-- *******************************************************************
+-- Juniper enterprise specific DHCPv6 MIB.
+--
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- *******************************************************************
+
+JUNIPER-JDHCPV6-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, IpAddress, 
+    Counter32, NOTIFICATION-TYPE, Unsigned32
+        FROM SNMPv2-SMI
+    ifIndex,InterfaceIndex
+        FROM IF-MIB
+    TEXTUAL-CONVENTION, DisplayString, DateAndTime
+        FROM SNMPv2-TC 
+     Ipv6Address, Ipv6AddressPrefix
+        FROM IPV6-TC
+    jnxJdhcpv6MibRoot
+        FROM JUNIPER-SMI;
+
+jnxJdhcpv6MIB  MODULE-IDENTITY
+    LAST-UPDATED "201103150000Z" --  March 15, 2011
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+        "The JUNOS DHCP MIB for the Juniper Networks enterprise."
+
+    -- revision history
+    REVISION      "201103150000Z"
+    DESCRIPTION   "Add OIDs to the Interface Statistics Table"
+    REVISION      "201101250000Z"
+    DESCRIPTION   "Add Interface Statistics Table"
+    REVISION      "201002150000Z"
+    DESCRIPTION   "Creation Date"
+    ::= { jnxJdhcpv6MibRoot 62 }
+
+-- Managed object groups
+jnxJdhcpv6Objects                         OBJECT IDENTIFIER ::= { jnxJdhcpv6MIB 1 }
+jnxJdhcpv6LocalServerObjects              OBJECT IDENTIFIER ::= { jnxJdhcpv6MIB 2 }
+
+
+-- Managed objects for DHCPv6 local server
+jnxJdhcpv6LocalServerStatistics OBJECT IDENTIFIER
+    ::= { jnxJdhcpv6LocalServerObjects 1 }
+jnxJdhcpv6LocalServerBindings   OBJECT IDENTIFIER
+    ::= { jnxJdhcpv6LocalServerObjects 2 }
+jnxJdhcpv6LocalServerTraps    OBJECT IDENTIFIER
+    ::= { jnxJdhcpv6LocalServerObjects 3 }
+jnxJdhcpv6LocalServerTrapVars   OBJECT IDENTIFIER 
+    ::= { jnxJdhcpv6LocalServerObjects 4 }
+jnxJdhcpv6LocalServerIfcStats   OBJECT IDENTIFIER
+    ::= { jnxJdhcpv6LocalServerObjects 5 }
+
+-- DHCP V6 Server Statistics
+jnxJdhcpv6LocalServerTotalDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total DHCP v6 packets dropped." 
+    ::= { jnxJdhcpv6LocalServerStatistics 1 }
+
+jnxJdhcpv6LocalServerNoSafdDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to no safd match."
+    ::= { jnxJdhcpv6LocalServerStatistics 2 }
+
+jnxJdhcpv6LocalServerBadSendDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to send error."
+    ::= { jnxJdhcpv6LocalServerStatistics 3 }
+
+jnxJdhcpv6LocalServerShortPacketDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to packet being too short."
+    ::= { jnxJdhcpv6LocalServerStatistics 4 }
+
+jnxJdhcpv6LocalServerBadMsgtypeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to bad opcode in the packet."
+    ::= { jnxJdhcpv6LocalServerStatistics 5 }
+
+jnxJdhcpv6LocalServerBadOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to bad options in the packet."
+    ::= { jnxJdhcpv6LocalServerStatistics 6 }
+
+jnxJdhcpv6LocalServerBadSrcAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to invalid addr family."
+    ::= { jnxJdhcpv6LocalServerStatistics 7 }
+
+jnxJdhcpv6LocalServerRelayHopCountDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to max relays supported."
+    ::= { jnxJdhcpv6LocalServerStatistics 8 }
+
+jnxJdhcpv6LocalServerNoClientIdDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to missing client id."
+    ::= { jnxJdhcpv6LocalServerStatistics 9 }
+
+jnxJdhcpv6LocalServerDeclineReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Decline packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 10}
+
+jnxJdhcpv6LocalServerSolicitReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Solicit packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 11}
+
+jnxJdhcpv6LocalServerInformationRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Information Request packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 12 }
+
+jnxJdhcpv6LocalServerReleaseReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Release packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 13 }
+
+jnxJdhcpv6LocalServerRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Request packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 14 }
+
+jnxJdhcpv6LocalServerConfirmReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Confirm packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 15 }
+
+jnxJdhcpv6LocalServerRenewReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Renew packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 16 }
+
+jnxJdhcpv6LocalServerRebindReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Rebind packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 17 }
+
+jnxJdhcpv6LocalServerRelayForwReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Relay Fowr packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 18 }
+
+jnxJdhcpv6LocalServerRelayReplReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Relay Repl packets received."
+    ::= { jnxJdhcpv6LocalServerStatistics 19 }
+
+jnxJdhcpv6LocalServerAdvertiseSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Advertise packets sent."
+    ::= { jnxJdhcpv6LocalServerStatistics 20 }
+
+jnxJdhcpv6LocalServerReplySent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Reply packets sent."
+    ::= { jnxJdhcpv6LocalServerStatistics 21 }
+
+jnxJdhcpv6LocalServerReconfigureSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Reconfigure packets sent."
+    ::= { jnxJdhcpv6LocalServerStatistics 22 }
+
+jnxJdhcpv6LocalServerTotalLeaseCount OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Bound DHCP Clients."
+    ::= { jnxJdhcpv6LocalServerStatistics 23}
+
+-- DHCPv6 Local Server Bindings Table
+
+jnxJdhcpv6LocalServerBindingsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJdhcpv6LocalServerBindingsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of address bindings maintained by this JUNOS DHCP Local Server."
+    ::= { jnxJdhcpv6LocalServerBindings 1 }
+
+jnxJdhcpv6LocalServerBindingsEntry OBJECT-TYPE
+    SYNTAX      JnxJdhcpv6LocalServerBindingsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry (conceptual row) representing an address binding (client) maintained by
+        this JUNOS DHCP Local Server."
+    INDEX     { jnxJdhcpv6LocalServerBindingsPrefix, jnxJdhcpv6LocalServerBindingsLength }
+    ::= { jnxJdhcpv6LocalServerBindingsTable 1 }
+
+JnxJdhcpv6LocalServerBindingsEntry ::= SEQUENCE {
+    jnxJdhcpv6LocalServerBindingsPrefix                       Ipv6AddressPrefix,
+    jnxJdhcpv6LocalServerBindingsLength                       Unsigned32,
+    jnxJdhcpv6LocalServerBindingsState                        DisplayString,
+    jnxJdhcpv6LocalServerBindingsLeaseEndTime                 DateAndTime,
+    jnxJdhcpv6LocalServerBindingsLeaseExpireTime              Unsigned32,
+    jnxJdhcpv6LocalServerBindingsLeaseStartTime               DateAndTime,
+    jnxJdhcpv6LocalServerBindingsIncomingClientInterface      DisplayString,
+    jnxJdhcpv6LocalServerBindingsClientInterfaceVlanId        Unsigned32,
+    jnxJdhcpv6LocalServerBindingsDemuxInterfaceName           DisplayString,
+    jnxJdhcpv6LocalServerBindingsServerIpAddress              IpAddress,
+    jnxJdhcpv6LocalServerBindingsBootpRelayAddress            IpAddress,
+    jnxJdhcpv6LocalServerBindingsPreviousBootpRelayAddress    IpAddress,
+    jnxJdhcpv6LocalServerBindingsClientPoolName               DisplayString,
+    jnxJdhcpv6LocalServerBindingsClientProfileName            DisplayString
+    }
+
+jnxJdhcpv6LocalServerBindingsPrefix OBJECT-TYPE
+    SYNTAX      Ipv6AddressPrefix
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The prefix associated with this entry in the bindings table."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 1 }
+
+jnxJdhcpv6LocalServerBindingsLength OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The length of the prefix in bits."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 2 }
+
+jnxJdhcpv6LocalServerBindingsState OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The state associated with this entry in the bindings table."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 3 }
+
+jnxJdhcpv6LocalServerBindingsLeaseEndTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time the lease expires on this binding."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 4 }
+
+jnxJdhcpv6LocalServerBindingsLeaseExpireTime OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time remaining until the lease expires for this binding."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 5 }
+
+jnxJdhcpv6LocalServerBindingsLeaseStartTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time the lease was started for this binding."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 6 }
+
+jnxJdhcpv6LocalServerBindingsIncomingClientInterface OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The incoming interface or this binding."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 7 }
+
+jnxJdhcpv6LocalServerBindingsClientInterfaceVlanId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The VLAN ID for this binding."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 8 }
+
+jnxJdhcpv6LocalServerBindingsDemuxInterfaceName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The demux interface for this binding."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 9 }
+
+jnxJdhcpv6LocalServerBindingsServerIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The IP Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 10 }
+
+jnxJdhcpv6LocalServerBindingsBootpRelayAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The BOOTP relay Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 11 }
+
+jnxJdhcpv6LocalServerBindingsPreviousBootpRelayAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Previous BOOTP relay Address associated with the server for this entry in the bindings table."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 12 }
+
+jnxJdhcpv6LocalServerBindingsClientPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The display client pool name."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 13 }
+
+jnxJdhcpv6LocalServerBindingsClientProfileName  OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The display client profile name."
+    ::= { jnxJdhcpv6LocalServerBindingsEntry 14 }
+
+-- DHCP V6 Local Server Interface Statistics Table
+
+jnxJdhcpv6LocalServerIfcStatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJdhcpv6LocalServerIfcStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of interface statistics maintained by this JUNOS DHCPv6 Local Server."
+    ::= { jnxJdhcpv6LocalServerIfcStats 1 }
+
+jnxJdhcpv6LocalServerIfcStatsEntry OBJECT-TYPE
+    SYNTAX      JnxJdhcpv6LocalServerIfcStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry (conceptual row) representing an address binding (client) maintained by
+        this JUNOS DHCPv6 Local Server."
+    INDEX     { jnxJdhcpv6LocalServerIfcStatsIfIndex }
+    ::= { jnxJdhcpv6LocalServerIfcStatsTable 1 }
+
+JnxJdhcpv6LocalServerIfcStatsEntry ::= SEQUENCE {
+    jnxJdhcpv6LocalServerIfcStatsIfIndex                    InterfaceIndex,
+    jnxJdhcpv6LocalServerIfcStatsTotalDropped               Counter32,
+    jnxJdhcpv6LocalServerIfcStatsNoSafdDropped              Counter32,
+    jnxJdhcpv6LocalServerIfcStatsBadSendDropped             Counter32,
+    jnxJdhcpv6LocalServerIfcStatsShortPacketDropped         Counter32,
+    jnxJdhcpv6LocalServerIfcStatsBadMsgtypeDropped          Counter32,
+    jnxJdhcpv6LocalServerIfcStatsBadOptionsDropped          Counter32,
+    jnxJdhcpv6LocalServerIfcStatsBadSrcAddressDropped       Counter32,
+    jnxJdhcpv6LocalServerIfcStatsRelayCountDropped          Counter32,
+    jnxJdhcpv6LocalServerIfcStatsNoClientIdDropped          Counter32,
+    jnxJdhcpv6LocalServerIfcStatsDeclineReceived            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsSolicitReceived            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsInformationRequestReceived Counter32,
+    jnxJdhcpv6LocalServerIfcStatsReleaseReceived            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsRequestReceived            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsConfirmReceived            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsRenewReceived              Counter32,
+    jnxJdhcpv6LocalServerIfcStatsRebindReceived             Counter32,
+    jnxJdhcpv6LocalServerIfcStatsRelayForwReceived          Counter32,
+    jnxJdhcpv6LocalServerIfcStatsRelayReplReceived          Counter32,
+    jnxJdhcpv6LocalServerIfcStatsAdvertiseSent              Counter32,
+    jnxJdhcpv6LocalServerIfcStatsReplySent                  Counter32,
+    jnxJdhcpv6LocalServerIfcStatsReconfigureSent            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsTotalLeaseCount            Counter32,
+    jnxJdhcpv6LocalServerIfcStatsStrictReconfigDropped      Counter32,
+    jnxJdhcpv6LocalServerIfcStatsAuthenticationDropped      Counter32,
+    jnxJdhcpv6LocalServerIfcStatsDynamicProfileDropped      Counter32,
+    jnxJdhcpv6LocalServerIfcStatsLicenseDropped             Counter32
+    }
+
+-- According to IF-MIB.txt and interface index is an Integer 32 (1 - 2147483647) 
+-- This will correlate with an IFL in DHCP
+
+jnxJdhcpv6LocalServerIfcStatsIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The ifIndex value of the interface for which this entry
+            contains information."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 1}
+
+jnxJdhcpv6LocalServerIfcStatsTotalDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total DHCP v6 packets dropped." 
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 2}
+
+jnxJdhcpv6LocalServerIfcStatsNoSafdDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to no safd match."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 3}
+
+jnxJdhcpv6LocalServerIfcStatsBadSendDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to send error."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 4}
+
+jnxJdhcpv6LocalServerIfcStatsShortPacketDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to packet being too short."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 5}
+
+jnxJdhcpv6LocalServerIfcStatsBadMsgtypeDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to bad opcode in the packet."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 6}
+
+jnxJdhcpv6LocalServerIfcStatsBadOptionsDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to bad options in the packet."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 7}
+
+jnxJdhcpv6LocalServerIfcStatsBadSrcAddressDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to invalid addr family."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 8}
+
+jnxJdhcpv6LocalServerIfcStatsRelayCountDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to max relays supported."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 9}
+
+jnxJdhcpv6LocalServerIfcStatsNoClientIdDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DHCPv6 packets dropped due to missing client id."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 10}
+
+jnxJdhcpv6LocalServerIfcStatsDeclineReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Decline packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 11}
+
+jnxJdhcpv6LocalServerIfcStatsSolicitReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Solicit packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 12}
+
+jnxJdhcpv6LocalServerIfcStatsInformationRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Information Request packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 13}
+
+jnxJdhcpv6LocalServerIfcStatsReleaseReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Release packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 14}
+
+jnxJdhcpv6LocalServerIfcStatsRequestReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Request packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 15}
+
+jnxJdhcpv6LocalServerIfcStatsConfirmReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Confirm packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 16}
+
+jnxJdhcpv6LocalServerIfcStatsRenewReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Renew packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 17}
+
+jnxJdhcpv6LocalServerIfcStatsRebindReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Rebind packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 18}
+
+jnxJdhcpv6LocalServerIfcStatsRelayForwReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Relay Fowr packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 19}
+
+jnxJdhcpv6LocalServerIfcStatsRelayReplReceived OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Relay Repl packets received."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 20}
+
+jnxJdhcpv6LocalServerIfcStatsAdvertiseSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Advertise packets sent."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 21}
+
+jnxJdhcpv6LocalServerIfcStatsReplySent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Reply packets sent."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 22}
+
+jnxJdhcpv6LocalServerIfcStatsReconfigureSent OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of DHCPv6 Reconfigure packets sent."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 23}
+
+jnxJdhcpv6LocalServerIfcStatsTotalLeaseCount OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of Bound DHCP Clients."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 24}
+
+jnxJdhcpv6LocalServerIfcStatsStrictReconfigDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to strict reconfigure."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 25}
+
+jnxJdhcpv6LocalServerIfcStatsAuthenticationDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to authentication failure."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 26}
+
+jnxJdhcpv6LocalServerIfcStatsDynamicProfileDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to dynamic profile error."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 27}
+
+jnxJdhcpv6LocalServerIfcStatsLicenseDropped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of packets dropped due to license error."
+    ::= { jnxJdhcpv6LocalServerIfcStatsEntry 28}
+
+-- Objects used for traps
+
+jnxJdhcpv6RouterName OBJECT-TYPE
+    SYNTAX      DisplayString 
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The VRF ID in JUNOS. Represented as the Logical Router (LR)
+         Name followed by the Router Instance (RI) Name."
+    ::= { jnxJdhcpv6LocalServerTrapVars 1 }
+
+jnxJdhcpv6LocalServerInterfaceName  OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The interface where the DHCP client was detected"
+    ::= { jnxJdhcpv6LocalServerTrapVars 2 }
+
+jnxJdhcpv6LocalServerInterfaceLimit  OBJECT-TYPE
+    SYNTAX       Unsigned32
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The number of clients supported on this interface."
+    ::= { jnxJdhcpv6LocalServerTrapVars 3 }
+
+jnxJdhcpv6LocalServerEventSeverity OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    debug(0),
+                    warning(1),
+                    critical(2)
+                }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The level of error. "
+    ::= { jnxJdhcpv6LocalServerTrapVars 4 }
+
+jnxJdhcpv6LocalServerEventString  OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The text of the event string associated with the health event."
+    ::= { jnxJdhcpv6LocalServerTrapVars 5 }
+
+-- Notifications
+
+jnxJdhcpv6LocalServerInterfaceLimitExceeded  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpv6RouterName,
+        jnxJdhcpv6LocalServerInterfaceName,
+        jnxJdhcpv6LocalServerInterfaceLimit }
+    STATUS      current
+    DESCRIPTION
+        "Reports when the limit of clients has been exceeded on an interface."
+    ::= { jnxJdhcpv6LocalServerTraps 1 }
+
+jnxJdhcpv6LocalServerInterfaceLimitAbated  NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpv6RouterName,
+        jnxJdhcpv6LocalServerInterfaceName,
+        jnxJdhcpv6LocalServerInterfaceLimit }
+    STATUS      current
+    DESCRIPTION
+        "Reports when the number of clients on an interface has fallen
+        below the limit allowed on that interface."
+    ::= { jnxJdhcpv6LocalServerTraps 2 }
+
+jnxJdhcpv6LocalServerHealth NOTIFICATION-TYPE
+    OBJECTS {
+        jnxJdhcpv6RouterName,
+        jnxJdhcpv6LocalServerEventSeverity,
+        jnxJdhcpv6LocalServerEventString }
+    STATUS      current
+    DESCRIPTION
+        "Reports when a health event occurs in the V6 Local Server 
+         application."
+    ::= { jnxJdhcpv6LocalServerTraps 4 }
+
+END

--- a/mibs/junos/mib-jnx-js-idp.txt
+++ b/mibs/junos/mib-jnx-js-idp.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise specific MIB: IDP MIB
 --
--- Copyright (c) 2006-2007, Juniper Networks, Inc.
+-- Copyright (c) 2006-2009, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.

--- a/mibs/junos/mib-jnx-js-if-ext.txt
+++ b/mibs/junos/mib-jnx-js-if-ext.txt
@@ -72,7 +72,7 @@
         INDEX {ifIndex}
         ::= {jnxJsIfMonTable 1}
 
-    JnxJsIfMonEntry::= SEQUENCE
+    JnxJsIfMonEntry ::= SEQUENCE
     {
         jnxJsIfMonInIcmp            Counter32,
         jnxJsIfMonInSelf            Counter32,

--- a/mibs/junos/mib-jnx-js-nat.txt
+++ b/mibs/junos/mib-jnx-js-nat.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper enterprise Network Address Translation (NAT) MIB.
 --
--- Copyright (c) 2001-2007, Juniper Networks, Inc.
+-- Copyright (c) 2001-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -12,6 +12,7 @@
 	IMPORTS
 
         Gauge32, Integer32,
+        Counter32,
         NOTIFICATION-TYPE,
     	MODULE-IDENTITY, OBJECT-TYPE	FROM SNMPv2-SMI
 
@@ -27,7 +28,7 @@
 
 
 	jnxJsNatMIB  	MODULE-IDENTITY
-    	LAST-UPDATED  "200910152022Z" -- October 15, 2009
+    	LAST-UPDATED  "201203011122Z" -- March 01, 2012
     	ORGANIZATION  "Juniper Networks, Inc."
     	CONTACT-INFO
 					"Juniper Technical Assistance Center
@@ -43,6 +44,11 @@
 
         REVISION        "200704132022Z" -- April 13, 2007
     	DESCRIPTION 	"Creation Date"
+
+        REVISION        "201203011122Z" -- March 01, 2012
+        DESCRIPTION     "Deprecated jnxJsNatRuleTransHits and
+                         jnxJsNatPoolTransHits, added
+                         jnxJsNatRuleHits and jnxJsNatPoolHits."
 
     ::= { jnxJsNAT 1 }   
 
@@ -431,7 +437,8 @@
     {
         jnxJsNatRuleName                     DisplayString,
         jnxJsNatRuleType                     INTEGER,
-        jnxJsNatRuleTransHits                INTEGER
+        jnxJsNatRuleTransHits                INTEGER,
+        jnxJsNatRuleHits                     Counter32
     }
 
     jnxJsNatRuleName OBJECT-TYPE
@@ -457,10 +464,20 @@
     jnxJsNatRuleTransHits OBJECT-TYPE
         SYNTAX        INTEGER
         MAX-ACCESS    read-only
+        STATUS        deprecated
+        DESCRIPTION
+        	"The number of hits on this NAT rule,
+             Deprecated to avoid negative value."
+    ::= { jnxJsNatRuleEntry 3 }
+
+    jnxJsNatRuleHits OBJECT-TYPE
+        SYNTAX        Counter32
+        MAX-ACCESS    read-only
         STATUS        current
         DESCRIPTION
-        	"The number of hits on this NAT rule"
-    ::= { jnxJsNatRuleEntry 3 }
+            "The number of hits on this NAT rule to 
+             deprecate jnxJsNatRuleTransHits"
+    ::= { jnxJsNatRuleEntry 4 }
 
     -- ***************************************************************
     --  NAT Pool Hit Table
@@ -487,7 +504,8 @@
     {
         jnxJsNatPoolName                     DisplayString,
         jnxJsNatPoolType                     INTEGER,
-        jnxJsNatPoolTransHits                INTEGER
+        jnxJsNatPoolTransHits                INTEGER,
+        jnxJsNatPoolHits                     Counter32
     }
 
     jnxJsNatPoolName OBJECT-TYPE
@@ -513,10 +531,20 @@
     jnxJsNatPoolTransHits OBJECT-TYPE
         SYNTAX        INTEGER
         MAX-ACCESS    read-only
+        STATUS        deprecated
+        DESCRIPTION
+        	"The number of hits on this NAT Pool,
+             Deprecated to avoid negative value."
+    ::= { jnxJsNatPoolEntry 3 }
+
+    jnxJsNatPoolHits OBJECT-TYPE
+        SYNTAX        Counter32
+        MAX-ACCESS    read-only
         STATUS        current
         DESCRIPTION
-        	"The number of hits on this NAT Pool"
-    ::= { jnxJsNatPoolEntry 3 }
+            "The number of hits on this NAT Pool
+             to deprecate jnxJsNatPoolTransHits."
+    ::= { jnxJsNatPoolEntry 4 }
 
     -- ***************************************************************
     --  NAT Trap definition

--- a/mibs/junos/mib-jnx-js-packet-mirror.txt
+++ b/mibs/junos/mib-jnx-js-packet-mirror.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper enterprise specific Packet Mirror MIB.
 --
--- Copyright (c) 2001-2010, Juniper Networks, Inc.
+-- Copyright (c) 2001-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -19,10 +19,13 @@
             FROM SNMPv2-TC 
 
         jnxJsPacketMirror 
-            FROM JUNIPER-JS-SMI;
+            FROM JUNIPER-JS-SMI
+
+        Ipv6AddressPrefix
+            FROM IPV6-TC;
 
     jnxJsPacketMirrorMIB  MODULE-IDENTITY
-        LAST-UPDATED  "200910290000Z"   -- October 29, 2009
+        LAST-UPDATED  "201111230000Z"    -- November 23, 2011
         ORGANIZATION  "Juniper Networks, Inc."
         CONTACT-INFO
             "Juniper Technical Assistance Center
@@ -34,13 +37,29 @@
              HTTP://www.juniper.net"
         DESCRIPTION
             "The packet mirror MIB for the Juniper Networks enterprise."
-    	REVISION      "200910290000Z"   -- October 29, 2009
+        REVISION      "200910290000Z"   -- October 29, 2009
     	DESCRIPTION   "Creation Date"
 
-    	REVISION      "201002250000Z"   -- February 25, 2010
-    	DESCRIPTION   "Added analyzer address to the LI Service Activated trap."
-    	::= { jnxJsPacketMirror 1 }   
+        REVISION     "201002250000Z"    -- February 25, 2010
+        DESCRIPTION  "Added analyzer address to the LI Service Activated trap."
 
+        REVISION     "201012160000Z"    -- December 16, 2010
+        DESCRIPTION  "Added Target Ipv6 Address address to traps."
+
+        REVISION     "201103160000Z"    -- March 16, 2011
+        DESCRIPTION  "Added Target Ipv6 Prefix Length to traps."
+
+        REVISION     "201103230000Z"    -- March 23, 2011
+        DESCRIPTION  "Add missing Ipv6 Prefix Length to traps. Use SYNTAX 
+                      Counter64 for tranmitted and received Octets."
+
+        REVISION     "201106070000Z"    -- June 7, 2011
+        DESCRIPTION  "Change SYNTAX of Mirror Identifier."
+
+
+        REVISION     "201111230000Z"    -- November 23, 2011
+        DESCRIPTION  "Add jnxJsPacketMirrorTriggerType circuitId."
+      	::= { jnxJsPacketMirror 1 }
 
     jnxJsPacketMirrorNotifications OBJECT IDENTIFIER ::= { jnxJsPacketMirrorMIB 0 }
     jnxJsPacketMirrorObjects       OBJECT IDENTIFIER ::= { jnxJsPacketMirrorMIB 1 }
@@ -57,12 +76,11 @@
         -- ********************************************************************
 
         jnxJsPacketMirrorIdentifier OBJECT-TYPE
-            SYNTAX      DisplayString (SIZE(1..8))
+            SYNTAX      Unsigned32
             MAX-ACCESS  accessible-for-notify
             STATUS      current
             DESCRIPTION
-                "The mirror identifier. A string which contains the 
-                 Version, Mirror ID and Session ID."
+                "The mirror identifier."
             ::= { jnxJsPacketMirrorTrapVars 1 }
 
         jnxJsPacketMirrorSessionIdentifier OBJECT-TYPE
@@ -88,7 +106,10 @@
                             nasPortId(2),
                             username(3),
                             callingStationId(4),
-                            acctSessionId(5) }
+                            acctSessionId(5),
+                            option82(6),
+                            remoteId(7),
+                            circuitId(8) }
             MAX-ACCESS  accessible-for-notify
             STATUS      current
             DESCRIPTION
@@ -232,6 +253,54 @@
                  interpret as an access or packet session event."
             ::= { jnxJsPacketMirrorTrapVars 15 }
 
+        jnxPacketMirrorCallingStationIdentifier  OBJECT-TYPE
+            SYNTAX      DisplayString (SIZE(1..64))
+            MAX-ACCESS  accessible-for-notify
+            STATUS      current
+            DESCRIPTION
+                "The calling station id of the subscriber who's traffic is being monitored."
+            ::= { jnxJsPacketMirrorTrapVars 16 }
+
+        jnxPacketMirrorNasIdentifier   OBJECT-TYPE
+            SYNTAX      DisplayString (SIZE(1..64))
+            MAX-ACCESS  accessible-for-notify
+            STATUS      current
+            DESCRIPTION
+                "The Nas identification where the traffic is being monitored."
+            ::= { jnxJsPacketMirrorTrapVars 17 }
+
+        jnxJsPacketMirrorOctetsReceived OBJECT-TYPE
+            SYNTAX      Counter64
+            MAX-ACCESS  accessible-for-notify
+            STATUS      current
+            DESCRIPTION
+                "The subscriber octet count received."
+            ::= { jnxJsPacketMirrorTrapVars 18 }
+
+        jnxJsPacketMirrorOctetsTransmitted OBJECT-TYPE
+            SYNTAX      Counter64
+            MAX-ACCESS  accessible-for-notify
+            STATUS      current
+            DESCRIPTION
+                "The subscriber octet count transmitted."
+            ::= { jnxJsPacketMirrorTrapVars 19 }
+
+        jnxJsPacketMirrorTargetIpv6Address OBJECT-TYPE
+            SYNTAX      Ipv6AddressPrefix
+            MAX-ACCESS  accessible-for-notify
+            STATUS      current
+            DESCRIPTION
+                "IPv6 address of the mirrored interface."
+            ::= { jnxJsPacketMirrorTrapVars 20 }
+
+        jnxJsPacketMirrorTrgtIpv6PfxLen OBJECT-TYPE
+            SYNTAX      Unsigned32
+            MAX-ACCESS  accessible-for-notify
+            STATUS      current
+            DESCRIPTION
+                "IPv6 prefix length of the mirrored interface."
+            ::= { jnxJsPacketMirrorTrapVars 21 }
+
     -- ***************************************************************
     -- definition of packet mirroring traps
     -- ***************************************************************
@@ -273,7 +342,11 @@
             jnxJsPacketMirrorSessionIdentifier,
             jnxJsPacketMirrorDirection,
             jnxJsPacketMirrorTargetIpAddress,
-            jnxJsPacketMirrorAnalyzerAddress }
+            jnxJsPacketMirrorAnalyzerAddress,
+            jnxPacketMirrorNasIdentifier,
+            jnxPacketMirrorCallingStationIdentifier,
+            jnxJsPacketMirrorTargetIpv6Address,
+            jnxJsPacketMirrorTrgtIpv6PfxLen }
         STATUS       current
         DESCRIPTION
         "The jnxJsPacketMirrorLiSubscriberLoggedIn Trap indicates that 
@@ -296,7 +369,10 @@
              jnxJsPacketMirrorTargetIpAddress,
              jnxJsPacketMirrorAnalyzerAddress,
              jnxJsPacketMirrorErrorCause,
-             jnxJsPacketMirrorErrorString }
+             jnxJsPacketMirrorErrorString,
+             jnxPacketMirrorCallingStationIdentifier,
+             jnxJsPacketMirrorTargetIpv6Address,
+             jnxJsPacketMirrorTrgtIpv6PfxLen }
         STATUS       current
         DESCRIPTION
             "The jnxJsPacketMirrorLiSubscriberLogInFailed Trap indicates that 
@@ -319,7 +395,11 @@
             jnxJsPacketMirrorDirection,
             jnxJsPacketMirrorTargetIpAddress,
             jnxJsPacketMirrorAnalyzerAddress,
-            jnxJsPacketMirrorTerminationReason }
+            jnxJsPacketMirrorTerminationReason,
+            jnxJsPacketMirrorOctetsReceived,
+            jnxJsPacketMirrorOctetsTransmitted,
+            jnxJsPacketMirrorTargetIpv6Address,
+            jnxJsPacketMirrorTrgtIpv6PfxLen }
         STATUS       current
         DESCRIPTION
             "The jnxJsPacketMirrorLiSubscriberLoggedOut Trap indicates that 
@@ -341,7 +421,11 @@
             jnxJsPacketMirrorSessionIdentifier,
             jnxJsPacketMirrorDirection,
             jnxJsPacketMirrorTargetIpAddress,
-            jnxJsPacketMirrorAnalyzerAddress }
+            jnxPacketMirrorNasIdentifier,
+            jnxPacketMirrorCallingStationIdentifier,
+            jnxJsPacketMirrorAnalyzerAddress,
+            jnxJsPacketMirrorTargetIpv6Address,
+            jnxJsPacketMirrorTrgtIpv6PfxLen }
         STATUS       current
         DESCRIPTION
             "The jnxJsPacketMirrorLiServiceActivated Trap indicates that 
@@ -364,7 +448,10 @@
             jnxJsPacketMirrorTargetIpAddress,
             jnxJsPacketMirrorAnalyzerAddress,
             jnxJsPacketMirrorErrorCause,
-            jnxJsPacketMirrorErrorString }
+            jnxJsPacketMirrorErrorString,
+            jnxPacketMirrorCallingStationIdentifier,
+            jnxJsPacketMirrorTargetIpv6Address,
+            jnxJsPacketMirrorTrgtIpv6PfxLen }
         STATUS       current
         DESCRIPTION
             "The jnxJsPacketMirrorLiServiceActivationFailed Trap indicates  
@@ -387,7 +474,9 @@
             jnxJsPacketMirrorDirection,
             jnxJsPacketMirrorTargetIpAddress,
             jnxJsPacketMirrorAnalyzerAddress,
-            jnxJsPacketMirrorTerminationReason }
+            jnxJsPacketMirrorTerminationReason,
+            jnxJsPacketMirrorTargetIpv6Address,
+            jnxJsPacketMirrorTrgtIpv6PfxLen }
         STATUS       current
         DESCRIPTION
             "The jnxJsPacketMirrorLiServiceDeactivated Trap indicates that 

--- a/mibs/junos/mib-jnx-js-smi.txt
+++ b/mibs/junos/mib-jnx-js-smi.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Structure of Management Information
 -- 
--- Copyright (c) 2002-2008, Juniper Networks, Inc.
+-- Copyright (c) 2002-2011, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -53,4 +53,5 @@ jnxJsUTMRoot                    OBJECT IDENTIFIER ::= { jnxJsSecurity 13 }
 jnxJsChassisCluster             OBJECT IDENTIFIER ::= { jnxJsSecurity 14 }
 jnxVoip                         OBJECT IDENTIFIER ::= { jnxJsSecurity 15 }
 jnxJsPacketMirror               OBJECT IDENTIFIER ::= { jnxJsSecurity 16 }
+jnxLsysSecurityProfile          OBJECT IDENTIFIER ::= { jnxJsSecurity 17 }
 END 

--- a/mibs/junos/mib-jnx-js-spu-monitoring.txt
+++ b/mibs/junos/mib-jnx-js-spu-monitoring.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise specific MIB: SRX5000 SPU monitoring MIB
 --
--- Copyright (c) 2008, Juniper Networks, Inc.
+-- Copyright (c) 2008-2010, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -12,13 +12,15 @@ JUNIPER-SRX5000-SPU-MONITORING-MIB DEFINITIONS ::= BEGIN
 IMPORTS
     MODULE-IDENTITY, OBJECT-TYPE, Gauge32, Unsigned32
         FROM SNMPv2-SMI
+    CounterBasedGauge64
+        FROM HCNUM-TC
     DisplayString 
         FROM SNMPv2-TC
     jnxJsSPUMonitoringRoot
         FROM JUNIPER-JS-SMI;
 
 jnxJsSPUMonitoringMIB MODULE-IDENTITY
-    LAST-UPDATED "200804160000Z" -- Apr 16 00:00:00 2008 UTC
+    LAST-UPDATED "201003250000Z" -- Mar 25 00:00:00 2010 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -29,6 +31,11 @@ jnxJsSPUMonitoringMIB MODULE-IDENTITY
     DESCRIPTION
         "This is Juniper Networks' implementation of enterprise
                  specific MIB for SRX5000 SPU monitoring."
+    REVISION
+        "201003250000Z" -- Mar 25 00:00:00 2010 UTC
+    DESCRIPTION
+        "add MIB for session creation per second."
+
     ::= { jnxJsSPUMonitoringRoot 1 }
 
     jnxJsSPUMonitoringObjectsTable OBJECT-TYPE
@@ -39,22 +46,6 @@ jnxJsSPUMonitoringMIB MODULE-IDENTITY
             "This table exposes SPUs utilization statistics." 
         ::= { jnxJsSPUMonitoringMIB 1 }
 
-    jnxJsSPUMonitoringCurrentTotalSession OBJECT-TYPE
-        SYNTAX Unsigned32
-        MAX-ACCESS  read-only
-        STATUS  current
-        DESCRIPTION
-                "System level total session in use."
-        ::= { jnxJsSPUMonitoringMIB 2 }
-
-    jnxJsSPUMonitoringMaxTotalSession OBJECT-TYPE
-        SYNTAX Unsigned32
-        MAX-ACCESS  read-only
-        STATUS  current
-        DESCRIPTION
-                "System level max session possible."
-        ::= { jnxJsSPUMonitoringMIB 3 }
-	
     jnxJsSPUMonitoringObjectsEntry OBJECT-TYPE
         SYNTAX        JnxJsSPUMonitoringObjectsEntry
         MAX-ACCESS    not-accessible
@@ -173,6 +164,94 @@ jnxJsSPUMonitoringMIB MODULE-IDENTITY
              cluster node.  When it is cluster mode, the chassis can be 
              denoted as a cluster node."
         ::= { jnxJsSPUMonitoringObjectsEntry 11 }
+
+    jnxJsSPUMonitoringCurrentTotalSession OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+                "System level total session in use."
+        ::= { jnxJsSPUMonitoringMIB 2 }
+
+    jnxJsSPUMonitoringMaxTotalSession OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+                "System level max session possible."
+        ::= { jnxJsSPUMonitoringMIB 3 }
+
+    jnxSPUClusterObjectsTable OBJECT-TYPE
+        SYNTAX        SEQUENCE OF JnxSPUClusterObjectsEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "This table exposes SPU monitoring objects in HA cluster."
+        ::= { jnxJsSPUMonitoringMIB 4 }
+
+
+    jnxSPUClusterObjectsEntry OBJECT-TYPE
+        SYNTAX        JnxSPUClusterObjectsEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "Each entry collects SPU monitoring contents in HA cluster."
+        INDEX   { jnxJsClusterMonitoringNodeIndex }
+        ::= { jnxSPUClusterObjectsTable 1 }
+
+    JnxSPUClusterObjectsEntry ::= SEQUENCE
+    {
+        jnxJsClusterMonitoringNodeIndex     Unsigned32,
+        jnxJsClusterMonitoringNodeDescr     DisplayString,
+        jnxJsNodeCurrentTotalSession 	Unsigned32,
+        jnxJsNodeMaxTotalSession	Unsigned32,
+        jnxJsNodeSessionCreationPerSecond	CounterBasedGauge64
+    }
+
+    jnxJsClusterMonitoringNodeIndex OBJECT-TYPE
+        SYNTAX  Unsigned32
+        MAX-ACCESS not-accessible
+        STATUS  current
+        DESCRIPTION
+                "This attribute is used to identify a chassis. A chassis can 
+                 be configured in a single or cluster mode.  When it is in a 
+                 cluster mode, the chassis can be denote as a cluster node."
+        ::= { jnxSPUClusterObjectsEntry 1 }
+
+    jnxJsClusterMonitoringNodeDescr OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(1..255))
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "This attribute is used to describe the chassis/cluster 
+             node information.  Chassis can be configured as a single, or 
+             cluster node.  When it is cluster mode, the chassis can be 
+             denoted as a cluster node."
+        ::= { jnxSPUClusterObjectsEntry 2 }
+	
+    jnxJsNodeCurrentTotalSession OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+                "Node total session in use."
+        ::= { jnxSPUClusterObjectsEntry 3 }
+
+    jnxJsNodeMaxTotalSession OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+                "Node max session possible."
+        ::= { jnxSPUClusterObjectsEntry 4 }
+	
+    jnxJsNodeSessionCreationPerSecond OBJECT-TYPE
+	SYNTAX CounterBasedGauge64
+	MAX-ACCESS  read-only
+	STATUS  current
+	DESCRIPTION
+		"Node average session created in last 96 seconds."
+	::= { jnxSPUClusterObjectsEntry 5 }
 
 END
 

--- a/mibs/junos/mib-jnx-js-utm-av.txt
+++ b/mibs/junos/mib-jnx-js-utm-av.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper enterprise security UTM MIB.       
 --
--- Copyright (c) 2001-2008, Juniper Networks, Inc.
+-- Copyright (c) 2001-2011, Juniper Networks, Inc.
 -- All rights reserved.      
 --                 
 -- The contents of this document are subject to change without notice.
@@ -19,7 +19,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
         
 
     jnxJsAntiVirus MODULE-IDENTITY
-        LAST-UPDATED  "200811241622Z" -- Nov 24, 2008
+        LAST-UPDATED  "201102080800Z" -- Feb 08, 2011
         ORGANIZATION  "Juniper Networks, Inc."    
         CONTACT-INFO
             "Juniper Technical Assistance Center
@@ -34,7 +34,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
              antivirus functionality. Juniper documentation is recommended
              as the reference."
             
-        REVISION      "200811241622Z" 
+        REVISION      "201102080800Z" 
         DESCRIPTION   "Creation Date"
 
         ::= { jnxJsUTMRoot 1 }                 
@@ -65,7 +65,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
             sophos-engine          (4)
         }
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "The scan engine type in use. User can use CLI to set the
              engine type to either full AV (kaspersky-lab-engine),
@@ -77,7 +77,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVCurrentPatternVersionString       OBJECT-TYPE
         SYNTAX        DisplayString (SIZE(1..255))
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Anti-Virus pattern database version currently in use."
         ::= { jnxJsAntiVirusEngine 2 }
@@ -90,7 +90,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
             sophos          (4)
         }
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "The Database type in use. User can use CLI to set the
              engine type to full AV, express AV or Sophos AV. 
@@ -108,7 +108,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeClean           OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests passed Anti-Virus scan."
         ::= { jnxJsAntiVirusStats 1 }
@@ -116,7 +116,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeInfected        OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests found infected by Anti-Virus scan engine."
         ::= { jnxJsAntiVirusStats 2 }
@@ -124,7 +124,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeProtected       OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to protected by password."
         ::= { jnxJsAntiVirusStats 3 }
@@ -132,7 +132,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeDecompress      OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to exceeding max 
             decmopress layer."
@@ -141,7 +141,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeCorrupted       OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to file corrupted."
         ::= { jnxJsAntiVirusStats 5 }
@@ -149,7 +149,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeNoResource      OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to out-of-resource."
         ::= { jnxJsAntiVirusStats 6 }
@@ -158,7 +158,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeInternalError   OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to internal error."
         ::= { jnxJsAntiVirusStats 7 }
@@ -166,7 +166,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeMaxContentSize  OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to exceeding max content
              size limit."
@@ -175,7 +175,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeTooManyReq      OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to exceeding maximum 
              requests limit."
@@ -185,7 +185,7 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeTimeout         OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to scan timeout."
         ::= { jnxJsAntiVirusStats 10 }
@@ -193,11 +193,227 @@ JUNIPER-JS-UTM-AV-MIB DEFINITIONS ::= BEGIN
     jnxJsAVScanCodeEngineNotReady  OBJECT-TYPE
         SYNTAX        Integer32
         MAX-ACCESS    read-only
-        STATUS        current
+        STATUS        deprecated 
         DESCRIPTION
             "Number of requests cannot be scanned due to scan engine not ready."
         ::= { jnxJsAntiVirusStats 11 }
 
+    -- ***************************************************************
+    -- scan engine table objects
+    -- ***************************************************************
+
+    jnxJsUTMAntiVirusEngine OBJECT-TYPE
+        SYNTAX        SEQUENCE OF JnxJsUTMAntiVirusEngineEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "Table of anti-virus engine objects."
+        ::= { jnxJsAntiVirusObjects 3 }
+        
+    jnxJsUTMAntiVirusEngineEntry OBJECT-TYPE
+        SYNTAX        JnxJsUTMAntiVirusEngineEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "Entry for anti-virus engine table."
+        INDEX         { jnxJsUTMAVEngineIndex }
+        ::= { jnxJsUTMAntiVirusEngine 1 }
+    
+    JnxJsUTMAntiVirusEngineEntry ::= SEQUENCE {
+        jnxJsUTMAVEngineIndex                    Integer32,
+        jnxJsUTMAVEngineType                     INTEGER,
+        jnxJsUTMAVPatternVersionString           DisplayString,
+        jnxJsUTMAVDatabaseType                   INTEGER
+    }
+
+    jnxJsUTMAVEngineIndex OBJECT-TYPE
+        SYNTAX        Integer32 (0..'7fffffff'h)
+        MAX-ACCESS    not-accessible 
+        STATUS        current
+        DESCRIPTION
+            "Index is the cluster node number. If the device is
+             not in a cluster mode then it will be the local node
+             number."
+        ::= { jnxJsUTMAntiVirusEngineEntry 1 }
+
+    jnxJsUTMAVEngineType OBJECT-TYPE
+        SYNTAX INTEGER {
+            unknown-engine         (1),
+            kaspersky-lab-engine   (2),
+            juniper-express-engine (3),
+            sophos-engine          (4)
+        }
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The scan engine type in use. User can use CLI to set the
+             engine type to either full AV (kaspersky-lab-engine),
+             express AV (juniper-express-engine) or Sophos AV
+             (sophos-engine). If AV is not configured then engine type
+             is not known."
+        ::= { jnxJsUTMAntiVirusEngineEntry 2 }
+
+    jnxJsUTMAVPatternVersionString       OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(1..255))
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Anti-Virus pattern database version currently in use."
+        ::= { jnxJsUTMAntiVirusEngineEntry 3 }
+
+    jnxJsUTMAVDatabaseType OBJECT-TYPE
+        SYNTAX INTEGER {
+            full            (1),
+            express         (2),
+            unknown         (3),
+            sophos          (4)
+        }
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The Database type in use. User can use CLI to set the
+             engine type to full AV, express AV or Sophos AV.
+             Corresponding database types are Full for KL Engine,
+             Express for Juniper Express Engine and Sophos for Sophos
+             AV Engine."
+        ::= { jnxJsUTMAntiVirusEngineEntry 4 }
+
+    -- ***************************************************************
+    -- scan statistics table objects
+    -- ***************************************************************
+
+    jnxJsUTMAntiVirusStats OBJECT-TYPE
+        SYNTAX        SEQUENCE OF JnxJsUTMAntiVirusStatsEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "Table of anti-virus stats objects."
+        ::= { jnxJsAntiVirusObjects 4 }
+
+    jnxJsUTMAntiVirusStatsEntry OBJECT-TYPE
+        SYNTAX        JnxJsUTMAntiVirusStatsEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "Entry of anti-virus stats object."
+        INDEX         { jnxJsUTMAVStatsIndex }
+        ::= { jnxJsUTMAntiVirusStats 1 }
+
+    JnxJsUTMAntiVirusStatsEntry ::= SEQUENCE {
+        jnxJsUTMAVStatsIndex                Integer32,
+        jnxJsUTMAVScanCodeClean             Integer32,
+        jnxJsUTMAVScanCodeInfected          Integer32,
+        jnxJsUTMAVScanCodeProtected         Integer32,
+        jnxJsUTMAVScanCodeDecompress        Integer32,
+        jnxJsUTMAVScanCodeCorrupted         Integer32,
+        jnxJsUTMAVScanCodeNoResource        Integer32,
+        jnxJsUTMAVScanCodeInternalError     Integer32,
+        jnxJsUTMAVScanCodeMaxContentSize    Integer32,
+        jnxJsUTMAVScanCodeTooManyReq        Integer32,
+        jnxJsUTMAVScanCodeTimeout           Integer32,
+        jnxJsUTMAVScanCodeEngineNotReady    Integer32
+    }
+
+    jnxJsUTMAVStatsIndex OBJECT-TYPE
+        SYNTAX        Integer32 (0..'7fffffff'h)
+        MAX-ACCESS    not-accessible 
+        STATUS        current
+        DESCRIPTION
+            "Index is the cluster node number. If the device is
+             not in a cluster mode then it will be the local node
+             number."
+        ::= { jnxJsUTMAntiVirusStatsEntry 1 }
+
+    jnxJsUTMAVScanCodeClean           OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests passed Anti-Virus scan."
+        ::= { jnxJsUTMAntiVirusStatsEntry 2 }
+
+    jnxJsUTMAVScanCodeInfected        OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests found infected by Anti-Virus scan engine."
+        ::= { jnxJsUTMAntiVirusStatsEntry 3 }
+
+    jnxJsUTMAVScanCodeProtected       OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to protected by password."
+        ::= { jnxJsUTMAntiVirusStatsEntry 4 }
+
+    jnxJsUTMAVScanCodeDecompress      OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to exceeding max
+            decmopress layer."
+        ::= { jnxJsUTMAntiVirusStatsEntry 5 }
+
+    jnxJsUTMAVScanCodeCorrupted       OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to file corrupted."
+        ::= { jnxJsUTMAntiVirusStatsEntry 6 }
+
+    jnxJsUTMAVScanCodeNoResource      OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to out-of-resource."
+        ::= { jnxJsUTMAntiVirusStatsEntry 7 }
+
+    jnxJsUTMAVScanCodeInternalError   OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to internal error."
+        ::= { jnxJsUTMAntiVirusStatsEntry 8 }
+
+    jnxJsUTMAVScanCodeMaxContentSize  OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to exceeding max content
+             size limit."
+        ::= { jnxJsUTMAntiVirusStatsEntry 9 }
+
+    jnxJsUTMAVScanCodeTooManyReq      OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to exceeding maximum
+             requests limit."
+        ::= { jnxJsUTMAntiVirusStatsEntry 10 }
+
+    jnxJsUTMAVScanCodeTimeout         OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to scan timeout."
+        ::= { jnxJsUTMAntiVirusStatsEntry 11 }
+
+    jnxJsUTMAVScanCodeEngineNotReady  OBJECT-TYPE
+        SYNTAX        Integer32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Number of requests cannot be scanned due to scan engine not ready."
+        ::= { jnxJsUTMAntiVirusStatsEntry 12 }
 
 
     -- ***************************************************************

--- a/mibs/junos/mib-jnx-jsrpd.txt
+++ b/mibs/junos/mib-jnx-jsrpd.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper enterprise specific Chassis Cluster objects MIB.
 --
--- Copyright (c) 2008, Juniper Networks, Inc.
+-- Copyright (c) 2008-2011, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -23,7 +23,7 @@
 
 
     jnxJsChassisClusterMIB  MODULE-IDENTITY
-        LAST-UPDATED  "200905270000Z"
+        LAST-UPDATED  "201106280000Z"
         ORGANIZATION  "Juniper Networks, Inc."
         CONTACT-INFO
             "Juniper Technical Assistance Center
@@ -39,6 +39,10 @@
              a cluster fails, the other chassis in the cluster takes over the function 
              of the failed chassis with minimal service interruption.
              This module defines the objects pertaining to Chassis Cluster."
+
+        REVISION      "201106280000Z"
+        DESCRIPTION   "Added trap jnxJsChClusterIntfTrap"
+
         REVISION      "200905270000Z"
         DESCRIPTION   "Added trap class for jnxJsChassisClusterSwitchover"
 
@@ -67,6 +71,22 @@
         DESCRIPTION
             "Notification to signal switchover/failover."
         ::= { jnxJsChassisClusterNotifications 1 }
+
+    -- ***************************************************************
+    -- definition of a trap that notifies changes in fabric
+    -- and control link status.
+    -- ***************************************************************
+
+    jnxJsChClusterIntfTrap  NOTIFICATION-TYPE
+        OBJECTS { jnxJsChClusterSwitchoverInfoClusterId, 
+                  jnxJsChClusterIntfName,
+                  jnxJsChClusterIntfState,
+                  jnxJsChClusterIntfSeverity,
+                  jnxJsChClusterIntfStateReason }
+        STATUS              current
+        DESCRIPTION
+            "Notification to signal change in HA interface state."
+        ::= { jnxJsChassisClusterNotifications 2 }
 
 	jnxJsChClusterSwitchoverInfoRedundancyGroup OBJECT-TYPE
         SYNTAX      DisplayString
@@ -120,4 +140,41 @@
         DESCRIPTION
             "This object contains the cause for switchover."
         ::= { jnxJsChassisClusterTrapObjects 6 }
+
+    jnxJsChClusterIntfName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "This object contains the name of the link 
+             that changed its state."
+        ::= { jnxJsChassisClusterTrapObjects 7 }
+
+    jnxJsChClusterIntfState OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "This object contains the state of the link; 
+             whether it is UP or DOWN."
+        ::= { jnxJsChassisClusterTrapObjects 8 }
+
+    jnxJsChClusterIntfSeverity OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "This object reflects the severity; 
+             whether it is minor or major."
+        ::= { jnxJsChassisClusterTrapObjects 9 }
+
+    jnxJsChClusterIntfStateReason OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "This object contains the reason why the link state 
+             changed."
+        ::= { jnxJsChassisClusterTrapObjects 10 }
+
 END

--- a/mibs/junos/mib-jnx-jvae-infra.txt
+++ b/mibs/junos/mib-jnx-jvae-infra.txt
@@ -1,0 +1,300 @@
+--
+-- Juniper JunosV App Engine Infrastructure MIB
+--
+-- Copyright (c) 2012 Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-JVAE-INFRA-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, OBJECT-IDENTITY
+        FROM SNMPv2-SMI
+
+    DisplayString
+        FROM SNMPv2-TC
+
+    InetAddressIPv4, InetAddressIPv6
+        FROM INET-ADDRESS-MIB
+
+    jnxJVAEMibRoot
+        FROM JUNIPER-SMI;
+
+jnxJVAEInfraMIB MODULE-IDENTITY
+    LAST-UPDATED "201208010000Z" -- Aug 01 00:00:00 2012 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+    DESCRIPTION
+        "The MIB module for JunosV App Engine Infrastructure."
+    REVISION    "201208010000Z" -- Aug 01 00:00:00 2012 UTC
+    DESCRIPTION
+            "Initial version of JVAE Infrastructure MIB."
+
+    ::= { jnxJVAEMibRoot 1 }
+
+
+jnxJVAEInfraNotifications  OBJECT IDENTIFIER ::= { jnxJVAEInfraMIB 0 }
+jnxJVAEInfraObjects        OBJECT IDENTIFIER ::= { jnxJVAEInfraMIB 1 }
+jnxJVAEInfraTables         OBJECT IDENTIFIER ::= { jnxJVAEInfraObjects 1 }
+
+
+   -- 
+   -- JVAE Infrstructure Objects
+   --
+
+   --
+   -- Compute Node Table
+   --
+
+jnxJVAECNTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of Compute Nodes."
+    ::= { jnxJVAEInfraTables 1 }
+
+jnxJVAECNEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A Compute Node."
+    INDEX { jnxJVAECNId }
+    ::= { jnxJVAECNTable 1 }
+
+JnxJVAECNEntry ::= SEQUENCE {
+    jnxJVAECNId                 DisplayString,
+    jnxJVAECNName               DisplayString,
+    jnxJVAECCName               DisplayString,
+    jnxJVAECNState              INTEGER,
+    jnxJVAECNLastStateChange    DisplayString,
+    jnxJVAECNRouterIPv4         InetAddressIPv4,
+    jnxJVAECNRouterIPv6         InetAddressIPv6,
+    jnxJVAECNMgmtIPv4           InetAddressIPv4,
+    jnxJVAECNMgmtIPv6           InetAddressIPv6,
+    jnxJVAECNSWVersion          DisplayString
+}
+
+jnxJVAECNId OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(1..32))
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+         "Id of the Compute Node."
+    ::= { jnxJVAECNEntry 1 }
+
+jnxJVAECNName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..60))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of the Compute Node."
+    ::= { jnxJVAECNEntry 2 }
+
+jnxJVAECCName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..60))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of the Compute Cluster, to which this Compute Node belongs."
+    ::= { jnxJVAECNEntry 3 }
+
+jnxJVAECNState OBJECT-TYPE
+    SYNTAX      INTEGER { offline(0), online(1), error(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "State of Compute Node as seen by the VE platform Manager."
+    ::= { jnxJVAECNEntry 4 }
+
+jnxJVAECNLastStateChange OBJECT-TYPE
+    SYNTAX     DisplayString (SIZE(26..30))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The date and time when last state change was observed for this
+         Compute Node."
+    ::= { jnxJVAECNEntry 5 }
+
+jnxJVAECNRouterIPv4  OBJECT-TYPE
+    SYNTAX       InetAddressIPv4
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+         "Network address on the router side, which used for all management
+          between the router and Compute Node."
+    ::= { jnxJVAECNEntry 6 }
+
+jnxJVAECNRouterIPv6  OBJECT-TYPE
+    SYNTAX       InetAddressIPv6
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+         "Network address on the router side, which used for all management
+          between the router and Compute Node."
+    ::= { jnxJVAECNEntry 7 }
+
+jnxJVAECNMgmtIPv4 OBJECT-TYPE
+    SYNTAX      InetAddressIPv4
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "Network address on the compute node side, which used for all management
+          between the router and Compute Node."
+    ::= { jnxJVAECNEntry 8 }
+
+jnxJVAECNMgmtIPv6 OBJECT-TYPE
+    SYNTAX      InetAddressIPv6
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "Network address on the compute node side, which used for all management
+          between the router and Compute Node."
+    ::= { jnxJVAECNEntry 9 }
+
+jnxJVAECNSWVersion OBJECT-TYPE
+    SYNTAX     DisplayString (SIZE(1..128))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+         "Compute Node software version."
+    ::= { jnxJVAECNEntry 10 }
+
+   --
+   -- Virtual Machine Instances Table
+   --
+
+jnxJVAEVMTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAEVMEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of virutal machine instances."
+    ::= { jnxJVAEInfraTables 2 }
+
+jnxJVAEVMEntry OBJECT-TYPE
+    SYNTAX      JnxJVAEVMEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A virutal machine instance."
+    INDEX { jnxJVAEVMId }
+    ::= { jnxJVAEVMTable 1 }
+
+JnxJVAEVMEntry ::= SEQUENCE {
+    jnxJVAEVMId               OCTET STRING,
+    jnxJVAEVMName             DisplayString,
+    jnxJVAEVMCCName           DisplayString,
+    jnxJVAEVMCNName           DisplayString,
+    jnxJVAEVMCNId             DisplayString,
+    jnxJVAEVMUuid             OCTET STRING,
+    jnxJVAEVMPkg              DisplayString,
+    jnxJVAEVMStatus           INTEGER
+}
+
+jnxJVAEVMId OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..127))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An unique identifier for this virtual machine instance. This
+	 identifier is not retained across restart of the subsytem."
+    ::= { jnxJVAEVMEntry 1 }
+
+jnxJVAEVMName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..60))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of the virtual machine instance."
+    ::= { jnxJVAEVMEntry 2 }
+
+jnxJVAEVMCCName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..60))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of the compute cluster which the compute node belongs."
+    ::= { jnxJVAEVMEntry 3 }
+
+jnxJVAEVMCNName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..60))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of the compute node on which the virtual machine runs."
+    ::= { jnxJVAEVMEntry 4 }
+
+jnxJVAEVMCNId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Id of the compute node on which the virtual machine runs."
+    ::= { jnxJVAEVMEntry 5 }
+
+jnxJVAEVMUuid OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(1..60))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "UUID of the virtual machine."
+    ::= { jnxJVAEVMEntry 6 }
+
+jnxJVAEVMPkg OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of package installed on the router holding the imgage for
+	 this virtual machine."
+    ::= { jnxJVAEVMEntry 7 }
+
+jnxJVAEVMStatus OBJECT-TYPE
+    SYNTAX      INTEGER { offline(0), online(1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Status of the virtual machine instance."
+    ::= { jnxJVAEVMEntry 8 }
+
+
+   --
+   -- JVAE Infrastructure Notifications
+   --
+
+jnxJVAECNStateChange NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNId,
+         jnxJVAECNName,
+         jnxJVAECCName,
+         jnxJVAECNState,
+         jnxJVAECNLastStateChange
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever compute node state changes."
+    ::= { jnxJVAEInfraNotifications  1 }
+
+jnxJVAEVMStateChange NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAEVMId,
+         jnxJVAEVMName,
+         jnxJVAEVMCNId,
+         jnxJVAEVMUuid,
+         jnxJVAEVMStatus
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification whenever the virutal machine status changes."
+    ::= { jnxJVAEInfraNotifications  2 }
+
+END

--- a/mibs/junos/mib-jnx-jvae-node.txt
+++ b/mibs/junos/mib-jnx-jvae-node.txt
@@ -1,0 +1,908 @@
+--
+-- Juniper JunosV App Engine Node MIB
+--
+-- Copyright (c) 2012 Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-JVAE-NODE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, OBJECT-IDENTITY,
+    Gauge32, Counter64
+        FROM SNMPv2-SMI
+
+    DisplayString, PhysAddress, TruthValue
+        FROM SNMPv2-TC
+
+    jnxJVAEMibRoot
+        FROM JUNIPER-SMI;
+
+jnxJVAENodeMIB MODULE-IDENTITY
+    LAST-UPDATED "201208010000Z" -- Aug 01 00:00:00 2012 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+    DESCRIPTION
+        "The MIB modules for JunosV App Engine Compute Nodes."
+    REVISION    "201208010000Z" -- Aug 01 00:00:00 2012 UTC
+    DESCRIPTION
+            "Initial version of JVAE Node MIB."
+
+    ::= { jnxJVAEMibRoot 2 }
+
+
+jnxJVAENodeNotifications  OBJECT IDENTIFIER ::= { jnxJVAENodeMIB 0 }
+jnxJVAENodeObjects        OBJECT IDENTIFIER ::= { jnxJVAENodeMIB 1 }
+jnxJVAENodeTables         OBJECT IDENTIFIER ::= { jnxJVAENodeObjects 1 }
+
+
+   -- 
+   -- JVAE Node Objects
+   --
+
+   --
+   -- Compute Node System Information Table
+   --
+
+jnxJVAECNSysInfoTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNSysInfoEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table for further information on Compute Nodes."
+    ::= { jnxJVAENodeTables 1 }
+
+jnxJVAECNSysInfoEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNSysInfoEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "System information for a Compute Node."
+    INDEX { jnxJVAECNSysId }
+    ::= { jnxJVAECNSysInfoTable 1 }
+
+JnxJVAECNSysInfoEntry ::= SEQUENCE {
+    jnxJVAECNSysId                 DisplayString,
+    jnxJVAECNSysCpus               INTEGER,
+    jnxJVAECNSysProcessingLoad     INTEGER,
+    jnxJVAECNSysMemCapacity        Gauge32,
+    jnxJVAECNSysMemUsed            Gauge32,
+    jnxJVAECNSysMemFree            Gauge32,
+    jnxJVAECNSysMemUsedPr          INTEGER,
+    jnxJVAECNSysSwapCapacity       Gauge32,
+    jnxJVAECNSysSwapFree           Gauge32,
+    jnxJVAECNSysBootMethod         INTEGER,
+    jnxJVAECNSysLastReboot         DisplayString
+}
+
+jnxJVAECNSysId OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(1..32))
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+         "Id of the Compute Node."
+    ::= { jnxJVAECNSysInfoEntry 1 }
+
+jnxJVAECNSysCpus OBJECT-TYPE
+    SYNTAX      INTEGER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "The number of CPUs or cores on the Compute Node."
+    ::= { jnxJVAECNSysInfoEntry 2 }
+
+jnxJVAECNSysProcessingLoad OBJECT-TYPE
+    SYNTAX      INTEGER (0..100)
+    UNITS	"%"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "Total processing load on the Compute Node, in percentage."
+    ::= { jnxJVAECNSysInfoEntry 3 }
+
+jnxJVAECNSysMemCapacity OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "The amount of RAM on the Compute Node, in kilo bytes. Zero if 
+	  information is unavailable."
+    ::= { jnxJVAECNSysInfoEntry 4 }
+
+jnxJVAECNSysMemUsed OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "The amount of RAM used on the Compute Node, in kilo bytes. Zero
+	  if information in unavailable."
+    ::= { jnxJVAECNSysInfoEntry 5 }
+
+jnxJVAECNSysMemFree OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "The amount of RAM free on the Compute Node, in kilo bytes. Zero
+	  if information in unavailable."
+    ::= { jnxJVAECNSysInfoEntry 6 }
+
+jnxJVAECNSysMemUsedPr OBJECT-TYPE
+    SYNTAX      INTEGER (0..100)
+    UNITS	"%"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "The amount of RAM used on the Compute Node, in percentage. Zero
+	  if information in unavailable."
+    ::= { jnxJVAECNSysInfoEntry 7 }
+
+jnxJVAECNSysSwapCapacity OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "Total swap space on the Compute Node, in kilo bytes. Zero if
+	  information is unavailable."
+    ::= { jnxJVAECNSysInfoEntry 8 }
+
+jnxJVAECNSysSwapFree OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "The amout of swap space free on the Compute Node, in kilo bytes.
+	  Zero if information is unavailable."
+    ::= { jnxJVAECNSysInfoEntry 9 }
+
+jnxJVAECNSysBootMethod OBJECT-TYPE
+    SYNTAX      INTEGER { unknown(0), network(1), local (2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "Boot method used by the Compute Node, in the last reboot."
+    ::= { jnxJVAECNSysInfoEntry 10 }
+
+jnxJVAECNSysLastReboot OBJECT-TYPE
+    SYNTAX     DisplayString (SIZE(30))
+    UNITS      "Secs"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+         "Seconds passed since the last reboot or restart of the Compute Node."
+    ::= { jnxJVAECNSysInfoEntry 11 }
+
+   --
+   -- Compute Node Processor (CPU) Table
+   --
+
+jnxJVAECNProcessorTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNProcessorEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of Processors contained in the Compute Nodes."
+    ::= { jnxJVAENodeTables 2 }
+
+jnxJVAECNProcessorEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNProcessorEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A Processor."
+    INDEX { jnxJVAECNSysId, jnxJVAECNProcessorId }
+    ::= { jnxJVAECNProcessorTable 1 }
+
+JnxJVAECNProcessorEntry ::= SEQUENCE {
+    jnxJVAECNProcessorId        INTEGER,
+    jnxJVAECNProcessorLoad      INTEGER
+}
+
+jnxJVAECNProcessorId OBJECT-TYPE
+    SYNTAX      INTEGER (1..256)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An unique identifier for the processor with this Compute Node."
+    ::= { jnxJVAECNProcessorEntry 1 }
+
+jnxJVAECNProcessorLoad OBJECT-TYPE
+    SYNTAX      INTEGER (0..100)
+    UNITS	"%"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Load on the processor, expressed in percentage. Zero if information
+         is unavailable."
+    ::= { jnxJVAECNProcessorEntry 2 }
+
+   --
+   -- Compute Node Network Interface Table
+   --
+
+jnxJVAECNifTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNifEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of network interfaces contained in the Compute Nodes."
+    ::= { jnxJVAENodeTables 3 }
+
+jnxJVAECNifEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNifEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A network interface."
+    INDEX { jnxJVAECNSysId, jnxJVAECNifId }
+    ::= { jnxJVAECNifTable 1 }
+
+JnxJVAECNifEntry ::= SEQUENCE {
+    jnxJVAECNifId              INTEGER,
+    jnxJVAECNifName            DisplayString,
+    jnxJVAECNifOperStatus      INTEGER,
+    jnxJVAECNifAdminStatus     INTEGER,
+    jnxJVAECNifLinkDetect      TruthValue,
+    jnxJVAECNifAddress         PhysAddress,
+    jnxJVAECNifInPkts          Counter64,
+    jnxJVAECNifInDiscards      Counter64,
+    jnxJVAECNifInErrors        Counter64,
+    jnxJVAECNifOutPkts         Counter64,
+    jnxJVAECNifOutDiscards     Counter64,
+    jnxJVAECNifOutErrors       Counter64
+}
+
+jnxJVAECNifId OBJECT-TYPE
+    SYNTAX      INTEGER (1..65535)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An unique identifier for the network interface."
+    ::= { jnxJVAECNifEntry 1 }
+
+jnxJVAECNifName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..10))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Description of the interface."
+    ::= { jnxJVAECNifEntry 2 }
+
+jnxJVAECNifOperStatus OBJECT-TYPE
+    SYNTAX      INTEGER { down(0), up (1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Operational state of the interface."
+    ::= { jnxJVAECNifEntry 3 }
+
+jnxJVAECNifAdminStatus OBJECT-TYPE
+    SYNTAX      INTEGER { down(0), up (1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Administrative state of the interface."
+    ::= { jnxJVAECNifEntry 4 }
+
+jnxJVAECNifLinkDetect OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Link presence, True if present else False. This field is meaningless
+         when the interface is  administered down."
+    ::= { jnxJVAECNifEntry 5 }
+
+jnxJVAECNifAddress OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Physcial address (MAC) of the interface."
+    ::= { jnxJVAECNifEntry 6 }
+
+jnxJVAECNifInPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received on the interface."
+    ::= { jnxJVAECNifEntry 7 }
+
+jnxJVAECNifInDiscards OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of received packets discarded, on the interface."
+    ::= { jnxJVAECNifEntry 8 }
+
+jnxJVAECNifInErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of received packets with errors, on the interface."
+    ::= { jnxJVAECNifEntry 9 }
+
+jnxJVAECNifOutPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets sent on the interface."
+    ::= { jnxJVAECNifEntry 10 }
+
+jnxJVAECNifOutDiscards OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of sent packets discarded, on the interface."
+    ::= { jnxJVAECNifEntry 11 }
+
+jnxJVAECNifOutErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of sent packets with errors, on the interface."
+    ::= { jnxJVAECNifEntry 12 }
+
+   --
+   -- Compute Node File System Table
+   --
+
+jnxJVAECNFileSysTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNFileSysEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of mounted file systems in the Compute Nodes."
+    ::= { jnxJVAENodeTables 4 }
+
+jnxJVAECNFileSysEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNFileSysEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A File System."
+    INDEX { jnxJVAECNSysId, jnxJVAECNFileSysId }
+    ::= { jnxJVAECNFileSysTable 1 }
+
+JnxJVAECNFileSysEntry ::= SEQUENCE {
+    jnxJVAECNFileSysId            INTEGER,
+    jnxJVAECNFileSysMountPoint    DisplayString,
+    jnxJVAECNFileSysSize          Gauge32,
+    jnxJVAECNFileSysUsed          Gauge32,
+    jnxJVAECNFileSysFree          Gauge32,
+    jnxJVAECNFileSysUsedPr        INTEGER
+}
+
+jnxJVAECNFileSysId OBJECT-TYPE
+    SYNTAX      INTEGER (1..127)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An unique identifier for the file system."
+    ::= { jnxJVAECNFileSysEntry 1 }
+
+jnxJVAECNFileSysMountPoint OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Filesystem path where the file system is mounted."
+    ::= { jnxJVAECNFileSysEntry 2 }
+
+jnxJVAECNFileSysSize OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total storage capacity of the file system, in kilo bytes."
+    ::= { jnxJVAECNFileSysEntry 3 }
+
+jnxJVAECNFileSysUsed OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Used Storage capacity of the file system, in kilo bytes."
+    ::= { jnxJVAECNFileSysEntry 4 }
+
+jnxJVAECNFileSysFree OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS	"KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Unused Storage capacity of the file system, in kilo bytes."
+    ::= { jnxJVAECNFileSysEntry 5 }
+
+jnxJVAECNFileSysUsedPr OBJECT-TYPE
+    SYNTAX      INTEGER (0..100)
+    UNITS	"%"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Used Storage capacity of the file system, in percentage."
+    ::= { jnxJVAECNFileSysEntry 6 }
+
+   --
+   -- Compute Node Disk Table
+   --
+
+jnxJVAECNDiskTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNDiskEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of Physical Disks connected to the Compute Nodes."
+    ::= { jnxJVAENodeTables 5 }
+
+jnxJVAECNDiskEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNDiskEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A disk."
+    INDEX { jnxJVAECNSysId, jnxJVAECNDiskId }
+    ::= { jnxJVAECNDiskTable 1 }
+
+JnxJVAECNDiskEntry ::= SEQUENCE {
+    jnxJVAECNDiskId            INTEGER,
+    jnxJVAECNDiskSlot          INTEGER,
+    jnxJVAECNDiskModel         DisplayString,
+    jnxJVAECNDiskRevision      DisplayString,
+    jnxJVAECNDiskVendor        DisplayString,
+    jnxJVAECNDiskOSPath        DisplayString
+}
+
+jnxJVAECNDiskId OBJECT-TYPE
+    SYNTAX      INTEGER (1..15)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The unique identifier for this disk."
+    ::= { jnxJVAECNDiskEntry 1 }
+
+jnxJVAECNDiskSlot OBJECT-TYPE
+    SYNTAX      INTEGER (0..14)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The slot at which disk is connected."
+    ::= { jnxJVAECNDiskEntry 2 }
+
+jnxJVAECNDiskModel OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Disk product model."
+    ::= { jnxJVAECNDiskEntry 3 }
+
+jnxJVAECNDiskRevision OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Disk product revision."
+    ::= { jnxJVAECNDiskEntry 4 }
+
+jnxJVAECNDiskVendor OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Disk product vendor."
+    ::= { jnxJVAECNDiskEntry 5 }
+
+jnxJVAECNDiskOSPath OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Disk device path."
+    ::= { jnxJVAECNDiskEntry 6 }
+
+   --
+   -- Compute Node Raid Table
+   --
+
+jnxJVAECNRaidTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNRaidEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of Raid Arrays on the Compute Nodes."
+    ::= { jnxJVAENodeTables 6 }
+
+jnxJVAECNRaidEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNRaidEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A Raid array."
+    INDEX { jnxJVAECNSysId, jnxJVAECNRaidId }
+    ::= { jnxJVAECNRaidTable 1 }
+
+JnxJVAECNRaidEntry ::= SEQUENCE {
+    jnxJVAECNRaidId                     INTEGER,
+    jnxJVAECNRaidName                   DisplayString,
+    jnxJVAECNRaidState                  DisplayString,
+    jnxJVAECNRaidLevel                  INTEGER,
+    jnxJVAECNRaidSize                   Gauge32,
+    jnxJVAECNRaidMembers                INTEGER,
+    jnxJVAECNRaidMemberDiskPartitions   DisplayString,
+    jnxJVAECNRaidMemberDiskAtSlots      DisplayString,
+    jnxJVAECNRaidOSPath                 DisplayString
+}
+
+jnxJVAECNRaidId OBJECT-TYPE
+    SYNTAX      INTEGER (1..15)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The unique identifier for this raid array."
+    ::= { jnxJVAECNRaidEntry 1 }
+
+jnxJVAECNRaidName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Name of the raid array."
+    ::= { jnxJVAECNRaidEntry 2 }
+
+jnxJVAECNRaidState OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "State of the raid array."
+    ::= { jnxJVAECNRaidEntry 3 }
+
+jnxJVAECNRaidLevel OBJECT-TYPE
+    SYNTAX      INTEGER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Raid level of the raid array."
+    ::= { jnxJVAECNRaidEntry 4 }
+
+jnxJVAECNRaidSize OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "GB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Size of the raid array."
+    ::= { jnxJVAECNRaidEntry 5 }
+
+jnxJVAECNRaidMembers OBJECT-TYPE
+    SYNTAX      INTEGER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of  members of the raid array."
+    ::= { jnxJVAECNRaidEntry 6 }
+
+jnxJVAECNRaidMemberDiskPartitions OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "List of device path of the partitions, that are members of the
+         raid array."
+    ::= { jnxJVAECNRaidEntry 7 }
+
+jnxJVAECNRaidMemberDiskAtSlots OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "List of slot numbers identifying the disks, that are members of
+         the raid array."
+    ::= { jnxJVAECNRaidEntry 8 }
+
+jnxJVAECNRaidOSPath OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The raid device disk path."
+    ::= { jnxJVAECNRaidEntry 9 }
+
+   --
+   -- Compute Node Sensor Table
+   --
+
+jnxJVAECNSensorTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxJVAECNSensorEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of Sensors on the Compute Nodes."
+    ::= { jnxJVAENodeTables 7 }
+
+jnxJVAECNSensorEntry OBJECT-TYPE
+    SYNTAX      JnxJVAECNSensorEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A Sensor."
+    INDEX { jnxJVAECNSysId, jnxJVAECNSensorId }
+    ::= { jnxJVAECNSensorTable 1 }
+
+JnxJVAECNSensorEntry ::= SEQUENCE {
+    jnxJVAECNSensorId                     INTEGER,
+    jnxJVAECNSensorType                   INTEGER,
+    jnxJVAECNSensorValue                  DisplayString,
+    jnxJVAECNSensorRange                  DisplayString,
+    jnxJVAECNSensorDesc                   DisplayString
+}
+
+jnxJVAECNSensorId OBJECT-TYPE
+    SYNTAX      INTEGER (1..65535)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The unique identifier for this sensor."
+    ::= { jnxJVAECNSensorEntry 1 }
+
+jnxJVAECNSensorType OBJECT-TYPE
+    SYNTAX      INTEGER { voltage(0), temperature(1), fan(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Type of the sensor."
+    ::= { jnxJVAECNSensorEntry 2 }
+
+jnxJVAECNSensorValue OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Sensor reading."
+    ::= { jnxJVAECNSensorEntry 3 }
+
+jnxJVAECNSensorRange OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Normal operating range for the sensor, traps are raised the reading
+         is no within this range."
+    ::= { jnxJVAECNSensorEntry 4 }
+
+jnxJVAECNSensorDesc OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Description of the sensor."
+    ::= { jnxJVAECNSensorEntry 5 }
+
+
+
+   --
+   -- JVAE Node Notifications
+   --
+
+jnxJVAECNMemoryLow NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNSysMemCapacity,
+         jnxJVAECNSysMemUsed,
+         jnxJVAECNSysMemFree,
+         jnxJVAECNSysMemUsedPr,
+         jnxJVAECNSysSwapCapacity,
+         jnxJVAECNSysSwapFree
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever the free (unused) RAM goes 
+	 below threshold for this compute node."
+    ::= { jnxJVAENodeNotifications  1 }
+
+jnxJVAECNMemoryOk NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNSysMemCapacity,
+         jnxJVAECNSysMemUsed,
+         jnxJVAECNSysMemFree,
+         jnxJVAECNSysMemUsedPr,
+         jnxJVAECNSysSwapCapacity,
+         jnxJVAECNSysSwapFree
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever the free (unused) RAM recovers
+	 above threshold for this compute node and previously a
+	 jnxJVAECNMemoryLow was reported."
+    ::= { jnxJVAENodeNotifications  2 }
+
+jnxJVAECNProcessingLoadHigh NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNSysProcessingLoad
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever the overall system processing
+	 load exceeds threshold."
+    ::= { jnxJVAENodeNotifications  3 }
+
+jnxJVAECNProcessingLoadOk NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNSysProcessingLoad
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever the overall system processing
+	 load is within threshold and previously a jnxJVAECNProcessingLoadHigh
+	 was reported."
+    ::= { jnxJVAENodeNotifications  4 }
+
+jnxJVAECNProcessorLoadHigh NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNProcessorId,
+         jnxJVAECNProcessorLoad
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever the load on a processor
+	 exceeds threshold."
+    ::= { jnxJVAENodeNotifications  5 }
+
+jnxJVAECNProcessorLoadOk NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNProcessorId,
+         jnxJVAECNProcessorLoad
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever the load on a processor
+	 is within threshold and previously a jnxJVAECNProcessorLoadHigh
+	 was reported."
+    ::= { jnxJVAENodeNotifications  6 }
+
+jnxJVAECNifDown NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNifId,
+         jnxJVAECNifName,
+         jnxJVAECNifOperStatus,
+         jnxJVAECNifAdminStatus,
+         jnxJVAECNifLinkDetect
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever network interface is down."
+    ::= { jnxJVAENodeNotifications  7 }
+
+jnxJVAECNifUp NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNifId,
+         jnxJVAECNifName,
+         jnxJVAECNifOperStatus,
+         jnxJVAECNifAdminStatus,
+         jnxJVAECNifLinkDetect
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever network interface is up and
+	 previously a jnxJVAECNifDown was reported."
+    ::= { jnxJVAENodeNotifications  8 }
+
+jnxJVAECNStorageLow NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNFileSysId,
+         jnxJVAECNFileSysMountPoint,
+         jnxJVAECNFileSysSize,
+         jnxJVAECNFileSysUsed,
+         jnxJVAECNFileSysFree,
+         jnxJVAECNFileSysUsedPr
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever storage space falls below
+	 threshold."
+    ::= { jnxJVAENodeNotifications  9 }
+
+jnxJVAECNStorageOk NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNFileSysId,
+         jnxJVAECNFileSysMountPoint,
+         jnxJVAECNFileSysSize,
+         jnxJVAECNFileSysUsed,
+         jnxJVAECNFileSysFree,
+         jnxJVAECNFileSysUsedPr
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever storage space recovers and
+	 previously a jnxJVAECNStorageLow was reported."
+    ::= { jnxJVAENodeNotifications  10 }
+
+jnxJVAECNRaidError NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNRaidId,
+         jnxJVAECNRaidName,
+         jnxJVAECNRaidState,
+         jnxJVAECNRaidOSPath
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever raid array degradation or
+	 failure is detected."
+    ::= { jnxJVAENodeNotifications  11 }
+
+jnxJVAECNRaidOk NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNRaidId,
+         jnxJVAECNRaidName,
+         jnxJVAECNRaidState,
+         jnxJVAECNRaidOSPath
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever raid array recovers and
+	 previously a jnxJVAECNRaidError was reported."
+    ::= { jnxJVAENodeNotifications  12 }
+
+jnxJVAECNSensorAlert NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNSensorId,
+         jnxJVAECNSensorValue,
+         jnxJVAECNSensorType,
+         jnxJVAECNSensorRange,
+         jnxJVAECNSensorDesc
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever sensor reading is not within
+         the normal operating range."
+    ::= { jnxJVAENodeNotifications  13 }
+
+jnxJVAECNSensorOk NOTIFICATION-TYPE
+    OBJECTS {
+         jnxJVAECNSysId,
+         jnxJVAECNSensorId,
+         jnxJVAECNSensorValue,
+         jnxJVAECNSensorType,
+         jnxJVAECNSensorRange,
+         jnxJVAECNSensorDesc
+    }
+    STATUS current
+    DESCRIPTION
+        "This notification is generated whenever sensor reading recovers and
+	 previously a jnxJVAECNSensorAlert was reported."
+    ::= { jnxJVAENodeNotifications  14 }
+
+END

--- a/mibs/junos/mib-jnx-l2ald.txt
+++ b/mibs/junos/mib-jnx-l2ald.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Structure of Management Information
 -- 
--- Copyright (c) 2002-2007, Juniper Networks, Inc.
+-- Copyright (c) 2002-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -22,7 +22,7 @@ JUNIPER-L2ALD-MIB DEFINITIONS ::=BEGIN
     ;
     
     jnxl2aldMib MODULE-IDENTITY
-       LAST-UPDATED "200702151000Z" -- Thursday February 15 10:00:00 2007 UTC
+       LAST-UPDATED "201208081000Z" -- Wednesday August 08 10:00:00 2012 UTC
        ORGANIZATION "Juniper Networks, Inc."
        CONTACT-INFO
               "        Juniper Technical Assistance Center
@@ -32,6 +32,15 @@ JUNIPER-L2ALD-MIB DEFINITIONS ::=BEGIN
                        E-mail: support@juniper.net"
        DESCRIPTION
               "The MIB modules for L2ALD traps"
+
+    -- Revision history
+    REVISION "201208081000Z" -- Wednesday August 08 10:00:00 2012 UTC
+    DESCRIPTION
+            "Added new notification jnxl2aldMacMoveThreshold"
+
+    REVISION "200702151000Z" -- Thursday February 15 10:00:00 2007 UTC
+    DESCRIPTION
+            "Initial Version"
     ::= { jnxl2aldMibRoot 1 }
 
     jnxl2aldNotification OBJECT IDENTIFIER ::= { jnxl2aldMib 0 }
@@ -141,6 +150,14 @@ JUNIPER-L2ALD-MIB DEFINITIONS ::=BEGIN
               "The mac limit count for the system."
     ::= { jnxl2aldObjects 6 }
 
+     jnxl2aldMacAdress OBJECT-TYPE
+        SYNTAX            DisplayString
+        MAX-ACCESS        accessible-for-notify
+        STATUS            current
+        DESCRIPTION
+             "The offending mac causing mac move threshold trap."
+    ::= { jnxl2aldObjects 7 }
+
 -- Trap definitions
 
     jnxl2aldRoutingInstMacLimit NOTIFICATION-TYPE
@@ -179,6 +196,21 @@ JUNIPER-L2ALD-MIB DEFINITIONS ::=BEGIN
                   the entire system is reached.
                   This trap is send only once we exceed the limit value."
      ::= { jnxl2aldNotification 3 }
+
+    jnxl2aldMacMoveThreshold NOTIFICATION-TYPE
+        OBJECTS    { jnxl2aldIntfLogicalRouter,
+                     jnxl2aldIntfRoutingInst,
+                     jnxl2aldIntfBridgeDomain,
+                     ifDescr,
+                     jnxl2aldMacAdress
+        }
+        STATUS     current
+        DESCRIPTION
+                 "This notification is generated when a mac move reaches threshold.
+                  The given interface (ifDescr) will be blocked for the Bridge
+                  Domain(jnxl2aldIntfBridgeDomain). This trap is send only once when
+                  mac move count exceeds the threshold for the Mac(jnxl2aldMacAdress)."
+    ::= { jnxl2aldNotification 4 }
 
 END
 

--- a/mibs/junos/mib-jnx-l2cp-features.txt
+++ b/mibs/junos/mib-jnx-l2cp-features.txt
@@ -5,13 +5,13 @@ IMPORTS
 
     OBJECT-TYPE, MODULE-IDENTITY,
     NOTIFICATION-TYPE FROM SNMPv2-SMI
-    TruthValue  FROM SNMPv2-TC
-    ifIndex  FROM IF-MIB
+    DisplayString, TruthValue  FROM SNMPv2-TC
+    InterfaceIndex, ifIndex  FROM IF-MIB
     dot1dStpPort, dot1dStpPortEntry  FROM BRIDGE-MIB
     jnxL2cpMibRoot FROM JUNIPER-SMI;
 
 jnxL2cpFeaturesMIB MODULE-IDENTITY
-    LAST-UPDATED "200712170000Z"
+    LAST-UPDATED "201206250000Z"
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
         "Juniper Technical Assistance Center
@@ -22,6 +22,16 @@ jnxL2cpFeaturesMIB MODULE-IDENTITY
     DESCRIPTION
         "This mib module is for Juniper Networks Proprietory
          Layer 2 control protocol (L2CP) features"
+
+    REVISION     "201206250000Z"    -- June 25, 2012
+    DESCRIPTION  "Modifying max access for LacpTimeOut trap objects."
+
+    REVISION     "201208150000Z"    -- Aug 15, 2012
+    DESCRIPTION  "Added new mib jnxLacpAggTimeout."
+
+    REVISION     "201006110000Z"    -- June 11, 2010
+    DESCRIPTION  "Added new trap jnxLacpTimeOut."
+
     ::= { jnxL2cpMibRoot 1 }
 
 
@@ -200,5 +210,165 @@ jnxPortBpduErrorStatusChangeTrap NOTIFICATION-TYPE
         "Generated when the ports BPDU error state (no-error or detected) 
          changes."
    ::= { jnxL2cpProtectTraps 3 }
+
+    -- ***************************************************************
+    --  Lacp Traps / Notifications Section
+    -- ***************************************************************
+
+    -- Lacp Notification Variables/Objects
+
+    jnxLacpNotifyVars OBJECT IDENTIFIER ::=  { jnxL2cpObjects 3 }
+
+    jnxLacpAggTimeout OBJECT IDENTIFIER ::=  { jnxL2cpObjects 4 }
+
+    jnxLacpNotificationsPrefix OBJECT IDENTIFIER ::= { jnxL2cpNotifications 1 }
+
+LacpState ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "The Actor and Partner State values from the LACPDU."
+    SYNTAX      BITS {
+                    lacpActivity(0),
+                    lacpTimeout(1),
+                    aggregation(2),
+                    synchronization(3),
+                    collecting(4),
+                    distributing(5),
+                    defaulted(6),
+                    expired(7)
+                }
+
+    jnxLacpInterfaceName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Lacp member interface."
+        ::= { jnxLacpNotifyVars 1 }
+
+    jnxLacpifIndex  OBJECT-TYPE 
+        SYNTAX      InterfaceIndex 
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current 
+        DESCRIPTION 
+            "Snmp ifIndex of member interface." 
+        ::= { jnxLacpNotifyVars 2 } 
+
+    jnxLacpAggregateInterfaceName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Lacp Aggregate interface."
+        ::= { jnxLacpNotifyVars 3 }
+
+    jnxLacpAggregateifIndex  OBJECT-TYPE
+        SYNTAX      InterfaceIndex
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Snmp ifIndex of Aggregator."
+        ::= { jnxLacpNotifyVars 4 } 
+
+    jnxLacpAggPortActorOperState OBJECT-TYPE
+        SYNTAX       DisplayString
+        MAX-ACCESS   accessible-for-notify
+        STATUS       current
+        DESCRIPTION
+            "Port actor operational state."
+        ::= { jnxLacpNotifyVars 5 }
+
+    jnxLacpTimeOut NOTIFICATION-TYPE
+        OBJECTS         { jnxLacpInterfaceName,
+                          jnxLacpifIndex,
+                          jnxLacpAggregateInterfaceName,
+                          jnxLacpAggregateifIndex,
+                          jnxLacpAggPortActorOperState
+                        }
+        STATUS          current
+        DESCRIPTION
+            "Lacp times out"
+        ::= { jnxLacpNotificationsPrefix  1 }
+
+dot3adAggPortTimeoutTable OBJECT-TYPE  
+    SYNTAX      SEQUENCE OF Dot3adAggPortTimeoutEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that contains Link Aggregation Timeout information
+        about a port that is associated with this device.
+        A row appears in this table for each physical port."
+    REFERENCE
+        "IEEE 802.3"
+    ::= { jnxLacpAggTimeout 1 }
+
+dot3adAggPortTimeoutEntry OBJECT-TYPE
+    SYNTAX      Dot3adAggPortTimeoutEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A list of Link Aggregation Control Protocol timeout information
+        for a port on this device."
+    INDEX { ifIndex }
+    ::= { dot3adAggPortTimeoutTable 1 }
+    
+Dot3adAggPortTimeoutEntry ::=
+    SEQUENCE {
+        dot3adInterfaceName
+            DisplayString,
+        dot3adOperState
+            LacpState,
+        dot3adAggname
+            DisplayString,
+        dot3adInterfaceTimeout
+            TimeTicks
+    }
+
+dot3adInterfaceName OBJECT-TYPE
+    SYNTAX       DisplayString 
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Physical port that is associated with
+        Aggregation Port. This value is read-only."
+    REFERENCE
+        "IEEE 802.3"
+    ::= { dot3adAggPortTimeoutEntry 1 }
+
+dot3adOperState OBJECT-TYPE
+    SYNTAX       LacpState
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "A string of 8 bits, corresponding to the current
+        operational values of Actor_State as transmitted by the
+        Actor in LACPDUs. The bit allocations are as defined in
+        30.7.2.1.20. This attribute value is read-only."
+    REFERENCE
+        "IEEE 802.3 Subclause 30.7.2.1.21"
+    ::= { dot3adAggPortTimeoutEntry 2 }
+
+dot3adAggname OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Aggregation Port where Physical port 
+        is associated with. This value is read-only."
+    REFERENCE
+        "IEEE 802.3"
+    ::= { dot3adAggPortTimeoutEntry 3 }
+
+dot3adInterfaceTimeout OBJECT-TYPE
+    SYNTAX       TimeTicks
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "This object represents the time elapsed in seconds
+         since lacp experienced timeout.
+         This value is read-only."
+    REFERENCE
+        "IEEE 802.3"
+    ::= { dot3adAggPortTimeoutEntry 4 }
 
 END

--- a/mibs/junos/mib-jnx-l2tp.txt
+++ b/mibs/junos/mib-jnx-l2tp.txt
@@ -20,7 +20,7 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
                FROM JUNIPER-SMI;
 
    jnxL2tp    MODULE-IDENTITY
-           LAST-UPDATED    "200701110000Z" -- 11 January 2007
+           LAST-UPDATED    "201311210000Z" -- 21 November 2013
            ORGANIZATION    "Juniper Networks Inc."
            CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -37,11 +37,24 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
                and l2tpSessionStatsTable."
 
            -- revision log
-
            REVISION        "200701110000Z" -- 11 January 2007
            DESCRIPTION
-              "Initial revision."
+           "Initial revision."
 
+           REVISION    "201206080000Z"  -- 08-Jun-12 03:12 PM EST  - JUNOS 12.1 
+           DESCRIPTION 
+           "Changes are done to change all Data packet/octet counters from 
+           32 to 64 bit counter. 32 bit counters were too small for data 
+           packets/octects and were consumed too early. All old counters are 
+           deprecated and new counters are added." 
+           
+           REVISION    "201309190000Z"  -- 19-Sept-13 03:12 PM EST - JUNOS 13.1 
+           DESCRIPTION 
+           "Updated the revision history and LAST-UPDATED field." 
+           
+           REVISION    "201311210000Z"  -- 21-Nov-13 03:12 PM EST - JUNOS 13.1 
+           DESCRIPTION 
+           "Corrected order of revision history" 
            ::= { jnxL2tpMibRoot 1 }
 
    --
@@ -130,13 +143,14 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpStatsPayloadRxOctets OBJECT-TYPE
            SYNTAX          Gauge32
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object returns the number of payload channel
                octets that were received on the exisiting tunnels. This is 
                an instantaneously accumulated value which can increase
                or decrease depending on number of tunnels established
-               at the time of querying."
+               at the time of querying. This is deprecated and replaced
+               by jnxL2tpStatsPayloadRxOctets64"
            ::= { jnxL2tpStats 7 }
 
    jnxL2tpStatsPayloadRxPkts OBJECT-TYPE
@@ -198,6 +212,18 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
                or decrease depending on number of tunnels established
                at the time of querying."
            ::= { jnxL2tpStats 12 }
+
+   jnxL2tpStatsPayloadRxOctets64 OBJECT-TYPE
+           SYNTAX          CounterBasedGauge64
+           MAX-ACCESS      read-only
+           STATUS          current 
+           DESCRIPTION
+              "This object returns the number of payload channel
+               octets that were received on the exisiting tunnels. This is 
+               an instantaneously accumulated value which can increase
+               or decrease depending on number of tunnels established
+               at the time of querying."
+           ::= { jnxL2tpStats 13 }
 
    --
    --      The L2TP Tunnel Group Status and Statistics Table
@@ -385,7 +411,15 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
                jnxL2tpTunnelStatsErrorTxPkts
                    Counter32,
                jnxL2tpTunnelStatsErrorRxPkts
-                   Counter32
+                   Counter32,
+               jnxL2tpTunnelStatsControlTxBytes32
+                   Counter32,
+               jnxL2tpTunnelStatsControlRxBytes32
+                   Counter32,
+               jnxL2tpTunnelStatsDataTxPkts64
+                   Counter64,
+               jnxL2tpTunnelStatsDataRxPkts64
+                   Counter64
            }
 
    jnxL2tpTunnelStatsLocalTID OBJECT-TYPE
@@ -631,11 +665,12 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpTunnelStatsControlTxBytes OBJECT-TYPE
            SYNTAX          Counter64
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of control
                bytes that were transmitted to the tunnel
-               peer."
+               peer. This is deprecated and replaced by 
+               jnxL2tpTunnelStatsControlTxBytes32"
            ::= { jnxL2tpTunnelStatsEntry 23 }
 
    jnxL2tpTunnelStatsControlRxPkts OBJECT-TYPE
@@ -650,20 +685,22 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpTunnelStatsControlRxBytes OBJECT-TYPE
            SYNTAX          Counter64
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of control
                bytes that were received from the tunnel
-               peer."
+               peer. This has been deprecated and replaced 
+               by jnxL2tpTunnelStatsControlRxBytes32"
            ::= { jnxL2tpTunnelStatsEntry 25 }
 
    jnxL2tpTunnelStatsDataTxPkts OBJECT-TYPE
            SYNTAX          Counter32
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of data packets
-               transmitted to the tunnel."
+               transmitted to the tunnel. This has been deprecated
+               and replaced by jnxL2tpTunnelStatsDataTxPkts64"
            ::= { jnxL2tpTunnelStatsEntry 26 }
 
    jnxL2tpTunnelStatsDataTxBytes OBJECT-TYPE
@@ -679,10 +716,11 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpTunnelStatsDataRxPkts OBJECT-TYPE
            SYNTAX          Counter32
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of data packets
-               received from this tunnel."
+               received from this tunnel. This is deprecated and
+               replaced by jnxL2tpTunnelStatsDataRxPkts64"
            ::= { jnxL2tpTunnelStatsEntry 28 }
 
    jnxL2tpTunnelStatsDataRxBytes OBJECT-TYPE
@@ -712,6 +750,44 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
               "This object contains the number of error
                receive packets on the tunnel."
            ::= { jnxL2tpTunnelStatsEntry 31 }
+
+   jnxL2tpTunnelStatsControlTxBytes32 OBJECT-TYPE
+           SYNTAX          Counter32
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of control
+               bytes that were transmitted to the tunnel
+               peer."
+           ::= { jnxL2tpTunnelStatsEntry 32 }
+
+   jnxL2tpTunnelStatsControlRxBytes32 OBJECT-TYPE
+           SYNTAX          Counter32
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of control
+               bytes that were received from the tunnel
+               peer."
+           ::= { jnxL2tpTunnelStatsEntry 33 }
+
+   jnxL2tpTunnelStatsDataTxPkts64 OBJECT-TYPE
+           SYNTAX          Counter64
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of data packets
+               transmitted to the tunnel."
+           ::= { jnxL2tpTunnelStatsEntry 34 }
+
+   jnxL2tpTunnelStatsDataRxPkts64 OBJECT-TYPE
+           SYNTAX          Counter64
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of data packets
+               received from this tunnel."
+           ::= { jnxL2tpTunnelStatsEntry 35 }
 
    --
    --      The L2TP Session Status and Statistics Table
@@ -864,7 +940,15 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
                jnxL2tpSessionStatsErrorTxPkts
                    Counter32,
                jnxL2tpSessionStatsErrorRxPkts
-                   Counter32
+                   Counter32,
+               jnxL2tpSessionStatsControlTxBytes32
+                   Counter32,
+               jnxL2tpSessionStatsControlRxBytes32
+                   Counter32,
+               jnxL2tpSessionStatsDataTxPkts64
+                   Counter64,
+               jnxL2tpSessionStatsDataRxPkts64
+                   Counter64
            }
 
    jnxL2tpSessionStatsLocalTID OBJECT-TYPE
@@ -1495,11 +1579,12 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpSessionStatsControlTxBytes OBJECT-TYPE
            SYNTAX          Counter64
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of control
                bytes that were transmitted to the session
-               peer."
+               peer. This is deprecated and replaced by 
+               jnxL2tpSessionStatsControlTxBytes32"
            ::= { jnxL2tpSessionStatsEntry 55 }
 
    jnxL2tpSessionStatsControlRxPkts OBJECT-TYPE
@@ -1514,20 +1599,22 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpSessionStatsControlRxBytes OBJECT-TYPE
            SYNTAX          Counter64
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of control
                bytes that were received from the session
-               peer."
+               peer. This is deprecated and replaced by 
+               jnxL2tpSessionStatsControlRxBytes32"
            ::= { jnxL2tpSessionStatsEntry 57 }
 
    jnxL2tpSessionStatsDataTxPkts OBJECT-TYPE
            SYNTAX          Counter32
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of data packets
-               transmitted to the remote session peer."
+               transmitted to the remote session peer. This is 
+               deprecated and replaced by jnxL2tpSessionStatsDataTxPkts64"
            ::= { jnxL2tpSessionStatsEntry 58 }
 
    jnxL2tpSessionStatsDataTxBytes OBJECT-TYPE
@@ -1543,10 +1630,11 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
    jnxL2tpSessionStatsDataRxPkts OBJECT-TYPE
            SYNTAX          Counter32
            MAX-ACCESS      read-only
-           STATUS          current
+           STATUS          deprecated
            DESCRIPTION
               "This object contains the number of data packets
-               received on this session."
+               received on this session. This is deprecated and
+               replaced by jnxL2tpSessionStatsDataRxPkts64"
            ::= { jnxL2tpSessionStatsEntry 60 }
 
    jnxL2tpSessionStatsDataRxBytes OBJECT-TYPE
@@ -1577,6 +1665,44 @@ JNX-L2TP-MIB DEFINITIONS ::= BEGIN
                receive packets on the session."
            ::= { jnxL2tpSessionStatsEntry 63 }
 
+
+   jnxL2tpSessionStatsControlTxBytes32 OBJECT-TYPE
+           SYNTAX          Counter32
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of control
+               bytes that were transmitted to the session
+               peer."
+           ::= { jnxL2tpSessionStatsEntry 64 }
+
+   jnxL2tpSessionStatsControlRxBytes32 OBJECT-TYPE
+           SYNTAX          Counter32
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of control
+               bytes that were received from the session
+               peer."
+           ::= { jnxL2tpSessionStatsEntry 65 }
+
+   jnxL2tpSessionStatsDataTxPkts64 OBJECT-TYPE
+           SYNTAX          Counter64
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of data packets
+               transmitted to the remote session peer."
+           ::= { jnxL2tpSessionStatsEntry 66 }
+
+   jnxL2tpSessionStatsDataRxPkts64 OBJECT-TYPE
+           SYNTAX          Counter64
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+              "This object contains the number of data packets
+               received on this session."
+           ::= { jnxL2tpSessionStatsEntry 67 }
 
    --
    --      The L2TP Multilink PPP bundle statistics table

--- a/mibs/junos/mib-jnx-ldp.txt
+++ b/mibs/junos/mib-jnx-ldp.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB:LDP MIB Extension
 -- 
--- Copyright (c) 2002-2004, 2006, 2008, Juniper Networks, Inc.
+-- Copyright (c) 2002-2010, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.

--- a/mibs/junos/mib-jnx-license.txt
+++ b/mibs/junos/mib-jnx-license.txt
@@ -1,0 +1,260 @@
+--
+-- Juniper Enterprise Specific MIB: License MIB
+--
+-- Copyright (c) 2010, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-LICENSE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Unsigned32, TimeTicks, IpAddress,
+    NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+    jnxLicenseMibRoot
+        FROM JUNIPER-SMI
+    DisplayString
+        FROM SNMPv2-TC;
+
+jnxLicenseMIB       MODULE-IDENTITY
+    LAST-UPDATED    "201007090000Z"
+    ORGANIZATION    "Juniper Networks, Inc."
+    CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+             E-mail: support@juniper.net"
+    DESCRIPTION
+        "Implementation of enterprise specific MIB
+         for license commands and configuration."
+    REVISION    "201007090000Z"    -- Jul 09, 2010
+    DESCRIPTION
+             "Initial version."
+    ::=  {  jnxLicenseMibRoot  1  }
+
+jnxLicenseNotifications     OBJECT IDENTIFIER ::=  {  jnxLicenseMIB  0  }
+jnxLicenseObjects           OBJECT IDENTIFIER ::=  {  jnxLicenseMIB  1  }
+
+jnxLicenseInstallObjects      OBJECT IDENTIFIER ::=  { jnxLicenseObjects 1 }
+jnxLicenseSettings            OBJECT IDENTIFIER ::=  { jnxLicenseObjects 2 }
+
+-- ****************************************************************
+-- License table for installed licenses
+-- ****************************************************************
+
+jnxLicenseInstallTable   OBJECT-TYPE
+    SYNTAX            SEQUENCE  OF  JnxLicenseInstallEntry
+    MAX-ACCESS        not-accessible
+    STATUS            current
+    DESCRIPTION       "This table contains installed feature license information."
+    ::=  { jnxLicenseInstallObjects 1 }
+
+jnxLicenseInstallEntry   OBJECT-TYPE
+    SYNTAX            JnxLicenseInstallEntry 
+    MAX-ACCESS        not-accessible
+    STATUS            current
+    DESCRIPTION       "A row of giving installed feature license information."
+    INDEX             {  IMPLIED jnxLicenseId  }
+    ::=  { jnxLicenseInstallTable 1 }
+
+JnxLicenseInstallEntry  ::=  SEQUENCE {
+    jnxLicenseId              DisplayString,
+    jnxLicenseVersion         INTEGER,
+    jnxLicenseDeviceId        DisplayString,
+    jnxLicenseType            INTEGER,
+    jnxLicenseKeys            OCTET STRING
+    }
+
+jnxLicenseId OBJECT-TYPE
+    SYNTAX          DisplayString
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION     "Installed feature licenses Id."
+    ::=  {  jnxLicenseInstallEntry 1  }
+
+jnxLicenseVersion OBJECT-TYPE
+    SYNTAX          INTEGER 
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "License Version information"
+    ::=  {  jnxLicenseInstallEntry 2  }
+
+jnxLicenseDeviceId OBJECT-TYPE
+    SYNTAX          DisplayString 
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "License Device Id "
+    ::=  {  jnxLicenseInstallEntry 3  }
+
+jnxLicenseType OBJECT-TYPE
+    SYNTAX          INTEGER { invalid(0), count-down(1), date-based(2),permanent(3) } 
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "License type information"
+    ::=  {  jnxLicenseInstallEntry 4  }
+
+jnxLicenseKeys      OBJECT-TYPE
+    SYNTAX          OCTET STRING 
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "License Keys"
+    ::=  {  jnxLicenseInstallEntry 5  }
+
+-- Feature Listing Table 
+
+jnxLicenseFeatureListTable OBJECT-TYPE
+    SYNTAX          SEQUENCE  OF  JnxLicenseFeatureListEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION     "list of features supporting Licensing."
+    ::=  { jnxLicenseInstallObjects  2 }
+
+jnxLicenseFeatureListEntry OBJECT-TYPE
+    SYNTAX          JnxLicenseFeatureListEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION     "A row of licensed features."
+    INDEX           {  jnxLicenseFeatureId  }
+    ::=  { jnxLicenseFeatureListTable 1 }
+
+JnxLicenseFeatureListEntry ::=  SEQUENCE {
+    jnxLicenseFeatureId              INTEGER,
+    jnxLicenseFeatureName            DisplayString,
+    jnxLicenseFeatureDescr           DisplayString,
+    jnxLicenseFeatureLicenseId       DisplayString,
+    jnxLicenseFeatureLicenseUsed            INTEGER,
+    jnxLicenseFeatureLicenseInstalled       INTEGER,
+    jnxLicenseFeatureLicenseNeeded          INTEGER
+    }
+
+jnxLicenseFeatureId OBJECT-TYPE
+    SYNTAX              INTEGER 
+    MAX-ACCESS          not-accessible
+    STATUS              current
+    DESCRIPTION         "Feature Id to point an entry in this table"
+    ::=  { jnxLicenseFeatureListEntry 1 }
+
+jnxLicenseFeatureName OBJECT-TYPE
+    SYNTAX                 DisplayString 
+    MAX-ACCESS             read-only
+    STATUS                 current
+    DESCRIPTION            "Feature Name"
+    ::=  {  jnxLicenseFeatureListEntry 2  } 
+
+jnxLicenseFeatureDescr OBJECT-TYPE
+    SYNTAX                 DisplayString
+    MAX-ACCESS             read-only
+    STATUS                 current
+    DESCRIPTION            "Feature Name"
+    ::=  {  jnxLicenseFeatureListEntry 3  }
+
+jnxLicenseFeatureLicenseId OBJECT-TYPE
+    SYNTAX                 DisplayString 
+    MAX-ACCESS             read-only
+    STATUS                 current
+    DESCRIPTION            "Feature License Id"
+    ::=  {  jnxLicenseFeatureListEntry 4  } 
+
+jnxLicenseFeatureLicenseUsed      OBJECT-TYPE
+    SYNTAX          INTEGER
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "Licenses Used"
+    ::=  {  jnxLicenseFeatureListEntry 5  }
+
+jnxLicenseFeatureLicenseInstalled OBJECT-TYPE
+    SYNTAX          INTEGER
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "Licenses Installed"
+    ::=  {  jnxLicenseFeatureListEntry 6  }
+
+jnxLicenseFeatureLicenseNeeded    OBJECT-TYPE
+    SYNTAX          INTEGER
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION     "Licenses Needed"
+    ::=  {  jnxLicenseFeatureListEntry 7  }
+
+
+-- ****************************************************************
+-- License configuration parameters
+-- ****************************************************************
+
+jnxLicenseRenewBeforExpiration  OBJECT-TYPE
+    SYNTAX                      INTEGER
+    MAX-ACCESS                  read-only
+    STATUS                      current
+    DESCRIPTION
+        "License renew lead time before expiration in days."
+    ::= { jnxLicenseSettings  1 }
+
+jnxLicenseRenewInterval  OBJECT-TYPE
+    SYNTAX               INTEGER
+    MAX-ACCESS           read-only
+    STATUS               current
+    DESCRIPTION
+        "License checking interval in hours."
+    ::= { jnxLicenseSettings  2 }
+
+jnxLicenseAutoUpdate    OBJECT-TYPE
+    SYNTAX               DisplayString
+    MAX-ACCESS           read-only
+    STATUS               current
+    DESCRIPTION
+        "License auto update URL of a license server."
+    ::= { jnxLicenseSettings  3 }
+
+
+
+-- ********************************************************************
+-- define branches for jnx license traps
+-- ********************************************************************
+
+jnxLicenseGraceExpired NOTIFICATION-TYPE
+    OBJECTS  { jnxLicenseFeatureName }
+    STATUS   current
+    DESCRIPTION
+        "The SNMP trap that is generated when the license grace period for
+         feature identified by jnxLicenseFeatureName is expired"
+    ::= { jnxLicenseNotifications 1 }
+
+jnxLicenseGraceAboutToExpire NOTIFICATION-TYPE
+    OBJECTS  { jnxLicenseFeatureName }
+    STATUS   current
+    DESCRIPTION
+        "The SNMP trap that is generated when the license grace period for
+         feature identified by jnxLicenseFeatureName is about to expire"
+    ::= { jnxLicenseNotifications 2 }
+
+jnxLicenseAboutToExpire NOTIFICATION-TYPE
+    OBJECTS  { jnxLicenseFeatureName }
+    STATUS   current
+    DESCRIPTION
+        "The SNMP trap that is generated when the license period for
+         feature identified by jnxLicenseFeatureName is about to expire"
+    ::= { jnxLicenseNotifications 3 }
+
+jnxLicenseInfringeCumulative NOTIFICATION-TYPE
+    OBJECTS  { jnxLicenseFeatureName }
+    STATUS   current
+    DESCRIPTION
+        "The SNMP trap that is generated when the feature is used more
+         times than as specified in number of licenses allowed for feature
+         as identified by jnxLicenseFeatureName"
+    ::= { jnxLicenseNotifications 4 }
+
+jnxLicenseInfringeSingle NOTIFICATION-TYPE
+    OBJECTS  { jnxLicenseFeatureName }
+    STATUS   current
+    DESCRIPTION
+        "The SNMP trap that is generated when the license for feature
+         identified by jnxLicenseFeatureName is not valid i.e. either expired or
+         not available."
+    ::= { jnxLicenseNotifications 5 }
+
+
+END

--- a/mibs/junos/mib-jnx-lsys-securityprofile.txt
+++ b/mibs/junos/mib-jnx-lsys-securityprofile.txt
@@ -1,0 +1,42 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYS-SECURITYPROFILE-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      jnxLsysSecurityProfile	     FROM JUNIPER-JS-SMI;
+
+--
+-- Object identifier added as the basis for identifying other logical-system
+-- Security profile nodes.
+
+
+--
+-- next level object identifiers under jnxLsysSecurityProfile
+-- 
+jnxLsysSpZone               OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 1 }
+jnxLsysSpScheduler          OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 2 }
+jnxLsysSpPolicy             OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 3 }
+jnxLsysSpPolicywcnt         OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 4 }
+jnxLsysSpFlowgate           OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 5 }
+jnxLsysSpFlowsess           OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 6 }
+jnxLsysSpAuthentry          OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 7 }
+jnxLsysSpNATsrcpool         OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 8 }
+jnxLsysSpNATdstpool         OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 9 }
+jnxLsysSpNATsrcpatad        OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 10 }
+jnxLsysSpNATsrcnopatad      OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 11 }
+jnxLsysSpNATsrcrule         OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 12 }
+jnxLsysSpNATdstrule         OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 13 }
+jnxLsysSpNATstaticrule      OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 14 }
+jnxLsysSpNATconebind        OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 15 }
+jnxLsysSpNATpoipnum         OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 16 }
+jnxLsysSpNATRuleRefPfx      OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 17 }
+jnxLsysSpCPU                OBJECT IDENTIFIER ::= { jnxLsysSecurityProfile 18 }
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-authentry.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-authentry.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSPAUTHENTRY-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpAuthentry                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpAuthentryMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- July 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the auth-entry-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security auth-entry resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpAuthentry 1 }
+
+    jnxLsysSpAuthentryObjects        OBJECT IDENTIFIER ::= { jnxLsysSpAuthentryMIB 1 }
+    jnxLsysSpAuthentrySummary        OBJECT IDENTIFIER ::= { jnxLsysSpAuthentryMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular auth-entry resource information objects per LSYS:
+--   Below are auth-entry resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- auth-entry resource table per LSYS
+
+    jnxLsysSpAuthentryTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpAuthentryEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE auth-entry objects for auth-entry resource consumption per LSYS."  
+    ::= { jnxLsysSpAuthentryObjects 1 }
+    
+    jnxLsysSpAuthentryEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpAuthentryEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in auth-entry resource table."
+    INDEX { IMPLIED jnxLsysSpAuthentryLsysName }          
+    ::= { jnxLsysSpAuthentryTable 1 }          
+
+    JnxLsysSpAuthentryEntry ::= 
+       SEQUENCE {
+          jnxLsysSpAuthentryLsysName    DisplayString,
+          jnxLsysSpAuthentryProfileName DisplayString,
+          jnxLsysSpAuthentryUsage       Unsigned32,
+          jnxLsysSpAuthentryReserved    Unsigned32,
+          jnxLsysSpAuthentryMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the auth-entry resource table
+ 
+    jnxLsysSpAuthentryLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which auth-entry resource information is retrieved. "
+        ::= { jnxLsysSpAuthentryEntry 1 }
+
+    jnxLsysSpAuthentryProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpAuthentryEntry 2 }
+
+    jnxLsysSpAuthentryUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpAuthentryEntry 3 }
+    
+    jnxLsysSpAuthentryReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpAuthentryEntry 4 } 
+
+    jnxLsysSpAuthentryMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpAuthentryEntry 5 }
+
+
+-- **********************************************************************
+-- auth-entry resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpAuthentryUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The auth-entry resource consumption over all LSYS."
+    ::= { jnxLsysSpAuthentrySummary 1 }          
+
+    jnxLsysSpAuthentryMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The auth-entry resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpAuthentrySummary 2 }
+    
+    jnxLsysSpAuthentryAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The auth-entry resource available in the whole device."
+    ::= { jnxLsysSpAuthentrySummary 3 }
+    
+    jnxLsysSpAuthentryHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of auth-entry resource consumed of a LSYS."
+    ::= { jnxLsysSpAuthentrySummary 4 }
+    
+    jnxLsysSpAuthentryHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most auth-entry resource."
+    ::= { jnxLsysSpAuthentrySummary 5 }
+    
+    jnxLsysSpAuthentryLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of auth-entry resource consumed of a LSYS."
+    ::= { jnxLsysSpAuthentrySummary 6 }
+    
+    jnxLsysSpAuthentryLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least auth-entry resource."
+    ::= { jnxLsysSpAuthentrySummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of auth-entry resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-cpu.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-cpu.txt
@@ -1,0 +1,280 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-CPU-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpCPU                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpCPUMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- October 1, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the CPU-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security CPU resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpCPU 1 }
+
+    jnxLsysSpCPUObjects        OBJECT IDENTIFIER ::= { jnxLsysSpCPUMIB 1 }
+    jnxLsysSpCPUSummary        OBJECT IDENTIFIER ::= { jnxLsysSpCPUMIB 2 }
+    jnxLsysSpCPSummary         OBJECT IDENTIFIER ::= { jnxLsysSpCPUSummary 1 }
+    jnxLsysSpSPUSummary        OBJECT IDENTIFIER ::= { jnxLsysSpCPUSummary 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular CPU resource information objects per LSYS:
+--   Below are CPU resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- CPU resource table per LSYS
+
+    jnxLsysSpCPUTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpCPUEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE CPU objects for CPU resource consumption per LSYS."  
+    ::= { jnxLsysSpCPUObjects 1 }
+    
+    jnxLsysSpCPUEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpCPUEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in CPU resource table."
+    INDEX { IMPLIED jnxLsysSpCPULsysName }          
+    ::= { jnxLsysSpCPUTable 1 }          
+
+    JnxLsysSpCPUEntry ::= 
+       SEQUENCE {
+          jnxLsysSpCPULsysName    DisplayString,
+          jnxLsysSpCPUProfileName DisplayString,
+          jnxLsysSpCPUsage        Unsigned32,
+          jnxLsysSpSPUUsage       Unsigned32,
+          jnxLsysSpCPUReserved    Unsigned32,
+          jnxLsysSpCPUMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the CPU resource table
+ 
+    jnxLsysSpCPULsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which CPU resource information is retrieved. "
+        ::= { jnxLsysSpCPUEntry 1 }
+
+    jnxLsysSpCPUProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpCPUEntry 2 }
+
+    jnxLsysSpCPUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        UNITS               "0.01 percent"
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current CP resource usage count for the LSYS."
+    ::= { jnxLsysSpCPUEntry 3 }
+    
+    jnxLsysSpSPUUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        UNITS               "0.01 percent"
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current SPU resource usage count for the LSYS."
+    ::= { jnxLsysSpCPUEntry 4 }
+    
+    jnxLsysSpCPUReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        UNITS               "0.01 percent"
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpCPUEntry 5 } 
+
+    jnxLsysSpCPUMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        UNITS               "0.01 percent"
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpCPUEntry 6 }
+
+
+-- **********************************************************************
+-- CP resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpCPUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The CP resource consumption over all LSYS."
+    ::= { jnxLsysSpCPSummary 1 }          
+
+    jnxLsysSpCPMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The CP resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpCPSummary 2 }
+    
+    jnxLsysSpCPAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The CP resource available in the whole device."
+    ::= { jnxLsysSpCPSummary 3 }
+    
+    jnxLsysSpCPHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of CP resource consumed of a LSYS."
+    ::= { jnxLsysSpCPSummary 4 }
+    
+    jnxLsysSpCPHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most CP resource."
+    ::= { jnxLsysSpCPSummary 5 }
+    
+    jnxLsysSpCPLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of CP resource consumed of a LSYS."
+    ::= { jnxLsysSpCPSummary 6 }
+    
+    jnxLsysSpCPLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least CP resource."
+    ::= { jnxLsysSpCPSummary 7 }
+    
+
+-- **********************************************************************
+-- SPU resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpSPUUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The SPU resource consumption over all LSYS."
+    ::= { jnxLsysSpSPUSummary 1 }          
+
+    jnxLsysSpSPUMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The SPU resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpSPUSummary 2 }
+    
+    jnxLsysSpSPUAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The SPU resource available in the whole device."
+    ::= { jnxLsysSpSPUSummary 3 }
+    
+    jnxLsysSpSPUHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of SPU resource consumed of a LSYS."
+    ::= { jnxLsysSpSPUSummary 4 }
+    
+    jnxLsysSpSPUHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most SPU resource."
+    ::= { jnxLsysSpSPUSummary 5 }
+    
+    jnxLsysSpSPULightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        UNITS                   "0.01 percent"
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of SPU resource consumed of a LSYS."
+    ::= { jnxLsysSpSPUSummary 6 }
+    
+    jnxLsysSpSPULightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least SPU resource."
+    ::= { jnxLsysSpSPUSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of CPU resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-flowgate.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-flowgate.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-FLOWGATE-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpFlowgate                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpFlowgateMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- July 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the flow-gate-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security flow-gate resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpFlowgate 1 }
+
+    jnxLsysSpFlowgateObjects        OBJECT IDENTIFIER ::= { jnxLsysSpFlowgateMIB 1 }
+    jnxLsysSpFlowgateSummary        OBJECT IDENTIFIER ::= { jnxLsysSpFlowgateMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular flow-gate resource information objects per LSYS:
+--   Below are flow-gate resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- flow-gate resource table per LSYS
+
+    jnxLsysSpFlowgateTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpFlowgateEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE flow-gate objects for flow-gate resource consumption per LSYS."  
+    ::= { jnxLsysSpFlowgateObjects 1 }
+    
+    jnxLsysSpFlowgateEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpFlowgateEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in flow-gate resource table."
+    INDEX { IMPLIED jnxLsysSpFlowgateLsysName }          
+    ::= { jnxLsysSpFlowgateTable 1 }          
+
+    JnxLsysSpFlowgateEntry ::= 
+       SEQUENCE {
+          jnxLsysSpFlowgateLsysName    DisplayString,
+          jnxLsysSpFlowgateProfileName DisplayString,
+          jnxLsysSpFlowgateUsage       Unsigned32,
+          jnxLsysSpFlowgateReserved    Unsigned32,
+          jnxLsysSpFlowgateMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the flow-gate resource table
+ 
+    jnxLsysSpFlowgateLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which flow-gate resource information is retrieved. "
+        ::= { jnxLsysSpFlowgateEntry 1 }
+
+    jnxLsysSpFlowgateProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpFlowgateEntry 2 }
+
+    jnxLsysSpFlowgateUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpFlowgateEntry 3 }
+    
+    jnxLsysSpFlowgateReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpFlowgateEntry 4 } 
+
+    jnxLsysSpFlowgateMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpFlowgateEntry 5 }
+
+
+-- **********************************************************************
+-- flow-gate resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpFlowgateUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The flow-gate resource consumption over all LSYS."
+    ::= { jnxLsysSpFlowgateSummary 1 }          
+
+    jnxLsysSpFlowgateMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The flow-gate resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpFlowgateSummary 2 }
+    
+    jnxLsysSpFlowgateAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The flow-gate resource available in the whole device."
+    ::= { jnxLsysSpFlowgateSummary 3 }
+    
+    jnxLsysSpFlowgateHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of flow-gate resource consumed of a LSYS."
+    ::= { jnxLsysSpFlowgateSummary 4 }
+    
+    jnxLsysSpFlowgateHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most flow-gate resource."
+    ::= { jnxLsysSpFlowgateSummary 5 }
+    
+    jnxLsysSpFlowgateLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of flow-gate resource consumed of a LSYS."
+    ::= { jnxLsysSpFlowgateSummary 6 }
+    
+    jnxLsysSpFlowgateLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least flow-gate resource."
+    ::= { jnxLsysSpFlowgateSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of flow-gate resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-flowsess.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-flowsess.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-FLOWSESS-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpFlowsess                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpFlowsessMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- July 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the flow-session-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security flow-session resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpFlowsess 1 }
+
+    jnxLsysSpFlowsessObjects        OBJECT IDENTIFIER ::= { jnxLsysSpFlowsessMIB 1 }
+    jnxLsysSpFlowsessSummary        OBJECT IDENTIFIER ::= { jnxLsysSpFlowsessMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular flowsess resource information objects per LSYS:
+--   Below are flowsess resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- Flowsess resource table per LSYS
+
+    jnxLsysSpFlowsessTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpFlowsessEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE flow-session objects for flow-session resource consumption per LSYS."  
+    ::= { jnxLsysSpFlowsessObjects 1 }
+    
+    jnxLsysSpFlowsessEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpFlowsessEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in flow-session resource table."
+    INDEX { IMPLIED jnxLsysSpFlowsessLsysName }          
+    ::= { jnxLsysSpFlowsessTable 1 }          
+
+    JnxLsysSpFlowsessEntry ::= 
+       SEQUENCE {
+          jnxLsysSpFlowsessLsysName    DisplayString,
+          jnxLsysSpFlowsessProfileName DisplayString,
+          jnxLsysSpFlowsessUsage       Unsigned32,
+          jnxLsysSpFlowsessReserved    Unsigned32,
+          jnxLsysSpFlowsessMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the flow-session resource table
+ 
+    jnxLsysSpFlowsessLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which flow-session resource information is retrieved. "
+        ::= { jnxLsysSpFlowsessEntry 1 }
+
+    jnxLsysSpFlowsessProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpFlowsessEntry 2 }
+
+    jnxLsysSpFlowsessUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpFlowsessEntry 3 }
+    
+    jnxLsysSpFlowsessReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpFlowsessEntry 4 } 
+
+    jnxLsysSpFlowsessMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpFlowsessEntry 5 }
+
+
+-- **********************************************************************
+-- Flow-session resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpFlowsessUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The flow-session resource consumption over all LSYS."
+    ::= { jnxLsysSpFlowsessSummary 1 }          
+
+    jnxLsysSpFlowsessMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The flow-session resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpFlowsessSummary 2 }
+    
+    jnxLsysSpFlowsessAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The flow-session resource available in the whole device."
+    ::= { jnxLsysSpFlowsessSummary 3 }
+    
+    jnxLsysSpFlowsessHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of flow-session resource consumed of a LSYS."
+    ::= { jnxLsysSpFlowsessSummary 4 }
+    
+    jnxLsysSpFlowsessHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most flow-session resource."
+    ::= { jnxLsysSpFlowsessSummary 5 }
+    
+    jnxLsysSpFlowsessLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of flow-session resource consumed of a LSYS."
+    ::= { jnxLsysSpFlowsessSummary 6 }
+    
+    jnxLsysSpFlowsessLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least flow-session resource."
+    ::= { jnxLsysSpFlowsessSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of flow-session resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natconebind.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natconebind.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATCONEBIND-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATconebind                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATconebindMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-cone-bind-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-cone-bind resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATconebind 1 }
+
+    jnxLsysSpNATconebindObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATconebindMIB 1 }
+    jnxLsysSpNATconebindSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATconebindMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-cone-bind resource information objects per LSYS:
+--   Below are NAT-cone-bind resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-cone-bind resource table per LSYS
+
+    jnxLsysSpNATconebindTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATconebindEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-cone-bind objects for NAT-cone-bind 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpNATconebindObjects 1 }
+    
+    jnxLsysSpNATconebindEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATconebindEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-cone-bind resource table."
+    INDEX { IMPLIED jnxLsysSpNATconebindLsysName }          
+    ::= { jnxLsysSpNATconebindTable 1 }          
+
+    JnxLsysSpNATconebindEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATconebindLsysName    DisplayString,
+          jnxLsysSpNATconebindProfileName DisplayString,
+          jnxLsysSpNATconebindUsage       Unsigned32,
+          jnxLsysSpNATconebindReserved    Unsigned32,
+          jnxLsysSpNATconebindMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-cone-bind resource table
+ 
+    jnxLsysSpNATconebindLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-cone-bind 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATconebindEntry 1 }
+
+    jnxLsysSpNATconebindProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATconebindEntry 2 }
+
+    jnxLsysSpNATconebindUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATconebindEntry 3 }
+    
+    jnxLsysSpNATconebindReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATconebindEntry 4 } 
+
+    jnxLsysSpNATconebindMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATconebindEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-cone-bind resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATconebindUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-cone-bind resource consumption over all LSYS."
+    ::= { jnxLsysSpNATconebindSummary 1 }          
+
+    jnxLsysSpNATconebindMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-cone-bind resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATconebindSummary 2 }
+    
+    jnxLsysSpNATconebindAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-cone-bind resource available in the whole device."
+    ::= { jnxLsysSpNATconebindSummary 3 }
+    
+    jnxLsysSpNATconebindHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-cone-bind resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATconebindSummary 4 }
+    
+    jnxLsysSpNATconebindHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-cone-bind resource."
+    ::= { jnxLsysSpNATconebindSummary 5 }
+    
+    jnxLsysSpNATconebindLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-cone-bind resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATconebindSummary 6 }
+    
+    jnxLsysSpNATconebindLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-cone-bind resource."
+    ::= { jnxLsysSpNATconebindSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-cone-bind resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natdstpool.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natdstpool.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATDSTPOOL-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATdstpool                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATdstpoolMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-destination-pool-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-destination-pool resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATdstpool 1 }
+
+    jnxLsysSpNATdstpoolObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATdstpoolMIB 1 }
+    jnxLsysSpNATdstpoolSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATdstpoolMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-destination-pool resource information objects per LSYS:
+--   Below are NAT-destination-pool resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-destination-pool resource table per LSYS
+
+    jnxLsysSpNATdstpoolTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATdstpoolEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-destination-pool objects for NAT-destination-pool 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpNATdstpoolObjects 1 }
+    
+    jnxLsysSpNATdstpoolEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATdstpoolEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-destination-pool resource table."
+    INDEX { IMPLIED jnxLsysSpNATdstpoolLsysName }          
+    ::= { jnxLsysSpNATdstpoolTable 1 }          
+
+    JnxLsysSpNATdstpoolEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATdstpoolLsysName    DisplayString,
+          jnxLsysSpNATdstpoolProfileName DisplayString,
+          jnxLsysSpNATdstpoolUsage       Unsigned32,
+          jnxLsysSpNATdstpoolReserved    Unsigned32,
+          jnxLsysSpNATdstpoolMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-destination-pool resource table
+ 
+    jnxLsysSpNATdstpoolLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-destination-pool 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATdstpoolEntry 1 }
+
+    jnxLsysSpNATdstpoolProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATdstpoolEntry 2 }
+
+    jnxLsysSpNATdstpoolUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATdstpoolEntry 3 }
+    
+    jnxLsysSpNATdstpoolReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATdstpoolEntry 4 } 
+
+    jnxLsysSpNATdstpoolMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATdstpoolEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-destination-pool resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATdstpoolUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-destination-pool resource consumption over all LSYS."
+    ::= { jnxLsysSpNATdstpoolSummary 1 }          
+
+    jnxLsysSpNATdstpoolMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-destination-pool resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATdstpoolSummary 2 }
+    
+    jnxLsysSpNATdstpoolAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-destination-pool resource available in the whole device."
+    ::= { jnxLsysSpNATdstpoolSummary 3 }
+    
+    jnxLsysSpNATdstpoolHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-destination-pool resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATdstpoolSummary 4 }
+    
+    jnxLsysSpNATdstpoolHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-destination-pool resource."
+    ::= { jnxLsysSpNATdstpoolSummary 5 }
+    
+    jnxLsysSpNATdstpoolLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-destination-pool resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATdstpoolSummary 6 }
+    
+    jnxLsysSpNATdstpoolLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-destination-pool resource."
+    ::= { jnxLsysSpNATdstpoolSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-destination-pool resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natdstrule.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natdstrule.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATDSTRULE-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATdstrule                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATdstruleMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-destination-rule-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-destination-rule resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATdstrule 1 }
+
+    jnxLsysSpNATdstruleObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATdstruleMIB 1 }
+    jnxLsysSpNATdstruleSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATdstruleMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-destination-rule resource information objects per LSYS:
+--   Below are NAT-destination-rule resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-destination-rule resource table per LSYS
+
+    jnxLsysSpNATdstruleTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATdstruleEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-destination-rule objects for NAT-destination-rule 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpNATdstruleObjects 1 }
+    
+    jnxLsysSpNATdstruleEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATdstruleEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-destination-rule resource table."
+    INDEX { IMPLIED jnxLsysSpNATdstruleLsysName }          
+    ::= { jnxLsysSpNATdstruleTable 1 }          
+
+    JnxLsysSpNATdstruleEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATdstruleLsysName    DisplayString,
+          jnxLsysSpNATdstruleProfileName DisplayString,
+          jnxLsysSpNATdstruleUsage       Unsigned32,
+          jnxLsysSpNATdstruleReserved    Unsigned32,
+          jnxLsysSpNATdstruleMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-destination-rule resource table
+ 
+    jnxLsysSpNATdstruleLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-destination-rule 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATdstruleEntry 1 }
+
+    jnxLsysSpNATdstruleProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATdstruleEntry 2 }
+
+    jnxLsysSpNATdstruleUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATdstruleEntry 3 }
+    
+    jnxLsysSpNATdstruleReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATdstruleEntry 4 } 
+
+    jnxLsysSpNATdstruleMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATdstruleEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-destination-rule resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATdstruleUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-destination-rule resource consumption over all LSYS."
+    ::= { jnxLsysSpNATdstruleSummary 1 }          
+
+    jnxLsysSpNATdstruleMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-destination-rule resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATdstruleSummary 2 }
+    
+    jnxLsysSpNATdstruleAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-destination-rule resource available in the whole device."
+    ::= { jnxLsysSpNATdstruleSummary 3 }
+    
+    jnxLsysSpNATdstruleHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-destination-rule resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATdstruleSummary 4 }
+    
+    jnxLsysSpNATdstruleHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-destination-rule resource."
+    ::= { jnxLsysSpNATdstruleSummary 5 }
+    
+    jnxLsysSpNATdstruleLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-destination-rule resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATdstruleSummary 6 }
+    
+    jnxLsysSpNATdstruleLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-destination-rule resource."
+    ::= { jnxLsysSpNATdstruleSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-destination-rule resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natpoipnum.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natpoipnum.txt
@@ -1,0 +1,204 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATPOIPNUM-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATpoipnum                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATpoipnumMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-port-overloading-IP-number-specific 
+             MIB for Juniper Enterprise Logical-System (LSYS) security profiles.
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-port-overloading-IP-number resource is the focus in 
+             this MIB. 
+            "
+        ::= { jnxLsysSpNATpoipnum 1 }
+
+    jnxLsysSpNATpoipnumObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATpoipnumMIB 1 }
+    jnxLsysSpNATpoipnumSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATpoipnumMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-port-overloading-IP-number resource information objects per LSYS:
+--   Below are NAT-port-overloading-IP-number resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-port-overloading-IP-number resource table per LSYS
+
+    jnxLsysSpNATpoipnumTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATpoipnumEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-port-overloading-IP-number objects for 
+             NAT-port-overloading-IP-number resource consumption per LSYS."  
+    ::= { jnxLsysSpNATpoipnumObjects 1 }
+    
+    jnxLsysSpNATpoipnumEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATpoipnumEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-port-overloading-IP-number resource table."
+    INDEX { IMPLIED jnxLsysSpNATpoipnumLsysName }          
+    ::= { jnxLsysSpNATpoipnumTable 1 }          
+
+    JnxLsysSpNATpoipnumEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATpoipnumLsysName    DisplayString,
+          jnxLsysSpNATpoipnumProfileName DisplayString,
+          jnxLsysSpNATpoipnumUsage       Unsigned32,
+          jnxLsysSpNATpoipnumReserved    Unsigned32,
+          jnxLsysSpNATpoipnumMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-port-overloading-IP-number resource table
+ 
+    jnxLsysSpNATpoipnumLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-port-overloading-IP-
+             number resource information is retrieved. "
+        ::= { jnxLsysSpNATpoipnumEntry 1 }
+
+    jnxLsysSpNATpoipnumProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATpoipnumEntry 2 }
+
+    jnxLsysSpNATpoipnumUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATpoipnumEntry 3 }
+    
+    jnxLsysSpNATpoipnumReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATpoipnumEntry 4 } 
+
+    jnxLsysSpNATpoipnumMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATpoipnumEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-port-overloading-IP-number resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATpoipnumUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-port-overloading-IP-number resource consumption over all 
+            LSYS."
+    ::= { jnxLsysSpNATpoipnumSummary 1 }          
+
+    jnxLsysSpNATpoipnumMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-port-overloading-IP-number resource maximum quota for the 
+            whole device for all LSYS."
+    ::= { jnxLsysSpNATpoipnumSummary 2 }
+    
+    jnxLsysSpNATpoipnumAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-port-overloading-IP-number resource available in the 
+            whole device."
+    ::= { jnxLsysSpNATpoipnumSummary 3 }
+    
+    jnxLsysSpNATpoipnumHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-port-overloading-IP-number resource 
+            consumed of a LSYS."
+    ::= { jnxLsysSpNATpoipnumSummary 4 }
+    
+    jnxLsysSpNATpoipnumHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-port-overloading-IP-number 
+            resource."
+    ::= { jnxLsysSpNATpoipnumSummary 5 }
+    
+    jnxLsysSpNATpoipnumLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-port-overloading-IP-number resource 
+            consumed of a LSYS."
+    ::= { jnxLsysSpNATpoipnumSummary 6 }
+    
+    jnxLsysSpNATpoipnumLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-port-overloading-IP-
+            number resource."
+    ::= { jnxLsysSpNATpoipnumSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-port-overloading-IP-number resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natsrcnopatad.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natsrcnopatad.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATSRCNOPATAD-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATsrcnopatad                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATsrcnopatadMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-src-no-pat-address-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-src-no-pat-address resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATsrcnopatad 1 }
+
+    jnxLsysSpNATsrcnopatadObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcnopatadMIB 1 }
+    jnxLsysSpNATsrcnopatadSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcnopatadMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-src-no-pat-address resource information objects per LSYS:
+--   Below are NAT-src-no-pat-address resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-src-no-pat-address resource table per LSYS
+
+    jnxLsysSpNATsrcnopatadTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATsrcnopatadEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-src-no-pat-address objects for NAT-src-no-pat-
+             address resource consumption per LSYS."  
+    ::= { jnxLsysSpNATsrcnopatadObjects 1 }
+    
+    jnxLsysSpNATsrcnopatadEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATsrcnopatadEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-src-no-pat-address resource table."
+    INDEX { IMPLIED jnxLsysSpNATsrcnopatadLsysName }          
+    ::= { jnxLsysSpNATsrcnopatadTable 1 }          
+
+    JnxLsysSpNATsrcnopatadEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATsrcnopatadLsysName    DisplayString,
+          jnxLsysSpNATsrcnopatadProfileName DisplayString,
+          jnxLsysSpNATsrcnopatadUsage       Unsigned32,
+          jnxLsysSpNATsrcnopatadReserved    Unsigned32,
+          jnxLsysSpNATsrcnopatadMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-src-no-pat-address resource table
+ 
+    jnxLsysSpNATsrcnopatadLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-src-no-pat-address 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATsrcnopatadEntry 1 }
+
+    jnxLsysSpNATsrcnopatadProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATsrcnopatadEntry 2 }
+
+    jnxLsysSpNATsrcnopatadUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcnopatadEntry 3 }
+    
+    jnxLsysSpNATsrcnopatadReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATsrcnopatadEntry 4 } 
+
+    jnxLsysSpNATsrcnopatadMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcnopatadEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-src-no-pat-address resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATsrcnopatadUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-src-no-pat-address resource consumption over all LSYS."
+    ::= { jnxLsysSpNATsrcnopatadSummary 1 }          
+
+    jnxLsysSpNATsrcnopatadMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-src-no-pat-address resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATsrcnopatadSummary 2 }
+    
+    jnxLsysSpNATsrcnopatadAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-src-no-pat-address resource available in the whole device."
+    ::= { jnxLsysSpNATsrcnopatadSummary 3 }
+    
+    jnxLsysSpNATsrcnopatadHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-src-no-pat-address resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATsrcnopatadSummary 4 }
+    
+    jnxLsysSpNATsrcnopatadHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-src-no-pat-address resource."
+    ::= { jnxLsysSpNATsrcnopatadSummary 5 }
+    
+    jnxLsysSpNATsrcnopatadLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-src-no-pat-address resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATsrcnopatadSummary 6 }
+    
+    jnxLsysSpNATsrcnopatadLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-src-no-pat-address resource."
+    ::= { jnxLsysSpNATsrcnopatadSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-src-no-pat-address resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natsrcpatad.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natsrcpatad.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATSRCPATAD-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATsrcpatad                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATsrcpatadMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-src-pat-address-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-src-pat-address resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATsrcpatad 1 }
+
+    jnxLsysSpNATsrcpatadObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcpatadMIB 1 }
+    jnxLsysSpNATsrcpatadSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcpatadMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-src-pat-address resource information objects per LSYS:
+--   Below are NAT-src-pat-address resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-src-pat-address resource table per LSYS
+
+    jnxLsysSpNATsrcpatadTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATsrcpatadEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-src-pat-address objects for NAT-src-pat-address 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpNATsrcpatadObjects 1 }
+    
+    jnxLsysSpNATsrcpatadEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATsrcpatadEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-src-pat-address resource table."
+    INDEX { IMPLIED jnxLsysSpNATsrcpatadLsysName }          
+    ::= { jnxLsysSpNATsrcpatadTable 1 }          
+
+    JnxLsysSpNATsrcpatadEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATsrcpatadLsysName    DisplayString,
+          jnxLsysSpNATsrcpatadProfileName DisplayString,
+          jnxLsysSpNATsrcpatadUsage       Unsigned32,
+          jnxLsysSpNATsrcpatadReserved    Unsigned32,
+          jnxLsysSpNATsrcpatadMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-src-pat-address resource table
+ 
+    jnxLsysSpNATsrcpatadLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-src-pat-address 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATsrcpatadEntry 1 }
+
+    jnxLsysSpNATsrcpatadProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATsrcpatadEntry 2 }
+
+    jnxLsysSpNATsrcpatadUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcpatadEntry 3 }
+    
+    jnxLsysSpNATsrcpatadReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATsrcpatadEntry 4 } 
+
+    jnxLsysSpNATsrcpatadMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcpatadEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-src-pat-address resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATsrcpatadUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-src-pat-address resource consumption over all LSYS."
+    ::= { jnxLsysSpNATsrcpatadSummary 1 }          
+
+    jnxLsysSpNATsrcpatadMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-src-pat-address resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATsrcpatadSummary 2 }
+    
+    jnxLsysSpNATsrcpatadAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-src-pat-address resource available in the whole device."
+    ::= { jnxLsysSpNATsrcpatadSummary 3 }
+    
+    jnxLsysSpNATsrcpatadHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-src-pat-address resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATsrcpatadSummary 4 }
+    
+    jnxLsysSpNATsrcpatadHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-src-pat-address resource."
+    ::= { jnxLsysSpNATsrcpatadSummary 5 }
+    
+    jnxLsysSpNATsrcpatadLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-src-pat-address resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATsrcpatadSummary 6 }
+    
+    jnxLsysSpNATsrcpatadLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-src-pat-address resource."
+    ::= { jnxLsysSpNATsrcpatadSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-src-pat-address resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natsrcpool.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natsrcpool.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATSRCPOOL-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATsrcpool                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATsrcpoolMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- July 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-src-pool-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-src-pool resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATsrcpool 1 }
+
+    jnxLsysSpNATsrcpoolObjects        OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcpoolMIB 1 }
+    jnxLsysSpNATsrcpoolSummary        OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcpoolMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-src-pool resource information objects per LSYS:
+--   Below are NAT-src-pool resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- NAT-src-pool resource table per LSYS
+
+    jnxLsysSpNATsrcpoolTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSppNATsrcpoolEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-src-pool objects for NAT-src-pool resource consumption per LSYS."  
+    ::= { jnxLsysSpNATsrcpoolObjects 1 }
+    
+    jnxLsysSpNATsrcpoolEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSppNATsrcpoolEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-src-pool resource table."
+    INDEX { IMPLIED jnxLsysSpNATsrcpoolLsysName }          
+    ::= { jnxLsysSpNATsrcpoolTable 1 }          
+
+    JnxLsysSppNATsrcpoolEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATsrcpoolLsysName    DisplayString,
+          jnxLsysSpNATsrcpoolProfileName DisplayString,
+          jnxLsysSpNATsrcpoolUsage       Unsigned32,
+          jnxLsysSpNATsrcpoolReserved    Unsigned32,
+          jnxLsysSpNATsrcpoolMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-src-pool resource table
+ 
+    jnxLsysSpNATsrcpoolLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-src-pool resource information is retrieved. "
+        ::= { jnxLsysSpNATsrcpoolEntry 1 }
+
+    jnxLsysSpNATsrcpoolProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATsrcpoolEntry 2 }
+
+    jnxLsysSpNATsrcpoolUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcpoolEntry 3 }
+    
+    jnxLsysSpNATsrcpoolReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATsrcpoolEntry 4 } 
+
+    jnxLsysSpNATsrcpoolMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcpoolEntry 5 }
+
+
+-- **********************************************************************
+-- NAT-src-pool resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATsrcpoolUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-src-pool resource consumption over all LSYS."
+    ::= { jnxLsysSpNATsrcpoolSummary 1 }          
+
+    jnxLsysSpNATsrcpoolMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-src-pool resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpNATsrcpoolSummary 2 }
+    
+    jnxLsysSpNATsrcpoolAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-src-pool resource available in the whole device."
+    ::= { jnxLsysSpNATsrcpoolSummary 3 }
+    
+    jnxLsysSpNATsrcpoolHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-src-pool resource consumed of a LSYS."
+    ::= { jnxLsysSpNATsrcpoolSummary 4 }
+    
+    jnxLsysSpNATsrcpoolHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-src-pool resource."
+    ::= { jnxLsysSpNATsrcpoolSummary 5 }
+    
+    jnxLsysSpNATsrcpoolLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-src-pool resource consumed of a LSYS."
+    ::= { jnxLsysSpNATsrcpoolSummary 6 }
+    
+    jnxLsysSpNATsrcpoolLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-src-pool resource."
+    ::= { jnxLsysSpNATsrcpoolSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-src-pool resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natsrcrule.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natsrcrule.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATSRCRULE-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATsrcrule                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATsrcruleMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-source-rule-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-source-rule resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATsrcrule 1 }
+
+    jnxLsysSpNATsrcruleObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcruleMIB 1 }
+    jnxLsysSpNATsrcruleSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATsrcruleMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-source-rule resource information objects per LSYS:
+--   Below are NAT-source-rule resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-source-rule resource table per LSYS
+
+    jnxLsysSpNATsrcruleTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATsrcruleEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-source-rule objects for NAT-source-rule 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpNATsrcruleObjects 1 }
+    
+    jnxLsysSpNATsrcruleEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATsrcruleEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-source-rule resource table."
+    INDEX { IMPLIED jnxLsysSpNATsrcruleLsysName }          
+    ::= { jnxLsysSpNATsrcruleTable 1 }          
+
+    JnxLsysSpNATsrcruleEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATsrcruleLsysName    DisplayString,
+          jnxLsysSpNATsrcruleProfileName DisplayString,
+          jnxLsysSpNATsrcruleUsage       Unsigned32,
+          jnxLsysSpNATsrcruleReserved    Unsigned32,
+          jnxLsysSpNATsrcruleMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-source-rule resource table
+ 
+    jnxLsysSpNATsrcruleLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-source-rule 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATsrcruleEntry 1 }
+
+    jnxLsysSpNATsrcruleProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATsrcruleEntry 2 }
+
+    jnxLsysSpNATsrcruleUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcruleEntry 3 }
+    
+    jnxLsysSpNATsrcruleReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATsrcruleEntry 4 } 
+
+    jnxLsysSpNATsrcruleMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATsrcruleEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-source-rule resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATsrcruleUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-source-rule resource consumption over all LSYS."
+    ::= { jnxLsysSpNATsrcruleSummary 1 }          
+
+    jnxLsysSpNATsrcruleMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-source-rule resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATsrcruleSummary 2 }
+    
+    jnxLsysSpNATsrcruleAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-source-rule resource available in the whole device."
+    ::= { jnxLsysSpNATsrcruleSummary 3 }
+    
+    jnxLsysSpNATsrcruleHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-source-rule resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATsrcruleSummary 4 }
+    
+    jnxLsysSpNATsrcruleHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-source-rule resource."
+    ::= { jnxLsysSpNATsrcruleSummary 5 }
+    
+    jnxLsysSpNATsrcruleLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-source-rule resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATsrcruleSummary 6 }
+    
+    jnxLsysSpNATsrcruleLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-source-rule resource."
+    ::= { jnxLsysSpNATsrcruleSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-source-rule resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-natstaticrule.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-natstaticrule.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-NATSTATICRULE-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpNATstaticrule                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpNATstaticruleMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the NAT-static-rule-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security NAT-static-rule resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpNATstaticrule 1 }
+
+    jnxLsysSpNATstaticruleObjects  OBJECT IDENTIFIER ::= { jnxLsysSpNATstaticruleMIB 1 }
+    jnxLsysSpNATstaticruleSummary  OBJECT IDENTIFIER ::= { jnxLsysSpNATstaticruleMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular NAT-static-rule resource information objects per LSYS:
+--   Below are NAT-static-rule resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The NAT-static-rule resource table per LSYS
+
+    jnxLsysSpNATstaticruleTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpNATstaticruleEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE NAT-static-rule objects for NAT-static-rule 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpNATstaticruleObjects 1 }
+    
+    jnxLsysSpNATstaticruleEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpNATstaticruleEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in NAT-static-rule resource table."
+    INDEX { IMPLIED jnxLsysSpNATstaticruleLsysName }          
+    ::= { jnxLsysSpNATstaticruleTable 1 }          
+
+    JnxLsysSpNATstaticruleEntry ::= 
+       SEQUENCE {
+          jnxLsysSpNATstaticruleLsysName    DisplayString,
+          jnxLsysSpNATstaticruleProfileName DisplayString,
+          jnxLsysSpNATstaticruleUsage       Unsigned32,
+          jnxLsysSpNATstaticruleReserved    Unsigned32,
+          jnxLsysSpNATstaticruleMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the NAT-static-rule resource table
+ 
+    jnxLsysSpNATstaticruleLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which NAT-static-rule 
+             resource information is retrieved. "
+        ::= { jnxLsysSpNATstaticruleEntry 1 }
+
+    jnxLsysSpNATstaticruleProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpNATstaticruleEntry 2 }
+
+    jnxLsysSpNATstaticruleUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpNATstaticruleEntry 3 }
+    
+    jnxLsysSpNATstaticruleReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpNATstaticruleEntry 4 } 
+
+    jnxLsysSpNATstaticruleMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpNATstaticruleEntry 5 }
+
+
+-- **********************************************************************
+-- The NAT-static-rule resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpNATstaticruleUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The NAT-static-rule resource consumption over all LSYS."
+    ::= { jnxLsysSpNATstaticruleSummary 1 }          
+
+    jnxLsysSpNATstaticruleMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-static-rule resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpNATstaticruleSummary 2 }
+    
+    jnxLsysSpNATstaticruleAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The NAT-static-rule resource available in the whole device."
+    ::= { jnxLsysSpNATstaticruleSummary 3 }
+    
+    jnxLsysSpNATstaticruleHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of NAT-static-rule resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATstaticruleSummary 4 }
+    
+    jnxLsysSpNATstaticruleHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most NAT-static-rule resource."
+    ::= { jnxLsysSpNATstaticruleSummary 5 }
+    
+    jnxLsysSpNATstaticruleLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of NAT-static-rule resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpNATstaticruleSummary 6 }
+    
+    jnxLsysSpNATstaticruleLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least NAT-static-rule resource."
+    ::= { jnxLsysSpNATstaticruleSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of NAT-static-rule resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-policy.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-policy.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-POLICY-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpPolicy                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpPolicyMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- July 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the policy-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security policy resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpPolicy 1 }
+
+    jnxLsysSpPolicyObjects        OBJECT IDENTIFIER ::= { jnxLsysSpPolicyMIB 1 }
+    jnxLsysSpPolicySummary        OBJECT IDENTIFIER ::= { jnxLsysSpPolicyMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular policy resource information objects per LSYS:
+--   Below are policy resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- policy resource table per LSYS
+
+    jnxLsysSpPolicyTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpPolicyEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE policy objects for policy resource consumption per LSYS."  
+    ::= { jnxLsysSpPolicyObjects 1 }
+    
+    jnxLsysSpPolicyEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpPolicyEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in policy resource table."
+    INDEX { IMPLIED jnxLsysSpPolicyLsysName }          
+    ::= { jnxLsysSpPolicyTable 1 }          
+
+    JnxLsysSpPolicyEntry ::= 
+       SEQUENCE {
+          jnxLsysSpPolicyLsysName    DisplayString,
+          jnxLsysSpPolicyProfileName DisplayString,
+          jnxLsysSpPolicyUsage       Unsigned32,
+          jnxLsysSpPolicyReserved    Unsigned32,
+          jnxLsysSpPolicyMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the policy resource table
+ 
+    jnxLsysSpPolicyLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which policy resource information is retrieved. "
+        ::= { jnxLsysSpPolicyEntry 1 }
+
+    jnxLsysSpPolicyProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpPolicyEntry 2 }
+
+    jnxLsysSpPolicyUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpPolicyEntry 3 }
+    
+    jnxLsysSpPolicyReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpPolicyEntry 4 } 
+
+    jnxLsysSpPolicyMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpPolicyEntry 5 }
+
+
+-- **********************************************************************
+-- policy resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpPolicyUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The policy resource consumption over all LSYS."
+    ::= { jnxLsysSpPolicySummary 1 }          
+
+    jnxLsysSpPolicyMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The policy resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpPolicySummary 2 }
+    
+    jnxLsysSpPolicyAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The policy resource available in the whole device."
+    ::= { jnxLsysSpPolicySummary 3 }
+    
+    jnxLsysSpPolicyHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of policy resource consumed of a LSYS."
+    ::= { jnxLsysSpPolicySummary 4 }
+    
+    jnxLsysSpPolicyHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most policy resource."
+    ::= { jnxLsysSpPolicySummary 5 }
+    
+    jnxLsysSpPolicyLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of policy resource consumed of a LSYS."
+    ::= { jnxLsysSpPolicySummary 6 }
+    
+    jnxLsysSpPolicyLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least policy resource."
+    ::= { jnxLsysSpPolicySummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of policy resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-policywcnt.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-policywcnt.txt
@@ -1,0 +1,199 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-POLICYWCNT-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpPolicywcnt                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpPolicywcntMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the policy-with-count-specific MIB for 
+             Juniper Enterprise Logical-System (LSYS) security profiles.  
+             Juniper documentation is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security policy-with-count resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpPolicywcnt 1 }
+
+    jnxLsysSpPolicywcntObjects  OBJECT IDENTIFIER ::= { jnxLsysSpPolicywcntMIB 1 }
+    jnxLsysSpPolicywcntSummary  OBJECT IDENTIFIER ::= { jnxLsysSpPolicywcntMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular policy-with-count resource information objects per LSYS:
+--   Below are policy-with-count resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- The policy-with-count resource table per LSYS
+
+    jnxLsysSpPolicywcntTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpPolicywcntEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE policy-with-count objects for policy-with-count 
+             resource consumption per LSYS."  
+    ::= { jnxLsysSpPolicywcntObjects 1 }
+    
+    jnxLsysSpPolicywcntEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpPolicywcntEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in policy-with-count resource table."
+    INDEX { IMPLIED jnxLsysSpPolicywcntLsysName }          
+    ::= { jnxLsysSpPolicywcntTable 1 }          
+
+    JnxLsysSpPolicywcntEntry ::= 
+       SEQUENCE {
+          jnxLsysSpPolicywcntLsysName    DisplayString,
+          jnxLsysSpPolicywcntProfileName DisplayString,
+          jnxLsysSpPolicywcntUsage       Unsigned32,
+          jnxLsysSpPolicywcntReserved    Unsigned32,
+          jnxLsysSpPolicywcntMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the policy-with-count resource table
+ 
+    jnxLsysSpPolicywcntLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which policy-with-count 
+             resource information is retrieved. "
+        ::= { jnxLsysSpPolicywcntEntry 1 }
+
+    jnxLsysSpPolicywcntProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpPolicywcntEntry 2 }
+
+    jnxLsysSpPolicywcntUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpPolicywcntEntry 3 }
+    
+    jnxLsysSpPolicywcntReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpPolicywcntEntry 4 } 
+
+    jnxLsysSpPolicywcntMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpPolicywcntEntry 5 }
+
+
+-- **********************************************************************
+-- The policy-with-count resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpPolicywcntUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The policy-with-count resource consumption over all LSYS."
+    ::= { jnxLsysSpPolicywcntSummary 1 }          
+
+    jnxLsysSpPolicywcntMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The policy-with-count resource maximum quota for the whole 
+            device for all LSYS."
+    ::= { jnxLsysSpPolicywcntSummary 2 }
+    
+    jnxLsysSpPolicywcntAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The policy-with-count resource available in the whole device."
+    ::= { jnxLsysSpPolicywcntSummary 3 }
+    
+    jnxLsysSpPolicywcntHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of policy-with-count resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpPolicywcntSummary 4 }
+    
+    jnxLsysSpPolicywcntHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most policy-with-count resource."
+    ::= { jnxLsysSpPolicywcntSummary 5 }
+    
+    jnxLsysSpPolicywcntLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of policy-with-count resource consumed of a 
+            LSYS."
+    ::= { jnxLsysSpPolicywcntSummary 6 }
+    
+    jnxLsysSpPolicywcntLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least policy-with-count resource."
+    ::= { jnxLsysSpPolicywcntSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of policy-with-count resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-scheduler.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-scheduler.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-SCHEDULER-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpScheduler                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpSchedulerMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- July 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the scheduler-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security scheduler resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpScheduler 1 }
+
+    jnxLsysSpSchedulerObjects        OBJECT IDENTIFIER ::= { jnxLsysSpSchedulerMIB 1 }
+    jnxLsysSpSchedulerSummary        OBJECT IDENTIFIER ::= { jnxLsysSpSchedulerMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular scheduler resource information objects per LSYS:
+--   Below are scheduler resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- scheduler resource table per LSYS
+
+    jnxLsysSpSchedulerTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpSchedulerEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE scheduler objects for scheduler resource consumption per LSYS."  
+    ::= { jnxLsysSpSchedulerObjects 1 }
+    
+    jnxLsysSpSchedulerEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpSchedulerEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in scheduler resource table."
+    INDEX { IMPLIED jnxLsysSpSchedulerLsysName }          
+    ::= { jnxLsysSpSchedulerTable 1 }          
+
+    JnxLsysSpSchedulerEntry ::= 
+       SEQUENCE {
+          jnxLsysSpSchedulerLsysName    DisplayString,
+          jnxLsysSpSchedulerProfileName DisplayString,
+          jnxLsysSpSchedulerUsage       Unsigned32,
+          jnxLsysSpSchedulerReserved    Unsigned32,
+          jnxLsysSpSchedulerMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the scheduler resource table
+ 
+    jnxLsysSpSchedulerLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which scheduler resource information is retrieved. "
+        ::= { jnxLsysSpSchedulerEntry 1 }
+
+    jnxLsysSpSchedulerProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpSchedulerEntry 2 }
+
+    jnxLsysSpSchedulerUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpSchedulerEntry 3 }
+    
+    jnxLsysSpSchedulerReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpSchedulerEntry 4 } 
+
+    jnxLsysSpSchedulerMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpSchedulerEntry 5 }
+
+
+-- **********************************************************************
+-- scheduler resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpSchedulerUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The scheduler resource consumption over all LSYS."
+    ::= { jnxLsysSpSchedulerSummary 1 }          
+
+    jnxLsysSpSchedulerMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The scheduler resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpSchedulerSummary 2 }
+    
+    jnxLsysSpSchedulerAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The scheduler resource available in the whole device."
+    ::= { jnxLsysSpSchedulerSummary 3 }
+    
+    jnxLsysSpSchedulerHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of scheduler resource consumed of a LSYS."
+    ::= { jnxLsysSpSchedulerSummary 4 }
+    
+    jnxLsysSpSchedulerHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most scheduler resource."
+    ::= { jnxLsysSpSchedulerSummary 5 }
+    
+    jnxLsysSpSchedulerLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of scheduler resource consumed of a LSYS."
+    ::= { jnxLsysSpSchedulerSummary 6 }
+    
+    jnxLsysSpSchedulerLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least scheduler resource."
+    ::= { jnxLsysSpSchedulerSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of scheduler resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-lsys-sp-zone.txt
+++ b/mibs/junos/mib-jnx-lsys-sp-zone.txt
@@ -1,0 +1,194 @@
+--
+-- Juniper Enterprise Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+
+JUNIPER-LSYSSP-ZONE-MIB DEFINITIONS ::= BEGIN
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+      Unsigned32
+        FROM SNMPv2-SMI
+      DisplayString
+        FROM SNMPv2-TC
+      jnxLsysSpZone                  
+        FROM JUNIPER-LSYS-SECURITYPROFILE-MIB
+    ;
+    
+    jnxLsysSpZoneMIB MODULE-IDENTITY
+        LAST-UPDATED  "201005191644Z" -- May 19, 2010
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+        DESCRIPTION
+            "This module defines the zone-specific MIB for Juniper Enterprise 
+             Logical-System (LSYS) security profiles.  Juniper documentation 
+             is recommended as the reference. 
+
+             The LSYS security profile provides various static and dynamic 
+             resource management by observing resource quota limits. 
+             Security zone resource is the focus in this MIB. 
+            "
+        ::= { jnxLsysSpZone 1 }
+
+    jnxLsysSpZoneObjects        OBJECT IDENTIFIER ::= { jnxLsysSpZoneMIB 1 }
+    jnxLsysSpZoneSummary        OBJECT IDENTIFIER ::= { jnxLsysSpZoneMIB 2 }
+    
+ 
+-- **********************************************************************
+-- Tabular zone resource information objects per LSYS:
+--   Below are zone resource table indexed by LSYS name.
+-- **********************************************************************
+
+-- Zone resource table per LSYS
+
+    jnxLsysSpZoneTable OBJECT-TYPE
+        SYNTAX              SEQUENCE OF JnxLsysSpZoneEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION 
+            "LSYSPROFILE zone objects for zone resource consumption per LSYS."  
+    ::= { jnxLsysSpZoneObjects 1 }
+    
+    jnxLsysSpZoneEntry OBJECT-TYPE
+        SYNTAX              JnxLsysSpZoneEntry
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION  
+            "An entry in zone resource table."
+    INDEX { IMPLIED jnxLsysSpZoneLsysName }          
+    ::= { jnxLsysSpZoneTable 1 }          
+
+    JnxLsysSpZoneEntry ::= 
+       SEQUENCE {
+          jnxLsysSpZoneLsysName    DisplayString,
+          jnxLsysSpZoneProfileName DisplayString,
+          jnxLsysSpZoneUsage       Unsigned32,
+          jnxLsysSpZoneReserved    Unsigned32,
+          jnxLsysSpZoneMaximum     Unsigned32
+    }   
+ 
+-- Entry definitions for the zone resource table
+ 
+    jnxLsysSpZoneLsysName       OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..64))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "The name of the logical system for which zone resource information is retrieved. "
+        ::= { jnxLsysSpZoneEntry 1 }
+
+    jnxLsysSpZoneProfileName    OBJECT-TYPE
+        SYNTAX              DisplayString (SIZE(1..32))
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The security profile name string for the LSYS."
+    ::= { jnxLsysSpZoneEntry 2 }
+
+    jnxLsysSpZoneUsage          OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION  
+            "The current resource usage count for the LSYS."
+    ::= { jnxLsysSpZoneEntry 3 }
+    
+    jnxLsysSpZoneReserved       OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The reserved resource count for the LSYS."
+    ::= { jnxLsysSpZoneEntry 4 } 
+
+    jnxLsysSpZoneMaximum        OBJECT-TYPE
+        SYNTAX              Unsigned32
+        MAX-ACCESS          read-only
+        STATUS              current
+        DESCRIPTION
+            "The maximum allowed resource usage count for the LSYS."
+    ::= { jnxLsysSpZoneEntry 5 }
+
+
+-- **********************************************************************
+-- Zone resource information summary:
+-- **********************************************************************
+
+    jnxLsysSpZoneUsedAmount         OBJECT-TYPE
+        SYNTAX                  Unsigned32 
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION
+           "The zone resource consumption over all LSYS."
+    ::= { jnxLsysSpZoneSummary 1 }          
+
+    jnxLsysSpZoneMaxQuota           OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The zone resource maximum quota for the whole device for all LSYS."
+    ::= { jnxLsysSpZoneSummary 2 }
+    
+    jnxLsysSpZoneAvailableAmount    OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The zone resource available in the whole device."
+    ::= { jnxLsysSpZoneSummary 3 }
+    
+    jnxLsysSpZoneHeaviestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The most amount of zone resource consumed of a LSYS."
+    ::= { jnxLsysSpZoneSummary 4 }
+    
+    jnxLsysSpZoneHeaviestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the most zone resource."
+    ::= { jnxLsysSpZoneSummary 5 }
+    
+    jnxLsysSpZoneLightestUsage      OBJECT-TYPE
+        SYNTAX                  Unsigned32
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The least amount of zone resource consumed of a LSYS."
+    ::= { jnxLsysSpZoneSummary 6 }
+    
+    jnxLsysSpZoneLightestUser       OBJECT-TYPE
+        SYNTAX                  DisplayString (SIZE(1..64))
+        MAX-ACCESS              read-only
+        STATUS                  current
+        DESCRIPTION 
+           "The LSYS name that consume the least zone resource."
+    ::= { jnxLsysSpZoneSummary 7 }
+    
+
+
+ -- ***************************************************************
+ -- definition of zone resource related traps. (TBD)
+ -- ***************************************************************
+
+--
+-- End of File 
+--
+
+END

--- a/mibs/junos/mib-jnx-mag.txt
+++ b/mibs/junos/mib-jnx-mag.txt
@@ -1,0 +1,89 @@
+-- *******************************************************************
+-- Juniper enterprise specific Access Authentication objects MIB.
+--
+-- Copyright (c) 2001-2010, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- *******************************************************************
+
+    JUNIPER-MAG-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+        Counter32, IpAddress, Integer32,
+        NOTIFICATION-TYPE, MODULE-IDENTITY,
+        OBJECT-TYPE
+            FROM SNMPv2-SMI
+
+        TEXTUAL-CONVENTION, DisplayString
+            FROM SNMPv2-TC
+
+        jnxMagMibRoot
+            FROM JUNIPER-SMI;
+
+
+    jnxMagMib  MODULE-IDENTITY
+        LAST-UPDATED  "201002201210Z"
+        ORGANIZATION  "Juniper Networks, Inc."
+        CONTACT-INFO
+            "Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+
+             E-mail: support@juniper.net
+             HTTP://www.juniper.net"
+
+        DESCRIPTION
+            "These MIB objects pertain to Secure access,
+             infranet controller and WAN acceleration service
+             modules?"
+
+        REVISION      "201002201200Z"
+        DESCRIPTION   "Creation Date"
+        ::= { jnxMagMibRoot 1 }
+
+
+    jnxMagNotifications OBJECT IDENTIFIER ::= { jnxMagMib 0 }
+    jnxMagObjects       OBJECT IDENTIFIER ::= { jnxMagMib 1 }
+
+    -- ***************************************************************
+    --  Next Branch node.
+    -- ***************************************************************
+
+    jnxMagSSOObjects OBJECT IDENTIFIER ::= { jnxMagObjects 1 }
+
+
+    -- ***************************************************************
+    -- Single Sign-on Statistics
+    -- ***************************************************************
+
+
+    jnxMagSSOAuthTokenAttempt OBJECT-TYPE
+        SYNTAX  Counter32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+        "Number of Auth Token attempts made"
+        ::= { jnxMagSSOObjects 1 }
+
+
+    jnxMagSSOFailedAuthToken OBJECT-TYPE
+        SYNTAX  Counter32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+        "Number of Failed Auth Token "
+        ::= { jnxMagSSOObjects 2 }
+
+
+    -- ***************************************************************
+    -- MAG Notfications
+    -- ***************************************************************
+
+    jnxMagSSOValidationError NOTIFICATION-TYPE
+       STATUS  current
+       DESCRIPTION
+       " Auth Token Validation error"
+       ::= { jnxMagNotifications 1 }
+
+END

--- a/mibs/junos/mib-jnx-mbg-smi.txt
+++ b/mibs/junos/mib-jnx-mbg-smi.txt
@@ -1,0 +1,60 @@
+--
+-- Juniper Mobile Gateway Specific MIB: Structure of Management Information
+-- 
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MBG-SMI DEFINITIONS ::= BEGIN
+
+IMPORTS
+       jnxMobileGatewayMibRoot, jnxJunosSpace FROM JUNIPER-SMI;
+
+--
+-- Object identifier added as the basis for
+-- identifying different Mobile Gateway nodes.
+-- 
+--
+-- This will be used as a root all the PDN-GW/GGSN MIBs.
+--
+jnxMobileGatewayPgwGgsn OBJECT IDENTIFIER
+    ::= { jnxMobileGatewayMibRoot 1 }
+--
+-- This will be used as a root all the Serving Gateway MIBs.
+--
+jnxMobileGatewaySgw OBJECT IDENTIFIER
+    ::= { jnxMobileGatewayMibRoot 2 }
+
+--
+-- This is the root of all EMS MIBs exposed for Mobility from Junos Space
+--
+jnxJunosSpaceMobility OBJECT IDENTIFIER ::= {jnxJunosSpace  2 }
+
+--
+-- This is the root of all EMS level Notifications for Mobility from Junos Space
+--
+jnxJunosSpaceMobilityNotifications OBJECT IDENTIFIER ::= {jnxJunosSpaceMobility  1 }
+
+--
+-- This is the root of all EMS level Objects for Mobility from Junos Space
+--
+jnxJunosSpaceMobilityObjects OBJECT IDENTIFIER ::= {jnxJunosSpaceMobility  2 }
+
+--
+-- Reserved OID for Mobility application Mobile Core Manager from Junos Space
+--
+jnxJunosSpaceMobilityMCM OBJECT IDENTIFIER ::= {jnxJunosSpaceMobility  3 }
+
+--
+-- Reserved OID for Mobility application Mobile Traffic Monitoring from Junos Space
+--
+jnxJunosSpaceMobilityMTM OBJECT IDENTIFIER ::= {jnxJunosSpaceMobility  4 }
+
+--
+-- This is the root of all EMS level Notification Vars for Mobility from Junos Space
+--
+jnxJunosSpaceMobilityNotificationvars OBJECT IDENTIFIER ::= { jnxJunosSpaceMobilityObjects 1 }
+   
+END 

--- a/mibs/junos/mib-jnx-mobile-gateway-aaa.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-aaa.txt
@@ -1,0 +1,2194 @@
+--
+-- Juniper Mobile Gateway AAA objects MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-AAA-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    Counter64, Counter32, Integer32, Unsigned32, Gauge32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString
+        FROM SNMPv2-TC
+
+    InetAddressType, InetAddress, InetPortNumber
+        FROM INET-ADDRESS-MIB
+
+    EnabledStatus
+        FROM JUNIPER-MIMSTP-MIB
+
+    jnxMobileGatewayMibRoot	
+        FROM JUNIPER-SMI
+
+    jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS;
+
+jnxMobileGatewayPgwAAAMib MODULE-IDENTITY
+    LAST-UPDATED "201111151200Z" -- Nov 15, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to Mobile-Edge AAA Services"
+    REVISION "201101031200Z" -- Jan 03, 2011, 12:00:00
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewayMibRoot 3 }
+
+jnxMbgAAANotifications OBJECT IDENTIFIER ::= 
+                                                { jnxMobileGatewayPgwAAAMib 0 }
+jnxMbgAAAObjects       OBJECT IDENTIFIER ::= 
+                                                { jnxMobileGatewayPgwAAAMib 1 }
+
+jnxMbgAAAGlobalAuthStats   OBJECT IDENTIFIER ::= 
+                                            { jnxMbgAAAObjects 1 }
+jnxMbgAAAGlobalAcctStats   OBJECT IDENTIFIER ::= 
+                                            { jnxMbgAAAObjects 2 }
+jnxMbgAAAGlobalDynAuthStats OBJECT IDENTIFIER ::= 
+                                            { jnxMbgAAAObjects 3 }
+jnxMbgAAANotificationVars  OBJECT IDENTIFIER ::= 
+                                            { jnxMbgAAAObjects 7 }
+
+JnxMbgAAAServerStatus ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION 
+        "Server status - dead or active."
+    SYNTAX  INTEGER {
+                        unknown   (0),
+                        active    (1),
+                        dead      (2)
+                    }
+
+JnxMbgQueueWaterMarkType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "The type of a queue threshold  - high or low."
+    SYNTAX  INTEGER {
+                        unknown   (0),
+                        high      (1),
+                        low       (2)
+                    }
+
+
+--
+-- Global RADIUS Authentication counters Table
+-- 
+
+jnxMbgAAAAuthStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgAAAAuthStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists authentication counters."
+    ::= { jnxMbgAAAObjects 8 }
+
+jnxMbgAAAAuthStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgAAAAuthStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing global radius authentication counters."
+    INDEX       { jnxMbgGwIndex }
+    ::= { jnxMbgAAAAuthStatsTable 1 }
+
+JnxMbgAAAAuthStatsEntry ::= SEQUENCE {
+    jnxMbgTtlAuthRequests              Counter64,
+    jnxMbgTtlAuthAccepts               Counter64,
+    jnxMbgTtlAuthRejects               Counter64,
+    jnxMbgTtlAuthChallenges            Counter64,
+    jnxMbgTtlAuthRequestTimeouts       Counter64,
+    jnxMbgTtlAuthRequestTxErrors       Counter64,
+    jnxMbgTtlAuthResponseErrors        Counter64,
+    jnxMbgTtlAuthPendingRequests       Counter64
+}
+
+jnxMbgTtlAuthRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication requests made."
+    ::= { jnxMbgAAAAuthStatsEntry 1 }
+
+jnxMbgTtlAuthAccepts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication requests that were accepted."
+    ::= { jnxMbgAAAAuthStatsEntry 2 }
+
+jnxMbgTtlAuthRejects OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication requests that were rejected."
+    ::= { jnxMbgAAAAuthStatsEntry 3 }
+
+jnxMbgTtlAuthChallenges OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication challenges received."
+    ::= { jnxMbgAAAAuthStatsEntry 4 }
+
+jnxMbgTtlAuthRequestTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication requests that timed out."
+    ::= { jnxMbgAAAAuthStatsEntry 5 }
+
+jnxMbgTtlAuthRequestTxErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication requests transmit errors."
+    ::= { jnxMbgAAAAuthStatsEntry 6 }
+
+jnxMbgTtlAuthResponseErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total authentication response errors."
+    ::= { jnxMbgAAAAuthStatsEntry 7 }
+
+jnxMbgTtlAuthPendingRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total pending authentication requests."
+    ::= { jnxMbgAAAAuthStatsEntry 8 }
+
+--
+-- Global counters related to Accounting
+--
+
+jnxMbgAAAAcctStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgAAAAcctStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists accounting counters."
+    ::= { jnxMbgAAAObjects 9 }
+
+jnxMbgAAAAcctStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgAAAAcctStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing global radius accounting counters."
+    INDEX       { jnxMbgGwIndex }
+    ::= { jnxMbgAAAAcctStatsTable 1 }
+
+JnxMbgAAAAcctStatsEntry ::= SEQUENCE {
+    jnxMbgTtlAcctRequests               Counter64,
+    jnxMbgTtlAcctResp               Counter64,
+    jnxMbgTtlAcctRequestTimeouts    Counter64,
+    jnxMbgTtlAcctRequestTxErrors    Counter64,
+    jnxMbgTtlAcctResponseErrors     Counter64,
+    jnxMbgTtlAcctPendingRequests        Counter64
+}
+jnxMbgTtlAcctRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total accounting requests made."
+    ::= { jnxMbgAAAAcctStatsEntry 1 }
+
+jnxMbgTtlAcctResp OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total accounting Resp that were received."
+    ::= { jnxMbgAAAAcctStatsEntry 2 }
+
+jnxMbgTtlAcctRequestTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total accounting requests that timed out."
+    ::= { jnxMbgAAAAcctStatsEntry 3 }
+
+jnxMbgTtlAcctRequestTxErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total accounting requests transmit errors."
+    ::= { jnxMbgAAAAcctStatsEntry 4 }
+
+jnxMbgTtlAcctResponseErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total accounting response errors."
+    ::= { jnxMbgAAAAcctStatsEntry 5 }
+
+jnxMbgTtlAcctPendingRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total pending accounting requests."
+    ::= { jnxMbgAAAAcctStatsEntry 6 }
+
+--
+-- Global Dynamic requests Statistics
+--
+
+jnxMbgAAADynAuthStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgAAADynAuthStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists dynamic request statistics counters."
+    ::= { jnxMbgAAAObjects 10 }
+
+jnxMbgAAADynAuthStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgAAADynAuthStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing global request statistics counters."
+    INDEX       { jnxMbgGwIndex }
+    ::= { jnxMbgAAADynAuthStatsTable 1 }
+
+JnxMbgAAADynAuthStatsEntry ::= SEQUENCE {
+    jnxMbgTtlDynAuthReceived       Counter64,
+    jnxMbgTtlDynAuthCoaReceived    Counter64,
+    jnxMbgTtlDynAuthDmReceived     Counter64,
+    jnxMbgTtlDynAuthCoaAckSent     Counter64,
+    jnxMbgTtlDynAuthCoaNackSent    Counter64,
+    jnxMbgTtlDynAuthDmAckSent      Counter64,
+    jnxMbgTtlDynAuthDmNackSent     Counter64,
+    jnxMbgTtlDynAuthDropped        Counter64,
+    jnxMbgTtlDynAuthDuplicate      Counter64,
+    jnxMbgTtlDynAuthForwarded      Counter64,
+    jnxMbgTtlDynAuthTimeouts       Counter64,
+    jnxMbgTtlDynAuthDelivered      Counter64,
+    jnxMbgTtlDynAuthErrors         Counter64,
+    jnxMbgTtlDynAuthUnknownClnts   Counter64,
+    jnxMbgTtlDynAuthInvalidCode    Counter64,
+    jnxMbgTtlDynAuthInvalidAuth    Counter64,
+    jnxMbgTtlDynAuthInvalidChId    Counter64,
+    jnxMbgTtlDynAuthMapErrors      Counter64,
+    jnxMbgTtlDynAuthInvalidTrId    Counter64
+}
+
+jnxMbgTtlDynAuthReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req received."
+    ::= { jnxMbgAAADynAuthStatsEntry 1 }
+
+jnxMbgTtlDynAuthCoaReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total CoA received."
+    ::= { jnxMbgAAADynAuthStatsEntry 2 }
+
+jnxMbgTtlDynAuthDmReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total DM received."
+    ::= { jnxMbgAAADynAuthStatsEntry 3 }
+
+jnxMbgTtlDynAuthCoaAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total CoA Ack sent."
+    ::= { jnxMbgAAADynAuthStatsEntry 4 }
+
+jnxMbgTtlDynAuthCoaNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total CoA Nack sent."
+    ::= { jnxMbgAAADynAuthStatsEntry 5 }
+
+jnxMbgTtlDynAuthDmAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total DM Ack sent."
+    ::= { jnxMbgAAADynAuthStatsEntry 6 }
+
+jnxMbgTtlDynAuthDmNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total DM Nack sent."
+    ::= { jnxMbgAAADynAuthStatsEntry 7 }
+
+jnxMbgTtlDynAuthDropped OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req that were dropped."
+    ::= { jnxMbgAAADynAuthStatsEntry 8 }
+
+jnxMbgTtlDynAuthDuplicate OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total duplicate dyn-req detected."
+    ::= { jnxMbgAAADynAuthStatsEntry 9 }
+
+jnxMbgTtlDynAuthForwarded OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req forwarded to anchor instance."
+    ::= { jnxMbgAAADynAuthStatsEntry 10 }
+
+jnxMbgTtlDynAuthTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req timed out."
+    ::= { jnxMbgAAADynAuthStatsEntry 11 }
+
+jnxMbgTtlDynAuthDelivered OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req that were delivered to application."
+    ::= { jnxMbgAAADynAuthStatsEntry 12 }
+
+jnxMbgTtlDynAuthErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req that had errors during processing."
+    ::= { jnxMbgAAADynAuthStatsEntry 13 }
+
+jnxMbgTtlDynAuthUnknownClnts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req received from unknown clients."
+    ::= { jnxMbgAAADynAuthStatsEntry 14 }
+
+jnxMbgTtlDynAuthInvalidCode OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req received with invalid RADIUS code."
+    ::= { jnxMbgAAADynAuthStatsEntry 15 }
+
+jnxMbgTtlDynAuthInvalidAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req received with invalid RADIUS authenticator."
+    ::= { jnxMbgAAADynAuthStatsEntry 16 }
+
+jnxMbgTtlDynAuthInvalidChId OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req received with invalid or missing Charging Id."
+    ::= { jnxMbgAAADynAuthStatsEntry 17 }
+
+jnxMbgTtlDynAuthMapErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req that had session mapping errors during processing."
+    ::= { jnxMbgAAADynAuthStatsEntry 18 }
+
+jnxMbgTtlDynAuthInvalidTrId OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total dyn-req with invalid transaction id during processing."
+    ::= { jnxMbgAAADynAuthStatsEntry 19 }
+
+
+--
+-- RADIUS Authentication Servers Table
+-- This table contains the status and stats related to RADIUS Authentication
+-- Servers
+
+jnxMbgRadiusAuthSrvrTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgRadiusAuthSrvrEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists RADIUS servers used for authentication."
+    ::= { jnxMbgAAAObjects 11 }
+
+jnxMbgRadiusAuthSrvrEntry OBJECT-TYPE
+    SYNTAX      JnxMbgRadiusAuthSrvrEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a RADIUS server used for authentication."
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgRadiusAuthSrvrName}
+    ::= { jnxMbgRadiusAuthSrvrTable 1 }
+
+JnxMbgRadiusAuthSrvrEntry ::= SEQUENCE {
+    jnxMbgRadiusAuthSrvrName                DisplayString,
+    jnxMbgRadiusAuthSrvrInetAddrType        InetAddressType,
+    jnxMbgRadiusAuthSrvrInetAddress         InetAddress,
+    jnxMbgRadiusAuthSrvrInetPort            InetPortNumber,
+    jnxMbgRadiusAuthSrvrRtngInstance        DisplayString,
+    jnxMbgRadiusAuthSrvrStatus              JnxMbgAAAServerStatus,
+    jnxMbgRadiusAuthSrvrRequests            Counter64,
+    jnxMbgRadiusAuthSrvrRetrans            Counter64,
+    jnxMbgRadiusAuthSrvrAccepts             Counter64,
+    jnxMbgRadiusAuthSrvrRejects             Counter64,
+    jnxMbgRadiusAuthSrvrChallenges          Counter64,
+    jnxMbgRadiusAuthSrvrMalformResp         Counter64,
+    jnxMbgRadiusAuthSrvrBadAuthen           Counter64,
+    jnxMbgRadiusAuthSrvrPendingRqsts        Counter64,
+    jnxMbgRadiusAuthSrvrTimeouts            Counter64,
+    jnxMbgRadiusAuthSrvrUnknownTypes        Counter64,
+    jnxMbgRadiusAuthSrvrPacketsDrop         Counter64,
+    jnxMbgRadiusAuthSrvrRTTAvg              Gauge32,
+    jnxMbgRadiusAuthSrvrRTTMin              Gauge32,
+    jnxMbgRadiusAuthSrvrRTTMax              Gauge32
+}
+
+jnxMbgRadiusAuthSrvrName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A name which uniquely identifies this server on the mobile-gateway."
+    ::= { jnxMbgRadiusAuthSrvrEntry 1 }
+
+jnxMbgRadiusAuthSrvrInetAddrType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The type of IP address used for this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 2 }
+
+jnxMbgRadiusAuthSrvrInetAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The IP address used for this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 3 }
+
+jnxMbgRadiusAuthSrvrInetPort OBJECT-TYPE
+    SYNTAX      InetPortNumber
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The UDP port number on the server to which authentication
+        requests are sent."
+    ::= { jnxMbgRadiusAuthSrvrEntry 4 }
+
+jnxMbgRadiusAuthSrvrRtngInstance OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The routing-instance used while contacting this server.
+        If not configured, the default routing-instance will be
+        used."
+    ::= { jnxMbgRadiusAuthSrvrEntry 5 }
+
+jnxMbgRadiusAuthSrvrStatus OBJECT-TYPE
+    SYNTAX      JnxMbgAAAServerStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The current status of the server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 6 }
+
+jnxMbgRadiusAuthSrvrRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Access-requests that have been sent to
+        this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 7 }
+
+jnxMbgRadiusAuthSrvrRetrans OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Access-requests that have been retransmitted
+        this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 8 }
+
+jnxMbgRadiusAuthSrvrAccepts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Access-Accepts that have been received from
+        this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 9 }
+
+jnxMbgRadiusAuthSrvrRejects OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Access-Rejects that have been received from
+        this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 10 }
+
+jnxMbgRadiusAuthSrvrChallenges OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Access-Challenges that have been received from
+        this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 11 }
+
+jnxMbgRadiusAuthSrvrMalformResp OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Malformed Resp have been received from
+        this server. A response could either accept, reject or challenge."
+    ::= { jnxMbgRadiusAuthSrvrEntry 12 }
+
+jnxMbgRadiusAuthSrvrBadAuthen OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Resp with invalid authenticators received from
+        this server. A response could either accept, reject or challenge."
+    ::= { jnxMbgRadiusAuthSrvrEntry 13 }
+
+jnxMbgRadiusAuthSrvrPendingRqsts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of requests to this server pending authentication."
+    ::= { jnxMbgRadiusAuthSrvrEntry 14 }
+
+jnxMbgRadiusAuthSrvrTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of requests to this server that timed out."
+    ::= { jnxMbgRadiusAuthSrvrEntry 15 }
+
+jnxMbgRadiusAuthSrvrUnknownTypes OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Resp received from this RADIUS server with
+        unknown types."
+    ::= { jnxMbgRadiusAuthSrvrEntry 16 }
+
+jnxMbgRadiusAuthSrvrPacketsDrop OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Resp received from this RADIUS server 
+        that were dropped for some other reason."
+    ::= { jnxMbgRadiusAuthSrvrEntry 17 }
+
+jnxMbgRadiusAuthSrvrRTTAvg OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Average round-trip time (in ms) for this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 18 }
+
+jnxMbgRadiusAuthSrvrRTTMin OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Minimum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 19 }
+
+jnxMbgRadiusAuthSrvrRTTMax OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAuthSrvrEntry 20 }
+
+--
+-- RADIUS Accounting Servers Table
+-- This table contains the status and stats related to RADIUS Accounting
+-- Servers
+
+jnxMbgRadiusAcctSrvrTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgRadiusAcctSrvrEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists RADIUS servers used for accounting."
+    ::= { jnxMbgAAAObjects 12 }
+
+jnxMbgRadiusAcctSrvrEntry OBJECT-TYPE
+    SYNTAX      JnxMbgRadiusAcctSrvrEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a RADIUS server used for accounting."
+
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgRadiusAcctSrvrName}
+    ::= { jnxMbgRadiusAcctSrvrTable 1 }
+
+JnxMbgRadiusAcctSrvrEntry ::= SEQUENCE {
+    jnxMbgRadiusAcctSrvrName             DisplayString,
+    jnxMbgRadiusAcctSrvrInetAddrType     InetAddressType,
+    jnxMbgRadiusAcctSrvrInetAddress      InetAddress,
+    jnxMbgRadiusAcctSrvrInetPort         InetPortNumber,
+    jnxMbgRadiusAcctSrvrRtngInstance     DisplayString,
+    jnxMbgRadiusAcctSrvrStatus           JnxMbgAAAServerStatus,
+    jnxMbgRadiusAcctSrvrRequests         Counter64,
+    jnxMbgRadiusAcctSrvrRetrans         Counter64,
+    jnxMbgRadiusAcctSrvrResp             Counter64,
+    jnxMbgRadiusAcctSrvrMalformResp      Counter64,
+    jnxMbgRadiusAcctSrvrBadAuthen        Counter64,
+    jnxMbgRadiusAcctSrvrPendingRqsts     Counter64,
+    jnxMbgRadiusAcctSrvrTimeouts         Counter64,
+    jnxMbgRadiusAcctSrvrUnknownTypes     Counter64,
+    jnxMbgRadiusAcctSrvrPacketsDrop      Counter64,
+    jnxMbgRadiusAcctSrvrRTTAvg           Gauge32,
+    jnxMbgRadiusAcctSrvrRTTMin           Gauge32,
+    jnxMbgRadiusAcctSrvrRTTMax           Gauge32
+}
+
+jnxMbgRadiusAcctSrvrName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A name which uniquely identifies this server on the mobile-gateway."
+    ::= { jnxMbgRadiusAcctSrvrEntry 1 }
+
+jnxMbgRadiusAcctSrvrInetAddrType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The type of IP address used for this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 2 }
+
+jnxMbgRadiusAcctSrvrInetAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The IP address used for this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 3 }
+
+jnxMbgRadiusAcctSrvrInetPort OBJECT-TYPE
+    SYNTAX      InetPortNumber
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The UDP port number on the server to which accounting
+        requests are sent."
+    ::= { jnxMbgRadiusAcctSrvrEntry 4 }
+
+jnxMbgRadiusAcctSrvrRtngInstance OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The routing-instance used while contacting this server.
+        If not configured, the default routing-instance will be
+        used."
+    ::= { jnxMbgRadiusAcctSrvrEntry 5 }
+
+jnxMbgRadiusAcctSrvrStatus OBJECT-TYPE
+    SYNTAX      JnxMbgAAAServerStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The current status of the server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 6 }
+
+jnxMbgRadiusAcctSrvrRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Accounting-requests that have been sent to
+        this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 7 }
+
+jnxMbgRadiusAcctSrvrRetrans OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Accounting-requests that have been retransmitted
+        this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 8 }
+
+jnxMbgRadiusAcctSrvrResp OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Accounting-Resp that have been received from
+        this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 9 }
+
+jnxMbgRadiusAcctSrvrMalformResp OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Malformed Resp have been received from
+        this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 10 }
+
+jnxMbgRadiusAcctSrvrBadAuthen OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Resp with invalid authenticators received from
+        this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 11 }
+
+jnxMbgRadiusAcctSrvrPendingRqsts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of requests to this server which are yet to be sent or
+        waiting for response."
+    ::= { jnxMbgRadiusAcctSrvrEntry 12 }
+
+jnxMbgRadiusAcctSrvrTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of requests to this server that timed out."
+    ::= { jnxMbgRadiusAcctSrvrEntry 13 }
+
+jnxMbgRadiusAcctSrvrUnknownTypes OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Resp received from this RADIUS server with
+        unknown types."
+    ::= { jnxMbgRadiusAcctSrvrEntry 14 }
+
+jnxMbgRadiusAcctSrvrPacketsDrop OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Resp received from this RADIUS server 
+        that were dropped for some other reason."
+    ::= { jnxMbgRadiusAcctSrvrEntry 15 }
+
+jnxMbgRadiusAcctSrvrRTTAvg OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Average round-trip time (in ms) for this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 16 }
+
+jnxMbgRadiusAcctSrvrRTTMin OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Minimum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 17 }
+
+jnxMbgRadiusAcctSrvrRTTMax OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAcctSrvrEntry 18 }
+
+--
+-- RADIUS Dyn Auth Clients Table
+-- This table contains the status and stats related to RADIUS Dyn Auth
+-- Servers
+
+jnxMbgDynAuthClntTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgDynAuthClntEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists RADIUS clients sending Dynamic Authorization requests."
+    ::= { jnxMbgAAAObjects 13 }
+
+jnxMbgDynAuthClntEntry OBJECT-TYPE
+    SYNTAX      JnxMbgDynAuthClntEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a RADIUS client sending Dynamic Authorization requests."
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgDynAuthClntName }
+    ::= { jnxMbgDynAuthClntTable 1 }
+
+JnxMbgDynAuthClntEntry ::= SEQUENCE {
+    jnxMbgDynAuthClntName                  DisplayString,
+    jnxMbgDynAuthClntInAddrType            InetAddressType,
+    jnxMbgDynAuthClntInetAddress           InetAddress,
+
+    jnxMbgDynAuthClntCoaReceived           Counter64,
+    jnxMbgDynAuthClntDmReceived            Counter64,
+    jnxMbgDynAuthClntCoaAckSent            Counter64,
+    jnxMbgDynAuthClntCoaNackSent           Counter64,
+    jnxMbgDynAuthClntDmAckSent             Counter64,
+    jnxMbgDynAuthClntDmNackSent            Counter64,
+    jnxMbgDynAuthClntDropped               Counter64,
+    jnxMbgDynAuthClntDuplicate             Counter64,
+    jnxMbgDynAuthClntForwarded             Counter64,
+    jnxMbgDynAuthClntTimeouts              Counter64,
+    jnxMbgDynAuthClntDelivered             Counter64,
+    jnxMbgDynAuthClntErrors                Counter64,
+    jnxMbgDynAuthClntInvalidAuth           Counter64,
+    jnxMbgDynAuthClntInvalidCode           Counter64,
+    jnxMbgDynAuthClntInvalidChId           Counter64,
+    jnxMbgDynAuthClntMapErrors             Counter64
+}
+
+jnxMbgDynAuthClntName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A name which uniquely identifies this client on the mobile-gateway."
+    ::= { jnxMbgDynAuthClntEntry 1 }
+
+jnxMbgDynAuthClntInAddrType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The type of IP address used for this client."
+    ::= { jnxMbgDynAuthClntEntry 2 }
+
+jnxMbgDynAuthClntInetAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The IP address of this client."
+    ::= { jnxMbgDynAuthClntEntry 3 }
+
+jnxMbgDynAuthClntCoaReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "CoA requests received from this client."
+    ::= { jnxMbgDynAuthClntEntry 4 }
+
+jnxMbgDynAuthClntDmReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DM requests received from this client."
+    ::= { jnxMbgDynAuthClntEntry 5 }
+
+jnxMbgDynAuthClntCoaAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "CoA Ack Resp sent to this client."
+    ::= { jnxMbgDynAuthClntEntry 6 }
+
+jnxMbgDynAuthClntCoaNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "CoA Nack Resp sent to this client."
+    ::= { jnxMbgDynAuthClntEntry 7 }
+
+jnxMbgDynAuthClntDmAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DM Ack Resp sent to this client."
+    ::= { jnxMbgDynAuthClntEntry 8 }
+
+jnxMbgDynAuthClntDmNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "DM Nack Resp sent to this client."
+    ::= { jnxMbgDynAuthClntEntry 9 }
+
+jnxMbgDynAuthClntDropped OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this server that were dropped."
+    ::= { jnxMbgDynAuthClntEntry 10 }
+
+jnxMbgDynAuthClntDuplicate OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Duplicate requests received from this client."
+    ::= { jnxMbgDynAuthClntEntry 11 }
+
+jnxMbgDynAuthClntForwarded OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client that were forwarded to anchor instance."
+    ::= { jnxMbgDynAuthClntEntry 12 }
+
+jnxMbgDynAuthClntTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client that timed out."
+    ::= { jnxMbgDynAuthClntEntry 13 }
+
+jnxMbgDynAuthClntDelivered OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client that were delivered to application."
+    ::= { jnxMbgDynAuthClntEntry 14 }
+
+jnxMbgDynAuthClntErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client that had errors during processing."
+    ::= { jnxMbgDynAuthClntEntry 15 }
+
+jnxMbgDynAuthClntInvalidAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client with invalid RADIUS authenticator."
+    ::= { jnxMbgDynAuthClntEntry 16 }
+
+jnxMbgDynAuthClntInvalidCode OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client with invalid RADIUS code."
+    ::= { jnxMbgDynAuthClntEntry 17 }
+
+jnxMbgDynAuthClntInvalidChId OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client with invalid or missing Charging Id."
+    ::= { jnxMbgDynAuthClntEntry 18 }
+
+jnxMbgDynAuthClntMapErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "requests received from this client that had session mapping errors during processing."
+    ::= { jnxMbgDynAuthClntEntry 19 }
+
+
+--
+-- Deprecated OIDs
+--
+
+--
+-- Global counters related to Authentication
+--
+
+jnxMbgTotalAuthRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication requests made."
+    ::= { jnxMbgAAAGlobalAuthStats 1 }
+
+jnxMbgTotalAuthAccepts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication requests that were accepted."
+    ::= { jnxMbgAAAGlobalAuthStats 2 }
+
+jnxMbgTotalAuthRejects OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication requests that were rejected."
+    ::= { jnxMbgAAAGlobalAuthStats 3 }
+
+jnxMbgTotalAuthChallenges OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication challenges received."
+    ::= { jnxMbgAAAGlobalAuthStats 4 }
+
+jnxMbgTotalAuthRequestTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication requests that timed out."
+    ::= { jnxMbgAAAGlobalAuthStats 5 }
+
+jnxMbgTotalAuthRequestTxErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication requests transmit errors."
+    ::= { jnxMbgAAAGlobalAuthStats 6 }
+
+jnxMbgTotalAuthResponseErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total authentication response errors."
+    ::= { jnxMbgAAAGlobalAuthStats 7 }
+
+jnxMbgTotalAuthPendingRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total pending authentication requests."
+    ::= { jnxMbgAAAGlobalAuthStats 8 }
+
+--
+-- Global counters related to Accounting
+--
+
+jnxMbgTotalAcctRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total accounting requests made."
+    ::= { jnxMbgAAAGlobalAcctStats 1 }
+
+jnxMbgTotalAcctResponses OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total accounting responses that were received."
+    ::= { jnxMbgAAAGlobalAcctStats 2 }
+
+jnxMbgTotalAcctRequestTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total accounting requests that timed out."
+    ::= { jnxMbgAAAGlobalAcctStats 3 }
+
+jnxMbgTotalAcctRequestTxErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total accounting requests transmit errors."
+    ::= { jnxMbgAAAGlobalAcctStats 4 }
+
+jnxMbgTotalAcctResponseErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total accounting response errors."
+    ::= { jnxMbgAAAGlobalAcctStats 5 }
+
+jnxMbgTotalAcctPendingRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total pending accounting requests."
+    ::= { jnxMbgAAAGlobalAcctStats 6 }
+
+--
+-- Global Dynamic Requests Statistics
+--
+
+jnxMbgTotalDynAuthReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req received."
+    ::= { jnxMbgAAAGlobalDynAuthStats 1 }
+
+jnxMbgTotalDynAuthCoaReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total CoA received."
+    ::= { jnxMbgAAAGlobalDynAuthStats 2 }
+
+jnxMbgTotalDynAuthDmReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total DM received."
+    ::= { jnxMbgAAAGlobalDynAuthStats 3 }
+    
+jnxMbgTotalDynAuthCoaAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total CoA Ack sent."
+    ::= { jnxMbgAAAGlobalDynAuthStats 4 }
+
+jnxMbgTotalDynAuthCoaNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total CoA Nack sent."
+    ::= { jnxMbgAAAGlobalDynAuthStats 5 }
+
+jnxMbgTotalDynAuthDmAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total DM Ack sent."
+    ::= { jnxMbgAAAGlobalDynAuthStats 6 }
+
+jnxMbgTotalDynAuthDmNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total DM Nack sent."
+    ::= { jnxMbgAAAGlobalDynAuthStats 7 }
+
+jnxMbgTotalDynAuthDropped OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req that were dropped."
+    ::= { jnxMbgAAAGlobalDynAuthStats 8 }
+    
+jnxMbgTotalDynAuthDuplicate OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total duplicate dyn-req detected."
+    ::= { jnxMbgAAAGlobalDynAuthStats 9 }
+
+jnxMbgTotalDynAuthForwarded OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req forwarded to anchor instance."
+    ::= { jnxMbgAAAGlobalDynAuthStats 10 }
+    
+jnxMbgTotalDynAuthTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req timed out."
+    ::= { jnxMbgAAAGlobalDynAuthStats 11 }
+
+jnxMbgTotalDynAuthDelivered OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req that were delivered to application."
+    ::= { jnxMbgAAAGlobalDynAuthStats 12 }    
+
+jnxMbgTotalDynAuthErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req that had errors during processing."
+    ::= { jnxMbgAAAGlobalDynAuthStats 13 }    
+    
+jnxMbgTotalDynAuthUnknownClnts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req received from unknown clients."
+    ::= { jnxMbgAAAGlobalDynAuthStats 14 }
+    
+jnxMbgTotalDynAuthInvalidCode OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req received with invalid RADIUS code."
+    ::= { jnxMbgAAAGlobalDynAuthStats 15 }
+    
+jnxMbgTotalDynAuthInvalidAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req received with invalid RADIUS authenticator."
+    ::= { jnxMbgAAAGlobalDynAuthStats 16 }
+    
+jnxMbgTotalDynAuthInvalidChId OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req received with invalid or missing Charging Id."
+    ::= { jnxMbgAAAGlobalDynAuthStats 17 }
+    
+jnxMbgTotalDynAuthMapErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req that had session mapping errors during processing."
+    ::= { jnxMbgAAAGlobalDynAuthStats 18 }    
+
+jnxMbgTotalDynAuthInvalidTrId OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total dyn-req with invalid transaction id during processing."
+    ::= { jnxMbgAAAGlobalDynAuthStats 19 }
+
+--
+-- RADIUS Authentication Servers Table
+-- This table contains the status and stats related to RADIUS Authentication
+-- Servers
+
+jnxMbgRadiusAuthServerTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgRadiusAuthServerEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The table lists RADIUS servers used for authentication."
+    ::= { jnxMbgAAAObjects 4 }
+
+jnxMbgRadiusAuthServerEntry OBJECT-TYPE
+    SYNTAX      JnxMbgRadiusAuthServerEntry 
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "An entry representing a RADIUS server used for authentication."
+    INDEX       { jnxMbgRadiusAuthServerName }
+    ::= { jnxMbgRadiusAuthServerTable 1 }
+
+JnxMbgRadiusAuthServerEntry ::= SEQUENCE {
+    jnxMbgRadiusAuthServerName                DisplayString,
+    jnxMbgRadiusAuthServerInetAddressType     InetAddressType,
+    jnxMbgRadiusAuthServerInetAddress         InetAddress,
+    jnxMbgRadiusAuthServerInetPort            InetPortNumber,
+    jnxMbgRadiusAuthServerRoutingInstance     DisplayString,
+    jnxMbgRadiusAuthServerStatus
+                                    JnxMbgAAAServerStatus,
+    jnxMbgRadiusAuthServerRequests            Counter64,
+    jnxMbgRadiusAuthServersRetransmissions    Counter64,
+    jnxMbgRadiusAuthServerAccepts             Counter64,
+    jnxMbgRadiusAuthServerRejects             Counter64,
+    jnxMbgRadiusAuthServerChallenges          Counter64,
+    jnxMbgRadiusAuthServerMalformedResponses  Counter64,
+    jnxMbgRadiusAuthServerBadAuthenticators   Counter64,
+    jnxMbgRadiusAuthServerPendingRequests     Counter64,
+    jnxMbgRadiusAuthServerTimeouts            Counter64,
+    jnxMbgRadiusAuthServerUnknownTypes        Counter64,
+    jnxMbgRadiusAuthServerPacketsDropped      Counter64,
+    jnxMbgRadiusAuthServerRTTAvg              Integer32,
+    jnxMbgRadiusAuthServerRTTMin              Integer32,
+    jnxMbgRadiusAuthServerRTTMax              Integer32
+}
+ 
+jnxMbgRadiusAuthServerName OBJECT-TYPE 
+    SYNTAX      DisplayString  (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A name which uniquely identifies this server on the mobile-gateway."
+    ::= { jnxMbgRadiusAuthServerEntry 1 }
+
+jnxMbgRadiusAuthServerInetAddressType OBJECT-TYPE 
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The type of IP address used for this server."
+    ::= { jnxMbgRadiusAuthServerEntry 2 }
+
+jnxMbgRadiusAuthServerInetAddress OBJECT-TYPE 
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The IP address used for this server."
+    ::= { jnxMbgRadiusAuthServerEntry 3 }
+
+jnxMbgRadiusAuthServerInetPort OBJECT-TYPE 
+    SYNTAX      InetPortNumber
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The UDP port number on the server to which authentication
+        requests are sent."
+    ::= { jnxMbgRadiusAuthServerEntry 4 }
+
+jnxMbgRadiusAuthServerRoutingInstance OBJECT-TYPE 
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The routing-instance used while contacting this server.
+        If not configured, the default routing-instance will be
+        used."
+    ::= { jnxMbgRadiusAuthServerEntry 5 }
+
+jnxMbgRadiusAuthServerStatus OBJECT-TYPE 
+    SYNTAX      JnxMbgAAAServerStatus
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The deprecated status of the server."
+    ::= { jnxMbgRadiusAuthServerEntry 6 }
+
+jnxMbgRadiusAuthServerRequests OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Access-Requests that have been sent to
+        this server." 
+    ::= { jnxMbgRadiusAuthServerEntry 7 }
+
+jnxMbgRadiusAuthServersRetransmissions OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Access-Requests that have been retransmitted
+        this server." 
+    ::= { jnxMbgRadiusAuthServerEntry 8 }
+
+jnxMbgRadiusAuthServerAccepts OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Access-Accepts that have been received from
+        this server." 
+    ::= { jnxMbgRadiusAuthServerEntry 9 }
+
+jnxMbgRadiusAuthServerRejects OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Access-Rejects that have been received from
+        this server." 
+    ::= { jnxMbgRadiusAuthServerEntry 10 }
+
+jnxMbgRadiusAuthServerChallenges OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Access-Challenges that have been received from
+        this server." 
+    ::= { jnxMbgRadiusAuthServerEntry 11 }
+
+jnxMbgRadiusAuthServerMalformedResponses OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Malformed Responses have been received from
+        this server. A response could either accept, reject or challenge." 
+    ::= { jnxMbgRadiusAuthServerEntry 12 }
+
+jnxMbgRadiusAuthServerBadAuthenticators OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of responses with invalid authenticators received from
+        this server. A response could either accept, reject or challenge." 
+    ::= { jnxMbgRadiusAuthServerEntry 13 }
+
+jnxMbgRadiusAuthServerPendingRequests OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of requests to this server pending authentication."
+    ::= { jnxMbgRadiusAuthServerEntry 14 }
+
+jnxMbgRadiusAuthServerTimeouts OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of requests to this server that timed out."
+    ::= { jnxMbgRadiusAuthServerEntry 15 }
+
+jnxMbgRadiusAuthServerUnknownTypes OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of responses received from this RADIUS server with
+        unknown types."
+    ::= { jnxMbgRadiusAuthServerEntry 16 }
+
+jnxMbgRadiusAuthServerPacketsDropped OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of responses received from this RADIUS server 
+        that were dropped for some other reason."
+    ::= { jnxMbgRadiusAuthServerEntry 17 }
+
+jnxMbgRadiusAuthServerRTTAvg OBJECT-TYPE 
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Average round-trip time (in ms) for this server."
+    ::= { jnxMbgRadiusAuthServerEntry 18 }
+
+jnxMbgRadiusAuthServerRTTMin OBJECT-TYPE 
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Minimum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAuthServerEntry 19 }
+
+jnxMbgRadiusAuthServerRTTMax OBJECT-TYPE 
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Maximum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAuthServerEntry 20 }
+
+--
+-- RADIUS Accounting Servers Table
+-- This table contains the status and stats related to RADIUS Accounting
+-- Servers
+
+jnxMbgRadiusAcctServerTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgRadiusAcctServerEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The table lists RADIUS servers used for accounting."
+    ::= { jnxMbgAAAObjects 5 }
+
+jnxMbgRadiusAcctServerEntry OBJECT-TYPE
+    SYNTAX      JnxMbgRadiusAcctServerEntry 
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "An entry representing a RADIUS server used for accounting."
+    INDEX       { jnxMbgRadiusAcctServerName }
+    ::= { jnxMbgRadiusAcctServerTable 1 }
+
+JnxMbgRadiusAcctServerEntry ::= SEQUENCE {
+    jnxMbgRadiusAcctServerName                DisplayString,
+    jnxMbgRadiusAcctServerInetAddressType     InetAddressType,
+    jnxMbgRadiusAcctServerInetAddress         InetAddress,
+    jnxMbgRadiusAcctServerInetPort            InetPortNumber,
+    jnxMbgRadiusAcctServerRoutingInstance     DisplayString,
+    jnxMbgRadiusAcctServerStatus
+                                    JnxMbgAAAServerStatus,
+    jnxMbgRadiusAcctServerRequests            Counter64,
+    jnxMbgRadiusAcctServersRetransmissions    Counter64,
+    jnxMbgRadiusAcctServerResponses           Counter64,
+    jnxMbgRadiusAcctServerMalformedResponses  Counter64,
+    jnxMbgRadiusAcctServerBadAuthenticators   Counter64,
+    jnxMbgRadiusAcctServerPendingRequests     Counter64,
+    jnxMbgRadiusAcctServerTimeouts            Counter64,
+    jnxMbgRadiusAcctServerUnknownTypes        Counter64,
+    jnxMbgRadiusAcctServerPacketsDropped      Counter64,
+    jnxMbgRadiusAcctServerRTTAvg              Integer32,
+    jnxMbgRadiusAcctServerRTTMin              Integer32,
+    jnxMbgRadiusAcctServerRTTMax              Integer32
+}
+ 
+jnxMbgRadiusAcctServerName OBJECT-TYPE 
+    SYNTAX      DisplayString  (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A name which uniquely identifies this server on the mobile-gateway."
+    ::= { jnxMbgRadiusAcctServerEntry 1 }
+
+jnxMbgRadiusAcctServerInetAddressType OBJECT-TYPE 
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The type of IP address used for this server."
+    ::= { jnxMbgRadiusAcctServerEntry 2 }
+
+jnxMbgRadiusAcctServerInetAddress OBJECT-TYPE 
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The IP address used for this server."
+    ::= { jnxMbgRadiusAcctServerEntry 3 }
+
+jnxMbgRadiusAcctServerInetPort OBJECT-TYPE 
+    SYNTAX      InetPortNumber
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The UDP port number on the server to which accounting
+        requests are sent."
+    ::= { jnxMbgRadiusAcctServerEntry 4 }
+
+jnxMbgRadiusAcctServerRoutingInstance OBJECT-TYPE 
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The routing-instance used while contacting this server.
+        If not configured, the default routing-instance will be
+        used."
+    ::= { jnxMbgRadiusAcctServerEntry 5 }
+
+jnxMbgRadiusAcctServerStatus OBJECT-TYPE 
+    SYNTAX      JnxMbgAAAServerStatus
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The deprecated status of the server."
+    ::= { jnxMbgRadiusAcctServerEntry 6 }
+
+jnxMbgRadiusAcctServerRequests OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Accounting-Requests that have been sent to
+        this server." 
+    ::= { jnxMbgRadiusAcctServerEntry 7 }
+
+jnxMbgRadiusAcctServersRetransmissions OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Accounting-Requests that have been retransmitted
+        this server." 
+    ::= { jnxMbgRadiusAcctServerEntry 8 }
+
+jnxMbgRadiusAcctServerResponses OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Accounting-Responses that have been received from
+        this server." 
+    ::= { jnxMbgRadiusAcctServerEntry 9 }
+
+jnxMbgRadiusAcctServerMalformedResponses OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Malformed Responses have been received from
+        this server." 
+    ::= { jnxMbgRadiusAcctServerEntry 10 }
+
+jnxMbgRadiusAcctServerBadAuthenticators OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of responses with invalid authenticators received from
+        this server."
+    ::= { jnxMbgRadiusAcctServerEntry 11 }
+
+jnxMbgRadiusAcctServerPendingRequests OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of requests to this server which are yet to be sent or
+        waiting for response."
+    ::= { jnxMbgRadiusAcctServerEntry 12 }
+
+jnxMbgRadiusAcctServerTimeouts OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of requests to this server that timed out."
+    ::= { jnxMbgRadiusAcctServerEntry 13 }
+
+jnxMbgRadiusAcctServerUnknownTypes OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of responses received from this RADIUS server with
+        unknown types."
+    ::= { jnxMbgRadiusAcctServerEntry 14 }
+
+jnxMbgRadiusAcctServerPacketsDropped OBJECT-TYPE 
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of responses received from this RADIUS server 
+        that were dropped for some other reason."
+    ::= { jnxMbgRadiusAcctServerEntry 15 }
+
+jnxMbgRadiusAcctServerRTTAvg OBJECT-TYPE 
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Average round-trip time (in ms) for this server."
+    ::= { jnxMbgRadiusAcctServerEntry 16 }
+
+jnxMbgRadiusAcctServerRTTMin OBJECT-TYPE 
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Minimum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAcctServerEntry 17 }
+
+jnxMbgRadiusAcctServerRTTMax OBJECT-TYPE 
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Maximum round-trip time (in ms) seen for this server."
+    ::= { jnxMbgRadiusAcctServerEntry 18 }
+
+--
+-- RADIUS Dyn Auth Clients Table
+-- This table contains the status and stats related to RADIUS Dyn Auth
+-- Servers
+
+jnxMbgDynAuthClientTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgDynAuthClientEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The table lists RADIUS clients sending Dynamic Authorization requests."
+    ::= { jnxMbgAAAObjects 6 }
+
+jnxMbgDynAuthClientEntry OBJECT-TYPE
+    SYNTAX      JnxMbgDynAuthClientEntry 
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "An entry representing a RADIUS client sending Dynamic Authorization requests."
+    INDEX       { jnxMbgRadiusAcctServerName }
+    ::= { jnxMbgDynAuthClientTable 1 }
+
+JnxMbgDynAuthClientEntry ::= SEQUENCE {
+    jnxMbgDynAuthClientName                  DisplayString,
+    jnxMbgDynAuthClientInAddrType            InetAddressType,
+    jnxMbgDynAuthClientInetAddress           InetAddress,
+
+    jnxMbgDynAuthClientCoaReceived           Counter64,
+    jnxMbgDynAuthClientDmReceived            Counter64,
+    jnxMbgDynAuthClientCoaAckSent            Counter64,
+    jnxMbgDynAuthClientCoaNackSent           Counter64,
+    jnxMbgDynAuthClientDmAckSent             Counter64,
+    jnxMbgDynAuthClientDmNackSent            Counter64,
+    jnxMbgDynAuthClientDropped               Counter64,
+    jnxMbgDynAuthClientDuplicate             Counter64,
+    jnxMbgDynAuthClientForwarded             Counter64,
+    jnxMbgDynAuthClientTimeouts              Counter64,
+    jnxMbgDynAuthClientDelivered             Counter64,
+    jnxMbgDynAuthClientErrors                Counter64,
+    jnxMbgDynAuthClientInvalidAuth           Counter64,
+    jnxMbgDynAuthClientInvalidCode           Counter64,
+    jnxMbgDynAuthClientInvalidChId           Counter64,
+    jnxMbgDynAuthClientMapErrors             Counter64
+}
+ 
+jnxMbgDynAuthClientName OBJECT-TYPE 
+    SYNTAX      DisplayString  (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A name which uniquely identifies this client on the mobile-gateway."
+    ::= { jnxMbgDynAuthClientEntry 1 }
+
+jnxMbgDynAuthClientInAddrType OBJECT-TYPE 
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The type of IP address used for this client."
+    ::= { jnxMbgDynAuthClientEntry 2 }
+
+jnxMbgDynAuthClientInetAddress OBJECT-TYPE 
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "The IP address of this client."
+    ::= { jnxMbgDynAuthClientEntry 3 }
+
+jnxMbgDynAuthClientCoaReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "CoA requests received from this client."
+    ::= { jnxMbgDynAuthClientEntry 4 }
+
+jnxMbgDynAuthClientDmReceived OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "DM requests received from this client."
+    ::= { jnxMbgDynAuthClientEntry 5 }
+    
+jnxMbgDynAuthClientCoaAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "CoA Ack responses sent to this client."
+    ::= { jnxMbgDynAuthClientEntry 6 }
+
+jnxMbgDynAuthClientCoaNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "CoA Nack responses sent to this client."
+    ::= { jnxMbgDynAuthClientEntry 7 }
+
+jnxMbgDynAuthClientDmAckSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "DM Ack responses sent to this client."
+    ::= { jnxMbgDynAuthClientEntry 8 }
+
+jnxMbgDynAuthClientDmNackSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "DM Nack responses sent to this client."
+    ::= { jnxMbgDynAuthClientEntry 9 }
+
+jnxMbgDynAuthClientDropped OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this server that were dropped."
+    ::= { jnxMbgDynAuthClientEntry 10 }
+    
+jnxMbgDynAuthClientDuplicate OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Duplicate requests received from this client."
+    ::= { jnxMbgDynAuthClientEntry 11 }
+
+jnxMbgDynAuthClientForwarded OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client that were forwarded to anchor instance."
+    ::= { jnxMbgDynAuthClientEntry 12 }
+    
+jnxMbgDynAuthClientTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client that timed out."
+    ::= { jnxMbgDynAuthClientEntry 13 }
+
+jnxMbgDynAuthClientDelivered OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client that were delivered to application."
+    ::= { jnxMbgDynAuthClientEntry 14 }    
+
+jnxMbgDynAuthClientErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client that had errors during processing."
+    ::= { jnxMbgDynAuthClientEntry 15 }    
+    
+jnxMbgDynAuthClientInvalidAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client with invalid RADIUS authenticator."
+    ::= { jnxMbgDynAuthClientEntry 17 }
+
+jnxMbgDynAuthClientInvalidCode OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client with invalid RADIUS code."
+    ::= { jnxMbgDynAuthClientEntry 18 }
+    
+jnxMbgDynAuthClientInvalidChId OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client with invalid or missing Charging Id."
+    ::= { jnxMbgDynAuthClientEntry 19 }
+    
+jnxMbgDynAuthClientMapErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Requests received from this client that had session mapping errors during processing."
+    ::= { jnxMbgDynAuthClientEntry 20 }    
+
+   
+--
+-- Objects used in Notifications
+--
+
+jnxMbgAAAServerName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which uniquely identifies the server on the mobile-gateway."
+    ::= { jnxMbgAAANotificationVars 1 }
+
+jnxMbgSPIdentifier OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This identifies the session-pic, in the for sp-a/b/0, where
+        <a> is the slot and <b> could be either 0 or 1."        
+    ::= { jnxMbgAAANotificationVars 2 }
+
+jnxMbgAAANetworkElementName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which uniquely identifies a AAA Network Element on 
+         the mobile-gateway."
+    ::= { jnxMbgAAANotificationVars 3 }
+
+jnxMbgPendQWaterMarkType OBJECT-TYPE
+    SYNTAX      JnxMbgQueueWaterMarkType
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The type of the pending queue water mark crossed - High or Low."
+    ::= { jnxMbgAAANotificationVars 4 }
+
+jnxMbgPendQWaterMarkValue OBJECT-TYPE
+    SYNTAX      Integer32 
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The water mark value for the pending queue."
+    ::= { jnxMbgAAANotificationVars 5 }
+
+jnxMbgPendQLength OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The size of the pending queue."
+    ::= { jnxMbgAAANotificationVars 6 }
+
+
+--
+-- Notifications
+--
+
+jnxMbgAAAServerUp NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgAAAServerName, 
+                  jnxMbgSPIdentifier }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked active again. This could be because the server started to
+        respond again. The ServerName identifies the server and the 
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgAAANotifications 1 }
+
+jnxMbgAAAServerDown NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgAAAServerName, 
+                  jnxMbgSPIdentifier }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked dead. The ServerName identifies the server and the 
+        SPIdentfier identifies the session-pic which originated this
+        notification." 
+    ::= { jnxMbgAAANotifications 2 }
+
+jnxMbgAAANetworkElementUp NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgAAANetworkElementName,
+                  jnxMbgSPIdentifier }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies that the specified Network Element
+        has been marked UP. This could be because atleast one server in 
+        the network element is active. SPIdentfier identifies the session-pic 
+        which originated this notification."
+    ::= { jnxMbgAAANotifications 3 }
+
+jnxMbgAAANetworkElementDown NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgAAANetworkElementName,
+                  jnxMbgSPIdentifier }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies that the specified Network Element has 
+        been marked DOWN. This could be because none of the servers  in the 
+        network element is active.  SPIdentfier identifies the session-pic 
+        which originated this notification."
+    ::= { jnxMbgAAANotifications 4 }
+
+jnxMbgAAANEPendAuthQStatus NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgAAANetworkElementName, 
+                  jnxMbgSPIdentifier, 
+                  jnxMbgPendQWaterMarkType,
+                  jnxMbgPendQWaterMarkValue,
+                  jnxMbgPendQLength }
+    STATUS      deprecated
+    DESCRIPTION
+       "This notification signifies the crossing-over of a  watermark 
+       (High or Low) of the pending authentication queue length of network 
+       element. The NetworkElementName identifies the network element and 
+       SPIdentfier identifies the session-pic which originated this notification.
+       jnxMbgPendQWaterMarkType identifies the water mark type (High/Low). 
+       jnxMbgPendQWaterMarkValue is the value that has been crossed over.
+       jnxMbgPendQLength is the size of the queue after crossing over." 
+    ::= { jnxMbgAAANotifications 5 }
+
+jnxMbgAAANEPendAcctQStatus NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgAAANetworkElementName, 
+                  jnxMbgSPIdentifier, 
+                  jnxMbgPendQWaterMarkType,
+                  jnxMbgPendQWaterMarkValue,
+                  jnxMbgPendQLength }
+    STATUS      deprecated
+    DESCRIPTION
+       "This notification signifies the crossing-over of a  watermark 
+       (High or Low) of the pending accounting queue length of network 
+       element. The NetworkElementName identifies the network element and 
+       SPIdentfier identifies the session-pic which originated this notification.
+       jnxMbgPendQWaterMarkType identifies the water mark type (High/Low). 
+       jnxMbgPendQWaterMarkValue is the value that has been crossed over.
+       jnxMbgPendQLength is the size of the queue after crossing over." 
+    ::= { jnxMbgAAANotifications 6 }
+
+jnxMbgAAARadiusServerUp NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwIndex,
+                  jnxMbgGwName,
+                  jnxMbgAAAServerName,
+                  jnxMbgSPIdentifier }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked active again. This could be because the server started to
+        respond again. The ServerName identifies the server and the 
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgAAANotifications 7 }
+
+jnxMbgAAARadiusServerDown NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwIndex,
+                  jnxMbgGwName,
+                  jnxMbgAAAServerName,
+                  jnxMbgSPIdentifier }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked dead. The ServerName identifies the server and the 
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgAAANotifications 8 }
+
+jnxMbgAAARadiusNetworkElementUp NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwIndex,
+                  jnxMbgGwName,
+                  jnxMbgAAANetworkElementName,
+                  jnxMbgSPIdentifier }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the specified Network Element
+        has been marked UP. This could be because atleast one server in 
+        the network element is active. SPIdentfier identifies the session-pic 
+        which originated this notification."
+    ::= { jnxMbgAAANotifications 9 }
+
+jnxMbgAAARadiusNetworkElementDown NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwIndex,
+                  jnxMbgGwName,
+                  jnxMbgAAANetworkElementName,
+                  jnxMbgSPIdentifier }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the specified Network Element has 
+        been marked DOWN. This could be because none of the servers  in the 
+        network element is active.  SPIdentfier identifies the session-pic 
+        which originated this notification."
+    ::= { jnxMbgAAANotifications 10 }
+
+jnxMbgAAARadiusNEPendAuthQStatus NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwIndex,
+                  jnxMbgGwName,
+                  jnxMbgAAANetworkElementName,
+                  jnxMbgSPIdentifier,
+                  jnxMbgPendQWaterMarkType,
+                  jnxMbgPendQWaterMarkValue,
+                  jnxMbgPendQLength }
+    STATUS      current
+    DESCRIPTION
+       "This notification signifies the crossing-over of a  watermark 
+       (High or Low) of the pending authentication queue length of network 
+       element. The NetworkElementName identifies the network element and 
+       SPIdentfier identifies the session-pic which originated this notification.
+       jnxMbgPendQWaterMarkType identifies the water mark type (High/Low). 
+       jnxMbgPendQWaterMarkValue is the value that has been crossed over.
+       jnxMbgPendQLength is the size of the queue after crossing over."
+    ::= { jnxMbgAAANotifications 11 }
+
+
+jnxMbgAAARadiusNEPendAcctQStatus NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwIndex,
+                  jnxMbgGwName,
+                  jnxMbgAAANetworkElementName,
+                  jnxMbgSPIdentifier,
+                  jnxMbgPendQWaterMarkType,
+                  jnxMbgPendQWaterMarkValue,
+                  jnxMbgPendQLength }
+    STATUS      current
+    DESCRIPTION
+       "This notification signifies the crossing-over of a  watermark 
+       (High or Low) of the pending accounting queue length of network 
+       element. The NetworkElementName identifies the network element and 
+       SPIdentfier identifies the session-pic which originated this notification.
+       jnxMbgPendQWaterMarkType identifies the water mark type (High/Low). 
+       jnxMbgPendQWaterMarkValue is the value that has been crossed over.
+       jnxMbgPendQLength is the size of the queue after crossing over."
+    ::= { jnxMbgAAANotifications 12 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-appfw.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-appfw.txt
@@ -1,0 +1,3695 @@
+-- ******************************************************************
+-- Juniper Mobile Gateway PGW Subscriber Manager objects MIB.
+--
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- ******************************************************************
+
+JUNIPER-MOBILE-GATEWAY-SM-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE,
+    Counter64, Unsigned32, Gauge32 
+        FROM SNMPv2-SMI
+
+    CounterBasedGauge64
+        FROM HCNUM-TC  
+
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue                 
+        FROM SNMPv2-TC
+
+    EnabledStatus              
+        FROM JUNIPER-MIMSTP-MIB
+
+     jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS
+   
+    jnxMobileGatewayPgwGgsn    
+        FROM JUNIPER-MBG-SMI;
+
+jnxMbgPgwSubscriberManagerMib MODULE-IDENTITY
+    LAST-UPDATED "201102281200Z" -- Feb 28, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to Mobile-Edge"
+
+    REVISION "201101121200Z" -- Jan 12, 2011, 12:00:00
+    DESCRIPTION "Initial version"
+
+    REVISION "201102281200Z" -- Feb 28, 2011, 12:00:00
+    DESCRIPTION
+        "Added the following traps
+            jnxMbgPgwQosBearersThresholdStatus
+            jnxMbgPgwQosCPUThresholdStatus
+            jnxMbgPgwAPNQosBearersThreStatus
+            jnxMbgPgwQosMemThresholdStatutus"
+
+    REVISION "201102281200Z" -- Nov 19, 2011, 12:00:00
+    DESCRIPTION
+        "Deprecated Tables not supporting multiple gateways
+         Deprecated undefined traps. Added new traps with 
+         discrete levels. Added new tables with multiple
+         gateway support"
+
+    REVISION "201203191200Z" -- Mar 19, 2012, 12:00:00
+    DESCRIPTION
+        "Added counters to Gateway statistics table and 
+        also to Apn level Statistics Table "
+      
+
+    REVISION "201203221200Z" -- Mar 22, 2012, 12:00:00
+    DESCRIPTION
+        "Deprecated unsupported objects from jnxMbgPgwSMStatusTable.
+         Added objects to jnxMbgPgwApnSMStatsTable & jnxMbgPgwSMOperStatsTable.
+         Added tables jnxMbgPgwSMSpicStatusTable & jnxMbgPgwSMClRateStatsTable.
+         Updated description for Interface State Maintenance Mode Change Traps."
+
+    REVISION "201210121200Z" -- Oct 12, 2012, 12:00:00
+    DESCRIPTION
+        "Deprecated unsupported objects from jnxMbgPgwSMOperStatsTable
+        and jnxMbgPgwApnSMStatsTable and added new objects in them.
+         Added tables jnxMbgPgwApnSMClRateStatsTable."
+    ::= { jnxMobileGatewayPgwGgsn 1 }
+
+jnxMbgPgwSMNotifications OBJECT IDENTIFIER
+    ::= { jnxMbgPgwSubscriberManagerMib 0 }
+
+jnxMbgPgwSMObjects OBJECT IDENTIFIER
+    ::= { jnxMbgPgwSubscriberManagerMib 1 }
+
+--
+-- APN Table
+-- This table contains the attributes of mobile-gateway APN stats.
+--
+
+jnxMbgPgwAPNStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwAPNStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The table listing Mobile Gateway Application Program Name level stats.
+         Key is APN Name."
+    ::= { jnxMbgPgwSMObjects 1 }
+
+jnxMbgPgwAPNStatsTableEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwAPNStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "An entry representing a Mobile Gateway APN Stats."
+    INDEX       { jnxMbgPgwAPNName }
+    ::= { jnxMbgPgwAPNStatsTable 1 }
+
+JnxMbgPgwAPNStatsEntry ::= SEQUENCE {
+    jnxMbgPgwAPNName                    DisplayString,
+    jnxMbgPgwSessnEstAttempts           Counter64,
+    jnxMbgPgwSuccSessnsEst              Counter64,
+    jnxMbgPgwSessnFailedServcUnaval     Counter64,
+    jnxMbgPgwSessnFailedSysFailure      Counter64,
+    jnxMbgPgwSessnFailedNoResource      Counter64,
+    jnxMbgPgwSessnFailedNoAddr          Counter64,
+    jnxMbgPgwSessnFailedServcDenied     Counter64,
+    jnxMbgPgwSessnFailedAuthFailed      Counter64,
+    jnxMbgPgwSessnFailedAccessDenied    Counter64,
+    jnxMbgPgwPeerInitSessnDeact         Counter64,
+    jnxMbgPgwSuccPeerInitSessnDeact     Counter64,
+    jnxMbgPgwGWInitSessnDeact           Counter64,
+    jnxMbgPgwSuccGWInitSessnDeact       Counter64
+}
+
+jnxMbgPgwAPNName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A string that uniquely identifies the APN."
+    ::= { jnxMbgPgwAPNStatsTableEntry 1 }
+
+jnxMbgPgwSessnEstAttempts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total Session establishment attempts made."
+    ::= { jnxMbgPgwAPNStatsTableEntry 2 }
+
+jnxMbgPgwSuccSessnsEst OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions established successfully."
+    ::= { jnxMbgPgwAPNStatsTableEntry 3 }
+
+jnxMbgPgwSessnFailedServcUnaval OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established due
+          to service unavailability."
+    ::= { jnxMbgPgwAPNStatsTableEntry 4 }
+
+jnxMbgPgwSessnFailedSysFailure OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established
+         due to system failure."
+    ::= { jnxMbgPgwAPNStatsTableEntry 5 }
+
+jnxMbgPgwSessnFailedNoResource OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established
+         due to lack of resource."
+    ::= { jnxMbgPgwAPNStatsTableEntry 6 }
+
+jnxMbgPgwSessnFailedNoAddr OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established
+         due to lack of address. The address pool
+         assigned to this APN is exhausted"
+    ::= { jnxMbgPgwAPNStatsTableEntry 7 }
+
+jnxMbgPgwSessnFailedServcDenied OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established
+         due to service denial."
+    ::= { jnxMbgPgwAPNStatsTableEntry 8 }
+
+jnxMbgPgwSessnFailedAuthFailed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established
+          due to authentication failure."
+    ::= { jnxMbgPgwAPNStatsTableEntry 9 }
+
+jnxMbgPgwSessnFailedAccessDenied OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Sessions that could not be established
+          due to APN access denial."
+    ::= { jnxMbgPgwAPNStatsTableEntry 10 }
+
+jnxMbgPgwPeerInitSessnDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total Session deactivations initiated by the peer/MS."
+    ::= { jnxMbgPgwAPNStatsTableEntry 11 }
+
+jnxMbgPgwSuccPeerInitSessnDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Peer/MS initiated session
+         deactivations that succeeded."
+    ::= { jnxMbgPgwAPNStatsTableEntry 12 }
+
+jnxMbgPgwGWInitSessnDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total gateway initiated Session deactivations."
+    ::= { jnxMbgPgwAPNStatsTableEntry 13 }
+
+jnxMbgPgwSuccGWInitSessnDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Gateway initiated Session deactivations that suceeded."
+    ::= { jnxMbgPgwAPNStatsTableEntry 14 }
+
+--
+-- Statistics Table for PGW 
+--
+
+jnxMbgPgwSMOperStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwSMOperStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table listing Mobile Gateway level statistics for PDN Gateway.
+         Key is Gateway Id."
+    ::= { jnxMbgPgwSMObjects 4 }
+
+JnxMbgPgwSMOperStatsEntry ::= SEQUENCE {
+    jnxMbgPgwSessnEstAttmpts         Counter64,
+    jnxMbgPgwSuccSessnEst            Counter64,
+    jnxMbgPgwPeerInitDeactv          Counter64,    
+    jnxMbgPgwPeerInitSuccDeactv      Counter64,
+    jnxMbgPgwGwInitDeactv            Counter64,
+    jnxMbgPgwGwInitSuccDeactv        Counter64,
+    jnxMbgPgwGtpStatsGnS5S8InpPkt    Counter64,
+    jnxMbgPgwGtpStatsGnS5S8InpByt    Counter64,
+    jnxMbgPgwGtpStatsGnS5S8OutPkt    Counter64,
+    jnxMbgPgwGtpStatsGnS5S8OutByt    Counter64,
+    jnxMbgPgwGtpStatsGiInpPkt        Counter64,
+    jnxMbgPgwGtpStatsGiInpByt        Counter64,
+    jnxMbgPgwGtpStatsGiOutPkt        Counter64,
+    jnxMbgPgwGtpStatsGiOutByt        Counter64,
+    jnxMbgPgwGtpStatsS58DscrdPkts    Counter64,
+    jnxMbgPgwGtpStatsGiDiscrdPkts    Counter64,
+    jnxMbgPgwSrcAddrViolationPkts    Counter64,
+    jnxMbgPgwSrcAddrViolationByts    Counter64,
+    jnxMbgPgwPktsRcvdNonExstTeids    Counter64,
+    jnxMbgPgwGtpErrLenPkts           Counter64,
+    jnxMbgPgwNonExstUeAddrPkts       Counter64,
+    jnxMbgPgwSessEstDynPolAttempt    Counter64,
+    jnxMbgPgwSuccSessEstDynPol       Counter64,
+    jnxMbgPgwDedBrActAttempt         Counter64,
+    jnxMbgPgwSuccDedBrAct            Counter64,
+    jnxMbgPgwMsInitDedBrDeact        Counter64,
+    jnxMbgPgwGwInitDedBrDeact        Counter64,
+    jnxMbgPgwPcrfInitDedBrDeact      Counter64,
+    jnxMbgPgwMsInitModAttempt        Counter64,
+    jnxMbgPgwSuccMsInitMod           Counter64,
+    jnxMbgPgwGwInitModAttempt        Counter64,
+    jnxMbgPgwSuccGwInitMod           Counter64,
+    jnxMbgPgwMsInitDedBrActAttempt   Counter64,
+    jnxMbgPgwSuccMsInitDedBrAct      Counter64,
+    jnxMbgPgwNwInitDedBrActAttempt   Counter64,
+    jnxMbgPgwSuccNwInitDedBrAct      Counter64,
+    jnxMbgPgwMsInitDedBrModAttempt   Counter64,
+    jnxMbgPgwSuccMsInitDedBrMod      Counter64,
+    jnxMbgPgwNwInitDedBrModAttempt   Counter64,
+    jnxMbgPgwSuccNwInitDedBrMod      Counter64,
+    jnxMbgPgwInterRatHoAttempt       Counter64,
+    jnxMbgPgwInterRatHoSucc          Counter64,
+    jnxMbgPgwIntraRatHoAttempt       Counter64,
+    jnxMbgPgwIntraRatHoSucc          Counter64,
+    jnxMbgPgwCdrsAllocd              Counter64,
+    jnxMbgPgwPartialCdrsAllocd       Counter64,
+    jnxMbgPgwCdrsClosed              Counter64,
+    jnxMbgPgwCdrCntainrsClosed       Counter64,
+    jnxMbgPgwGySessEstAttempt        Counter64,
+    jnxMbgPgwGySuccSessEst           Counter64,
+    jnxMbgPgwGyReauthAttempt         Counter64,
+    jnxMbgPgwGySuccReauth            Counter64,
+    jnxMbgPgwGyAuthTimeout           Counter64,
+    jnxMbgPgwGyMsInitSessDeact       Counter64,
+    jnxMbgPgwGyOcsInitSessDeact      Counter64,
+    jnxMbgPgwGyGwInitSessDeact       Counter64,
+    jnxMbgPgwGxMsInitMod             Counter64, 
+    jnxMbgPgwGxSuccMsInitMod         Counter64,
+    jnxMbgPgwGxPcrfInitMod           Counter64,
+    jnxMbgPgwGxSuccPcrfInitMod       Counter64,
+    jnxMbgPgwGxMsInitSessTerm        Counter64,
+    jnxMbgPgwGxPcrfInitSessTerm      Counter64,
+    jnxMbgPgwGxGwInitSessTerm        Counter64
+}    
+
+jnxMbgPgwSMOperStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwSMOperStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Gateway Stats."
+    INDEX       { jnxMbgGwIndex }
+    ::= { jnxMbgPgwSMOperStatsTable 1 }
+
+jnxMbgPgwSessnEstAttmpts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Session establishment attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 1 }
+
+jnxMbgPgwSuccSessnEst OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Sessions established successfully."
+    ::= { jnxMbgPgwSMOperStatsEntry 2 }
+    
+jnxMbgPgwPeerInitDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total MS/peer initiated session deactivation attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 3 }    
+    
+jnxMbgPgwPeerInitSuccDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total MS/peer initiated successful session deactivations."
+    ::= { jnxMbgPgwSMOperStatsEntry 4 }    
+
+jnxMbgPgwGwInitDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Gateway initiated session deactivation attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 5 }    
+
+jnxMbgPgwGwInitSuccDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Gateway initiated successful session deactivations."
+    ::= { jnxMbgPgwSMOperStatsEntry 6 }    
+
+jnxMbgPgwGtpStatsGnS5S8InpPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Input packets."
+    ::= { jnxMbgPgwSMOperStatsEntry 7 }    
+
+jnxMbgPgwGtpStatsGnS5S8InpByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Input bytes."
+    ::= { jnxMbgPgwSMOperStatsEntry 8 } 
+
+jnxMbgPgwGtpStatsGnS5S8OutPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Output packets."
+    ::= { jnxMbgPgwSMOperStatsEntry 9 }    
+
+jnxMbgPgwGtpStatsGnS5S8OutByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Output bytes."
+    ::= { jnxMbgPgwSMOperStatsEntry 10 }     
+    
+jnxMbgPgwGtpStatsGiInpPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Input packets."
+    ::= { jnxMbgPgwSMOperStatsEntry 11 }    
+
+jnxMbgPgwGtpStatsGiInpByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Input bytes."
+    ::= { jnxMbgPgwSMOperStatsEntry 12 } 
+
+jnxMbgPgwGtpStatsGiOutPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Output packets."
+    ::= { jnxMbgPgwSMOperStatsEntry 13 }    
+
+jnxMbgPgwGtpStatsGiOutByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Output bytes."
+    ::= { jnxMbgPgwSMOperStatsEntry 14 }
+
+jnxMbgPgwGtpStatsS58DscrdPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) discarded packets"
+    ::= { jnxMbgPgwSMOperStatsEntry 15 }
+
+jnxMbgPgwGtpStatsGiDiscrdPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi discarded packets"
+    ::= { jnxMbgPgwSMOperStatsEntry 16 }
+
+jnxMbgPgwSrcAddrViolationPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Source address violation packets."
+    ::= { jnxMbgPgwSMOperStatsEntry 17 }
+
+jnxMbgPgwSrcAddrViolationByts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Source address violation bytes."
+    ::= { jnxMbgPgwSMOperStatsEntry 18 }
+
+jnxMbgPgwPktsRcvdNonExstTeids OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total packets received with non-existent TEIDs."
+    ::= { jnxMbgPgwSMOperStatsEntry 19 }
+
+jnxMbgPgwGtpErrLenPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP packets received with erroneous length."
+    ::= { jnxMbgPgwSMOperStatsEntry 20 }
+
+jnxMbgPgwNonExstUeAddrPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Non-existent UE address packets."
+    ::= { jnxMbgPgwSMOperStatsEntry 21 }
+
+jnxMbgPgwSessEstDynPolAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session attempts 
+         using dynamic policy."
+    ::= { jnxMbgPgwSMOperStatsEntry 22 }
+   
+jnxMbgPgwSuccSessEstDynPol OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current 
+    DESCRIPTION
+        "Number of successful session
+        attempts using dynamic policy."
+    ::= { jnxMbgPgwSMOperStatsEntry 23 }
+
+jnxMbgPgwDedBrActAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated 
+    DESCRIPTION
+        "Number of dedicated bearer
+         activation attempt."
+    ::= { jnxMbgPgwSMOperStatsEntry 24 }
+
+jnxMbgPgwSuccDedBrAct OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of successful 
+        dedicated bearer creation."
+    ::= { jnxMbgPgwSMOperStatsEntry 25 }
+
+jnxMbgPgwMsInitDedBrDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS initiated Dedicated
+        bearer deactivation ."
+    ::= { jnxMbgPgwSMOperStatsEntry 26 }
+
+jnxMbgPgwGwInitDedBrDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of gateway initiated dedicated 
+        bearer deactivation."
+    ::= { jnxMbgPgwSMOperStatsEntry 27 }
+
+jnxMbgPgwPcrfInitDedBrDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Pcrf initiated dedicated
+        bearer deactivation ."
+    ::= { jnxMbgPgwSMOperStatsEntry 28 }
+   
+jnxMbgPgwMsInitModAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS/Peer Initiated modification attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 29 }
+
+jnxMbgPgwSuccMsInitMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Successful MS/Peer Initiated modifications. "
+    ::= { jnxMbgPgwSMOperStatsEntry 30 }
+
+jnxMbgPgwGwInitModAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of gateway initiated modification attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 31 }
+
+jnxMbgPgwSuccGwInitMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful gateway initiated modifications."
+    ::= { jnxMbgPgwSMOperStatsEntry 32 }
+
+jnxMbgPgwMsInitDedBrActAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Ms/Peer initiated activation attempt."
+    ::= { jnxMbgPgwSMOperStatsEntry 33 }
+
+jnxMbgPgwSuccMsInitDedBrAct OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful MS/Peer initiated activation."
+    ::= { jnxMbgPgwSMOperStatsEntry 34 }
+
+jnxMbgPgwNwInitDedBrActAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of network initiated dedicated
+        bearer activation attempt."
+    ::= { jnxMbgPgwSMOperStatsEntry 35 }
+
+jnxMbgPgwSuccNwInitDedBrAct OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful network initiated 
+        dedicated bearer activation."
+    ::= { jnxMbgPgwSMOperStatsEntry 36 }
+
+jnxMbgPgwMsInitDedBrModAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS/Peer initiated modification attempt."
+    ::= { jnxMbgPgwSMOperStatsEntry 37 }
+
+jnxMbgPgwSuccMsInitDedBrMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful MS/Peer initiated modifications."
+    ::= { jnxMbgPgwSMOperStatsEntry 38 }
+
+jnxMbgPgwNwInitDedBrModAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of  network initiated modification attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 39 }
+
+jnxMbgPgwSuccNwInitDedBrMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful network initiated modifications."
+    ::= { jnxMbgPgwSMOperStatsEntry 40 }
+
+jnxMbgPgwInterRatHoAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Inter RAT Handover attempt."
+    ::= { jnxMbgPgwSMOperStatsEntry 41 }
+    
+jnxMbgPgwInterRatHoSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Inter RAT Handovers."
+    ::= { jnxMbgPgwSMOperStatsEntry 42 }
+    
+jnxMbgPgwIntraRatHoAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Intra RAT Handover attempt."
+    ::= { jnxMbgPgwSMOperStatsEntry 43 }                        
+                
+jnxMbgPgwIntraRatHoSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Intra RAT Handover."
+    ::= { jnxMbgPgwSMOperStatsEntry 44 }
+          
+jnxMbgPgwCdrsAllocd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of CDRs allocated."
+    ::= { jnxMbgPgwSMOperStatsEntry 45 } 
+
+jnxMbgPgwPartialCdrsAllocd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of partial CDRs allocated."
+    ::= { jnxMbgPgwSMOperStatsEntry 46 } 
+
+jnxMbgPgwCdrsClosed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of CDRs closed."
+    ::= { jnxMbgPgwSMOperStatsEntry 47 }
+
+jnxMbgPgwCdrCntainrsClosed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of Containers closed."
+    ::= { jnxMbgPgwSMOperStatsEntry 48 }
+
+jnxMbgPgwGySessEstAttempt  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy session 
+        establishment attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 49 }
+
+jnxMbgPgwGySuccSessEst  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Successful Gy session 
+        establishments."
+    ::= { jnxMbgPgwSMOperStatsEntry 50 }
+
+jnxMbgPgwGyReauthAttempt  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy reauthorization 
+        requests to OCS."
+    ::= { jnxMbgPgwSMOperStatsEntry 51 }
+
+jnxMbgPgwGySuccReauth  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Gy reauthorization."
+    ::= { jnxMbgPgwSMOperStatsEntry 52 }
+
+jnxMbgPgwGyAuthTimeout  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy authorization timeout."
+    ::= { jnxMbgPgwSMOperStatsEntry 53 }
+
+jnxMbgPgwGyMsInitSessDeact  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy Ms/Peer initiated 
+        session deactivations."
+    ::= { jnxMbgPgwSMOperStatsEntry 54 }
+
+jnxMbgPgwGyOcsInitSessDeact  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy OCS initiated 
+        session deactivations."
+    ::= { jnxMbgPgwSMOperStatsEntry 55 }
+
+jnxMbgPgwGyGwInitSessDeact  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy gateway initiated 
+        session deactivations."
+    ::= { jnxMbgPgwSMOperStatsEntry 56 }
+
+jnxMbgPgwGxMsInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS/Peer initiated
+        session modification attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 57 }
+
+jnxMbgPgwGxSuccMsInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful MS/Peer initiated
+        session modification ."
+    ::= { jnxMbgPgwSMOperStatsEntry 58 }
+
+jnxMbgPgwGxPcrfInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PCRF initiated
+        session modification attempts."
+    ::= { jnxMbgPgwSMOperStatsEntry 59 }
+
+jnxMbgPgwGxSuccPcrfInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful PCRF initiated
+        session modification ."
+    ::= { jnxMbgPgwSMOperStatsEntry 60 }
+
+jnxMbgPgwGxMsInitSessTerm          OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gx Ms/Peer initiated session termination ."
+    ::= { jnxMbgPgwSMOperStatsEntry 61 }
+
+jnxMbgPgwGxPcrfInitSessTerm        OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gx PCRF initiated session termination ."
+    ::= { jnxMbgPgwSMOperStatsEntry 62 }
+
+jnxMbgPgwGxGwInitSessTerm          OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gx Gateway initiated session termination."
+    ::= { jnxMbgPgwSMOperStatsEntry 63 }
+
+--
+-- Statistics Table for PGW per APN
+-- To access APN based info we need to use BOTH Gateway Id and APN Name as keys
+--
+jnxMbgPgwApnSMStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwApnSMStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table listing Mobile APN Level statistics for PDN Gateway.
+         Gateway ID and  APN Name are used as keys"
+    ::= { jnxMbgPgwSMObjects 6 }
+
+JnxMbgPgwApnSMStatsEntry ::= SEQUENCE {
+    jnxMbgPgwApnName                    DisplayString,
+    jnxMbgPgwApnSessnEstAttmpts         Counter64,
+    jnxMbgPgwApnSuccSessnEst            Counter64,
+    jnxMbgPgwApnPeerInitDeactv          Counter64,
+    jnxMbgPgwApnPeerInitSuccDeactv      Counter64,
+    jnxMbgPgwApnGwInitDeactv            Counter64,
+    jnxMbgPgwApnGwInitSuccDeactv        Counter64,
+    jnxMbgPgwApnGtpStatsGnS5S8InpPkt    Counter64,
+    jnxMbgPgwApnGtpStatsGnS5S8InpByt    Counter64,
+    jnxMbgPgwApnGtpStatsGnS5S8OutPkt    Counter64,
+    jnxMbgPgwApnGtpStatsGnS5S8OutByt    Counter64,
+    jnxMbgPgwApnGtpStatsGiInpPkt        Counter64,
+    jnxMbgPgwApnGtpStatsGiInpByt        Counter64,
+    jnxMbgPgwApnGtpStatsGiOutPkt        Counter64,
+    jnxMbgPgwApnGtpStatsGiOutByt        Counter64,
+    jnxMbgPgwApnSessnFailSrvcUnaval     Counter64,
+    jnxMbgPgwApnSessnFailSysFailure     Counter64,
+    jnxMbgPgwApnSessnFailNoResource     Counter64,
+    jnxMbgPgwApnSessnFailNoAddr         Counter64,
+    jnxMbgPgwApnSessnFailSrvcDenied     Counter64,
+    jnxMbgPgwApnSessnFailAuthFailed     Counter64,
+    jnxMbgPgwApnSessnFailAccsDenied     Counter64,
+    jnxMbgPgwApnMSInitModAttmpts        Counter64,
+    jnxMbgPgwApnSuccMSInitMod           Counter64,
+    jnxMbgPgwApnPgwGgsnInitMod          Counter64,
+    jnxMbgPgwApnSuccPgwGgsnInitMod      Counter64,
+    jnxMbgPgwApnUsrAuthAttmpts          Counter64,
+    jnxMbgPgwApnSuccUsrAuth             Counter64,
+    jnxMbgPgwApnFailUsrAuth             Counter64,
+    jnxMbgPgwApnDynIPAllocAttmpts       Counter64,
+    jnxMbgPgwApnSuccDynIPAlloc          Counter64, 
+    jnxMbgPgwApnCdrsAllocd              Counter64,
+    jnxMbgPgwApnPartialCdrsAllocd       Counter64,    
+    jnxMbgPgwApnCdrsClosed              Counter64,
+    jnxMbgPgwApnCdrCntainrsClosed       Counter64,
+    jnxMbgPgwApnPktsViolMIFAcl          Counter64,
+    jnxMbgPgwApnReDrctMblToMblPkts      Counter64,
+    jnxMbgPgwApnReDrctMblToMblByts      Counter64,
+    jnxMbgPgwApnIpv6RsRcvd              Counter64,
+    jnxMbgPgwApnIpv6RaTxd               Counter64,
+    jnxMbgPgwApnIpv6NsRcvd              Counter64,
+    jnxMbgPgwApnIpv6NaTxd               Counter64,
+    jnxMbgPgwApnSessnFailOther          Counter64,
+    jnxMbgPgwApnGtpStatsS58DscrdPkts    Counter64,
+    jnxMbgPgwApnGtpStatsGiDiscrdPkts    Counter64,
+    jnxMbgPgwApnSessEstDynPolAttempt    Counter64,
+    jnxMbgPgwApnSuccSessEstDynPol       Counter64,
+    jnxMbgPgwApnSessEstStaPolAttempt    Counter64,
+    jnxMbgPgwApnSuccSessEstStaPol       Counter64,
+    jnxMbgPgwApnMsInitAmbrModReq        Counter64,
+    jnxMbgPgwApnMsInitAmbrModSucc       Counter64,
+    jnxMbgPgwApnMsInitQoSModReq         Counter64,
+    jnxMbgPgwApnMsInitQoSModSucc        Counter64,
+    jnxMbgPgwApnPcrfInitSessTerm        Counter64,
+    jnxMbgPgwApnGwInitSessTerm          Counter64,
+    jnxMbgPgwApnMsInitSessTerm          Counter64,
+    jnxMbgPgwApnMsInitSessModTrgr       Counter64,
+    jnxMbgPgwApnMsInitSessModSucc       Counter64,
+    jnxMbgPgwApnPcrfInitSessModTrgr     Counter64,
+    jnxMbgPgwApnPcrfInitSessModSucc     Counter64,
+    jnxMbgPgwApnSessModTrgrQoSChg       Counter64,
+    jnxMbgPgwApnSessModTrgrRatChg       Counter64,
+    jnxMbgPgwApnSessModTrgrSgsnChg      Counter64,
+    jnxMbgPgwApnSessModTrgrSgwChg       Counter64,
+    jnxMbgPgwApnSessModTrgrPlmnChg      Counter64,
+    jnxMbgPgwApnSessModTrgrRaiChg       Counter64,
+    jnxMbgPgwApnSessModTrgrUliChg       Counter64,
+    jnxMbgPgwApnSessModTrgrIPCanChg     Counter64,
+    jnxMbgPgwApnMsInitSessModTftChg     Counter64,
+    jnxMbgPgwApnNwInitSessModTftChg     Counter64,
+    jnxMbgPgwApnSessModTrgrBrLoss       Counter64,
+    jnxMbgPgwApnSessModTrgrBrRecvry     Counter64,
+    jnxMbgPgwApnSessModTrgrRsrAlloc     Counter64,
+    jnxMbgPgwApnSessModTrgrRevldTO      Counter64,
+    jnxMbgPgwApnSessModQoSExceedAuth    Counter64,
+    jnxMbgPgwApnSessModTodProc          Counter64,
+    jnxMbgPgwApnSessModTrgrChgSubsc     Counter64,
+    jnxMbgPgwApnSessModAmbrChg          Counter64,
+    jnxMbgPgwApnSessModEcgiChg          Counter64,
+    jnxMbgPgwApnSessModTaiChg           Counter64,
+    jnxMbgPgwApnSessModMsTimezoneChg    Counter64,
+    jnxMbgPgwApnSessModDefQosChg        Counter64,
+    jnxMbgPgwApnMsDedBrActAttempt       Counter64,
+    jnxMbgPgwApnMsDedBrActSucc          Counter64,
+    jnxMbgPgwApnNwDedBrActAttempt       Counter64,
+    jnxMbgPgwApnNwDedBrActSucc          Counter64,
+    jnxMbgPgwApnMsDedBrModAttempt       Counter64,
+    jnxMbgPgwApnMsDedBrModSucc          Counter64,
+    jnxMbgPgwApnNwDedBrModAttempt       Counter64,
+    jnxMbgPgwApnNwDedBrModSucc          Counter64,
+    jnxMbgPgwApnMsDedBrDeactAttempt     Counter64,
+    jnxMbgPgwApnNwDedBrDeactAttempt     Counter64,
+    jnxMbgPgwApnGwDedBrDeactAttempt     Counter64,
+    jnxMbgPgwApnGbrDedBrCrtFailCAC      Counter64,
+    jnxMbgPgwApnNGbrDedBrCrtFailCAC     Counter64,
+    jnxMbgPgwApnSessTermUnreachPcrf     Counter64,
+    jnxMbgPgwApnSessTermPcrfRestart     Counter64,
+    jnxMbgPgwApnGxCcrISent              Counter64,
+    jnxMbgPgwApnGxCcaIRcvd              Counter64,
+    jnxMbgPgwApnGxCcrUSent              Counter64,
+    jnxMbgPgwApnGxCcaURcvd              Counter64,
+    jnxMbgPgwApnGxCcrTSent              Counter64,
+    jnxMbgPgwApnGxCcaTRcvd              Counter64,
+    jnxMbgPgwApnGxRarRcvd               Counter64,
+    jnxMbgPgwApnGxRaaSent               Counter64,
+    jnxMbgPgwApnGxRaaSentRsrFail        Counter64,
+    jnxMbgPgwApnGxCcrRejTransntFail     Counter64,
+    jnxMbgPgwApnGxCcrRejInitlParErr     Counter64,
+    jnxMbgPgwApnGxCcrRejPermFail        Counter64,
+    jnxMbgPgwApnGxCcrRejUknCode         Counter64,
+    jnxMbgPgwApnGxCcrRejUknSess         Counter64,
+    jnxMbgPgwApnPccActiveDynRules       Counter64,
+    jnxMbgPgwApnPccDynRuleDeact         Counter64,
+    jnxMbgPgwApnPccRuleStaticAct        Counter64,
+    jnxMbgPgwApnPccRuleStaticDeact      Counter64,
+    jnxMbgPgwApnPccRuleDynMod           Counter64,
+    jnxMbgPgwApnPccRuleValidnFail       Counter64,
+    jnxMbgPgwApnPccRuleEnforceFail      Counter64,
+    jnxMbgPgwApnPccActFailNoRsr         Counter64,
+    jnxMbgPgwApnPccRuleUpdProcFail      Counter64,
+    jnxMbgPgwApnInterRatHoAttempt       Counter64,
+    jnxMbgPgwApnInterRatHoSucc          Counter64,
+    jnxMbgPgwApnIntraRatHoAttempt       Counter64,
+    jnxMbgPgwApnIntraRatHoSucc          Counter64,
+    jnxMbgPgwApnOnlineAuthAttempt       Counter64,
+    jnxMbgPgwApnOnlineAuthSucc          Counter64,
+    jnxMbgPgwApnOnlineAuthTimeout       Counter64,
+    jnxMbgPgwApnOnlineQuotaThdUpdReq    Counter64,
+    jnxMbgPgwApnGyCcrISent              Counter64,
+    jnxMbgPgwApnGyCcaISucc              Counter64,
+    jnxMbgPgwApnGyCcrIFail              Counter64,
+    jnxMbgPgwApnGyCcrUSent              Counter64,
+    jnxMbgPgwApnGyCcaUSucc              Counter64,
+    jnxMbgPgwApnGyCcrUFail              Counter64,
+    jnxMbgPgwApnGyCcrTSent              Counter64,
+    jnxMbgPgwApnGyCcaTSucc              Counter64,
+    jnxMbgPgwApnGyCcrTFail              Counter64,
+    jnxMbgPgwApnGyRarRcvd               Counter64,
+    jnxMbgPgwApnGyRaaSent               Counter64,
+    jnxMbgPgwApnGyRaaFail               Counter64,
+    jnxMbgPgwApnGyAbortSessReqRcvd      Counter64,
+    jnxMbgPgwApnGyAbortSessAnsSent      Counter64,
+    jnxMbgPgwApnGyCcrRejTransntFail     Counter64,
+    jnxMbgPgwApnGyCcrRejInitlParErr     Counter64,
+    jnxMbgPgwApnGyCcrRejPermFail        Counter64,
+    jnxMbgPgwApnGyCcrRejUknCode         Counter64,
+    jnxMbgPgwApnGyCcrRejUknSess         Counter64,
+    jnxMbgPgwApnGwAttemptedRedirect     Counter64,
+    jnxMbgPgwApnSuccGwRedirect          Counter64,
+    jnxMbgPgwApnSuccApnRedirect         Counter64,
+    jnxMbgPgwApnSessnFailCtxNotFound    Counter64,
+    jnxMbgPgwApnGxMsInitModAttempt      Counter64,
+    jnxMbgPgwApnGxSuccMsInitMod         Counter64,
+    jnxMbgPgwApnGxPcrfInitMod           Counter64,
+    jnxMbgPgwApnGxSuccPcrfInitMod       Counter64,
+    jnxMbgPgwApnGxMsInitSessTerm        Counter64,
+    jnxMbgPgwApnGxPcrfInitSessTerm      Counter64,
+    jnxMbgPgwApnGxGwInitSessTerm        Counter64,
+    jnxMbgPgwApnGySessEstAttempt        Counter64,
+    jnxMbgPgwApnGySuccSessEst           Counter64,
+    jnxMbgPgwApnGyReauthAttempt         Counter64,
+    jnxMbgPgwApnGySuccReauth            Counter64,
+    jnxMbgPgwApnGyAuthTimeout           Counter64,
+    jnxMbgPgwApnGyMsInitSessDeact       Counter64,
+    jnxMbgPgwApnGyOcsInitSessDeact      Counter64,
+    jnxMbgPgwApnGyGwInitSessDeact       Counter64
+}    
+
+jnxMbgPgwApnSMStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwApnSMStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Gateway Stats."
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgPgwApnName }
+    ::= { jnxMbgPgwApnSMStatsTable 1 }
+
+jnxMbgPgwApnName OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+    "A string that uniquely identifies the APN."
+    ::= { jnxMbgPgwApnSMStatsEntry 1 }
+
+
+jnxMbgPgwApnSessnEstAttmpts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Session establishment attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 2 }
+
+jnxMbgPgwApnSuccSessnEst OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Sessions established successfully."
+    ::= { jnxMbgPgwApnSMStatsEntry 3 }
+
+jnxMbgPgwApnPeerInitDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total MS/peer initiated session deactivation attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 4 }    
+    
+jnxMbgPgwApnPeerInitSuccDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total MS/peer initiated successful session deactivations."
+    ::= { jnxMbgPgwApnSMStatsEntry 5 }    
+
+jnxMbgPgwApnGwInitDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Gateway initiated session deactivation attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 6 }    
+
+jnxMbgPgwApnGwInitSuccDeactv OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Gateway initiated successful session deactivations."
+    ::= { jnxMbgPgwApnSMStatsEntry 7 }    
+
+jnxMbgPgwApnGtpStatsGnS5S8InpPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Input packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 8 }    
+
+jnxMbgPgwApnGtpStatsGnS5S8InpByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Input bytes."
+    ::= { jnxMbgPgwApnSMStatsEntry 9 } 
+
+jnxMbgPgwApnGtpStatsGnS5S8OutPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Output packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 10 }    
+
+jnxMbgPgwApnGtpStatsGnS5S8OutByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) Output bytes."
+    ::= { jnxMbgPgwApnSMStatsEntry 11 }     
+    
+jnxMbgPgwApnGtpStatsGiInpPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Input packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 12 }    
+
+jnxMbgPgwApnGtpStatsGiInpByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Input bytes."
+    ::= { jnxMbgPgwApnSMStatsEntry 13 } 
+
+jnxMbgPgwApnGtpStatsGiOutPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Output packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 14 }    
+
+jnxMbgPgwApnGtpStatsGiOutByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi Output bytes."
+    ::= { jnxMbgPgwApnSMStatsEntry 15 }  
+
+jnxMbgPgwApnSessnFailSrvcUnaval OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established due
+          to service unavailability."
+    ::= { jnxMbgPgwApnSMStatsEntry 16 }
+
+jnxMbgPgwApnSessnFailSysFailure OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+         due to system failure."
+    ::= { jnxMbgPgwApnSMStatsEntry 17 }
+
+jnxMbgPgwApnSessnFailNoResource OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+         due to lack of resource."
+    ::= { jnxMbgPgwApnSMStatsEntry 18 }
+
+jnxMbgPgwApnSessnFailNoAddr OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+         due to lack of address. The address pool
+         assigned to this APN is exhausted"
+    ::= { jnxMbgPgwApnSMStatsEntry 19 }
+
+jnxMbgPgwApnSessnFailSrvcDenied OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+         due to service denial."
+    ::= { jnxMbgPgwApnSMStatsEntry 20 }
+
+jnxMbgPgwApnSessnFailAuthFailed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+          due to authentication failure."
+    ::= { jnxMbgPgwApnSMStatsEntry 21 }
+
+jnxMbgPgwApnSessnFailAccsDenied OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+          due to APN access denial."
+    ::= { jnxMbgPgwApnSMStatsEntry 22 }
+
+jnxMbgPgwApnMSInitModAttmpts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total MS initiated modification attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 23 }
+
+jnxMbgPgwApnSuccMSInitMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Successful MS initiated modifications."
+    ::= { jnxMbgPgwApnSMStatsEntry 24 }
+
+jnxMbgPgwApnPgwGgsnInitMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total PGW/GGSN initiated modification attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 25 }
+
+jnxMbgPgwApnSuccPgwGgsnInitMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total PGW/GGSN initiated modification attempts successful."
+    ::= { jnxMbgPgwApnSMStatsEntry 26 }
+
+jnxMbgPgwApnUsrAuthAttmpts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total User Authentication attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 27 }
+
+jnxMbgPgwApnSuccUsrAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total User Authentication attempts successful."
+    ::= { jnxMbgPgwApnSMStatsEntry 28 }
+
+jnxMbgPgwApnFailUsrAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total User Authentication attempts failed."
+    ::= { jnxMbgPgwApnSMStatsEntry 29 }
+
+jnxMbgPgwApnDynIPAllocAttmpts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Dynamic IP address allocation attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 30 }
+
+jnxMbgPgwApnSuccDynIPAlloc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Dynamic IP address allocations successful."
+    ::= { jnxMbgPgwApnSMStatsEntry 31 }    
+    
+jnxMbgPgwApnCdrsAllocd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of CDRs allocated."
+    ::= { jnxMbgPgwApnSMStatsEntry 32 } 
+
+jnxMbgPgwApnPartialCdrsAllocd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of partial CDRs allocated."
+    ::= { jnxMbgPgwApnSMStatsEntry 33 } 
+
+jnxMbgPgwApnCdrsClosed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of CDRs closed."
+    ::= { jnxMbgPgwApnSMStatsEntry 34 }
+
+jnxMbgPgwApnCdrCntainrsClosed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total Number of CDR containers closed."
+    ::= { jnxMbgPgwApnSMStatsEntry 35 }
+
+jnxMbgPgwApnPktsViolMIFAcl OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total packets violating MIF ACL."
+    ::= { jnxMbgPgwApnSMStatsEntry 36 }
+
+jnxMbgPgwApnReDrctMblToMblPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total redirected mobile-to-mobile packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 37 }
+
+jnxMbgPgwApnReDrctMblToMblByts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total redirected mobile-to-mobile bytes."
+    ::= { jnxMbgPgwApnSMStatsEntry 38 }
+    
+jnxMbgPgwApnIpv6RsRcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total IPv6 Router Solicitations received."
+    ::= { jnxMbgPgwApnSMStatsEntry 39 }
+
+jnxMbgPgwApnIpv6RaTxd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total IPv6 Router Advertisements transmitted."
+    ::= { jnxMbgPgwApnSMStatsEntry 40 }
+
+jnxMbgPgwApnIpv6NsRcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total IPv6 Neighbor Solicitations received."
+    ::= { jnxMbgPgwApnSMStatsEntry 41 }
+
+jnxMbgPgwApnIpv6NaTxd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total IPv6 Neighbor Advertisements transmitted."
+    ::= { jnxMbgPgwApnSMStatsEntry 42 }
+
+jnxMbgPgwApnSessnFailOther  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+         due to miscellaneous causes."
+    ::= { jnxMbgPgwApnSMStatsEntry 43 }
+
+jnxMbgPgwApnGtpStatsS58DscrdPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics (Gn/S5/S8) discarded packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 44 }
+
+jnxMbgPgwApnGtpStatsGiDiscrdPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gi discarded packets."
+    ::= { jnxMbgPgwApnSMStatsEntry 45 }
+
+jnxMbgPgwApnSessEstDynPolAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session  establishment 
+        attempts using dynamic policy ."
+    ::= { jnxMbgPgwApnSMStatsEntry 46 }
+   
+jnxMbgPgwApnSuccSessEstDynPol OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful session 
+        establishment using dynamic policy."
+    ::= { jnxMbgPgwApnSMStatsEntry 47 }
+
+jnxMbgPgwApnSessEstStaPolAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of session establishment attempt 
+        using static policy."
+    ::= { jnxMbgPgwApnSMStatsEntry 48 }
+ 
+jnxMbgPgwApnSuccSessEstStaPol OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of successful session 
+        establishment using dynamic policy."
+    ::= { jnxMbgPgwApnSMStatsEntry 49 }
+       
+jnxMbgPgwApnMsInitAmbrModReq OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of MS initiated Apn Ambr 
+        modification request."
+    ::= { jnxMbgPgwApnSMStatsEntry 50 }
+
+ jnxMbgPgwApnMsInitAmbrModSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of successful MS initiated
+        Apn Ambr modifications."
+    ::= { jnxMbgPgwApnSMStatsEntry 51 } 
+    
+jnxMbgPgwApnMsInitQoSModReq OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of MS initiated QOS 
+        modification request."
+    ::= { jnxMbgPgwApnSMStatsEntry 52 }
+    
+jnxMbgPgwApnMsInitQoSModSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of successful MS initiated QOS 
+        modification."
+    ::= { jnxMbgPgwApnSMStatsEntry 53 }
+    
+jnxMbgPgwApnPcrfInitSessTerm OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of PCRF initiated 
+        sesssion termination trigger."
+    ::= { jnxMbgPgwApnSMStatsEntry 54 }
+    
+jnxMbgPgwApnGwInitSessTerm OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gateway initiated
+        session termination trigger."
+    ::= { jnxMbgPgwApnSMStatsEntry 55 }
+    
+jnxMbgPgwApnMsInitSessTerm OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of MS initiated 
+        session termination trigger."
+    ::= { jnxMbgPgwApnSMStatsEntry 56 }    
+
+jnxMbgPgwApnMsInitSessModTrgr OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Ms initiated
+        session modification trigger."
+    ::= { jnxMbgPgwApnSMStatsEntry 57 }
+    
+jnxMbgPgwApnMsInitSessModSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of successful MS initiated
+        session modification."
+    ::= { jnxMbgPgwApnSMStatsEntry 58 }
+    
+jnxMbgPgwApnPcrfInitSessModTrgr OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of PCRF initiated
+        session modification trigger."
+    ::= { jnxMbgPgwApnSMStatsEntry 59 }
+    
+jnxMbgPgwApnPcrfInitSessModSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of successful PCRF initiated
+        session modification."
+    ::= { jnxMbgPgwApnSMStatsEntry 60 }
+
+jnxMbgPgwApnSessModTrgrQoSChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to QOS change."
+    ::= { jnxMbgPgwApnSMStatsEntry 61 }
+                        
+jnxMbgPgwApnSessModTrgrRatChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to RAT change."
+    ::= { jnxMbgPgwApnSMStatsEntry 62 }
+
+jnxMbgPgwApnSessModTrgrSgsnChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to SGSN change."
+    ::= { jnxMbgPgwApnSMStatsEntry 63 }    
+
+jnxMbgPgwApnSessModTrgrSgwChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to SGW change."
+    ::= { jnxMbgPgwApnSMStatsEntry 64 }
+
+jnxMbgPgwApnSessModTrgrPlmnChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to PLMN change."
+    ::= { jnxMbgPgwApnSMStatsEntry 65 }
+
+jnxMbgPgwApnSessModTrgrRaiChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to RAI change."
+    ::= { jnxMbgPgwApnSMStatsEntry 66 }
+
+jnxMbgPgwApnSessModTrgrUliChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to ULI change."
+    ::= { jnxMbgPgwApnSMStatsEntry 67 } 
+    
+jnxMbgPgwApnSessModTrgrIPCanChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to IP CAN change."
+    ::= { jnxMbgPgwApnSMStatsEntry 68 }
+
+jnxMbgPgwApnMsInitSessModTftChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS session modification
+        trigger due to TFT change."
+    ::= { jnxMbgPgwApnSMStatsEntry 69 }
+
+jnxMbgPgwApnNwInitSessModTftChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Network session modification
+        trigger due to TFT change."
+    ::= { jnxMbgPgwApnSMStatsEntry 70 }
+
+jnxMbgPgwApnSessModTrgrBrLoss OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to Bearer Loss."
+    ::= { jnxMbgPgwApnSMStatsEntry 71 }    
+
+jnxMbgPgwApnSessModTrgrBrRecvry OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to bearer recovery."
+    ::= { jnxMbgPgwApnSMStatsEntry 72 }
+
+jnxMbgPgwApnSessModTrgrRsrAlloc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to resource allocation."
+    ::= { jnxMbgPgwApnSMStatsEntry 73 }
+
+jnxMbgPgwApnSessModTrgrRevldTO OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to Revalidation Timeout."
+    ::= { jnxMbgPgwApnSMStatsEntry 74 }
+
+jnxMbgPgwApnSessModQoSExceedAuth OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to QoS Exceed Auth."
+    ::= { jnxMbgPgwApnSMStatsEntry 75 }
+
+jnxMbgPgwApnSessModTodProc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to Time of day procedure."
+    ::= { jnxMbgPgwApnSMStatsEntry 76 }
+
+jnxMbgPgwApnSessModTrgrChgSubsc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to change of subscription."
+    ::= { jnxMbgPgwApnSMStatsEntry 77 }
+
+jnxMbgPgwApnSessModAmbrChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to AMBR change."
+    ::= { jnxMbgPgwApnSMStatsEntry 78 }
+
+jnxMbgPgwApnSessModEcgiChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to ECGI change."
+    ::= { jnxMbgPgwApnSMStatsEntry 79 }
+
+jnxMbgPgwApnSessModTaiChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to TAI change."
+    ::= { jnxMbgPgwApnSMStatsEntry 80 }
+
+jnxMbgPgwApnSessModMsTimezoneChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to MS timezone change."
+    ::= { jnxMbgPgwApnSMStatsEntry 81 }
+
+
+jnxMbgPgwApnSessModDefQosChg OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session modification
+        trigger due to Default QoS change."
+    ::= { jnxMbgPgwApnSMStatsEntry 82 }
+
+jnxMbgPgwApnMsDedBrActAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS initiated dedicated 
+        bearer activation attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 83 }  
+    
+jnxMbgPgwApnMsDedBrActSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful MS initiated 
+        dedicated bearer activation ."
+    ::= { jnxMbgPgwApnSMStatsEntry 84 }      
+
+jnxMbgPgwApnNwDedBrActAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of network initiated dedicated 
+        bearer activation attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 85 }
+
+jnxMbgPgwApnNwDedBrActSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Network initiated 
+        dedicated bearer activation."
+    ::= { jnxMbgPgwApnSMStatsEntry 86 }
+
+jnxMbgPgwApnMsDedBrModAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS initiated dedicated 
+        bearer modification attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 87 }
+
+jnxMbgPgwApnMsDedBrModSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful MS initiated 
+        dedicated bearer modification."
+    ::= { jnxMbgPgwApnSMStatsEntry 88 }
+    
+jnxMbgPgwApnNwDedBrModAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Network initiated dedicated 
+        bearer modification attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 89 }        
+
+jnxMbgPgwApnNwDedBrModSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Network initiated 
+        dedicated bearer modification."
+    ::= { jnxMbgPgwApnSMStatsEntry 90 }
+
+jnxMbgPgwApnMsDedBrDeactAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS initiated dedicated 
+        bearer deactivation attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 91 }
+
+jnxMbgPgwApnNwDedBrDeactAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Network initiated dedicated 
+        bearer deactivation attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 92 }
+
+jnxMbgPgwApnGwDedBrDeactAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gateway initiated dedicated 
+        bearer deactivation attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 93 }
+
+jnxMbgPgwApnGbrDedBrCrtFailCAC OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of GBR dedicated bearer 
+        creation failure due to CAC."
+    ::= { jnxMbgPgwApnSMStatsEntry 94 }
+
+jnxMbgPgwApnNGbrDedBrCrtFailCAC OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Non-GBR dedicated bearer 
+        creation failure due to CAC."
+    ::= { jnxMbgPgwApnSMStatsEntry 95 }
+    
+jnxMbgPgwApnSessTermUnreachPcrf OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session termination 
+        due to unreachable PCRF."
+    ::= { jnxMbgPgwApnSMStatsEntry 96 }       
+
+jnxMbgPgwApnSessTermPcrfRestart OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session termination 
+        due to PCRF restart."
+    ::= { jnxMbgPgwApnSMStatsEntry 97 }
+    
+jnxMbgPgwApnGxCcrISent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR-I sent on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 98 }
+
+jnxMbgPgwApnGxCcaIRcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCA-I received on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 99 } 
+    
+jnxMbgPgwApnGxCcrUSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR-U sent on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 100 }
+    
+jnxMbgPgwApnGxCcaURcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCA-U received on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 101 }
+
+jnxMbgPgwApnGxCcrTSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR-T sent on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 102 }
+    
+jnxMbgPgwApnGxCcaTRcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCA-T receieved on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 103 }        
+
+jnxMbgPgwApnGxRarRcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of RAR received on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 104 }
+    
+jnxMbgPgwApnGxRaaSent OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of RAA sent on Gx."
+    ::= { jnxMbgPgwApnSMStatsEntry 105 }  
+
+jnxMbgPgwApnGxRaaSentRsrFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of RAA sent on Gx due to 
+        resouce failure ."
+    ::= { jnxMbgPgwApnSMStatsEntry 106 }
+    
+jnxMbgPgwApnGxCcrRejTransntFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR rejects 
+        due to trancient failure ."
+    ::= { jnxMbgPgwApnSMStatsEntry 107 } 
+    
+jnxMbgPgwApnGxCcrRejInitlParErr OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR rejects 
+        due to Initial parameters error ."
+    ::= { jnxMbgPgwApnSMStatsEntry 108 }
+
+jnxMbgPgwApnGxCcrRejPermFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR rejects 
+        due to permanent failure ."
+    ::= { jnxMbgPgwApnSMStatsEntry 109 }
+    
+jnxMbgPgwApnGxCcrRejUknCode OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR rejects 
+        due to unknown code ."
+    ::= { jnxMbgPgwApnSMStatsEntry 110 }
+
+jnxMbgPgwApnGxCcrRejUknSess OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of CCR rejects 
+        due to unknown session ."
+    ::= { jnxMbgPgwApnSMStatsEntry 111 }    
+
+jnxMbgPgwApnPccActiveDynRules OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of active 
+        dynamic rules."
+    ::= { jnxMbgPgwApnSMStatsEntry 112 }
+
+jnxMbgPgwApnPccDynRuleDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of dynamic rules
+        deactivation."
+    ::= { jnxMbgPgwApnSMStatsEntry 113 }
+    
+jnxMbgPgwApnPccRuleStaticAct OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of static  rule activation."
+    ::= { jnxMbgPgwApnSMStatsEntry 114 } 
+
+jnxMbgPgwApnPccRuleStaticDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+         "Number of static  rule deactivation."
+    ::= { jnxMbgPgwApnSMStatsEntry 115 }    
+
+jnxMbgPgwApnPccRuleDynMod OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of dynamic rule modifications."
+    ::= { jnxMbgPgwApnSMStatsEntry 116 }
+    
+jnxMbgPgwApnPccRuleValidnFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Pcc rule validation failure."
+    ::= { jnxMbgPgwApnSMStatsEntry 117 }
+
+jnxMbgPgwApnPccRuleEnforceFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of PCC rule enforcement failures."
+    ::= { jnxMbgPgwApnSMStatsEntry 118 }
+    
+jnxMbgPgwApnPccActFailNoRsr OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PCC rule activation failure 
+        due to no resource."
+    ::= { jnxMbgPgwApnSMStatsEntry 119 }
+    
+jnxMbgPgwApnPccRuleUpdProcFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PCC rule  
+         update procedure failure."
+    ::= { jnxMbgPgwApnSMStatsEntry 120 }
+    
+jnxMbgPgwApnInterRatHoAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Inter RAT Handover attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 121 }
+    
+jnxMbgPgwApnInterRatHoSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Inter RAT Handovers."
+    ::= { jnxMbgPgwApnSMStatsEntry 122 }
+    
+jnxMbgPgwApnIntraRatHoAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Intra RAT Handover attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 123 }                        
+                
+jnxMbgPgwApnIntraRatHoSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Intra RAT Handover."
+    ::= { jnxMbgPgwApnSMStatsEntry 124 }
+          
+jnxMbgPgwApnOnlineAuthAttempt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of online authorization 
+        attempt."
+    ::= { jnxMbgPgwApnSMStatsEntry 125 }
+
+jnxMbgPgwApnOnlineAuthSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of online authorization
+        successful."
+    ::= { jnxMbgPgwApnSMStatsEntry 126 }
+
+jnxMbgPgwApnOnlineAuthTimeout OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of online authorization
+        request timeout."
+    ::= { jnxMbgPgwApnSMStatsEntry 127 }
+
+jnxMbgPgwApnOnlineQuotaThdUpdReq OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of online Quota threshold
+        update request."
+    ::= { jnxMbgPgwApnSMStatsEntry 128 }
+
+jnxMbgPgwApnGyCcrISent  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Ccr-I sent."
+    ::= { jnxMbgPgwApnSMStatsEntry 129 }
+
+jnxMbgPgwApnGyCcaISucc  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Cca-I Successful."
+    ::= { jnxMbgPgwApnSMStatsEntry 130 } 
+    
+jnxMbgPgwApnGyCcrIFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Cca-Send-Fail ."
+    ::= { jnxMbgPgwApnSMStatsEntry 131 }       
+
+jnxMbgPgwApnGyCcrUSent  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Ccr-U sent."
+    ::= { jnxMbgPgwApnSMStatsEntry 132 }
+
+jnxMbgPgwApnGyCcaUSucc  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Cca-U Succssful."
+    ::= { jnxMbgPgwApnSMStatsEntry 133 }
+    
+jnxMbgPgwApnGyCcrUFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Cca-U-Send-Fail ."
+    ::= { jnxMbgPgwApnSMStatsEntry 134 }        
+
+jnxMbgPgwApnGyCcrTSent  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Ccr-T Sent."
+    ::= { jnxMbgPgwApnSMStatsEntry 135 }
+
+jnxMbgPgwApnGyCcaTSucc  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Cca-T Successful."
+    ::= { jnxMbgPgwApnSMStatsEntry 136 }
+
+jnxMbgPgwApnGyCcrTFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Cca-T-Send_Fail ."
+    ::= { jnxMbgPgwApnSMStatsEntry 137 }    
+
+jnxMbgPgwApnGyRarRcvd  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Rar Rcvd."
+    ::= { jnxMbgPgwApnSMStatsEntry 138 }
+
+jnxMbgPgwApnGyRaaSent   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Raa Sent."
+    ::= { jnxMbgPgwApnSMStatsEntry 139 }
+
+jnxMbgPgwApnGyRaaFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Raa-Send-Fail ."
+    ::= { jnxMbgPgwApnSMStatsEntry 140 }    
+
+jnxMbgPgwApnGyAbortSessReqRcvd  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy Abort Session Request 
+        received."
+    ::= { jnxMbgPgwApnSMStatsEntry 141 }
+
+jnxMbgPgwApnGyAbortSessAnsSent  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy Abort Session Answer 
+        sent."
+    ::= { jnxMbgPgwApnSMStatsEntry 142 }    
+
+jnxMbgPgwApnGyCcrRejTransntFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Raa rejects
+        transcient failure."
+    ::= { jnxMbgPgwApnSMStatsEntry 143 }
+
+jnxMbgPgwApnGyCcrRejInitlParErr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-ccr rejects 
+        initial paramater error."
+    ::= { jnxMbgPgwApnSMStatsEntry 144 }
+
+jnxMbgPgwApnGyCcrRejPermFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Ccr rejects 
+        permanent fail."
+    ::= { jnxMbgPgwApnSMStatsEntry 145 }
+
+jnxMbgPgwApnGyCcrRejUknCode  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Ccr rejects
+        Unknown Code."
+    ::= { jnxMbgPgwApnSMStatsEntry 146 }
+
+jnxMbgPgwApnGyCcrRejUknSess  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of Gy-Ccr rejects
+        unknown session."
+    ::= { jnxMbgPgwApnSMStatsEntry 147 }
+
+jnxMbgPgwApnGwAttemptedRedirect OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gateway Attempted Redirects."
+    ::= { jnxMbgPgwApnSMStatsEntry 148 }
+
+jnxMbgPgwApnSuccGwRedirect OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful gateway redirects."
+    ::= { jnxMbgPgwApnSMStatsEntry 149 }
+
+jnxMbgPgwApnSuccApnRedirect OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful apn redirects."
+    ::= { jnxMbgPgwApnSMStatsEntry 150 }
+
+jnxMbgPgwApnSessnFailCtxNotFound OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions that could not be established
+          due to Context Not Found."
+    ::= { jnxMbgPgwApnSMStatsEntry 151 }
+
+jnxMbgPgwApnGxMsInitModAttempt  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of MS/Peer initiated
+        session modification attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 152 }
+
+jnxMbgPgwApnGxSuccMsInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful MS/Peer initiated
+        session modification ."
+    ::= { jnxMbgPgwApnSMStatsEntry 153 }
+
+jnxMbgPgwApnGxPcrfInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PCRF initiated
+        session modification attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 154 }
+
+jnxMbgPgwApnGxSuccPcrfInitMod  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful PCRF initiated
+        session modification ."
+    ::= { jnxMbgPgwApnSMStatsEntry 155 }
+
+ jnxMbgPgwApnGxMsInitSessTerm          OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gx Ms/Peer initiated session termination ."
+    ::= { jnxMbgPgwApnSMStatsEntry 156 }
+
+ jnxMbgPgwApnGxPcrfInitSessTerm        OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gx PCRF initiated session termination ."
+    ::= { jnxMbgPgwApnSMStatsEntry 157 }
+
+ jnxMbgPgwApnGxGwInitSessTerm          OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gx Gateway initiated session termination ."
+    ::= { jnxMbgPgwApnSMStatsEntry 158 }
+
+jnxMbgPgwApnGySessEstAttempt  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy session 
+        establishment attempts."
+    ::= { jnxMbgPgwApnSMStatsEntry 159 }
+
+jnxMbgPgwApnGySuccSessEst  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Successful Gy session 
+        establishments."
+    ::= { jnxMbgPgwApnSMStatsEntry 160 }
+
+jnxMbgPgwApnGyReauthAttempt  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy reauthorization 
+        requests to OCS."
+    ::= { jnxMbgPgwApnSMStatsEntry 161 }
+
+jnxMbgPgwApnGySuccReauth  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of successful Gy reauthorization."
+    ::= { jnxMbgPgwApnSMStatsEntry 162 }
+
+jnxMbgPgwApnGyAuthTimeout  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy authorization timeout."
+    ::= { jnxMbgPgwApnSMStatsEntry 163 }
+
+jnxMbgPgwApnGyMsInitSessDeact  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy Ms/Peer initiated 
+        session deactivations."
+    ::= { jnxMbgPgwApnSMStatsEntry 164 }
+
+jnxMbgPgwApnGyOcsInitSessDeact  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy OCS initiated 
+        session deactivations."
+    ::= { jnxMbgPgwApnSMStatsEntry 165 }
+
+jnxMbgPgwApnGyGwInitSessDeact  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of Gy gateway initiated 
+        session deactivations."
+    ::= { jnxMbgPgwApnSMStatsEntry 166 }
+
+--
+-- Status Table for PGW 
+--
+
+jnxMbgPgwSMStatusTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwSMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table listing Mobile Gateway level Status for PDN Gateway.
+         Key is Gateway Name."
+    ::= { jnxMbgPgwSMObjects 5 }
+
+JnxMbgPgwSMStatusEntry ::= SEQUENCE {
+    jnxMbgPgwActvSubscribers        CounterBasedGauge64,
+    jnxMbgPgwActvSessions           CounterBasedGauge64,
+    jnxMbgPgwActvBearers            CounterBasedGauge64,
+    jnxMbgPgwIdleSubscribers        CounterBasedGauge64,
+    jnxMbgPgwIdleSessions           CounterBasedGauge64,
+    jnxMbgPgwIdleBearers            CounterBasedGauge64,
+    jnxMbgPgwSuspSubscribers        CounterBasedGauge64,
+    jnxMbgPgwSuspSessions           CounterBasedGauge64,
+    jnxMbgPgwSuspBearers            CounterBasedGauge64,
+    jnxMbgPgwCPUUtil                Gauge32,
+    jnxMbgPgwMemoryUtil             Gauge32,
+    jnxMbgPgwActvPrepaidBearers     CounterBasedGauge64,
+    jnxMbgPgwActvPostpaidBearers    CounterBasedGauge64,
+    jnxMbgPgwActvGbrBearers         CounterBasedGauge64,
+    jnxMbgPgwActvNonGbrBearers      CounterBasedGauge64
+}
+
+jnxMbgPgwSMStatusEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwSMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Gateway Status."
+    INDEX       { jnxMbgGwIndex }
+    ::= { jnxMbgPgwSMStatusTable 1 }
+
+jnxMbgPgwActvSubscribers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active subscribers."
+    ::= { jnxMbgPgwSMStatusEntry 1 }
+
+jnxMbgPgwActvSessions OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active sessions."
+    ::= { jnxMbgPgwSMStatusEntry 2 }
+
+jnxMbgPgwActvBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active bearers."
+    ::= { jnxMbgPgwSMStatusEntry 3 }
+
+jnxMbgPgwIdleSubscribers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total idle subscribers. 
+        Deprecated : Reported as zero"
+    ::= { jnxMbgPgwSMStatusEntry 4 }
+
+jnxMbgPgwIdleSessions OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total idle sessions.
+        Deprecated : Reported as zero"
+    ::= { jnxMbgPgwSMStatusEntry 5 }
+
+jnxMbgPgwIdleBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total idle bearers.
+        Deprecated : Reported as zero"
+    ::= { jnxMbgPgwSMStatusEntry 6 }
+
+jnxMbgPgwSuspSubscribers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total suspended subscribers.
+        Deprecated : Reported as zero"
+    ::= { jnxMbgPgwSMStatusEntry 7 }
+
+jnxMbgPgwSuspSessions OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total suspended sessions.
+        Deprecated : Reported as zero"
+    ::= { jnxMbgPgwSMStatusEntry 8 }
+
+jnxMbgPgwSuspBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total suspended bearers.
+        Deprecated : Reported as zero"
+    ::= { jnxMbgPgwSMStatusEntry 9 }
+    
+jnxMbgPgwCPUUtil OBJECT-TYPE
+    SYNTAX      Gauge32 
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Current CPU Utilizationization."
+    ::= { jnxMbgPgwSMStatusEntry 10 }
+
+jnxMbgPgwMemoryUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Current Memory Utilizationization."
+    ::= { jnxMbgPgwSMStatusEntry 11 }
+
+jnxMbgPgwActvPrepaidBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active prepaid bearers."
+    ::= { jnxMbgPgwSMStatusEntry 12 }
+ 
+jnxMbgPgwActvPostpaidBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active postpaid bearers."
+    ::= { jnxMbgPgwSMStatusEntry 13 }       
+
+jnxMbgPgwActvGbrBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active Gbr bearers."
+    ::= { jnxMbgPgwSMStatusEntry 14 }
+
+jnxMbgPgwActvNonGbrBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active Non-Gbr bearers."
+    ::= { jnxMbgPgwSMStatusEntry 15 }    
+
+jnxMbgPgwApnSMClRateStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwApnClRateEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists the call rate statistics for 
+         the most recent configured interval for APN .
+         Gateway ID plus Apn Name is used as a key."
+    ::= { jnxMbgPgwSMObjects 10 }
+
+JnxMbgPgwApnClRateEntry ::= SEQUENCE {
+    jnxMbgPgwApnCRName                  DisplayString,
+    jnxMbgPgwApnCRIntervalMin           Unsigned32,
+    jnxMbgPgwApnCRPrepaidBrAct          Counter64,
+    jnxMbgPgwApnCRPrepaidBrDeact        Counter64,
+    jnxMbgPgwApnCRPostpaidBrAct         Counter64,
+    jnxMbgPgwApnCRPostpaidBrDeact       Counter64,
+    jnxMbgPgwApnCROnlineAuthTimeout     Counter64,
+    jnxMbgPgwApnCRQuotaThdUpdReq        Counter64,
+    jnxMbgPgwApnCROnlineRarRcvd         Counter64,
+    jnxMbgPgwApnCROnlineRarSucc         Counter64
+}
+
+jnxMbgPgwApnSMClRateStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwApnClRateEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Apn Call Rate Statistics."
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgPgwApnCRName }
+    ::= { jnxMbgPgwApnSMClRateStatsTable 1 }
+
+jnxMbgPgwApnCRName OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+    "A string that uniquely identifies the APN."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 1 }
+
+ jnxMbgPgwApnCRIntervalMin  OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Aggregation interval for call rate statisitcs in minutes."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 2 }
+    
+
+ jnxMbgPgwApnCRPrepaidBrAct          OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of prepaid bearer activations."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 3 }
+    
+ jnxMbgPgwApnCRPrepaidBrDeact          OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of prepaid bearer deactivations."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 4 }
+
+ jnxMbgPgwApnCRPostpaidBrAct         OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of postpaid bearer activations."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 5 }
+
+jnxMbgPgwApnCRPostpaidBrDeact OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of postpaid bearer deactivations."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 6 }
+
+jnxMbgPgwApnCROnlineAuthTimeout OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of online authorization timeout."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 7 }
+               
+jnxMbgPgwApnCRQuotaThdUpdReq OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of quota threshold update request sent."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 8 }
+               
+jnxMbgPgwApnCROnlineRarRcvd OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of reauthrization received ."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 9 }
+               
+jnxMbgPgwApnCROnlineRarSucc OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of successful reauthorization."
+    ::= { jnxMbgPgwApnSMClRateStatsEntry 10 }
+
+jnxMbgPgwSMClRateStatsTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwClRateEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists the call rate statistics for 
+         the most recent configured interval for PDN Gateway.
+         Gateway ID is used as a key."
+    ::= { jnxMbgPgwSMObjects 8 }
+
+JnxMbgPgwClRateEntry ::= SEQUENCE {
+    jnxMbgPgwClRateIntervalMin      Unsigned32,
+    jnxMbgPgwClRateSuccSessnEst     Counter64,
+    jnxMbgPgwClRateSuccSessnDel     Counter64,
+    jnxMbgPgwClRateStatsGnInpPkt    Counter64,
+    jnxMbgPgwClRateStatsGnOutPkt    Counter64,
+    jnxMbgPgwClRateStatsGnInpByt    Counter64,
+    jnxMbgPgwClRateStatsGnOutByt    Counter64
+}
+
+jnxMbgPgwSMClRateStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwClRateEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Gateway Call Rate Statistics."
+    INDEX       { jnxMbgGwIndex }
+    ::= { jnxMbgPgwSMClRateStatsTable 1 }
+
+jnxMbgPgwClRateIntervalMin OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Aggregation interval for call rate statisitcs in minutes."
+    ::= { jnxMbgPgwSMClRateStatsEntry 1 }
+    
+
+jnxMbgPgwClRateSuccSessnEst OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions successfully established."
+    ::= { jnxMbgPgwSMClRateStatsEntry 2 }
+    
+jnxMbgPgwClRateSuccSessnDel OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total sessions successfully deleted."
+    ::= { jnxMbgPgwSMClRateStatsEntry 3 }
+
+jnxMbgPgwClRateStatsGnInpPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gn Input packets."
+    ::= { jnxMbgPgwSMClRateStatsEntry 4 }
+
+jnxMbgPgwClRateStatsGnInpByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gn Input bytes."
+    ::= { jnxMbgPgwSMClRateStatsEntry 5 }
+
+jnxMbgPgwClRateStatsGnOutPkt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gn Output packets."
+    ::= { jnxMbgPgwSMClRateStatsEntry 6 }
+
+jnxMbgPgwClRateStatsGnOutByt OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total GTP statistics Gn Output bytes."
+    ::= { jnxMbgPgwSMClRateStatsEntry 7 }
+               
+ 
+jnxMbgPgwSMSpicStatusTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwSMSpicStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table lists the Mobile Gateway SPIC level 
+         Status for PDN Gateway .
+         Gateway ID and SPIC Id - 
+         provided as FPC & PIC Id are used as keys."
+    ::= { jnxMbgPgwSMObjects 9 }
+
+JnxMbgPgwSMSpicStatusEntry ::= SEQUENCE {
+    jnxMbgGwFpc                         Unsigned32,
+    jnxMbgGwPic                         Unsigned32,
+    jnxMbgPgwSpicStatusName             DisplayString,
+    jnxMbgPgwSpicStatusState            INTEGER,
+    jnxMbgPgwSpicStatusType             INTEGER,
+    jnxMbgPgwSpicActvSubscribers        CounterBasedGauge64,
+    jnxMbgPgwSpicActvSessions           CounterBasedGauge64,
+    jnxMbgPgwSpicActvBearers            CounterBasedGauge64,
+    jnxMbgPgwSpicCPUUtil                Gauge32,
+    jnxMbgPgwSpicMemoryUtil             Gauge32,
+    jnxMbgPgwSpicActvPrepaidBearers     CounterBasedGauge64,
+    jnxMbgPgwSpicActvPostpaidBearers    CounterBasedGauge64,
+    jnxMbgPgwSpicActvGbrBearers         CounterBasedGauge64,
+    jnxMbgPgwSpicActvNonGbrBearers      CounterBasedGauge64
+}
+
+jnxMbgPgwSMSpicStatusEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwSMSpicStatusEntry 
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Gateway Status."
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgGwFpc,
+                  jnxMbgGwPic
+                }
+    ::= { jnxMbgPgwSMSpicStatusTable 1 }
+
+jnxMbgGwFpc OBJECT-TYPE
+    SYNTAX       Unsigned32 
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+    "An integer that uniquely identifies the FPC Slot."
+    ::= { jnxMbgPgwSMSpicStatusEntry 1 }
+
+jnxMbgGwPic OBJECT-TYPE
+    SYNTAX       Unsigned32 
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+    "An integer that uniquely identifies the PIC Slot."
+    ::= { jnxMbgPgwSMSpicStatusEntry 2 }
+
+
+jnxMbgPgwSpicStatusName OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+    "A string that uniquely identifies the SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 3 }
+
+jnxMbgPgwSpicStatusState OBJECT-TYPE
+    SYNTAX       INTEGER {
+                    invalid(0),
+                    standalone(1),
+                    active(2),
+                    backup(3)
+                 }
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+    "An integer that identifies the SPIC state."
+    ::= { jnxMbgPgwSMSpicStatusEntry 4 }
+
+jnxMbgPgwSpicStatusType OBJECT-TYPE
+    SYNTAX       INTEGER {
+                    sessionPic(1),
+                    servicePic(2),
+                    pfe(3)   
+                 }
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+    "An integer that identifies the SPIC type."
+    ::= { jnxMbgPgwSMSpicStatusEntry 5 }
+
+jnxMbgPgwSpicActvSubscribers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active subscribers per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 6 }
+
+jnxMbgPgwSpicActvSessions OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active sessions per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 7 }
+    
+jnxMbgPgwSpicActvBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active bearers per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 8 }
+   
+jnxMbgPgwSpicCPUUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Current CPU utilization per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 9 }
+
+jnxMbgPgwSpicMemoryUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Current Memory utilization per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 10 }
+
+jnxMbgPgwSpicActvPrepaidBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active prepaid bearers per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 11 }
+    
+jnxMbgPgwSpicActvPostpaidBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active postpaid bearers per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 12 }
+    
+jnxMbgPgwSpicActvGbrBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active Gbr bearers per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 13 }
+
+jnxMbgPgwSpicActvNonGbrBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active Non-Gbr bearers per SPIC."
+    ::= { jnxMbgPgwSMSpicStatusEntry 14 }
+
+--
+-- Status Table for PGW for APN
+-- To access APN based info we need to use BOTH GwId and APN Name as keys
+--
+
+jnxMbgPgwApnSMStatusTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgPgwApnSMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The table listing Mobile APN Level Status for PDN Gateway.
+         Gateway ID and  APN Name are used as keys"
+    ::= { jnxMbgPgwSMObjects 7 }
+
+JnxMbgPgwApnSMStatusEntry ::= SEQUENCE {
+    jnxMbgPgwApnActvSubscribers         CounterBasedGauge64,
+    jnxMbgPgwApnActvSessions            CounterBasedGauge64,
+    jnxMbgPgwApnActvBearers             CounterBasedGauge64,
+    jnxMbgPgwApnActvPrepaidBearers      CounterBasedGauge64,
+    jnxMbgPgwApnActvPostpaidBearers     CounterBasedGauge64,
+    jnxMbgPgwApnActvGbrBearers          CounterBasedGauge64,
+    jnxMbgPgwApnActvNonGbrBearers       CounterBasedGauge64
+}
+
+jnxMbgPgwApnSMStatusEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwApnSMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile PDN Gateway Status."
+    INDEX       { jnxMbgGwIndex,
+                  jnxMbgPgwApnName 
+                }
+    ::= { jnxMbgPgwApnSMStatusTable 1 }
+
+jnxMbgPgwApnActvSubscribers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active subscribers."
+    ::= { jnxMbgPgwApnSMStatusEntry 1 }
+
+jnxMbgPgwApnActvSessions OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active sessions."
+    ::= { jnxMbgPgwApnSMStatusEntry 2 }
+
+jnxMbgPgwApnActvBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active bearers."
+    ::= { jnxMbgPgwApnSMStatusEntry 3 }
+
+jnxMbgPgwApnActvPrepaidBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active prepaid bearers."
+    ::= { jnxMbgPgwApnSMStatusEntry 4 }
+    
+jnxMbgPgwApnActvPostpaidBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active postpaid bearers."
+    ::= { jnxMbgPgwApnSMStatusEntry 5 }
+
+jnxMbgPgwApnActvGbrBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active Gbr bearers."
+    ::= { jnxMbgPgwApnSMStatusEntry 6 }
+    
+jnxMbgPgwApnActvNonGbrBearers OBJECT-TYPE
+    SYNTAX      CounterBasedGauge64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total active Non-GBr bearers."
+    ::= { jnxMbgPgwApnSMStatusEntry 7 }                
+
+--
+-- Global counters related to gateway Status
+--
+
+jnxMbgPgwStatus OBJECT IDENTIFIER
+    ::= { jnxMbgPgwSMObjects 2 }
+
+jnxMbgPgwActiveSubscribers OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total active subscriber."
+    ::= { jnxMbgPgwStatus 1 }
+
+jnxMbgPgwActiveSessions OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total active sessions."
+    ::= { jnxMbgPgwStatus 2 }
+
+jnxMbgPgwActiveBearers OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total active bearers."
+    ::= { jnxMbgPgwStatus 3 }
+
+jnxMbgPgwCPUUtilization OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Current CPU Utilization."
+    ::= { jnxMbgPgwStatus 4 }
+
+jnxMbgPgwMemoryUtilization OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Current Memory Utilization."
+    ::= { jnxMbgPgwStatus 5 }
+
+--------------------------------------------------
+-- Notifications Vars
+--------------------------------------------------
+
+jnxMbgPgwSMNotificationVars  OBJECT IDENTIFIER
+    ::= { jnxMbgPgwSMObjects 3 }
+
+jnxMbgPgwGatewayName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the mobile edge gateway."
+    ::= { jnxMbgPgwSMNotificationVars 1 }
+
+jnxMbgPgwQosAPNName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies an APN ."
+    ::= { jnxMbgPgwSMNotificationVars 2 }
+
+jnxMbgPgwQosThreshold1Status OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "False - threshold not crossed
+         True  - threshold crossed"
+    ::= { jnxMbgPgwSMNotificationVars 3 }
+
+jnxMbgPgwQosThreshold2Status OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "False - threshold not crossed
+         True  - threshold crossed "
+    ::= { jnxMbgPgwSMNotificationVars 4 }
+
+jnxMbgPgwSMGTPEventType  OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Subscriber Management GTP Event Type Value 
+         Supported Events :
+          PDP_CTXT_CREATE_REJECT - PDP Context Creation Failure"
+    ::= { jnxMbgPgwSMNotificationVars 5 }
+
+jnxMbgPgwSMGTPEventCause OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Subscriber Management GTP Event Cause Value
+         Supported Causes :
+          RESOURCE_ERR -Generic Resource Allocation Failure
+          SYS_ERR      -System Error"
+    ::= { jnxMbgPgwSMNotificationVars 6 }
+
+jnxMbgPgwSMAlarmThrshld OBJECT-TYPE
+    SYNTAX        DisplayString
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current 
+    DESCRIPTION
+    "Alarm threshold::THRESHOLD_LOW/THRESHOLD_HIGH" 
+   ::= { jnxMbgPgwSMNotificationVars 7 }
+
+jnxMbgPgwSMAlarmState OBJECT-TYPE
+    SYNTAX        DisplayString
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current 
+    DESCRIPTION
+    "Alarm state:: CLEARED/RAISED"
+   ::= { jnxMbgPgwSMNotificationVars 8 }
+
+jnxMbgPgwSMSPICName OBJECT-TYPE
+     SYNTAX      DisplayString
+     MAX-ACCESS  accessible-for-notify
+     STATUS      current
+     DESCRIPTION
+     "This identifies the session-pic"
+    ::= { jnxMbgPgwSMNotificationVars 9 }
+
+jnxMbgPgwSMTCName OBJECT-TYPE
+     SYNTAX      DisplayString
+     MAX-ACCESS  accessible-for-notify
+     STATUS      current
+     DESCRIPTION
+     "This identifies the traffic class (gtpv1)"
+    ::= { jnxMbgPgwSMNotificationVars 10 }
+
+jnxMbgPgwSMQCIName OBJECT-TYPE
+     SYNTAX      DisplayString
+     MAX-ACCESS  accessible-for-notify
+     STATUS      current
+     DESCRIPTION
+     "This identifies the QCI"
+    ::= { jnxMbgPgwSMNotificationVars 11 }
+
+jnxMbgPgwSMSessionEstFailReason OBJECT-TYPE
+     SYNTAX      DisplayString
+     MAX-ACCESS  accessible-for-notify
+     STATUS      current
+     DESCRIPTION
+     "Reason for Session Establishment Failue"
+    ::= { jnxMbgPgwSMNotificationVars 12 }
+
+jnxMbgPgwMMGatewayName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies a Gateway ."
+    ::= { jnxMbgPgwSMNotificationVars 13 }
+
+jnxMbgPgwPrevGatewayMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwSMNotificationVars 14 }
+
+jnxMbgPgwNewGatewayMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwSMNotificationVars 15 }
+
+jnxMbgPgwAPNMMGatewayName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies a Gateway ."
+    ::= { jnxMbgPgwSMNotificationVars 16 }
+
+jnxMbgPgwAPNMMAPNName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies an APN ."
+    ::= { jnxMbgPgwSMNotificationVars 17 }
+
+jnxMbgPgwPrevAPNMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwSMNotificationVars 18 }
+
+jnxMbgPgwNewAPNMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwSMNotificationVars 19 }
+
+jnxMbgPgwTrapGwIndex   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify 
+    STATUS      current
+    DESCRIPTION
+        "Gateway Index."
+    ::= { jnxMbgPgwSMNotificationVars 20 }
+
+jnxMbgPgwTrapGwName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify 
+    STATUS      current
+    DESCRIPTION
+        "Gateway Name."
+    ::= { jnxMbgPgwSMNotificationVars 21 }
+
+jnxMbgPgwSpicName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This identifies the session-pic"
+    ::= { jnxMbgPgwSMNotificationVars 22 }
+
+jnxMbgPgwSMInterfaceName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies PGW interface"
+    ::= { jnxMbgPgwSMNotificationVars 23 }
+
+--------------------------------------------------
+-- Notifications 
+--------------------------------------------------
+
+jnxMbgPgwQosBearersThresStatus NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwGatewayName,
+              jnxMbgPgwQosThreshold1Status,
+              jnxMbgPgwQosThreshold2Status 
+            }
+    STATUS     deprecated 
+    DESCRIPTION
+        "This notification signifies that the configured thresholds
+          for bearers at gateway level are reached. The gateway name
+          identifies the notifying gateway name and the next two
+          fields would indicate the Thresholds."
+    ::= { jnxMbgPgwSMNotifications 1 }
+
+jnxMbgPgwQosCPUThresholdStatus NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwGatewayName,
+              jnxMbgPgwQosThreshold1Status,
+              jnxMbgPgwQosThreshold2Status 
+            }
+    STATUS     deprecated 
+    DESCRIPTION
+        "This notification signifies that the configured thresholds
+         for CPU have been reached. The gateway name identifies the
+         notifying gateway and the next two fields would indicate
+         the Thresholds."
+    ::= { jnxMbgPgwSMNotifications 2 }
+
+jnxMbgPgwQosMemThresholdStatus NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwGatewayName,
+              jnxMbgPgwQosThreshold1Status,
+              jnxMbgPgwQosThreshold2Status 
+            }
+    STATUS     deprecated 
+    DESCRIPTION
+        "This notification indicates whether the configured thresholds
+         for Memory have been reached. The gateway name identifies the
+         notifying gateway name and the next two fields would indicate
+         the Thresholds."
+    ::= { jnxMbgPgwSMNotifications 3 }
+
+jnxMbgPgwAPNQosBearersThreStatus NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwQosAPNName,
+              jnxMbgPgwQosThreshold1Status,
+              jnxMbgPgwQosThreshold2Status 
+            }
+    STATUS     deprecated 
+    DESCRIPTION
+        "This notification signifies that the configured APN thresholds
+         for bearers have been reached. The APN Name identifies for
+         which APN the thresholds are being reported and the next two
+         fields would indicate the Thresholds."
+    ::= { jnxMbgPgwSMNotifications 4 }
+
+jnxMbgPgwSMGtpEventNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMGTPEventType,
+              jnxMbgPgwSMGTPEventCause 
+            }
+    STATUS     deprecated
+    DESCRIPTION
+        "Subscriber Management GTP Event Notify"      
+    ::= { jnxMbgPgwSMNotifications 5 } 
+
+jnxMbgPgwSMSubscribersThresGblNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState    
+            }
+    STATUS    deprecated
+    DESCRIPTION
+        "Subscriber Threshold Global."      
+    ::= { jnxMbgPgwSMNotifications 6 } 
+
+jnxMbgPgwSMSubscribersThresPerSPNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState,
+              jnxMbgPgwSMSPICName    
+            }
+    STATUS    deprecated 
+    DESCRIPTION
+        "Subscriber Threshold Per SPIC."      
+    ::= { jnxMbgPgwSMNotifications 7 } 
+
+jnxMbgPgwSMSessionEstFailThresPerSPNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState,
+              jnxMbgPgwSMSessionEstFailReason,
+              jnxMbgPgwSMSPICName    
+            }
+    STATUS    deprecated 
+    DESCRIPTION
+        "Session Establishment Failure Threshold."      
+    ::= { jnxMbgPgwSMNotifications 8 } 
+
+jnxMbgPgwSMSessionEstFailThresPerTCNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState,
+              jnxMbgPgwSMSessionEstFailReason,
+              jnxMbgPgwSMTCName     
+            }
+    STATUS    deprecated
+    DESCRIPTION
+        "Session Establishment Failure Threshold 
+         Per Traffic Class (GTPv1)."      
+    ::= { jnxMbgPgwSMNotifications 9 } 
+
+jnxMbgPgwSMSessionEstFailThresPerQCINotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState,
+              jnxMbgPgwSMSessionEstFailReason,
+              jnxMbgPgwSMQCIName     
+            }
+    STATUS    deprecated
+    DESCRIPTION
+        "Session Establishment Failure Threshold 
+         per QoS Class Identifier."      
+    ::= { jnxMbgPgwSMNotifications 10 } 
+
+jnxMbgPgwSMBearersThresGblNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState    
+            }
+    STATUS    deprecated
+    DESCRIPTION
+        "Bearer Threshold Global."      
+    ::= { jnxMbgPgwSMNotifications 11 } 
+
+jnxMbgPgwSMBearersThresPerSPNotif NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwSMAlarmThrshld,
+              jnxMbgPgwSMAlarmState,
+              jnxMbgPgwSMSPICName    
+            }
+    STATUS    deprecated
+    DESCRIPTION
+        "Bearer Threshold Per SPIC."      
+    ::= { jnxMbgPgwSMNotifications 12 } 
+
+jnxMbgPgwGatewayMMStateChange NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwMMGatewayName,
+              jnxMbgPgwPrevGatewayMMState,
+              jnxMbgPgwNewGatewayMMState 
+            }
+    STATUS    current
+    DESCRIPTION
+        "This notification indicates that the Gateway identified by
+         jnxMbgPgwGatewayName undergoes a change in the maintenance 
+         mode state."
+    ::= { jnxMbgPgwSMNotifications 13 }
+
+jnxMbgPgwAPNMMStateChange NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwAPNMMGatewayName,
+              jnxMbgPgwAPNMMAPNName,
+              jnxMbgPgwPrevAPNMMState,
+              jnxMbgPgwNewAPNMMState 
+            }
+    STATUS     current
+    DESCRIPTION
+        "This notification indicates that the APN identified by 
+         jnxMbgPgwAPNMMGatewayName and jnxMbgPgwAPNMMAPNName undergoes 
+         a change in the maintenance mode state."
+    ::= { jnxMbgPgwSMNotifications 14 }
+
+
+--------------------------------------------------
+-- PGW Notifications - Individual Levels 
+--------------------------------------------------
+
+jnxMbgPgwQosBrThreshStatusHi NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the configured high threshold
+         for bearers at gateway level are reached. The gateway name and id
+         identifies the notifying gateway"
+    ::= { jnxMbgPgwSMNotifications 15 }
+
+jnxMbgPgwQosBrThreshStatusLow NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the configured low threshold
+         for bearers at gateway level are reached. The gateway name and id
+         identifies the notifying gateway"
+    ::= { jnxMbgPgwSMNotifications 16 }
+
+jnxMbgPgwQosBrThreshStatusClear NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the normal threshold 
+         for bearers at gateway level are reached. The gateway name and id
+         identifies the notifying gateway"
+    ::= { jnxMbgPgwSMNotifications 17 }
+
+
+jnxMbgPgwQosCPUThreshStatusHi NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the configured high threshold
+         for CPU Utilization has been reached. The gateway name and id identifies the
+         notifying gateway."
+    ::= { jnxMbgPgwSMNotifications 18 }
+
+jnxMbgPgwQosCPUThreshStatusLow NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the configured low threshold
+         for CPU Utilization has been reached. The gateway name and id identifies the
+         notifying gateway."
+    ::= { jnxMbgPgwSMNotifications 19 }
+
+jnxMbgPgwQosCPUThreshStatusClear NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the normal threshold 
+         for CPU Utilization has been reached. The gateway name and id identifies the
+         notifying gateway."
+    ::= { jnxMbgPgwSMNotifications 20 }
+
+
+jnxMbgPgwQosMemThreshStatusHi NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the configured high threshold
+         for Memory Utilization has been reached. The gateway name and id identifies the
+         notifying gateway."
+    ::= { jnxMbgPgwSMNotifications 21 }
+
+jnxMbgPgwQosMemThreshStatusLow NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the configured low threshold
+         for Memory Utilization has been reached. The gateway name and id identifies the
+         notifying gateway."
+    ::= { jnxMbgPgwSMNotifications 22 }
+
+jnxMbgPgwQosMemThreshStatusClear NOTIFICATION-TYPE
+    OBJECTS { 
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName
+            }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the normal threshold
+         for Memory Utilization has been reached. The gateway name and id identifies the
+         notifying gateway."
+    ::= { jnxMbgPgwSMNotifications 23 }
+
+jnxMbgPgwSMGtpEvntNotif NOTIFICATION-TYPE
+    OBJECTS {
+              jnxMbgPgwTrapGwIndex,
+              jnxMbgPgwTrapGwName,
+              jnxMbgPgwSMGTPEventType,
+              jnxMbgPgwSMGTPEventCause 
+            }
+    STATUS          current
+    DESCRIPTION
+        "Subscriber Management GTP Event Notify"      
+    ::= { jnxMbgPgwSMNotifications 24 } 
+
+jnxMbgPgwPFEMMStateChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwTrapGwIndex,
+                  jnxMbgPgwAPNMMGatewayName,
+                  jnxMbgPgwSMInterfaceName,
+                  jnxMbgPgwPrevAPNMMState,
+                  jnxMbgPgwNewAPNMMState }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates change in the maintenance mode state
+         for a PFE.  The gateway name, PFE interface name, interface previous state and 
+         new state information are included in the trap."
+    ::= { jnxMbgPgwSMNotifications 25 }
+
+jnxMbgPgwMSMMStateChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwTrapGwIndex,
+                  jnxMbgPgwAPNMMGatewayName,
+                  jnxMbgPgwSMInterfaceName,
+                  jnxMbgPgwPrevAPNMMState,
+                  jnxMbgPgwNewAPNMMState }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates change in the maintenance mode state
+         for a SPIC. The gateway name, interface name, interface 
+         previous state and new state information are included in the trap."
+    ::= { jnxMbgPgwSMNotifications 26 }
+
+jnxMbgPgwAPFEMMStateChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwTrapGwIndex,
+                  jnxMbgPgwAPNMMGatewayName,
+                  jnxMbgPgwSMInterfaceName,
+                  jnxMbgPgwPrevAPNMMState,
+                  jnxMbgPgwNewAPNMMState }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates a change in the maintenance mode state 
+         for an APFE. The gateway name, interface name, interface previous state 
+         and new state information are included in the trap."
+    ::= { jnxMbgPgwSMNotifications 27 }
+jnxMbgPgwAMSMMStateChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwTrapGwIndex,
+                  jnxMbgPgwAPNMMGatewayName,
+                  jnxMbgPgwSMInterfaceName,
+                  jnxMbgPgwPrevAPNMMState,
+                  jnxMbgPgwNewAPNMMState }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates a change in the maintenance mode state 
+         for an AMS. The gateway name, interface name, interface 
+         previous state and new state information are included in the trap."
+    ::= { jnxMbgPgwSMNotifications 28 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-charging.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-charging.txt
@@ -1,0 +1,1355 @@
+-- JUNIPER-MOBILITY-CHARGING-MIB 
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILITY-CHARGING-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+     Counter32,  Counter64, Gauge32, Integer32, Unsigned32, IpAddress
+        FROM SNMPv2-SMI
+    TruthValue
+        FROM SNMPv2-TC
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS
+
+    jnxMobileGatewayPgwGgsn
+        FROM JUNIPER-MBG-SMI;
+
+jnxMbgPgwChargingMib MODULE-IDENTITY
+    LAST-UPDATED        "201006151430Z" -- Tue Jun 15 14:30:00 2010 UTC
+    ORGANIZATION        "Juniper Networks, Inc."
+    CONTACT-INFO
+                        "Juniper Technical Assistance Center
+                        Juniper Networks, Inc.
+                        1194 N. Mathilda Avenue
+                        Sunnyvale, CA 94089
+                        E-mail: support@juniper.net"
+
+    DESCRIPTION
+         "This is Juniper Networks implementation of Mobility Charging MIB for 
+    PGW (Packet Data Networks Gateway ) in 3GPP LTE network  and the 
+    Gateway GPRS Support Node (GGSN) in the 3GPP 3G Network."
+    -- revision history --
+        REVISION "201006151430Z"    -- 15 June, 2010
+        DESCRIPTION
+                "Initial version."
+
+        REVISION "201110101430Z"    -- 10 Oct, 2011
+        DESCRIPTION
+                "CGF group and CGF tables index keys has changed to 
+                gateway id and profile id. Gateway id and gateway name has 
+                added to all the traps."
+    
+    REVISION "201203161430Z"    -- 16 March, 2012
+    DESCRIPTION
+                "GGSN/PGW Charging global statistics table has added."
+	::= { jnxMobileGatewayPgwGgsn 3 }
+
+jnxMbgPgwCgNotifications      OBJECT IDENTIFIER ::= { jnxMbgPgwChargingMib 0 }
+jnxMbgPgwChargingObjects      OBJECT IDENTIFIER ::= { jnxMbgPgwChargingMib 1 }
+jnxMbgPgwCgLcStorageStats     OBJECT IDENTIFIER ::= { 
+                                              jnxMbgPgwChargingObjects 1 }
+jnxMbgPgwCgCgfGroupsStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgPgwCgCgfGrpStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+       "A table listing the stats for all (Charging Gateway Function) CGF 
+        Groups configured on the PGW."
+   ::= { jnxMbgPgwChargingObjects 2 }
+
+jnxMbgPgwCgNotificationVars   OBJECT IDENTIFIER ::= { 
+                                             jnxMbgPgwChargingObjects 3 }
+jnxMbgPgwCgCgfStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgPgwCgCgfStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the statistics for all CGF configured on the PGW."
+   ::= { jnxMbgPgwChargingObjects 4 }
+
+
+jnxMbgPgwCgLpsStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF  JnxMbgPgwCgLpsStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+       "A table listing the stats for all Local persistent storage stats 
+        configured on the PGW."
+   ::= { jnxMbgPgwChargingObjects 5 }
+
+jnxMbgPgwCgTspStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgPgwCgTspStatsEntry
+   MAX-ACCESS    not-accessible
+
+   STATUS        current
+   DESCRIPTION 
+       "A table listing the stats for all (Charging Gateway Function) CGF 
+        Groups configured on the PGW."
+   ::= { jnxMbgPgwChargingObjects 6 }
+
+jnxMbgPgwCgPeerStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgPgwCgPeerStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A table listing the statistics for all CGF configured on the PGW."
+   ::= { jnxMbgPgwChargingObjects 7 }
+
+jnxMbgPgwCgGlobalStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgPgwCgGlobalStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A table listing the charging global statistics of the PGW."
+   ::= { jnxMbgPgwChargingObjects 8 }
+
+--
+-- Local Storage Stats
+--
+jnxMbgPgwCgFilesOnLcStorage OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only 
+   STATUS        obsolete
+   DESCRIPTION
+         "The number of Files containing Charging Data Records (CDRs) present 
+          on the Local Storage Device.Incremented when a file containing CDRs 
+          is closed on the Local storage device Decremented when sftp is done 
+          and a file is removed from the Local storage device"
+   ::= { jnxMbgPgwCgLcStorageStats 1 }
+
+jnxMbgPgwCgLcStorageAvailSpace OBJECT-TYPE
+   SYNTAX        Counter64 
+   UNITS         "MBytes"
+   MAX-ACCESS    read-only
+   STATUS        obsolete
+   DESCRIPTION
+         "The space available on the Local Storage Device in MB."
+   ::= { jnxMbgPgwCgLcStorageStats 2 }
+
+--
+-- CG LPS Stats
+--
+
+jnxMbgPgwCgLpsStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgPgwCgLpsStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          LPS configured on the PGW."
+   INDEX         { jnxMbgGwIndex }
+   ::= { jnxMbgPgwCgLpsStatsTable 1 }
+
+JnxMbgPgwCgLpsStatsEntry ::= SEQUENCE {
+   jnxMbgPgwCgLpsFilesOnLcStorage      Gauge32,
+   jnxMbgPgwCgLpsStorageAvailSpace     Gauge32
+}
+
+jnxMbgPgwCgLpsFilesOnLcStorage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Files containing Charging Data Records (CDRs) present 
+          on the Local Storage Device.Incremented when a file containing CDRs 
+          is closed on the Local storage device Decremented when sftp is done 
+          and a file is removed from the Local storage device"
+   ::= { jnxMbgPgwCgLpsStatsEntry 1 }
+
+jnxMbgPgwCgLpsStorageAvailSpace OBJECT-TYPE
+   SYNTAX        Gauge32 
+   UNITS         "MBytes"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The space available on the Local Storage Device in MB."
+   ::= { jnxMbgPgwCgLpsStatsEntry 2 }
+
+--
+-- CGF Group Stats
+--
+jnxMbgPgwCgCgfGroupStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgPgwCgCgfGrpStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete 
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          CGF Server configured on the PGW."
+   INDEX         { jnxMbgPgwCgCgfGrpProfName }
+   ::= { jnxMbgPgwCgCgfGroupsStatsTable 1 }
+
+JnxMbgPgwCgCgfGrpStatsEntry ::= SEQUENCE {
+   jnxMbgPgwCgCgfGrpProfName          DisplayString,
+   jnxMbgPgwCgCgfGrpDRTReqTx          Counter32,
+   jnxMbgPgwCgCgfGrpDRTReqRx          Counter32,
+   jnxMbgPgwCgCgfGrpDRTReqTmout       Counter32,
+   jnxMbgPgwCgCgfGrpDRTSucRspRx       Counter32,
+   jnxMbgPgwCgCgfGrpDRTErrRspRx       Counter32,
+   jnxMbgPgwCgCgfGrpRediReqRx         Counter32,
+   jnxMbgPgwCgCgfGrpRediRspTx         Counter32,
+   jnxMbgPgwCgCgfGrpSwitchovers       Counter32,
+   jnxMbgPgwCgCgfGrpBatchReqTx        Counter32,
+   jnxMbgPgwCgCgfGrpBatchRspErrors    Counter32,
+   jnxMbgPgwCgCgfGrpBatchCDRsTx       Counter32,
+   jnxMbgPgwCgCgfGroupTotalWFA        Counter32
+}
+
+jnxMbgPgwCgCgfGrpProfName OBJECT-TYPE
+    SYNTAX      DisplayString  (SIZE (0..127)) 
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the CGF group profile."
+    ::= { jnxMbgPgwCgCgfGroupStatsEntry 1 }
+
+jnxMbgPgwCgCgfGrpDRTReqTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT (Detailed Record Time) request transmitted 
+         for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 2 }
+
+jnxMbgPgwCgCgfGrpDRTReqRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT request received for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 3 }
+
+jnxMbgPgwCgCgfGrpDRTReqTmout OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT request timeouts happend for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 4 }
+
+jnxMbgPgwCgCgfGrpDRTSucRspRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total number of the DRT success responses received"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 5 }
+
+jnxMbgPgwCgCgfGrpDRTErrRspRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT error responses received for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 6 }
+
+jnxMbgPgwCgCgfGrpRediReqRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        "Total number of the redirection responses received for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 7 }
+
+jnxMbgPgwCgCgfGrpRediRspTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the redirection responses transmitted for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 8 }
+
+jnxMbgPgwCgCgfGrpSwitchovers OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the switch overs on the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 9 }
+
+jnxMbgPgwCgCgfGrpBatchReqTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the batch req transmitted for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 10 }
+
+jnxMbgPgwCgCgfGrpBatchRspErrors OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Tatal number of the batch response errors for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 11 }
+
+jnxMbgPgwCgCgfGrpBatchCDRsTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total number of the batch CDRs transmitted for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 12 }
+
+jnxMbgPgwCgCgfGroupTotalWFA OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total WFA available for the CGF group"
+   ::= { jnxMbgPgwCgCgfGroupStatsEntry 13 }
+
+-- CGF Group Stats
+--
+jnxMbgPgwCgTspStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgPgwCgTspStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          CGF Server configured on the PGW."
+   INDEX         { jnxMbgGwIndex, jnxMbgPgwCgTspProfId }
+   ::= { jnxMbgPgwCgTspStatsTable 1 }
+
+JnxMbgPgwCgTspStatsEntry ::= SEQUENCE {
+   jnxMbgPgwCgTspProfId            Unsigned32,
+   jnxMbgPgwCgTspDRTReqTx          Counter32,
+   jnxMbgPgwCgTspDRTReqTmout       Counter32,
+   jnxMbgPgwCgTspDRTSucRspRx       Counter32,
+   jnxMbgPgwCgTspDRTErrRspRx       Counter32,
+   jnxMbgPgwCgTspRediReqRx         Counter32,
+   jnxMbgPgwCgTspRediRspTx         Counter32,
+   jnxMbgPgwCgTspSwitchovers       Counter32,
+   jnxMbgPgwCgTspBatchReqTx        Counter32,
+   jnxMbgPgwCgTspBatchRspErrors    Counter32,
+   jnxMbgPgwCgTspBatchCDRsTx       Counter32,
+   jnxMbgPgwCgTspTotalWFA          Counter32,
+   jnxMbgPgwCgTspProfName          DisplayString
+}
+
+jnxMbgPgwCgTspProfId OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+        "This will identify the CGF Group profile id uniquely and used as 
+         secondary key for CGF group table"
+   ::= { jnxMbgPgwCgTspStatsEntry 1 }
+
+jnxMbgPgwCgTspDRTReqTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT (Detailed Record Time) request transmitted 
+         for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 2}
+
+jnxMbgPgwCgTspDRTReqTmout OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT request timeouts happend for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 3 }
+
+jnxMbgPgwCgTspDRTSucRspRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the DRT success responses received"
+   ::= { jnxMbgPgwCgTspStatsEntry 4 }
+
+jnxMbgPgwCgTspDRTErrRspRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT error responses received for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 5 }
+
+jnxMbgPgwCgTspRediReqRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the redirection responses received for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 6 }
+
+jnxMbgPgwCgTspRediRspTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the redirection responses transmitted 
+         for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 7}
+
+jnxMbgPgwCgTspSwitchovers OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the switch overs on the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 8 }
+
+jnxMbgPgwCgTspBatchReqTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the batch req transmitted for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 9 }
+
+jnxMbgPgwCgTspBatchRspErrors OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Tatal number of the batch response errors for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 10 }
+
+jnxMbgPgwCgTspBatchCDRsTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total number of the batch CDRs transmitted for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 11 }
+
+jnxMbgPgwCgTspTotalWFA OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total WFA available for the CGF group"
+   ::= { jnxMbgPgwCgTspStatsEntry 12 }
+
+jnxMbgPgwCgTspProfName OBJECT-TYPE
+    SYNTAX      DisplayString 
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the TSP Profile."
+    ::= { jnxMbgPgwCgTspStatsEntry 13 }
+
+--
+-- CGF Stats
+--
+
+jnxMbgPgwCgCgfStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgPgwCgCgfStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete 
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          CGF Server configured on the PGW."
+   INDEX         { jnxMbgPgwCgCgfIndex }
+   ::= { jnxMbgPgwCgCgfStatsTable 1 }
+
+JnxMbgPgwCgCgfStatsEntry ::= SEQUENCE {
+   jnxMbgPgwCgCgfProfName          DisplayString,
+   jnxMbgPgwCgCgfIndex             Integer32,
+   jnxMbgPgwCgCgfIpAddress         IpAddress,
+   jnxMbgPgwCgCgfStatus            INTEGER,
+   jnxMbgPgwCgCgfUpDuration        Counter64,
+   jnxMbgPgwCgCgfDownDuration      Counter64,
+   jnxMbgPgwCgCgfEchoReqTx         Counter64, 
+   jnxMbgPgwCgCgfEchoReqRx         Counter64,
+   jnxMbgPgwCgCgfEchoReqTmout      Counter64, 
+   jnxMbgPgwCgCgfEchoRespTx        Counter64,
+   jnxMbgPgwCgCgfEchoRespRx        Counter64,
+   jnxMbgPgwCgCgfVerUnsuppTx       Counter64,
+   jnxMbgPgwCgCgfVerUnsuppRx       Counter64,
+   jnxMbgPgwCgCgfNodeAliveReqTx    Counter64,
+   jnxMbgPgwCgCgfNodeAliveReqRx    Counter64,
+   jnxMbgPgwCgCgfNodeAliveReqTmout Counter64,
+   jnxMbgPgwCgCgfNodeAliveRespTx   Counter64,
+   jnxMbgPgwCgCgfNodeAliveRespRx   Counter64,
+   jnxMbgPgwCgCgfRedirectReqRx     Counter64,
+   jnxMbgPgwCgCgfRedirectRespTx    Counter64, 
+   jnxMbgPgwCgCgfDRTReqTx          Counter64,
+   jnxMbgPgwCgCgfDRTReqTmout       Counter64,
+   jnxMbgPgwCgCgfDRTSuccRespRx     Counter64,
+   jnxMbgPgwCgCgfDRTErrRespRx      Counter64,
+   jnxMbgPgwCgCgfCdrTx             Counter64,
+   jnxMbgPgwCgCgfDRTRTTMean        Counter64,
+   jnxMbgPgwCgCgfDRTRTTMin         Counter64,
+   jnxMbgPgwCgCgfDRTRTTMax         Counter64,
+   jnxMbgPgwCgCgfTransToDownState  Counter64,
+   jnxMbgPgwCgCgfContainers        Counter64
+}
+
+jnxMbgPgwCgCgfProfName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..127)) 
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the CGF Profile."
+    ::= { jnxMbgPgwCgCgfStatsEntry 1 }
+
+jnxMbgPgwCgCgfIndex OBJECT-TYPE
+   SYNTAX        Integer32 (1..48)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A number representing each CGF Server whose statistics
+          is being generated."
+   ::= { jnxMbgPgwCgCgfStatsEntry 2 }
+
+jnxMbgPgwCgCgfIpAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "CGF Server IP-address."
+   ::= { jnxMbgPgwCgCgfStatsEntry 3 }
+
+jnxMbgPgwCgCgfStatus OBJECT-TYPE
+   SYNTAX        INTEGER {
+        up(1),     -- server is up
+        down(2)     -- server is not reachable or unconfigured
+   }
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION 
+         "This indicates the state of the CGF Server i.e UP or DOWN."
+   ::= { jnxMbgPgwCgCgfStatsEntry 4 }
+
+jnxMbgPgwCgCgfUpDuration OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "minutes"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total duration in minutes for which the CGF Server
+                  was in UP State."
+   ::= { jnxMbgPgwCgCgfStatsEntry 5 }
+
+jnxMbgPgwCgCgfDownDuration OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "minutes"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total duration in minutes for which the CGF Server 
+                  was in DOWN State."
+   ::= { jnxMbgPgwCgCgfStatsEntry 6 }
+
+jnxMbgPgwCgCgfEchoReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests transmitted to the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 7 }
+
+jnxMbgPgwCgCgfEchoReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests received from the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 8 }
+
+jnxMbgPgwCgCgfEchoReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests to the CGF Server that 
+                  timed out."
+   ::= { jnxMbgPgwCgCgfStatsEntry 9 }
+
+jnxMbgPgwCgCgfEchoRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Responses transmitted to the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 10 }
+
+jnxMbgPgwCgCgfEchoRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Responses received from the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 11 }
+
+jnxMbgPgwCgCgfVerUnsuppTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Version Unsupported messages transmitted to 
+                 the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 12 }
+
+jnxMbgPgwCgCgfVerUnsuppRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Version Unsupported messages received 
+                 from the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 13 }
+
+jnxMbgPgwCgCgfNodeAliveReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Requests transmitted to the
+                  CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 14 }
+
+jnxMbgPgwCgCgfNodeAliveReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Requests received from 
+                  the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 15 }
+
+jnxMbgPgwCgCgfNodeAliveReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Requests to the CGF Server 
+                  that timed out."
+   ::= { jnxMbgPgwCgCgfStatsEntry 16 }
+
+jnxMbgPgwCgCgfNodeAliveRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Responses transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 17 }
+
+jnxMbgPgwCgCgfNodeAliveRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Responses received from 
+                  the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 18 }
+
+jnxMbgPgwCgCgfRedirectReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Redirect Requests received from 
+                  the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 19 }
+
+jnxMbgPgwCgCgfRedirectRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Redirect Responses transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 20 }
+
+jnxMbgPgwCgCgfDRTReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Requests transmitted to 
+                  the CGF Server.This includes the retransmission counts also."
+   ::= { jnxMbgPgwCgCgfStatsEntry 21 }
+
+jnxMbgPgwCgCgfDRTReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Requests to the CGF  
+                 Server that timed out after the configured number of retries."
+   ::= { jnxMbgPgwCgCgfStatsEntry 22 }
+
+jnxMbgPgwCgCgfDRTSuccRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Responses indicating 
+                  success received from the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 23 }
+
+jnxMbgPgwCgCgfDRTErrRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Responses indicating 
+                  error received from the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 24 }
+
+
+jnxMbgPgwCgCgfCdrTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Call Data Records (CDRs) transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 25 }
+
+jnxMbgPgwCgCgfDRTRTTMean OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "seconds"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Mean Round Trip Time of the Data Record Transfer Request and Response 
+         to and from the CGF Server in seconds. This is calculated from the 
+         average of the minimum and maximum round trip times of the Data Record 
+         Transfer Request. This is applicable for CGF Servers which are 
+         connected via UDP protocol."
+   ::= { jnxMbgPgwCgCgfStatsEntry 26 }
+
+jnxMbgPgwCgCgfDRTRTTMin OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "seconds"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Minimum Round Trip Time of the Data Record Transfer Request and 
+        Response to and from the CGF Server in seconds. This is 
+        applicable for CGF Servers which are connected via UDP protocol."
+   ::= { jnxMbgPgwCgCgfStatsEntry 27 }
+
+jnxMbgPgwCgCgfDRTRTTMax OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "seconds"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Maximum Round Trip Time of the Data Record Transfer Request and 
+         Response to and from the CGF Server in seconds.This is 
+         applicable for CGF Servers which are connected via UDP protocol."
+   ::= { jnxMbgPgwCgCgfStatsEntry 28 }
+
+jnxMbgPgwCgCgfTransToDownState OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of transitions of the CGF Server to 
+                  the DOWN state."
+   ::= { jnxMbgPgwCgCgfStatsEntry 29 }
+
+jnxMbgPgwCgCgfContainers OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of closed containers to the CGF Server."
+   ::= { jnxMbgPgwCgCgfStatsEntry 30 }
+
+--
+-- CGF Stats
+--
+
+jnxMbgPgwCgPeerStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgPgwCgPeerStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          CGF Server configured on the PGW."
+   INDEX         { jnxMbgGwIndex, jnxMbgPgwCgPeerIndex }
+   ::= { jnxMbgPgwCgPeerStatsTable 1 }
+
+JnxMbgPgwCgPeerStatsEntry ::= SEQUENCE {
+   jnxMbgPgwCgPeerIndex             Unsigned32,
+   jnxMbgPgwCgPeerIpAddress         IpAddress,
+   jnxMbgPgwCgPeerStatus            INTEGER,
+   jnxMbgPgwCgPeerEchoReqTx         Counter64, 
+   jnxMbgPgwCgPeerEchoReqRx         Counter64,
+   jnxMbgPgwCgPeerEchoReqTmout      Counter64, 
+   jnxMbgPgwCgPeerEchoRespTx        Counter64,
+   jnxMbgPgwCgPeerEchoRespRx        Counter64,
+   jnxMbgPgwCgPeerVerUnsuppTx       Counter64,
+   jnxMbgPgwCgPeerVerUnsuppRx       Counter64,
+   jnxMbgPgwCgPeerNodeAliveReqRx    Counter64,
+   jnxMbgPgwCgPeerNodeAliveRespTx   Counter64,
+   jnxMbgPgwCgPeerRedirectReqRx     Counter64,
+   jnxMbgPgwCgPeerRedirectRespTx    Counter64, 
+   jnxMbgPgwCgPeerDRTReqTx          Counter64,
+   jnxMbgPgwCgPeerDRTSuccRespRx     Counter64,
+   jnxMbgPgwCgPeerDRTErrRespRx      Counter64,
+   jnxMbgPgwCgPeerProfileName       DisplayString 
+}
+
+jnxMbgPgwCgPeerIndex OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A number representing each CGF Server whose statistics
+          is being generated."
+   ::= { jnxMbgPgwCgPeerStatsEntry 1 }
+
+jnxMbgPgwCgPeerIpAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "CGF Server IP-address."
+   ::= { jnxMbgPgwCgPeerStatsEntry 2 }
+
+jnxMbgPgwCgPeerStatus OBJECT-TYPE
+   SYNTAX        INTEGER {
+        up(1),     -- server is up
+        down(2)     -- server is not reachable or unconfigured
+   }
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION 
+         "This indicates the state of the CGF Server i.e UP or DOWN."
+   ::= { jnxMbgPgwCgPeerStatsEntry 3 }
+
+jnxMbgPgwCgPeerEchoReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests transmitted to the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 4 }
+
+jnxMbgPgwCgPeerEchoReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests received from the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 5 }
+
+jnxMbgPgwCgPeerEchoReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests to the CGF Server that 
+                  timed out."
+   ::= { jnxMbgPgwCgPeerStatsEntry 6 }
+
+jnxMbgPgwCgPeerEchoRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Responses transmitted to the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 7 }
+
+jnxMbgPgwCgPeerEchoRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Responses received from the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 8 }
+
+jnxMbgPgwCgPeerVerUnsuppTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Version Unsupported messages transmitted to 
+                 the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 9 }
+
+jnxMbgPgwCgPeerVerUnsuppRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Version Unsupported messages received 
+                 from the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 10 }
+
+jnxMbgPgwCgPeerNodeAliveReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Requests received from 
+                  the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 11 }
+
+jnxMbgPgwCgPeerNodeAliveRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Responses transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 12 }
+
+jnxMbgPgwCgPeerRedirectReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Redirect Requests received from 
+                  the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 13 }
+
+jnxMbgPgwCgPeerRedirectRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Redirect Responses transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 14 }
+
+jnxMbgPgwCgPeerDRTReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Requests transmitted to 
+                  the CGF Server.This includes the retransmission counts also."
+   ::= { jnxMbgPgwCgPeerStatsEntry 15 }
+
+jnxMbgPgwCgPeerDRTSuccRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Responses indicating 
+                  success received from the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 16 }
+
+jnxMbgPgwCgPeerDRTErrRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Responses indicating 
+                  error received from the CGF Server."
+   ::= { jnxMbgPgwCgPeerStatsEntry 17 }
+
+jnxMbgPgwCgPeerProfileName OBJECT-TYPE
+    SYNTAX      DisplayString 
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the CGF Peer Profile."
+    ::= { jnxMbgPgwCgPeerStatsEntry 18 }
+
+ jnxMbgPgwCgGlobalStatsEntry OBJECT-TYPE
+   SYNTAX       JnxMbgPgwCgGlobalStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          PGW charging global statistics."
+   INDEX         { jnxMbgGwIndex }
+   ::= { jnxMbgPgwCgGlobalStatsTable 1 }
+
+JnxMbgPgwCgGlobalStatsEntry ::= SEQUENCE {
+   jnxMbgPgwCgCdrSendErrors           Counter64,
+   jnxMbgPgwCgCdrEncodeErrors         Counter64,
+   jnxMbgPgwCgCdrAllocFailures        Counter64,
+   jnxMbgPgwCgContFailures            Counter64,
+   jnxMbgPgwCgCmBearersCreated        Counter64,
+   jnxMbgPgwCgCmBearersDeleted        Counter64
+}
+
+--Charging Global Stats*/
+jnxMbgPgwCgCdrSendErrors OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of CDR send errors to charging module" 
+   ::= { jnxMbgPgwCgGlobalStatsEntry 1 }
+
+jnxMbgPgwCgCdrEncodeErrors OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of CDR (charging data record) encoding errors." 
+   ::= { jnxMbgPgwCgGlobalStatsEntry 2 }
+
+jnxMbgPgwCgCdrAllocFailures OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of CDR memory allocation failures."
+   ::= { jnxMbgPgwCgGlobalStatsEntry 3 }
+
+jnxMbgPgwCgContFailures OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of container failures."
+   ::= { jnxMbgPgwCgGlobalStatsEntry 4 }
+
+jnxMbgPgwCgCmBearersCreated OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number bearers created."
+   ::= { jnxMbgPgwCgGlobalStatsEntry 5 }
+
+jnxMbgPgwCgCmBearersDeleted OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of bearers deleted."
+   ::= { jnxMbgPgwCgGlobalStatsEntry 6 }
+
+jnxMbgPgwCgServerName OBJECT-TYPE
+    SYNTAX      DisplayString  (SIZE (0..31))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "A string that uniquely identifies the CGF server name."
+   ::= { jnxMbgPgwCgNotificationVars 1 }
+
+jnxMbgPgwCgServicePicName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..31))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "This identifies the session-pic, in the form ms-a/b/0, 
+     where <a> is the slot and <b> could be either 0 or 1."
+   ::= { jnxMbgPgwCgNotificationVars 2 }
+
+jnxMbgPgwCgCDRDest OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      cdrcgf       (1),    
+                      cdrbackup    (2),    
+                      cdrnobackup  (3) }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION 
+"This indicates any transisitions in the state of the CGF.
+Value 1 indicates one of the CGF for the Group came up. Redirecting CDRs to the Active CGF.
+Value 2 indicates last active CGF for the Group went down. CDRs being written to backup Local storage device.
+Value 3 indicates last active CGF for the Group went down. Backup Local storage device not configured."
+   ::= { jnxMbgPgwCgNotificationVars 3 }
+
+jnxMbgPgwCgActiveCgfIpAddr OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    accessible-for-notify
+   STATUS        current
+   DESCRIPTION   "CGF Server IP-address."
+   ::= { jnxMbgPgwCgNotificationVars 4 }
+
+jnxMbgPgwCgTSPName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..31)) 
+    MAX-ACCESS  accessible-for-notify
+    STATUS       deprecated
+    DESCRIPTION
+        "A string that uniquely identifies the Transport Profile."
+    ::= { jnxMbgPgwCgNotificationVars 5 }
+
+jnxMbgPgwCgMemLimit OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      memfulldisconnectnew          (1),
+                      memfulldisconnectnewrslvd     (2),
+                      memfulldisconnectexistnew     (3),
+                      memfulldisconnectexistnewrslvd(4)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION 
+"This indicates any transisitions in the state of the CGF.
+Value 1 indicates System has reached Level 1 critical memory threshold. 
+Action - Check the CGF server connections. If local storage is enabled,
+         please ftp the charging records immediately.
+         If local storage is not enabled, please enable it so the
+         charging records can be stored in local persistent storage. 
+Risk -  No new sessions will be allowed.
+Value 2 indicates System reaching Level 1 critical memory threshold
+        condition has been resolved.
+Value 3 indicates System has reached Level 2 critical memory threshold.
+Action - Check the CGF server connections. If local storage is enabled,
+         please ftp the charging records immediately.
+         If local storage is not enabled, please enable it so the
+         charging records can be stored in local persistent storage.
+Risk -  New and existing sessions will be not be allowed.
+Value 4 indicates System reaching Level 2 critical memory threshold
+        condition has been resolved."
+    ::= { jnxMbgPgwCgNotificationVars 6 }
+
+jnxMbgPgwCgLcsSpace OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      localstoragememlevel1     (1),
+                      localstoragememlevel2     (2),
+                      localstoragememlevel3     (3)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current 
+    DESCRIPTION
+    "Water marking for the local storage levels in charged of RE."
+   ::= { jnxMbgPgwCgNotificationVars 7 }
+
+jnxMbgPgwCgLcsUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The percentage of the total of Local Storage
+         Space by one the Charged on RE"
+        ::= { jnxMbgPgwCgNotificationVars 8 }
+
+jnxMbgPgwCgAlarmStatus OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      raised	    (1),
+                      cleared	    (2)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current 
+    DESCRIPTION
+    "Value 1 indicates that the Alarm for a particular condition is present.
+    Value 2 indicates that the Alarm for a particular condition is absent."
+   ::= { jnxMbgPgwCgNotificationVars 9 }
+
+jnxMbgPgwCgProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "A string that identifies a charging profile ."
+    ::= { jnxMbgPgwCgNotificationVars 10 }
+
+jnxMbgPgwCgPrevMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwCgNotificationVars 11 }
+
+jnxMbgPgwCgNewMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwCgNotificationVars 12 }
+
+jnxMbgPgwCgTProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "A string that identifies a charging profile ."
+    ::= { jnxMbgPgwCgNotificationVars 13 }
+
+jnxMbgPgwCgTPrevMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwCgNotificationVars 14 }
+
+jnxMbgPgwCgTNewMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgPgwCgNotificationVars 15 }
+
+jnxMbgPgwCgPeerProfName OBJECT-TYPE
+  SYNTAX      DisplayString  
+  MAX-ACCESS  accessible-for-notify
+  STATUS      current
+  DESCRIPTION
+    "A string that uniquely identifies the CGF Profile."
+  ::= { jnxMbgPgwCgNotificationVars 16 }
+
+jnxMbgPgwCgGtpGWUpNotif NOTIFICATION-TYPE
+     OBJECTS          { jnxMbgPgwCgServerName, 
+                        jnxMbgPgwCgServicePicName }
+     STATUS             deprecated 
+     DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked alive.  The ServerName identifies the server and the
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgPgwCgNotifications 1 }
+
+jnxMbgPgwCgGtpGWDownNotif NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwCgServerName, 
+                  jnxMbgPgwCgServicePicName }
+    STATUS        deprecated
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked dead.  The ServerName identifies the server and the
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgPgwCgNotifications 2 }
+
+jnxMbgPgwCgCDRDestNotif NOTIFICATION-TYPE
+    OBJECTS	    { jnxMbgPgwCgCDRDest,
+		      jnxMbgPgwCgTSPName,
+		      jnxMbgPgwCgActiveCgfIpAddr }
+    STATUS            deprecated
+    DESCRIPTION
+          "This signifies change in the destination of the CDRs 
+           (Charging Data Record)"        
+    ::= { jnxMbgPgwCgNotifications 3 } 
+
+jnxMbgPgwCgMemThresNotif NOTIFICATION-TYPE
+    OBJECTS	{   jnxMbgPgwCgAlarmStatus,
+                    jnxMbgPgwCgMemLimit,
+		    jnxMbgPgwCgTSPName,
+		    jnxMbgPgwCgServicePicName }
+    STATUS          deprecated
+    DESCRIPTION
+        "This signifies the internal memory unavalability in the system."
+      ::= { jnxMbgPgwCgNotifications 4 } 
+
+jnxMbgPgwCgLcsThresNotif NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgPgwCgLcsSpace, 
+                   jnxMbgPgwCgLcsUtil  }
+    STATUS          deprecated
+    DESCRIPTION
+          "This signifies the memory unavailability in the local storage in 
+            the system."
+    ::= { jnxMbgPgwCgNotifications 5 }
+
+jnxMbgPgwCgServiceUpNotif NOTIFICATION-TYPE
+    OBJECTS	{  jnxMbgPgwCgServicePicName } 
+    STATUS         deprecated
+    DESCRIPTION
+        "This signifies the Charging daemon is UP on the SP."      
+    ::= { jnxMbgPgwCgNotifications 6 } 
+
+jnxMbgPgwCgMMStateChange NOTIFICATION-TYPE
+    OBJECTS     {  jnxMbgPgwCgProfileName,
+                   jnxMbgPgwCgPrevMMState,
+                   jnxMbgPgwCgNewMMState   }
+    STATUS         deprecated
+    DESCRIPTION
+        "This indicates that the given charging profile underwent a change
+         in the maintenance-mode."
+    ::= { jnxMbgPgwCgNotifications 7 }
+
+jnxMbgPgwCgTMMStateChange NOTIFICATION-TYPE
+    OBJECTS     {  jnxMbgPgwCgTProfileName,
+                   jnxMbgPgwCgTPrevMMState,
+                   jnxMbgPgwCgTNewMMState   }
+    STATUS         deprecated
+    DESCRIPTION
+        "This indicates that the given transport profile underwent a change
+         in the maintenance-mode."
+    ::= { jnxMbgPgwCgNotifications 8 }
+
+jnxMbgPgwCgGtpGWUpNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgServerName, 
+                   jnxMbgPgwCgServicePicName }
+     STATUS        current 
+     DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked alive.  The ServerName identifies the server and the
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgPgwCgNotifications 9 }
+
+jnxMbgPgwCgGtpGWDownNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgServerName, 
+                   jnxMbgPgwCgServicePicName }
+    STATUS         current
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked dead.  The ServerName identifies the server and the
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgPgwCgNotifications 10 }
+
+
+jnxMbgPgwCgCDRDestNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgCDRDest,
+                   jnxMbgPgwCgPeerProfName,
+                   jnxMbgPgwCgActiveCgfIpAddr }
+    STATUS         current 
+    DESCRIPTION
+          "This signifies change in the destination of the CDRs 
+           (Charging Data Record)"        
+    ::= { jnxMbgPgwCgNotifications 11 } 
+
+jnxMbgPgwCgServiceUpNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgServicePicName } 
+    STATUS         current
+    DESCRIPTION
+        "This signifies the Charging daemon is UP on the SP."
+    ::= { jnxMbgPgwCgNotifications 12 } 
+
+jnxMbgPgwCgMMStateChangeNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgPeerProfName,
+                   jnxMbgPgwCgPrevMMState,
+                   jnxMbgPgwCgNewMMState   }
+    STATUS         current
+    DESCRIPTION
+        "This indicates that the given charging profile underwent a change
+         in the maintenance-mode."
+    ::= { jnxMbgPgwCgNotifications 13 }
+
+jnxMbgPgwCgTMMStateChangeNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgPeerProfName,
+                   jnxMbgPgwCgPrevMMState,
+                   jnxMbgPgwCgNewMMState   }
+    STATUS         current
+    DESCRIPTION
+        "This indicates that the given transport profile underwent a change
+         in the maintenance-mode."
+    ::= { jnxMbgPgwCgNotifications 14 }
+
+jnxMbgPgwCgMemHighThresNotify NOTIFICATION-TYPE
+    OBJECTS        { jnxMbgGwName,
+                     jnxMbgPgwCgPeerProfName,
+                     jnxMbgPgwCgServicePicName,
+                     jnxMbgPgwCgMemLimit,
+                     jnxMbgPgwCgAlarmStatus }
+    STATUS           current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of inernal memory space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured high threshold value. Thealarm status (Active/Clear)is indicated by the jnxMbgPgwCgAlarmStatus variable."
+      ::= { jnxMbgPgwCgNotifications 15 } 
+
+jnxMbgPgwCgMemMediumThresNotify NOTIFICATION-TYPE
+    OBJECTS        { jnxMbgGwName,
+                     jnxMbgPgwCgPeerProfName,
+                     jnxMbgPgwCgServicePicName,
+                     jnxMbgPgwCgMemLimit,
+                     jnxMbgPgwCgAlarmStatus }
+    STATUS           current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of inernal memory space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured medium threshold value.  The alarm status (Active/Clear)is indicated by the jnxMbgPgwCgAlarmStatus variable."
+      ::= { jnxMbgPgwCgNotifications 16 } 
+
+jnxMbgPgwCgMemLowThresNotify NOTIFICATION-TYPE
+    OBJECTS        { jnxMbgGwName,
+                     jnxMbgPgwCgPeerProfName,
+                     jnxMbgPgwCgServicePicName,
+                     jnxMbgPgwCgMemLimit,
+                     jnxMbgPgwCgAlarmStatus }
+    STATUS           current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of inernal memory space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured low threshold value. The alarm status (Active/Clear)is indicated by the jnxMbgPgwCgAlarmStatus variable."
+      ::= { jnxMbgPgwCgNotifications 17 } 
+
+jnxMbgPgwCgLcsThresHighNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgAlarmStatus,
+                   jnxMbgPgwCgLcsUtil  }
+    STATUS         current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of local storage space for charging records. This alarm is sent out when the utilization exceeds or falls below configured high threshold of available disk space. The alarm status (Active/Clear)is indicated by the jnxMbgPgwCgAlarmStatus variable."
+    ::= { jnxMbgPgwCgNotifications 18 }
+
+jnxMbgPgwCgLcsThresMediumNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgAlarmStatus,
+                   jnxMbgPgwCgLcsUtil }
+    STATUS         current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of local storage space for charging records. This alarm is sent out when the utilization exceeds or falls below configured medium threshold of available disk space. The alarm status (Active/Clear)is indicated by  the jnxMbgPgwCgAlarmStatus variable."
+    ::= { jnxMbgPgwCgNotifications 19 }
+
+jnxMbgPgwCgLcsThresLowNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgPgwCgAlarmStatus,  
+                   jnxMbgPgwCgLcsUtil }
+    STATUS         current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of local storage space for charging records. This alarm is sent out when the utilization exceeds or falls below configured low threshold of available disk space. The alarm status (Active/Clear)is indicated by  the jnxMbgPgwCgAlarmStatus variable."
+    ::= { jnxMbgPgwCgNotifications 20 }
+
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-dhcp.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-dhcp.txt
@@ -1,0 +1,130 @@
+--
+-- Juniper Mobile Gateway Shared Memory IP pool objects MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-DHCP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+Counter64, Integer32, Unsigned32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE, IpAddress
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString, TruthValue
+        FROM SNMPv2-TC
+
+    InetAddressType, InetAddress, InetAddressPrefixLength
+        FROM INET-ADDRESS-MIB
+
+    jnxMobileGatewayMibRoot	
+        FROM JUNIPER-SMI;
+
+jnxMbgDhcpMib MODULE-IDENTITY
+    LAST-UPDATED "201103301200Z" -- Mar 30, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to Mobile-Edge
+         DHCP Services"
+    REVISION "201103301200Z" -- Mar 30, 2011, 12:00:00
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewayMibRoot 8 }
+
+jnxMbgDhcpNotifications          OBJECT IDENTIFIER ::= 
+                                         { jnxMbgDhcpMib 0 }
+jnxMbgDhcpObjects                OBJECT IDENTIFIER ::=
+                                         { jnxMbgDhcpMib 1 }
+jnxMbgDhcpNotificationVars       OBJECT IDENTIFIER ::=
+                                         { jnxMbgDhcpObjects 1 }
+--
+-- Objects used in Notifications
+--
+
+jnxMbgDhcpServerIP OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP address of the dhcp server."
+    ::= { jnxMbgDhcpNotificationVars 1 }
+
+jnxMbgDhcpLogicalSystemName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the logical-system
+         on the mobile-gateway"
+    ::= { jnxMbgDhcpNotificationVars 2 }
+
+jnxMbgDhcpRoutingInstanceName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the routing instance
+         on the mobile-gateway."
+    ::= { jnxMbgDhcpNotificationVars 3 }
+
+jnxMbgDhcpProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The configured dhcp profile name"
+    ::= { jnxMbgDhcpNotificationVars 4 }
+
+jnxMbgDhcpPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The configured dhcp pool name with in a dhcp profile" 
+    ::= { jnxMbgDhcpNotificationVars 5 }
+
+jnxMbgDhcpReachability OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "True  - The server is reachable
+         False - The server is unreachable."
+    ::= { jnxMbgDhcpNotificationVars 6 }
+--
+-- Notifications
+--
+jnxMbgDhcpServerReachability NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgDhcpServerIP,
+                  jnxMbgDhcpLogicalSystemName,
+                  jnxMbgDhcpRoutingInstanceName,
+                  jnxMbgDhcpProfileName,
+                  jnxMbgDhcpReachability }
+    STATUS      current
+    DESCRIPTION
+        "This notification is used to notify if the given
+         dhcp server is reachable/unreachable."
+    ::= { jnxMbgDhcpNotifications 1 }
+
+jnxMbgDhcpAddrPoolExhaust NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgDhcpServerIP,
+                  jnxMbgDhcpLogicalSystemName,
+                  jnxMbgDhcpRoutingInstanceName,
+                  jnxMbgDhcpProfileName,
+                  jnxMbgDhcpPoolName }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the addresses
+         from a given address pool have exhusted."
+    ::= { jnxMbgDhcpNotifications 2 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-example.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-example.txt
@@ -1,0 +1,236 @@
+--
+-- Juniper Mobile Gateway EXAMPLE objects MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-EXAMPLE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    Counter64, IpAddress, Integer32, Counter32, Unsigned32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+        FROM SNMPv2-TC
+
+    Ipv6AddressPrefix, Ipv6AddressIfIdentifier, Ipv6Address
+        FROM IPV6-TC
+
+    InetAddressType, InetAddress, InetPortNumber, InetAddressPrefixLength
+        FROM INET-ADDRESS-MIB
+
+    EnabledStatus
+        FROM JUNIPER-MIMSTP-MIB
+
+    jnxExampleMibRoot
+        FROM JUNIPER-EXPERIMENT-MIB;
+
+jnxMobileGatewayExampleMib MODULE-IDENTITY
+    LAST-UPDATED "201011221200Z" -- Nov 22, 2010, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines some sample objects pertaining to Mobile-Edge Services."
+    REVISION "201011221200Z" -- Nov 22, 2010, 12:00:00
+    DESCRIPTION "Initial version"
+
+    ::= { jnxExampleMibRoot 2 }
+
+
+jnxMobileGatewayExampleObjects       OBJECT IDENTIFIER ::= 
+                                                { jnxMobileGatewayExampleMib 1 }
+jnxMobileGatewayExampleNotifications OBJECT IDENTIFIER ::=
+                                                { jnxMobileGatewayExampleMib 2 }
+
+jnxMobileGatewayExampleSyncStats OBJECT IDENTIFIER ::= 
+                                            { jnxMobileGatewayExampleObjects 1 }
+jnxMobileGatewayExampleAsyncStats OBJECT IDENTIFIER ::= 
+                                            { jnxMobileGatewayExampleObjects 2 }
+
+jnxMobileGatewayProfileTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMobileGatewayProfileEntry
+    MAX-ACCESS  not-accessible 
+    STATUS      current
+    DESCRIPTION
+        "The table listing Mobile Gateway Test Profiles, key is Profile Name."
+    ::= { jnxMobileGatewayExampleObjects 3 }
+
+jnxMobileGatewayExampleNotificationVars OBJECT IDENTIFIER ::=
+                                            { jnxMobileGatewayExampleObjects 4 }
+
+
+--
+-- Global counters that are returned by mobiled test module in a synchronous manner
+--
+
+jnxMobileGatewayTotalRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total requests made."
+    ::= { jnxMobileGatewayExampleSyncStats 1 }
+
+jnxMobileGatewayTotalAccepts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total requests that were accepted."
+    ::= { jnxMobileGatewayExampleSyncStats 2 }
+
+jnxMobileGatewayTotalRejects OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total requests that were rejected."
+    ::= { jnxMobileGatewayExampleSyncStats 3 }
+
+jnxMobileGatewayTotalChallenges OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total challenges received."
+    ::= { jnxMobileGatewayExampleSyncStats 4 }
+
+
+--
+-- Global counters that are returned by mobiled test module in an async manner.
+-- test module queries Service PICs and aggregates their responses before sending
+-- data to snmp.
+--
+
+jnxMobileGatewayTotalRequestTimeouts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total  requests that timed out."
+    ::= { jnxMobileGatewayExampleAsyncStats 1 }
+
+jnxMobileGatewayTotalRequestTxErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total  requests transmit errors."
+    ::= { jnxMobileGatewayExampleAsyncStats 2 }
+
+jnxMobileGatewayTotalResponseErrors OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total  response errors."
+    ::= { jnxMobileGatewayExampleAsyncStats 3 }
+
+jnxMobileGatewayTotalPendingRequests OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total pending requests."
+    ::= { jnxMobileGatewayExampleAsyncStats 4 }
+
+--
+-- Profile Table
+-- This table contains the attributes of mobile-gateway test profiles.
+-- mobiled test module queries the service PICS for this information and 
+-- conveys this data to snmp in an asynchronous manner
+--
+jnxMobileGatewayProfileEntry OBJECT-TYPE
+    SYNTAX      JnxMobileGatewayProfileEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a Mobile Gateway Test Profile."
+    INDEX       { jnxMobileGatewayProfileName }
+    ::= { jnxMobileGatewayProfileTable 1 }
+
+JnxMobileGatewayProfileEntry ::= SEQUENCE {
+    jnxMobileGatewayProfileName              DisplayString,
+    jnxMobileGatewayProfileDescription       DisplayString,
+    jnxMobileGatewayProfileType              Integer32 
+}
+
+
+jnxMobileGatewayProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the Test Profile."
+    ::= { jnxMobileGatewayProfileEntry 1 }
+
+jnxMobileGatewayProfileDescription OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A string that describes the Test Profile."
+    ::= { jnxMobileGatewayProfileEntry 2 }
+
+jnxMobileGatewayProfileType OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Test Profile Type."
+    ::= { jnxMobileGatewayProfileEntry 3 }
+
+--
+-- Objects used in EXAMPLE Notifications
+--
+jnxMobileGatewayExampleServerName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name identifies an external server (charging,AAA,etc) on mobile-gateway."
+    ::= { jnxMobileGatewayExampleNotificationVars 1 }
+
+jnxMobileGatewayExampleServicePicName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This identifies the session-pic, in the form ms-a/b/0, where
+        <a> is the slot and <b> could be either 0 or 1."
+    ::= { jnxMobileGatewayExampleNotificationVars 2 }
+
+jnxMobileGatewayExampleServerState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This indicates whether the server status is Up or Down"
+    ::= { jnxMobileGatewayExampleNotificationVars 3 }
+
+--
+-- EXAMPLE MIB Notifications
+--
+
+jnxMobileGatewayExampleServerStatus NOTIFICATION-TYPE
+    OBJECTS     { jnxMobileGatewayExampleServerName, jnxMobileGatewayExampleServicePicName, jnxMobileGatewayExampleServerState }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the specified server has 
+        changed state. The ServerName identifies the server, the 
+        ServicePicName identifies the session-pic that originated this
+        notification and ServerState indicates whether server came up or went down." 
+    ::= { jnxMobileGatewayExampleNotifications 1 }
+
+-- End of JUNIPER Mobile Gateway EXAMPLE MIB
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-gtp.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-gtp.txt
@@ -1,0 +1,14622 @@
+--
+-- Juniper Mobile Gateway GTP objects MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-GTP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    Counter64, IpAddress, Integer32, Counter32, Unsigned32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY,OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+        FROM SNMPv2-TC
+
+    Ipv6AddressPrefix, Ipv6AddressIfIdentifier, Ipv6Address
+        FROM IPV6-TC
+
+    InetAddressType, InetAddress, InetPortNumber, InetAddressPrefixLength
+        FROM INET-ADDRESS-MIB
+
+    EnabledStatus
+        FROM JUNIPER-MIMSTP-MIB
+
+    jnxMobileGatewayPgwGgsn
+        FROM JUNIPER-MBG-SMI
+
+    jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS;
+
+-- 
+-- Module Identity for GPRS Tunneling Protocol
+-- GTPC generally refers to Control Path of the GTP protocol and
+-- GTPU generally refers to the Data Path of the GTP Protocol
+--
+
+jnxMbgPgwGtpMib MODULE-IDENTITY
+    LAST-UPDATED "201101281200Z" -- Jan 28, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines some sample objects pertaining to GTP protocol."
+    REVISION "201101281200Z" -- Jan 28, 2011, 12:00:00 UTC
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewayPgwGgsn 2 }
+
+jnxMbgPgwGtpNotifications  OBJECT IDENTIFIER ::= 
+                                    { jnxMbgPgwGtpMib 0 }
+jnxMbgPgwGtpObjects     OBJECT IDENTIFIER ::=
+                                    { jnxMbgPgwGtpMib 1 }
+
+--
+-- Global Statistics Table : Gateway level statistics
+--
+
+jnxMbgPgwGtpCGlbStatsTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgPgwGtpGlbStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to a Gateway level GTP Control statistic"
+  ::= { jnxMbgPgwGtpObjects 10 }
+
+jnxMbgPgwGtpGlbStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwGtpGlbStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the GTPC Global Statistics Table ."
+    INDEX     { jnxMbgGwIndex}
+    ::= { jnxMbgPgwGtpCGlbStatsTable 1}
+
+JnxMbgPgwGtpGlbStatsEntry ::= SEQUENCE {
+    jnxMbgPgwRxPacketsDropped       Counter64,
+    jnxMbgPgwPacketAllocFail        Counter64,
+    jnxMbgPgwPacketSendFail         Counter64,
+    jnxMbgPgwIPVerErrRx             Counter64,
+    jnxMbgPgwIPProtoErrRx           Counter64,
+    jnxMbgPgwGTPPortErrRx           Counter64,
+    jnxMbgPgwGTPUnknVerRx           Counter64,
+    jnxMbgPgwPcktLenErrRx           Counter64,
+    jnxMbgPgwUnknMsgRx              Counter64,
+    jnxMbgPgwV2ProtocolErrRx        Counter64,
+    jnxMbgPgwV2UnSupportedMsgRx     Counter64,
+    jnxMbgPgwV2T3RespTmrExpRx       Counter64,
+    jnxMbgPgwV2GlbNumMsgRx          Counter64,
+    jnxMbgPgwV2GlbNumMsgTx          Counter64,
+    jnxMbgPgwV2GlbNumBytesRx        Counter64,
+    jnxMbgPgwV2GlbNumBytesTx        Counter64,
+    jnxMbgPgwV2GlbEchoReqRx         Counter64,
+    jnxMbgPgwV2GlbEchoReqTx         Counter64,
+    jnxMbgPgwV2GlbEchoRespRx        Counter64,
+    jnxMbgPgwV2GlbEchoRespTx        Counter64,
+    jnxMbgPgwV2VerNotSupRx          Counter64,
+    jnxMbgPgwV2VerNotSupTx          Counter64,
+    jnxMbgPgwV2CreateSessReqRx      Counter64,
+    jnxMbgPgwV2CreateSessReqTx      Counter64,
+    jnxMbgPgwV2CreateSessRspRx      Counter64,
+    jnxMbgPgwV2CreateSessRspTx      Counter64,
+    jnxMbgPgwV2ModBrReqRx           Counter64,
+    jnxMbgPgwV2ModBrReqTx           Counter64,
+    jnxMbgPgwV2ModBrRspRx           Counter64,
+    jnxMbgPgwV2ModBrRspTx           Counter64,
+    jnxMbgPgwV2DelSessReqRx         Counter64,
+    jnxMbgPgwV2DelSessReqTx         Counter64,
+    jnxMbgPgwV2DelSessRspRx         Counter64,
+    jnxMbgPgwV2DelSessRspTx         Counter64,
+    jnxMbgPgwV2CrtBrReqRx           Counter64,
+    jnxMbgPgwV2CrtBrReqTx           Counter64,
+    jnxMbgPgwV2CrtBrRspRx           Counter64,
+    jnxMbgPgwV2CrtBrRspTx           Counter64,
+    jnxMbgPgwV2UpdBrReqRx           Counter64,
+    jnxMbgPgwV2UpdBrReqTx           Counter64,
+    jnxMbgPgwV2UpdBrRspRx           Counter64,
+    jnxMbgPgwV2UpdBrRspTx           Counter64,
+    jnxMbgPgwV2DelBrReqRx           Counter64,
+    jnxMbgPgwV2DelBrReqTx           Counter64,
+    jnxMbgPgwV2DelBrRspRx           Counter64,
+    jnxMbgPgwV2DelBrRspTx           Counter64,
+    jnxMbgPgwV2DelConnSetReqRx      Counter64,
+    jnxMbgPgwV2DelConnSetReqTx      Counter64,
+    jnxMbgPgwV2DelConnSetRspRx      Counter64,
+    jnxMbgPgwV2DelConnSetRspTx      Counter64,
+    jnxMbgPgwV2UpdConnSetReqRx      Counter64,
+    jnxMbgPgwV2UpdConnSetReqTx      Counter64,
+    jnxMbgPgwV2UpdConnSetRspRx      Counter64,
+    jnxMbgPgwV2UpdConnSetRspTx      Counter64,
+    jnxMbgPgwV2ModBrCmdRx           Counter64,
+    jnxMbgPgwV2ModBrCmdTx           Counter64,
+    jnxMbgPgwV2ModBrFlrIndRx        Counter64,
+    jnxMbgPgwV2ModBrFlrIndTx        Counter64,
+    jnxMbgPgwV2DelBrCmdRx           Counter64,
+    jnxMbgPgwV2DelBrCmdTx           Counter64,
+    jnxMbgPgwV2DelBrFlrIndRx        Counter64,
+    jnxMbgPgwV2DelBrFlrIndTx        Counter64,
+    jnxMbgPgwV2BrResCmdRx           Counter64,
+    jnxMbgPgwV2BrResCmdTx           Counter64,
+    jnxMbgPgwV2BrResFlrIndRx        Counter64,
+    jnxMbgPgwV2BrResFlrIndTx        Counter64,
+    jnxMbgPgwV2RelAcsBrReqRx        Counter64,
+    jnxMbgPgwV2RelAcsBrReqTx        Counter64,
+    jnxMbgPgwV2RelAcsBrRespRx       Counter64,
+    jnxMbgPgwV2RelAcsBrRespTx       Counter64,
+    jnxMbgPgwV2CrIndTunReqRx        Counter64,
+    jnxMbgPgwV2CrIndTunReqTx        Counter64,
+    jnxMbgPgwV2CrIndTunRespRx       Counter64,
+    jnxMbgPgwV2CrIndTunRespTx       Counter64,
+    jnxMbgPgwV2DelIndTunReqRx       Counter64,
+    jnxMbgPgwV2DelIndTunReqTx       Counter64,
+    jnxMbgPgwV2DelIndTunRespRx      Counter64,
+    jnxMbgPgwV2DelIndTunRespTx      Counter64,
+    jnxMbgPgwV2DlDataNotifRx        Counter64,
+    jnxMbgPgwV2DlDataNotifTx        Counter64,
+    jnxMbgPgwV2DlDataAckRx          Counter64,
+    jnxMbgPgwV2DlDataAckTx          Counter64,
+    jnxMbgPgwV2DlDataNotiFlrIndRx   Counter64,
+    jnxMbgPgwV2DlDataNotiFlrIndTx   Counter64,
+    jnxMbgPgwV2StopPagingIndRx      Counter64,
+    jnxMbgPgwV2StopPagingIndTx      Counter64,
+    jnxMbgPgwV2ICsPageRx            Counter64,
+    jnxMbgPgwV2ICsPageTx            Counter64,
+    jnxMbgPgwV2ICsReqAcceptRx       Counter64,
+    jnxMbgPgwV2ICsReqAcceptTx       Counter64,
+    jnxMbgPgwV2ICsAcceptPartRx      Counter64,
+    jnxMbgPgwV2ICsAcceptPartTx      Counter64,
+    jnxMbgPgwV2ICsNewPTNPrefRx      Counter64,
+    jnxMbgPgwV2ICsNewPTNPrefTx      Counter64,
+    jnxMbgPgwV2ICsNewPTSIAdbrRx     Counter64,
+    jnxMbgPgwV2ICsNewPTSIAdbrTx     Counter64,
+    jnxMbgPgwV2ICsCtxNotFndRx       Counter64,
+    jnxMbgPgwV2ICsCtxNotFndTx       Counter64,
+    jnxMbgPgwV2ICsInvMsgFmtRx       Counter64,
+    jnxMbgPgwV2ICsInvMsgFmtTx       Counter64,
+    jnxMbgPgwV2ICsVerNotSuppRx      Counter64,
+    jnxMbgPgwV2ICsVerNotSuppTx      Counter64,
+    jnxMbgPgwV2ICsInvLenRx          Counter64,
+    jnxMbgPgwV2ICsInvLenTx          Counter64,
+    jnxMbgPgwV2ICsServNotSuppRx     Counter64,
+    jnxMbgPgwV2ICsServNotSuppTx     Counter64,
+    jnxMbgPgwV2ICsManIEIncorrRx     Counter64,
+    jnxMbgPgwV2ICsManIEIncorrTx     Counter64,
+    jnxMbgPgwV2ICsManIEMissRx       Counter64,
+    jnxMbgPgwV2ICsManIEMissTx       Counter64,
+    jnxMbgPgwV2ICsOptIEIncorrRx     Counter64,
+    jnxMbgPgwV2ICsOptIEIncorrTx     Counter64,
+    jnxMbgPgwV2ICsSysFailRx         Counter64,
+    jnxMbgPgwV2ICsSysFailTx         Counter64,
+    jnxMbgPgwV2ICsNoResRx           Counter64,
+    jnxMbgPgwV2ICsNoResTx           Counter64,
+    jnxMbgPgwV2ICsTFTSMANTErRx      Counter64,
+    jnxMbgPgwV2ICsTFTSMANTErTx      Counter64,
+    jnxMbgPgwV2ICsTFTSysErrRx       Counter64,
+    jnxMbgPgwV2ICsTFTSysErrTx       Counter64,
+    jnxMbgPgwV2ICsPkFltManErrRx     Counter64,
+    jnxMbgPgwV2ICsPkFltManErrTx     Counter64,
+    jnxMbgPgwV2ICsPkFltSynErrRx     Counter64,
+    jnxMbgPgwV2ICsPkFltSynErrTx     Counter64,
+    jnxMbgPgwV2ICsMisUnknAPNRx      Counter64,
+    jnxMbgPgwV2ICsMisUnknAPNTx      Counter64,
+    jnxMbgPgwV2ICsUnexpRptIERx      Counter64,
+    jnxMbgPgwV2ICsUnexpRptIETx      Counter64,
+    jnxMbgPgwV2ICsGREKeyNtFdRx      Counter64,
+    jnxMbgPgwV2ICsGREKeyNtFdTx      Counter64,
+    jnxMbgPgwV2ICsRelocFailRx       Counter64,
+    jnxMbgPgwV2ICsRelocFailTx       Counter64,
+    jnxMbgPgwV2ICsDeniedINRatRx     Counter64,
+    jnxMbgPgwV2ICsDeniedINRatTx     Counter64,
+    jnxMbgPgwV2ICsPTNotSuppRx       Counter64,
+    jnxMbgPgwV2ICsPTNotSuppTx       Counter64,
+    jnxMbgPgwV2ICsAllDynAdOccRx     Counter64,
+    jnxMbgPgwV2ICsAllDynAdOccTx     Counter64,
+    jnxMbgPgwV2ICsNOTFTUECTXRx      Counter64,
+    jnxMbgPgwV2ICsNOTFTUECTXTx      Counter64,
+    jnxMbgPgwV2ICsProtoNtSupRx      Counter64,
+    jnxMbgPgwV2ICsProtoNtSupTx      Counter64,
+    jnxMbgPgwV2ICsUENotRespRx       Counter64,
+    jnxMbgPgwV2ICsUENotRespTx       Counter64,
+    jnxMbgPgwV2ICsUERefusesRx       Counter64,
+    jnxMbgPgwV2ICsUERefusesTx       Counter64,
+    jnxMbgPgwV2ICsServDeniedRx      Counter64,
+    jnxMbgPgwV2ICsServDeniedTx      Counter64,
+    jnxMbgPgwV2ICsUnabPageUERx      Counter64,
+    jnxMbgPgwV2ICsUnabPageUETx      Counter64,
+    jnxMbgPgwV2ICsNoMemRx           Counter64,
+    jnxMbgPgwV2ICsNoMemTx           Counter64,
+    jnxMbgPgwV2ICsUserAUTHFlRx      Counter64,
+    jnxMbgPgwV2ICsUserAUTHFlTx      Counter64,
+    jnxMbgPgwV2ICsAPNAcsDenRx       Counter64,
+    jnxMbgPgwV2ICsAPNAcsDenTx       Counter64,
+    jnxMbgPgwV2ICsReqRejRx          Counter64,
+    jnxMbgPgwV2ICsReqRejTx          Counter64,
+    jnxMbgPgwV2ICsPTMSISigMMRx      Counter64,
+    jnxMbgPgwV2ICsPTMSISigMMTx      Counter64,
+    jnxMbgPgwV2ICsIMSINotKnRx       Counter64,
+    jnxMbgPgwV2ICsIMSINotKnTx       Counter64,
+    jnxMbgPgwV2ICsCondIEMsRx        Counter64,
+    jnxMbgPgwV2ICsCondIEMsTx        Counter64,
+    jnxMbgPgwV2ICsAPNResTIncRx      Counter64,
+    jnxMbgPgwV2ICsAPNResTIncTx      Counter64,
+    jnxMbgPgwV2ICsUnknownRx         Counter64,
+    jnxMbgPgwV2ICsUnknownTx         Counter64,
+    jnxMbgPgwV1ProtocolErrRx        Counter64,
+    jnxMbgPgwV1UnSupportedMsgRx     Counter64,
+    jnxMbgPgwV1T3RespTmrExpRx       Counter64,
+    jnxMbgPgwV1GlbNumMsgRx          Counter64,
+    jnxMbgPgwV1GlbNumMsgTx          Counter64,
+    jnxMbgPgwV1GlbNumBytesRx        Counter64,
+    jnxMbgPgwV1GlbNumBytesTx        Counter64,
+    jnxMbgPgwV1GlbEchoReqRx         Counter64,
+    jnxMbgPgwV1GlbEchoReqTx         Counter64,
+    jnxMbgPgwV1GlbEchoRespRx        Counter64,
+    jnxMbgPgwV1GlbEchoRespTx        Counter64,
+    jnxMbgPgwV1VerNotSupRx          Counter64,
+    jnxMbgPgwV1VerNotSupTx          Counter64,
+    jnxMbgPgwV1CrtPdpCxtReqRx       Counter64,
+    jnxMbgPgwV1CrtPdpCxtReqTx       Counter64,
+    jnxMbgPgwV1CrtPdpCxtRspRx       Counter64,
+    jnxMbgPgwV1CrtPdpCxtRspTx       Counter64,
+    jnxMbgPgwV1UpdPdpCxtReqRx       Counter64,
+    jnxMbgPgwV1UpdPdpCxtReqTx       Counter64,
+    jnxMbgPgwV1UpdPdpCxtRspRx       Counter64,
+    jnxMbgPgwV1UpdPdpCxtRspTx       Counter64,
+    jnxMbgPgwV1DelPdpCxtReqRx       Counter64,
+    jnxMbgPgwV1DelPdpCxtReqTx       Counter64,
+    jnxMbgPgwV1DelPdpCxtRspRx       Counter64,
+    jnxMbgPgwV1DelPdpCxtRspTx       Counter64,
+    jnxMbgPgwV1CrtAAPdpCxtReqRx     Counter64,
+    jnxMbgPgwV1CrtAAPdpCxtReqTx     Counter64,
+    jnxMbgPgwV1CrtAAPdpCxtRspRx     Counter64,
+    jnxMbgPgwV1CrtAAPdpCxtRspTx     Counter64,
+    jnxMbgPgwV1DelAAPdpCxtReqRx     Counter64,
+    jnxMbgPgwV1DelAAPdpCxtReqTx     Counter64,
+    jnxMbgPgwV1DelAAPdpCxtRspRx     Counter64,
+    jnxMbgPgwV1DelAAPdpCxtRspTx     Counter64,
+    jnxMbgPgwV1ErrorIndRx           Counter64,
+    jnxMbgPgwV1ErrorIndTx           Counter64,
+    jnxMbgPgwV1NotifReqRx           Counter64,
+    jnxMbgPgwV1NotifReqTx           Counter64,
+    jnxMbgPgwV1NotifRspRx           Counter64,
+    jnxMbgPgwV1NotifRspTx           Counter64,
+    jnxMbgPgwV1NotifRejReqRx        Counter64,
+    jnxMbgPgwV1NotifRejReqTx        Counter64,
+    jnxMbgPgwV1NotifRejRspRx        Counter64,
+    jnxMbgPgwV1NotifRejRspTx        Counter64,
+    jnxMbgPgwV1RtInfReqRx           Counter64,
+    jnxMbgPgwV1RtInfReqTx           Counter64,
+    jnxMbgPgwV1RtInfRspRx           Counter64,
+    jnxMbgPgwV1RtInfRspTx           Counter64,
+    jnxMbgPgwV1FailRptReqRx         Counter64,
+    jnxMbgPgwV1FailRptReqTx         Counter64,
+    jnxMbgPgwV1FailRptRspRx         Counter64,
+    jnxMbgPgwV1FailRptRspTx         Counter64,
+    jnxMbgPgwV1NotMSPresReqRx       Counter64,
+    jnxMbgPgwV1NotMSPresReqTx       Counter64,
+    jnxMbgPgwV1NotMSPresRspRx       Counter64,
+    jnxMbgPgwV1NotMSPresRspTx       Counter64,
+    jnxMbgPgwV1ICsReqAcceptedRx     Counter64,
+    jnxMbgPgwV1ICsReqAcceptedTx     Counter64,
+    jnxMbgPgwV1ICsNonExistRx        Counter64,
+    jnxMbgPgwV1ICsNonExistTx        Counter64,
+    jnxMbgPgwV1ICsInvMsgFmtRx       Counter64,
+    jnxMbgPgwV1ICsInvMsgFmtTx       Counter64,
+    jnxMbgPgwV1ICsIMSINotKnownRx    Counter64,
+    jnxMbgPgwV1ICsIMSINotKnownTx    Counter64,
+    jnxMbgPgwV1ICsMSGRPSDetachRx    Counter64,
+    jnxMbgPgwV1ICsMSGRPSDetachTx    Counter64,
+    jnxMbgPgwV1ICsMSNotGRPSRespRx   Counter64,
+    jnxMbgPgwV1ICsMSNotGRPSRespTx   Counter64,
+    jnxMbgPgwV1ICsMSRefusesRx       Counter64,
+    jnxMbgPgwV1ICsMSRefusesTx       Counter64,
+    jnxMbgPgwV1ICsVerNotSuppRx      Counter64,
+    jnxMbgPgwV1ICsVerNotSuppTx      Counter64,
+    jnxMbgPgwV1ICsNoResRx           Counter64,
+    jnxMbgPgwV1ICsNoResTx           Counter64,
+    jnxMbgPgwV1ICsServNotSuppRx     Counter64,
+    jnxMbgPgwV1ICsServNotSuppTx     Counter64,
+    jnxMbgPgwV1ICsManIEIncrtRx      Counter64,
+    jnxMbgPgwV1ICsManIEIncrtTx      Counter64,
+    jnxMbgPgwV1ICsManIEMissRx       Counter64,
+    jnxMbgPgwV1ICsManIEMissTx       Counter64,
+    jnxMbgPgwV1ICsOptIEIncrtRx      Counter64,
+    jnxMbgPgwV1ICsOptIEIncrtTx      Counter64,
+    jnxMbgPgwV1ICsSysFailRx         Counter64,
+    jnxMbgPgwV1ICsSysFailTx         Counter64,
+    jnxMbgPgwV1ICsRoamRestrictRx    Counter64,
+    jnxMbgPgwV1ICsRoamRestrictTx    Counter64,
+    jnxMbgPgwV1ICsPTMSISigMMRx      Counter64,
+    jnxMbgPgwV1ICsPTMSISigMMTx      Counter64,
+    jnxMbgPgwV1ICsGPRSConnSuppRx    Counter64,
+    jnxMbgPgwV1ICsGPRSConnSuppTx    Counter64,
+    jnxMbgPgwV1ICsAuthFailRx        Counter64,
+    jnxMbgPgwV1ICsAuthFailTx        Counter64,
+    jnxMbgPgwV1ICsUserAuthFailRx    Counter64,
+    jnxMbgPgwV1ICsUserAuthFailTx    Counter64,
+    jnxMbgPgwV1ICsCtxNotFndRx       Counter64,
+    jnxMbgPgwV1ICsCtxNotFndTx       Counter64,
+    jnxMbgPgwV1ICsAllDynPDPAdRx     Counter64,
+    jnxMbgPgwV1ICsAllDynPDPAdTx     Counter64,
+    jnxMbgPgwV1ICsNoMemRx           Counter64,
+    jnxMbgPgwV1ICsNoMemTx           Counter64,
+    jnxMbgPgwV1ICsRelocFailRx       Counter64,
+    jnxMbgPgwV1ICsRelocFailTx       Counter64,
+    jnxMbgPgwV1ICsUnkManExhdrRx     Counter64,
+    jnxMbgPgwV1ICsUnkManExhdrTx     Counter64,
+    jnxMbgPgwV1ICsSMANTTFTEr1Rx     Counter64,
+    jnxMbgPgwV1ICsSMANTTFTEr1Tx     Counter64,
+    jnxMbgPgwV1ICsSYNTFTErr2Rx      Counter64,
+    jnxMbgPgwV1ICsSYNTFTErr2Tx      Counter64,
+    jnxMbgPgwV1ICsSMNTPkFlEr1Rx     Counter64,
+    jnxMbgPgwV1ICsSMNTPkFlEr1Tx     Counter64,
+    jnxMbgPgwV1ICsSYNPkFlErr2Rx     Counter64,
+    jnxMbgPgwV1ICsSYNPkFlErr2Tx     Counter64,
+    jnxMbgPgwV1ICsMissUnknAPNRx     Counter64,
+    jnxMbgPgwV1ICsMissUnknAPNTx     Counter64,
+    jnxMbgPgwV1ICsUnknPDPAdRx       Counter64,
+    jnxMbgPgwV1ICsUnknPDPAdTx       Counter64,
+    jnxMbgPgwV1ICsNoTFTCtxExRx      Counter64,
+    jnxMbgPgwV1ICsNoTFTCtxExTx      Counter64,
+    jnxMbgPgwV0ProtocolErrRx        Counter64,
+    jnxMbgPgwV0UnSupportedMsgRx     Counter64,
+    jnxMbgPgwV0T3RespTmrExpRx       Counter64,
+    jnxMbgPgwV0GlbNumMsgRx          Counter64,
+    jnxMbgPgwV0GlbNumMsgTx          Counter64,
+    jnxMbgPgwV0GlbNumBytesRx        Counter64,
+    jnxMbgPgwV0GlbNumBytesTx        Counter64,
+    jnxMbgPgwV0GlbEchoReqRx         Counter64,
+    jnxMbgPgwV0GlbEchoReqTx         Counter64,
+    jnxMbgPgwV0GlbEchoRespRx        Counter64,
+    jnxMbgPgwV0GlbEchoRespTx        Counter64,
+    jnxMbgPgwV0GlbVerNotSupRx       Counter64,
+    jnxMbgPgwV0GlbVerNotSupTx       Counter64,
+    jnxMbgPgwV0GlbCrtPdpCxtReqRx    Counter64,
+    jnxMbgPgwV0GlbCrtPdpCxtReqTx    Counter64,
+    jnxMbgPgwV0GlbCrtPdpCxtRspRx    Counter64,
+    jnxMbgPgwV0GlbCrtPdpCxtRspTx    Counter64,
+    jnxMbgPgwV0GlbUpdPdpCxtReqRx    Counter64,
+    jnxMbgPgwV0GlbUpdPdpCxtReqTx    Counter64,
+    jnxMbgPgwV0GlbUpdPdpCxtRspRx    Counter64,
+    jnxMbgPgwV0GlbUpdPdpCxtRspTx    Counter64,
+    jnxMbgPgwV0GlbDelPdpCxtReqRx    Counter64,
+    jnxMbgPgwV0GlbDelPdpCxtReqTx    Counter64,
+    jnxMbgPgwV0GlbDelPdpCxtRspRx    Counter64,
+    jnxMbgPgwV0GlbDelPdpCxtRspTx    Counter64,
+    jnxMbgPgwV0GlbCrtAAPdpCxtReqRx  Counter64,
+    jnxMbgPgwV0GlbCrtAAPdpCxtReqTx  Counter64,
+    jnxMbgPgwV0GlbCrtAAPdpCxtRspRx  Counter64,
+    jnxMbgPgwV0GlbCrtAAPdpCxtRspTx  Counter64,
+    jnxMbgPgwV0GlbDelAAPdpCxtReqRx  Counter64,
+    jnxMbgPgwV0GlbDelAAPdpCxtReqTx  Counter64,
+    jnxMbgPgwV0GlbDelAAPdpCxtRspRx  Counter64,
+    jnxMbgPgwV0GlbDelAAPdpCxtRspTx  Counter64,
+    jnxMbgPgwV0GlbErrorIndRx        Counter64,
+    jnxMbgPgwV0GlbErrorIndTx        Counter64,
+    jnxMbgPgwV0GlbNotifReqRx        Counter64,
+    jnxMbgPgwV0GlbNotifReqTx        Counter64,
+    jnxMbgPgwV0GlbNotifRspRx        Counter64,
+    jnxMbgPgwV0GlbNotifRspTx        Counter64,
+    jnxMbgPgwV0GlbNotifRejReqRx     Counter64,
+    jnxMbgPgwV0GlbNotifRejReqTx     Counter64,
+    jnxMbgPgwV0GlbNotifRejRspRx     Counter64,
+    jnxMbgPgwV0GlbNotifRejRspTx     Counter64,
+    jnxMbgPgwV0GlbRtInfReqRx        Counter64,
+    jnxMbgPgwV0GlbRtInfReqTx        Counter64,
+    jnxMbgPgwV0GlbRtInfRspRx        Counter64,
+    jnxMbgPgwV0GlbRtInfRspTx        Counter64,
+    jnxMbgPgwV0GlbFailRptReqRx      Counter64,
+    jnxMbgPgwV0GlbFailRptReqTx      Counter64,
+    jnxMbgPgwV0GlbFailRptRspRx      Counter64,
+    jnxMbgPgwV0GlbFailRptRspTx      Counter64,
+    jnxMbgPgwV0GlbNotMSPresReqRx    Counter64,
+    jnxMbgPgwV0GlbNotMSPresReqTx    Counter64,
+    jnxMbgPgwV0GlbNotMSPresRspRx    Counter64,
+    jnxMbgPgwV0GlbNotMSPresRspTx    Counter64,
+    jnxMbgPgwV0ICsReqAcceptedRx     Counter64,
+    jnxMbgPgwV0ICsReqAcceptedTx     Counter64,
+    jnxMbgPgwV0ICsNonExistRx        Counter64,
+    jnxMbgPgwV0ICsNonExistTx        Counter64,
+    jnxMbgPgwV0ICsInvMsgFmtRx       Counter64,
+    jnxMbgPgwV0ICsInvMsgFmtTx       Counter64,
+    jnxMbgPgwV0ICsIMSINotKnownRx    Counter64,
+    jnxMbgPgwV0ICsIMSINotKnownTx    Counter64,
+    jnxMbgPgwV0ICsMSGRPSDetachRx    Counter64,
+    jnxMbgPgwV0ICsMSGRPSDetachTx    Counter64,
+    jnxMbgPgwV0ICsMSNotGRPSRespRx   Counter64,
+    jnxMbgPgwV0ICsMSNotGRPSRespTx   Counter64,
+    jnxMbgPgwV0ICsMSRefusesRx       Counter64,
+    jnxMbgPgwV0ICsMSRefusesTx       Counter64,
+    jnxMbgPgwV0ICsVerNotSuppRx      Counter64,
+    jnxMbgPgwV0ICsVerNotSuppTx      Counter64,
+    jnxMbgPgwV0ICsNoResRx           Counter64,
+    jnxMbgPgwV0ICsNoResTx           Counter64,
+    jnxMbgPgwV0ICsServNotSuppRx     Counter64,
+    jnxMbgPgwV0ICsServNotSuppTx     Counter64,
+    jnxMbgPgwV0ICsManIEIncrtRx      Counter64,
+    jnxMbgPgwV0ICsManIEIncrtTx      Counter64,
+    jnxMbgPgwV0ICsManIEMissRx       Counter64,
+    jnxMbgPgwV0ICsManIEMissTx       Counter64,
+    jnxMbgPgwV0ICsOptIEIncrtRx      Counter64,
+    jnxMbgPgwV0ICsOptIEIncrtTx      Counter64,
+    jnxMbgPgwV0ICsSysFailRx         Counter64,
+    jnxMbgPgwV0ICsSysFailTx         Counter64,
+    jnxMbgPgwV0ICsRoamRestrictRx    Counter64,
+    jnxMbgPgwV0ICsRoamRestrictTx    Counter64,
+    jnxMbgPgwV0ICsPTMSISigMMRx      Counter64,
+    jnxMbgPgwV0ICsPTMSISigMMTx      Counter64,
+    jnxMbgPgwV0ICsGPRSConnSuppRx    Counter64,
+    jnxMbgPgwV0ICsGPRSConnSuppTx    Counter64,
+    jnxMbgPgwV0ICsAuthFailRx        Counter64,
+    jnxMbgPgwV0ICsAuthFailTx        Counter64,
+    jnxMbgPgwV0ICsUserAuthFailRx    Counter64,
+    jnxMbgPgwV0ICsUserAuthFailTx    Counter64,
+    jnxMbgPgwGtpV2ICsLclDetRx       Counter64,
+    jnxMbgPgwGtpV2ICsLclDetTx       Counter64,
+    jnxMbgPgwGtpV2ICsCmpDetRx       Counter64,
+    jnxMbgPgwGtpV2ICsCmpDetTx       Counter64,
+    jnxMbgPgwGtpV2ICsRATChgRx       Counter64,
+    jnxMbgPgwGtpV2ICsRATChgTx       Counter64,
+    jnxMbgPgwGtpV2ICsISRDeactRx     Counter64,
+    jnxMbgPgwGtpV2ICsISRDeactTx     Counter64,
+    jnxMbgPgwGtpV2ICsEIFRNCEnRx     Counter64,
+    jnxMbgPgwGtpV2ICsEIFRNCEnTx     Counter64,
+    jnxMbgPgwGtpV2ICsSemErTADRx     Counter64,
+    jnxMbgPgwGtpV2ICsSemErTADTx     Counter64,
+    jnxMbgPgwGtpV2ICsSynErTADRx     Counter64,
+    jnxMbgPgwGtpV2ICsSynErTADTx     Counter64,
+    jnxMbgPgwGtpV2ICsRMValRcvRx     Counter64,
+    jnxMbgPgwGtpV2ICsRMValRcvTx     Counter64,
+    jnxMbgPgwGtpV2ICsRPrNtRspRx     Counter64,
+    jnxMbgPgwGtpV2ICsRPrNtRspTx     Counter64,
+    jnxMbgPgwGtpV2ICsColNWReqRx     Counter64,
+    jnxMbgPgwGtpV2ICsColNWReqTx     Counter64,
+    jnxMbgPgwGtpV2ICsUnPgUESusRx    Counter64,
+    jnxMbgPgwGtpV2ICsUnPgUESusTx    Counter64,
+    jnxMbgPgwGtpV2ICsInvTotLenRx    Counter64,
+    jnxMbgPgwGtpV2ICsInvTotLenTx    Counter64,
+    jnxMbgPgwGtpV2ICsDtForNtSupRx   Counter64,
+    jnxMbgPgwGtpV2ICsDtForNtSupTx   Counter64,
+    jnxMbgPgwGtpV2ICsInReFRePrRx    Counter64,
+    jnxMbgPgwGtpV2ICsInReFRePrTx    Counter64,
+    jnxMbgPgwGtpV2ICsInvPrRx        Counter64,
+    jnxMbgPgwGtpV2ICsInvPrTx        Counter64,
+    jnxMbgPgwV1InitPdpCxtReqRx      Counter64,
+    jnxMbgPgwV1InitPdpCxtReqTx      Counter64,
+    jnxMbgPgwV1InitPdpCxtRspRx      Counter64,
+    jnxMbgPgwV1InitPdpCxtRspTx      Counter64,
+    jnxMbgPgwV2SuspNotifRx          Counter64,
+    jnxMbgPgwV2SuspNotifTx          Counter64,
+    jnxMbgPgwV2SuspAckRx            Counter64,
+    jnxMbgPgwV2SuspAckTx            Counter64,
+    jnxMbgPgwV2ResumeNotifRx        Counter64,
+    jnxMbgPgwV2ResumeNotifTx        Counter64,
+    jnxMbgPgwV2ResumeAckRx          Counter64,
+    jnxMbgPgwV2ResumeAckTx          Counter64,
+    jnxMbgPgwV2PiggybackMsgRx       Counter64,
+    jnxMbgPgwV2PiggybackMsgTx       Counter64
+}
+
+jnxMbgPgwRxPacketsDropped  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Received GTP Packets Dropped by the Gateway."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 1 }
+
+jnxMbgPgwPacketAllocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet allocation failures in the Gateway."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 2 }
+
+jnxMbgPgwPacketSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP Packet Send failures in the Gateway."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 3 }
+
+jnxMbgPgwIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Version Error Packets Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 4 }
+
+jnxMbgPgwIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  IP Protocol Error packets Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 5 }
+
+jnxMbgPgwGTPPortErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Port Error Packets Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 6 }
+
+jnxMbgPgwGTPUnknVerRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Version Packets Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 7 }
+
+jnxMbgPgwPcktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Length Error Packets Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 8 }
+
+jnxMbgPgwUnknMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Messages Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 9 }
+
+jnxMbgPgwV2ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 10 }
+
+jnxMbgPgwV2UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 11 }
+
+jnxMbgPgwV2T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Number of T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 12 }
+
+jnxMbgPgwV2GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 13 }
+
+jnxMbgPgwV2GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 messages sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 14 }
+
+jnxMbgPgwV2GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 15 }
+
+jnxMbgPgwV2GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 bytes sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 16 }
+
+jnxMbgPgwV2GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 19 }
+
+jnxMbgPgwV2GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 20 }
+
+jnxMbgPgwV2GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 21 }
+
+jnxMbgPgwV2GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 22 }
+
+jnxMbgPgwV2VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 23 }
+
+jnxMbgPgwV2VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 version not supported messages Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 24 }
+
+jnxMbgPgwV2CreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 25 }
+
+jnxMbgPgwV2CreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 26 }
+
+jnxMbgPgwV2CreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 27 }
+
+jnxMbgPgwV2CreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 28 }
+
+jnxMbgPgwV2ModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 29 }
+
+jnxMbgPgwV2ModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 30 }
+
+jnxMbgPgwV2ModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 31 }
+
+jnxMbgPgwV2ModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 32 }
+
+jnxMbgPgwV2DelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 33 }
+
+jnxMbgPgwV2DelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 34 }
+
+jnxMbgPgwV2DelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 35 }
+
+jnxMbgPgwV2DelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 36 }
+
+jnxMbgPgwV2CrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 37 }
+
+jnxMbgPgwV2CrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 38 }
+
+jnxMbgPgwV2CrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 39 }
+
+jnxMbgPgwV2CrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 40 }
+
+jnxMbgPgwV2UpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 41 }
+
+jnxMbgPgwV2UpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 42 }
+
+jnxMbgPgwV2UpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 43 }
+
+jnxMbgPgwV2UpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 44 }
+
+jnxMbgPgwV2DelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 45 }
+
+jnxMbgPgwV2DelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 46 }
+
+jnxMbgPgwV2DelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 47 }
+
+jnxMbgPgwV2DelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 48 }
+
+jnxMbgPgwV2DelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 49 }
+
+jnxMbgPgwV2DelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 50 }
+
+jnxMbgPgwV2DelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 51 }
+
+jnxMbgPgwV2DelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 52 }
+
+jnxMbgPgwV2UpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 53 }
+
+jnxMbgPgwV2UpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 54 }
+
+jnxMbgPgwV2UpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connetion set Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 55 }
+
+jnxMbgPgwV2UpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 56 }
+
+jnxMbgPgwV2ModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 57 }
+
+jnxMbgPgwV2ModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 58 }
+
+jnxMbgPgwV2ModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 59 }
+
+jnxMbgPgwV2ModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 60 }
+
+jnxMbgPgwV2DelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 61 }
+
+jnxMbgPgwV2DelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 62 }
+
+jnxMbgPgwV2DelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 63 }
+
+jnxMbgPgwV2DelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 64 }
+
+jnxMbgPgwV2BrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 65 }
+
+jnxMbgPgwV2BrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 66 }
+
+jnxMbgPgwV2BrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 67 }
+
+jnxMbgPgwV2BrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 68 }
+
+jnxMbgPgwV2RelAcsBrReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 69 }
+
+jnxMbgPgwV2RelAcsBrReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 70 }
+
+jnxMbgPgwV2RelAcsBrRespRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 71 }
+
+jnxMbgPgwV2RelAcsBrRespTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 72 }
+
+jnxMbgPgwV2CrIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Requests Received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 73 }
+
+jnxMbgPgwV2CrIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Requests Sent"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 74 }
+
+jnxMbgPgwV2CrIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Responses Received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 75 }
+
+jnxMbgPgwV2CrIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Responses Sent"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 76 }
+
+jnxMbgPgwV2DelIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 77 }
+
+jnxMbgPgwV2DelIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 78 }
+
+jnxMbgPgwV2DelIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Responses Received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 79 }
+
+jnxMbgPgwV2DelIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 80 }
+
+jnxMbgPgwV2DlDataNotifRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 81 }
+
+jnxMbgPgwV2DlDataNotifTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 82 }
+
+jnxMbgPgwV2DlDataAckRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgements received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 83 }
+
+jnxMbgPgwV2DlDataAckTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgements Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 84 }
+
+jnxMbgPgwV2DlDataNotiFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification failures received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 85 }
+
+jnxMbgPgwV2DlDataNotiFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification failures Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 86 }
+
+jnxMbgPgwV2StopPagingIndRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Stop Paging Indication Messages Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 87 }
+
+jnxMbgPgwV2StopPagingIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Stop Paging Indicaton messages Transmitted"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 88 }
+
+jnxMbgPgwV2ICsPageRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Page."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 89 }
+
+jnxMbgPgwV2ICsPageTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Page."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 90 }
+
+jnxMbgPgwV2ICsReqAcceptRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Accept."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 91 }
+
+jnxMbgPgwV2ICsReqAcceptTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Request Accept messsges sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 92 }
+
+jnxMbgPgwV2ICsAcceptPartRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Accept Partial messages receive."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 93 }
+
+jnxMbgPgwV2ICsAcceptPartTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Accept Partial."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 94 }
+
+jnxMbgPgwV2ICsNewPTNPrefRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Network Preference."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 95 }
+
+jnxMbgPgwV2ICsNewPTNPrefTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause New PDN type due to Network Preference."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 96 }
+
+
+jnxMbgPgwV2ICsNewPTSIAdbrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 97 }
+
+jnxMbgPgwV2ICsNewPTSIAdbrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 98 }
+
+jnxMbgPgwV2ICsCtxNotFndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  GTPV2 packets received with cause Context not found."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 99 }
+
+jnxMbgPgwV2ICsCtxNotFndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Context not found."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 100 }
+
+jnxMbgPgwV2ICsInvMsgFmtRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 101 }
+
+jnxMbgPgwV2ICsInvMsgFmtTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 102 }
+
+jnxMbgPgwV2ICsVerNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Version not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 103 }
+
+jnxMbgPgwV2ICsVerNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Version not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 104 }
+
+jnxMbgPgwV2ICsInvLenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Length."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 105 }
+
+jnxMbgPgwV2ICsInvLenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Invalid Length."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 106 }
+
+jnxMbgPgwV2ICsServNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Not supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 107 }
+
+jnxMbgPgwV2ICsServNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Service Not supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 108 }
+
+jnxMbgPgwV2ICsManIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 109 }
+
+jnxMbgPgwV2ICsManIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 110 }
+
+jnxMbgPgwV2ICsManIEMissRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 111 }
+
+jnxMbgPgwV2ICsManIEMissTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 112 }
+
+jnxMbgPgwV2ICsOptIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 113 }
+
+jnxMbgPgwV2ICsOptIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 114 }
+
+jnxMbgPgwV2ICsSysFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 115 }
+
+jnxMbgPgwV2ICsSysFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 116 }
+
+jnxMbgPgwV2ICsNoResRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Resource."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 117 }
+
+jnxMbgPgwV2ICsNoResTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause No Resource."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 118 }
+
+jnxMbgPgwV2ICsTFTSMANTErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 119 }
+
+jnxMbgPgwV2ICsTFTSMANTErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 120 }
+
+jnxMbgPgwV2ICsTFTSysErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT System Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 121 }
+
+jnxMbgPgwV2ICsTFTSysErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause TFT System Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 122 }
+
+jnxMbgPgwV2ICsPkFltManErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 123 }
+
+jnxMbgPgwV2ICsPkFltManErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 124 }
+
+jnxMbgPgwV2ICsPkFltSynErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 125 }
+
+jnxMbgPgwV2ICsPkFltSynErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 126 }
+
+jnxMbgPgwV2ICsMisUnknAPNRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unknown APN."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 127 }
+
+jnxMbgPgwV2ICsMisUnknAPNTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unknown APN."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 128 }
+
+jnxMbgPgwV2ICsUnexpRptIERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 129 }
+
+jnxMbgPgwV2ICsUnexpRptIETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 130 }
+
+jnxMbgPgwV2ICsGREKeyNtFdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 131 }
+
+jnxMbgPgwV2ICsGREKeyNtFdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 132 }
+
+jnxMbgPgwV2ICsRelocFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 133 }
+
+jnxMbgPgwV2ICsRelocFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 134 }
+
+jnxMbgPgwV2ICsDeniedINRatRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Denied in RAT."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 135 }
+
+jnxMbgPgwV2ICsDeniedINRatTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Denied in RAT."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 136 }
+
+jnxMbgPgwV2ICsPTNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 137 }
+
+jnxMbgPgwV2ICsPTNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 138 }
+
+jnxMbgPgwV2ICsAllDynAdOccRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 139 }
+
+jnxMbgPgwV2ICsAllDynAdOccTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 140 }
+
+jnxMbgPgwV2ICsNOTFTUECTXRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 141 }
+
+jnxMbgPgwV2ICsNOTFTUECTXTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 142 }
+
+jnxMbgPgwV2ICsProtoNtSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 143 }
+
+jnxMbgPgwV2ICsProtoNtSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 144 }
+
+jnxMbgPgwV2ICsUENotRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Not Responding."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 145 }
+
+jnxMbgPgwV2ICsUENotRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Not Responding."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 146 }
+
+jnxMbgPgwV2ICsUERefusesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Refuses."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 147 }
+
+jnxMbgPgwV2ICsUERefusesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Refuses."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 148 }
+
+jnxMbgPgwV2ICsServDeniedRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Denied."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 149 }
+
+jnxMbgPgwV2ICsServDeniedTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Service Denied."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 150 }
+
+jnxMbgPgwV2ICsUnabPageUERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 151 }
+
+jnxMbgPgwV2ICsUnabPageUETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 152 }
+
+jnxMbgPgwV2ICsNoMemRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Memory."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 153 }
+
+jnxMbgPgwV2ICsNoMemTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause No Memory."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 154 }
+
+jnxMbgPgwV2ICsUserAUTHFlRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 155 }
+
+jnxMbgPgwV2ICsUserAUTHFlTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 156 }
+
+jnxMbgPgwV2ICsAPNAcsDenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause APN Access Denied."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 157 }
+
+jnxMbgPgwV2ICsAPNAcsDenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause APN Access Denied."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 158 }
+
+jnxMbgPgwV2ICsReqRejRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Rejected."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 159 }
+
+jnxMbgPgwV2ICsReqRejTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Request Rejected."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 160 }
+
+jnxMbgPgwV2ICsPTMSISigMMRx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets received with cause P-TMSI Signature Mismatc."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 161 }
+
+jnxMbgPgwV2ICsPTMSISigMMTx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets sent with cause P-TMSI Signature Mismatch"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 162 }
+
+jnxMbgPgwV2ICsIMSINotKnRx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 163 }
+
+jnxMbgPgwV2ICsIMSINotKnTx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 164 }
+
+jnxMbgPgwV2ICsCondIEMsRx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets received with cause Conditional IE Missing."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 165 }
+
+jnxMbgPgwV2ICsCondIEMsTx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets sent with cause Conditional IE Missing."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 166 }
+
+jnxMbgPgwV2ICsAPNResTIncRx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets received with cause APN Restriction Type Incompatible"
+     ::= { jnxMbgPgwGtpGlbStatsEntry 167 }
+
+jnxMbgPgwV2ICsAPNResTIncTx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets sent with cause APN Restriction Type Incompatible"
+     ::= { jnxMbgPgwGtpGlbStatsEntry 168 }
+
+jnxMbgPgwV2ICsUnknownRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets received with cause Unknown"
+     ::= { jnxMbgPgwGtpGlbStatsEntry 169 }
+
+jnxMbgPgwV2ICsUnknownTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets sent with cause Unknown"
+     ::= { jnxMbgPgwGtpGlbStatsEntry 170 }
+
+jnxMbgPgwV1ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 171 }
+
+jnxMbgPgwV1UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 172 }
+
+jnxMbgPgwV1T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 173 }
+
+jnxMbgPgwV1GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 messages received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 174 }
+
+jnxMbgPgwV1GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 messages sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 175 }
+
+jnxMbgPgwV1GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 bytes received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 176 }
+
+jnxMbgPgwV1GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 bytes sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 177 }
+
+jnxMbgPgwV1GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 178 }
+
+jnxMbgPgwV1GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 179 }
+
+jnxMbgPgwV1GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 180 }
+
+jnxMbgPgwV1GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 181 }
+
+jnxMbgPgwV1VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 182 }
+
+jnxMbgPgwV1VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 version not supported messages Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 183 }
+
+jnxMbgPgwV1CrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 184 }
+
+jnxMbgPgwV1CrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 185 }
+
+jnxMbgPgwV1CrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 186 }
+
+jnxMbgPgwV1CrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 187 }
+
+jnxMbgPgwV1UpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 188 }
+
+jnxMbgPgwV1UpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 189 }
+
+jnxMbgPgwV1UpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 190 }
+
+jnxMbgPgwV1UpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 191 }
+
+jnxMbgPgwV1DelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 192 }
+
+jnxMbgPgwV1DelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 193 }
+
+jnxMbgPgwV1DelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 194 }
+
+jnxMbgPgwV1DelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 195 }
+
+jnxMbgPgwV1CrtAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 196 }
+
+jnxMbgPgwV1CrtAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 197 }
+
+jnxMbgPgwV1CrtAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 198 }
+
+jnxMbgPgwV1CrtAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 199 }
+
+jnxMbgPgwV1DelAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 200 }
+
+jnxMbgPgwV1DelAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 201 }
+
+jnxMbgPgwV1DelAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 202 }
+
+jnxMbgPgwV1DelAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 203 }
+
+jnxMbgPgwV1ErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Error Indication Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 204 }
+
+jnxMbgPgwV1ErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Error Indication Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 205 }
+
+jnxMbgPgwV1NotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 206 }
+
+jnxMbgPgwV1NotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 207 }
+
+jnxMbgPgwV1NotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 208 }
+
+jnxMbgPgwV1NotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 209 }
+
+jnxMbgPgwV1NotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 210 }
+
+jnxMbgPgwV1NotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 211 }
+
+jnxMbgPgwV1NotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 212 }
+
+jnxMbgPgwV1NotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 213 }
+
+jnxMbgPgwV1RtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 214 }
+
+jnxMbgPgwV1RtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 215 }
+
+jnxMbgPgwV1RtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 216 }
+
+jnxMbgPgwV1RtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 217 }
+
+jnxMbgPgwV1FailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 218 }
+
+jnxMbgPgwV1FailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 219 }
+
+jnxMbgPgwV1FailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 220 }
+
+jnxMbgPgwV1FailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 221 }
+
+jnxMbgPgwV1NotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Request Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 222 }
+
+jnxMbgPgwV1NotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Request Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 223 }
+
+jnxMbgPgwV1NotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 224 }
+
+jnxMbgPgwV1NotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 225 }
+
+jnxMbgPgwV1ICsReqAcceptedRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Request Accepted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 226 }
+
+jnxMbgPgwV1ICsReqAcceptedTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Request Accepted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 227 }
+
+jnxMbgPgwV1ICsNonExistRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Non Existant."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 228 }
+
+jnxMbgPgwV1ICsNonExistTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Non Existant."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 229 }
+
+jnxMbgPgwV1ICsInvMsgFmtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 230 }
+
+jnxMbgPgwV1ICsInvMsgFmtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 231 }
+
+jnxMbgPgwV1ICsIMSINotKnownRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 232 }
+
+
+jnxMbgPgwV1ICsIMSINotKnownTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 233 }
+
+jnxMbgPgwV1ICsMSGRPSDetachRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 234 }
+
+jnxMbgPgwV1ICsMSGRPSDetachTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 235 }
+
+jnxMbgPgwV1ICsMSNotGRPSRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 236 }
+
+jnxMbgPgwV1ICsMSNotGRPSRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 237 }
+
+jnxMbgPgwV1ICsMSRefusesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS Refues."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 238 }
+
+jnxMbgPgwV1ICsMSRefusesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS Refues."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 239 }
+
+jnxMbgPgwV1ICsVerNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 240 }
+
+jnxMbgPgwV1ICsVerNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 241 }
+
+jnxMbgPgwV1ICsNoResRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 242 }
+
+jnxMbgPgwV1ICsNoResTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 243 }
+
+jnxMbgPgwV1ICsServNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 244 }
+
+jnxMbgPgwV1ICsServNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 245 }
+
+jnxMbgPgwV1ICsManIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 246 }
+
+jnxMbgPgwV1ICsManIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 247 }
+
+jnxMbgPgwV1ICsManIEMissRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 248 }
+
+jnxMbgPgwV1ICsManIEMissTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 249 }
+
+jnxMbgPgwV1ICsOptIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 250 }
+
+jnxMbgPgwV1ICsOptIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 251 }
+
+jnxMbgPgwV1ICsSysFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 252 }
+
+jnxMbgPgwV1ICsSysFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 253 }
+
+jnxMbgPgwV1ICsRoamRestrictRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 254 }
+
+jnxMbgPgwV1ICsRoamRestrictTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 255 }
+
+jnxMbgPgwV1ICsPTMSISigMMRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 256 }
+
+jnxMbgPgwV1ICsPTMSISigMMTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 257 }
+
+jnxMbgPgwV1ICsGPRSConnSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 258 }
+
+jnxMbgPgwV1ICsGPRSConnSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 259 }
+
+jnxMbgPgwV1ICsAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 260 }
+
+jnxMbgPgwV1ICsAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 261 }
+
+jnxMbgPgwV1ICsUserAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 262 }
+
+jnxMbgPgwV1ICsUserAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 263 }
+
+jnxMbgPgwV1ICsCtxNotFndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Context Not Found."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 264 }
+
+jnxMbgPgwV1ICsCtxNotFndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Context Not Found."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 265 }
+
+jnxMbgPgwV1ICsAllDynPDPAdRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 266 }
+
+jnxMbgPgwV1ICsAllDynPDPAdTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 267 }
+
+jnxMbgPgwV1ICsNoMemRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No Memory."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 268 }
+
+jnxMbgPgwV1ICsNoMemTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No Memory."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 269 }
+
+jnxMbgPgwV1ICsRelocFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 270 }
+
+jnxMbgPgwV1ICsRelocFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 271 }
+
+jnxMbgPgwV1ICsUnkManExhdrRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 272 }
+
+jnxMbgPgwV1ICsUnkManExhdrTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 273 }
+
+jnxMbgPgwV1ICsSMANTTFTEr1Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 274 }
+
+jnxMbgPgwV1ICsSMANTTFTEr1Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 275 }
+
+jnxMbgPgwV1ICsSYNTFTErr2Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 276 }
+
+jnxMbgPgwV1ICsSYNTFTErr2Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 277 }
+
+jnxMbgPgwV1ICsSMNTPkFlEr1Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 278 }
+
+jnxMbgPgwV1ICsSMNTPkFlEr1Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 279 }
+
+jnxMbgPgwV1ICsSYNPkFlErr2Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 280 }
+
+jnxMbgPgwV1ICsSYNPkFlErr2Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 281 }
+
+jnxMbgPgwV1ICsMissUnknAPNRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 282 }
+
+jnxMbgPgwV1ICsMissUnknAPNTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 283 }
+
+jnxMbgPgwV1ICsUnknPDPAdRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 284 }
+
+jnxMbgPgwV1ICsUnknPDPAdTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 285 }
+
+jnxMbgPgwV1ICsNoTFTCtxExRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 286 }
+
+jnxMbgPgwV1ICsNoTFTCtxExTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 287 }
+
+jnxMbgPgwV0ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 288 }
+
+jnxMbgPgwV0UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 289 }
+
+jnxMbgPgwV0T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 290 }
+
+jnxMbgPgwV0GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 messages received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 291 }
+
+jnxMbgPgwV0GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 messages sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 292 }
+
+jnxMbgPgwV0GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 bytes received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 293 }
+
+jnxMbgPgwV0GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 bytes sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 294 }
+
+jnxMbgPgwV0GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+   "Number of GTP V0 Echo Requests received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 295 }
+
+jnxMbgPgwV0GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 296 }
+
+jnxMbgPgwV0GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Responses received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 297 }
+
+jnxMbgPgwV0GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 298 }
+
+jnxMbgPgwV0GlbVerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpGlbStatsEntry 299 }
+
+jnxMbgPgwV0GlbVerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 version not supported messages Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 300 }
+
+jnxMbgPgwV0GlbCrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 301 }
+
+jnxMbgPgwV0GlbCrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 302 }
+
+jnxMbgPgwV0GlbCrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 303 }
+
+jnxMbgPgwV0GlbCrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 304 }
+
+jnxMbgPgwV0GlbUpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 305 }
+
+jnxMbgPgwV0GlbUpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 306 }
+
+jnxMbgPgwV0GlbUpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 307 }
+
+jnxMbgPgwV0GlbUpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 308 }
+
+jnxMbgPgwV0GlbDelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 309 }
+
+jnxMbgPgwV0GlbDelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 310 }
+
+jnxMbgPgwV0GlbDelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 311 }
+
+jnxMbgPgwV0GlbDelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 312 }
+
+jnxMbgPgwV0GlbCrtAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 313 }
+
+jnxMbgPgwV0GlbCrtAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 314 }
+
+jnxMbgPgwV0GlbCrtAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 315 }
+
+jnxMbgPgwV0GlbCrtAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 316 }
+
+jnxMbgPgwV0GlbDelAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 317 }
+
+jnxMbgPgwV0GlbDelAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 318 }
+
+jnxMbgPgwV0GlbDelAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 319 }
+
+jnxMbgPgwV0GlbDelAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 320 }
+
+jnxMbgPgwV0GlbErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Error Indication messages Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 321 }
+
+jnxMbgPgwV0GlbErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Error Indication messages Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 322 }
+
+jnxMbgPgwV0GlbNotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 323 }
+
+jnxMbgPgwV0GlbNotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 324 }
+
+jnxMbgPgwV0GlbNotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 325 }
+
+jnxMbgPgwV0GlbNotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 326 }
+
+jnxMbgPgwV0GlbNotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 327 }
+
+jnxMbgPgwV0GlbNotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 328 }
+
+jnxMbgPgwV0GlbNotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 329 }
+
+jnxMbgPgwV0GlbNotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 330 }
+
+jnxMbgPgwV0GlbRtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 331 }
+
+jnxMbgPgwV0GlbRtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 332 }
+
+jnxMbgPgwV0GlbRtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 333 }
+
+jnxMbgPgwV0GlbRtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 334 }
+
+jnxMbgPgwV0GlbFailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 335 }
+
+jnxMbgPgwV0GlbFailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 336 }
+
+jnxMbgPgwV0GlbFailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 337 }
+
+jnxMbgPgwV0GlbFailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 338 }
+
+jnxMbgPgwV0GlbNotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 339 }
+
+jnxMbgPgwV0GlbNotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Requests Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 340 }
+
+jnxMbgPgwV0GlbNotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 341 }
+
+jnxMbgPgwV0GlbNotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 342 }
+
+jnxMbgPgwV0ICsReqAcceptedRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Request Accepted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 343 }
+
+jnxMbgPgwV0ICsReqAcceptedTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Request Accepted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 344 }
+
+jnxMbgPgwV0ICsNonExistRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Non Existant ."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 345 }
+
+jnxMbgPgwV0ICsNonExistTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Non Existant."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 346 }
+
+jnxMbgPgwV0ICsInvMsgFmtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 347 }
+
+jnxMbgPgwV0ICsInvMsgFmtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 348 }
+
+jnxMbgPgwV0ICsIMSINotKnownRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 349 }
+
+
+jnxMbgPgwV0ICsIMSINotKnownTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 350 }
+
+jnxMbgPgwV0ICsMSGRPSDetachRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 351 }
+
+jnxMbgPgwV0ICsMSGRPSDetachTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 352 }
+
+jnxMbgPgwV0ICsMSNotGRPSRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 353 }
+
+jnxMbgPgwV0ICsMSNotGRPSRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 354 }
+
+jnxMbgPgwV0ICsMSRefusesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS Refues."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 355 }
+
+jnxMbgPgwV0ICsMSRefusesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS Refues."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 356 }
+
+jnxMbgPgwV0ICsVerNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 357 }
+
+jnxMbgPgwV0ICsVerNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 358 }
+
+jnxMbgPgwV0ICsNoResRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause No Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 359 }
+
+jnxMbgPgwV0ICsNoResTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause No Response."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 360 }
+
+jnxMbgPgwV0ICsServNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 361 }
+
+jnxMbgPgwV0ICsServNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 362 }
+
+jnxMbgPgwV0ICsManIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 363 }
+
+jnxMbgPgwV0ICsManIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 364 }
+
+jnxMbgPgwV0ICsManIEMissRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 365 }
+
+jnxMbgPgwV0ICsManIEMissTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 366 }
+
+jnxMbgPgwV0ICsOptIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 367 }
+
+jnxMbgPgwV0ICsOptIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 368 }
+
+jnxMbgPgwV0ICsSysFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 369 }
+
+jnxMbgPgwV0ICsSysFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 370 }
+
+jnxMbgPgwV0ICsRoamRestrictRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 371 }
+
+jnxMbgPgwV0ICsRoamRestrictTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 372 }
+
+jnxMbgPgwV0ICsPTMSISigMMRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 373 }
+
+jnxMbgPgwV0ICsPTMSISigMMTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 374 }
+
+jnxMbgPgwV0ICsGPRSConnSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 375 }
+
+jnxMbgPgwV0ICsGPRSConnSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 376 }
+
+jnxMbgPgwV0ICsAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 377 }
+
+jnxMbgPgwV0ICsAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 378 }
+
+jnxMbgPgwV0ICsUserAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 379 }
+
+jnxMbgPgwV0ICsUserAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 380 }
+
+jnxMbgPgwGtpV2ICsLclDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Local Detach."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 381 }
+
+jnxMbgPgwGtpV2ICsLclDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Local Detach."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 382 }
+
+jnxMbgPgwGtpV2ICsCmpDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Complete Detach."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 383 }
+
+jnxMbgPgwGtpV2ICsCmpDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Complete Detach."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 384 }
+
+jnxMbgPgwGtpV2ICsRATChgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 385 }
+
+jnxMbgPgwGtpV2ICsRATChgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 386 }
+
+jnxMbgPgwGtpV2ICsISRDeactRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause ISR Deactivated."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 387 }
+
+jnxMbgPgwGtpV2ICsISRDeactTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause ISR Deactivated."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 388 }
+
+jnxMbgPgwGtpV2ICsEIFRNCEnRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 389 }
+
+jnxMbgPgwGtpV2ICsEIFRNCEnTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 390 }
+
+jnxMbgPgwGtpV2ICsSemErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 391 }
+
+jnxMbgPgwGtpV2ICsSemErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 392 }
+
+jnxMbgPgwGtpV2ICsSynErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 393 }
+
+jnxMbgPgwGtpV2ICsSynErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 394 }
+
+jnxMbgPgwGtpV2ICsRMValRcvRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Reserved Message Value Received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 395 }
+
+jnxMbgPgwGtpV2ICsRMValRcvTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Reserved Message Value Received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 396 }
+
+jnxMbgPgwGtpV2ICsRPrNtRspRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Remote peer not responding."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 397 }
+
+jnxMbgPgwGtpV2ICsRPrNtRspTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Remote peer not responding."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 398 }
+
+jnxMbgPgwGtpV2ICsColNWReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Collision with network initiated request."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 399 }
+
+jnxMbgPgwGtpV2ICsColNWReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Collision with network initiated request."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 400 }
+
+jnxMbgPgwGtpV2ICsUnPgUESusRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Unable to page UE due to suspension."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 401 }
+
+jnxMbgPgwGtpV2ICsUnPgUESusTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unable to page UE due to suspension."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 402 }
+
+jnxMbgPgwGtpV2ICsInvTotLenRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid total len."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 403 }
+
+jnxMbgPgwGtpV2ICsInvTotLenTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid total len."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 404 }
+
+jnxMbgPgwGtpV2ICsDtForNtSupRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Data forwarding not supported."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 405 }
+
+jnxMbgPgwGtpV2ICsDtForNtSupTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Data forwarding not supported."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 406 }
+
+jnxMbgPgwGtpV2ICsInReFRePrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 407 }
+
+jnxMbgPgwGtpV2ICsInReFRePrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 408 }
+
+jnxMbgPgwGtpV2ICsInvPrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid peer."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 409 }
+
+jnxMbgPgwGtpV2ICsInvPrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid peer."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 410 }
+
+jnxMbgPgwV1InitPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiate PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 411 }
+
+jnxMbgPgwV1InitPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiate PDP Context Requests Send."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 412 }
+
+jnxMbgPgwV1InitPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiate PDP Context Response Received."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 413 }
+
+jnxMbgPgwV1InitPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiate PDP Context Response Send."
+    ::= { jnxMbgPgwGtpGlbStatsEntry 414 }
+
+jnxMbgPgwV2SuspNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 415 }
+
+jnxMbgPgwV2SuspNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages sent."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 416 }
+
+jnxMbgPgwV2SuspAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 417 }
+
+jnxMbgPgwV2SuspAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages sent."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 418 }
+
+jnxMbgPgwV2ResumeNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 419 }
+   
+jnxMbgPgwV2ResumeNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages sent."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 420 }
+
+jnxMbgPgwV2ResumeAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 421 }
+
+jnxMbgPgwV2ResumeAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages sent."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 422 }
+
+jnxMbgPgwV2PiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S5 Piggyback messages received."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 423 }
+
+jnxMbgPgwV2PiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S5 Piggyback messages sent."
+     ::= { jnxMbgPgwGtpGlbStatsEntry 424 }
+
+--
+-- Peer Statistics Table: Peer leve statistics
+--
+
+jnxMbgPgwGtpCPerPeerStatsTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgPgwGtpPerPeerStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to a Peer level GTP Control statistic."
+  ::= { jnxMbgPgwGtpObjects 9 }
+
+jnxMbgPgwGtpPerPeerStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwGtpPerPeerStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the GTPC peer statistics Group."
+    INDEX     { jnxMbgGwIndex,
+                jnxMbgPgwPPGtpRmtAddr,
+                jnxMbgPgwPPGtpLclAddr,
+                jnxMbgPgwPPGtpRtgInst }
+    ::= { jnxMbgPgwGtpCPerPeerStatsTable 1}
+
+JnxMbgPgwGtpPerPeerStatsEntry ::= SEQUENCE {
+    jnxMbgPgwPPGtpRmtAddr           IpAddress,
+    jnxMbgPgwPPGtpLclAddr           IpAddress,
+    jnxMbgPgwPPGtpRtgInst           Unsigned32,
+    jnxMbgPgwPPRxPacketsDropped     Counter64,
+    jnxMbgPgwPPPacketAllocFail      Counter64,
+    jnxMbgPgwPPPacketSendFail       Counter64,
+    jnxMbgPgwPPIPVerErrRx           Counter64,
+    jnxMbgPgwPPIPProtoErrRx         Counter64,
+    jnxMbgPgwPPGTPPortErrRx         Counter64,
+    jnxMbgPgwPPGTPUnknVerRx         Counter64,
+    jnxMbgPgwPPPcktLenErrRx         Counter64,
+    jnxMbgPgwPPUnknMsgRx            Counter64,
+    jnxMbgPgwPPProtocolErrRx        Counter64,
+    jnxMbgPgwPPV2UnSupportedMsgRx   Counter64,
+    jnxMbgPgwPPV2T3RespTmrExpRx     Counter64,
+    jnxMbgPgwPPV2GlbNumMsgRx        Counter64,
+    jnxMbgPgwPPV2GlbNumMsgTx        Counter64,
+    jnxMbgPgwPPV2GlbNumBytesRx      Counter64,
+    jnxMbgPgwPPV2GlbNumBytesTx      Counter64,
+    jnxMbgPgwPPV2GlbEchoReqRx       Counter64,
+    jnxMbgPgwPPV2GlbEchoReqTx       Counter64,
+    jnxMbgPgwPPV2GlbEchoRespRx      Counter64,
+    jnxMbgPgwPPV2GlbEchoRespTx      Counter64,
+    jnxMbgPgwPPV2VerNotSupRx        Counter64,
+    jnxMbgPgwPPV2VerNotSupTx        Counter64,
+    jnxMbgPgwPPV2CreateSessReqRx    Counter64,
+    jnxMbgPgwPPV2CreateSessReqTx    Counter64,
+    jnxMbgPgwPPV2CreateSessRspRx    Counter64,
+    jnxMbgPgwPPV2CreateSessRspTx    Counter64,
+    jnxMbgPgwPPV2ModBrReqRx         Counter64,
+    jnxMbgPgwPPV2ModBrReqTx         Counter64,
+    jnxMbgPgwPPV2ModBrRspRx         Counter64,
+    jnxMbgPgwPPV2ModBrRspTx         Counter64,
+    jnxMbgPgwPPV2DelSessReqRx       Counter64,
+    jnxMbgPgwPPV2DelSessReqTx       Counter64,
+    jnxMbgPgwPPV2DelSessRspRx       Counter64,
+    jnxMbgPgwPPV2DelSessRspTx       Counter64,
+    jnxMbgPgwPPV2CrtBrReqRx         Counter64,
+    jnxMbgPgwPPV2CrtBrReqTx         Counter64,
+    jnxMbgPgwPPV2CrtBrRspRx         Counter64,
+    jnxMbgPgwPPV2CrtBrRspTx         Counter64,
+    jnxMbgPgwPPV2UpdBrReqRx         Counter64,
+    jnxMbgPgwPPV2UpdBrReqTx         Counter64,
+    jnxMbgPgwPPV2UpdBrRspRx         Counter64,
+    jnxMbgPgwPPV2UpdBrRspTx         Counter64,
+    jnxMbgPgwPPV2DelBrReqRx         Counter64,
+    jnxMbgPgwPPV2DelBrReqTx         Counter64,
+    jnxMbgPgwPPV2DelBrRspRx         Counter64,
+    jnxMbgPgwPPV2DelBrRspTx         Counter64,
+    jnxMbgPgwPPV2DelConnSetReqRx    Counter64,
+    jnxMbgPgwPPV2DelConnSetReqTx    Counter64,
+    jnxMbgPgwPPV2DelConnSetRspRx    Counter64,
+    jnxMbgPgwPPV2DelConnSetRspTx    Counter64,
+    jnxMbgPgwPPV2UpdConnSetReqRx    Counter64,
+    jnxMbgPgwPPV2UpdConnSetReqTx    Counter64,
+    jnxMbgPgwPPV2UpdConnSetRspRx    Counter64,
+    jnxMbgPgwPPV2UpdConnSetRspTx    Counter64,
+    jnxMbgPgwPPV2ModBrCmdRx         Counter64,
+    jnxMbgPgwPPV2ModBrCmdTx         Counter64,
+    jnxMbgPgwPPV2ModBrFlrIndRx      Counter64,
+    jnxMbgPgwPPV2ModBrFlrIndTx      Counter64,
+    jnxMbgPgwPPV2DelBrCmdRx         Counter64,
+    jnxMbgPgwPPV2DelBrCmdTx         Counter64,
+    jnxMbgPgwPPV2DelBrFlrIndRx      Counter64,
+    jnxMbgPgwPPV2DelBrFlrIndTx      Counter64,
+    jnxMbgPgwPPV2BrResCmdRx         Counter64,
+    jnxMbgPgwPPV2BrResCmdTx         Counter64,
+    jnxMbgPgwPPV2BrResFlrIndRx      Counter64,
+    jnxMbgPgwPPV2BrResFlrIndTx      Counter64,
+    jnxMbgPgwPPV2RelAcsBrReqRx      Counter64,
+    jnxMbgPgwPPV2RelAcsBrReqTx      Counter64,
+    jnxMbgPgwPPV2RelAcsBrRespRx     Counter64,
+    jnxMbgPgwPPV2RelAcsBrRespTx     Counter64,
+    jnxMbgPgwPPV2CrIndTunReqRx      Counter64,
+    jnxMbgPgwPPV2CrIndTunReqTx      Counter64,
+    jnxMbgPgwPPV2CrIndTunRespRx     Counter64,
+    jnxMbgPgwPPV2CrIndTunRespTx     Counter64,
+    jnxMbgPgwPPV2DelIndTunReqRx     Counter64,
+    jnxMbgPgwPPV2DelIndTunReqTx     Counter64,
+    jnxMbgPgwPPV2DelIndTunRespRx    Counter64,
+    jnxMbgPgwPPV2DelIndTunRespTx    Counter64,
+    jnxMbgPgwPPV2DlDataNotifRx      Counter64,
+    jnxMbgPgwPPV2DlDataNotifTx      Counter64,
+    jnxMbgPgwPPV2DlDataAckRx        Counter64,
+    jnxMbgPgwPPV2DlDataAckTx        Counter64,
+    jnxMbgPgwPPV2DlDataNotiFlrIndRx Counter64,
+    jnxMbgPgwPPV2DlDataNotiFlrIndTx Counter64,
+    jnxMbgPgwPPV2StopPagingIndRx    Counter64,
+    jnxMbgPgwPPV2StopPagingIndTx    Counter64,
+    jnxMbgPgwPPV2ICsPageRx          Counter64,
+    jnxMbgPgwPPV2ICsPageTx          Counter64,
+    jnxMbgPgwPPV2ICsReqAcceptRx     Counter64,
+    jnxMbgPgwPPV2ICsReqAcceptTx     Counter64,
+    jnxMbgPgwPPV2ICsAcceptPartRx    Counter64,
+    jnxMbgPgwPPV2ICsAcceptPartTx    Counter64,
+    jnxMbgPgwPPV2ICsNewPTNPrefRx    Counter64,
+    jnxMbgPgwPPV2ICsNewPTNPrefTx    Counter64,
+    jnxMbgPgwPPV2ICsNewPTSIAdbrRx   Counter64,
+    jnxMbgPgwPPV2ICsNewPTSIAdbrTx   Counter64,
+    jnxMbgPgwPPV2ICsCtxNotFndRx     Counter64,
+    jnxMbgPgwPPV2ICsCtxNotFndTx     Counter64,
+    jnxMbgPgwPPV2ICsInvMsgFmtRx     Counter64,
+    jnxMbgPgwPPV2ICsInvMsgFmtTx     Counter64,
+    jnxMbgPgwPPV2ICsVerNotSuppRx    Counter64,
+    jnxMbgPgwPPV2ICsVerNotSuppTx    Counter64,
+    jnxMbgPgwPPV2ICsInvLenRx        Counter64,
+    jnxMbgPgwPPV2ICsInvLenTx        Counter64,
+    jnxMbgPgwPPV2ICsServNotSuppRx   Counter64,
+    jnxMbgPgwPPV2ICsServNotSuppTx   Counter64,
+    jnxMbgPgwPPV2ICsManIEIncorrRx   Counter64,
+    jnxMbgPgwPPV2ICsManIEIncorrTx   Counter64,
+    jnxMbgPgwPPV2ICsManIEMissRx     Counter64,
+    jnxMbgPgwPPV2ICsManIEMissTx     Counter64,
+    jnxMbgPgwPPV2ICsOptIEIncorrRx   Counter64,
+    jnxMbgPgwPPV2ICsOptIEIncorrTx   Counter64,
+    jnxMbgPgwPPV2ICsSysFailRx       Counter64,
+    jnxMbgPgwPPV2ICsSysFailTx       Counter64,
+    jnxMbgPgwPPV2ICsNoResRx         Counter64,
+    jnxMbgPgwPPV2ICsNoResTx         Counter64,
+    jnxMbgPgwPPV2ICsTFTSMANTErRx    Counter64,
+    jnxMbgPgwPPV2ICsTFTSMANTErTx    Counter64,
+    jnxMbgPgwPPV2ICsTFTSysErrRx     Counter64,
+    jnxMbgPgwPPV2ICsTFTSysErrTx     Counter64,
+    jnxMbgPgwPPV2ICsPkFltManErrRx   Counter64,
+    jnxMbgPgwPPV2ICsPkFltManErrTx   Counter64,
+    jnxMbgPgwPPV2ICsPkFltSynErrRx   Counter64,
+    jnxMbgPgwPPV2ICsPkFltSynErrTx   Counter64,
+    jnxMbgPgwPPV2ICsMisUnknAPNRx    Counter64,
+    jnxMbgPgwPPV2ICsMisUnknAPNTx    Counter64,
+    jnxMbgPgwPPV2ICsUnexpRptIERx    Counter64,
+    jnxMbgPgwPPV2ICsUnexpRptIETx    Counter64,
+    jnxMbgPgwPPV2ICsGREKeyNtFdRx    Counter64,
+    jnxMbgPgwPPV2ICsGREKeyNtFdTx    Counter64,
+    jnxMbgPgwPPV2ICsRelocFailRx     Counter64,
+    jnxMbgPgwPPV2ICsRelocFailTx     Counter64,
+    jnxMbgPgwPPV2ICsDeniedINRatRx   Counter64,
+    jnxMbgPgwPPV2ICsDeniedINRatTx   Counter64,
+    jnxMbgPgwPPV2ICsPTNotSuppRx     Counter64,
+    jnxMbgPgwPPV2ICsPTNotSuppTx     Counter64,
+    jnxMbgPgwPPV2ICsAllDynAdOccRx   Counter64,
+    jnxMbgPgwPPV2ICsAllDynAdOccTx   Counter64,
+    jnxMbgPgwPPV2ICsNOTFTUECTXRx    Counter64,
+    jnxMbgPgwPPV2ICsNOTFTUECTXTx    Counter64,
+    jnxMbgPgwPPV2ICsProtoNtSupRx    Counter64,
+    jnxMbgPgwPPV2ICsProtoNtSupTx    Counter64,
+    jnxMbgPgwPPV2ICsUENotRespRx     Counter64,
+    jnxMbgPgwPPV2ICsUENotRespTx     Counter64,
+    jnxMbgPgwPPV2ICsUERefusesRx     Counter64,
+    jnxMbgPgwPPV2ICsUERefusesTx     Counter64,
+    jnxMbgPgwPPV2ICsServDeniedRx    Counter64,
+    jnxMbgPgwPPV2ICsServDeniedTx    Counter64,
+    jnxMbgPgwPPV2ICsUnabPageUERx    Counter64,
+    jnxMbgPgwPPV2ICsUnabPageUETx    Counter64,
+    jnxMbgPgwPPV2ICsNoMemRx         Counter64,
+    jnxMbgPgwPPV2ICsNoMemTx         Counter64,
+    jnxMbgPgwPPV2ICsUserAUTHFlRx    Counter64,
+    jnxMbgPgwPPV2ICsUserAUTHFlTx    Counter64,
+    jnxMbgPgwPPV2ICsAPNAcsDenRx     Counter64,
+    jnxMbgPgwPPV2ICsAPNAcsDenTx     Counter64,
+    jnxMbgPgwPPV2ICsReqRejRx        Counter64,
+    jnxMbgPgwPPV2ICsReqRejTx        Counter64,
+    jnxMbgPgwPPV2ICsPTMSISigMMRx    Counter64,
+    jnxMbgPgwPPV2ICsPTMSISigMMTx    Counter64,
+    jnxMbgPgwPPV2ICsIMSINotKnRx     Counter64,
+    jnxMbgPgwPPV2ICsIMSINotKnTx     Counter64,
+    jnxMbgPgwPPV2ICsCondIEMsRx      Counter64,
+    jnxMbgPgwPPV2ICsCondIEMsTx      Counter64,
+    jnxMbgPgwPPV2ICsAPNResTIncRx    Counter64,
+    jnxMbgPgwPPV2ICsAPNResTIncTx    Counter64,
+    jnxMbgPgwPPV2ICsUnknownRx       Counter64,
+    jnxMbgPgwPPV2ICsUnknownTx       Counter64,
+    jnxMbgPgwPPV1ProtocolErrRx      Counter64,
+    jnxMbgPgwPPV1UnSupportedMsgRx   Counter64,
+    jnxMbgPgwPPV1T3RespTmrExpRx     Counter64,
+    jnxMbgPgwPPV1GlbNumMsgRx        Counter64,
+    jnxMbgPgwPPV1GlbNumMsgTx        Counter64,
+    jnxMbgPgwPPV1GlbNumBytesRx      Counter64,
+    jnxMbgPgwPPV1GlbNumBytesTx      Counter64,
+    jnxMbgPgwPPV1GlbEchoReqRx       Counter64,
+    jnxMbgPgwPPV1GlbEchoReqTx       Counter64,
+    jnxMbgPgwPPV1GlbEchoRespRx      Counter64,
+    jnxMbgPgwPPV1GlbEchoRespTx      Counter64,
+    jnxMbgPgwPPV1VerNotSupRx        Counter64,
+    jnxMbgPgwPPV1VerNotSupTx        Counter64,
+    jnxMbgPgwPPV1CrtPdpCxtReqRx     Counter64,
+    jnxMbgPgwPPV1CrtPdpCxtReqTx     Counter64,
+    jnxMbgPgwPPV1CrtPdpCxtRspRx     Counter64,
+    jnxMbgPgwPPV1CrtPdpCxtRspTx     Counter64,
+    jnxMbgPgwPPV1UpdPdpCxtReqRx     Counter64,
+    jnxMbgPgwPPV1UpdPdpCxtReqTx     Counter64,
+    jnxMbgPgwPPV1UpdPdpCxtRspRx     Counter64,
+    jnxMbgPgwPPV1UpdPdpCxtRspTx     Counter64,
+    jnxMbgPgwPPV1DelPdpCxtReqRx     Counter64,
+    jnxMbgPgwPPV1DelPdpCxtReqTx     Counter64,
+    jnxMbgPgwPPV1DelPdpCxtRspRx     Counter64,
+    jnxMbgPgwPPV1DelPdpCxtRspTx     Counter64,
+    jnxMbgPgwPPV1CrtAAPdpCxtReqRx   Counter64,
+    jnxMbgPgwPPV1CrtAAPdpCxtReqTx   Counter64,
+    jnxMbgPgwPPV1CrtAAPdpCxtRspRx   Counter64,
+    jnxMbgPgwPPV1CrtAAPdpCxtRspTx   Counter64,
+    jnxMbgPgwPPV1DelAAPdpCxtReqRx   Counter64,
+    jnxMbgPgwPPV1DelAAPdpCxtReqTx   Counter64,
+    jnxMbgPgwPPV1DelAAPdpCxtRspRx   Counter64,
+    jnxMbgPgwPPV1DelAAPdpCxtRspTx   Counter64,
+    jnxMbgPgwPPV1ErrorIndRx         Counter64,
+    jnxMbgPgwPPV1ErrorIndTx         Counter64,
+    jnxMbgPgwPPV1NotifReqRx         Counter64,
+    jnxMbgPgwPPV1NotifReqTx         Counter64,
+    jnxMbgPgwPPV1NotifRspRx         Counter64,
+    jnxMbgPgwPPV1NotifRspTx         Counter64,
+    jnxMbgPgwPPV1NotifRejReqRx      Counter64,
+    jnxMbgPgwPPV1NotifRejReqTx      Counter64,
+    jnxMbgPgwPPV1NotifRejRspRx      Counter64,
+    jnxMbgPgwPPV1NotifRejRspTx      Counter64,
+    jnxMbgPgwPPV1RtInfReqRx         Counter64,
+    jnxMbgPgwPPV1RtInfReqTx         Counter64,
+    jnxMbgPgwPPV1RtInfRspRx         Counter64,
+    jnxMbgPgwPPV1RtInfRspTx         Counter64,
+    jnxMbgPgwPPV1FailRptReqRx       Counter64,
+    jnxMbgPgwPPV1FailRptReqTx       Counter64,
+    jnxMbgPgwPPV1FailRptRspRx       Counter64,
+    jnxMbgPgwPPV1FailRptRspTx       Counter64,
+    jnxMbgPgwPPV1NotMSPresReqRx     Counter64,
+    jnxMbgPgwPPV1NotMSPresReqTx     Counter64,
+    jnxMbgPgwPPV1NotMSPresRspRx     Counter64,
+    jnxMbgPgwPPV1NotMSPresRspTx     Counter64,
+    jnxMbgPgwPPV1ICsReqAcceptedRx   Counter64,
+    jnxMbgPgwPPV1ICsReqAcceptedTx   Counter64,
+    jnxMbgPgwPPV1ICsNonExistRx      Counter64,
+    jnxMbgPgwPPV1ICsNonExistTx      Counter64,
+    jnxMbgPgwPPV1ICsInvMsgFmtRx     Counter64,
+    jnxMbgPgwPPV1ICsInvMsgFmtTx     Counter64,
+    jnxMbgPgwPPV1ICsIMSINotKnownRx  Counter64,
+    jnxMbgPgwPPV1ICsIMSINotKnownTx  Counter64,
+    jnxMbgPgwPPV1ICsMSGRPSDetachRx  Counter64,
+    jnxMbgPgwPPV1ICsMSGRPSDetachTx  Counter64,
+    jnxMbgPgwPPV1ICsMSNotGRPSRespRx Counter64,
+    jnxMbgPgwPPV1ICsMSNotGRPSRespTx Counter64,
+    jnxMbgPgwPPV1ICsMSRefusesRx     Counter64,
+    jnxMbgPgwPPV1ICsMSRefusesTx     Counter64,
+    jnxMbgPgwPPV1ICsVerNotSuppRx    Counter64,
+    jnxMbgPgwPPV1ICsVerNotSuppTx    Counter64,
+    jnxMbgPgwPPV1ICsNoResRx         Counter64,
+    jnxMbgPgwPPV1ICsNoResTx         Counter64,
+    jnxMbgPgwPPV1ICsServNotSuppRx   Counter64,
+    jnxMbgPgwPPV1ICsServNotSuppTx   Counter64,
+    jnxMbgPgwPPV1ICsManIEIncrtRx    Counter64,
+    jnxMbgPgwPPV1ICsManIEIncrtTx    Counter64,
+    jnxMbgPgwPPV1ICsManIEMissRx     Counter64,
+    jnxMbgPgwPPV1ICsManIEMissTx     Counter64,
+    jnxMbgPgwPPV1ICsOptIEIncrtRx    Counter64,
+    jnxMbgPgwPPV1ICsOptIEIncrtTx    Counter64,
+    jnxMbgPgwPPV1ICsSysFailRx       Counter64,
+    jnxMbgPgwPPV1ICsSysFailTx       Counter64,
+    jnxMbgPgwPPV1ICsRoamRestrictRx  Counter64,
+    jnxMbgPgwPPV1ICsRoamRestrictTx  Counter64,
+    jnxMbgPgwPPV1ICsPTMSISigMMRx    Counter64,
+    jnxMbgPgwPPV1ICsPTMSISigMMTx    Counter64,
+    jnxMbgPgwPPV1ICsGPRSConnSuppRx  Counter64,
+    jnxMbgPgwPPV1ICsGPRSConnSuppTx  Counter64,
+    jnxMbgPgwPPV1ICsAuthFailRx      Counter64,
+    jnxMbgPgwPPV1ICsAuthFailTx      Counter64,
+    jnxMbgPgwPPV1ICsUserAuthFailRx  Counter64,
+    jnxMbgPgwPPV1ICsUserAuthFailTx  Counter64,
+    jnxMbgPgwPPV1ICsCtxNotFndRx     Counter64,
+    jnxMbgPgwPPV1ICsCtxNotFndTx     Counter64,
+    jnxMbgPgwPPV1ICsAllDynPDPAdRx   Counter64,
+    jnxMbgPgwPPV1ICsAllDynPDPAdTx   Counter64,
+    jnxMbgPgwPPV1ICsNoMemRx         Counter64,
+    jnxMbgPgwPPV1ICsNoMemTx         Counter64,
+    jnxMbgPgwPPV1ICsRelocFailRx     Counter64,
+    jnxMbgPgwPPV1ICsRelocFailTx     Counter64,
+    jnxMbgPgwPPV1ICsUnkManExhdrRx   Counter64,
+    jnxMbgPgwPPV1ICsUnkManExhdrTx   Counter64,
+    jnxMbgPgwPPV1ICsSMANTTFTEr1Rx   Counter64,
+    jnxMbgPgwPPV1ICsSMANTTFTEr1Tx   Counter64,
+    jnxMbgPgwPPV1ICsSYNTFTErr2Rx    Counter64,
+    jnxMbgPgwPPV1ICsSYNTFTErr2Tx    Counter64,
+    jnxMbgPgwPPV1ICsSMNTPkFlEr1Rx   Counter64,
+    jnxMbgPgwPPV1ICsSMNTPkFlEr1Tx   Counter64,
+    jnxMbgPgwPPV1ICsSYNPkFlErr2Rx   Counter64,
+    jnxMbgPgwPPV1ICsSYNPkFlErr2Tx   Counter64,
+    jnxMbgPgwPPV1ICsMissUnknAPNRx   Counter64,
+    jnxMbgPgwPPV1ICsMissUnknAPNTx   Counter64,
+    jnxMbgPgwPPV1ICsUnknPDPAdRx     Counter64,
+    jnxMbgPgwPPV1ICsUnknPDPAdTx     Counter64,
+    jnxMbgPgwPPV1ICsNoTFTCtxExRx    Counter64,
+    jnxMbgPgwPPV1ICsNoTFTCtxExTx    Counter64,
+    jnxMbgPgwPPV0ProtocolErrRx      Counter64,
+    jnxMbgPgwPPV0UnSupportedMsgRx   Counter64,
+    jnxMbgPgwPPV0T3RespTmrExpRx     Counter64,
+    jnxMbgPgwPPV0GlbNumMsgRx        Counter64,
+    jnxMbgPgwPPV0GlbNumMsgTx        Counter64,
+    jnxMbgPgwPPV0GlbNumBytesRx      Counter64,
+    jnxMbgPgwPPV0GlbNumBytesTx      Counter64,
+    jnxMbgPgwPPV0GlbEchoReqRx       Counter64,
+    jnxMbgPgwPPV0GlbEchoReqTx       Counter64,
+    jnxMbgPgwPPV0GlbEchoRespRx      Counter64,
+    jnxMbgPgwPPV0GlbEchoRespTx      Counter64,
+    jnxMbgPgwPPV0GlbVerNotSupRx     Counter64,
+    jnxMbgPgwPPV0GlbVerNotSupTx     Counter64,
+    jnxMbgPgwPPV0GlbCrtPdpCxtReqRx  Counter64,
+    jnxMbgPgwPPV0GlbCrtPdpCxtReqTx  Counter64,
+    jnxMbgPgwPPV0GlbCrtPdpCxtRspRx  Counter64,
+    jnxMbgPgwPPV0GlbCrtPdpCxtRspTx  Counter64,
+    jnxMbgPgwPPV0GlbUpdPdpCxtReqRx  Counter64,
+    jnxMbgPgwPPV0GlbUpdPdpCxtReqTx  Counter64,
+    jnxMbgPgwPPV0GlbUpdPdpCxtRspRx  Counter64,
+    jnxMbgPgwPPV0GlbUpdPdpCxtRspTx  Counter64,
+    jnxMbgPgwPPV0GlbDelPdpCxtReqRx  Counter64,
+    jnxMbgPgwPPV0GlbDelPdpCxtReqTx  Counter64,
+    jnxMbgPgwPPV0GlbDelPdpCxtRspRx  Counter64,
+    jnxMbgPgwPPV0GlbDelPdpCxtRspTx  Counter64,
+    jnxMbgPgwPPV0GlbCrAAPdpCxtReqRx Counter64,
+    jnxMbgPgwPPV0GlbCrAAPdpCxtReqTx Counter64,
+    jnxMbgPgwPPV0GlbCrAAPdpCxtRspRx Counter64,
+    jnxMbgPgwPPV0GlbCrAAPdpCxtRspTx Counter64,
+    jnxMbgPgwPPV0GlbDlAAPdpCxtReqRx Counter64,
+    jnxMbgPgwPPV0GlbDlAAPdpCxtReqTx Counter64,
+    jnxMbgPgwPPV0GlbDlAAPdpCxtRspRx Counter64,
+    jnxMbgPgwPPV0GlbDlAAPdpCxtRspTx Counter64,
+    jnxMbgPgwPPV0GlbErrorIndRx      Counter64,
+    jnxMbgPgwPPV0GlbErrorIndTx      Counter64,
+    jnxMbgPgwPPV0GlbNotifReqRx      Counter64,
+    jnxMbgPgwPPV0GlbNotifReqTx      Counter64,
+    jnxMbgPgwPPV0GlbNotifRspRx      Counter64,
+    jnxMbgPgwPPV0GlbNotifRspTx      Counter64,
+    jnxMbgPgwPPV0GlbNotifRejReqRx   Counter64,
+    jnxMbgPgwPPV0GlbNotifRejReqTx   Counter64,
+    jnxMbgPgwPPV0GlbNotifRejRspRx   Counter64,
+    jnxMbgPgwPPV0GlbNotifRejRspTx   Counter64,
+    jnxMbgPgwPPV0GlbRtInfReqRx      Counter64,
+    jnxMbgPgwPPV0GlbRtInfReqTx      Counter64,
+    jnxMbgPgwPPV0GlbRtInfRspRx      Counter64,
+    jnxMbgPgwPPV0GlbRtInfRspTx      Counter64,
+    jnxMbgPgwPPV0GlbFailRptReqRx    Counter64,
+    jnxMbgPgwPPV0GlbFailRptReqTx    Counter64,
+    jnxMbgPgwPPV0GlbFailRptRspRx    Counter64,
+    jnxMbgPgwPPV0GlbFailRptRspTx    Counter64,
+    jnxMbgPgwPPV0GlbNotMSPresReqRx  Counter64,
+    jnxMbgPgwPPV0GlbNotMSPresReqTx  Counter64,
+    jnxMbgPgwPPV0GlbNotMSPresRspRx  Counter64,
+    jnxMbgPgwPPV0GlbNotMSPresRspTx  Counter64,
+    jnxMbgPgwPPV0ICsReqAcceptedRx   Counter64,
+    jnxMbgPgwPPV0ICsReqAcceptedTx   Counter64,
+    jnxMbgPgwPPV0ICsNonExistRx      Counter64,
+    jnxMbgPgwPPV0ICsNonExistTx      Counter64,
+    jnxMbgPgwPPV0ICsInvMsgFmtRx     Counter64,
+    jnxMbgPgwPPV0ICsInvMsgFmtTx     Counter64,
+    jnxMbgPgwPPV0ICsIMSINotKnownRx  Counter64,
+    jnxMbgPgwPPV0ICsIMSINotKnownTx  Counter64,
+    jnxMbgPgwPPV0ICsMSGRPSDetachRx  Counter64,
+    jnxMbgPgwPPV0ICsMSGRPSDetachTx  Counter64,
+    jnxMbgPgwPPV0ICsMSNotGRPSRespRx Counter64,
+    jnxMbgPgwPPV0ICsMSNotGRPSRespTx Counter64,
+    jnxMbgPgwPPV0ICsMSRefusesRx     Counter64,
+    jnxMbgPgwPPV0ICsMSRefusesTx     Counter64,
+    jnxMbgPgwPPV0ICsVerNotSuppRx    Counter64,
+    jnxMbgPgwPPV0ICsVerNotSuppTx    Counter64,
+    jnxMbgPgwPPV0ICsNoResRx         Counter64,
+    jnxMbgPgwPPV0ICsNoResTx         Counter64,
+    jnxMbgPgwPPV0ICsServNotSuppRx   Counter64,
+    jnxMbgPgwPPV0ICsServNotSuppTx   Counter64,
+    jnxMbgPgwPPV0ICsManIEIncrtRx    Counter64,
+    jnxMbgPgwPPV0ICsManIEIncrtTx    Counter64,
+    jnxMbgPgwPPV0ICsManIEMissRx     Counter64,
+    jnxMbgPgwPPV0ICsManIEMissTx     Counter64,
+    jnxMbgPgwPPV0ICsOptIEIncrtRx    Counter64,
+    jnxMbgPgwPPV0ICsOptIEIncrtTx    Counter64,
+    jnxMbgPgwPPV0ICsSysFailRx       Counter64,
+    jnxMbgPgwPPV0ICsSysFailTx       Counter64,
+    jnxMbgPgwPPV0ICsRoamRestrictRx  Counter64,
+    jnxMbgPgwPPV0ICsRoamRestrictTx  Counter64,
+    jnxMbgPgwPPV0ICsPTMSISigMMRx    Counter64,
+    jnxMbgPgwPPV0ICsPTMSISigMMTx    Counter64,
+    jnxMbgPgwPPV0ICsGPRSConnSuppRx  Counter64,
+    jnxMbgPgwPPV0ICsGPRSConnSuppTx  Counter64,
+    jnxMbgPgwPPV0ICsAuthFailRx      Counter64,
+    jnxMbgPgwPPV0ICsAuthFailTx      Counter64,
+    jnxMbgPgwPPV0ICsUserAuthFailRx  Counter64,
+    jnxMbgPgwPPV0ICsUserAuthFailTx  Counter64,
+    jnxMbgPgwPPGtpV2ICsLclDetRx     Counter64,
+    jnxMbgPgwPPGtpV2ICsLclDetTx     Counter64,
+    jnxMbgPgwPPGtpV2ICsCmpDetRx     Counter64,
+    jnxMbgPgwPPGtpV2ICsCmpDetTx     Counter64,
+    jnxMbgPgwPPGtpV2ICsRATChgRx     Counter64,
+    jnxMbgPgwPPGtpV2ICsRATChgTx     Counter64,
+    jnxMbgPgwPPGtpV2ICsISRDeactRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsISRDeactTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsEIFRNCEnRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsEIFRNCEnTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsSemErTADRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsSemErTADTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsSynErTADRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsSynErTADTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsRMValRcvRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsRMValRcvTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsRPrNtRspRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsRPrNtRspTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsColNWReqRx   Counter64,
+    jnxMbgPgwPPGtpV2ICsColNWReqTx   Counter64,
+    jnxMbgPgwPPGtpV2ICsUnPgUESusRx  Counter64,
+    jnxMbgPgwPPGtpV2ICsUnPgUESusTx  Counter64,
+    jnxMbgPgwPPGtpV2ICsInvTotLenRx  Counter64,
+    jnxMbgPgwPPGtpV2ICsInvTotLenTx  Counter64,
+    jnxMbgPgwPPGtpV2ICsDtForNtSupRx Counter64,
+    jnxMbgPgwPPGtpV2ICsDtForNtSupTx Counter64,
+    jnxMbgPgwPPGtpV2ICsInReFRePrRx  Counter64,
+    jnxMbgPgwPPGtpV2ICsInReFRePrTx  Counter64,
+    jnxMbgPgwPPGtpV2ICsInvPrRx      Counter64,
+    jnxMbgPgwPPGtpV2ICsInvPrTx      Counter64,
+    jnxMbgPgwPPV1InitPdpCxtReqRx    Counter64,
+    jnxMbgPgwPPV1InitPdpCxtReqTx    Counter64,
+    jnxMbgPgwPPV1InitPdpCxtRspRx    Counter64,
+    jnxMbgPgwPPV1InitPdpCxtRspTx    Counter64,
+    jnxMbgPgwPPV2SuspNotifRx        Counter64,
+    jnxMbgPgwPPV2SuspNotifTx        Counter64,
+    jnxMbgPgwPPV2SuspAckRx          Counter64,
+    jnxMbgPgwPPV2SuspAckTx          Counter64,
+    jnxMbgPgwPPV2ResumeNotifRx      Counter64,
+    jnxMbgPgwPPV2ResumeNotifTx      Counter64,
+    jnxMbgPgwPPV2ResumeAckRx        Counter64,
+    jnxMbgPgwPPV2ResumeAckTx        Counter64,
+    jnxMbgPgwPPV2PiggybackMsgRx     Counter64,
+    jnxMbgPgwPPV2PiggybackMsgTx     Counter64
+}
+
+jnxMbgPgwPPGtpRmtAddr OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Remote IP address of this GTP entry."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 1 }
+
+jnxMbgPgwPPGtpLclAddr OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Local IP address of this GTP entry."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 2 }
+
+jnxMbgPgwPPGtpRtgInst OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Routing Instance for this Peer."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 3 }
+
+jnxMbgPgwPPRxPacketsDropped  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Received GTP Packets Dropped."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 4 }
+
+jnxMbgPgwPPPacketAllocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet allocation failures."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 5 }
+
+jnxMbgPgwPPPacketSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Send failures."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 6 }
+
+jnxMbgPgwPPIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Version Error Packets Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 7 }
+
+jnxMbgPgwPPIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  IP Protocol Error packets Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 8 }
+
+jnxMbgPgwPPGTPPortErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Port Error Packets Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 9 }
+
+jnxMbgPgwPPGTPUnknVerRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Version Packets Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 10 }
+
+jnxMbgPgwPPPcktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Length Error Packets Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 11 }
+
+jnxMbgPgwPPUnknMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Messages Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 12 }
+
+jnxMbgPgwPPProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 13 }
+
+jnxMbgPgwPPV2UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 14 }
+
+jnxMbgPgwPPV2T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 15 }
+
+jnxMbgPgwPPV2GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 16 }
+
+jnxMbgPgwPPV2GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 messages sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 17 }
+
+jnxMbgPgwPPV2GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 18 }
+
+jnxMbgPgwPPV2GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 bytes sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 19 }
+
+jnxMbgPgwPPV2GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 20 }
+
+jnxMbgPgwPPV2GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 21 }
+
+jnxMbgPgwPPV2GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 22 }
+
+jnxMbgPgwPPV2GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 23 }
+
+jnxMbgPgwPPV2VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 24 }
+
+jnxMbgPgwPPV2VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of version not supported messages Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 25 }
+
+jnxMbgPgwPPV2CreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 26 }
+
+jnxMbgPgwPPV2CreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 27 }
+
+jnxMbgPgwPPV2CreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 28 }
+
+jnxMbgPgwPPV2CreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 29 }
+
+jnxMbgPgwPPV2ModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 30 }
+
+jnxMbgPgwPPV2ModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 31 }
+
+jnxMbgPgwPPV2ModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 32 }
+
+jnxMbgPgwPPV2ModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 33 }
+
+jnxMbgPgwPPV2DelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 34 }
+
+jnxMbgPgwPPV2DelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 35 }
+
+jnxMbgPgwPPV2DelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 36 }
+
+jnxMbgPgwPPV2DelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 37 }
+
+jnxMbgPgwPPV2CrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 38 }
+
+jnxMbgPgwPPV2CrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 39 }
+
+jnxMbgPgwPPV2CrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 40 }
+
+jnxMbgPgwPPV2CrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 41 }
+
+jnxMbgPgwPPV2UpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 42 }
+
+jnxMbgPgwPPV2UpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 43 }
+
+jnxMbgPgwPPV2UpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 44 }
+
+jnxMbgPgwPPV2UpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 45 }
+
+jnxMbgPgwPPV2DelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 46 }
+
+jnxMbgPgwPPV2DelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 47 }
+
+jnxMbgPgwPPV2DelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 48 }
+
+jnxMbgPgwPPV2DelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 49 }
+jnxMbgPgwPPV2DelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Delete PDN connection set Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 50 }
+
+jnxMbgPgwPPV2DelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Delete PDN connection set Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 51 }
+
+jnxMbgPgwPPV2DelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Delete PDN connection set Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 52 }
+
+jnxMbgPgwPPV2DelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Delete PDN connection set Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 53 }
+
+jnxMbgPgwPPV2UpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Update Connection set Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 54 }
+
+jnxMbgPgwPPV2UpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Update Connection set Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 55 }
+
+jnxMbgPgwPPV2UpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Update Connecton set Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 56 }
+
+jnxMbgPgwPPV2UpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Update Connection set Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 57 }
+
+jnxMbgPgwPPV2ModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 58 }
+
+jnxMbgPgwPPV2ModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 59 }
+
+jnxMbgPgwPPV2ModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 60 }
+
+jnxMbgPgwPPV2ModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 61 }
+
+jnxMbgPgwPPV2DelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 62 }
+
+jnxMbgPgwPPV2DelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 63 }
+
+jnxMbgPgwPPV2DelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 64 }
+
+jnxMbgPgwPPV2DelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 65 }
+
+jnxMbgPgwPPV2BrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 66 }
+
+jnxMbgPgwPPV2BrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 67 }
+
+jnxMbgPgwPPV2BrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 68 }
+
+jnxMbgPgwPPV2BrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 69 }
+
+jnxMbgPgwPPV2RelAcsBrReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 70 }
+
+jnxMbgPgwPPV2RelAcsBrReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 71 }
+
+jnxMbgPgwPPV2RelAcsBrRespRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 72 }
+
+jnxMbgPgwPPV2RelAcsBrRespTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 73 }
+
+jnxMbgPgwPPV2CrIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Requests Received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 74 }
+
+jnxMbgPgwPPV2CrIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Requests sent"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 75 }
+
+jnxMbgPgwPPV2CrIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Responses Received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 76 }
+
+jnxMbgPgwPPV2CrIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Responses sent"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 77 }
+
+jnxMbgPgwPPV2DelIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Requests Received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 78 }
+
+jnxMbgPgwPPV2DelIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Requests sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 79 }
+
+jnxMbgPgwPPV2DelIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Responses Received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 80 }
+
+jnxMbgPgwPPV2DelIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Responses sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 81 }
+
+jnxMbgPgwPPV2DlDataNotifRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 82 }
+
+jnxMbgPgwPPV2DlDataNotifTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 83 }
+
+jnxMbgPgwPPV2DlDataAckRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgements received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 84 }
+
+jnxMbgPgwPPV2DlDataAckTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgements Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 85 }
+
+jnxMbgPgwPPV2DlDataNotiFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 86 }
+
+jnxMbgPgwPPV2DlDataNotiFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 87 }
+
+jnxMbgPgwPPV2StopPagingIndRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Stop Paging Indication Messages Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 88 }
+
+jnxMbgPgwPPV2StopPagingIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP V2 Stop Paging Indicaton messages sent"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 89 }
+
+jnxMbgPgwPPV2ICsPageRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Page."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 90 }
+
+jnxMbgPgwPPV2ICsPageTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Page."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 91 }
+
+jnxMbgPgwPPV2ICsReqAcceptRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Accept."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 92 }
+
+jnxMbgPgwPPV2ICsReqAcceptTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Request Accept."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 93 }
+
+jnxMbgPgwPPV2ICsAcceptPartRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Accept Partial."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 94 }
+
+jnxMbgPgwPPV2ICsAcceptPartTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Accept Partial."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 95 }
+
+jnxMbgPgwPPV2ICsNewPTNPrefRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Network Preference."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 96 }
+
+jnxMbgPgwPPV2ICsNewPTNPrefTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause New PDN type due to Network Preference."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 97 }
+
+
+jnxMbgPgwPPV2ICsNewPTSIAdbrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 98 }
+
+jnxMbgPgwPPV2ICsNewPTSIAdbrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 99 }
+
+jnxMbgPgwPPV2ICsCtxNotFndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Context not found ."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 100 }
+
+jnxMbgPgwPPV2ICsCtxNotFndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Context not found."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 101 }
+
+jnxMbgPgwPPV2ICsInvMsgFmtRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 102 }
+
+jnxMbgPgwPPV2ICsInvMsgFmtTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 103 }
+
+jnxMbgPgwPPV2ICsVerNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Version not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 104 }
+
+jnxMbgPgwPPV2ICsVerNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Version not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 105 }
+
+jnxMbgPgwPPV2ICsInvLenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Length."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 106 }
+
+jnxMbgPgwPPV2ICsInvLenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Invalid Length."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 107 }
+
+jnxMbgPgwPPV2ICsServNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Not supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 108 }
+
+jnxMbgPgwPPV2ICsServNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Service Not supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 109 }
+
+jnxMbgPgwPPV2ICsManIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 110 }
+
+jnxMbgPgwPPV2ICsManIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 111 }
+
+jnxMbgPgwPPV2ICsManIEMissRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 112 }
+
+jnxMbgPgwPPV2ICsManIEMissTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 113 }
+
+jnxMbgPgwPPV2ICsOptIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 114 }
+
+jnxMbgPgwPPV2ICsOptIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 115 }
+
+jnxMbgPgwPPV2ICsSysFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 116 }
+
+jnxMbgPgwPPV2ICsSysFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 117 }
+
+jnxMbgPgwPPV2ICsNoResRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Resource."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 118 }
+
+jnxMbgPgwPPV2ICsNoResTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause No Resource."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 119 }
+
+jnxMbgPgwPPV2ICsTFTSMANTErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 120 }
+
+jnxMbgPgwPPV2ICsTFTSMANTErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 121 }
+
+jnxMbgPgwPPV2ICsTFTSysErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT System Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 122 }
+
+jnxMbgPgwPPV2ICsTFTSysErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause TFT System Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 123 }
+
+jnxMbgPgwPPV2ICsPkFltManErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 124 }
+
+jnxMbgPgwPPV2ICsPkFltManErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 125 }
+
+jnxMbgPgwPPV2ICsPkFltSynErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 126 }
+
+jnxMbgPgwPPV2ICsPkFltSynErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 127 }
+
+jnxMbgPgwPPV2ICsMisUnknAPNRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unknown APN."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 128 }
+
+jnxMbgPgwPPV2ICsMisUnknAPNTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unknown APN."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 129 }
+
+jnxMbgPgwPPV2ICsUnexpRptIERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 130 }
+
+jnxMbgPgwPPV2ICsUnexpRptIETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 131 }
+
+jnxMbgPgwPPV2ICsGREKeyNtFdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 132 }
+
+jnxMbgPgwPPV2ICsGREKeyNtFdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 133 }
+
+jnxMbgPgwPPV2ICsRelocFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 134 }
+
+jnxMbgPgwPPV2ICsRelocFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 135 }
+
+jnxMbgPgwPPV2ICsDeniedINRatRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Denied in RAT."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 136 }
+
+jnxMbgPgwPPV2ICsDeniedINRatTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Denied in RAT."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 137 }
+
+jnxMbgPgwPPV2ICsPTNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 138 }
+
+jnxMbgPgwPPV2ICsPTNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 139 }
+
+jnxMbgPgwPPV2ICsAllDynAdOccRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 140 }
+
+jnxMbgPgwPPV2ICsAllDynAdOccTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 141 }
+
+jnxMbgPgwPPV2ICsNOTFTUECTXRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 142 }
+
+jnxMbgPgwPPV2ICsNOTFTUECTXTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 143 }
+
+jnxMbgPgwPPV2ICsProtoNtSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 144 }
+
+jnxMbgPgwPPV2ICsProtoNtSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 145 }
+
+jnxMbgPgwPPV2ICsUENotRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Not Responding."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 146 }
+
+jnxMbgPgwPPV2ICsUENotRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Not Responding."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 147 }
+
+jnxMbgPgwPPV2ICsUERefusesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Refuses."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 148 }
+
+jnxMbgPgwPPV2ICsUERefusesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Refuses."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 149 }
+
+jnxMbgPgwPPV2ICsServDeniedRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Denied."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 150 }
+
+jnxMbgPgwPPV2ICsServDeniedTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Service Denied."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 151 }
+
+jnxMbgPgwPPV2ICsUnabPageUERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 152 }
+
+jnxMbgPgwPPV2ICsUnabPageUETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 153 }
+
+jnxMbgPgwPPV2ICsNoMemRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Memory."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 154 }
+
+jnxMbgPgwPPV2ICsNoMemTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause No Memory."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 155 }
+
+jnxMbgPgwPPV2ICsUserAUTHFlRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 156 }
+
+jnxMbgPgwPPV2ICsUserAUTHFlTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 157 }
+
+jnxMbgPgwPPV2ICsAPNAcsDenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause APN Access Denied."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 158 }
+
+jnxMbgPgwPPV2ICsAPNAcsDenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause APN Access Denied."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 159 }
+
+jnxMbgPgwPPV2ICsReqRejRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Rejected."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 160 }
+
+jnxMbgPgwPPV2ICsReqRejTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Request Rejected."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 161 }
+
+jnxMbgPgwPPV2ICsPTMSISigMMRx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets received with cause P-TMSI Signature Mismatch"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 162 }
+
+jnxMbgPgwPPV2ICsPTMSISigMMTx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets sent with cause P-TMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 163 }
+
+jnxMbgPgwPPV2ICsIMSINotKnRx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 164 }
+
+jnxMbgPgwPPV2ICsIMSINotKnTx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 165 }
+
+jnxMbgPgwPPV2ICsCondIEMsRx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets received with cause Conditional IE Missing."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 166 }
+
+jnxMbgPgwPPV2ICsCondIEMsTx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets sent with cause Conditional IE Missing."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 167 }
+
+jnxMbgPgwPPV2ICsAPNResTIncRx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets received with cause APN Restriction Type Incompatible msgs received"
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 168 }
+
+jnxMbgPgwPPV2ICsAPNResTIncTx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets sent with cause APN Restriction Type Incompatible msgs sent."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 169 }
+
+jnxMbgPgwPPV2ICsUnknownRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets received with cause Unknown."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 170 }
+
+jnxMbgPgwPPV2ICsUnknownTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets sent with cause Unknown."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 171 }
+
+jnxMbgPgwPPV1ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 172 }
+
+jnxMbgPgwPPV1UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 173 }
+
+jnxMbgPgwPPV1T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 174 }
+
+jnxMbgPgwPPV1GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 messages received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 175 }
+
+jnxMbgPgwPPV1GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 messages sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 176 }
+
+jnxMbgPgwPPV1GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 bytes received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 177 }
+
+jnxMbgPgwPPV1GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 bytes sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 178 }
+
+jnxMbgPgwPPV1GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Requests received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 179 }
+
+jnxMbgPgwPPV1GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 180 }
+
+jnxMbgPgwPPV1GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Responses received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 181 }
+
+jnxMbgPgwPPV1GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 182 }
+
+jnxMbgPgwPPV1VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 183 }
+
+jnxMbgPgwPPV1VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Number of version not supported messages sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 184 }
+
+jnxMbgPgwPPV1CrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 185 }
+
+jnxMbgPgwPPV1CrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 186 }
+
+jnxMbgPgwPPV1CrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 187 }
+
+jnxMbgPgwPPV1CrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 188 }
+
+jnxMbgPgwPPV1UpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 189 }
+
+jnxMbgPgwPPV1UpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 190 }
+
+jnxMbgPgwPPV1UpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 191 }
+
+jnxMbgPgwPPV1UpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 192 }
+
+jnxMbgPgwPPV1DelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 193 }
+
+jnxMbgPgwPPV1DelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 194 }
+
+jnxMbgPgwPPV1DelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 195 }
+
+jnxMbgPgwPPV1DelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 196 }
+
+jnxMbgPgwPPV1CrtAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 197 }
+
+jnxMbgPgwPPV1CrtAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 198 }
+
+jnxMbgPgwPPV1CrtAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 199 }
+
+jnxMbgPgwPPV1CrtAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 200 }
+
+jnxMbgPgwPPV1DelAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 201 }
+
+jnxMbgPgwPPV1DelAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 202 }
+
+jnxMbgPgwPPV1DelAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 203 }
+
+jnxMbgPgwPPV1DelAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 204 }
+
+jnxMbgPgwPPV1ErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Error Indication Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 205 }
+
+jnxMbgPgwPPV1ErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Error Indication Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 206 }
+
+jnxMbgPgwPPV1NotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 207 }
+
+jnxMbgPgwPPV1NotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 208 }
+
+jnxMbgPgwPPV1NotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 209 }
+
+jnxMbgPgwPPV1NotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 210 }
+
+jnxMbgPgwPPV1NotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 211 }
+
+jnxMbgPgwPPV1NotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 212 }
+
+jnxMbgPgwPPV1NotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 213 }
+
+jnxMbgPgwPPV1NotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 214 }
+
+jnxMbgPgwPPV1RtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 215 }
+
+jnxMbgPgwPPV1RtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 216 }
+
+jnxMbgPgwPPV1RtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 217 }
+
+jnxMbgPgwPPV1RtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 218 }
+
+jnxMbgPgwPPV1FailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 219 }
+
+jnxMbgPgwPPV1FailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 220 }
+
+jnxMbgPgwPPV1FailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 221 }
+
+jnxMbgPgwPPV1FailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 222 }
+
+jnxMbgPgwPPV1NotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Request Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 223 }
+
+jnxMbgPgwPPV1NotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Request Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 224 }
+
+jnxMbgPgwPPV1NotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 225 }
+
+jnxMbgPgwPPV1NotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 226 }
+
+jnxMbgPgwPPV1ICsReqAcceptedRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Request Accepted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 227 }
+
+jnxMbgPgwPPV1ICsReqAcceptedTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Request Accepted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 228 }
+
+jnxMbgPgwPPV1ICsNonExistRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Non Existant."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 229 }
+
+jnxMbgPgwPPV1ICsNonExistTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Non Existant."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 230 }
+
+jnxMbgPgwPPV1ICsInvMsgFmtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 231 }
+
+jnxMbgPgwPPV1ICsInvMsgFmtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 232 }
+
+jnxMbgPgwPPV1ICsIMSINotKnownRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 233 }
+
+
+jnxMbgPgwPPV1ICsIMSINotKnownTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 234 }
+
+jnxMbgPgwPPV1ICsMSGRPSDetachRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 235 }
+
+jnxMbgPgwPPV1ICsMSGRPSDetachTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 236 }
+
+jnxMbgPgwPPV1ICsMSNotGRPSRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 237 }
+
+jnxMbgPgwPPV1ICsMSNotGRPSRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 238 }
+
+jnxMbgPgwPPV1ICsMSRefusesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS Refues."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 239 }
+
+jnxMbgPgwPPV1ICsMSRefusesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS Refues."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 240 }
+
+jnxMbgPgwPPV1ICsVerNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 241 }
+
+jnxMbgPgwPPV1ICsVerNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 242 }
+
+jnxMbgPgwPPV1ICsNoResRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 243 }
+
+jnxMbgPgwPPV1ICsNoResTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 244 }
+
+jnxMbgPgwPPV1ICsServNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 245 }
+
+jnxMbgPgwPPV1ICsServNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 246 }
+
+jnxMbgPgwPPV1ICsManIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 247 }
+
+jnxMbgPgwPPV1ICsManIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 248 }
+
+jnxMbgPgwPPV1ICsManIEMissRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 249 }
+
+jnxMbgPgwPPV1ICsManIEMissTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 250 }
+
+jnxMbgPgwPPV1ICsOptIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 251 }
+
+jnxMbgPgwPPV1ICsOptIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 252 }
+
+jnxMbgPgwPPV1ICsSysFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 253 }
+
+jnxMbgPgwPPV1ICsSysFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 254 }
+
+jnxMbgPgwPPV1ICsRoamRestrictRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 255 }
+
+jnxMbgPgwPPV1ICsRoamRestrictTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 256 }
+
+jnxMbgPgwPPV1ICsPTMSISigMMRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 257 }
+
+jnxMbgPgwPPV1ICsPTMSISigMMTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 258 }
+
+jnxMbgPgwPPV1ICsGPRSConnSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 259 }
+
+jnxMbgPgwPPV1ICsGPRSConnSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 260 }
+
+jnxMbgPgwPPV1ICsAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 261 }
+
+jnxMbgPgwPPV1ICsAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 262 }
+
+jnxMbgPgwPPV1ICsUserAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 263 }
+
+jnxMbgPgwPPV1ICsUserAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 264 }
+
+jnxMbgPgwPPV1ICsCtxNotFndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Context Not Found."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 265 }
+
+jnxMbgPgwPPV1ICsCtxNotFndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Context Not Found."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 266 }
+
+jnxMbgPgwPPV1ICsAllDynPDPAdRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 267 }
+
+jnxMbgPgwPPV1ICsAllDynPDPAdTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 268 }
+
+jnxMbgPgwPPV1ICsNoMemRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No Memory."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 269 }
+
+jnxMbgPgwPPV1ICsNoMemTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No Memory."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 270 }
+
+jnxMbgPgwPPV1ICsRelocFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 271 }
+
+jnxMbgPgwPPV1ICsRelocFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 272 }
+
+jnxMbgPgwPPV1ICsUnkManExhdrRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 273 }
+
+jnxMbgPgwPPV1ICsUnkManExhdrTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 274 }
+
+jnxMbgPgwPPV1ICsSMANTTFTEr1Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 275 }
+
+jnxMbgPgwPPV1ICsSMANTTFTEr1Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 276 }
+
+jnxMbgPgwPPV1ICsSYNTFTErr2Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 277 }
+
+jnxMbgPgwPPV1ICsSYNTFTErr2Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 278 }
+
+jnxMbgPgwPPV1ICsSMNTPkFlEr1Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 279 }
+
+jnxMbgPgwPPV1ICsSMNTPkFlEr1Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 280 }
+
+jnxMbgPgwPPV1ICsSYNPkFlErr2Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 281 }
+
+jnxMbgPgwPPV1ICsSYNPkFlErr2Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 282 }
+
+jnxMbgPgwPPV1ICsMissUnknAPNRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 283 }
+
+jnxMbgPgwPPV1ICsMissUnknAPNTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 284 }
+
+jnxMbgPgwPPV1ICsUnknPDPAdRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 285 }
+
+jnxMbgPgwPPV1ICsUnknPDPAdTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 286 }
+
+jnxMbgPgwPPV1ICsNoTFTCtxExRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 287 }
+
+jnxMbgPgwPPV1ICsNoTFTCtxExTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 288 }
+
+jnxMbgPgwPPV0ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 289 }
+
+jnxMbgPgwPPV0UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 290 }
+
+jnxMbgPgwPPV0T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 291 }
+
+jnxMbgPgwPPV0GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 messages received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 292 }
+
+jnxMbgPgwPPV0GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 messages sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 293 }
+
+jnxMbgPgwPPV0GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 bytes received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 294 }
+
+jnxMbgPgwPPV0GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 bytes sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 295 }
+
+jnxMbgPgwPPV0GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+   "Number of GTP V0 Echo Request received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 296 }
+
+jnxMbgPgwPPV0GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Request Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 297 }
+
+jnxMbgPgwPPV0GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Response received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 298 }
+
+jnxMbgPgwPPV0GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Response Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 299 }
+
+jnxMbgPgwPPV0GlbVerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 300 }
+
+jnxMbgPgwPPV0GlbVerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Number of version not supported messages sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 301 }
+
+jnxMbgPgwPPV0GlbCrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 302 }
+
+jnxMbgPgwPPV0GlbCrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 303 }
+
+jnxMbgPgwPPV0GlbCrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 304 }
+
+jnxMbgPgwPPV0GlbCrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 305 }
+
+jnxMbgPgwPPV0GlbUpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 306 }
+
+jnxMbgPgwPPV0GlbUpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 307 }
+
+jnxMbgPgwPPV0GlbUpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 308 }
+
+jnxMbgPgwPPV0GlbUpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 309 }
+
+jnxMbgPgwPPV0GlbDelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 310 }
+
+jnxMbgPgwPPV0GlbDelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 311 }
+
+jnxMbgPgwPPV0GlbDelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 312 }
+
+jnxMbgPgwPPV0GlbDelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 313 }
+
+jnxMbgPgwPPV0GlbCrAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 314 }
+
+jnxMbgPgwPPV0GlbCrAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 315 }
+
+jnxMbgPgwPPV0GlbCrAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 316 }
+
+jnxMbgPgwPPV0GlbCrAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 317 }
+
+jnxMbgPgwPPV0GlbDlAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 318 }
+
+jnxMbgPgwPPV0GlbDlAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 319 }
+
+jnxMbgPgwPPV0GlbDlAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 320 }
+
+jnxMbgPgwPPV0GlbDlAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 321 }
+
+jnxMbgPgwPPV0GlbErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Error Indication Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 322 }
+
+jnxMbgPgwPPV0GlbErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Error Indication Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 323 }
+
+jnxMbgPgwPPV0GlbNotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 324 }
+
+jnxMbgPgwPPV0GlbNotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 325 }
+
+jnxMbgPgwPPV0GlbNotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 326 }
+
+jnxMbgPgwPPV0GlbNotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 327 }
+
+jnxMbgPgwPPV0GlbNotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 328 }
+
+jnxMbgPgwPPV0GlbNotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 329 }
+
+jnxMbgPgwPPV0GlbNotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 330 }
+
+jnxMbgPgwPPV0GlbNotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 331 }
+
+jnxMbgPgwPPV0GlbRtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 332 }
+
+jnxMbgPgwPPV0GlbRtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 333 }
+
+jnxMbgPgwPPV0GlbRtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 334 }
+
+jnxMbgPgwPPV0GlbRtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 335 }
+
+jnxMbgPgwPPV0GlbFailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 336 }
+
+jnxMbgPgwPPV0GlbFailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 337 }
+
+jnxMbgPgwPPV0GlbFailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 338 }
+
+jnxMbgPgwPPV0GlbFailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 339 }
+
+jnxMbgPgwPPV0GlbNotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Request Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 340 }
+
+jnxMbgPgwPPV0GlbNotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Request Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 341 }
+
+jnxMbgPgwPPV0GlbNotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 342 }
+
+jnxMbgPgwPPV0GlbNotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 343 }
+
+jnxMbgPgwPPV0ICsReqAcceptedRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Request Accepted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 344 }
+
+jnxMbgPgwPPV0ICsReqAcceptedTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Request Accepted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 345 }
+
+jnxMbgPgwPPV0ICsNonExistRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Non Existant."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 346 }
+
+jnxMbgPgwPPV0ICsNonExistTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Non Existant."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 347 }
+
+jnxMbgPgwPPV0ICsInvMsgFmtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 348 }
+
+jnxMbgPgwPPV0ICsInvMsgFmtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 349 }
+
+jnxMbgPgwPPV0ICsIMSINotKnownRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 350 }
+
+
+jnxMbgPgwPPV0ICsIMSINotKnownTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 351 }
+
+jnxMbgPgwPPV0ICsMSGRPSDetachRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 352 }
+
+jnxMbgPgwPPV0ICsMSGRPSDetachTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 353 }
+
+jnxMbgPgwPPV0ICsMSNotGRPSRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 354 }
+
+jnxMbgPgwPPV0ICsMSNotGRPSRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 355 }
+
+jnxMbgPgwPPV0ICsMSRefusesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS Refues."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 356 }
+
+jnxMbgPgwPPV0ICsMSRefusesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS Refues."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 357 }
+
+jnxMbgPgwPPV0ICsVerNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 358 }
+
+jnxMbgPgwPPV0ICsVerNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 359 }
+
+jnxMbgPgwPPV0ICsNoResRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause No Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 360 }
+
+jnxMbgPgwPPV0ICsNoResTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause No Response."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 361 }
+
+jnxMbgPgwPPV0ICsServNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 362 }
+
+jnxMbgPgwPPV0ICsServNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 363 }
+
+jnxMbgPgwPPV0ICsManIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 364 }
+
+jnxMbgPgwPPV0ICsManIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 365 }
+
+jnxMbgPgwPPV0ICsManIEMissRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 366 }
+
+jnxMbgPgwPPV0ICsManIEMissTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 367 }
+
+jnxMbgPgwPPV0ICsOptIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 368 }
+
+jnxMbgPgwPPV0ICsOptIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 369 }
+
+jnxMbgPgwPPV0ICsSysFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 370 }
+
+jnxMbgPgwPPV0ICsSysFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 371 }
+
+jnxMbgPgwPPV0ICsRoamRestrictRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 372 }
+
+jnxMbgPgwPPV0ICsRoamRestrictTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 373 }
+
+jnxMbgPgwPPV0ICsPTMSISigMMRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 374 }
+
+jnxMbgPgwPPV0ICsPTMSISigMMTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 375 }
+
+jnxMbgPgwPPV0ICsGPRSConnSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 376 }
+
+jnxMbgPgwPPV0ICsGPRSConnSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 377 }
+
+jnxMbgPgwPPV0ICsAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 378 }
+
+jnxMbgPgwPPV0ICsAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 379 }
+
+jnxMbgPgwPPV0ICsUserAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 380 }
+
+jnxMbgPgwPPV0ICsUserAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 381 }
+
+jnxMbgPgwPPGtpV2ICsLclDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Local Detach."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 382 }
+
+jnxMbgPgwPPGtpV2ICsLclDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Local Detach."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 383 }
+
+jnxMbgPgwPPGtpV2ICsCmpDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Complete Detach."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 384 }
+
+jnxMbgPgwPPGtpV2ICsCmpDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Complete Detach."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 385 }
+
+jnxMbgPgwPPGtpV2ICsRATChgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 386 }
+
+jnxMbgPgwPPGtpV2ICsRATChgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 387 }
+
+jnxMbgPgwPPGtpV2ICsISRDeactRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause ISR Deactivated."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 388 }
+
+jnxMbgPgwPPGtpV2ICsISRDeactTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause ISR Deactivated."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 389 }
+
+jnxMbgPgwPPGtpV2ICsEIFRNCEnRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 390 }
+
+jnxMbgPgwPPGtpV2ICsEIFRNCEnTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 391 }
+
+jnxMbgPgwPPGtpV2ICsSemErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 392 }
+
+jnxMbgPgwPPGtpV2ICsSemErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 393 }
+
+jnxMbgPgwPPGtpV2ICsSynErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 394 }
+
+jnxMbgPgwPPGtpV2ICsSynErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 395 }
+
+jnxMbgPgwPPGtpV2ICsRMValRcvRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Reserved Message Value Received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 396 }
+
+jnxMbgPgwPPGtpV2ICsRMValRcvTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Reserved Message Value Received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 397 }
+
+jnxMbgPgwPPGtpV2ICsRPrNtRspRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Remote peer not responding."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 398 }
+
+jnxMbgPgwPPGtpV2ICsRPrNtRspTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Remote peer not responding."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 399 }
+
+jnxMbgPgwPPGtpV2ICsColNWReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Collision with network initiated request."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 400 }
+
+jnxMbgPgwPPGtpV2ICsColNWReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Collision with network initiated request."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 401 }
+
+jnxMbgPgwPPGtpV2ICsUnPgUESusRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Unable to page UE due to suspension."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 402 }
+
+jnxMbgPgwPPGtpV2ICsUnPgUESusTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unable to page UE due to suspension."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 403 }
+
+jnxMbgPgwPPGtpV2ICsInvTotLenRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid total len."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 404 }
+
+jnxMbgPgwPPGtpV2ICsInvTotLenTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid total len."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 405 }
+
+jnxMbgPgwPPGtpV2ICsDtForNtSupRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Data forwarding not supported."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 406 }
+
+jnxMbgPgwPPGtpV2ICsDtForNtSupTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Data forwarding not supported."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 407 }
+
+jnxMbgPgwPPGtpV2ICsInReFRePrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 408 }
+
+jnxMbgPgwPPGtpV2ICsInReFRePrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 409 }
+
+jnxMbgPgwPPGtpV2ICsInvPrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid peer."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 410 }
+
+jnxMbgPgwPPGtpV2ICsInvPrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid peer."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 411 }
+
+jnxMbgPgwPPV1InitPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 412 }
+
+jnxMbgPgwPPV1InitPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 413 }
+
+jnxMbgPgwPPV1InitPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Response Received."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 414 }
+
+jnxMbgPgwPPV1InitPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Response Sent."
+    ::= { jnxMbgPgwGtpPerPeerStatsEntry 415 }
+
+jnxMbgPgwPPV2SuspNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 416 }
+
+jnxMbgPgwPPV2SuspNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages sent."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 417 }
+
+jnxMbgPgwPPV2SuspAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 418 }
+
+jnxMbgPgwPPV2SuspAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages sent."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 419 }
+
+jnxMbgPgwPPV2ResumeNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 420 }
+
+jnxMbgPgwPPV2ResumeNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages sent."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 421 }
+
+jnxMbgPgwPPV2ResumeAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 422 }
+
+jnxMbgPgwPPV2ResumeAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages sent."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 423 }
+
+jnxMbgPgwPPV2PiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Piggyback messages received."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 424 }
+
+jnxMbgPgwPPV2PiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Piggyback messages sent."
+     ::= { jnxMbgPgwGtpPerPeerStatsEntry 425 }
+
+--
+-- GTP Object for showing GTP Interface Statistics
+--
+jnxMbgPgwGtpIfStatsTable  OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgPgwGtpIfStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to an interface level GTP statistic."
+    ::= { jnxMbgPgwGtpObjects 11 }
+
+jnxMbgPgwGtpIfStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwGtpIfStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the GTP interface level control Statistics."
+    INDEX     { jnxMbgGwIndex,
+                jnxMbgPgwIfIndex }
+    ::= { jnxMbgPgwGtpIfStatsTable 1}
+
+JnxMbgPgwGtpIfStatsEntry ::= SEQUENCE {
+    jnxMbgPgwIfIndex                Unsigned32,
+    jnxMbgPgwIfType                 DisplayString,
+    jnxMbgPgwIfRxPacketsDropped     Counter64,
+    jnxMbgPgwIfPacketAllocFail      Counter64,
+    jnxMbgPgwIfPacketSendFail       Counter64,
+    jnxMbgPgwIfIPVerErrRx           Counter64,
+    jnxMbgPgwIfIPProtoErrRx         Counter64,
+    jnxMbgPgwIfGTPPortErrRx         Counter64,
+    jnxMbgPgwIfGTPUnknVerRx         Counter64,
+    jnxMbgPgwIfPcktLenErrRx         Counter64,
+    jnxMbgPgwIfUnknMsgRx            Counter64,
+    jnxMbgPgwIfV2ProtocolErrRx      Counter64,
+    jnxMbgPgwIfV2UnSupportedMsgRx   Counter64,
+    jnxMbgPgwIfV2T3RespTmrExpRx     Counter64,
+    jnxMbgPgwIfV2GlbNumMsgRx        Counter64,
+    jnxMbgPgwIfV2GlbNumMsgTx        Counter64,
+    jnxMbgPgwIfV2GlbNumBytesRx      Counter64,
+    jnxMbgPgwIfV2GlbNumBytesTx      Counter64,
+    jnxMbgPgwIfV2GlbEchoReqRx       Counter64,
+    jnxMbgPgwIfV2GlbEchoReqTx       Counter64,
+    jnxMbgPgwIfV2GlbEchoRespRx      Counter64,
+    jnxMbgPgwIfV2GlbEchoRespTx      Counter64,
+    jnxMbgPgwIfV2VerNotSupRx        Counter64,
+    jnxMbgPgwIfV2VerNotSupTx        Counter64,
+    jnxMbgPgwIfV2CreateSessReqRx    Counter64,
+    jnxMbgPgwIfV2CreateSessReqTx    Counter64,
+    jnxMbgPgwIfV2CreateSessRspRx    Counter64,
+    jnxMbgPgwIfV2CreateSessRspTx    Counter64,
+    jnxMbgPgwIfV2ModBrReqRx         Counter64,
+    jnxMbgPgwIfV2ModBrReqTx         Counter64,
+    jnxMbgPgwIfV2ModBrRspRx         Counter64,
+    jnxMbgPgwIfV2ModBrRspTx         Counter64,
+    jnxMbgPgwIfV2DelSessReqRx       Counter64,
+    jnxMbgPgwIfV2DelSessReqTx       Counter64,
+    jnxMbgPgwIfV2DelSessRspRx       Counter64,
+    jnxMbgPgwIfV2DelSessRspTx       Counter64,
+    jnxMbgPgwIfV2CrtBrReqRx         Counter64,
+    jnxMbgPgwIfV2CrtBrReqTx         Counter64,
+    jnxMbgPgwIfV2CrtBrRspRx         Counter64,
+    jnxMbgPgwIfV2CrtBrRspTx         Counter64,
+    jnxMbgPgwIfV2UpdBrReqRx         Counter64,
+    jnxMbgPgwIfV2UpdBrReqTx         Counter64,
+    jnxMbgPgwIfV2UpdBrRspRx         Counter64,
+    jnxMbgPgwIfV2UpdBrRspTx         Counter64,
+    jnxMbgPgwIfV2DelBrReqRx         Counter64,
+    jnxMbgPgwIfV2DelBrReqTx         Counter64,
+    jnxMbgPgwIfV2DelBrRspRx         Counter64,
+    jnxMbgPgwIfV2DelBrRspTx         Counter64,
+    jnxMbgPgwIfV2DelConnSetReqRx    Counter64,
+    jnxMbgPgwIfV2DelConnSetReqTx    Counter64,
+    jnxMbgPgwIfV2DelConnSetRspRx    Counter64,
+    jnxMbgPgwIfV2DelConnSetRspTx    Counter64,
+    jnxMbgPgwIfV2UpdConnSetReqRx    Counter64,
+    jnxMbgPgwIfV2UpdConnSetReqTx    Counter64,
+    jnxMbgPgwIfV2UpdConnSetRspRx    Counter64,
+    jnxMbgPgwIfV2UpdConnSetRspTx    Counter64,
+    jnxMbgPgwIfV2ModBrCmdRx         Counter64,
+    jnxMbgPgwIfV2ModBrCmdTx         Counter64,
+    jnxMbgPgwIfV2ModBrFlrIndRx      Counter64,
+    jnxMbgPgwIfV2ModBrFlrIndTx      Counter64,
+    jnxMbgPgwIfV2DelBrCmdRx         Counter64,
+    jnxMbgPgwIfV2DelBrCmdTx         Counter64,
+    jnxMbgPgwIfV2DelBrFlrIndRx      Counter64,
+    jnxMbgPgwIfV2DelBrFlrIndTx      Counter64,
+    jnxMbgPgwIfV2BrResCmdRx         Counter64,
+    jnxMbgPgwIfV2BrResCmdTx         Counter64,
+    jnxMbgPgwIfV2BrResFlrIndRx      Counter64,
+    jnxMbgPgwIfV2BrResFlrIndTx      Counter64,
+    jnxMbgPgwIfV2ICsReqAcceptRx     Counter64,
+    jnxMbgPgwIfV2ICsReqAcceptTx     Counter64,
+    jnxMbgPgwIfV2ICsAcceptPartRx    Counter64,
+    jnxMbgPgwIfV2ICsAcceptPartTx    Counter64,
+    jnxMbgPgwIfV2ICsNewPTNPrefRx    Counter64,
+    jnxMbgPgwIfV2ICsNewPTNPrefTx    Counter64,
+    jnxMbgPgwIfV2ICsNewPTSIAdbrRx   Counter64,
+    jnxMbgPgwIfV2ICsNewPTSIAdbrTx   Counter64,
+    jnxMbgPgwIfV2ICsCtxNotFndRx     Counter64,
+    jnxMbgPgwIfV2ICsCtxNotFndTx     Counter64,
+    jnxMbgPgwIfV2ICsInvMsgFmtRx     Counter64,
+    jnxMbgPgwIfV2ICsInvMsgFmtTx     Counter64,
+    jnxMbgPgwIfV2ICsVerNotSuppRx    Counter64,
+    jnxMbgPgwIfV2ICsVerNotSuppTx    Counter64,
+    jnxMbgPgwIfV2ICsInvLenRx        Counter64,
+    jnxMbgPgwIfV2ICsInvLenTx        Counter64,
+    jnxMbgPgwIfV2ICsServNotSuppRx   Counter64,
+    jnxMbgPgwIfV2ICsServNotSuppTx   Counter64,
+    jnxMbgPgwIfV2ICsManIEIncorrRx   Counter64,
+    jnxMbgPgwIfV2ICsManIEIncorrTx   Counter64,
+    jnxMbgPgwIfV2ICsManIEMissRx     Counter64,
+    jnxMbgPgwIfV2ICsManIEMissTx     Counter64,
+    jnxMbgPgwIfV2ICsOptIEIncorrRx   Counter64,
+    jnxMbgPgwIfV2ICsOptIEIncorrTx   Counter64,
+    jnxMbgPgwIfV2ICsSysFailRx       Counter64,
+    jnxMbgPgwIfV2ICsSysFailTx       Counter64,
+    jnxMbgPgwIfV2ICsNoResRx         Counter64,
+    jnxMbgPgwIfV2ICsNoResTx         Counter64,
+    jnxMbgPgwIfV2ICsTFTSMANTErRx    Counter64,
+    jnxMbgPgwIfV2ICsTFTSMANTErTx    Counter64,
+    jnxMbgPgwIfV2ICsTFTSysErrRx     Counter64,
+    jnxMbgPgwIfV2ICsTFTSysErrTx     Counter64,
+    jnxMbgPgwIfV2ICsPkFltManErrRx   Counter64,
+    jnxMbgPgwIfV2ICsPkFltManErrTx   Counter64,
+    jnxMbgPgwIfV2ICsPkFltSynErrRx   Counter64,
+    jnxMbgPgwIfV2ICsPkFltSynErrTx   Counter64,
+    jnxMbgPgwIfV2ICsMisUnknAPNRx    Counter64,
+    jnxMbgPgwIfV2ICsMisUnknAPNTx    Counter64,
+    jnxMbgPgwIfV2ICsUnexpRptIERx    Counter64,
+    jnxMbgPgwIfV2ICsUnexpRptIETx    Counter64,
+    jnxMbgPgwIfV2ICsGREKeyNtFdRx    Counter64,
+    jnxMbgPgwIfV2ICsGREKeyNtFdTx    Counter64,
+    jnxMbgPgwIfV2ICsRelocFailRx     Counter64,
+    jnxMbgPgwIfV2ICsRelocFailTx     Counter64,
+    jnxMbgPgwIfV2ICsDeniedINRatRx   Counter64,
+    jnxMbgPgwIfV2ICsDeniedINRatTx   Counter64,
+    jnxMbgPgwIfV2ICsPTNotSuppRx     Counter64,
+    jnxMbgPgwIfV2ICsPTNotSuppTx     Counter64,
+    jnxMbgPgwIfV2ICsAllDynAdOccRx   Counter64,
+    jnxMbgPgwIfV2ICsAllDynAdOccTx   Counter64,
+    jnxMbgPgwIfV2ICsNOTFTUECTXRx    Counter64,
+    jnxMbgPgwIfV2ICsNOTFTUECTXTx    Counter64,
+    jnxMbgPgwIfV2ICsProtoNtSupRx    Counter64,
+    jnxMbgPgwIfV2ICsProtoNtSupTx    Counter64,
+    jnxMbgPgwIfV2ICsUENotRespRx     Counter64,
+    jnxMbgPgwIfV2ICsUENotRespTx     Counter64,
+    jnxMbgPgwIfV2ICsUERefusesRx     Counter64,
+    jnxMbgPgwIfV2ICsUERefusesTx     Counter64,
+    jnxMbgPgwIfV2ICsServDeniedRx    Counter64,
+    jnxMbgPgwIfV2ICsServDeniedTx    Counter64,
+    jnxMbgPgwIfV2ICsUnabPageUERx    Counter64,
+    jnxMbgPgwIfV2ICsUnabPageUETx    Counter64,
+    jnxMbgPgwIfV2ICsNoMemRx         Counter64,
+    jnxMbgPgwIfV2ICsNoMemTx         Counter64,
+    jnxMbgPgwIfV2ICsUserAUTHFlRx    Counter64,
+    jnxMbgPgwIfV2ICsUserAUTHFlTx    Counter64,
+    jnxMbgPgwIfV2ICsAPNAcsDenRx     Counter64,
+    jnxMbgPgwIfV2ICsAPNAcsDenTx     Counter64,
+    jnxMbgPgwIfV2ICsReqRejRx        Counter64,
+    jnxMbgPgwIfV2ICsReqRejTx        Counter64,
+    jnxMbgPgwIfV2ICsPTMSISigMMRx    Counter64,
+    jnxMbgPgwIfV2ICsPTMSISigMMTx    Counter64,
+    jnxMbgPgwIfV2ICsIMSINotKnRx     Counter64,
+    jnxMbgPgwIfV2ICsIMSINotKnTx     Counter64,
+    jnxMbgPgwIfV2ICsCondIEMsRx      Counter64,
+    jnxMbgPgwIfV2ICsCondIEMsTx      Counter64,
+    jnxMbgPgwIfV2ICsAPNResTIncRx    Counter64,
+    jnxMbgPgwIfV2ICsAPNResTIncTx    Counter64,
+    jnxMbgPgwIfV2ICsUnknownRx       Counter64,
+    jnxMbgPgwIfV2ICsUnknownTx       Counter64,
+    jnxMbgPgwIfV1ProtocolErrRx      Counter64,
+    jnxMbgPgwIfV1UnSupportedMsgRx   Counter64,
+    jnxMbgPgwIfV1T3RespTmrExpRx     Counter64,
+    jnxMbgPgwIfV1GlbNumMsgRx        Counter64,
+    jnxMbgPgwIfV1GlbNumMsgTx        Counter64,
+    jnxMbgPgwIfV1GlbNumBytesRx      Counter64,
+    jnxMbgPgwIfV1GlbNumBytesTx      Counter64,
+    jnxMbgPgwIfV1GlbEchoReqRx       Counter64,
+    jnxMbgPgwIfV1GlbEchoReqTx       Counter64,
+    jnxMbgPgwIfV1GlbEchoRespRx      Counter64,
+    jnxMbgPgwIfV1GlbEchoRespTx      Counter64,
+    jnxMbgPgwIfV1VerNotSupRx        Counter64,
+    jnxMbgPgwIfV1VerNotSupTx        Counter64,
+    jnxMbgPgwIfV1CrtPdpCxtReqRx     Counter64,
+    jnxMbgPgwIfV1CrtPdpCxtReqTx     Counter64,
+    jnxMbgPgwIfV1CrtPdpCxtRspRx     Counter64,
+    jnxMbgPgwIfV1CrtPdpCxtRspTx     Counter64,
+    jnxMbgPgwIfV1UpdPdpCxtReqRx     Counter64,
+    jnxMbgPgwIfV1UpdPdpCxtReqTx     Counter64,
+    jnxMbgPgwIfV1UpdPdpCxtRspRx     Counter64,
+    jnxMbgPgwIfV1UpdPdpCxtRspTx     Counter64,
+    jnxMbgPgwIfV1DelPdpCxtReqRx     Counter64,
+    jnxMbgPgwIfV1DelPdpCxtReqTx     Counter64,
+    jnxMbgPgwIfV1DelPdpCxtRspRx     Counter64,
+    jnxMbgPgwIfV1DelPdpCxtRspTx     Counter64,
+    jnxMbgPgwIfV1CrtAAPdpCxtReqRx   Counter64,
+    jnxMbgPgwIfV1CrtAAPdpCxtReqTx   Counter64,
+    jnxMbgPgwIfV1CrtAAPdpCxtRspRx   Counter64,
+    jnxMbgPgwIfV1CrtAAPdpCxtRspTx   Counter64,
+    jnxMbgPgwIfV1DelAAPdpCxtReqRx   Counter64,
+    jnxMbgPgwIfV1DelAAPdpCxtReqTx   Counter64,
+    jnxMbgPgwIfV1DelAAPdpCxtRspRx   Counter64,
+    jnxMbgPgwIfV1DelAAPdpCxtRspTx   Counter64,
+    jnxMbgPgwIfV1ErrorIndRx         Counter64,
+    jnxMbgPgwIfV1ErrorIndTx         Counter64,
+    jnxMbgPgwIfV1NotifReqRx         Counter64,
+    jnxMbgPgwIfV1NotifReqTx         Counter64,
+    jnxMbgPgwIfV1NotifRspRx         Counter64,
+    jnxMbgPgwIfV1NotifRspTx         Counter64,
+    jnxMbgPgwIfV1NotifRejReqRx      Counter64,
+    jnxMbgPgwIfV1NotifRejReqTx      Counter64,
+    jnxMbgPgwIfV1NotifRejRspRx      Counter64,
+    jnxMbgPgwIfV1NotifRejRspTx      Counter64,
+    jnxMbgPgwIfV1RtInfReqRx         Counter64,
+    jnxMbgPgwIfV1RtInfReqTx         Counter64,
+    jnxMbgPgwIfV1RtInfRspRx         Counter64,
+    jnxMbgPgwIfV1RtInfRspTx         Counter64,
+    jnxMbgPgwIfV1FailRptReqRx       Counter64,
+    jnxMbgPgwIfV1FailRptReqTx       Counter64,
+    jnxMbgPgwIfV1FailRptRspRx       Counter64,
+    jnxMbgPgwIfV1FailRptRspTx       Counter64,
+    jnxMbgPgwIfV1NotMSPresReqRx     Counter64,
+    jnxMbgPgwIfV1NotMSPresReqTx     Counter64,
+    jnxMbgPgwIfV1NotMSPresRspRx     Counter64,
+    jnxMbgPgwIfV1NotMSPresRspTx     Counter64,
+    jnxMbgPgwIfV1ICsReqAcceptedRx   Counter64,
+    jnxMbgPgwIfV1ICsReqAcceptedTx   Counter64,
+    jnxMbgPgwIfV1ICsNonExistRx      Counter64,
+    jnxMbgPgwIfV1ICsNonExistTx      Counter64,
+    jnxMbgPgwIfV1ICsInvMsgFmtRx     Counter64,
+    jnxMbgPgwIfV1ICsInvMsgFmtTx     Counter64,
+    jnxMbgPgwIfV1ICsIMSINotKnownRx  Counter64,
+    jnxMbgPgwIfV1ICsIMSINotKnownTx  Counter64,
+    jnxMbgPgwIfV1ICsMSGRPSDetachRx  Counter64,
+    jnxMbgPgwIfV1ICsMSGRPSDetachTx  Counter64,
+    jnxMbgPgwIfV1ICsMSNotGRPSRespRx Counter64,
+    jnxMbgPgwIfV1ICsMSNotGRPSRespTx Counter64,
+    jnxMbgPgwIfV1ICsMSRefusesRx     Counter64,
+    jnxMbgPgwIfV1ICsMSRefusesTx     Counter64,
+    jnxMbgPgwIfV1ICsVerNotSuppRx    Counter64,
+    jnxMbgPgwIfV1ICsVerNotSuppTx    Counter64,
+    jnxMbgPgwIfV1ICsNoResRx         Counter64,
+    jnxMbgPgwIfV1ICsNoResTx         Counter64,
+    jnxMbgPgwIfV1ICsServNotSuppRx   Counter64,
+    jnxMbgPgwIfV1ICsServNotSuppTx   Counter64,
+    jnxMbgPgwIfV1ICsManIEIncrtRx    Counter64,
+    jnxMbgPgwIfV1ICsManIEIncrtTx    Counter64,
+    jnxMbgPgwIfV1ICsManIEMissRx     Counter64,
+    jnxMbgPgwIfV1ICsManIEMissTx     Counter64,
+    jnxMbgPgwIfV1ICsOptIEIncrtRx    Counter64,
+    jnxMbgPgwIfV1ICsOptIEIncrtTx    Counter64,
+    jnxMbgPgwIfV1ICsSysFailRx       Counter64,
+    jnxMbgPgwIfV1ICsSysFailTx       Counter64,
+    jnxMbgPgwIfV1ICsRoamRestrictRx  Counter64,
+    jnxMbgPgwIfV1ICsRoamRestrictTx  Counter64,
+    jnxMbgPgwIfV1ICsPTMSISigMMRx    Counter64,
+    jnxMbgPgwIfV1ICsPTMSISigMMTx    Counter64,
+    jnxMbgPgwIfV1ICsGPRSConnSuppRx  Counter64,
+    jnxMbgPgwIfV1ICsGPRSConnSuppTx  Counter64,
+    jnxMbgPgwIfV1ICsAuthFailRx      Counter64,
+    jnxMbgPgwIfV1ICsAuthFailTx      Counter64,
+    jnxMbgPgwIfV1ICsUserAuthFailRx  Counter64,
+    jnxMbgPgwIfV1ICsUserAuthFailTx  Counter64,
+    jnxMbgPgwIfV1ICsCtxNotFndRx     Counter64,
+    jnxMbgPgwIfV1ICsCtxNotFndTx     Counter64,
+    jnxMbgPgwIfV1ICsAllDynPDPAdRx   Counter64,
+    jnxMbgPgwIfV1ICsAllDynPDPAdTx   Counter64,
+    jnxMbgPgwIfV1ICsNoMemRx         Counter64,
+    jnxMbgPgwIfV1ICsNoMemTx         Counter64,
+    jnxMbgPgwIfV1ICsRelocFailRx     Counter64,
+    jnxMbgPgwIfV1ICsRelocFailTx     Counter64,
+    jnxMbgPgwIfV1ICsUnkManExhdrRx   Counter64,
+    jnxMbgPgwIfV1ICsUnkManExhdrTx   Counter64,
+    jnxMbgPgwIfV1ICsSMANTTFTEr1Rx   Counter64,
+    jnxMbgPgwIfV1ICsSMANTTFTEr1Tx   Counter64,
+    jnxMbgPgwIfV1ICsSYNTFTErr2Rx    Counter64,
+    jnxMbgPgwIfV1ICsSYNTFTErr2Tx    Counter64,
+    jnxMbgPgwIfV1ICsSMNTPkFlEr1Rx   Counter64,
+    jnxMbgPgwIfV1ICsSMNTPkFlEr1Tx   Counter64,
+    jnxMbgPgwIfV1ICsSYNPkFlErr2Rx   Counter64,
+    jnxMbgPgwIfV1ICsSYNPkFlErr2Tx   Counter64,
+    jnxMbgPgwIfV1ICsMissUnknAPNRx   Counter64,
+    jnxMbgPgwIfV1ICsMissUnknAPNTx   Counter64,
+    jnxMbgPgwIfV1ICsUnknPDPAdRx     Counter64,
+    jnxMbgPgwIfV1ICsUnknPDPAdTx     Counter64,
+    jnxMbgPgwIfV1ICsNoTFTCtxExRx    Counter64,
+    jnxMbgPgwIfV1ICsNoTFTCtxExTx    Counter64,
+    jnxMbgPgwIfV0ProtocolErrRx      Counter64,
+    jnxMbgPgwIfV0UnSupportedMsgRx   Counter64,
+    jnxMbgPgwIfV0T3RespTmrExpRx     Counter64,
+    jnxMbgPgwIfV0GlbNumMsgRx        Counter64,
+    jnxMbgPgwIfV0GlbNumMsgTx        Counter64,
+    jnxMbgPgwIfV0GlbNumBytesRx      Counter64,
+    jnxMbgPgwIfV0GlbNumBytesTx      Counter64,
+    jnxMbgPgwIfV0GlbEchoReqRx       Counter64,
+    jnxMbgPgwIfV0GlbEchoReqTx       Counter64,
+    jnxMbgPgwIfV0GlbEchoRespRx      Counter64,
+    jnxMbgPgwIfV0GlbEchoRespTx      Counter64,
+    jnxMbgPgwIfV0GlbVerNotSupRx     Counter64,
+    jnxMbgPgwIfV0GlbVerNotSupTx     Counter64,
+    jnxMbgPgwIfV0GlbCrtPdpCxtReqRx  Counter64,
+    jnxMbgPgwIfV0GlbCrtPdpCxtReqTx  Counter64,
+    jnxMbgPgwIfV0GlbCrtPdpCxtRspRx  Counter64,
+    jnxMbgPgwIfV0GlbCrtPdpCxtRspTx  Counter64,
+    jnxMbgPgwIfV0GlbUpdPdpCxtReqRx  Counter64,
+    jnxMbgPgwIfV0GlbUpdPdpCxtReqTx  Counter64,
+    jnxMbgPgwIfV0GlbUpdPdpCxtRspRx  Counter64,
+    jnxMbgPgwIfV0GlbUpdPdpCxtRspTx  Counter64,
+    jnxMbgPgwIfV0GlbDelPdpCxtReqRx  Counter64,
+    jnxMbgPgwIfV0GlbDelPdpCxtReqTx  Counter64,
+    jnxMbgPgwIfV0GlbDelPdpCxtRspRx  Counter64,
+    jnxMbgPgwIfV0GlbDelPdpCxtRspTx  Counter64,
+    jnxMbgPgwIfV0GlbCrtAAPdpCxtRqRx Counter64,
+    jnxMbgPgwIfV0GlbCrtAAPdpCxtRqTx Counter64,
+    jnxMbgPgwIfV0GlbCrtAAPdpCxtRpRx Counter64,
+    jnxMbgPgwIfV0GlbCrtAAPdpCxtRpTx Counter64,
+    jnxMbgPgwIfV0GlbDelAAPdpCxtRqRx Counter64,
+    jnxMbgPgwIfV0GlbDelAAPdpCxtRqTx Counter64,
+    jnxMbgPgwIfV0GlbDelAAPdpCxtRpRx Counter64,
+    jnxMbgPgwIfV0GlbDelAAPdpCxtRpTx Counter64,
+    jnxMbgPgwIfV0GlbErrorIndRx      Counter64,
+    jnxMbgPgwIfV0GlbErrorIndTx      Counter64,
+    jnxMbgPgwIfV0GlbNotifReqRx      Counter64,
+    jnxMbgPgwIfV0GlbNotifReqTx      Counter64,
+    jnxMbgPgwIfV0GlbNotifRspRx      Counter64,
+    jnxMbgPgwIfV0GlbNotifRspTx      Counter64,
+    jnxMbgPgwIfV0GlbNotifRejReqRx   Counter64,
+    jnxMbgPgwIfV0GlbNotifRejReqTx   Counter64,
+    jnxMbgPgwIfV0GlbNotifRejRspRx   Counter64,
+    jnxMbgPgwIfV0GlbNotifRejRspTx   Counter64,
+    jnxMbgPgwIfV0GlbRtInfReqRx      Counter64,
+    jnxMbgPgwIfV0GlbRtInfReqTx      Counter64,
+    jnxMbgPgwIfV0GlbRtInfRspRx      Counter64,
+    jnxMbgPgwIfV0GlbRtInfRspTx      Counter64,
+    jnxMbgPgwIfV0GlbFailRptReqRx    Counter64,
+    jnxMbgPgwIfV0GlbFailRptReqTx    Counter64,
+    jnxMbgPgwIfV0GlbFailRptRspRx    Counter64,
+    jnxMbgPgwIfV0GlbFailRptRspTx    Counter64,
+    jnxMbgPgwIfV0GlbNotMSPresReqRx  Counter64,
+    jnxMbgPgwIfV0GlbNotMSPresReqTx  Counter64,
+    jnxMbgPgwIfV0GlbNotMSPresRspRx  Counter64,
+    jnxMbgPgwIfV0GlbNotMSPresRspTx  Counter64,
+    jnxMbgPgwIfV0ICsReqAcceptedRx   Counter64,
+    jnxMbgPgwIfV0ICsReqAcceptedTx   Counter64,
+    jnxMbgPgwIfV0ICsNonExistRx      Counter64,
+    jnxMbgPgwIfV0ICsNonExistTx      Counter64,
+    jnxMbgPgwIfV0ICsInvMsgFmtRx     Counter64,
+    jnxMbgPgwIfV0ICsInvMsgFmtTx     Counter64,
+    jnxMbgPgwIfV0ICsIMSINotKnownRx  Counter64,
+    jnxMbgPgwIfV0ICsIMSINotKnownTx  Counter64,
+    jnxMbgPgwIfV0ICsMSGRPSDetachRx  Counter64,
+    jnxMbgPgwIfV0ICsMSGRPSDetachTx  Counter64,
+    jnxMbgPgwIfV0ICsMSNotGRPSRespRx Counter64,
+    jnxMbgPgwIfV0ICsMSNotGRPSRespTx Counter64,
+    jnxMbgPgwIfV0ICsMSRefusesRx     Counter64,
+    jnxMbgPgwIfV0ICsMSRefusesTx     Counter64,
+    jnxMbgPgwIfV0ICsVerNotSuppRx    Counter64,
+    jnxMbgPgwIfV0ICsVerNotSuppTx    Counter64,
+    jnxMbgPgwIfV0ICsNoResRx         Counter64,
+    jnxMbgPgwIfV0ICsNoResTx         Counter64,
+    jnxMbgPgwIfV0ICsServNotSuppRx   Counter64,
+    jnxMbgPgwIfV0ICsServNotSuppTx   Counter64,
+    jnxMbgPgwIfV0ICsManIEIncrtRx    Counter64,
+    jnxMbgPgwIfV0ICsManIEIncrtTx    Counter64,
+    jnxMbgPgwIfV0ICsManIEMissRx     Counter64,
+    jnxMbgPgwIfV0ICsManIEMissTx     Counter64,
+    jnxMbgPgwIfV0ICsOptIEIncrtRx    Counter64,
+    jnxMbgPgwIfV0ICsOptIEIncrtTx    Counter64,
+    jnxMbgPgwIfV0ICsSysFailRx       Counter64,
+    jnxMbgPgwIfV0ICsSysFailTx       Counter64,
+    jnxMbgPgwIfV0ICsRoamRestrictRx  Counter64,
+    jnxMbgPgwIfV0ICsRoamRestrictTx  Counter64,
+    jnxMbgPgwIfV0ICsPTMSISigMMRx    Counter64,
+    jnxMbgPgwIfV0ICsPTMSISigMMTx    Counter64,
+    jnxMbgPgwIfV0ICsGPRSConnSuppRx  Counter64,
+    jnxMbgPgwIfV0ICsGPRSConnSuppTx  Counter64,
+    jnxMbgPgwIfV0ICsAuthFailRx      Counter64,
+    jnxMbgPgwIfV0ICsAuthFailTx      Counter64,
+    jnxMbgPgwIfV0ICsUserAuthFailRx  Counter64,
+    jnxMbgPgwIfV0ICsUserAuthFailTx  Counter64,
+    jnxMbgPgwIfGtpV2ICsLclDetRx     Counter64,
+    jnxMbgPgwIfGtpV2ICsLclDetTx     Counter64,
+    jnxMbgPgwIfGtpV2ICsCmpDetRx     Counter64,
+    jnxMbgPgwIfGtpV2ICsCmpDetTx     Counter64,
+    jnxMbgPgwIfGtpV2ICsRATChgRx     Counter64,
+    jnxMbgPgwIfGtpV2ICsRATChgTx     Counter64,
+    jnxMbgPgwIfGtpV2ICsISRDeactRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsISRDeactTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsEIFRNCEnRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsEIFRNCEnTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsSemErTADRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsSemErTADTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsSynErTADRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsSynErTADTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsRMValRcvRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsRMValRcvTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsRPrNtRspRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsRPrNtRspTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsColNWReqRx   Counter64,
+    jnxMbgPgwIfGtpV2ICsColNWReqTx   Counter64,
+    jnxMbgPgwIfGtpV2ICsUnPgUESusRx  Counter64,
+    jnxMbgPgwIfGtpV2ICsUnPgUESusTx  Counter64,
+    jnxMbgPgwIfGtpV2ICsInvTotLenRx  Counter64,
+    jnxMbgPgwIfGtpV2ICsInvTotLenTx  Counter64,
+    jnxMbgPgwIfGtpV2ICsDtForNtSupRx Counter64,
+    jnxMbgPgwIfGtpV2ICsDtForNtSupTx Counter64,
+    jnxMbgPgwIfGtpV2ICsInReFRePrRx  Counter64,
+    jnxMbgPgwIfGtpV2ICsInReFRePrTx  Counter64,
+    jnxMbgPgwIfGtpV2ICsInvPrRx      Counter64,
+    jnxMbgPgwIfGtpV2ICsInvPrTx      Counter64,
+    jnxMbgPgwIfV1InitPdpCxtReqRx    Counter64,
+    jnxMbgPgwIfV1InitPdpCxtReqTx    Counter64,
+    jnxMbgPgwIfV1InitPdpCxtRspRx    Counter64,
+    jnxMbgPgwIfV1InitPdpCxtRspTx    Counter64,
+    jnxMbgPgwIfV2SuspNotifRx        Counter64,
+    jnxMbgPgwIfV2SuspNotifTx        Counter64,
+    jnxMbgPgwIfV2SuspAckRx          Counter64,
+    jnxMbgPgwIfV2SuspAckTx          Counter64,
+    jnxMbgPgwIfV2ResumeNotifRx      Counter64,
+    jnxMbgPgwIfV2ResumeNotifTx      Counter64,
+    jnxMbgPgwIfV2ResumeAckRx        Counter64,
+    jnxMbgPgwIfV2ResumeAckTx        Counter64,
+    jnxMbgPgwIfV2PiggybackMsgRx     Counter64,
+    jnxMbgPgwIfV2PiggybackMsgTx     Counter64
+}
+
+jnxMbgPgwIfIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "GTP Interface Index"
+    ::= { jnxMbgPgwGtpIfStatsEntry 1 }
+
+jnxMbgPgwIfType OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Interface Name."
+    ::= { jnxMbgPgwGtpIfStatsEntry 2 }
+
+jnxMbgPgwIfRxPacketsDropped  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Received GTP Packets Dropped by the Gateway."
+    ::= { jnxMbgPgwGtpIfStatsEntry 3 }
+
+jnxMbgPgwIfPacketAllocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet allocation failures in the Gateway."
+    ::= { jnxMbgPgwGtpIfStatsEntry 4 }
+
+jnxMbgPgwIfPacketSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP Packet Send failures in the Gateway."
+    ::= { jnxMbgPgwGtpIfStatsEntry 5 }
+
+jnxMbgPgwIfIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Version Error Packets Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 6 }
+
+jnxMbgPgwIfIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  IP Protocol Error packets Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 7 }
+
+jnxMbgPgwIfGTPPortErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Port Error Packets Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 8 }
+
+jnxMbgPgwIfGTPUnknVerRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Version Packets Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 9 }
+
+jnxMbgPgwIfPcktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Length Error Packets Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 10 }
+
+jnxMbgPgwIfUnknMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Messages Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 11 }
+
+jnxMbgPgwIfV2ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 12 }
+
+jnxMbgPgwIfV2UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 13 }
+
+jnxMbgPgwIfV2T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "GTP V2 Number of T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 14 }
+
+jnxMbgPgwIfV2GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 15 }
+
+jnxMbgPgwIfV2GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 messages sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 16 }
+
+jnxMbgPgwIfV2GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 17 }
+
+jnxMbgPgwIfV2GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 bytes sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 18 }
+
+jnxMbgPgwIfV2GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 19 }
+
+jnxMbgPgwIfV2GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 20 }
+
+jnxMbgPgwIfV2GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 21 }
+
+jnxMbgPgwIfV2GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 22 }
+
+jnxMbgPgwIfV2VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpIfStatsEntry 23 }
+
+jnxMbgPgwIfV2VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 version not supported messages Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 24 }
+
+jnxMbgPgwIfV2CreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 25 }
+
+jnxMbgPgwIfV2CreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 26 }
+
+jnxMbgPgwIfV2CreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 27 }
+
+jnxMbgPgwIfV2CreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 28 }
+
+jnxMbgPgwIfV2ModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 29 }
+
+jnxMbgPgwIfV2ModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 30 }
+
+jnxMbgPgwIfV2ModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 31 }
+
+jnxMbgPgwIfV2ModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 32 }
+
+jnxMbgPgwIfV2DelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 33 }
+
+jnxMbgPgwIfV2DelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 34 }
+
+jnxMbgPgwIfV2DelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 35 }
+
+jnxMbgPgwIfV2DelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 36 }
+
+jnxMbgPgwIfV2CrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 37 }
+
+jnxMbgPgwIfV2CrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 38 }
+
+jnxMbgPgwIfV2CrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 39 }
+
+jnxMbgPgwIfV2CrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 40 }
+
+jnxMbgPgwIfV2UpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 41 }
+
+jnxMbgPgwIfV2UpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 42 }
+
+jnxMbgPgwIfV2UpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 43 }
+
+jnxMbgPgwIfV2UpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 44 }
+
+jnxMbgPgwIfV2DelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 45 }
+
+jnxMbgPgwIfV2DelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 46 }
+
+jnxMbgPgwIfV2DelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 47 }
+
+jnxMbgPgwIfV2DelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 48 }
+
+jnxMbgPgwIfV2DelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 49 }
+
+jnxMbgPgwIfV2DelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 50 }
+
+jnxMbgPgwIfV2DelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 51 }
+
+jnxMbgPgwIfV2DelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 52 }
+
+jnxMbgPgwIfV2UpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 53 }
+
+jnxMbgPgwIfV2UpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 54 }
+
+jnxMbgPgwIfV2UpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connetion set Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 55 }
+
+jnxMbgPgwIfV2UpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 56 }
+
+jnxMbgPgwIfV2ModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 57 }
+
+jnxMbgPgwIfV2ModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 58 }
+
+jnxMbgPgwIfV2ModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 59 }
+
+jnxMbgPgwIfV2ModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 60 }
+
+jnxMbgPgwIfV2DelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 61 }
+
+jnxMbgPgwIfV2DelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 62 }
+
+jnxMbgPgwIfV2DelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 63 }
+
+jnxMbgPgwIfV2DelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 64 }
+
+jnxMbgPgwIfV2BrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 65 }
+
+jnxMbgPgwIfV2BrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 66 }
+
+jnxMbgPgwIfV2BrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 67 }
+
+jnxMbgPgwIfV2BrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 68 }
+
+jnxMbgPgwIfV2ICsReqAcceptRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Accept."
+    ::= { jnxMbgPgwGtpIfStatsEntry 69 }
+
+jnxMbgPgwIfV2ICsReqAcceptTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Request Accept messsges sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 70 }
+
+jnxMbgPgwIfV2ICsAcceptPartRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Accept Partial messages receive."
+    ::= { jnxMbgPgwGtpIfStatsEntry 71 }
+
+jnxMbgPgwIfV2ICsAcceptPartTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Accept Partial."
+    ::= { jnxMbgPgwGtpIfStatsEntry 72 }
+
+jnxMbgPgwIfV2ICsNewPTNPrefRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Network Preference."
+    ::= { jnxMbgPgwGtpIfStatsEntry 73 }
+
+jnxMbgPgwIfV2ICsNewPTNPrefTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause New PDN type due to Network Preference."
+    ::= { jnxMbgPgwGtpIfStatsEntry 74 }
+
+
+jnxMbgPgwIfV2ICsNewPTSIAdbrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpIfStatsEntry 75 }
+
+jnxMbgPgwIfV2ICsNewPTSIAdbrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpIfStatsEntry 76 }
+
+jnxMbgPgwIfV2ICsCtxNotFndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  GTPV2 packets received with cause Context not found."
+    ::= { jnxMbgPgwGtpIfStatsEntry 77 }
+
+jnxMbgPgwIfV2ICsCtxNotFndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Context not found."
+    ::= { jnxMbgPgwGtpIfStatsEntry 78 }
+
+jnxMbgPgwIfV2ICsInvMsgFmtRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpIfStatsEntry 79 }
+
+jnxMbgPgwIfV2ICsInvMsgFmtTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpIfStatsEntry 80 }
+
+jnxMbgPgwIfV2ICsVerNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Version not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 81 }
+
+jnxMbgPgwIfV2ICsVerNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Version not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 82 }
+
+jnxMbgPgwIfV2ICsInvLenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Length."
+    ::= { jnxMbgPgwGtpIfStatsEntry 83 }
+
+jnxMbgPgwIfV2ICsInvLenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Invalid Length."
+    ::= { jnxMbgPgwGtpIfStatsEntry 84 }
+
+jnxMbgPgwIfV2ICsServNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Not supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 85 }
+
+jnxMbgPgwIfV2ICsServNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Service Not supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 86 }
+
+jnxMbgPgwIfV2ICsManIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 87 }
+
+jnxMbgPgwIfV2ICsManIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 88 }
+
+jnxMbgPgwIfV2ICsManIEMissRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 89 }
+
+jnxMbgPgwIfV2ICsManIEMissTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 90 }
+
+jnxMbgPgwIfV2ICsOptIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 91 }
+
+jnxMbgPgwIfV2ICsOptIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 92 }
+
+jnxMbgPgwIfV2ICsSysFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 93 }
+
+jnxMbgPgwIfV2ICsSysFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 94 }
+
+jnxMbgPgwIfV2ICsNoResRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Resource."
+    ::= { jnxMbgPgwGtpIfStatsEntry 95 }
+
+jnxMbgPgwIfV2ICsNoResTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause No Resource."
+    ::= { jnxMbgPgwGtpIfStatsEntry 96 }
+
+jnxMbgPgwIfV2ICsTFTSMANTErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 97 }
+
+jnxMbgPgwIfV2ICsTFTSMANTErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 98 }
+
+jnxMbgPgwIfV2ICsTFTSysErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT System Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 99 }
+
+jnxMbgPgwIfV2ICsTFTSysErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause TFT System Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 100 }
+
+jnxMbgPgwIfV2ICsPkFltManErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 101 }
+
+jnxMbgPgwIfV2ICsPkFltManErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 102 }
+
+jnxMbgPgwIfV2ICsPkFltSynErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 103 }
+
+jnxMbgPgwIfV2ICsPkFltSynErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 104 }
+
+jnxMbgPgwIfV2ICsMisUnknAPNRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unknown APN."
+    ::= { jnxMbgPgwGtpIfStatsEntry 105 }
+
+jnxMbgPgwIfV2ICsMisUnknAPNTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unknown APN."
+    ::= { jnxMbgPgwGtpIfStatsEntry 106 }
+
+jnxMbgPgwIfV2ICsUnexpRptIERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpIfStatsEntry 107 }
+
+jnxMbgPgwIfV2ICsUnexpRptIETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpIfStatsEntry 108 }
+
+jnxMbgPgwIfV2ICsGREKeyNtFdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpIfStatsEntry 109 }
+
+jnxMbgPgwIfV2ICsGREKeyNtFdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpIfStatsEntry 110 }
+
+jnxMbgPgwIfV2ICsRelocFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpIfStatsEntry 111 }
+
+jnxMbgPgwIfV2ICsRelocFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpIfStatsEntry 112 }
+
+jnxMbgPgwIfV2ICsDeniedINRatRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Denied in RAT."
+    ::= { jnxMbgPgwGtpIfStatsEntry 113 }
+
+jnxMbgPgwIfV2ICsDeniedINRatTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Denied in RAT."
+    ::= { jnxMbgPgwGtpIfStatsEntry 114 }
+
+jnxMbgPgwIfV2ICsPTNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 115 }
+
+jnxMbgPgwIfV2ICsPTNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 116 }
+
+jnxMbgPgwIfV2ICsAllDynAdOccRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpIfStatsEntry 117 }
+
+jnxMbgPgwIfV2ICsAllDynAdOccTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpIfStatsEntry 118 }
+
+jnxMbgPgwIfV2ICsNOTFTUECTXRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpIfStatsEntry 119 }
+
+jnxMbgPgwIfV2ICsNOTFTUECTXTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpIfStatsEntry 120 }
+
+jnxMbgPgwIfV2ICsProtoNtSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 121 }
+
+jnxMbgPgwIfV2ICsProtoNtSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 122 }
+
+jnxMbgPgwIfV2ICsUENotRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Not Responding."
+    ::= { jnxMbgPgwGtpIfStatsEntry 123 }
+
+jnxMbgPgwIfV2ICsUENotRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Not Responding."
+    ::= { jnxMbgPgwGtpIfStatsEntry 124 }
+
+jnxMbgPgwIfV2ICsUERefusesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Refuses."
+    ::= { jnxMbgPgwGtpIfStatsEntry 125 }
+
+jnxMbgPgwIfV2ICsUERefusesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause UE Refuses."
+    ::= { jnxMbgPgwGtpIfStatsEntry 126 }
+
+jnxMbgPgwIfV2ICsServDeniedRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Denied."
+    ::= { jnxMbgPgwGtpIfStatsEntry 127 }
+
+jnxMbgPgwIfV2ICsServDeniedTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Service Denied."
+    ::= { jnxMbgPgwGtpIfStatsEntry 128 }
+
+jnxMbgPgwIfV2ICsUnabPageUERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpIfStatsEntry 129 }
+
+jnxMbgPgwIfV2ICsUnabPageUETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpIfStatsEntry 130 }
+
+jnxMbgPgwIfV2ICsNoMemRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Memory."
+    ::= { jnxMbgPgwGtpIfStatsEntry 131 }
+
+jnxMbgPgwIfV2ICsNoMemTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause No Memory."
+    ::= { jnxMbgPgwGtpIfStatsEntry 132 }
+
+jnxMbgPgwIfV2ICsUserAUTHFlRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpIfStatsEntry 133 }
+
+jnxMbgPgwIfV2ICsUserAUTHFlTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpIfStatsEntry 134 }
+
+jnxMbgPgwIfV2ICsAPNAcsDenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause APN Access Denied."
+    ::= { jnxMbgPgwGtpIfStatsEntry 135 }
+
+jnxMbgPgwIfV2ICsAPNAcsDenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause APN Access Denied."
+    ::= { jnxMbgPgwGtpIfStatsEntry 136 }
+
+jnxMbgPgwIfV2ICsReqRejRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Rejected."
+    ::= { jnxMbgPgwGtpIfStatsEntry 137 }
+
+jnxMbgPgwIfV2ICsReqRejTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets sent with cause Request Rejected."
+    ::= { jnxMbgPgwGtpIfStatsEntry 138 }
+
+jnxMbgPgwIfV2ICsPTMSISigMMRx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets received with cause P-TMSI Signature Mismatc."
+    ::= { jnxMbgPgwGtpIfStatsEntry 139 }
+
+jnxMbgPgwIfV2ICsPTMSISigMMTx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets sent with cause P-TMSI Signature Mismatch"
+    ::= { jnxMbgPgwGtpIfStatsEntry 140 }
+
+jnxMbgPgwIfV2ICsIMSINotKnRx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpIfStatsEntry 141 }
+
+jnxMbgPgwIfV2ICsIMSINotKnTx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpIfStatsEntry 142 }
+
+jnxMbgPgwIfV2ICsCondIEMsRx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets received with cause Conditional IE Missing."
+     ::= { jnxMbgPgwGtpIfStatsEntry 143 }
+
+jnxMbgPgwIfV2ICsCondIEMsTx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets sent with cause Conditional IE Missing."
+     ::= { jnxMbgPgwGtpIfStatsEntry 144 }
+
+jnxMbgPgwIfV2ICsAPNResTIncRx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets received with cause APN Restriction Type Incompatible"
+     ::= { jnxMbgPgwGtpIfStatsEntry 145 }
+
+jnxMbgPgwIfV2ICsAPNResTIncTx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets sent with cause APN Restriction Type Incompatible"
+     ::= { jnxMbgPgwGtpIfStatsEntry 146 }
+
+jnxMbgPgwIfV2ICsUnknownRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets received with cause Unknown"
+     ::= { jnxMbgPgwGtpIfStatsEntry 147 }
+
+jnxMbgPgwIfV2ICsUnknownTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets sent with cause Unknown"
+     ::= { jnxMbgPgwGtpIfStatsEntry 148 }
+
+jnxMbgPgwIfV1ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 149 }
+
+jnxMbgPgwIfV1UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 150 }
+
+jnxMbgPgwIfV1T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 151 }
+
+jnxMbgPgwIfV1GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 messages received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 152 }
+
+jnxMbgPgwIfV1GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 messages sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 153 }
+
+jnxMbgPgwIfV1GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv1 bytes received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 154 }
+
+jnxMbgPgwIfV1GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 bytes sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 155 }
+
+jnxMbgPgwIfV1GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 156 }
+
+jnxMbgPgwIfV1GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 157 }
+
+jnxMbgPgwIfV1GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 158 }
+
+jnxMbgPgwIfV1GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 159 }
+
+jnxMbgPgwIfV1VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpIfStatsEntry 160 }
+
+jnxMbgPgwIfV1VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 version not supported messages Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 161 }
+
+jnxMbgPgwIfV1CrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 162 }
+
+jnxMbgPgwIfV1CrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 163 }
+
+jnxMbgPgwIfV1CrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 164 }
+
+jnxMbgPgwIfV1CrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 165 }
+
+jnxMbgPgwIfV1UpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 166 }
+
+jnxMbgPgwIfV1UpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 167 }
+
+jnxMbgPgwIfV1UpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 168 }
+
+jnxMbgPgwIfV1UpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 169 }
+
+jnxMbgPgwIfV1DelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 170 }
+
+jnxMbgPgwIfV1DelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 171 }
+
+jnxMbgPgwIfV1DelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 172 }
+
+jnxMbgPgwIfV1DelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 173 }
+
+jnxMbgPgwIfV1CrtAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 174 }
+
+jnxMbgPgwIfV1CrtAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 175 }
+
+jnxMbgPgwIfV1CrtAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 176 }
+
+jnxMbgPgwIfV1CrtAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 177 }
+
+jnxMbgPgwIfV1DelAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 178 }
+
+jnxMbgPgwIfV1DelAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 179 }
+
+jnxMbgPgwIfV1DelAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 180 }
+
+jnxMbgPgwIfV1DelAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 181 }
+
+jnxMbgPgwIfV1ErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Error Indication Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 182 }
+
+jnxMbgPgwIfV1ErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Error Indication Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 183 }
+
+jnxMbgPgwIfV1NotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 184 }
+
+jnxMbgPgwIfV1NotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 185 }
+
+jnxMbgPgwIfV1NotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 186 }
+
+jnxMbgPgwIfV1NotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 187 }
+
+jnxMbgPgwIfV1NotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 188 }
+
+jnxMbgPgwIfV1NotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 189 }
+
+jnxMbgPgwIfV1NotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 190 }
+
+jnxMbgPgwIfV1NotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 191 }
+
+jnxMbgPgwIfV1RtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 192 }
+
+jnxMbgPgwIfV1RtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 193 }
+
+jnxMbgPgwIfV1RtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 194 }
+
+jnxMbgPgwIfV1RtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 195 }
+
+jnxMbgPgwIfV1FailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 196 }
+
+jnxMbgPgwIfV1FailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 197 }
+
+jnxMbgPgwIfV1FailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 198 }
+
+jnxMbgPgwIfV1FailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 199 }
+
+jnxMbgPgwIfV1NotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Request Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 200 }
+
+jnxMbgPgwIfV1NotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Request Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 201 }
+
+jnxMbgPgwIfV1NotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 202 }
+
+jnxMbgPgwIfV1NotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 203 }
+
+jnxMbgPgwIfV1ICsReqAcceptedRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Request Accepted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 204 }
+
+jnxMbgPgwIfV1ICsReqAcceptedTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Request Accepted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 205 }
+
+jnxMbgPgwIfV1ICsNonExistRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Non Existant."
+    ::= { jnxMbgPgwGtpIfStatsEntry 206 }
+
+jnxMbgPgwIfV1ICsNonExistTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Non Existant."
+    ::= { jnxMbgPgwGtpIfStatsEntry 207 }
+
+jnxMbgPgwIfV1ICsInvMsgFmtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpIfStatsEntry 208 }
+
+jnxMbgPgwIfV1ICsInvMsgFmtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpIfStatsEntry 209 }
+
+jnxMbgPgwIfV1ICsIMSINotKnownRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpIfStatsEntry 210 }
+
+
+jnxMbgPgwIfV1ICsIMSINotKnownTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpIfStatsEntry 211 }
+
+jnxMbgPgwIfV1ICsMSGRPSDetachRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpIfStatsEntry 212 }
+
+jnxMbgPgwIfV1ICsMSGRPSDetachTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpIfStatsEntry 213 }
+
+jnxMbgPgwIfV1ICsMSNotGRPSRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 214 }
+
+jnxMbgPgwIfV1ICsMSNotGRPSRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 215 }
+
+jnxMbgPgwIfV1ICsMSRefusesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause MS Refues."
+    ::= { jnxMbgPgwGtpIfStatsEntry 216 }
+
+jnxMbgPgwIfV1ICsMSRefusesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause MS Refues."
+    ::= { jnxMbgPgwGtpIfStatsEntry 217 }
+
+jnxMbgPgwIfV1ICsVerNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 218 }
+
+jnxMbgPgwIfV1ICsVerNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 219 }
+
+jnxMbgPgwIfV1ICsNoResRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 220 }
+
+jnxMbgPgwIfV1ICsNoResTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 221 }
+
+jnxMbgPgwIfV1ICsServNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 222 }
+
+jnxMbgPgwIfV1ICsServNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 223 }
+
+jnxMbgPgwIfV1ICsManIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 224 }
+
+jnxMbgPgwIfV1ICsManIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 225 }
+
+jnxMbgPgwIfV1ICsManIEMissRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 226 }
+
+jnxMbgPgwIfV1ICsManIEMissTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 227 }
+
+jnxMbgPgwIfV1ICsOptIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 228 }
+
+jnxMbgPgwIfV1ICsOptIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 229 }
+
+jnxMbgPgwIfV1ICsSysFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 230 }
+
+jnxMbgPgwIfV1ICsSysFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 231 }
+
+jnxMbgPgwIfV1ICsRoamRestrictRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 232 }
+
+jnxMbgPgwIfV1ICsRoamRestrictTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 233 }
+
+jnxMbgPgwIfV1ICsPTMSISigMMRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpIfStatsEntry 234 }
+
+jnxMbgPgwIfV1ICsPTMSISigMMTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpIfStatsEntry 235 }
+
+jnxMbgPgwIfV1ICsGPRSConnSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 236 }
+
+jnxMbgPgwIfV1ICsGPRSConnSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 237 }
+
+jnxMbgPgwIfV1ICsAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 238 }
+
+jnxMbgPgwIfV1ICsAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 239 }
+
+jnxMbgPgwIfV1ICsUserAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 240 }
+
+jnxMbgPgwIfV1ICsUserAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 241 }
+
+jnxMbgPgwIfV1ICsCtxNotFndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Context Not Found."
+    ::= { jnxMbgPgwGtpIfStatsEntry 242 }
+
+jnxMbgPgwIfV1ICsCtxNotFndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Context Not Found."
+    ::= { jnxMbgPgwGtpIfStatsEntry 243 }
+
+jnxMbgPgwIfV1ICsAllDynPDPAdRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpIfStatsEntry 244 }
+
+jnxMbgPgwIfV1ICsAllDynPDPAdTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpIfStatsEntry 245 }
+
+jnxMbgPgwIfV1ICsNoMemRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No Memory."
+    ::= { jnxMbgPgwGtpIfStatsEntry 246 }
+
+jnxMbgPgwIfV1ICsNoMemTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No Memory."
+    ::= { jnxMbgPgwGtpIfStatsEntry 247 }
+
+jnxMbgPgwIfV1ICsRelocFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpIfStatsEntry 248 }
+
+jnxMbgPgwIfV1ICsRelocFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Relocation Failed."
+    ::= { jnxMbgPgwGtpIfStatsEntry 249 }
+
+jnxMbgPgwIfV1ICsUnkManExhdrRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpIfStatsEntry 250 }
+
+jnxMbgPgwIfV1ICsUnkManExhdrTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpIfStatsEntry 251 }
+
+jnxMbgPgwIfV1ICsSMANTTFTEr1Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 252 }
+
+jnxMbgPgwIfV1ICsSMANTTFTEr1Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 253 }
+
+jnxMbgPgwIfV1ICsSYNTFTErr2Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 254 }
+
+jnxMbgPgwIfV1ICsSYNTFTErr2Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 255 }
+
+jnxMbgPgwIfV1ICsSMNTPkFlEr1Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 256 }
+
+jnxMbgPgwIfV1ICsSMNTPkFlEr1Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 257 }
+
+jnxMbgPgwIfV1ICsSYNPkFlErr2Rx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 258 }
+
+jnxMbgPgwIfV1ICsSYNPkFlErr2Tx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpIfStatsEntry 259 }
+
+jnxMbgPgwIfV1ICsMissUnknAPNRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 260 }
+
+jnxMbgPgwIfV1ICsMissUnknAPNTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 261 }
+
+jnxMbgPgwIfV1ICsUnknPDPAdRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpIfStatsEntry 262 }
+
+jnxMbgPgwIfV1ICsUnknPDPAdTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpIfStatsEntry 263 }
+
+jnxMbgPgwIfV1ICsNoTFTCtxExRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets received with cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpIfStatsEntry 264 }
+
+jnxMbgPgwIfV1ICsNoTFTCtxExTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV1 packets sent with cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpIfStatsEntry 265 }
+
+jnxMbgPgwIfV0ProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 Protocol Errors Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 266 }
+
+jnxMbgPgwIfV0UnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 267 }
+
+jnxMbgPgwIfV0T3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 T3 timer expiries Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 268 }
+
+jnxMbgPgwIfV0GlbNumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 messages received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 269 }
+
+jnxMbgPgwIfV0GlbNumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 messages sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 270 }
+
+jnxMbgPgwIfV0GlbNumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv0 bytes received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 271 }
+
+jnxMbgPgwIfV0GlbNumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 bytes sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 272 }
+
+jnxMbgPgwIfV0GlbEchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+   "Number of GTP V0 Echo Requests received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 273 }
+
+jnxMbgPgwIfV0GlbEchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 274 }
+
+jnxMbgPgwIfV0GlbEchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Responses received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 275 }
+
+jnxMbgPgwIfV0GlbEchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 276 }
+
+jnxMbgPgwIfV0GlbVerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Version Not supported messages received"
+    ::= { jnxMbgPgwGtpIfStatsEntry 277 }
+
+jnxMbgPgwIfV0GlbVerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 version not supported messages Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 278 }
+
+jnxMbgPgwIfV0GlbCrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 279 }
+
+jnxMbgPgwIfV0GlbCrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 280 }
+
+jnxMbgPgwIfV0GlbCrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 281 }
+
+jnxMbgPgwIfV0GlbCrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 282 }
+
+jnxMbgPgwIfV0GlbUpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 283 }
+
+jnxMbgPgwIfV0GlbUpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 284 }
+
+jnxMbgPgwIfV0GlbUpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 285 }
+
+jnxMbgPgwIfV0GlbUpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 286 }
+
+jnxMbgPgwIfV0GlbDelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 287 }
+
+jnxMbgPgwIfV0GlbDelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 288 }
+
+jnxMbgPgwIfV0GlbDelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 289 }
+
+jnxMbgPgwIfV0GlbDelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 290 }
+
+jnxMbgPgwIfV0GlbCrtAAPdpCxtRqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 291 }
+
+jnxMbgPgwIfV0GlbCrtAAPdpCxtRqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 292 }
+
+jnxMbgPgwIfV0GlbCrtAAPdpCxtRpRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 293 }
+
+jnxMbgPgwIfV0GlbCrtAAPdpCxtRpTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 294 }
+
+jnxMbgPgwIfV0GlbDelAAPdpCxtRqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 295 }
+
+jnxMbgPgwIfV0GlbDelAAPdpCxtRqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 296 }
+
+jnxMbgPgwIfV0GlbDelAAPdpCxtRpRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 297 }
+
+jnxMbgPgwIfV0GlbDelAAPdpCxtRpTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 298 }
+
+jnxMbgPgwIfV0GlbErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Error Indication messages Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 299 }
+
+jnxMbgPgwIfV0GlbErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Error Indication messages Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 300 }
+
+jnxMbgPgwIfV0GlbNotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 301 }
+
+jnxMbgPgwIfV0GlbNotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 302 }
+
+jnxMbgPgwIfV0GlbNotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 303 }
+
+jnxMbgPgwIfV0GlbNotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 304 }
+
+jnxMbgPgwIfV0GlbNotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 305 }
+
+jnxMbgPgwIfV0GlbNotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 306 }
+
+jnxMbgPgwIfV0GlbNotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 307 }
+
+jnxMbgPgwIfV0GlbNotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 308 }
+
+jnxMbgPgwIfV0GlbRtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 309 }
+
+jnxMbgPgwIfV0GlbRtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 310 }
+
+jnxMbgPgwIfV0GlbRtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 311 }
+
+jnxMbgPgwIfV0GlbRtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 312 }
+
+jnxMbgPgwIfV0GlbFailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 313 }
+
+jnxMbgPgwIfV0GlbFailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 314 }
+
+jnxMbgPgwIfV0GlbFailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 315 }
+
+jnxMbgPgwIfV0GlbFailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 316 }
+
+jnxMbgPgwIfV0GlbNotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 317 }
+
+jnxMbgPgwIfV0GlbNotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 318 }
+
+jnxMbgPgwIfV0GlbNotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 319 }
+
+jnxMbgPgwIfV0GlbNotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V0 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 320 }
+
+jnxMbgPgwIfV0ICsReqAcceptedRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Request Accepted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 321 }
+
+jnxMbgPgwIfV0ICsReqAcceptedTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Request Accepted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 322 }
+
+jnxMbgPgwIfV0ICsNonExistRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Non Existant ."
+    ::= { jnxMbgPgwGtpIfStatsEntry 323 }
+
+jnxMbgPgwIfV0ICsNonExistTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Non Existant."
+    ::= { jnxMbgPgwGtpIfStatsEntry 324 }
+
+jnxMbgPgwIfV0ICsInvMsgFmtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpIfStatsEntry 325 }
+
+jnxMbgPgwIfV0ICsInvMsgFmtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpIfStatsEntry 326 }
+
+jnxMbgPgwIfV0ICsIMSINotKnownRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpIfStatsEntry 327 }
+
+
+jnxMbgPgwIfV0ICsIMSINotKnownTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpIfStatsEntry 328 }
+
+jnxMbgPgwIfV0ICsMSGRPSDetachRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpIfStatsEntry 329 }
+
+jnxMbgPgwIfV0ICsMSGRPSDetachTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpIfStatsEntry 330 }
+
+jnxMbgPgwIfV0ICsMSNotGRPSRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 331 }
+
+jnxMbgPgwIfV0ICsMSNotGRPSRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 332 }
+
+jnxMbgPgwIfV0ICsMSRefusesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause MS Refues."
+    ::= { jnxMbgPgwGtpIfStatsEntry 333 }
+
+jnxMbgPgwIfV0ICsMSRefusesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause MS Refues."
+    ::= { jnxMbgPgwGtpIfStatsEntry 334 }
+
+jnxMbgPgwIfV0ICsVerNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 335 }
+
+jnxMbgPgwIfV0ICsVerNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Version Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 336 }
+
+jnxMbgPgwIfV0ICsNoResRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause No Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 337 }
+
+jnxMbgPgwIfV0ICsNoResTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause No Response."
+    ::= { jnxMbgPgwGtpIfStatsEntry 338 }
+
+jnxMbgPgwIfV0ICsServNotSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 339 }
+
+jnxMbgPgwIfV0ICsServNotSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Service Not Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 340 }
+
+jnxMbgPgwIfV0ICsManIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 341 }
+
+jnxMbgPgwIfV0ICsManIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 342 }
+
+jnxMbgPgwIfV0ICsManIEMissRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 343 }
+
+jnxMbgPgwIfV0ICsManIEMissTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpIfStatsEntry 344 }
+
+jnxMbgPgwIfV0ICsOptIEIncrtRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 345 }
+
+jnxMbgPgwIfV0ICsOptIEIncrtTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpIfStatsEntry 346 }
+
+jnxMbgPgwIfV0ICsSysFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause System Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 347 }
+
+jnxMbgPgwIfV0ICsSysFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause System Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 348 }
+
+jnxMbgPgwIfV0ICsRoamRestrictRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 349 }
+
+jnxMbgPgwIfV0ICsRoamRestrictTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpIfStatsEntry 350 }
+
+jnxMbgPgwIfV0ICsPTMSISigMMRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpIfStatsEntry 351 }
+
+jnxMbgPgwIfV0ICsPTMSISigMMTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpIfStatsEntry 352 }
+
+jnxMbgPgwIfV0ICsGPRSConnSuppRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 353 }
+
+jnxMbgPgwIfV0ICsGPRSConnSuppTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpIfStatsEntry 354 }
+
+jnxMbgPgwIfV0ICsAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 355 }
+
+jnxMbgPgwIfV0ICsAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 356 }
+
+jnxMbgPgwIfV0ICsUserAuthFailRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets received with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 357 }
+
+jnxMbgPgwIfV0ICsUserAuthFailTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV0 packets sent with cause User Auth Failure."
+    ::= { jnxMbgPgwGtpIfStatsEntry 358 }
+
+jnxMbgPgwIfGtpV2ICsLclDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Local Detach."
+     ::= { jnxMbgPgwGtpIfStatsEntry 359 }
+
+jnxMbgPgwIfGtpV2ICsLclDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Local Detach."
+     ::= { jnxMbgPgwGtpIfStatsEntry 360 }
+
+jnxMbgPgwIfGtpV2ICsCmpDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Complete Detach."
+     ::= { jnxMbgPgwGtpIfStatsEntry 361 }
+
+jnxMbgPgwIfGtpV2ICsCmpDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Complete Detach."
+     ::= { jnxMbgPgwGtpIfStatsEntry 362 }
+
+jnxMbgPgwIfGtpV2ICsRATChgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgPgwGtpIfStatsEntry 363 }
+
+jnxMbgPgwIfGtpV2ICsRATChgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgPgwGtpIfStatsEntry 364 }
+
+jnxMbgPgwIfGtpV2ICsISRDeactRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause ISR Deactivated."
+     ::= { jnxMbgPgwGtpIfStatsEntry 365 }
+
+jnxMbgPgwIfGtpV2ICsISRDeactTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause ISR Deactivated."
+     ::= { jnxMbgPgwGtpIfStatsEntry 366 }
+
+jnxMbgPgwIfGtpV2ICsEIFRNCEnRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgPgwGtpIfStatsEntry 367 }
+
+jnxMbgPgwIfGtpV2ICsEIFRNCEnTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgPgwGtpIfStatsEntry 368 }
+
+jnxMbgPgwIfGtpV2ICsSemErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpIfStatsEntry 369 }
+
+jnxMbgPgwIfGtpV2ICsSemErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpIfStatsEntry 370 }
+
+jnxMbgPgwIfGtpV2ICsSynErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpIfStatsEntry 371 }
+
+jnxMbgPgwIfGtpV2ICsSynErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgPgwGtpIfStatsEntry 372 }
+
+jnxMbgPgwIfGtpV2ICsRMValRcvRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Reserved Message Value Received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 373 }
+
+jnxMbgPgwIfGtpV2ICsRMValRcvTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Reserved Message Value Received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 374 }
+
+jnxMbgPgwIfGtpV2ICsRPrNtRspRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Remote peer not responding."
+     ::= { jnxMbgPgwGtpIfStatsEntry 375 }
+
+jnxMbgPgwIfGtpV2ICsRPrNtRspTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Remote peer not responding."
+     ::= { jnxMbgPgwGtpIfStatsEntry 376 }
+
+jnxMbgPgwIfGtpV2ICsColNWReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Collision with network initiated request."
+     ::= { jnxMbgPgwGtpIfStatsEntry 377 }
+
+jnxMbgPgwIfGtpV2ICsColNWReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Collision with network initiated request."
+     ::= { jnxMbgPgwGtpIfStatsEntry 378 }
+
+jnxMbgPgwIfGtpV2ICsUnPgUESusRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Unable to page UE due to suspension."
+     ::= { jnxMbgPgwGtpIfStatsEntry 379 }
+
+jnxMbgPgwIfGtpV2ICsUnPgUESusTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unable to page UE due to suspension."
+     ::= { jnxMbgPgwGtpIfStatsEntry 380 }
+
+jnxMbgPgwIfGtpV2ICsInvTotLenRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid total len."
+     ::= { jnxMbgPgwGtpIfStatsEntry 381 }
+
+jnxMbgPgwIfGtpV2ICsInvTotLenTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid total len."
+     ::= { jnxMbgPgwGtpIfStatsEntry 382 }
+
+jnxMbgPgwIfGtpV2ICsDtForNtSupRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Data forwarding not supported."
+     ::= { jnxMbgPgwGtpIfStatsEntry 383 }
+
+jnxMbgPgwIfGtpV2ICsDtForNtSupTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Data forwarding not supported."
+     ::= { jnxMbgPgwGtpIfStatsEntry 384 }
+
+jnxMbgPgwIfGtpV2ICsInReFRePrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgPgwGtpIfStatsEntry 385 }
+
+jnxMbgPgwIfGtpV2ICsInReFRePrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgPgwGtpIfStatsEntry 386 }
+
+jnxMbgPgwIfGtpV2ICsInvPrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid peer."
+     ::= { jnxMbgPgwGtpIfStatsEntry 387 }
+
+jnxMbgPgwIfGtpV2ICsInvPrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid peer."
+     ::= { jnxMbgPgwGtpIfStatsEntry 388 }
+
+jnxMbgPgwIfV1InitPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 389 }
+
+jnxMbgPgwIfV1InitPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 390 }
+
+jnxMbgPgwIfV1InitPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Response Received."
+    ::= { jnxMbgPgwGtpIfStatsEntry 391 }
+
+jnxMbgPgwIfV1InitPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V1 Initiated PDP Context Response Sent."
+    ::= { jnxMbgPgwGtpIfStatsEntry 392 }
+
+jnxMbgPgwIfV2SuspNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 393 }
+
+jnxMbgPgwIfV2SuspNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages sent."
+     ::= { jnxMbgPgwGtpIfStatsEntry 394 }
+
+jnxMbgPgwIfV2SuspAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 395 }
+
+jnxMbgPgwIfV2SuspAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages sent."
+     ::= { jnxMbgPgwGtpIfStatsEntry 396 }
+
+jnxMbgPgwIfV2ResumeNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 397 }
+
+jnxMbgPgwIfV2ResumeNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages sent."
+     ::= { jnxMbgPgwGtpIfStatsEntry 398 }
+
+jnxMbgPgwIfV2ResumeAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 399 }
+
+jnxMbgPgwIfV2ResumeAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages sent."
+     ::= { jnxMbgPgwGtpIfStatsEntry 400 }
+
+jnxMbgPgwIfV2PiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Piggyback messages received."
+     ::= { jnxMbgPgwGtpIfStatsEntry 401 }
+
+jnxMbgPgwIfV2PiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Piggyback messages sent."
+     ::= { jnxMbgPgwGtpIfStatsEntry 402 }
+
+--
+-- GTP Object for showing GTP Global Config Parameters
+--
+jnxMbgPgwGtpCGlblCfgGroup      OBJECT IDENTIFIER ::= 
+                                              { jnxMbgPgwGtpObjects 1 }
+
+--
+-- GTP Object for showing GTP Gn and GP Config Parameters
+--
+
+jnxMbgPgwGtpCGnGpGlblCfgGroup  OBJECT IDENTIFIER ::= 
+                                              { jnxMbgPgwGtpObjects 2 }
+
+--
+-- GTP Object for showing GTP S5 and S8 Config Parameters
+--
+
+jnxMbgPgwGtpCS5S8GlblCfgGroup  OBJECT IDENTIFIER ::= 
+                                              { jnxMbgPgwGtpObjects 3 }
+
+--
+-- GTP Object for showing GTP Version 2 Statistics
+--
+jnxMbgPgwGtpV2Stats                 OBJECT IDENTIFIER ::= 
+                                              { jnxMbgPgwGtpObjects 4 }
+
+--
+-- GTP Object for showing GTP Version 1 Statistics
+--
+
+jnxMbgPgwGtpV1Stats                 OBJECT IDENTIFIER ::= 
+                                              { jnxMbgPgwGtpObjects 5 }
+--
+-- GTP Object for showing GTP Version 0 Statistics
+--
+
+jnxMbgPgwGtpV0Stats                 OBJECT IDENTIFIER ::= 
+                                              { jnxMbgPgwGtpObjects 8 }
+-- 
+-- GtpC Global Configuration Group elements. 
+--
+
+jnxMbgPgwGtpGWName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Gateway Name."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 1 }
+
+
+jnxMbgPgwGtpPeerHistory   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Peers to be retained in history."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 2 }
+
+
+jnxMbgPgwGtpN3Reqs   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of N3 Requests."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 3 }
+
+
+jnxMbgPgwGtpT3Resp   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of T3 Responses."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 4 }
+
+
+jnxMbgPgwGtpCtrlEchIntr   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Echo Interval in seconds."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 5 }
+
+
+jnxMbgPgwGtpCtrlNoPathMgmt   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Detremine if Control Path Management is Enabled."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 6 }
+
+
+jnxMbgPgwGtpCtrlIfName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Interface Name."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 7 }
+
+
+jnxMbgPgwGtpCtrlIfRtbId   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Control RTB ID."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 8 }
+
+
+jnxMbgPgwGtpCtrlIPv4Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (4) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Local IPv4 Address."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 9 }
+
+
+jnxMbgPgwGtpCtrlIPv6Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (16) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Local IPv6 Address, if absent returns NULL."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 10 }
+
+
+jnxMbgPgwGtpDataN3Reqs   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Datapath N3 Requests."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 11 }
+
+
+jnxMbgPgwGtpDataT3Resp   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Datapath T3 Responses."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 12 }
+
+
+jnxMbgPgwGtpDataEchIntr   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Echo Interval in seconds."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 13 }
+
+
+jnxMbgPgwGtpDataNoPathMgmt   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Determine if Datapath Path Management is enabled."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 14 }
+
+
+jnxMbgPgwGtpDataIfName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU datapath Interface Name."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 15 }
+
+
+jnxMbgPgwGtpDataIfRtbId   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Datapath RTB Id."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 16 }
+
+
+jnxMbgPgwGtpDataIPv4Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (4) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Local IPv4 Address."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 17 }
+
+
+jnxMbgPgwGtpDataIPv6Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (16) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Local IPv6 Address, if absent returns NULL."
+    ::= { jnxMbgPgwGtpCGlblCfgGroup 18 }
+
+-- 
+-- GTP V2 Stats Elements.
+--
+
+jnxMbgPgwV2NumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgPgwGtpV2Stats 1 }
+
+
+jnxMbgPgwV2NumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgPgwGtpV2Stats 2 }
+
+
+jnxMbgPgwUnSupportedMsg  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgPgwGtpV2Stats 3 }
+
+
+jnxMbgPgwProtocolErr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors."
+    ::= { jnxMbgPgwGtpV2Stats 4 }
+
+
+jnxMbgPgwT3RespTmrExp  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Number of T3 timer expiries."
+    ::= { jnxMbgPgwGtpV2Stats 5 }
+
+
+jnxMbgPgwmsgRedirectRX  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Number of received message redirected to SPs for error handling received."
+    ::= { jnxMbgPgwGtpV2Stats 6 }
+
+
+jnxMbgPgwmsgRedirectTX  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 sent messages redirected to SPs for error handling sent."
+    ::= { jnxMbgPgwGtpV2Stats 7 }
+
+
+jnxMbgPgwCreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgPgwGtpV2Stats 8 }
+
+
+jnxMbgPgwCreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgPgwGtpV2Stats 9 }
+
+
+jnxMbgPgwModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgPgwGtpV2Stats 10 }
+
+
+jnxMbgPgwModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgPgwGtpV2Stats 11 }
+
+
+jnxMbgPgwDelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgPgwGtpV2Stats 12 }
+
+
+jnxMbgPgwDelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgPgwGtpV2Stats 13 }
+
+
+jnxMbgPgwCngNotifReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 CNG Notify Requests received."
+    ::= { jnxMbgPgwGtpV2Stats 14 }
+
+
+jnxMbgPgwCngNotifRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 CNG Notify Responses received."
+    ::= { jnxMbgPgwGtpV2Stats 15 }
+
+
+jnxMbgPgwModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgPgwGtpV2Stats 16 }
+
+
+jnxMbgPgwModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgPgwGtpV2Stats 17 }
+
+
+jnxMbgPgwDelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgPgwGtpV2Stats 18 }
+
+
+jnxMbgPgwDelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgPgwGtpV2Stats 19 }
+
+
+jnxMbgPgwBrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgPgwGtpV2Stats 20 }
+
+
+jnxMbgPgwBrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure. received."
+    ::= { jnxMbgPgwGtpV2Stats 21 }
+
+
+jnxMbgPgwDlDataNotiFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Downlink Data Notification fail received."
+    ::= { jnxMbgPgwGtpV2Stats 22 }
+
+
+jnxMbgPgwTraceSessActRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Trace Session Activate received."
+    ::= { jnxMbgPgwGtpV2Stats 23 }
+
+
+jnxMbgPgwTraceSessDeactRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Trace Session De-activate received."
+    ::= { jnxMbgPgwGtpV2Stats 24 }
+
+
+jnxMbgPgwCrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgPgwGtpV2Stats 25 }
+
+
+jnxMbgPgwCrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response received."
+    ::= { jnxMbgPgwGtpV2Stats 26 }
+
+
+jnxMbgPgwUpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request received."
+    ::= { jnxMbgPgwGtpV2Stats 27 }
+
+
+jnxMbgPgwUpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response received."
+    ::= { jnxMbgPgwGtpV2Stats 28 }
+
+
+jnxMbgPgwDelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request received."
+    ::= { jnxMbgPgwGtpV2Stats 29 }
+
+
+jnxMbgPgwDelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response received."
+    ::= { jnxMbgPgwGtpV2Stats 30 }
+
+
+jnxMbgPgwDelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Delete PDN conn set Request received."
+    ::= { jnxMbgPgwGtpV2Stats 31 }
+
+
+jnxMbgPgwDelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Delete PDN conn set Response received."
+    ::= { jnxMbgPgwGtpV2Stats 32 }
+
+
+jnxMbgPgwDlDataNotifRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Downlink Data Notify received."
+    ::= { jnxMbgPgwGtpV2Stats 33 }
+
+
+jnxMbgPgwDlDataAckRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Downlink Data Notify Acknowledgement received."
+    ::= { jnxMbgPgwGtpV2Stats 34 }
+
+
+jnxMbgPgwUpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Update Connset Request received."
+    ::= { jnxMbgPgwGtpV2Stats 35 }
+
+
+jnxMbgPgwUpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Update Connset Response received."
+    ::= { jnxMbgPgwGtpV2Stats 36 }
+
+
+jnxMbgPgwV2EchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Echo Request received."
+    ::= { jnxMbgPgwGtpV2Stats 37 }
+
+
+jnxMbgPgwV2EchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Echo Response received."
+    ::= { jnxMbgPgwGtpV2Stats 38 }
+
+
+jnxMbgPgwGtpV2ICsPage  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Page."
+    ::= { jnxMbgPgwGtpV2Stats 39 }
+
+
+jnxMbgPgwGtpV2ICsReqAccept  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Request Accept."
+    ::= { jnxMbgPgwGtpV2Stats 40 }
+
+
+jnxMbgPgwGtpV2ICsAcceptPart  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Accept Partial."
+    ::= { jnxMbgPgwGtpV2Stats 41 }
+
+
+jnxMbgPgwGtpV2ICsNewPTSubLT  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause New PDN type due to Subscriber LImit."
+    ::= { jnxMbgPgwGtpV2Stats 42 }
+
+
+jnxMbgPgwGtpV2ICsNewPTNPref  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause New PDN type due to Network Preference"
+    ::= { jnxMbgPgwGtpV2Stats 43 }
+
+
+jnxMbgPgwGtpV2ICsNewPTSIAddrbr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgPgwGtpV2Stats 44 }
+
+
+jnxMbgPgwGtpV2ICsCtxNotFnd  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Context not found."
+    ::= { jnxMbgPgwGtpV2Stats 45 }
+
+
+jnxMbgPgwGtpV2ICsInvMsgFmt  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Invalid Message Format."
+    ::= { jnxMbgPgwGtpV2Stats 46 }
+
+
+jnxMbgPgwGtpV2ICsVerNotSupp  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Version not Supported."
+    ::= { jnxMbgPgwGtpV2Stats 47 }
+
+
+jnxMbgPgwGtpV2ICsInvLen  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Invalid Length."
+    ::= { jnxMbgPgwGtpV2Stats 48 }
+
+
+jnxMbgPgwGtpV2ICsServNotSupp  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Service Not supported."
+    ::= { jnxMbgPgwGtpV2Stats 49 }
+
+
+jnxMbgPgwGtpV2ICsManIEIncorr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpV2Stats 50 }
+
+
+jnxMbgPgwGtpV2ICsManIEMiss  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpV2Stats 51 }
+
+
+jnxMbgPgwGtpV2ICsOptIEIncorr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Optional IE Incorrect."
+    ::= { jnxMbgPgwGtpV2Stats 52 }
+
+
+jnxMbgPgwGtpV2ICsSysFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause System Failure."
+    ::= { jnxMbgPgwGtpV2Stats 53 }
+
+
+jnxMbgPgwGtpV2ICsNoRes  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause No Resource."
+    ::= { jnxMbgPgwGtpV2Stats 54 }
+
+
+jnxMbgPgwGtpV2ICsTFTSMANTErr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause TFT Symantic Error."
+    ::= { jnxMbgPgwGtpV2Stats 55 }
+
+
+jnxMbgPgwGtpV2ICsTFTSysErr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause TFT System Error."
+    ::= { jnxMbgPgwGtpV2Stats 56 }
+
+
+jnxMbgPgwGtpV2ICsPktFltrsMantErr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Packet Filter Symantic Error."
+    ::= { jnxMbgPgwGtpV2Stats 57 }
+
+
+jnxMbgPgwGtpV2ICsPktFltrSynErr  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Packet Filter Syntax Error."
+    ::= { jnxMbgPgwGtpV2Stats 58 }
+
+
+jnxMbgPgwGtpV2ICsMissUnkownAPN  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Unknown APN."
+    ::= { jnxMbgPgwGtpV2Stats 59 }
+
+
+jnxMbgPgwGtpV2ICsUnexpRepeatIE  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Unexpected Repeated IE."
+    ::= { jnxMbgPgwGtpV2Stats 60 }
+
+
+jnxMbgPgwGtpV2ICsGREKeyNotFnd  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause GRE Key Not Found."
+    ::= { jnxMbgPgwGtpV2Stats 61 }
+
+
+jnxMbgPgwGtpV2ICsRelocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Relocation Failed."
+    ::= { jnxMbgPgwGtpV2Stats 62 }
+
+
+jnxMbgPgwGtpV2ICsDeniedINRat  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Denied in RAT."
+    ::= { jnxMbgPgwGtpV2Stats 63 }
+
+
+jnxMbgPgwGtpV2ICsPTNotSupp  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause PDN Type Not Supported."
+    ::= { jnxMbgPgwGtpV2Stats 64 }
+
+
+jnxMbgPgwGtpV2ICsAllDynAddrOcc  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgPgwGtpV2Stats 65 }
+
+
+jnxMbgPgwGtpV2ICsNOTFTUECTXEXIS  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause UE Context Without TFT Exists."
+    ::= { jnxMbgPgwGtpV2Stats 66 }
+
+
+jnxMbgPgwGtpV2ICsProtoNotSupp  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Protocol Not Supported."
+    ::= { jnxMbgPgwGtpV2Stats 67 }
+
+
+jnxMbgPgwGtpV2ICsUENotResp  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause UE Not Responding."
+    ::= { jnxMbgPgwGtpV2Stats 68 }
+
+
+jnxMbgPgwGtpV2ICsUERefuses  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause UE Refuses."
+    ::= { jnxMbgPgwGtpV2Stats 69 }
+
+
+jnxMbgPgwGtpV2ICsServDenied  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Service Denied."
+    ::= { jnxMbgPgwGtpV2Stats 70 }
+
+
+jnxMbgPgwGtpV2ICsUnablePageUE  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Unable to Page UE."
+    ::= { jnxMbgPgwGtpV2Stats 71 }
+
+
+jnxMbgPgwGtpV2ICsNoMem  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause No Memory."
+    ::= { jnxMbgPgwGtpV2Stats 72 }
+
+
+jnxMbgPgwGtpV2ICsUserAUTHFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause User AUTH Failed."
+    ::= { jnxMbgPgwGtpV2Stats 73 }
+
+
+jnxMbgPgwGtpV2ICsAPNAccessDenied  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause APN Access Denied."
+    ::= { jnxMbgPgwGtpV2Stats 74 }
+
+
+jnxMbgPgwGtpV2ICsReqRej  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Request Rejected."
+    ::= { jnxMbgPgwGtpV2Stats 75 }
+
+jnxMbgPgwV2NumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of V2 messages sent."
+    ::= { jnxMbgPgwGtpV2Stats 76 }
+
+
+jnxMbgPgwV2NumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of V2 bytes sent."
+    ::= { jnxMbgPgwGtpV2Stats 77 }
+
+jnxMbgPgwCreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgPgwGtpV2Stats 78 }
+
+
+jnxMbgPgwCreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgPgwGtpV2Stats 79 }
+
+
+jnxMbgPgwModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpV2Stats 80 }
+
+
+jnxMbgPgwModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgPgwGtpV2Stats 81 }
+
+
+jnxMbgPgwDelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgPgwGtpV2Stats 82 }
+
+
+jnxMbgPgwDelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgPgwGtpV2Stats 83 }
+
+
+jnxMbgPgwCngNotifReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 CNG Notify Requests Sent."
+    ::= { jnxMbgPgwGtpV2Stats 84 }
+
+
+jnxMbgPgwCngNotifRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 CNG Notify Responses Sent."
+    ::= { jnxMbgPgwGtpV2Stats 85 }
+
+
+jnxMbgPgwModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgPgwGtpV2Stats 86 }
+
+
+jnxMbgPgwModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpV2Stats 87 }
+
+
+jnxMbgPgwDelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgPgwGtpV2Stats 88 }
+
+
+jnxMbgPgwDelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgPgwGtpV2Stats 89 }
+
+
+jnxMbgPgwBrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgPgwGtpV2Stats 90 }
+
+
+jnxMbgPgwBrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure. Sent."
+    ::= { jnxMbgPgwGtpV2Stats 91 }
+
+
+jnxMbgPgwDlDataNotiFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Downlink Data Notification fail Sent."
+    ::= { jnxMbgPgwGtpV2Stats 92 }
+
+
+jnxMbgPgwTraceSessActTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Trace Session Activate Sent."
+    ::= { jnxMbgPgwGtpV2Stats 93 }
+
+
+jnxMbgPgwTraceSessDeactTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Trace Session De-activate Sent."
+    ::= { jnxMbgPgwGtpV2Stats 94 }
+
+
+jnxMbgPgwCrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgPgwGtpV2Stats 95 }
+
+
+jnxMbgPgwCrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response Sent."
+    ::= { jnxMbgPgwGtpV2Stats 96 }
+
+
+jnxMbgPgwUpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request Sent."
+    ::= { jnxMbgPgwGtpV2Stats 97 }
+
+
+jnxMbgPgwUpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response Sent."
+    ::= { jnxMbgPgwGtpV2Stats 98 }
+
+
+jnxMbgPgwDelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request Sent."
+    ::= { jnxMbgPgwGtpV2Stats 99 }
+
+
+jnxMbgPgwDelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response Sent."
+    ::= { jnxMbgPgwGtpV2Stats 100 }
+
+
+jnxMbgPgwDelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Delete PDN conn set Request Sent."
+    ::= { jnxMbgPgwGtpV2Stats 101 }
+
+
+jnxMbgPgwDelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Delete PDN conn set Response Sent."
+    ::= { jnxMbgPgwGtpV2Stats 102 }
+
+
+jnxMbgPgwDlDataNotifTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Downlink Data Notify Sent."
+    ::= { jnxMbgPgwGtpV2Stats 103 }
+
+
+jnxMbgPgwDlDataAckTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Downlink Data Notify Acknowledgement Sent."
+    ::= { jnxMbgPgwGtpV2Stats 104 }
+
+
+jnxMbgPgwUpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Update Connset Request Sent."
+    ::= { jnxMbgPgwGtpV2Stats 105 }
+
+
+jnxMbgPgwUpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Update Connset Response Sent."
+    ::= { jnxMbgPgwGtpV2Stats 106 }
+
+
+jnxMbgPgwV2EchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Echo Request Sent."
+    ::= { jnxMbgPgwGtpV2Stats 107 }
+
+
+jnxMbgPgwV2EchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V2 Echo Response Sent."
+    ::= { jnxMbgPgwGtpV2Stats 108 }
+                                           
+-- 
+-- GtpC Gn Gp Global Configuration Group elements. 
+--
+
+jnxMbgPgwGtpCGnGpGWName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Gateway Name."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 1 }
+
+
+jnxMbgPgwGtpCGnGpPeerHistory   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Peers to be retained in history."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 2 }
+
+
+jnxMbgPgwGtpCGnGpN3Reqs   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of N3 Requests."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 3 }
+
+
+jnxMbgPgwGtpCGnGpT3Resp   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of T3 Responses."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 4 }
+
+
+jnxMbgPgwGtpCGnGpCtrlEchIntr   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Echo Interval in seconds."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 5 }
+
+
+jnxMbgPgwGtpCGnGpCtrlNoPathMgmt   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Control Path Management Enabled."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 6 }
+
+
+jnxMbgPgwGtpCGnGpCtrlIfName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Interface Name."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 7 }
+
+
+jnxMbgPgwGtpCGnGpCtrlIfRtbId   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Control RTB ID."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 8 }
+
+
+jnxMbgPgwGtpCGnGpCtrlIPv4Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (4) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Local IPv4 Address."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 9 }
+
+
+jnxMbgPgwGtpCGnGpCtrlIPv6Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (16) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Local IPv6 Address."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 10 }
+
+
+jnxMbgPgwGtpCGnGpDataN3Reqs   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Datapath N3 Requests."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 11 }
+
+
+jnxMbgPgwGtpCGnGpDataT3Resp   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Datapath T3 Responses."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 12 }
+
+
+jnxMbgPgwGtpCGnGpDataEchIntr   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Echo Interval in seconds."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 13 }
+
+
+jnxMbgPgwGtpCGnGpDataNoPathMgmt   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Datapath Path Management enabled."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 14 }
+
+
+jnxMbgPgwGtpCGnGpDataIfName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU datapath Interface Name."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 15 }
+
+
+jnxMbgPgwGtpCGnGpDataIfRtbId   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Datapath RTB Id."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 16 }
+
+
+jnxMbgPgwGtpCGnGpDataIPv4Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (4) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Local IPv4 Address."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 17 }
+
+
+jnxMbgPgwGtpCGnGpDataIPv6Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (16) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Local IPv6 Address."
+    ::= { jnxMbgPgwGtpCGnGpGlblCfgGroup 18 } 
+
+-- 
+-- GtpC s5 s8 Global Configuration Group elements. 
+--
+
+jnxMbgPgwGtpCS5S8GWName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Gateway Name."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 1 }
+
+
+jnxMbgPgwGtpCS5S8PeerHistory   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Peers to be retained in history."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 2 }
+
+
+jnxMbgPgwGtpCS5S8N3Reqs   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of N3 Requests."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 3 }
+
+
+jnxMbgPgwGtpCS5S8T3Resp   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of T3 Responses."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 4 }
+
+
+jnxMbgPgwGtpCS5S8CtrlEchIntr   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Echo Interval in seconds."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 5 }
+
+
+jnxMbgPgwGtpCS5S8CtrlNoPathMgmt   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Control Path Management Enabled."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 6 }
+
+
+jnxMbgPgwGtpCS5S8CtrlIfName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Interface Name."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 7 }
+
+
+jnxMbgPgwGtpCS5S8CtrlIfRtbId   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Control RTB ID."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 8 }
+
+
+jnxMbgPgwGtpCS5S8CtrlIPv4Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (4) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Local IPv4 Address."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 9 }
+
+
+jnxMbgPgwGtpCS5S8CtrlIPv6Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (16) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPC Local IPv6 Address."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 10 }
+
+
+jnxMbgPgwGtpCS5S8DataN3Reqs   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Datapath N3 Requests."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 11 }
+
+
+jnxMbgPgwGtpCS5S8DataT3Resp   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Datapath T3 Responses."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 12 }
+
+
+jnxMbgPgwGtpCS5S8DataEchIntr   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Echo Interval in seconds."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 13 }
+
+
+jnxMbgPgwGtpCS5S8DataNoPathMgmt   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Datapath Path Management enabled."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 14 }
+
+
+jnxMbgPgwGtpCS5S8DataIfName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU datapath Interface Name."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 15 }
+
+
+jnxMbgPgwGtpCS5S8DataIfRtbId   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Datapath RTB Id."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 16 }
+
+
+jnxMbgPgwGtpCS5S8DataIPv4Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (4) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Local IPv4 Address."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 17 }
+
+
+jnxMbgPgwGtpCS5S8DataIPv6Addr   OBJECT-TYPE
+    SYNTAX      InetAddress ( SIZE (16) )
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTPU Local IPv6 Address."
+    ::= { jnxMbgPgwGtpCS5S8GlblCfgGroup 18 }  
+
+--
+-- GTP V0 Stats elements
+--
+
+jnxMbgPgwV0NumMsgRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number Of GTP V0 Messages Rx."
+    ::= { jnxMbgPgwGtpV0Stats 1 }
+
+
+jnxMbgPgwV0NumBytesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V0 Bytes Rx."
+    ::= { jnxMbgPgwGtpV0Stats 2 }
+
+
+jnxMbgPgwV0UnSupportedMsg   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Unsupported Messages."
+    ::= { jnxMbgPgwGtpV0Stats 3 }
+
+
+jnxMbgPgwV0ProtErr   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Protocol Errors."
+    ::= { jnxMbgPgwGtpV0Stats 4 }
+
+
+jnxMbgPgwV0T3RespTmrExp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 T3 Response Timer Expiries."
+    ::= { jnxMbgPgwGtpV0Stats 5 }
+
+
+jnxMbgPgwV0MsgRedirectRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Rx Message Redirected."
+    ::= { jnxMbgPgwGtpV0Stats 6 }
+
+
+jnxMbgPgwV0MsgRedirectTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Tx Message Redirected."
+    ::= { jnxMbgPgwGtpV0Stats 7 }
+
+
+jnxMbgPgwV0SuppExtHdrNot   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Extension Header Not Supported."
+    ::= { jnxMbgPgwGtpV0Stats 8 }
+
+
+jnxMbgPgwV0EchoReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Echo Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 9 }
+
+
+jnxMbgPgwV0EchoRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Echo Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 10 }
+
+
+jnxMbgPgwV0CrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 11 }
+
+
+jnxMbgPgwV0CrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 12 }
+
+
+jnxMbgPgwV0UpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 13 }
+
+
+jnxMbgPgwV0UpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 14 }
+
+
+jnxMbgPgwV0DelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 15 }
+
+
+jnxMbgPgwV0DelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 16 }
+
+
+jnxMbgPgwV0CrtAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 17 }
+
+
+jnxMbgPgwV0CrtAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 18 }
+
+
+jnxMbgPgwV0DelAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 19 }
+
+
+jnxMbgPgwV0DelAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 20 }
+
+
+jnxMbgPgwV0ErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Error Indication Received."
+    ::= { jnxMbgPgwGtpV0Stats 21 }
+
+
+jnxMbgPgwV0NotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 22 }
+
+
+jnxMbgPgwV0NotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 23 }
+
+
+jnxMbgPgwV0NotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 24 }
+
+
+jnxMbgPgwV0NotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 25 }
+
+
+jnxMbgPgwV0RtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 26 }
+
+
+jnxMbgPgwV0RtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 27 }
+
+
+jnxMbgPgwV0FailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpV0Stats 28 }
+
+
+jnxMbgPgwV0FailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 29 }
+
+
+jnxMbgPgwV0NotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 MS Not Present Request Received."
+    ::= { jnxMbgPgwGtpV0Stats 30 }
+
+
+jnxMbgPgwV0NotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpV0Stats 31 }
+
+
+jnxMbgPgwGTPV0ICsReqAccepted   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Request Accepted."
+    ::= { jnxMbgPgwGtpV0Stats 32 }               
+
+
+jnxMbgPgwGTPV0ICsNonExist   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Non Existant."
+    ::= { jnxMbgPgwGtpV0Stats 33 }
+
+
+jnxMbgPgwGTPV0ICsInvMsgFmt   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpV0Stats 34 }
+
+
+jnxMbgPgwGTPV0ICsIMSINotKnown   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpV0Stats 35 }
+
+
+jnxMbgPgwGTPV0ICsMSGRPSDetach   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpV0Stats 36 }
+
+
+jnxMbgPgwGTPV0ICsMSNotGRPSResp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpV0Stats 37 }
+
+
+jnxMbgPgwGTPV0ICsMSRefuses   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause MS Refues."
+    ::= { jnxMbgPgwGtpV0Stats 38 }
+
+
+jnxMbgPgwGTPV0ICsVerNotSupp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Version Not Supported."
+    ::= { jnxMbgPgwGtpV0Stats 39 }
+
+
+jnxMbgPgwGTPV0ICsNoRes   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause No Response."
+    ::= { jnxMbgPgwGtpV0Stats 40 }
+
+
+jnxMbgPgwGTPV0ICsServNotSupp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Service Not Supported."
+    ::= { jnxMbgPgwGtpV0Stats 41 }
+
+
+jnxMbgPgwGTPV0ICsManIEIncrt   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpV0Stats 42 }
+
+
+jnxMbgPgwGTPV0ICsManIEMiss   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpV0Stats 43 }
+
+
+jnxMbgPgwGTPV0ICsOptIEIncrt   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpV0Stats 44 }
+
+
+jnxMbgPgwGTPV0ICsSysFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause System Failure."
+    ::= { jnxMbgPgwGtpV0Stats 45 }
+
+
+jnxMbgPgwGTPV0ICsRoamRestrict   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpV0Stats 46 }
+
+
+jnxMbgPgwGTPV0ICsPTMSISigMismatch   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpV0Stats 47 }
+
+
+jnxMbgPgwGTPV0ICsGPRSConnSupp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpV0Stats 48 }
+
+
+jnxMbgPgwGTPV0ICsAuthFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Auth Failure."
+    ::= { jnxMbgPgwGtpV0Stats 49 }
+
+
+jnxMbgPgwGTPV0ICsUserAuthFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause User Auth Failure."
+    ::= { jnxMbgPgwGtpV0Stats 50 }
+
+jnxMbgPgwV0NumMsgTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number Of Messages Tx."
+    ::= { jnxMbgPgwGtpV0Stats 51 }
+
+
+jnxMbgPgwV0NumBytesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Bytes Tx."
+    ::= { jnxMbgPgwGtpV0Stats 52 }
+
+
+jnxMbgPgwV0EchoReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 53 }
+
+ 
+jnxMbgPgwV0EchoRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 54 }
+
+
+jnxMbgPgwV0CrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 55 }
+
+
+jnxMbgPgwV0CrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 56 }
+
+
+jnxMbgPgwV0UpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 57 }
+
+
+jnxMbgPgwV0UpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 58 }
+
+
+jnxMbgPgwV0DelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 59 }
+
+
+jnxMbgPgwV0DelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 60 }
+
+
+jnxMbgPgwV0CrtAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 61 }
+
+
+jnxMbgPgwV0CrtAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 62 }
+
+
+jnxMbgPgwV0DelAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 63 }
+
+
+jnxMbgPgwV0DelAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 64 }
+
+
+jnxMbgPgwV0ErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Error Indication Sent."
+    ::= { jnxMbgPgwGtpV0Stats 65 }
+
+
+jnxMbgPgwV0NotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 66 }
+
+
+jnxMbgPgwV0NotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 67 }
+
+
+jnxMbgPgwV0NotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 68 }
+
+
+jnxMbgPgwV0NotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 69 }
+
+
+jnxMbgPgwV0RtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 70 }
+
+
+jnxMbgPgwV0RtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 71 }
+
+
+jnxMbgPgwV0FailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpV0Stats 72 }
+
+
+jnxMbgPgwV0FailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 73 }
+
+
+jnxMbgPgwV0NotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 MS Not Present Request Sent."
+    ::= { jnxMbgPgwGtpV0Stats 74 }
+
+
+jnxMbgPgwV0NotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V0 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpV0Stats 75 }
+
+--
+-- GTP V1 Stats elements
+--
+
+jnxMbgPgwV1NumMsgRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number Of GTP V1 Messages Rx."
+    ::= { jnxMbgPgwGtpV1Stats 1 }
+
+
+jnxMbgPgwV1NumBytesRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of GTP V1 Bytes Rx."
+    ::= { jnxMbgPgwGtpV1Stats 2 }
+
+
+jnxMbgPgwV1UnSupportedMsg   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Unsupported Messages."
+    ::= { jnxMbgPgwGtpV1Stats 3 }
+
+
+jnxMbgPgwProtErr   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Protocol Errors."
+    ::= { jnxMbgPgwGtpV1Stats 4 }
+
+
+jnxMbgPgwV1T3RespTmrExp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 T3 Response Timer Expiries."
+    ::= { jnxMbgPgwGtpV1Stats 5 }
+
+
+jnxMbgPgwMsgRedirectRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Rx Message Redirected."
+    ::= { jnxMbgPgwGtpV1Stats 6 }
+
+
+jnxMbgPgwMsgRedirectTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Tx Message Redirected."
+    ::= { jnxMbgPgwGtpV1Stats 7 }
+
+
+jnxMbgPgwSuppExtHdrNot   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Extension Header Not Supported."
+    ::= { jnxMbgPgwGtpV1Stats 8 }
+
+
+jnxMbgPgwV1EchoReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Echo Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 9 }
+
+
+jnxMbgPgwV1EchoRespRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Echo Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 10 }
+
+
+jnxMbgPgwCrtPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 11 }
+
+
+jnxMbgPgwCrtPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 12 }
+
+
+jnxMbgPgwUpdPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Update PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 13 }
+
+
+jnxMbgPgwUpdPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Update PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 14 }
+
+
+jnxMbgPgwDelPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 15 }
+
+
+jnxMbgPgwDelPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 16 }
+
+
+jnxMbgPgwCrtAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 17 }
+
+
+jnxMbgPgwCrtAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 18 }
+
+
+jnxMbgPgwDelAAPdpCxtReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete AA PDP Context Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 19 }
+
+
+jnxMbgPgwDelAAPdpCxtRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete AA PDP Context Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 20 }
+
+
+jnxMbgPgwErrorIndRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Error Indication Received."
+    ::= { jnxMbgPgwGtpV1Stats 21 }
+
+
+jnxMbgPgwNotifReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 22 }
+
+
+jnxMbgPgwNotifRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 23 }
+
+
+jnxMbgPgwNotifRejReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Reject Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 24 }
+
+
+jnxMbgPgwNotifRejRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Reject Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 25 }
+
+
+jnxMbgPgwRtInfReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Routing Information Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 26 }
+
+
+jnxMbgPgwRtInfRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Routing Information Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 27 }
+
+
+jnxMbgPgwFailRptReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Fail Repeat Requests Received."
+    ::= { jnxMbgPgwGtpV1Stats 28 }
+
+
+jnxMbgPgwFailRptRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Fail Repeat Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 29 }
+
+
+jnxMbgPgwNotMSPresReqRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 MS Not Present Request Received."
+    ::= { jnxMbgPgwGtpV1Stats 30 }
+
+
+jnxMbgPgwNotMSPresRspRx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 MS Not Present Responses Received."
+    ::= { jnxMbgPgwGtpV1Stats 31 }
+
+
+jnxMbgPgwGTPICsReqAccepted   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Request Accepted."
+    ::= { jnxMbgPgwGtpV1Stats 32 }               
+
+
+jnxMbgPgwGTPICsNonExist   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Non Existant."
+    ::= { jnxMbgPgwGtpV1Stats 33 }
+
+
+jnxMbgPgwGTPICsInvMsgFmt   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Invalid Mesage Format."
+    ::= { jnxMbgPgwGtpV1Stats 34 }
+
+
+jnxMbgPgwGTPICsIMSINotKnown   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause IMSI Not Known."
+    ::= { jnxMbgPgwGtpV1Stats 35 }
+
+
+jnxMbgPgwGTPICsMSGRPSDetach   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause MS GPRS Detached."
+    ::= { jnxMbgPgwGtpV1Stats 36 }
+
+
+jnxMbgPgwGTPICsMSNotGRPSResp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause MS No GPRS Response."
+    ::= { jnxMbgPgwGtpV1Stats 37 }
+
+
+jnxMbgPgwGTPICsMSRefuses   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause MS Refues."
+    ::= { jnxMbgPgwGtpV1Stats 38 }
+
+
+jnxMbgPgwGTPICsVerNotSupp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Version Not Supported."
+    ::= { jnxMbgPgwGtpV1Stats 39 }
+
+
+jnxMbgPgwGTPICsNoRes   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause No Response."
+    ::= { jnxMbgPgwGtpV1Stats 40 }
+
+
+jnxMbgPgwGTPICsServNotSupp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Service Not Supported."
+    ::= { jnxMbgPgwGtpV1Stats 41 }
+
+
+jnxMbgPgwGTPICsManIEIncrt   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory IE incorrect."
+    ::= { jnxMbgPgwGtpV1Stats 42 }
+
+
+jnxMbgPgwGTPICsManIEMiss   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory IE Missing."
+    ::= { jnxMbgPgwGtpV1Stats 43 }
+
+
+jnxMbgPgwGTPICsOptIEIncrt   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Optional IE incorrect."
+    ::= { jnxMbgPgwGtpV1Stats 44 }
+
+
+jnxMbgPgwGTPICsSysFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause System Failure."
+    ::= { jnxMbgPgwGtpV1Stats 45 }
+
+
+jnxMbgPgwGTPICsRoamRestrict   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Roaming Restricted."
+    ::= { jnxMbgPgwGtpV1Stats 46 }
+
+
+jnxMbgPgwGTPICsPTMSISigMismatch   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause PTMSI Signature Mismatch."
+    ::= { jnxMbgPgwGtpV1Stats 47 }
+
+
+jnxMbgPgwGTPICsGPRSConnSupp   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause GPRS Connection Supported."
+    ::= { jnxMbgPgwGtpV1Stats 48 }
+
+
+jnxMbgPgwGTPICsAuthFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Auth Failure."
+    ::= { jnxMbgPgwGtpV1Stats 49 }
+
+
+jnxMbgPgwGTPICsUserAuthFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause User Auth Failure."
+    ::= { jnxMbgPgwGtpV1Stats 50 }
+
+
+jnxMbgPgwGTPV1ICsCtxNotFnd   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Context Not Found."
+    ::= { jnxMbgPgwGtpV1Stats 51 }
+
+
+jnxMbgPgwGTPV1ICsAllDynPDPAddr   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Allow Dynamic PDP Address."
+    ::= { jnxMbgPgwGtpV1Stats 52 }
+
+
+jnxMbgPgwGTPV1ICsNoMem   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause No Memory."
+    ::= { jnxMbgPgwGtpV1Stats 53 }
+
+
+jnxMbgPgwGTPV1ICsRelocFail   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Relocation Failed."
+    ::= { jnxMbgPgwGtpV1Stats 54 }
+
+
+jnxMbgPgwGTPV1ICsUnkManExthdr   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Unknown Mandatory Extension Header."
+    ::= { jnxMbgPgwGtpV1Stats 55 }
+
+
+jnxMbgPgwGTPV1ICsSMANTTFTErr1   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpV1Stats 56 }
+
+
+jnxMbgPgwGTPV1ICsSYNTFTErr2   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory TFT Error."
+    ::= { jnxMbgPgwGtpV1Stats 57 }
+
+
+jnxMbgPgwGTPV1ICsSMNTPktFltrErr1   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpV1Stats 58 }
+
+
+jnxMbgPgwGTPV1ICsSYNPktFltrErr2   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Mandatory Packet Filter Error."
+    ::= { jnxMbgPgwGtpV1Stats 59 }
+
+
+jnxMbgPgwGTPV1ICsMissUnknownAPN   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Unknowkn APN missing."
+    ::= { jnxMbgPgwGtpV1Stats 60 }
+
+
+jnxMbgPgwGTPV1ICsUnknownPDPAddr   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause Unknowkn PDP Address."
+    ::= { jnxMbgPgwGtpV1Stats 61 }
+
+
+jnxMbgPgwGTPV1ICsNoTFTCtxExist   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP Cause No TFT Context Exists."
+    ::= { jnxMbgPgwGtpV1Stats 62 }
+     
+jnxMbgPgwV1NumMsgTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number Of Messages Tx."
+    ::= { jnxMbgPgwGtpV1Stats 63 }
+
+
+jnxMbgPgwV1NumBytesTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "Number of Bytes Tx."
+    ::= { jnxMbgPgwGtpV1Stats 64 }
+
+
+jnxMbgPgwV1EchoReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Echo Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 65 }
+
+ 
+jnxMbgPgwV1EchoRespTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Echo Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 66 }
+
+
+jnxMbgPgwCrtPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 67 }
+
+
+jnxMbgPgwCrtPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 68 }
+
+
+jnxMbgPgwUpdPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Update PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 69 }
+
+
+jnxMbgPgwUpdPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Update PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 70 }
+
+
+jnxMbgPgwDelPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 71 }
+
+
+jnxMbgPgwDelPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 72 }
+
+
+jnxMbgPgwCrtAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 73 }
+
+
+jnxMbgPgwCrtAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Create AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 74 }
+
+
+jnxMbgPgwDelAAPdpCxtReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete AA PDP Context Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 75 }
+
+
+jnxMbgPgwDelAAPdpCxtRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Delete AA PDP Context Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 76 }
+
+
+jnxMbgPgwErrorIndTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Error Indication Sent."
+    ::= { jnxMbgPgwGtpV1Stats 77 }
+
+
+jnxMbgPgwNotifReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 78 }
+
+
+jnxMbgPgwNotifRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 79 }
+
+
+jnxMbgPgwNotifRejReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Reject Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 80 }
+
+
+jnxMbgPgwNotifRejRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Notify Reject Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 81 }
+
+
+jnxMbgPgwRtInfReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Routing Information Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 82 }
+
+
+jnxMbgPgwRtInfRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Routing Information Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 83 }
+
+
+jnxMbgPgwFailRptReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Fail Repeat Requests Sent."
+    ::= { jnxMbgPgwGtpV1Stats 84 }
+
+
+jnxMbgPgwFailRptRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 Fail Repeat Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 85 }
+
+
+jnxMbgPgwNotMSPresReqTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 MS Not Present Request Sent."
+    ::= { jnxMbgPgwGtpV1Stats 86 }
+
+
+jnxMbgPgwNotMSPresRspTx   OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+    "GTP V1 MS Not Present Responses Sent."
+    ::= { jnxMbgPgwGtpV1Stats 87 }
+ 
+--
+-- GTP peer table to store stats.
+-- The table is indexed by remote address, local address and routing instance 
+--
+
+jnxMbgPgwGtpPeerStatsTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgPgwGtpPeerEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "Each entry corresponds to a GTP Peer discovered."
+    ::= { jnxMbgPgwGtpObjects 6 }
+
+jnxMbgPgwGtpPeerEntry OBJECT-TYPE
+    SYNTAX      JnxMbgPgwGtpPeerEntry  
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A specification of the GTP peer node connected to the GW."
+    INDEX     { jnxMbgPgwGtpPeerRmtAddr,
+                jnxMbgPgwGtpPeerLclAddr,
+                jnxMbgPgwGtpPeerRtgInst }
+    ::= { jnxMbgPgwGtpPeerStatsTable 1}
+
+JnxMbgPgwGtpPeerEntry ::= SEQUENCE {
+    jnxMbgPgwGtpPeerRmtAddr      IpAddress,
+    jnxMbgPgwGtpPeerLclAddr      IpAddress,
+    jnxMbgPgwGtpPeerRtgInst      Unsigned32,
+    jnxMbgPgwGtpDropCounter      Counter64,
+    jnxMbgPgwGtpPktAllocFail     Counter64,
+    jnxMbgPgwGtpPktSendFail      Counter64,
+    jnxMbgPgwGtpIPVerErrRx       Counter64,
+    jnxMbgPgwGtpIPProtoErrRx     Counter64,
+    jnxMbgPgwGtpPktLenErrRx      Counter64,
+    jnxMbgPgwGtpUnkMsgRx         Counter64,
+    jnxMbgPgwGtpMemAllocFailed   Counter64 
+}
+
+jnxMbgPgwGtpPeerRmtAddr OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The Remote IP address of this GTP entry."
+    ::= { jnxMbgPgwGtpPeerEntry 1 }
+
+jnxMbgPgwGtpPeerLclAddr OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The Local IP address of this GTP entry."
+    ::= { jnxMbgPgwGtpPeerEntry 2 }
+
+jnxMbgPgwGtpPeerRtgInst OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "The Routing Instance for this Peer."
+    ::= { jnxMbgPgwGtpPeerEntry 3 }
+
+jnxMbgPgwGtpDropCounter OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Message Drop Counter."
+    ::= { jnxMbgPgwGtpPeerEntry 4 }
+
+jnxMbgPgwGtpPktAllocFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Packet allocation failure count."
+    ::= { jnxMbgPgwGtpPeerEntry 5 }
+
+jnxMbgPgwGtpPktSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Packet sending failure count."
+    ::= { jnxMbgPgwGtpPeerEntry 6 }
+
+jnxMbgPgwGtpIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Rx Packet IP Version Error."
+    ::= { jnxMbgPgwGtpPeerEntry 7 }
+
+jnxMbgPgwGtpIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Rx Packet IP Protocol Error."
+    ::= { jnxMbgPgwGtpPeerEntry 8 }
+
+jnxMbgPgwGtpPktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Rx Packet Length Error."
+    ::= { jnxMbgPgwGtpPeerEntry 9 }
+
+jnxMbgPgwGtpUnkMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Unknown Message Count."
+    ::= { jnxMbgPgwGtpPeerEntry 10 }
+
+jnxMbgPgwGtpMemAllocFailed OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Memory Allocation Failed."
+    ::= { jnxMbgPgwGtpPeerEntry 11 }
+
+jnxMbgPgwGtpNotificationVars   OBJECT IDENTIFIER ::= { 
+                                             jnxMbgPgwGtpObjects 7 }
+jnxMbgPgwGtpPeerName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "GTP Peer Name/IP"
+   ::= { jnxMbgPgwGtpNotificationVars 1 }
+
+jnxMbgPgwGtpAlarmThrshld OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      thresholdlow     (0),
+                      thresholdhigh    (1)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        deprecated
+    DESCRIPTION
+    "Alarm threshold:: 
+     0: MOBILED_ALARM_THRESHOLD_LOW
+     1: MOBILED_ALARM_THRESHOLD_HIGH"
+   ::= { jnxMbgPgwGtpNotificationVars 2 }
+
+jnxMbgPgwGtpAlarmState OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      alarmcleared    (0),
+                      alarmraised     (1)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        deprecated
+    DESCRIPTION
+    "Alarm state:: 
+     0: MOBILED_ALARM_CLEARED
+     1: MOBILED_ALARM_RAISED"
+   ::= { jnxMbgPgwGtpNotificationVars 3 }
+
+jnxMbgPgwGtpAlarmStatCounter OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION
+    "Current Value of (Alarm) Statistics Counter
+     eg: in jnxMbgPgwGtpPrDNTPerPrAlrmActv it spefies the number
+         of times peer is down with in the monitoring interval"
+   ::= { jnxMbgPgwGtpNotificationVars 4 }
+
+jnxMbgPgwGtpInterfaceType OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "GTP Interface Type which can be one of gn/gp/S5/S8"
+   ::= { jnxMbgPgwGtpNotificationVars 5 }
+
+jnxMbgPgwGtpGwName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the gateway name"
+    ::= { jnxMbgPgwGtpNotificationVars 6 }
+
+jnxMbgPgwGtpGwIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Current Gateway ID value"
+    ::= { jnxMbgPgwGtpNotificationVars 7 }
+
+jnxMbgPgwGtpPeerGWUpNotif NOTIFICATION-TYPE
+     OBJECTS          { jnxMbgPgwGtpPeerName }
+     STATUS      deprecated
+     DESCRIPTION
+     "GTPC Peer UP Notification"
+    ::= { jnxMbgPgwGtpNotifications 1 }
+
+jnxMbgPgwGtpPeerDownNotif NOTIFICATION-TYPE
+    OBJECTS          { jnxMbgPgwGtpPeerName }
+    STATUS      deprecated
+    DESCRIPTION
+     "GTPC Peer Down Notification"
+    ::= { jnxMbgPgwGtpNotifications 2 }
+
+jnxMbgPgwGtpPeerDNThresPerPeerNotif NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwGtpPeerName,
+              jnxMbgPgwGtpAlarmState,
+              jnxMbgPgwGtpAlarmStatCounter }
+    STATUS          deprecated
+    DESCRIPTION
+        "Per Peer Threshold For The
+         Number of GTP Peer Down."
+    ::= { jnxMbgPgwGtpNotifications 3 }
+
+jnxMbgPgwGtpPeerGwUpNotify NOTIFICATION-TYPE
+     OBJECTS          { jnxMbgPgwGtpGwIndex,
+                        jnxMbgPgwGtpGwName,
+                        jnxMbgPgwGtpInterfaceType,
+                        jnxMbgPgwGtpPeerName }
+     STATUS      current
+     DESCRIPTION
+     "GTPC Peer UP Notification. This trap is sent when a new peer is added
+       or an existing peer goes down and comes back up."
+    ::= { jnxMbgPgwGtpNotifications 4 }
+
+jnxMbgPgwGtpPeerGwDnNotify NOTIFICATION-TYPE
+    OBJECTS          { jnxMbgPgwGtpGwIndex,
+                        jnxMbgPgwGtpGwName,
+                       jnxMbgPgwGtpInterfaceType,
+                       jnxMbgPgwGtpPeerName }
+    STATUS      current
+    DESCRIPTION
+     "GTPC Peer Down Notification. This trap is sent when a peer connection
+      goes down."
+    ::= { jnxMbgPgwGtpNotifications 5 }
+
+jnxMbgPgwGtpPrDnTPerPrAlrmActv NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwGtpGwIndex,
+                        jnxMbgPgwGtpGwName,
+                  jnxMbgPgwGtpInterfaceType,
+                  jnxMbgPgwGtpPeerName,
+                  jnxMbgPgwGtpAlarmStatCounter }
+    STATUS          current
+    DESCRIPTION
+        "Peer down Threshold trap Active. This is sent when a peer connection
+         flaps for more than a higher threshold number of times with in a
+         monitor interval."
+    ::= { jnxMbgPgwGtpNotifications 6 }
+
+jnxMbgPgwGtpPrDnTPerPrAlrmClr NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgPgwGtpGwIndex,
+                        jnxMbgPgwGtpGwName,
+                  jnxMbgPgwGtpInterfaceType,
+                  jnxMbgPgwGtpPeerName,
+                  jnxMbgPgwGtpAlarmStatCounter }
+    STATUS          current
+    DESCRIPTION
+        "Peer down Threshold trap Cleared. This is sent when the number of
+         times a peer connection flaps in a monitor interval come down below
+         the lower threshold."
+    ::= { jnxMbgPgwGtpNotifications 7 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-rmps.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-rmps.txt
@@ -1,0 +1,141 @@
+--
+-- Juniper Mobile Gateway Resource Manager MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-RMPS-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    Counter64, Integer32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString
+        FROM SNMPv2-TC
+
+    InetAddressType, InetAddress, InetPortNumber
+        FROM INET-ADDRESS-MIB
+
+    jnxMbgGwName                   FROM JUNIPER-MOBILE-GATEWAYS
+
+    jnxMobileGatewayMibRoot	
+        FROM JUNIPER-SMI;
+
+jnxMbgRMPSMib MODULE-IDENTITY
+    LAST-UPDATED "201103231200Z" -- March 23, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to Mobile-Edge Resource Manager"
+    REVISION "201103231200Z" -- March 23, 2011, 12:00:00
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewayMibRoot 7 }
+
+jnxMbgRMPSNotifications OBJECT IDENTIFIER ::= 
+                                                { jnxMbgRMPSMib 0 }
+jnxMbgRMPSObjects       OBJECT IDENTIFIER ::= 
+                                                { jnxMbgRMPSMib 1 }
+
+jnxMbgRMPSNotificationVars  OBJECT IDENTIFIER ::= 
+                                            { jnxMbgRMPSObjects 5 }
+
+--
+-- Objects used in Notifications
+--
+
+jnxMbgRMPSClientIdentifier OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This identifies the Resource Manager client, in the form 
+        ms-a/b/c or pfe-a/b/c, where <a> is the fpc slot, <b> is pic slot,
+        and <c> is the port."        
+    ::= { jnxMbgRMPSNotificationVars 1 }
+
+jnxMbgRMPSClientStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+        inService(0),
+        outOfService(1)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This specifies the status of a client registered with the Resource
+        Manager server."
+    ::= { jnxMbgRMPSNotificationVars 2 }
+
+jnxMbgRMPSServiceStatus OBJECT-TYPE
+    SYNTAX        INTEGER {
+        up(0),
+        down(1)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION
+    "This specifies the status of the Resource Manager server."
+   ::= { jnxMbgRMPSNotificationVars 3 }
+
+jnxMbgRMPSClientRedundancyRole OBJECT-TYPE
+    SYNTAX        INTEGER {
+        invalid(0),
+        primary(1),
+        secondary(2),
+        standalone(3)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION
+    "This specifies the redundancy role of the Resource Manager client"
+   ::= { jnxMbgRMPSNotificationVars 4 }
+
+--
+-- Notifications
+--
+
+jnxMbgRMPSServiceStatusChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgRMPSServiceStatus }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that status of the Resource Manager
+        service changed."
+    ::= { jnxMbgRMPSNotifications 1 }
+
+jnxMbgRMPSClientStatusChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgRMPSClientIdentifier, jnxMbgRMPSClientStatus }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies that status of a Resource Manager  
+        client changed."
+    ::= { jnxMbgRMPSNotifications 2 }
+
+jnxMbgRMPSClientInfo NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgRMPSClientIdentifier, jnxMbgRMPSClientStatus,
+                  jnxMbgRMPSClientRedundancyRole }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies a change in status or redundancy role
+        of the specified Resource Manager client."
+    ::= { jnxMbgRMPSNotifications 3 }
+
+jnxMbgRMPSClientStateChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwName,
+                  jnxMbgRMPSClientIdentifier, jnxMbgRMPSClientRedundancyRole,
+                  jnxMbgRMPSClientStatus }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies a change in status or redundancy role
+        of the specified Resource Manager client."
+    ::= { jnxMbgRMPSNotifications 4 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-sgw-charging.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-sgw-charging.txt
@@ -1,0 +1,923 @@
+-- JUNIPER-MOBILITY-CHARGING-MIB 
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- This file contains the SGW (MIURA) charging mib information. 
+--The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILITY-SGW-CHARGING-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+     Counter32,  Counter64, Gauge32, Integer32,Unsigned32, IpAddress
+        FROM SNMPv2-SMI
+    TruthValue
+        FROM SNMPv2-TC
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS
+    jnxMobileGatewaySgw
+        FROM JUNIPER-MBG-SMI;
+
+
+jnxMbgSgwChargingMib MODULE-IDENTITY
+    LAST-UPDATED        "201106271430Z" -- Tue Jun 27 14:30:00 2011 UTC
+    ORGANIZATION        "Juniper Networks, Inc."
+    CONTACT-INFO
+                        "Juniper Technical Assistance Center
+                        Juniper Networks, Inc.
+                        1194 N. Mathilda Avenue
+                        Sunnyvale, CA 94089
+                        E-mail: support@juniper.net"
+
+    DESCRIPTION
+         "This is Juniper Networks implementation of Mobility Charging MIB for 
+    SGW (Serving Gateway ) in 3GPP LTE network."
+
+    REVISION "201110101430Z"    -- 10 Oct, 2011
+    DESCRIPTION
+                "CGF group and CGF tables index keys has changed to 
+                gateway id and profile id. Gateway id and gateway name has 
+                added to all the traps."
+    
+    REVISION "201203161430Z"    -- 16 March, 2012
+    DESCRIPTION
+                "SGW Charging global statistics table has added."
+    ::= { jnxMobileGatewaySgw 3 }
+
+jnxMbgSgwCgNotifications      OBJECT IDENTIFIER ::= { jnxMbgSgwChargingMib 0 }
+jnxMbgSgwChargingObjects      OBJECT IDENTIFIER ::= { jnxMbgSgwChargingMib 1 }
+
+jnxMbgSgwCgLpsStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF  JnxMbgSgwCgLpsStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+       "A table listing the stats for all Local persistent storage stats 
+        configured on the SGW."
+   ::= { jnxMbgSgwChargingObjects 1 }
+
+jnxMbgSgwCgCgfGroupsStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgSgwCgCgfGrpStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+       "A table listing the stats for all (Charging Gateway Function) CGF 
+        Groups configured on the SGW."
+   ::= { jnxMbgSgwChargingObjects 2 }
+
+jnxMbgSgwCgNotificationVars   OBJECT IDENTIFIER ::= { 
+                                             jnxMbgSgwChargingObjects 3 }
+
+jnxMbgSgwCgCgfStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgSgwCgCgfStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A table listing the statistics for all CGF configured on the SGW."
+   ::= { jnxMbgSgwChargingObjects 4 }
+
+jnxMbgSgwCgGlobalStatsTable OBJECT-TYPE
+   SYNTAX        SEQUENCE OF JnxMbgSgwCgGlobalStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+         "A table listing the charging global statistics of the SGW."
+   ::= { jnxMbgSgwChargingObjects 5 }
+--
+-- CG LPS Stats
+--
+jnxMbgSgwCgLpsStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgSgwCgLpsStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          LPS configured on the SGW."
+   INDEX         {jnxMbgGwIndex }
+   ::= { jnxMbgSgwCgLpsStatsTable 1 }
+
+JnxMbgSgwCgLpsStatsEntry ::= SEQUENCE {
+   jnxMbgSgwCgFilesOnLcStorage        Gauge32,
+   jnxMbgSgwCgLcStorageAvailSpace     Gauge32
+}
+
+jnxMbgSgwCgFilesOnLcStorage OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The number of Files containing Charging Data Records (CDRs) present 
+          on the Local Storage Device.Incremented when a file containing CDRs 
+          is closed on the Local storage device Decremented when sftp is done 
+          and a file is removed from the Local storage device"
+   ::= { jnxMbgSgwCgLpsStatsEntry 1 }
+
+jnxMbgSgwCgLcStorageAvailSpace OBJECT-TYPE
+   SYNTAX        Gauge32 
+   UNITS         "MBytes"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+         "The space available on the Local Storage Device in MB."
+   ::= { jnxMbgSgwCgLpsStatsEntry 2 }
+
+--
+-- CGF Group Stats
+--
+jnxMbgSgwCgCgfGroupStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgSgwCgCgfGrpStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          CGF Server configured on the SGW."
+   INDEX         { jnxMbgGwIndex, jnxMbgSgwCgCgfGrpProfId }
+   ::= { jnxMbgSgwCgCgfGroupsStatsTable 1 }
+
+JnxMbgSgwCgCgfGrpStatsEntry ::= SEQUENCE {
+   jnxMbgSgwCgCgfGrpProfId            Unsigned32,
+   jnxMbgSgwCgCgfGrpDRTReqTx          Counter32,
+   jnxMbgSgwCgCgfGrpDRTReqRx          Counter32,
+   jnxMbgSgwCgCgfGrpDRTReqTmout       Counter32,
+   jnxMbgSgwCgCgfGrpDRTSucRspRx       Counter32,
+   jnxMbgSgwCgCgfGrpDRTErrRspRx       Counter32,
+   jnxMbgSgwCgCgfGrpRediReqRx         Counter32,
+   jnxMbgSgwCgCgfGrpRediRspTx         Counter32,
+   jnxMbgSgwCgCgfGrpSwitchovers       Counter32,
+   jnxMbgSgwCgCgfGrpBatchReqTx        Counter32,
+   jnxMbgSgwCgCgfGrpBatchRspErrors    Counter32,
+   jnxMbgSgwCgCgfGrpBatchCDRsTx       Counter32,
+   jnxMbgSgwCgCgfGroupTotalWFA        Counter32,
+   jnxMbgSgwCgCgfGroupProfName        DisplayString
+}
+
+jnxMbgSgwCgCgfGrpProfId OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+        "This will identify the CGF Group profile id uniquely and used as 
+         secondary key for CGF group table"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 1 }
+
+jnxMbgSgwCgCgfGrpDRTReqTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT (Detailed Record Time) request transmitted 
+         for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 2 }
+
+jnxMbgSgwCgCgfGrpDRTReqRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+        "Total number of the DRT request received for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 3 }
+
+jnxMbgSgwCgCgfGrpDRTReqTmout OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT request timeouts happend for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 4 }
+
+jnxMbgSgwCgCgfGrpDRTSucRspRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total number of the DRT success responses received"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 5 }
+
+jnxMbgSgwCgCgfGrpDRTErrRspRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the DRT error responses received for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 6 }
+
+jnxMbgSgwCgCgfGrpRediReqRx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        "Total number of the redirection responses received for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 7 }
+
+jnxMbgSgwCgCgfGrpRediRspTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        "Total number of the redirection reqests transmitted for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 8 }
+
+jnxMbgSgwCgCgfGrpSwitchovers OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the switch overs on the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 9 }
+
+jnxMbgSgwCgCgfGrpBatchReqTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Total number of the batch req transmitted for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 10 }
+
+jnxMbgSgwCgCgfGrpBatchRspErrors OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+        " Tatal number of the batch response errors for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 11 }
+
+jnxMbgSgwCgCgfGrpBatchCDRsTx OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total number of the batch CDRs transmitted for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 12 }
+
+jnxMbgSgwCgCgfGroupTotalWFA OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   
+        " Total WFA available for the CGF group"
+   ::= { jnxMbgSgwCgCgfGroupStatsEntry 13 }
+
+jnxMbgSgwCgCgfGroupProfName OBJECT-TYPE
+    SYNTAX      DisplayString   
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the TSP Profile."
+    ::= { jnxMbgSgwCgCgfGroupStatsEntry 14 }
+--
+-- CGF Stats
+--
+
+jnxMbgSgwCgCgfStatsEntry OBJECT-TYPE
+   SYNTAX        JnxMbgSgwCgCgfStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each
+          CGF Server configured on the SGW."
+   INDEX         {jnxMbgGwIndex, jnxMbgSgwCgCgfIndex }
+   ::= { jnxMbgSgwCgCgfStatsTable 1 }
+
+JnxMbgSgwCgCgfStatsEntry ::= SEQUENCE {
+   jnxMbgSgwCgCgfIndex             Unsigned32,
+   jnxMbgSgwCgCgfIpAddress         IpAddress,
+   jnxMbgSgwCgCgfStatus            INTEGER,
+   jnxMbgSgwCgCgfUpDuration        Counter64,
+   jnxMbgSgwCgCgfDownDuration      Counter64,
+   jnxMbgSgwCgCgfEchoReqTx         Counter64, 
+   jnxMbgSgwCgCgfEchoReqRx         Counter64,
+   jnxMbgSgwCgCgfEchoReqTmout      Counter64, 
+   jnxMbgSgwCgCgfEchoRespTx        Counter64,
+   jnxMbgSgwCgCgfEchoRespRx        Counter64,
+   jnxMbgSgwCgCgfVerUnsuppTx       Counter64,
+   jnxMbgSgwCgCgfVerUnsuppRx       Counter64,
+   jnxMbgSgwCgCgfNodeAliveReqTx    Counter64,
+   jnxMbgSgwCgCgfNodeAliveReqRx    Counter64,
+   jnxMbgSgwCgCgfNodeAliveReqTmout Counter64,
+   jnxMbgSgwCgCgfNodeAliveRespTx   Counter64,
+   jnxMbgSgwCgCgfNodeAliveRespRx   Counter64,
+   jnxMbgSgwCgCgfRedirectReqRx     Counter64,
+   jnxMbgSgwCgCgfRedirectRespTx    Counter64, 
+   jnxMbgSgwCgCgfDRTReqTx          Counter64,
+   jnxMbgSgwCgCgfDRTReqTmout       Counter64,
+   jnxMbgSgwCgCgfDRTSuccRespRx     Counter64,
+   jnxMbgSgwCgCgfDRTErrRespRx      Counter64,
+   jnxMbgSgwCgCgfCdrTx             Counter64,
+   jnxMbgSgwCgCgfDRTRTTMean        Counter64,
+   jnxMbgSgwCgCgfDRTRTTMin         Counter64,
+   jnxMbgSgwCgCgfDRTRTTMax         Counter64,
+   jnxMbgSgwCgCgfTransToDownState  Counter64,
+   jnxMbgSgwCgCgfContainers        Counter64,
+   jnxMbgSgwCgCgfProfileName       DisplayString
+}
+
+jnxMbgSgwCgCgfIndex OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A number representing each CGF Server whose statistics
+          is being generated."
+    ::= { jnxMbgSgwCgCgfStatsEntry 1 }
+
+jnxMbgSgwCgCgfIpAddress OBJECT-TYPE
+   SYNTAX        IpAddress
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "CGF Server IP-address."
+   ::= { jnxMbgSgwCgCgfStatsEntry 2 }
+
+jnxMbgSgwCgCgfStatus OBJECT-TYPE
+   SYNTAX        INTEGER {
+        up(1),     -- server is up
+        down(2)     -- server is not reachable or unconfigured
+   }
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION 
+         "This indicates the state of the CGF Server i.e UP or DOWN."
+   ::= { jnxMbgSgwCgCgfStatsEntry 3 }
+
+jnxMbgSgwCgCgfUpDuration OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "minutes"
+   MAX-ACCESS    not-accessible
+   STATUS         obsolete
+   DESCRIPTION   "Total duration in minutes for which the CGF Server
+                  was in UP State."
+   ::= { jnxMbgSgwCgCgfStatsEntry 4 }
+
+jnxMbgSgwCgCgfDownDuration OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "minutes"
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total duration in minutes for which the CGF Server 
+                  was in DOWN State."
+   ::= { jnxMbgSgwCgCgfStatsEntry 5 }
+
+jnxMbgSgwCgCgfEchoReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests transmitted to the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 6 }
+
+jnxMbgSgwCgCgfEchoReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests received from the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 7 }
+
+jnxMbgSgwCgCgfEchoReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Requests to the CGF Server that 
+                  timed out."
+   ::= { jnxMbgSgwCgCgfStatsEntry 8 }
+
+jnxMbgSgwCgCgfEchoRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Responses transmitted to the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 9 }
+
+jnxMbgSgwCgCgfEchoRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Echo Responses received from the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 10 }
+
+jnxMbgSgwCgCgfVerUnsuppTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Version Unsupported messages transmitted to 
+                 the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 11 }
+
+jnxMbgSgwCgCgfVerUnsuppRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Version Unsupported messages received 
+                 from the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 12 }
+
+jnxMbgSgwCgCgfNodeAliveReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of Node Alive Requests transmitted to the
+                  CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 13 }
+
+jnxMbgSgwCgCgfNodeAliveReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Requests received from 
+                  the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 14 }
+
+jnxMbgSgwCgCgfNodeAliveReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of Node Alive Requests to the CGF Server 
+                  that timed out."
+   ::= { jnxMbgSgwCgCgfStatsEntry 15 }
+
+jnxMbgSgwCgCgfNodeAliveRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Node Alive Responses transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 16 }
+
+jnxMbgSgwCgCgfNodeAliveRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of Node Alive Responses received from 
+                  the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 17 }
+
+jnxMbgSgwCgCgfRedirectReqRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Redirect Requests received from 
+                  the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 18 }
+
+jnxMbgSgwCgCgfRedirectRespTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Redirect Responses transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 19 }
+
+jnxMbgSgwCgCgfDRTReqTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Requests transmitted to 
+                  the CGF Server.This includes the retransmission counts also."
+   ::= { jnxMbgSgwCgCgfStatsEntry 20 }
+
+jnxMbgSgwCgCgfDRTReqTmout OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of Data Record Transfer Requests to the CGF  
+                 Server that timed out after the configured number of retries."
+   ::= { jnxMbgSgwCgCgfStatsEntry 21 }
+
+jnxMbgSgwCgCgfDRTSuccRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Responses indicating 
+                  success received from the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 22 }
+
+jnxMbgSgwCgCgfDRTErrRespRx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of Data Record Transfer Responses indicating 
+                  error received from the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 23 }
+
+
+jnxMbgSgwCgCgfCdrTx OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of Call Data Records (CDRs) transmitted 
+                  to the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 24 }
+
+jnxMbgSgwCgCgfDRTRTTMean OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "seconds"
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+        "Mean Round Trip Time of the Data Record Transfer Request and Response 
+         to and from the CGF Server in seconds. This is calculated from the 
+         average of the minimum and maximum round trip times of the Data Record 
+         Transfer Request. This is applicable for CGF Servers which are 
+         connected via UDP protocol."
+   ::= { jnxMbgSgwCgCgfStatsEntry 25 }
+
+jnxMbgSgwCgCgfDRTRTTMin OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "seconds"
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+        "Minimum Round Trip Time of the Data Record Transfer Request and 
+        Response to and from the CGF Server in seconds. This is 
+        applicable for CGF Servers which are connected via UDP protocol."
+   ::= { jnxMbgSgwCgCgfStatsEntry 26 }
+
+jnxMbgSgwCgCgfDRTRTTMax OBJECT-TYPE
+   SYNTAX        Counter64
+   UNITS         "seconds"
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION
+        "Maximum Round Trip Time of the Data Record Transfer Request and 
+         Response to and from the CGF Server in seconds.This is 
+         applicable for CGF Servers which are connected via UDP protocol."
+   ::= { jnxMbgSgwCgCgfStatsEntry 27 }
+
+jnxMbgSgwCgCgfTransToDownState OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of transitions of the CGF Server to 
+                  the DOWN state."
+   ::= { jnxMbgSgwCgCgfStatsEntry 28 }
+
+jnxMbgSgwCgCgfContainers OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    not-accessible
+   STATUS        obsolete
+   DESCRIPTION   "Total number of closed containers to the CGF Server."
+   ::= { jnxMbgSgwCgCgfStatsEntry 29 }
+jnxMbgSgwCgCgfProfileName OBJECT-TYPE
+    SYNTAX      DisplayString  
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the CGF Peer Profile."
+    ::= { jnxMbgSgwCgCgfStatsEntry 30 }
+
+ jnxMbgSgwCgGlobalStatsEntry OBJECT-TYPE
+   SYNTAX       JnxMbgSgwCgGlobalStatsEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION 
+         "A conceptual row listing the statistics for each SGW charging
+          global statistics."
+   INDEX         { jnxMbgGwIndex }
+   ::= { jnxMbgSgwCgGlobalStatsTable 1 }
+
+JnxMbgSgwCgGlobalStatsEntry ::= SEQUENCE {
+   jnxMbgSgwCgCdrSendErrors           Counter64,
+   jnxMbgSgwCgCdrEncodeErrors         Counter64,
+   jnxMbgSgwCgCdrAllocFailures        Counter64,
+   jnxMbgSgwCgContFailures            Counter64,
+   jnxMbgSgwCgCmBearersCreated        Counter64,
+   jnxMbgSgwCgCmBearersDeleted        Counter64
+}
+
+-- Charging Global Stats
+jnxMbgSgwCgCdrSendErrors OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of CDR send errors to charging module."
+   ::= { jnxMbgSgwCgGlobalStatsEntry 1 }
+
+jnxMbgSgwCgCdrEncodeErrors OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of CDR (charging data record) encoding errors."
+   ::= { jnxMbgSgwCgGlobalStatsEntry 2 }
+
+jnxMbgSgwCgCdrAllocFailures OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of CDR memory allocation failures."
+   ::= { jnxMbgSgwCgGlobalStatsEntry 3 }
+
+jnxMbgSgwCgContFailures OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of container failures."
+   ::= { jnxMbgSgwCgGlobalStatsEntry 4 }
+
+jnxMbgSgwCgCmBearersCreated OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number bearers created."
+   ::= { jnxMbgSgwCgGlobalStatsEntry 5 }
+
+jnxMbgSgwCgCmBearersDeleted OBJECT-TYPE
+   SYNTAX        Counter64
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION   "Total number of bearers destroyed."
+   ::= { jnxMbgSgwCgGlobalStatsEntry 6 }
+
+jnxMbgSgwCgServerName OBJECT-TYPE
+    SYNTAX      DisplayString  (SIZE (0..31))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "A string that uniquely identifies the CGF server name." 
+   ::= { jnxMbgSgwCgNotificationVars 1 }
+
+jnxMbgSgwCgServicePicName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..31))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "This identifies the session-pic, in the form ms-a/b/0, 
+     where <a> is the slot and <b> could be either 0 or 1."
+   ::= { jnxMbgSgwCgNotificationVars 2 }
+jnxMbgSgwCgCDRDest OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      cdrcgf       (1),    
+                      cdrbackup    (2),    
+                      cdrnobackup  (3) }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION 
+"This indicates any transisitions in the state of the CGF.
+Value 1 indicates one of the CGF for the Group came up. Redirecting CDRs to the Active CGF.
+Value 2 indicates last active CGF for the Group went down. CDRs being written to backup Local storage device.
+Value 3 indicates last active CGF for the Group went down. Backup Local storage device not configured."
+   ::= { jnxMbgSgwCgNotificationVars 3 }
+
+jnxMbgSgwCgTSPName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..31)) 
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that uniquely identifies the Transport Profile."
+    ::= { jnxMbgSgwCgNotificationVars 4 }
+
+jnxMbgSgwCgMemLimit OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      memfulldisconnectnew          (1),
+                      memfulldisconnectnewrslvd     (2),
+                      memfulldisconnectexistnew     (3),
+                      memfulldisconnectexistnewrslvd(4)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION 
+"This indicates any transisitions in the state of the CGF.
+Value 1 indicates System has reached Level 1 critical memory threshold. 
+Action - Check the CGF server connections. If local storage is enabled,
+         please ftp the charging records immediately.
+         If local storage is not enabled, please enable it so the
+         charging records can be stored in local persistent storage. 
+Risk -  No new sessions will be allowed.
+Value 2 indicates System reaching Level 1 critical memory threshold
+        condition has been resolved.
+Value 3 indicates System has reached Level 2 critical memory threshold.
+Action - Check the CGF server connections. If local storage is enabled,
+         please ftp the charging records immediately.
+         If local storage is not enabled, please enable it so the
+         charging records can be stored in local persistent storage.
+Risk -  New and existing sessions will be not be allowed.
+Value 4 indicates System reaching Level 2 critical memory threshold
+        condition has been resolved."
+    ::= { jnxMbgSgwCgNotificationVars 5 }
+
+jnxMbgSgwCgLcsSpace OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      localstoragememlevel1     (1),
+                      localstoragememlevel2     (2),
+                      localstoragememlevel3     (3)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current 
+    DESCRIPTION
+    "Water marking for the local storage levels in charged of RE."
+   ::= { jnxMbgSgwCgNotificationVars 6 }
+
+jnxMbgSgwCgLcsUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The percentage of the total of Local Storage
+         Space by one the Charged on RE"
+        ::= { jnxMbgSgwCgNotificationVars 7 }
+
+jnxMbgSgwCgAlarmStatus OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      raised	    (1),
+                      cleared	    (2)
+    }
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current 
+    DESCRIPTION
+    "Value 1 indicates that the Alarm for a particular condition is present.
+    Value 2 indicates that the Alarm for a particular condition is absent."
+   ::= { jnxMbgSgwCgNotificationVars 8 }
+
+jnxMbgSgwCgProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that identifies a charging profile ."
+    ::= { jnxMbgSgwCgNotificationVars 9 }
+
+jnxMbgSgwCgPrevMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgSgwCgNotificationVars 10 }
+
+jnxMbgSgwCgNewMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgSgwCgNotificationVars 11 }
+
+jnxMbgSgwCgTProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that identifies a charging profile ."
+    ::= { jnxMbgSgwCgNotificationVars 12 }
+
+jnxMbgSgwCgTPrevMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgSgwCgNotificationVars 13 }
+
+jnxMbgSgwCgTNewMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgSgwCgNotificationVars 14 }
+
+jnxMbgSgwCgSGwName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the gateway name"
+    ::= { jnxMbgSgwCgNotificationVars 15 }
+
+jnxMbgSgwCgCgfProfName OBJECT-TYPE
+  SYNTAX      DisplayString 
+  MAX-ACCESS   accessible-for-notify
+  STATUS      current
+  DESCRIPTION
+    "A string that uniquely identifies the CGF Profile."
+  ::= { jnxMbgSgwCgNotificationVars 16 }
+
+jnxMbgSgwCgGtpGWUpNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgServerName, 
+                   jnxMbgSgwCgServicePicName }
+     STATUS        current
+     DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked alive.  The ServerName identifies the server and the
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgSgwCgNotifications 1 }
+
+jnxMbgSgwCgGtpGWDownNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgServerName, 
+                   jnxMbgSgwCgServicePicName }
+    STATUS         current
+    DESCRIPTION
+        "This notification signifies that the specified server has been
+        marked dead.  The ServerName identifies the server and the
+        SPIdentfier identifies the session-pic which originated this
+        notification."
+    ::= { jnxMbgSgwCgNotifications 2 }
+
+jnxMbgSgwCgCDRDestNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgCDRDest,
+                   jnxMbgSgwCgTSPName,
+                   jnxMbgSgwCgCgfIpAddress }
+    STATUS         current
+    DESCRIPTION
+          "This signifies change in the destination of the CDRs 
+           (Charging Data Record)"
+::= { jnxMbgSgwCgNotifications 3 } 
+
+jnxMbgSgwCgServiceUpNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgServicePicName } 
+    STATUS         current
+    DESCRIPTION
+        "This signifies the Charging daemon is UP on the SP."
+::= { jnxMbgSgwCgNotifications 4 } 
+
+jnxMbgSgwCgMMStateChangeNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgProfileName,
+                   jnxMbgSgwCgPrevMMState,
+                   jnxMbgSgwCgNewMMState }
+    STATUS         current
+    DESCRIPTION
+        "This indicates that the given charging profile underwent a change
+         in the maintenance-mode."
+    ::= { jnxMbgSgwCgNotifications 5 }
+
+jnxMbgSgwCgTMMStateChangeNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgTProfileName,
+                   jnxMbgSgwCgTPrevMMState,
+                   jnxMbgSgwCgTNewMMState }
+    STATUS         current
+    DESCRIPTION
+        "This indicates that the given transport profile underwent a change
+         in the maintenance-mode."
+    ::= { jnxMbgSgwCgNotifications 6 }
+
+jnxMbgSgwCgMemHighThresNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgTSPName,
+                   jnxMbgSgwCgServicePicName,
+                   jnxMbgSgwCgMemLimit,
+                   jnxMbgSgwCgAlarmStatus }
+    STATUS         current 
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of inernal memory space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured high threshold value. Thealarm status (Active/Clear)is indicated by the jnxMbgSgwCgAlarmStatus variable."
+      ::= { jnxMbgSgwCgNotifications 7 } 
+
+jnxMbgSgwCgMemMediumThresNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgTSPName,
+                   jnxMbgSgwCgServicePicName,
+                   jnxMbgSgwCgMemLimit,
+                   jnxMbgSgwCgAlarmStatus }
+    STATUS         current
+    DESCRIPTION
+         "This trap indicates the alarm status on the node associated with the  utilization of inernal memory space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured medium threshold value. The alarm status (Active/Clear)is indicated by the jnxMbgSgwCgAlarmStatus variable."
+      ::= { jnxMbgSgwCgNotifications 8 } 
+
+jnxMbgSgwCgMemLowThresNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgTSPName,
+                   jnxMbgSgwCgServicePicName,
+                   jnxMbgSgwCgMemLimit,
+                   jnxMbgSgwCgAlarmStatus }
+    STATUS          current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of inernal memory space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured low threshold value. The alarm status (Active/Clear)is indicated by the jnxMbgSgwCgAlarmStatus variable."
+      ::= { jnxMbgSgwCgNotifications 9 }
+
+jnxMbgSgwCgLcsThresHighNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgAlarmStatus,
+                   jnxMbgSgwCgLcsUtil }
+    STATUS         current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of local storage space for charging records. This alarm is sent out when the utilization exceeds or falls below configured high threshold of available disk space. The alarm status (Active/Clear)is indicated by the jnxMbgSgwCgAlarmStatus variable."
+    ::= { jnxMbgSgwCgNotifications 10 }
+
+jnxMbgSgwCgLcsThresMediumNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgAlarmStatus,
+                   jnxMbgSgwCgLcsUtil }
+    STATUS         current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of local storage space for charging records. This alarm is sent outwhen the utilization exceeds or falls below configured medium threshold of available disk space. The alarm status (Active/Clear)is indicated by the jnxMbgSgwCgAlarmStatus variable."
+    ::= { jnxMbgSgwCgNotifications 11 }
+
+jnxMbgSgwCgLcsThresLowNotify NOTIFICATION-TYPE
+    OBJECTS      { jnxMbgGwName,
+                   jnxMbgSgwCgAlarmStatus,  
+                   jnxMbgSgwCgLcsUtil }
+    STATUS         current
+    DESCRIPTION
+          "This trap indicates the alarm status on the node associated with the utilization of local storage space for charging records. This alarm is sent out when the utilization exceeds or falls below configured low threshold of available disk space. The alarm status (Active/Clear)is indicated by the jnxMbgSgwCgAlarmStatus variable."
+    ::= { jnxMbgSgwCgNotifications 12 }
+
+END
+

--- a/mibs/junos/mib-jnx-mobile-gateway-sgw-gtp.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-sgw-gtp.txt
@@ -1,0 +1,6208 @@
+
+--
+-- Juniper Mobile SGateway GTP objects MIB.
+--
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-SGW-GTP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    Counter64, IpAddress, Integer32, Counter32, Unsigned32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY,OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+        FROM SNMPv2-TC
+
+    Ipv6AddressPrefix, Ipv6AddressIfIdentifier, Ipv6Address
+        FROM IPV6-TC
+
+    InetAddressType, InetAddress, InetPortNumber, InetAddressPrefixLength
+        FROM INET-ADDRESS-MIB
+
+    EnabledStatus
+        FROM JUNIPER-MIMSTP-MIB
+
+    jnxMobileGatewaySgw
+        FROM JUNIPER-MBG-SMI
+
+    jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS;
+
+--
+-- Module Identity for GPRS Tunneling Protocol
+-- GTPC generally refers to Control Path of the GTP protocol and
+-- GTPU generally refers to the Data Path of the GTP Protocol
+--
+
+jnxMbgSgwGtpMib MODULE-IDENTITY
+    LAST-UPDATED "201109211200Z" -- Sep 21, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines some sample objects pertaining to GTP protocol."
+    REVISION "201109211200Z" -- Sep 21, 2011, 12:00:00 UTC
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewaySgw 2 }
+
+jnxMbgSgwGtpNotifications  OBJECT IDENTIFIER ::=
+                                    { jnxMbgSgwGtpMib 0 }
+jnxMbgSgwGtpObjects     OBJECT IDENTIFIER ::=
+                                    { jnxMbgSgwGtpMib 1 }
+
+--
+-- GTP Object for showing GTP Global Statistics
+--
+jnxMbgSgwGtpCGlbStatsTable  OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgSgwGtpGlbStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to a gateway level GTP Control statistic."
+    ::= { jnxMbgSgwGtpObjects 2 }
+
+jnxMbgSgwGtpGlbStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgSgwGtpGlbStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the GTP gateway level control Statistics."
+    INDEX     { jnxMbgGwIndex }
+    ::= { jnxMbgSgwGtpCGlbStatsTable 1}
+
+JnxMbgSgwGtpGlbStatsEntry ::= SEQUENCE {
+    jnxMbgSgwRxPacketsDropped       Counter64,
+    jnxMbgSgwPacketAllocFail        Counter64,
+    jnxMbgSgwPacketSendFail         Counter64,
+    jnxMbgSgwIPVerErrRx             Counter64,
+    jnxMbgSgwIPProtoErrRx           Counter64,
+    jnxMbgSgwGTPPortErrRx           Counter64,
+    jnxMbgSgwGTPUnknVerRx           Counter64,
+    jnxMbgSgwPcktLenErrRx           Counter64,
+    jnxMbgSgwUnknMsgRx              Counter64,
+    jnxMbgSgwProtocolErrRx          Counter64,
+    jnxMbgSgwUnSupportedMsgRx       Counter64,
+    jnxMbgSgwT3RespTmrExpRx         Counter64,
+    jnxMbgSgwV2NumMsgRx             Counter64,
+    jnxMbgSgwV2NumMsgTx             Counter64,
+    jnxMbgSgwV2NumBytesRx           Counter64,
+    jnxMbgSgwV2NumBytesTx           Counter64,
+    jnxMbgSgwV2EchoReqRx            Counter64,
+    jnxMbgSgwV2EchoReqTx            Counter64,
+    jnxMbgSgwV2EchoRespRx           Counter64,
+    jnxMbgSgwV2EchoRespTx           Counter64,
+    jnxMbgSgwV2VerNotSupRx          Counter64,
+    jnxMbgSgwV2VerNotSupTx          Counter64,
+    jnxMbgSgwCreateSessReqRx        Counter64,
+    jnxMbgSgwCreateSessReqTx        Counter64,
+    jnxMbgSgwCreateSessRspRx        Counter64,
+    jnxMbgSgwCreateSessRspTx        Counter64,
+    jnxMbgSgwModBrReqRx             Counter64,
+    jnxMbgSgwModBrReqTx             Counter64,
+    jnxMbgSgwModBrRspRx             Counter64,
+    jnxMbgSgwModBrRspTx             Counter64,
+    jnxMbgSgwDelSessReqRx           Counter64,
+    jnxMbgSgwDelSessReqTx           Counter64,
+    jnxMbgSgwDelSessRspRx           Counter64,
+    jnxMbgSgwDelSessRspTx           Counter64,
+    jnxMbgSgwCrtBrReqRx             Counter64,
+    jnxMbgSgwCrtBrReqTx             Counter64,
+    jnxMbgSgwCrtBrRspRx             Counter64,
+    jnxMbgSgwCrtBrRspTx             Counter64,
+    jnxMbgSgwUpdBrReqRx             Counter64,
+    jnxMbgSgwUpdBrReqTx             Counter64,
+    jnxMbgSgwUpdBrRspRx             Counter64,
+    jnxMbgSgwUpdBrRspTx             Counter64,
+    jnxMbgSgwDelBrReqRx             Counter64,
+    jnxMbgSgwDelBrReqTx             Counter64,
+    jnxMbgSgwDelBrRspRx             Counter64,
+    jnxMbgSgwDelBrRspTx             Counter64,
+    jnxMbgSgwDelConnSetReqRx        Counter64,
+    jnxMbgSgwDelConnSetReqTx        Counter64,
+    jnxMbgSgwDelConnSetRspRx        Counter64,
+    jnxMbgSgwDelConnSetRspTx        Counter64,
+    jnxMbgSgwUpdConnSetReqRx        Counter64,
+    jnxMbgSgwUpdConnSetReqTx        Counter64,
+    jnxMbgSgwUpdConnSetRspRx        Counter64,
+    jnxMbgSgwUpdConnSetRspTx        Counter64,
+    jnxMbgSgwModBrCmdRx             Counter64,
+    jnxMbgSgwModBrCmdTx             Counter64,
+    jnxMbgSgwModBrFlrIndRx          Counter64,
+    jnxMbgSgwModBrFlrIndTx          Counter64,
+    jnxMbgSgwDelBrCmdRx             Counter64,
+    jnxMbgSgwDelBrCmdTx             Counter64,
+    jnxMbgSgwDelBrFlrIndRx          Counter64,
+    jnxMbgSgwDelBrFlrIndTx          Counter64,
+    jnxMbgSgwBrResCmdRx             Counter64,
+    jnxMbgSgwBrResCmdTx             Counter64,
+    jnxMbgSgwBrResFlrIndRx          Counter64,
+    jnxMbgSgwBrResFlrIndTx          Counter64,
+    jnxMbgSgwRelAcsBrReqRx          Counter64,
+    jnxMbgSgwRelAcsBrReqTx          Counter64,
+    jnxMbgSgwRelAcsBrRespRx         Counter64,
+    jnxMbgSgwRelAcsBrRespTx         Counter64,
+    jnxMbgSgwCrIndTunReqRx          Counter64,
+    jnxMbgSgwCrIndTunReqTx          Counter64,
+    jnxMbgSgwCrIndTunRespRx         Counter64,
+    jnxMbgSgwCrIndTunRespTx         Counter64,
+    jnxMbgSgwDelIndTunReqRx         Counter64,
+    jnxMbgSgwDelIndTunReqTx         Counter64,
+    jnxMbgSgwDelIndTunRespRx        Counter64,
+    jnxMbgSgwDelIndTunRespTx        Counter64,
+    jnxMbgSgwDlDataNotifRx          Counter64,
+    jnxMbgSgwDlDataNotifTx          Counter64,
+    jnxMbgSgwDlDataAckRx            Counter64,
+    jnxMbgSgwDlDataAckTx            Counter64,
+    jnxMbgSgwDlDataNotiFlrIndRx     Counter64,
+    jnxMbgSgwDlDataNotiFlrIndTx     Counter64,
+    jnxMbgSgwStopPagingIndRx        Counter64,
+    jnxMbgSgwStopPagingIndTx        Counter64,
+    jnxMbgSgwGtpV2ICsPageRx         Counter64,
+    jnxMbgSgwGtpV2ICsPageTx         Counter64,
+    jnxMbgSgwGtpV2ICsReqAcceptRx    Counter64,
+    jnxMbgSgwGtpV2ICsReqAcceptTx    Counter64,
+    jnxMbgSgwGtpV2ICsAcceptPartRx   Counter64,
+    jnxMbgSgwGtpV2ICsAcceptPartTx   Counter64,
+    jnxMbgSgwGtpV2ICsNewPTNPrefRx   Counter64,
+    jnxMbgSgwGtpV2ICsNewPTNPrefTx   Counter64,
+    jnxMbgSgwGtpV2ICsNewPTSIAdbrRx  Counter64,
+    jnxMbgSgwGtpV2ICsNewPTSIAdbrTx  Counter64,
+    jnxMbgSgwGtpV2ICsCtxNotFndRx    Counter64,
+    jnxMbgSgwGtpV2ICsCtxNotFndTx    Counter64,
+    jnxMbgSgwGtpV2ICsInvMsgFmtRx    Counter64,
+    jnxMbgSgwGtpV2ICsInvMsgFmtTx    Counter64,
+    jnxMbgSgwGtpV2ICsVerNotSuppRx   Counter64,
+    jnxMbgSgwGtpV2ICsVerNotSuppTx   Counter64,
+    jnxMbgSgwGtpV2ICsInvLenRx       Counter64,
+    jnxMbgSgwGtpV2ICsInvLenTx       Counter64,
+    jnxMbgSgwGtpV2ICsServNotSuppRx  Counter64,
+    jnxMbgSgwGtpV2ICsServNotSuppTx  Counter64,
+    jnxMbgSgwGtpV2ICsManIEIncorrRx  Counter64,
+    jnxMbgSgwGtpV2ICsManIEIncorrTx  Counter64,
+    jnxMbgSgwGtpV2ICsManIEMissRx    Counter64,
+    jnxMbgSgwGtpV2ICsManIEMissTx    Counter64,
+    jnxMbgSgwGtpV2ICsOptIEIncorrRx  Counter64,
+    jnxMbgSgwGtpV2ICsOptIEIncorrTx  Counter64,
+    jnxMbgSgwGtpV2ICsSysFailRx      Counter64,
+    jnxMbgSgwGtpV2ICsSysFailTx      Counter64,
+    jnxMbgSgwGtpV2ICsNoResRx        Counter64,
+    jnxMbgSgwGtpV2ICsNoResTx        Counter64,
+    jnxMbgSgwGtpV2ICsTFTSMANTErRx   Counter64,
+    jnxMbgSgwGtpV2ICsTFTSMANTErTx   Counter64,
+    jnxMbgSgwGtpV2ICsTFTSysErrRx    Counter64,
+    jnxMbgSgwGtpV2ICsTFTSysErrTx    Counter64,
+    jnxMbgSgwGtpV2ICsPkFltManErrRx  Counter64,
+    jnxMbgSgwGtpV2ICsPkFltManErrTx  Counter64,
+    jnxMbgSgwGtpV2ICsPkFltSynErrRx  Counter64,
+    jnxMbgSgwGtpV2ICsPkFltSynErrTx  Counter64,
+    jnxMbgSgwGtpV2ICsMisUnknAPNRx   Counter64,
+    jnxMbgSgwGtpV2ICsMisUnknAPNTx   Counter64,
+    jnxMbgSgwGtpV2ICsUnexpRptIERx   Counter64,
+    jnxMbgSgwGtpV2ICsUnexpRptIETx   Counter64,
+    jnxMbgSgwGtpV2ICsGREKeyNtFdRx   Counter64,
+    jnxMbgSgwGtpV2ICsGREKeyNtFdTx   Counter64,
+    jnxMbgSgwGtpV2ICsRelocFailRx    Counter64,
+    jnxMbgSgwGtpV2ICsRelocFailTx    Counter64,
+    jnxMbgSgwGtpV2ICsDeniedINRatRx  Counter64,
+    jnxMbgSgwGtpV2ICsDeniedINRatTx  Counter64,
+    jnxMbgSgwGtpV2ICsPTNotSuppRx    Counter64,
+    jnxMbgSgwGtpV2ICsPTNotSuppTx    Counter64,
+    jnxMbgSgwGtpV2ICsAllDynAdOccRx  Counter64,
+    jnxMbgSgwGtpV2ICsAllDynAdOccTx  Counter64,
+    jnxMbgSgwGtpV2ICsNOTFTUECTXRx   Counter64,
+    jnxMbgSgwGtpV2ICsNOTFTUECTXTx   Counter64,
+    jnxMbgSgwGtpV2ICsProtoNtSupRx   Counter64,
+    jnxMbgSgwGtpV2ICsProtoNtSupTx   Counter64,
+    jnxMbgSgwGtpV2ICsUENotRespRx    Counter64,
+    jnxMbgSgwGtpV2ICsUENotRespTx    Counter64,
+    jnxMbgSgwGtpV2ICsUERefusesRx    Counter64,
+    jnxMbgSgwGtpV2ICsUERefusesTx    Counter64,
+    jnxMbgSgwGtpV2ICsServDeniedRx   Counter64,
+    jnxMbgSgwGtpV2ICsServDeniedTx   Counter64,
+    jnxMbgSgwGtpV2ICsUnabPageUERx   Counter64,
+    jnxMbgSgwGtpV2ICsUnabPageUETx   Counter64,
+    jnxMbgSgwGtpV2ICsNoMemRx        Counter64,
+    jnxMbgSgwGtpV2ICsNoMemTx        Counter64,
+    jnxMbgSgwGtpV2ICsUserAUTHFlRx   Counter64,
+    jnxMbgSgwGtpV2ICsUserAUTHFlTx   Counter64,
+    jnxMbgSgwGtpV2ICsAPNAcsDenRx    Counter64,
+    jnxMbgSgwGtpV2ICsAPNAcsDenTx    Counter64,
+    jnxMbgSgwGtpV2ICsReqRejRx       Counter64,
+    jnxMbgSgwGtpV2ICsReqRejTx       Counter64,
+    jnxMbgSgwGtpV2ICsPTMSISigMMRx   Counter64,
+    jnxMbgSgwGtpV2ICsPTMSISigMMTx   Counter64,
+    jnxMbgSgwGtpV2ICsIMSINotKnRx    Counter64,
+    jnxMbgSgwGtpV2ICsIMSINotKnTx    Counter64,
+    jnxMbgSgwGtpV2ICsCondIEMsRx     Counter64,
+    jnxMbgSgwGtpV2ICsCondIEMsTx     Counter64,
+    jnxMbgSgwGtpV2ICsAPNResTIncRx   Counter64,
+    jnxMbgSgwGtpV2ICsAPNResTIncTx   Counter64,
+    jnxMbgSgwGtpV2ICsUnknownRx      Counter64,
+    jnxMbgSgwGtpV2ICsUnknownTx      Counter64,
+    jnxMbgSgwGtpV2ICsLclDetRx       Counter64,
+    jnxMbgSgwGtpV2ICsLclDetTx       Counter64,
+    jnxMbgSgwGtpV2ICsCmpDetRx       Counter64,
+    jnxMbgSgwGtpV2ICsCmpDetTx       Counter64,
+    jnxMbgSgwGtpV2ICsRATChgRx       Counter64,
+    jnxMbgSgwGtpV2ICsRATChgTx       Counter64,
+    jnxMbgSgwGtpV2ICsISRDeactRx     Counter64,
+    jnxMbgSgwGtpV2ICsISRDeactTx     Counter64,
+    jnxMbgSgwGtpV2ICsEIFRNCEnRx     Counter64,
+    jnxMbgSgwGtpV2ICsEIFRNCEnTx     Counter64,
+    jnxMbgSgwGtpV2ICsSemErTADRx     Counter64,
+    jnxMbgSgwGtpV2ICsSemErTADTx     Counter64,
+    jnxMbgSgwGtpV2ICsSynErTADRx     Counter64,
+    jnxMbgSgwGtpV2ICsSynErTADTx     Counter64,
+    jnxMbgSgwGtpV2ICsRMValRcvRx     Counter64,
+    jnxMbgSgwGtpV2ICsRMValRcvTx     Counter64,
+    jnxMbgSgwGtpV2ICsRPrNtRspRx     Counter64,
+    jnxMbgSgwGtpV2ICsRPrNtRspTx     Counter64,
+    jnxMbgSgwGtpV2ICsColNWReqRx     Counter64,
+    jnxMbgSgwGtpV2ICsColNWReqTx     Counter64,
+    jnxMbgSgwGtpV2ICsUnPgUESusRx    Counter64,
+    jnxMbgSgwGtpV2ICsUnPgUESusTx    Counter64,
+    jnxMbgSgwGtpV2ICsInvTotLenRx    Counter64,
+    jnxMbgSgwGtpV2ICsInvTotLenTx    Counter64,
+    jnxMbgSgwGtpV2ICsDtForNtSupRx   Counter64,
+    jnxMbgSgwGtpV2ICsDtForNtSupTx   Counter64,
+    jnxMbgSgwGtpV2ICsInReFRePrRx    Counter64,
+    jnxMbgSgwGtpV2ICsInReFRePrTx    Counter64,
+    jnxMbgSgwGtpV2ICsInvPrRx        Counter64,
+    jnxMbgSgwGtpV2ICsInvPrTx        Counter64,
+    jnxMbgSgwGtpV1ProtocolErrRx     Counter64,
+    jnxMbgSgwGtpV1UnSupMsgRx        Counter64,
+    jnxMbgSgwGtpV1T3RespTmrExpRx    Counter64,
+    jnxMbgSgwGtpV1EndMarkerRx       Counter64,
+    jnxMbgSgwGtpV1EndMarkerTx       Counter64,
+    jnxMbgSgwGtpV1EchoReqRx         Counter64,
+    jnxMbgSgwGtpV1EchoReqTx         Counter64,
+    jnxMbgSgwGtpV1EchoRespRx        Counter64,
+    jnxMbgSgwGtpV1EchoRespTx        Counter64,
+    jnxMbgSgwGtpV1ErrIndRx          Counter64,
+    jnxMbgSgwGtpV1ErrIndTx          Counter64,
+    jnxMbgSgwSuspNotifRx            Counter64,
+    jnxMbgSgwSuspNotifTx            Counter64,
+    jnxMbgSgwSuspAckRx              Counter64,
+    jnxMbgSgwSuspAckTx              Counter64,
+    jnxMbgSgwResumeNotifRx          Counter64,
+    jnxMbgSgwResumeNotifTx          Counter64,
+    jnxMbgSgwResumeAckRx            Counter64,
+    jnxMbgSgwResumeAckTx            Counter64,
+    jnxMbgSgwS11PiggybackMsgRx      Counter64,
+    jnxMbgSgwS11PiggybackMsgTx      Counter64,
+    jnxMbgSgwS4PiggybackMsgRx       Counter64,
+    jnxMbgSgwS4PiggybackMsgTx       Counter64,
+    jnxMbgSgwS5PiggybackMsgRx       Counter64,
+    jnxMbgSgwS5PiggybackMsgTx       Counter64
+}
+
+jnxMbgSgwRxPacketsDropped  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Received Packets Dropped."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 1 }
+
+jnxMbgSgwPacketAllocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet allocation failures."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 2 }
+
+jnxMbgSgwPacketSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Send failures."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 3 }
+ 
+jnxMbgSgwIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Version Error Packets Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 4 }
+
+jnxMbgSgwIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP protocol Error packets Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 5 }
+
+jnxMbgSgwGTPPortErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Port Error Packets Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 6 }
+
+jnxMbgSgwGTPUnknVerRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Version Packets Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 7 }
+
+jnxMbgSgwPcktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Length Error Packets Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 8 }
+
+jnxMbgSgwUnknMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Messages Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 9 }
+
+jnxMbgSgwProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 10 }
+
+jnxMbgSgwUnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 11 }
+
+jnxMbgSgwT3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 T3 timer expiries Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 12 }
+
+jnxMbgSgwV2NumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 13 }
+
+jnxMbgSgwV2NumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of V2 messages sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 14 }
+
+jnxMbgSgwV2NumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 15 }
+
+jnxMbgSgwV2NumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of V2 bytes sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 16 }
+
+jnxMbgSgwV2EchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 19 }
+
+jnxMbgSgwV2EchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 20 }
+
+jnxMbgSgwV2EchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 21 }
+
+jnxMbgSgwV2EchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 22 }
+
+jnxMbgSgwV2VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Version Not supported messages received"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 23 }
+
+jnxMbgSgwV2VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 version not supported messages sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 24 }
+
+jnxMbgSgwCreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 25 }
+
+jnxMbgSgwCreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 26 }
+
+jnxMbgSgwCreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 27 }
+
+jnxMbgSgwCreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 28 }
+
+jnxMbgSgwModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 29 }
+
+jnxMbgSgwModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 30 }
+
+jnxMbgSgwModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 31 }
+
+jnxMbgSgwModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 32 }
+
+jnxMbgSgwDelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 33 }
+
+jnxMbgSgwDelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 34 }
+
+jnxMbgSgwDelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 35 }
+
+jnxMbgSgwDelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 36 }
+
+jnxMbgSgwCrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 37 }
+
+jnxMbgSgwCrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 38 }
+
+jnxMbgSgwCrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 39 }
+
+jnxMbgSgwCrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 40 }
+
+jnxMbgSgwUpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 41 }
+
+jnxMbgSgwUpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 42 }
+
+jnxMbgSgwUpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 43 }
+
+jnxMbgSgwUpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 44 }
+
+jnxMbgSgwDelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 45 }
+
+jnxMbgSgwDelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 46 }
+
+jnxMbgSgwDelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 47 }
+
+jnxMbgSgwDelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 48 }
+
+jnxMbgSgwDelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Request received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 49 }
+
+jnxMbgSgwDelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Request Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 50 }
+
+jnxMbgSgwDelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 51 }
+
+jnxMbgSgwDelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Response Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 52 }
+
+jnxMbgSgwUpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 53 }
+
+jnxMbgSgwUpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 54 }
+
+jnxMbgSgwUpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 55 }
+
+jnxMbgSgwUpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Response Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 56 }
+
+jnxMbgSgwModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 57 }
+
+jnxMbgSgwModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 58 }
+
+jnxMbgSgwModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 59 }
+
+jnxMbgSgwModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 60 }
+
+jnxMbgSgwDelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 61 }
+
+jnxMbgSgwDelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 62 }
+
+jnxMbgSgwDelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 63 }
+
+jnxMbgSgwDelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 64 }
+
+jnxMbgSgwBrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 65 }
+
+jnxMbgSgwBrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 66 }
+
+jnxMbgSgwBrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 67 }
+
+jnxMbgSgwBrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 68 }
+
+jnxMbgSgwRelAcsBrReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 69 }
+
+jnxMbgSgwRelAcsBrReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 70 }
+
+jnxMbgSgwRelAcsBrRespRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 71 }
+
+jnxMbgSgwRelAcsBrRespTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 72 }
+
+jnxMbgSgwCrIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 73 }
+
+jnxMbgSgwCrIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Request sent"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 74 }
+
+jnxMbgSgwCrIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Response Received"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 75 }
+
+jnxMbgSgwCrIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Response sent"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 76 }
+
+jnxMbgSgwDelIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 77 }
+
+jnxMbgSgwDelIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 78 }
+
+jnxMbgSgwDelIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Response Received"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 79 }
+
+jnxMbgSgwDelIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Response sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 80 }
+
+jnxMbgSgwDlDataNotifRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 81 }
+
+jnxMbgSgwDlDataNotifTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 82 }
+
+jnxMbgSgwDlDataAckRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgement received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 83 }
+
+jnxMbgSgwDlDataAckTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgement Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 84 }
+
+jnxMbgSgwDlDataNotiFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 85 }
+
+jnxMbgSgwDlDataNotiFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail Sent."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 86 }
+
+jnxMbgSgwStopPagingIndRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of Stop Paging Indication Messages Received."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 87 }
+
+jnxMbgSgwStopPagingIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of Stop Paging Indicaton messages sent"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 88 }
+
+jnxMbgSgwGtpV2ICsPageRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Page."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 89 }
+
+jnxMbgSgwGtpV2ICsPageTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP packets sent with cause Page."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 90 }
+
+jnxMbgSgwGtpV2ICsReqAcceptRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Accept."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 91 }
+
+jnxMbgSgwGtpV2ICsReqAcceptTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Request Accept."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 92 }
+
+jnxMbgSgwGtpV2ICsAcceptPartRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Accept Partial."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 93 }
+
+jnxMbgSgwGtpV2ICsAcceptPartTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Accept Partial."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 94 }
+
+jnxMbgSgwGtpV2ICsNewPTNPrefRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Network Preference."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 95 }
+
+jnxMbgSgwGtpV2ICsNewPTNPrefTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause New PDN type due to Network Preference"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 96 }
+
+
+jnxMbgSgwGtpV2ICsNewPTSIAdbrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 97 }
+
+jnxMbgSgwGtpV2ICsNewPTSIAdbrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 98 }
+
+jnxMbgSgwGtpV2ICsCtxNotFndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Context not found."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 99 }
+
+jnxMbgSgwGtpV2ICsCtxNotFndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Context not found."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 100 }
+
+jnxMbgSgwGtpV2ICsInvMsgFmtRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Message Format."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 101 }
+
+jnxMbgSgwGtpV2ICsInvMsgFmtTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Invalid Message Format."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 102 }
+
+jnxMbgSgwGtpV2ICsVerNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Version not Supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 103 }
+
+jnxMbgSgwGtpV2ICsVerNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Version not Supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 104 }
+
+jnxMbgSgwGtpV2ICsInvLenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Length."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 105 }
+
+jnxMbgSgwGtpV2ICsInvLenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Invalid Length."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 106 }
+
+jnxMbgSgwGtpV2ICsServNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Not supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 107 }
+
+jnxMbgSgwGtpV2ICsServNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Service Not supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 108 }
+
+jnxMbgSgwGtpV2ICsManIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 109 }
+
+jnxMbgSgwGtpV2ICsManIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 110 }
+
+jnxMbgSgwGtpV2ICsManIEMissRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 111 }
+
+jnxMbgSgwGtpV2ICsManIEMissTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 112 }
+
+jnxMbgSgwGtpV2ICsOptIEIncorrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Optional IE Incorrect."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 113 }
+
+jnxMbgSgwGtpV2ICsOptIEIncorrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Optional IE Incorrect."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 114 }
+
+jnxMbgSgwGtpV2ICsSysFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause System Failure."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 115 }
+
+jnxMbgSgwGtpV2ICsSysFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause System Failure."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 116 }
+
+jnxMbgSgwGtpV2ICsNoResRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Resource."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 117 }
+
+jnxMbgSgwGtpV2ICsNoResTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause No Resource."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 118 }
+
+jnxMbgSgwGtpV2ICsTFTSMANTErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT Symantic Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 119 }
+
+jnxMbgSgwGtpV2ICsTFTSMANTErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause TFT Symantic Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 120 }
+
+jnxMbgSgwGtpV2ICsTFTSysErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT System Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 121 }
+
+jnxMbgSgwGtpV2ICsTFTSysErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause TFT System Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 122 }
+
+jnxMbgSgwGtpV2ICsPkFltManErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Symantic Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 123 }
+
+jnxMbgSgwGtpV2ICsPkFltManErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Packet Filter Symantic Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 124 }
+
+jnxMbgSgwGtpV2ICsPkFltSynErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Syntax Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 125 }
+
+jnxMbgSgwGtpV2ICsPkFltSynErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Packet Filter Syntax Error."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 126 }
+
+jnxMbgSgwGtpV2ICsMisUnknAPNRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unknown APN."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 127 }
+
+jnxMbgSgwGtpV2ICsMisUnknAPNTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unknown APN."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 128 }
+
+jnxMbgSgwGtpV2ICsUnexpRptIERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unexpected Repeated IE."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 129 }
+
+jnxMbgSgwGtpV2ICsUnexpRptIETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unexpected Repeated IE."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 130 }
+
+jnxMbgSgwGtpV2ICsGREKeyNtFdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause GRE Key Not Found."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 131 }
+
+jnxMbgSgwGtpV2ICsGREKeyNtFdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause GRE Key Not Found."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 132 }
+
+jnxMbgSgwGtpV2ICsRelocFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Relocation Failed."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 133 }
+
+jnxMbgSgwGtpV2ICsRelocFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Relocation Failed."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 134 }
+
+jnxMbgSgwGtpV2ICsDeniedINRatRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Denied in RAT."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 135 }
+
+jnxMbgSgwGtpV2ICsDeniedINRatTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Denied in RAT."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 136 }
+
+jnxMbgSgwGtpV2ICsPTNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause PDN Type Not Supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 137 }
+
+jnxMbgSgwGtpV2ICsPTNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause PDN Type Not Supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 138 }
+
+jnxMbgSgwGtpV2ICsAllDynAdOccRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 139 }
+
+jnxMbgSgwGtpV2ICsAllDynAdOccTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 140 }
+
+jnxMbgSgwGtpV2ICsNOTFTUECTXRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Context Without TFT Exists."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 141 }
+
+jnxMbgSgwGtpV2ICsNOTFTUECTXTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Context Without TFT Exists."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 142 }
+
+jnxMbgSgwGtpV2ICsProtoNtSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Protocol Not Supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 143 }
+
+jnxMbgSgwGtpV2ICsProtoNtSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Protocol Not Supported."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 144 }
+
+jnxMbgSgwGtpV2ICsUENotRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Not Responding."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 145 }
+
+jnxMbgSgwGtpV2ICsUENotRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Not Responding."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 146 }
+
+jnxMbgSgwGtpV2ICsUERefusesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Refuses."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 147 }
+
+jnxMbgSgwGtpV2ICsUERefusesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Refuses."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 148 }
+
+jnxMbgSgwGtpV2ICsServDeniedRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Denied."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 149 }
+
+jnxMbgSgwGtpV2ICsServDeniedTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Service Denied."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 150 }
+
+jnxMbgSgwGtpV2ICsUnabPageUERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unable to Page UE."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 151 }
+
+jnxMbgSgwGtpV2ICsUnabPageUETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unable to Page UE."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 152 }
+
+jnxMbgSgwGtpV2ICsNoMemRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Memory."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 153 }
+
+jnxMbgSgwGtpV2ICsNoMemTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause No Memory."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 154 }
+
+jnxMbgSgwGtpV2ICsUserAUTHFlRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause User AUTH Failed."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 155 }
+
+jnxMbgSgwGtpV2ICsUserAUTHFlTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause User AUTH Failed."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 156 }
+
+jnxMbgSgwGtpV2ICsAPNAcsDenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause APN Access Denied."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 157 }
+
+jnxMbgSgwGtpV2ICsAPNAcsDenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause APN Access Denied."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 158 }
+
+jnxMbgSgwGtpV2ICsReqRejRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Rejected."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 159 }
+
+jnxMbgSgwGtpV2ICsReqRejTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Request Rejected."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 160 }
+
+jnxMbgSgwGtpV2ICsPTMSISigMMRx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets received with cause P-TMSI Signature Mismatch."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 161 }
+
+jnxMbgSgwGtpV2ICsPTMSISigMMTx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTP packets sent with cause P-TMSI Signature Mismatch"
+    ::= { jnxMbgSgwGtpGlbStatsEntry 162 }
+
+jnxMbgSgwGtpV2ICsIMSINotKnRx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets received with cause IMSI Not Known."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 163 }
+
+jnxMbgSgwGtpV2ICsIMSINotKnTx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTP packets sent with cause IMSI Not Known."
+    ::= { jnxMbgSgwGtpGlbStatsEntry 164 }
+
+jnxMbgSgwGtpV2ICsCondIEMsRx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets received with cause Conditional IE Missing."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 165 }
+
+jnxMbgSgwGtpV2ICsCondIEMsTx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTP packets sent with cause Conditional IE Missing."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 166 }
+
+jnxMbgSgwGtpV2ICsAPNResTIncRx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets received with cause APN Restriction Type Incompatible."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 167 }
+
+jnxMbgSgwGtpV2ICsAPNResTIncTx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTP packets sent with cause APN Restriction Type Incompatible."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 168 }
+
+jnxMbgSgwGtpV2ICsUnknownRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets received with cause Unknown."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 169 }
+
+jnxMbgSgwGtpV2ICsUnknownTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unknown."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 170 }
+
+jnxMbgSgwGtpV2ICsLclDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Local Detach."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 171 }
+
+jnxMbgSgwGtpV2ICsLclDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Local Detach."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 172 }
+
+jnxMbgSgwGtpV2ICsCmpDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Complete Detach."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 173 }
+
+jnxMbgSgwGtpV2ICsCmpDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Complete Detach."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 174 }
+
+jnxMbgSgwGtpV2ICsRATChgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 175 }
+
+jnxMbgSgwGtpV2ICsRATChgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 176 }
+
+jnxMbgSgwGtpV2ICsISRDeactRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause ISR Deactivated."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 177 }
+
+jnxMbgSgwGtpV2ICsISRDeactTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause ISR Deactivated."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 178 }
+
+jnxMbgSgwGtpV2ICsEIFRNCEnRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 179 }
+
+jnxMbgSgwGtpV2ICsEIFRNCEnTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 180 }
+
+jnxMbgSgwGtpV2ICsSemErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 181 }
+
+jnxMbgSgwGtpV2ICsSemErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 182 }
+
+jnxMbgSgwGtpV2ICsSynErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 183 }
+
+jnxMbgSgwGtpV2ICsSynErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 184 }
+
+jnxMbgSgwGtpV2ICsRMValRcvRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Reserved Message Value Received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 185 }
+
+jnxMbgSgwGtpV2ICsRMValRcvTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Reserved Message Value Received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 186 }
+
+jnxMbgSgwGtpV2ICsRPrNtRspRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Remote peer not responding."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 187 }
+
+jnxMbgSgwGtpV2ICsRPrNtRspTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Remote peer not responding."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 188 }
+
+jnxMbgSgwGtpV2ICsColNWReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Collision with network initiated request."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 189 }
+
+jnxMbgSgwGtpV2ICsColNWReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Collision with network initiated request."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 190 }
+
+jnxMbgSgwGtpV2ICsUnPgUESusRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Unable to page UE due to suspension."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 191 }
+
+jnxMbgSgwGtpV2ICsUnPgUESusTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unable to page UE due to suspension."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 192 }
+
+jnxMbgSgwGtpV2ICsInvTotLenRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid total len."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 193 }
+
+jnxMbgSgwGtpV2ICsInvTotLenTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid total len."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 194 }
+
+jnxMbgSgwGtpV2ICsDtForNtSupRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Data forwarding not supported."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 195 }
+
+jnxMbgSgwGtpV2ICsDtForNtSupTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Data forwarding not supported."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 196 }
+
+jnxMbgSgwGtpV2ICsInReFRePrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 197 }
+
+jnxMbgSgwGtpV2ICsInReFRePrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 198 }
+
+jnxMbgSgwGtpV2ICsInvPrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid peer."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 199 }
+
+jnxMbgSgwGtpV2ICsInvPrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid peer."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 200 }
+
+jnxMbgSgwGtpV1ProtocolErrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv1 Protocol Errors Received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 201 }
+
+jnxMbgSgwGtpV1UnSupMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv1 Unsupported Messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 202 }
+
+jnxMbgSgwGtpV1T3RespTmrExpRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 T3 timer expiries Received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 203 }
+
+jnxMbgSgwGtpV1EndMarkerRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 end marker packets received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 204 }
+
+jnxMbgSgwGtpV1EndMarkerTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 end marker packets sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 205 }
+
+jnxMbgSgwGtpV1EchoReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo request packets received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 206 }
+
+jnxMbgSgwGtpV1EchoReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo request packets sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 207 }
+
+jnxMbgSgwGtpV1EchoRespRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo response packets received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 208 }
+
+jnxMbgSgwGtpV1EchoRespTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo response packets sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 209 }
+
+jnxMbgSgwGtpV1ErrIndRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 Error Indication packets received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 210 }
+
+jnxMbgSgwGtpV1ErrIndTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 Error Indication packets sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 211 }
+
+jnxMbgSgwSuspNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 212 } 
+
+jnxMbgSgwSuspNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 213 } 
+
+jnxMbgSgwSuspAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 214 }
+
+jnxMbgSgwSuspAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 215 }
+
+jnxMbgSgwResumeNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 216 }
+    
+jnxMbgSgwResumeNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 217 }
+
+jnxMbgSgwResumeAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 218 }
+   
+jnxMbgSgwResumeAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 219 }
+
+jnxMbgSgwS11PiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S11 Piggyback messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 220 }
+    
+jnxMbgSgwS11PiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S11 Piggyback messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 221 }
+
+jnxMbgSgwS4PiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S4 Piggyback messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 222 }
+    
+jnxMbgSgwS4PiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S4 Piggyback messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 223 }
+
+jnxMbgSgwS5PiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S5 Piggyback messages received."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 224 }
+    
+jnxMbgSgwS5PiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S5 Piggyback messages sent."
+     ::= { jnxMbgSgwGtpGlbStatsEntry 225 }
+
+--
+-- GTP Object for showing GTP Per Peer Statistics
+--
+
+jnxMbgSgwGtpCPerPeerStatsTable  OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgSgwGtpPerPeerStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to a GTP per peer level control statistic."
+    ::= { jnxMbgSgwGtpObjects 1 }
+
+jnxMbgSgwGtpPerPeerStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgSgwGtpPerPeerStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the GTPC peer level Statistics."
+    INDEX     { jnxMbgGwIndex,
+                jnxMbgSgwPPGtpRmtAddr,
+                jnxMbgSgwPPGtpLclAddr,
+                jnxMbgSgwPPGtpRtgInst }
+    ::= { jnxMbgSgwGtpCPerPeerStatsTable 1}
+
+JnxMbgSgwGtpPerPeerStatsEntry ::= SEQUENCE {
+    jnxMbgSgwPPGtpRmtAddr           IpAddress,
+    jnxMbgSgwPPGtpLclAddr           IpAddress,
+    jnxMbgSgwPPGtpRtgInst           Unsigned32,
+    jnxMbgSgwPPRxPacketsDropped     Counter64,
+    jnxMbgSgwPPPacketAllocFail      Counter64,
+    jnxMbgSgwPPPacketSendFail       Counter64,
+    jnxMbgSgwPPIPVerErrRx           Counter64,
+    jnxMbgSgwPPIPProtoErrRx         Counter64,
+    jnxMbgSgwPPGTPPortErrRx         Counter64,
+    jnxMbgSgwPPGTPUnknVerRx         Counter64,
+    jnxMbgSgwPPPcktLenErrRx         Counter64,
+    jnxMbgSgwPPUnknMsgRx            Counter64,
+    jnxMbgSgwPPProtocolErrRx        Counter64,
+    jnxMbgSgwPPUnSupportedMsgRx     Counter64,
+    jnxMbgSgwPPT3RespTmrExpRx       Counter64,
+    jnxMbgSgwPPV2NumMsgRx           Counter64,
+    jnxMbgSgwPPV2NumMsgTx           Counter64,
+    jnxMbgSgwPPV2NumBytesRx         Counter64,
+    jnxMbgSgwPPV2NumBytesTx         Counter64,
+    jnxMbgSgwPPV2EchoReqRx          Counter64,
+    jnxMbgSgwPPV2EchoReqTx          Counter64,
+    jnxMbgSgwPPV2EchoRespRx         Counter64,
+    jnxMbgSgwPPV2EchoRespTx         Counter64,
+    jnxMbgSgwPPV2VerNotSupRx        Counter64,
+    jnxMbgSgwPPV2VerNotSupTx        Counter64,
+    jnxMbgSgwPPCreateSessReqRx      Counter64,
+    jnxMbgSgwPPCreateSessReqTx      Counter64,
+    jnxMbgSgwPPCreateSessRspRx      Counter64,
+    jnxMbgSgwPPCreateSessRspTx      Counter64,
+    jnxMbgSgwPPModBrReqRx           Counter64,
+    jnxMbgSgwPPModBrReqTx           Counter64,
+    jnxMbgSgwPPModBrRspRx           Counter64,
+    jnxMbgSgwPPModBrRspTx           Counter64,
+    jnxMbgSgwPPDelSessReqRx         Counter64,
+    jnxMbgSgwPPDelSessReqTx         Counter64,
+    jnxMbgSgwPPDelSessRspRx         Counter64,
+    jnxMbgSgwPPDelSessRspTx         Counter64,
+    jnxMbgSgwPPCrtBrReqRx           Counter64,
+    jnxMbgSgwPPCrtBrReqTx           Counter64,
+    jnxMbgSgwPPCrtBrRspRx           Counter64,
+    jnxMbgSgwPPCrtBrRspTx           Counter64,
+    jnxMbgSgwPPUpdBrReqRx           Counter64,
+    jnxMbgSgwPPUpdBrReqTx           Counter64,
+    jnxMbgSgwPPUpdBrRspRx           Counter64,
+    jnxMbgSgwPPUpdBrRspTx           Counter64,
+    jnxMbgSgwPPDelBrReqRx           Counter64,
+    jnxMbgSgwPPDelBrReqTx           Counter64,
+    jnxMbgSgwPPDelBrRspRx           Counter64,
+    jnxMbgSgwPPDelBrRspTx           Counter64,
+    jnxMbgSgwPPDelConnSetReqRx      Counter64,
+    jnxMbgSgwPPDelConnSetReqTx      Counter64,
+    jnxMbgSgwPPDelConnSetRspRx      Counter64,
+    jnxMbgSgwPPDelConnSetRspTx      Counter64,
+    jnxMbgSgwPPUpdConnSetReqRx      Counter64,
+    jnxMbgSgwPPUpdConnSetReqTx      Counter64,
+    jnxMbgSgwPPUpdConnSetRspRx      Counter64,
+    jnxMbgSgwPPUpdConnSetRspTx      Counter64,
+    jnxMbgSgwPPModBrCmdRx           Counter64,
+    jnxMbgSgwPPModBrCmdTx           Counter64,
+    jnxMbgSgwPPModBrFlrIndRx        Counter64,
+    jnxMbgSgwPPModBrFlrIndTx        Counter64,
+    jnxMbgSgwPPDelBrCmdRx           Counter64,
+    jnxMbgSgwPPDelBrCmdTx           Counter64,
+    jnxMbgSgwPPDelBrFlrIndRx        Counter64,
+    jnxMbgSgwPPDelBrFlrIndTx        Counter64,
+    jnxMbgSgwPPBrResCmdRx           Counter64,
+    jnxMbgSgwPPBrResCmdTx           Counter64,
+    jnxMbgSgwPPBrResFlrIndRx        Counter64,
+    jnxMbgSgwPPBrResFlrIndTx        Counter64,
+    jnxMbgSgwPPRelAcsBrReqRx        Counter64,
+    jnxMbgSgwPPRelAcsBrReqTx        Counter64,
+    jnxMbgSgwPPRelAcsBrRespRx       Counter64,
+    jnxMbgSgwPPRelAcsBrRespTx       Counter64,
+    jnxMbgSgwPPCrIndTunReqRx        Counter64,
+    jnxMbgSgwPPCrIndTunReqTx        Counter64,
+    jnxMbgSgwPPCrIndTunRespRx       Counter64,
+    jnxMbgSgwPPCrIndTunRespTx       Counter64,
+    jnxMbgSgwPPDelIndTunReqRx       Counter64,
+    jnxMbgSgwPPDelIndTunReqTx       Counter64,
+    jnxMbgSgwPPDelIndTunRespRx      Counter64,
+    jnxMbgSgwPPDelIndTunRespTx      Counter64,
+    jnxMbgSgwPPDlDataNotifRx        Counter64,
+    jnxMbgSgwPPDlDataNotifTx        Counter64,
+    jnxMbgSgwPPDlDataAckRx          Counter64,
+    jnxMbgSgwPPDlDataAckTx          Counter64,
+    jnxMbgSgwPPDlDataNotiFlrIndRx   Counter64,
+    jnxMbgSgwPPDlDataNotiFlrIndTx   Counter64,
+    jnxMbgSgwPPStopPagingIndRx      Counter64,
+    jnxMbgSgwPPStopPagingIndTx      Counter64,
+    jnxMbgSgwPPGtpV2ICsPageRx       Counter64,
+    jnxMbgSgwPPGtpV2ICsPageTx       Counter64,
+    jnxMbgSgwPPGtpV2ICsReqAcceptRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsReqAcceptTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsAcceptPartRx Counter64,
+    jnxMbgSgwPPGtpV2ICsAcceptPartTx Counter64,
+    jnxMbgSgwPPGtpV2ICsNewPTNPrefRx Counter64,
+    jnxMbgSgwPPGtpV2ICsNewPTNPrefTx Counter64,
+    jnxMbgSgwPPGtpV2ICsNPTSIAdbrRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsNPTSIAdbrTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsCtxNotFndRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsCtxNotFndTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsInvMsgFmtRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsInvMsgFmtTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsVerNotSuppRx Counter64,
+    jnxMbgSgwPPGtpV2ICsVerNotSuppTx Counter64,
+    jnxMbgSgwPPGtpV2ICsInvLenRx     Counter64,
+    jnxMbgSgwPPGtpV2ICsInvLenTx     Counter64,
+    jnxMbgSgwPPGtpV2ICsServNotSupRx Counter64,
+    jnxMbgSgwPPGtpV2ICsServNotSupTx Counter64,
+    jnxMbgSgwPPGtpV2ICsManIEIncorRx Counter64,
+    jnxMbgSgwPPGtpV2ICsManIEIncorTx Counter64,
+    jnxMbgSgwPPGtpV2ICsManIEMissRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsManIEMissTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsOptIEIncorRx Counter64,
+    jnxMbgSgwPPGtpV2ICsOptIEIncorTx Counter64,
+    jnxMbgSgwPPGtpV2ICsSysFailRx    Counter64,
+    jnxMbgSgwPPGtpV2ICsSysFailTx    Counter64,
+    jnxMbgSgwPPGtpV2ICsNoResRx      Counter64,
+    jnxMbgSgwPPGtpV2ICsNoResTx      Counter64,
+    jnxMbgSgwPPGtpV2ICsTFTSMANTErRx Counter64,
+    jnxMbgSgwPPGtpV2ICsTFTSMANTErTx Counter64,
+    jnxMbgSgwPPGtpV2ICsTFTSysErrRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsTFTSysErrTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsPkFltManErRx Counter64,
+    jnxMbgSgwPPGtpV2ICsPkFltManErTx Counter64,
+    jnxMbgSgwPPGtpV2ICsPkFltSynErRx Counter64,
+    jnxMbgSgwPPGtpV2ICsPkFltSynErTx Counter64,
+    jnxMbgSgwPPGtpV2ICsMisUnknAPNRx Counter64,
+    jnxMbgSgwPPGtpV2ICsMisUnknAPNTx Counter64,
+    jnxMbgSgwPPGtpV2ICsUnexpRptIERx Counter64,
+    jnxMbgSgwPPGtpV2ICsUnexpRptIETx Counter64,
+    jnxMbgSgwPPGtpV2ICsGREKeyNtFdRx Counter64,
+    jnxMbgSgwPPGtpV2ICsGREKeyNtFdTx Counter64,
+    jnxMbgSgwPPGtpV2ICsRelocFailRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsRelocFailTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsDenINRatRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsDenINRatTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsPTNotSuppRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsPTNotSuppTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsAllDynAdOcRx Counter64,
+    jnxMbgSgwPPGtpV2ICsAllDynAdOcTx Counter64,
+    jnxMbgSgwPPGtpV2ICsNOTFTUECTXRx Counter64,
+    jnxMbgSgwPPGtpV2ICsNOTFTUECTXTx Counter64,
+    jnxMbgSgwPPGtpV2ICsProtoNtSupRx Counter64,
+    jnxMbgSgwPPGtpV2ICsProtoNtSupTx Counter64,
+    jnxMbgSgwPPGtpV2ICsUENotRespRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsUENotRespTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsUERefusesRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsUERefusesTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsServDeniedRx Counter64,
+    jnxMbgSgwPPGtpV2ICsServDeniedTx Counter64,
+    jnxMbgSgwPPGtpV2ICsUnabPageUERx Counter64,
+    jnxMbgSgwPPGtpV2ICsUnabPageUETx Counter64,
+    jnxMbgSgwPPGtpV2ICsNoMemRx      Counter64,
+    jnxMbgSgwPPGtpV2ICsNoMemTx      Counter64,
+    jnxMbgSgwPPGtpV2ICsUserAUTHFlRx Counter64,
+    jnxMbgSgwPPGtpV2ICsUserAUTHFlTx Counter64,
+    jnxMbgSgwPPGtpV2ICsAPNAcsDenRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsAPNAcsDenTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsReqRejRx     Counter64,
+    jnxMbgSgwPPGtpV2ICsReqRejTx     Counter64,
+    jnxMbgSgwPPGtpV2ICsPTMSISigMMRx Counter64,
+    jnxMbgSgwPPGtpV2ICsPTMSISigMMTx Counter64,
+    jnxMbgSgwPPGtpV2ICsIMSINotKnRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsIMSINotKnTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsCondIEMsRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsCondIEMsTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsAPNResTIncRx Counter64,
+    jnxMbgSgwPPGtpV2ICsAPNResTIncTx Counter64,
+    jnxMbgSgwPPGtpV2ICsUnknownRx    Counter64,
+    jnxMbgSgwPPGtpV2ICsUnknownTx    Counter64,
+    jnxMbgSgwPPGtpV2ICsLclDetRx     Counter64,
+    jnxMbgSgwPPGtpV2ICsLclDetTx     Counter64,
+    jnxMbgSgwPPGtpV2ICsCmpDetRx     Counter64,
+    jnxMbgSgwPPGtpV2ICsCmpDetTx     Counter64,
+    jnxMbgSgwPPGtpV2ICsRATChgRx     Counter64,
+    jnxMbgSgwPPGtpV2ICsRATChgTx     Counter64,
+    jnxMbgSgwPPGtpV2ICsISRDeactRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsISRDeactTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsEIFRNCEnRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsEIFRNCEnTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsSemErTADRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsSemErTADTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsSynErTADRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsSynErTADTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsRMValRcvRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsRMValRcvTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsRPrNtRspRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsRPrNtRspTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsColNWReqRx   Counter64,
+    jnxMbgSgwPPGtpV2ICsColNWReqTx   Counter64,
+    jnxMbgSgwPPGtpV2ICsUnPgUESusRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsUnPgUESusTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsInvTotLenRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsInvTotLenTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsDtForNtSupRx Counter64,
+    jnxMbgSgwPPGtpV2ICsDtForNtSupTx Counter64,
+    jnxMbgSgwPPGtpV2ICsInReFRePrRx  Counter64,
+    jnxMbgSgwPPGtpV2ICsInReFRePrTx  Counter64,
+    jnxMbgSgwPPGtpV2ICsInvPrRx      Counter64,
+    jnxMbgSgwPPGtpV2ICsInvPrTx      Counter64,
+    jnxMbgSgwPPGtpV1ProtocolErrRx   Counter64,
+    jnxMbgSgwPPGtpV1UnSupMsgRx      Counter64,
+    jnxMbgSgwPPGtpV1T3RespTmrExpRx  Counter64,
+    jnxMbgSgwPPGtpV1EndMarkerRx     Counter64,
+    jnxMbgSgwPPGtpV1EndMarkerTx     Counter64,
+    jnxMbgSgwPPGtpV1EchoReqRx       Counter64,
+    jnxMbgSgwPPGtpV1EchoReqTx       Counter64,
+    jnxMbgSgwPPGtpV1EchoRespRx      Counter64,
+    jnxMbgSgwPPGtpV1EchoRespTx      Counter64,
+    jnxMbgSgwPPGtpV1ErrIndRx        Counter64,
+    jnxMbgSgwPPGtpV1ErrIndTx        Counter64,
+    jnxMbgSgwPPSuspNotifRx          Counter64,
+    jnxMbgSgwPPSuspNotifTx          Counter64,
+    jnxMbgSgwPPSuspAckRx            Counter64,
+    jnxMbgSgwPPSuspAckTx            Counter64,
+    jnxMbgSgwPPResumeNotifRx        Counter64,
+    jnxMbgSgwPPResumeNotifTx        Counter64,
+    jnxMbgSgwPPResumeAckRx          Counter64,
+    jnxMbgSgwPPResumeAckTx          Counter64,
+    jnxMbgSgwPPPiggybackMsgRx       Counter64,
+    jnxMbgSgwPPPiggybackMsgTx       Counter64
+}
+
+jnxMbgSgwPPGtpRmtAddr OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Remote IP address of this GTP peer entry."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 1 }
+
+jnxMbgSgwPPGtpLclAddr OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Local IP address of this GTP peer entry."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 2 }
+
+jnxMbgSgwPPGtpRtgInst OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Routing Instance for this Peer."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 3 }
+
+jnxMbgSgwPPRxPacketsDropped  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Received Packets Dropped."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 4 }
+
+jnxMbgSgwPPPacketAllocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet allocation failures."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 5 }
+
+jnxMbgSgwPPPacketSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Send failures."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 6 }
+
+jnxMbgSgwPPIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Version Error Packets Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 7 }
+
+jnxMbgSgwPPIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Protocol Error packets Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 8 }
+
+jnxMbgSgwPPGTPPortErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Port Error Packets Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 9 }
+
+jnxMbgSgwPPGTPUnknVerRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Version Packets Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 10 }
+
+jnxMbgSgwPPPcktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Length Error Packets Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 11 }
+
+jnxMbgSgwPPUnknMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Messages Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 12 }
+
+jnxMbgSgwPPProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 13 }
+
+jnxMbgSgwPPUnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 14 }
+
+jnxMbgSgwPPT3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 T3 timer expiries Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 15 }
+
+jnxMbgSgwPPV2NumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 16 }
+
+jnxMbgSgwPPV2NumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 messages sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 17 }
+
+jnxMbgSgwPPV2NumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 18 }
+
+jnxMbgSgwPPV2NumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 bytes sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 19 }
+
+jnxMbgSgwPPV2EchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 20 }
+
+jnxMbgSgwPPV2EchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 21 }
+
+jnxMbgSgwPPV2EchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 22 }
+
+jnxMbgSgwPPV2EchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 23 }
+
+jnxMbgSgwPPV2VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Version Not supported messages received"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 24 }
+
+jnxMbgSgwPPV2VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of version not supported messages sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 25 }
+
+jnxMbgSgwPPCreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 26 }
+
+jnxMbgSgwPPCreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 27 }
+
+jnxMbgSgwPPCreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 28 }
+
+jnxMbgSgwPPCreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 29 }
+
+jnxMbgSgwPPModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 30 }
+
+jnxMbgSgwPPModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 31 }
+
+jnxMbgSgwPPModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 32 }
+
+jnxMbgSgwPPModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 33 }
+
+jnxMbgSgwPPDelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 34 }
+
+jnxMbgSgwPPDelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 35 }
+
+jnxMbgSgwPPDelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 36 }
+
+jnxMbgSgwPPDelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 37 }
+jnxMbgSgwPPCrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 38 }
+
+jnxMbgSgwPPCrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 39 }
+
+jnxMbgSgwPPCrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 40 }
+
+jnxMbgSgwPPCrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 41 }
+
+jnxMbgSgwPPUpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 42 }
+
+jnxMbgSgwPPUpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 43 }
+
+jnxMbgSgwPPUpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 44 }
+
+jnxMbgSgwPPUpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 45 }
+
+jnxMbgSgwPPDelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 46 }
+
+jnxMbgSgwPPDelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 47 }
+
+jnxMbgSgwPPDelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 48 }
+
+jnxMbgSgwPPDelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 49 }
+
+jnxMbgSgwPPDelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Request received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 50 }
+
+jnxMbgSgwPPDelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Request Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 51 }
+
+jnxMbgSgwPPDelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 52 }
+
+jnxMbgSgwPPDelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Response Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 53 }
+
+jnxMbgSgwPPUpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 54 }
+
+jnxMbgSgwPPUpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 55 }
+
+jnxMbgSgwPPUpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 56 }
+
+jnxMbgSgwPPUpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Response Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 57 }
+
+jnxMbgSgwPPModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 58 }
+
+jnxMbgSgwPPModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 59 }
+
+jnxMbgSgwPPModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 60 }
+
+jnxMbgSgwPPModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 61 }
+
+jnxMbgSgwPPDelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 62 }
+
+jnxMbgSgwPPDelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 63 }
+
+jnxMbgSgwPPDelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 64 }
+
+jnxMbgSgwPPDelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 65 }
+
+jnxMbgSgwPPBrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 66 }
+
+jnxMbgSgwPPBrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 67 }
+
+jnxMbgSgwPPBrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 68 }
+
+jnxMbgSgwPPBrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 69 }
+
+jnxMbgSgwPPRelAcsBrReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 70 }
+
+jnxMbgSgwPPRelAcsBrReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 71 }
+
+jnxMbgSgwPPRelAcsBrRespRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 72 }
+
+jnxMbgSgwPPRelAcsBrRespTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 73 }
+
+jnxMbgSgwPPCrIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 74 }
+
+jnxMbgSgwPPCrIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Request sent"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 75 }
+
+jnxMbgSgwPPCrIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Response Received"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 76 }
+
+jnxMbgSgwPPCrIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Response sent"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 77 }
+
+jnxMbgSgwPPDelIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 78 }
+
+jnxMbgSgwPPDelIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 79 }
+
+jnxMbgSgwPPDelIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Response Received"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 80 }
+
+jnxMbgSgwPPDelIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Response sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 81 }
+
+jnxMbgSgwPPDlDataNotifRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 82 }
+
+jnxMbgSgwPPDlDataNotifTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 83 }
+
+jnxMbgSgwPPDlDataAckRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgement received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 84 }
+
+jnxMbgSgwPPDlDataAckTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgement Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 85 }
+
+jnxMbgSgwPPDlDataNotiFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 86 }
+
+jnxMbgSgwPPDlDataNotiFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail Sent."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 87 }
+
+jnxMbgSgwPPStopPagingIndRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of Stop Paging Indication Messages Received."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 88 }
+
+jnxMbgSgwPPStopPagingIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of Stop Paging Indicaton messages sent"
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 89 }
+
+jnxMbgSgwPPGtpV2ICsPageRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Page."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 90 }
+
+jnxMbgSgwPPGtpV2ICsPageTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+    "Number of GTP packets sent with cause Page."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 91 }
+
+jnxMbgSgwPPGtpV2ICsReqAcceptRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Accept."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 92 }
+
+jnxMbgSgwPPGtpV2ICsReqAcceptTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Request Accept."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 93 }
+
+jnxMbgSgwPPGtpV2ICsAcceptPartRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Accept Partial."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 94 }
+
+jnxMbgSgwPPGtpV2ICsAcceptPartTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Accept Partial."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 95 }
+
+jnxMbgSgwPPGtpV2ICsNewPTNPrefRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Network Preference."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 96 }
+
+jnxMbgSgwPPGtpV2ICsNewPTNPrefTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause New PDN type due to Network Preference."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 97 }
+
+
+jnxMbgSgwPPGtpV2ICsNPTSIAdbrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 98 }
+
+jnxMbgSgwPPGtpV2ICsNPTSIAdbrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 99 }
+
+jnxMbgSgwPPGtpV2ICsCtxNotFndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Context not found."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 100 }
+
+jnxMbgSgwPPGtpV2ICsCtxNotFndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Context not found."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 101 }
+
+jnxMbgSgwPPGtpV2ICsInvMsgFmtRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Message Format."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 102 }
+
+jnxMbgSgwPPGtpV2ICsInvMsgFmtTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Invalid Message Format."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 103 }
+
+jnxMbgSgwPPGtpV2ICsVerNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Version not Supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 104 }
+
+jnxMbgSgwPPGtpV2ICsVerNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Version not Supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 105 }
+
+jnxMbgSgwPPGtpV2ICsInvLenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Length."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 106 }
+
+jnxMbgSgwPPGtpV2ICsInvLenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Invalid Length."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 107 }
+
+jnxMbgSgwPPGtpV2ICsServNotSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Not supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 108 }
+
+jnxMbgSgwPPGtpV2ICsServNotSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Service Not supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 109 }
+
+jnxMbgSgwPPGtpV2ICsManIEIncorRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 110 }
+
+jnxMbgSgwPPGtpV2ICsManIEIncorTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 111 }
+
+jnxMbgSgwPPGtpV2ICsManIEMissRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 112 }
+
+jnxMbgSgwPPGtpV2ICsManIEMissTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 113 }
+
+jnxMbgSgwPPGtpV2ICsOptIEIncorRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Optional IE Incorrect."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 114 }
+
+jnxMbgSgwPPGtpV2ICsOptIEIncorTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Optional IE Incorrect."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 115 }
+
+jnxMbgSgwPPGtpV2ICsSysFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause System Failure."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 116 }
+
+jnxMbgSgwPPGtpV2ICsSysFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause System Failure."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 117 }
+
+jnxMbgSgwPPGtpV2ICsNoResRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Resource."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 118 }
+
+jnxMbgSgwPPGtpV2ICsNoResTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause No Resource."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 119 }
+
+jnxMbgSgwPPGtpV2ICsTFTSMANTErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT Symantic Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 120 }
+
+jnxMbgSgwPPGtpV2ICsTFTSMANTErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause TFT Symantic Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 121 }
+
+jnxMbgSgwPPGtpV2ICsTFTSysErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT System Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 122 }
+
+jnxMbgSgwPPGtpV2ICsTFTSysErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause TFT System Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 123 }
+
+jnxMbgSgwPPGtpV2ICsPkFltManErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Symantic Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 124 }
+
+jnxMbgSgwPPGtpV2ICsPkFltManErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Packet Filter Symantic Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 125 }
+
+jnxMbgSgwPPGtpV2ICsPkFltSynErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Syntax Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 126 }
+
+jnxMbgSgwPPGtpV2ICsPkFltSynErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Packet Filter Syntax Error."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 127 }
+
+jnxMbgSgwPPGtpV2ICsMisUnknAPNRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unknown APN."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 128 }
+
+jnxMbgSgwPPGtpV2ICsMisUnknAPNTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unknown APN."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 129 }
+
+jnxMbgSgwPPGtpV2ICsUnexpRptIERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unexpected Repeated IE."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 130 }
+
+jnxMbgSgwPPGtpV2ICsUnexpRptIETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unexpected Repeated IE."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 131 }
+
+jnxMbgSgwPPGtpV2ICsGREKeyNtFdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause GRE Key Not Found."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 132 }
+
+jnxMbgSgwPPGtpV2ICsGREKeyNtFdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause GRE Key Not Found."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 133 }
+
+jnxMbgSgwPPGtpV2ICsRelocFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Relocation Failed."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 134 }
+
+jnxMbgSgwPPGtpV2ICsRelocFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Relocation Failed."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 135 }
+
+jnxMbgSgwPPGtpV2ICsDenINRatRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Denied in RAT."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 136 }
+
+jnxMbgSgwPPGtpV2ICsDenINRatTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Denied in RAT."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 137 }
+
+jnxMbgSgwPPGtpV2ICsPTNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause PDN Type Not Supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 138 }
+
+jnxMbgSgwPPGtpV2ICsPTNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause PDN Type Not Supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 139 }
+
+jnxMbgSgwPPGtpV2ICsAllDynAdOcRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 140 }
+
+jnxMbgSgwPPGtpV2ICsAllDynAdOcTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 141 }
+
+jnxMbgSgwPPGtpV2ICsNOTFTUECTXRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Context Without TFT Exists."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 142 }
+
+jnxMbgSgwPPGtpV2ICsNOTFTUECTXTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Context Without TFT Exists."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 143 }
+
+jnxMbgSgwPPGtpV2ICsProtoNtSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Protocol Not Supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 144 }
+
+jnxMbgSgwPPGtpV2ICsProtoNtSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Protocol Not Supported."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 145 }
+
+jnxMbgSgwPPGtpV2ICsUENotRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Not Responding."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 146 }
+
+jnxMbgSgwPPGtpV2ICsUENotRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Not Responding."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 147 }
+
+jnxMbgSgwPPGtpV2ICsUERefusesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Refuses."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 148 }
+
+jnxMbgSgwPPGtpV2ICsUERefusesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Refuses."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 149 }
+
+jnxMbgSgwPPGtpV2ICsServDeniedRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Denied."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 150 }
+
+jnxMbgSgwPPGtpV2ICsServDeniedTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Service Denied."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 151 }
+
+jnxMbgSgwPPGtpV2ICsUnabPageUERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unable to Page UE."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 152 }
+
+jnxMbgSgwPPGtpV2ICsUnabPageUETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unable to Page UE."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 153 }
+
+jnxMbgSgwPPGtpV2ICsNoMemRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Memory."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 154 }
+
+jnxMbgSgwPPGtpV2ICsNoMemTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause No Memory."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 155 }
+
+jnxMbgSgwPPGtpV2ICsUserAUTHFlRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause User AUTH Failed."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 156 }
+
+jnxMbgSgwPPGtpV2ICsUserAUTHFlTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause User AUTH Failed."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 157 }
+
+jnxMbgSgwPPGtpV2ICsAPNAcsDenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause APN Access Denied."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 158 }
+
+jnxMbgSgwPPGtpV2ICsAPNAcsDenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause APN Access Denied."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 159 }
+
+jnxMbgSgwPPGtpV2ICsReqRejRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Rejected."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 160 }
+
+jnxMbgSgwPPGtpV2ICsReqRejTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Request Rejected."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 161 }
+
+jnxMbgSgwPPGtpV2ICsPTMSISigMMRx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets received with cause P-TMSI Signature Mismatch."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 162 }
+
+jnxMbgSgwPPGtpV2ICsPTMSISigMMTx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTP packets sent with cause P-TMSI Signature Mismatch."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 163 }
+
+jnxMbgSgwPPGtpV2ICsIMSINotKnRx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets received with cause IMSI Not Known."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 164 }
+
+jnxMbgSgwPPGtpV2ICsIMSINotKnTx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTP packets sent with cause IMSI Not Known."
+    ::= { jnxMbgSgwGtpPerPeerStatsEntry 165 }
+
+jnxMbgSgwPPGtpV2ICsCondIEMsRx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets received with cause Conditional IE Missing."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 166 }
+
+jnxMbgSgwPPGtpV2ICsCondIEMsTx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTP packets sent with cause Conditional IE Missing."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 167 }
+
+jnxMbgSgwPPGtpV2ICsAPNResTIncRx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets received with cause APN Restriction Type Incompatible."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 168 }
+
+jnxMbgSgwPPGtpV2ICsAPNResTIncTx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTP packets sent with cause APN Restriction Type Incompatible."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 169 }
+
+jnxMbgSgwPPGtpV2ICsUnknownRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets received with cause Unknown."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 170 }
+
+jnxMbgSgwPPGtpV2ICsUnknownTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unknown."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 171 }
+
+jnxMbgSgwPPGtpV2ICsLclDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Local Detach."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 172 }
+
+jnxMbgSgwPPGtpV2ICsLclDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Local Detach."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 173 }
+
+jnxMbgSgwPPGtpV2ICsCmpDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Complete Detach."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 174 }
+
+jnxMbgSgwPPGtpV2ICsCmpDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Complete Detach."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 175 }
+
+jnxMbgSgwPPGtpV2ICsRATChgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 176 }
+
+jnxMbgSgwPPGtpV2ICsRATChgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 177 }
+
+jnxMbgSgwPPGtpV2ICsISRDeactRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause ISR Deactivated."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 178 }
+
+jnxMbgSgwPPGtpV2ICsISRDeactTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause ISR Deactivated."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 179 }
+
+jnxMbgSgwPPGtpV2ICsEIFRNCEnRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 180 }
+
+jnxMbgSgwPPGtpV2ICsEIFRNCEnTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 181 }
+
+jnxMbgSgwPPGtpV2ICsSemErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 182 }
+
+jnxMbgSgwPPGtpV2ICsSemErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 183 }
+
+jnxMbgSgwPPGtpV2ICsSynErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 184 }
+
+jnxMbgSgwPPGtpV2ICsSynErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 185 }
+
+jnxMbgSgwPPGtpV2ICsRMValRcvRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Reserved Message Value Received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 186 }
+
+jnxMbgSgwPPGtpV2ICsRMValRcvTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Reserved Message Value Received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 187 }
+
+jnxMbgSgwPPGtpV2ICsRPrNtRspRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Remote peer not responding."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 188 }
+
+jnxMbgSgwPPGtpV2ICsRPrNtRspTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Remote peer not responding."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 189 }
+
+jnxMbgSgwPPGtpV2ICsColNWReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Collision with network initiated request."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 190 }
+
+jnxMbgSgwPPGtpV2ICsColNWReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Collision with network initiated request."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 191 }
+
+jnxMbgSgwPPGtpV2ICsUnPgUESusRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Unable to page UE due to suspension."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 192 }
+
+jnxMbgSgwPPGtpV2ICsUnPgUESusTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unable to page UE due to suspension."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 193 }
+
+jnxMbgSgwPPGtpV2ICsInvTotLenRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid total len."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 194 }
+
+jnxMbgSgwPPGtpV2ICsInvTotLenTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid total len."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 195 }
+
+jnxMbgSgwPPGtpV2ICsDtForNtSupRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Data forwarding not supported."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 196 }
+
+jnxMbgSgwPPGtpV2ICsDtForNtSupTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Data forwarding not supported."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 197 }
+
+jnxMbgSgwPPGtpV2ICsInReFRePrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 198 }
+
+jnxMbgSgwPPGtpV2ICsInReFRePrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 199 }
+
+jnxMbgSgwPPGtpV2ICsInvPrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid peer."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 200 }
+
+jnxMbgSgwPPGtpV2ICsInvPrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid peer."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 201 }
+
+jnxMbgSgwPPGtpV1ProtocolErrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv1 Protocol Errors Received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 202 }
+
+jnxMbgSgwPPGtpV1UnSupMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv1 Unsupported Messages received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 203 }
+
+jnxMbgSgwPPGtpV1T3RespTmrExpRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 T3 timer expiries Received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 204 }
+
+jnxMbgSgwPPGtpV1EndMarkerRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 end marker packets received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 205 }
+
+jnxMbgSgwPPGtpV1EndMarkerTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 end marker packets sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 206 }
+
+jnxMbgSgwPPGtpV1EchoReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo request packets received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 207 }
+
+jnxMbgSgwPPGtpV1EchoReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP iV1 echo request packets sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 208 }
+
+jnxMbgSgwPPGtpV1EchoRespRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo response packets received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 209 }
+
+jnxMbgSgwPPGtpV1EchoRespTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo response packets sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 210 }
+
+jnxMbgSgwPPGtpV1ErrIndRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 Error Indication packets received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 211 }
+
+jnxMbgSgwPPGtpV1ErrIndTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 Error Indication packets sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 212 }
+
+jnxMbgSgwPPSuspNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 213 } 
+
+jnxMbgSgwPPSuspNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 214 } 
+
+jnxMbgSgwPPSuspAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 215 }
+
+jnxMbgSgwPPSuspAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 216 }
+
+jnxMbgSgwPPResumeNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 217 }
+    
+jnxMbgSgwPPResumeNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 218 }
+
+jnxMbgSgwPPResumeAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 219 }
+   
+jnxMbgSgwPPResumeAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 220 }
+
+jnxMbgSgwPPPiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Piggyback messages received."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 221 }
+    
+jnxMbgSgwPPPiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S11 Piggyback messages sent."
+     ::= { jnxMbgSgwGtpPerPeerStatsEntry 222 }
+
+--
+-- GTP Object for showing GTP Interface Statistics
+--
+jnxMbgSgwGtpIfStatsTable  OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgSgwGtpIfStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to an interface level GTP statistic."
+    ::= { jnxMbgSgwGtpObjects 4 }
+
+jnxMbgSgwGtpIfStatsEntry OBJECT-TYPE
+    SYNTAX      JnxMbgSgwGtpIfStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the GTP interface level control Statistics."
+    INDEX     { jnxMbgGwIndex,
+                jnxMbgSgwIfIndex }
+    ::= { jnxMbgSgwGtpIfStatsTable 1}
+
+JnxMbgSgwGtpIfStatsEntry ::= SEQUENCE {
+    jnxMbgSgwIfIndex                Unsigned32,
+    jnxMbgSgwIfType                 DisplayString,
+    jnxMbgSgwIfRxPacketsDropped     Counter64,
+    jnxMbgSgwIfPacketAllocFail      Counter64,
+    jnxMbgSgwIfPacketSendFail       Counter64,
+    jnxMbgSgwIfIPVerErrRx           Counter64,
+    jnxMbgSgwIfIPProtoErrRx         Counter64,
+    jnxMbgSgwIfGTPPortErrRx         Counter64,
+    jnxMbgSgwIfGTPUnknVerRx         Counter64,
+    jnxMbgSgwIfPcktLenErrRx         Counter64,
+    jnxMbgSgwIfUnknMsgRx            Counter64,
+    jnxMbgSgwIfProtocolErrRx        Counter64,
+    jnxMbgSgwIfUnSupportedMsgRx     Counter64,
+    jnxMbgSgwIfT3RespTmrExpRx       Counter64,
+    jnxMbgSgwIfV2NumMsgRx           Counter64,
+    jnxMbgSgwIfV2NumMsgTx           Counter64,
+    jnxMbgSgwIfV2NumBytesRx         Counter64,
+    jnxMbgSgwIfV2NumBytesTx         Counter64,
+    jnxMbgSgwIfV2EchoReqRx          Counter64,
+    jnxMbgSgwIfV2EchoReqTx          Counter64,
+    jnxMbgSgwIfV2EchoRespRx         Counter64,
+    jnxMbgSgwIfV2EchoRespTx         Counter64,
+    jnxMbgSgwIfV2VerNotSupRx        Counter64,
+    jnxMbgSgwIfV2VerNotSupTx        Counter64,
+    jnxMbgSgwIfCreateSessReqRx      Counter64,
+    jnxMbgSgwIfCreateSessReqTx      Counter64,
+    jnxMbgSgwIfCreateSessRspRx      Counter64,
+    jnxMbgSgwIfCreateSessRspTx      Counter64,
+    jnxMbgSgwIfModBrReqRx           Counter64,
+    jnxMbgSgwIfModBrReqTx           Counter64,
+    jnxMbgSgwIfModBrRspRx           Counter64,
+    jnxMbgSgwIfModBrRspTx           Counter64,
+    jnxMbgSgwIfDelSessReqRx         Counter64,
+    jnxMbgSgwIfDelSessReqTx         Counter64,
+    jnxMbgSgwIfDelSessRspRx         Counter64,
+    jnxMbgSgwIfDelSessRspTx         Counter64,
+    jnxMbgSgwIfCrtBrReqRx           Counter64,
+    jnxMbgSgwIfCrtBrReqTx           Counter64,
+    jnxMbgSgwIfCrtBrRspRx           Counter64,
+    jnxMbgSgwIfCrtBrRspTx           Counter64,
+    jnxMbgSgwIfUpdBrReqRx           Counter64,
+    jnxMbgSgwIfUpdBrReqTx           Counter64,
+    jnxMbgSgwIfUpdBrRspRx           Counter64,
+    jnxMbgSgwIfUpdBrRspTx           Counter64,
+    jnxMbgSgwIfDelBrReqRx           Counter64,
+    jnxMbgSgwIfDelBrReqTx           Counter64,
+    jnxMbgSgwIfDelBrRspRx           Counter64,
+    jnxMbgSgwIfDelBrRspTx           Counter64,
+    jnxMbgSgwIfDelConnSetReqRx      Counter64,
+    jnxMbgSgwIfDelConnSetReqTx      Counter64,
+    jnxMbgSgwIfDelConnSetRspRx      Counter64,
+    jnxMbgSgwIfDelConnSetRspTx      Counter64,
+    jnxMbgSgwIfUpdConnSetReqRx      Counter64,
+    jnxMbgSgwIfUpdConnSetReqTx      Counter64,
+    jnxMbgSgwIfUpdConnSetRspRx      Counter64,
+    jnxMbgSgwIfUpdConnSetRspTx      Counter64,
+    jnxMbgSgwIfModBrCmdRx           Counter64,
+    jnxMbgSgwIfModBrCmdTx           Counter64,
+    jnxMbgSgwIfModBrFlrIndRx        Counter64,
+    jnxMbgSgwIfModBrFlrIndTx        Counter64,
+    jnxMbgSgwIfDelBrCmdRx           Counter64,
+    jnxMbgSgwIfDelBrCmdTx           Counter64,
+    jnxMbgSgwIfDelBrFlrIndRx        Counter64,
+    jnxMbgSgwIfDelBrFlrIndTx        Counter64,
+    jnxMbgSgwIfBrResCmdRx           Counter64,
+    jnxMbgSgwIfBrResCmdTx           Counter64,
+    jnxMbgSgwIfBrResFlrIndRx        Counter64,
+    jnxMbgSgwIfBrResFlrIndTx        Counter64,
+    jnxMbgSgwIfRelAcsBrReqRx        Counter64,
+    jnxMbgSgwIfRelAcsBrReqTx        Counter64,
+    jnxMbgSgwIfRelAcsBrRespRx       Counter64,
+    jnxMbgSgwIfRelAcsBrRespTx       Counter64,
+    jnxMbgSgwIfCrIndTunReqRx        Counter64,
+    jnxMbgSgwIfCrIndTunReqTx        Counter64,
+    jnxMbgSgwIfCrIndTunRespRx       Counter64,
+    jnxMbgSgwIfCrIndTunRespTx       Counter64,
+    jnxMbgSgwIfDelIndTunReqRx       Counter64,
+    jnxMbgSgwIfDelIndTunReqTx       Counter64,
+    jnxMbgSgwIfDelIndTunRespRx      Counter64,
+    jnxMbgSgwIfDelIndTunRespTx      Counter64,
+    jnxMbgSgwIfDlDataNotifRx        Counter64,
+    jnxMbgSgwIfDlDataNotifTx        Counter64,
+    jnxMbgSgwIfDlDataAckRx          Counter64,
+    jnxMbgSgwIfDlDataAckTx          Counter64,
+    jnxMbgSgwIfDlDataNotiFlrIndRx   Counter64,
+    jnxMbgSgwIfDlDataNotiFlrIndTx   Counter64,
+    jnxMbgSgwIfStopPagingIndRx      Counter64,
+    jnxMbgSgwIfStopPagingIndTx      Counter64,
+    jnxMbgSgwIfGtpV2ICsReqAcceptRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsReqAcceptTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsAcceptPartRx Counter64,
+    jnxMbgSgwIfGtpV2ICsAcceptPartTx Counter64,
+    jnxMbgSgwIfGtpV2ICsNewPTNPrefRx Counter64,
+    jnxMbgSgwIfGtpV2ICsNewPTNPrefTx Counter64,
+    jnxMbgSgwIfGtpV2ICsNPTSIAdbrRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsNPTSIAdbrTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsCtxNotFndRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsCtxNotFndTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsInvMsgFmtRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsInvMsgFmtTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsVerNotSuppRx Counter64,
+    jnxMbgSgwIfGtpV2ICsVerNotSuppTx Counter64,
+    jnxMbgSgwIfGtpV2ICsInvLenRx     Counter64,
+    jnxMbgSgwIfGtpV2ICsInvLenTx     Counter64,
+    jnxMbgSgwIfGtpV2ICsSrvNotSuppRx Counter64,
+    jnxMbgSgwIfGtpV2ICsSrvNotSuppTx Counter64,
+    jnxMbgSgwIfGtpV2ICsManIEIncorRx Counter64,
+    jnxMbgSgwIfGtpV2ICsManIEIncorTx Counter64,
+    jnxMbgSgwIfGtpV2ICsManIEMissRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsManIEMissTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsOptIEIncorRx Counter64,
+    jnxMbgSgwIfGtpV2ICsOptIEIncorTx Counter64,
+    jnxMbgSgwIfGtpV2ICsSysFailRx    Counter64,
+    jnxMbgSgwIfGtpV2ICsSysFailTx    Counter64,
+    jnxMbgSgwIfGtpV2ICsNoResRx      Counter64,
+    jnxMbgSgwIfGtpV2ICsNoResTx      Counter64,
+    jnxMbgSgwIfGtpV2ICsTFTSMANTErRx Counter64,
+    jnxMbgSgwIfGtpV2ICsTFTSMANTErTx Counter64,
+    jnxMbgSgwIfGtpV2ICsTFTSysErrRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsTFTSysErrTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsPkFltManErRx Counter64,
+    jnxMbgSgwIfGtpV2ICsPkFltManErTx Counter64,
+    jnxMbgSgwIfGtpV2ICsPkFltSynErRx Counter64,
+    jnxMbgSgwIfGtpV2ICsPkFltSynErTx Counter64,
+    jnxMbgSgwIfGtpV2ICsMisUnknAPNRx Counter64,
+    jnxMbgSgwIfGtpV2ICsMisUnknAPNTx Counter64,
+    jnxMbgSgwIfGtpV2ICsUnexpRptIERx Counter64,
+    jnxMbgSgwIfGtpV2ICsUnexpRptIETx Counter64,
+    jnxMbgSgwIfGtpV2ICsGREKeyNtFdRx Counter64,
+    jnxMbgSgwIfGtpV2ICsGREKeyNtFdTx Counter64,
+    jnxMbgSgwIfGtpV2ICsRelocFailRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsRelocFailTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsDenINRatRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsDenINRatTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsPTNotSuppRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsPTNotSuppTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsAlDynAdOccRx Counter64,
+    jnxMbgSgwIfGtpV2ICsAlDynAdOccTx Counter64,
+    jnxMbgSgwIfGtpV2ICsNOTFTUECTXRx Counter64,
+    jnxMbgSgwIfGtpV2ICsNOTFTUECTXTx Counter64,
+    jnxMbgSgwIfGtpV2ICsProtoNtSupRx Counter64,
+    jnxMbgSgwIfGtpV2ICsProtoNtSupTx Counter64,
+    jnxMbgSgwIfGtpV2ICsUENotRespRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsUENotRespTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsUERefusesRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsUERefusesTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsServDeniedRx Counter64,
+    jnxMbgSgwIfGtpV2ICsServDeniedTx Counter64,
+    jnxMbgSgwIfGtpV2ICsUnabPageUERx Counter64,
+    jnxMbgSgwIfGtpV2ICsUnabPageUETx Counter64,
+    jnxMbgSgwIfGtpV2ICsNoMemRx      Counter64,
+    jnxMbgSgwIfGtpV2ICsNoMemTx      Counter64,
+    jnxMbgSgwIfGtpV2ICsUserAUTHFlRx Counter64,
+    jnxMbgSgwIfGtpV2ICsUserAUTHFlTx Counter64,
+    jnxMbgSgwIfGtpV2ICsAPNAcsDenRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsAPNAcsDenTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsReqRejRx     Counter64,
+    jnxMbgSgwIfGtpV2ICsReqRejTx     Counter64,
+    jnxMbgSgwIfGtpV2ICsPTMSISigMMRx Counter64,
+    jnxMbgSgwIfGtpV2ICsPTMSISigMMTx Counter64,
+    jnxMbgSgwIfGtpV2ICsIMSINotKnRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsIMSINotKnTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsCondIEMsRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsCondIEMsTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsAPNResTIncRx Counter64,
+    jnxMbgSgwIfGtpV2ICsAPNResTIncTx Counter64,
+    jnxMbgSgwIfGtpV2ICsUnknownRx    Counter64,
+    jnxMbgSgwIfGtpV2ICsUnknownTx    Counter64,
+    jnxMbgSgwIfGtpV2ICsLclDetRx     Counter64,
+    jnxMbgSgwIfGtpV2ICsLclDetTx     Counter64,
+    jnxMbgSgwIfGtpV2ICsCmpDetRx     Counter64,
+    jnxMbgSgwIfGtpV2ICsCmpDetTx     Counter64,
+    jnxMbgSgwIfGtpV2ICsRATChgRx     Counter64,
+    jnxMbgSgwIfGtpV2ICsRATChgTx     Counter64,
+    jnxMbgSgwIfGtpV2ICsISRDeactRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsISRDeactTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsEIFRNCEnRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsEIFRNCEnTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsSemErTADRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsSemErTADTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsSynErTADRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsSynErTADTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsRMValRcvRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsRMValRcvTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsRPrNtRspRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsRPrNtRspTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsColNWReqRx   Counter64,
+    jnxMbgSgwIfGtpV2ICsColNWReqTx   Counter64,
+    jnxMbgSgwIfGtpV2ICsUnPgUESusRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsUnPgUESusTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsInvTotLenRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsInvTotLenTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsDtForNtSupRx Counter64,
+    jnxMbgSgwIfGtpV2ICsDtForNtSupTx Counter64,
+    jnxMbgSgwIfGtpV2ICsInReFRePrRx  Counter64,
+    jnxMbgSgwIfGtpV2ICsInReFRePrTx  Counter64,
+    jnxMbgSgwIfGtpV2ICsInvPrRx      Counter64,
+    jnxMbgSgwIfGtpV2ICsInvPrTx      Counter64,
+    jnxMbgSgwIfGtpV1ProtocolErrRx   Counter64,
+    jnxMbgSgwIfGtpV1UnSupMsgRx      Counter64,
+    jnxMbgSgwIfGtpV1T3RespTmrExpRx  Counter64,
+    jnxMbgSgwIfGtpV1EndMarkerRx     Counter64,
+    jnxMbgSgwIfGtpV1EndMarkerTx     Counter64,
+    jnxMbgSgwIfGtpV1EchoReqRx       Counter64,
+    jnxMbgSgwIfGtpV1EchoReqTx       Counter64,
+    jnxMbgSgwIfGtpV1EchoRespRx      Counter64,
+    jnxMbgSgwIfGtpV1EchoRespTx      Counter64,
+    jnxMbgSgwIfGtpV1ErrIndRx        Counter64,
+    jnxMbgSgwIfGtpV1ErrIndTx        Counter64,
+    jnxMbgSgwIfSuspNotifRx          Counter64,
+    jnxMbgSgwIfSuspNotifTx          Counter64,
+    jnxMbgSgwIfSuspAckRx            Counter64,
+    jnxMbgSgwIfSuspAckTx            Counter64,
+    jnxMbgSgwIfResumeNotifRx        Counter64,
+    jnxMbgSgwIfResumeNotifTx        Counter64,
+    jnxMbgSgwIfResumeAckRx          Counter64,
+    jnxMbgSgwIfResumeAckTx          Counter64,
+    jnxMbgSgwIfPiggybackMsgRx       Counter64,
+    jnxMbgSgwIfPiggybackMsgTx       Counter64
+}
+
+jnxMbgSgwIfIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+    "GTP Interface Index"
+    ::= { jnxMbgSgwGtpIfStatsEntry 1 }
+
+jnxMbgSgwIfType OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Interface Name."
+    ::= { jnxMbgSgwGtpIfStatsEntry 2 }
+
+jnxMbgSgwIfRxPacketsDropped  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Received GTP Packets Dropped by the Gateway."
+    ::= { jnxMbgSgwGtpIfStatsEntry 3 }
+
+jnxMbgSgwIfPacketAllocFail  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet allocation failures in the Gateway."
+    ::= { jnxMbgSgwGtpIfStatsEntry 4 }
+
+jnxMbgSgwIfPacketSendFail OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP Packet Send failures in the Gateway."
+    ::= { jnxMbgSgwGtpIfStatsEntry 5 }
+
+jnxMbgSgwIfIPVerErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of IP Version Error Packets Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 6 }
+
+jnxMbgSgwIfIPProtoErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  IP Protocol Error packets Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 7 }
+
+jnxMbgSgwIfGTPPortErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Port Error Packets Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 8 }
+
+jnxMbgSgwIfGTPUnknVerRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Version Packets Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 9 }
+
+jnxMbgSgwIfPcktLenErrRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of Packet Length Error Packets Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 10 }
+
+jnxMbgSgwIfUnknMsgRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of  Unknown Messages Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 11 }
+
+jnxMbgSgwIfProtocolErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Protocol Errors Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 12 }
+
+jnxMbgSgwIfUnSupportedMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 Unsupported Messages received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 13 }
+
+jnxMbgSgwIfT3RespTmrExpRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 T3 timer expiries Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 14 }
+
+jnxMbgSgwIfV2NumMsgRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 messages received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 15 }
+
+jnxMbgSgwIfV2NumMsgTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of V2 messages sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 16 }
+
+jnxMbgSgwIfV2NumBytesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPv2 bytes received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 17 }
+
+jnxMbgSgwIfV2NumBytesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of V2 bytes sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 18 }
+
+jnxMbgSgwIfV2EchoReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 19 }
+
+jnxMbgSgwIfV2EchoReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Request Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 20 }
+
+jnxMbgSgwIfV2EchoRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 21 }
+
+jnxMbgSgwIfV2EchoRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Echo Response Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 22 }
+
+jnxMbgSgwIfV2VerNotSupRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Version Not supported messages received"
+    ::= { jnxMbgSgwGtpIfStatsEntry 23 }
+
+jnxMbgSgwIfV2VerNotSupTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 version not supported messages sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 24 }
+
+jnxMbgSgwIfCreateSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 25 }
+
+jnxMbgSgwIfCreateSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Requests Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 26 }
+
+jnxMbgSgwIfCreateSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 27 }
+
+jnxMbgSgwIfCreateSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Session Responses Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 28 }
+
+jnxMbgSgwIfModBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 29 }
+
+jnxMbgSgwIfModBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Requests Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 30 }
+
+jnxMbgSgwIfModBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 31 }
+
+jnxMbgSgwIfModBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Responses Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 32 }
+
+jnxMbgSgwIfDelSessReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 33 }
+
+jnxMbgSgwIfDelSessReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Requests Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 34 }
+
+jnxMbgSgwIfDelSessRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 35 }
+
+jnxMbgSgwIfDelSessRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Session Responses Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 36 }
+
+jnxMbgSgwIfCrtBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 37 }
+
+jnxMbgSgwIfCrtBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Requests Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 38 }
+
+jnxMbgSgwIfCrtBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 39 }
+
+jnxMbgSgwIfCrtBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Bearer Response Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 40 }
+
+jnxMbgSgwIfUpdBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 41 }
+
+jnxMbgSgwIfUpdBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Request Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 42 }
+
+jnxMbgSgwIfUpdBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 43 }
+
+jnxMbgSgwIfUpdBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Bearer Response Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 44 }
+
+jnxMbgSgwIfDelBrReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 45 }
+
+jnxMbgSgwIfDelBrReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Request Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 46 }
+
+jnxMbgSgwIfDelBrRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 47 }
+
+jnxMbgSgwIfDelBrRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Response Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 48 }
+
+jnxMbgSgwIfDelConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Request received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 49 }
+
+jnxMbgSgwIfDelConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Request Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 50 }
+
+jnxMbgSgwIfDelConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 51 }
+
+jnxMbgSgwIfDelConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete PDN connection set Response Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 52 }
+
+jnxMbgSgwIfUpdConnSetReqRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 53 }
+
+jnxMbgSgwIfUpdConnSetReqTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Request Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 54 }
+
+jnxMbgSgwIfUpdConnSetRspRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 55 }
+
+jnxMbgSgwIfUpdConnSetRspTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Update Connection set Response Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 56 }
+
+jnxMbgSgwIfModBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 57 }
+
+jnxMbgSgwIfModBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Command Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 58 }
+
+jnxMbgSgwIfModBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 59 }
+
+jnxMbgSgwIfModBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Modify Bearer Failure Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 60 }
+
+jnxMbgSgwIfDelBrCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 61 }
+
+jnxMbgSgwIfDelBrCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Command Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 62 }
+
+jnxMbgSgwIfDelBrFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 63 }
+
+jnxMbgSgwIfDelBrFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Bearer Failure Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 64 }
+
+jnxMbgSgwIfBrResCmdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 65 }
+
+jnxMbgSgwIfBrResCmdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Response Command Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 66 }
+
+jnxMbgSgwIfBrResFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 67 }
+
+jnxMbgSgwIfBrResFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Bearer Resource Failure Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 68 }
+
+jnxMbgSgwIfRelAcsBrReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 69 }
+
+jnxMbgSgwIfRelAcsBrReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Requests sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 70 }
+
+jnxMbgSgwIfRelAcsBrRespRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 71 }
+
+jnxMbgSgwIfRelAcsBrRespTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Release Access Bearer Response sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 72 }
+
+jnxMbgSgwIfCrIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgSgwGtpIfStatsEntry 73 }
+
+jnxMbgSgwIfCrIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Request sent"
+    ::= { jnxMbgSgwGtpIfStatsEntry 74 }
+
+jnxMbgSgwIfCrIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Response Received"
+    ::= { jnxMbgSgwGtpIfStatsEntry 75 }
+
+jnxMbgSgwIfCrIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Create Indirect Tunnel Forward Response sent"
+    ::= { jnxMbgSgwGtpIfStatsEntry 76 }
+
+jnxMbgSgwIfDelIndTunReqRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request Received"
+    ::= { jnxMbgSgwGtpIfStatsEntry 77 }
+
+jnxMbgSgwIfDelIndTunReqTx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Request sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 78 }
+
+jnxMbgSgwIfDelIndTunRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Response Received"
+    ::= { jnxMbgSgwGtpIfStatsEntry 79 }
+
+jnxMbgSgwIfDelIndTunRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Delete Indirect Tunnel Forward Response sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 80 }
+
+jnxMbgSgwIfDlDataNotifRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 81 }
+
+jnxMbgSgwIfDlDataNotifTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 82 }
+
+jnxMbgSgwIfDlDataAckRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgement received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 83 }
+
+jnxMbgSgwIfDlDataAckTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notify Acknowledgement Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 84 }
+
+jnxMbgSgwIfDlDataNotiFlrIndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 85 }
+
+jnxMbgSgwIfDlDataNotiFlrIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Downlink Data Notification fail Sent."
+    ::= { jnxMbgSgwGtpIfStatsEntry 86 }
+
+jnxMbgSgwIfStopPagingIndRx OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of Stop Paging Indication Messages Received."
+    ::= { jnxMbgSgwGtpIfStatsEntry 87 }
+
+jnxMbgSgwIfStopPagingIndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP V2 Number of Stop Paging Indicaton messages sent"
+    ::= { jnxMbgSgwGtpIfStatsEntry 88 }
+
+jnxMbgSgwIfGtpV2ICsReqAcceptRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Accept."
+    ::= { jnxMbgSgwGtpIfStatsEntry 89 }
+
+jnxMbgSgwIfGtpV2ICsReqAcceptTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Request Accept."
+    ::= { jnxMbgSgwGtpIfStatsEntry 90 }
+
+jnxMbgSgwIfGtpV2ICsAcceptPartRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Accept Partial."
+    ::= { jnxMbgSgwGtpIfStatsEntry 91 }
+
+jnxMbgSgwIfGtpV2ICsAcceptPartTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Accept Partial."
+    ::= { jnxMbgSgwGtpIfStatsEntry 92 }
+
+jnxMbgSgwIfGtpV2ICsNewPTNPrefRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Network Preference."
+    ::= { jnxMbgSgwGtpIfStatsEntry 93 }
+
+jnxMbgSgwIfGtpV2ICsNewPTNPrefTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause New PDN type due to Network Preference"
+    ::= { jnxMbgSgwGtpIfStatsEntry 94 }
+
+
+jnxMbgSgwIfGtpV2ICsNPTSIAdbrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgSgwGtpIfStatsEntry 95 }
+
+jnxMbgSgwIfGtpV2ICsNPTSIAdbrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause New PDN type due to Single Address Bearer."
+    ::= { jnxMbgSgwGtpIfStatsEntry 96 }
+
+jnxMbgSgwIfGtpV2ICsCtxNotFndRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Context not found."
+    ::= { jnxMbgSgwGtpIfStatsEntry 97 }
+
+jnxMbgSgwIfGtpV2ICsCtxNotFndTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Context not found."
+    ::= { jnxMbgSgwGtpIfStatsEntry 98 }
+
+jnxMbgSgwIfGtpV2ICsInvMsgFmtRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Message Format."
+    ::= { jnxMbgSgwGtpIfStatsEntry 99 }
+
+jnxMbgSgwIfGtpV2ICsInvMsgFmtTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Invalid Message Format."
+    ::= { jnxMbgSgwGtpIfStatsEntry 100 }
+
+jnxMbgSgwIfGtpV2ICsVerNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Version not Supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 101 }
+
+jnxMbgSgwIfGtpV2ICsVerNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Version not Supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 102 }
+
+jnxMbgSgwIfGtpV2ICsInvLenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Invalid Length."
+    ::= { jnxMbgSgwGtpIfStatsEntry 103 }
+
+jnxMbgSgwIfGtpV2ICsInvLenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Invalid Length."
+    ::= { jnxMbgSgwGtpIfStatsEntry 104 }
+
+jnxMbgSgwIfGtpV2ICsSrvNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Not supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 105 }
+
+jnxMbgSgwIfGtpV2ICsSrvNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Service Not supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 106 }
+
+jnxMbgSgwIfGtpV2ICsManIEIncorRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE incorrect."
+    ::= { jnxMbgSgwGtpIfStatsEntry 107 }
+
+jnxMbgSgwIfGtpV2ICsManIEIncorTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Mandatory IE incorrect."
+    ::= { jnxMbgSgwGtpIfStatsEntry 108 }
+
+jnxMbgSgwIfGtpV2ICsManIEMissRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Mandatory IE Missing."
+    ::= { jnxMbgSgwGtpIfStatsEntry 109 }
+
+jnxMbgSgwIfGtpV2ICsManIEMissTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Mandatory IE Missing."
+    ::= { jnxMbgSgwGtpIfStatsEntry 110 }
+
+jnxMbgSgwIfGtpV2ICsOptIEIncorRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Optional IE Incorrect."
+    ::= { jnxMbgSgwGtpIfStatsEntry 111 }
+
+jnxMbgSgwIfGtpV2ICsOptIEIncorTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Optional IE Incorrect."
+    ::= { jnxMbgSgwGtpIfStatsEntry 112 }
+
+jnxMbgSgwIfGtpV2ICsSysFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause System Failure."
+    ::= { jnxMbgSgwGtpIfStatsEntry 113 }
+
+jnxMbgSgwIfGtpV2ICsSysFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause System Failure."
+    ::= { jnxMbgSgwGtpIfStatsEntry 114 }
+
+jnxMbgSgwIfGtpV2ICsNoResRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Resource."
+    ::= { jnxMbgSgwGtpIfStatsEntry 115 }
+
+jnxMbgSgwIfGtpV2ICsNoResTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause No Resource."
+    ::= { jnxMbgSgwGtpIfStatsEntry 116 }
+
+jnxMbgSgwIfGtpV2ICsTFTSMANTErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT Symantic Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 117 }
+
+jnxMbgSgwIfGtpV2ICsTFTSMANTErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause TFT Symantic Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 118 }
+
+jnxMbgSgwIfGtpV2ICsTFTSysErrRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause TFT System Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 119 }
+
+jnxMbgSgwIfGtpV2ICsTFTSysErrTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause TFT System Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 120 }
+
+jnxMbgSgwIfGtpV2ICsPkFltManErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Symantic Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 121 }
+
+jnxMbgSgwIfGtpV2ICsPkFltManErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Packet Filter Symantic Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 122 }
+
+jnxMbgSgwIfGtpV2ICsPkFltSynErRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Packet Filter Syntax Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 123 }
+
+jnxMbgSgwIfGtpV2ICsPkFltSynErTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Packet Filter Syntax Error."
+    ::= { jnxMbgSgwGtpIfStatsEntry 124 }
+
+jnxMbgSgwIfGtpV2ICsMisUnknAPNRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unknown APN."
+    ::= { jnxMbgSgwGtpIfStatsEntry 125 }
+
+jnxMbgSgwIfGtpV2ICsMisUnknAPNTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unknown APN."
+    ::= { jnxMbgSgwGtpIfStatsEntry 126 }
+
+jnxMbgSgwIfGtpV2ICsUnexpRptIERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unexpected Repeated IE."
+    ::= { jnxMbgSgwGtpIfStatsEntry 127 }
+
+jnxMbgSgwIfGtpV2ICsUnexpRptIETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unexpected Repeated IE."
+    ::= { jnxMbgSgwGtpIfStatsEntry 128 }
+
+jnxMbgSgwIfGtpV2ICsGREKeyNtFdRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause GRE Key Not Found."
+    ::= { jnxMbgSgwGtpIfStatsEntry 129 }
+
+jnxMbgSgwIfGtpV2ICsGREKeyNtFdTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause GRE Key Not Found."
+    ::= { jnxMbgSgwGtpIfStatsEntry 130 }
+
+jnxMbgSgwIfGtpV2ICsRelocFailRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Relocation Failed."
+    ::= { jnxMbgSgwGtpIfStatsEntry 131 }
+
+jnxMbgSgwIfGtpV2ICsRelocFailTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Relocation Failed."
+    ::= { jnxMbgSgwGtpIfStatsEntry 132 }
+
+jnxMbgSgwIfGtpV2ICsDenINRatRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Denied in RAT."
+    ::= { jnxMbgSgwGtpIfStatsEntry 133 }
+
+jnxMbgSgwIfGtpV2ICsDenINRatTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Denied in RAT."
+    ::= { jnxMbgSgwGtpIfStatsEntry 134 }
+
+jnxMbgSgwIfGtpV2ICsPTNotSuppRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause PDN Type Not Supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 135 }
+
+jnxMbgSgwIfGtpV2ICsPTNotSuppTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause PDN Type Not Supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 136 }
+
+jnxMbgSgwIfGtpV2ICsAlDynAdOccRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgSgwGtpIfStatsEntry 137 }
+
+jnxMbgSgwIfGtpV2ICsAlDynAdOccTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Allocated Dynamic Address Occupied."
+    ::= { jnxMbgSgwGtpIfStatsEntry 138 }
+
+jnxMbgSgwIfGtpV2ICsNOTFTUECTXRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Context Without TFT Exists."
+    ::= { jnxMbgSgwGtpIfStatsEntry 139 }
+
+jnxMbgSgwIfGtpV2ICsNOTFTUECTXTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Context Without TFT Exists."
+    ::= { jnxMbgSgwGtpIfStatsEntry 140 }
+
+jnxMbgSgwIfGtpV2ICsProtoNtSupRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Protocol Not Supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 141 }
+
+jnxMbgSgwIfGtpV2ICsProtoNtSupTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Protocol Not Supported."
+    ::= { jnxMbgSgwGtpIfStatsEntry 142 }
+
+jnxMbgSgwIfGtpV2ICsUENotRespRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Not Responding."
+    ::= { jnxMbgSgwGtpIfStatsEntry 143 }
+
+jnxMbgSgwIfGtpV2ICsUENotRespTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Not Responding."
+    ::= { jnxMbgSgwGtpIfStatsEntry 144 }
+
+jnxMbgSgwIfGtpV2ICsUERefusesRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause UE Refuses."
+    ::= { jnxMbgSgwGtpIfStatsEntry 145 }
+
+jnxMbgSgwIfGtpV2ICsUERefusesTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause UE Refuses."
+    ::= { jnxMbgSgwGtpIfStatsEntry 146 }
+
+jnxMbgSgwIfGtpV2ICsServDeniedRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Service Denied."
+    ::= { jnxMbgSgwGtpIfStatsEntry 147 }
+
+jnxMbgSgwIfGtpV2ICsServDeniedTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Service Denied."
+    ::= { jnxMbgSgwGtpIfStatsEntry 148 }
+
+jnxMbgSgwIfGtpV2ICsUnabPageUERx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Unable to Page UE."
+    ::= { jnxMbgSgwGtpIfStatsEntry 149 }
+
+jnxMbgSgwIfGtpV2ICsUnabPageUETx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Unable to Page UE."
+    ::= { jnxMbgSgwGtpIfStatsEntry 150 }
+
+jnxMbgSgwIfGtpV2ICsNoMemRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause No Memory."
+    ::= { jnxMbgSgwGtpIfStatsEntry 151 }
+
+jnxMbgSgwIfGtpV2ICsNoMemTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause No Memory."
+    ::= { jnxMbgSgwGtpIfStatsEntry 152 }
+
+jnxMbgSgwIfGtpV2ICsUserAUTHFlRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause User AUTH Failed."
+    ::= { jnxMbgSgwGtpIfStatsEntry 153 }
+
+jnxMbgSgwIfGtpV2ICsUserAUTHFlTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause User AUTH Failed."
+    ::= { jnxMbgSgwGtpIfStatsEntry 154 }
+
+jnxMbgSgwIfGtpV2ICsAPNAcsDenRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause APN Access Denied."
+    ::= { jnxMbgSgwGtpIfStatsEntry 155 }
+
+jnxMbgSgwIfGtpV2ICsAPNAcsDenTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause APN Access Denied."
+    ::= { jnxMbgSgwGtpIfStatsEntry 156 }
+
+jnxMbgSgwIfGtpV2ICsReqRejRx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTPV2 packets received with cause Request Rejected."
+    ::= { jnxMbgSgwGtpIfStatsEntry 157 }
+
+jnxMbgSgwIfGtpV2ICsReqRejTx  OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Number of GTP packets sent with cause Request Rejected."
+    ::= { jnxMbgSgwGtpIfStatsEntry 158 }
+
+jnxMbgSgwIfGtpV2ICsPTMSISigMMRx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTPV2 packets received with cause P-TMSI Signature Mismatch."
+    ::= { jnxMbgSgwGtpIfStatsEntry 159 }
+
+jnxMbgSgwIfGtpV2ICsPTMSISigMMTx OBJECT-TYPE
+     SYNTAX      Counter64
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of GTP packets sent with cause P-TMSI Signature Mismatch"
+    ::= { jnxMbgSgwGtpIfStatsEntry 160 }
+
+jnxMbgSgwIfGtpV2ICsIMSINotKnRx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTPV2 packets received with cause IMSI Not Known."
+    ::= { jnxMbgSgwGtpIfStatsEntry 161 }
+
+jnxMbgSgwIfGtpV2ICsIMSINotKnTx OBJECT-TYPE
+      SYNTAX      Counter64
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+      "Number of GTP packets sent with cause IMSI Not Known."
+    ::= { jnxMbgSgwGtpIfStatsEntry 162 }
+
+jnxMbgSgwIfGtpV2ICsCondIEMsRx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTPV2 packets received with cause Conditional IE Missing."
+     ::= { jnxMbgSgwGtpIfStatsEntry 163 }
+
+jnxMbgSgwIfGtpV2ICsCondIEMsTx OBJECT-TYPE
+       SYNTAX      Counter64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+       "Number of GTP packets sent with cause Conditional IE Missing."
+     ::= { jnxMbgSgwGtpIfStatsEntry 164 }
+
+jnxMbgSgwIfGtpV2ICsAPNResTIncRx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTPV2 packets received with cause APN Restriction Type Incompatible."
+     ::= { jnxMbgSgwGtpIfStatsEntry 165 }
+
+jnxMbgSgwIfGtpV2ICsAPNResTIncTx OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "Number of GTP packets sent with cause APN Restriction Type Incompatible."
+     ::= { jnxMbgSgwGtpIfStatsEntry 166 }
+
+jnxMbgSgwIfGtpV2ICsUnknownRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPV2 packets received with cause Unknown."
+     ::= { jnxMbgSgwGtpIfStatsEntry 167 }
+
+jnxMbgSgwIfGtpV2ICsUnknownTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unknown."
+     ::= { jnxMbgSgwGtpIfStatsEntry 168 }
+
+jnxMbgSgwIfGtpV2ICsLclDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Local Detach."
+     ::= { jnxMbgSgwGtpIfStatsEntry 169 }
+
+jnxMbgSgwIfGtpV2ICsLclDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Local Detach."
+     ::= { jnxMbgSgwGtpIfStatsEntry 170 }
+
+jnxMbgSgwIfGtpV2ICsCmpDetRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Complete Detach."
+     ::= { jnxMbgSgwGtpIfStatsEntry 171 }
+
+jnxMbgSgwIfGtpV2ICsCmpDetTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Complete Detach."
+     ::= { jnxMbgSgwGtpIfStatsEntry 172 }
+
+jnxMbgSgwIfGtpV2ICsRATChgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgSgwGtpIfStatsEntry 173 }
+
+jnxMbgSgwIfGtpV2ICsRATChgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause RAT changed from 3GPP to non 3GPP."
+     ::= { jnxMbgSgwGtpIfStatsEntry 174 }
+
+jnxMbgSgwIfGtpV2ICsISRDeactRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause ISR Deactivated."
+     ::= { jnxMbgSgwGtpIfStatsEntry 175 }
+
+jnxMbgSgwIfGtpV2ICsISRDeactTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause ISR Deactivated."
+     ::= { jnxMbgSgwGtpIfStatsEntry 176 }
+
+jnxMbgSgwIfGtpV2ICsEIFRNCEnRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgSgwGtpIfStatsEntry 177 }
+
+jnxMbgSgwIfGtpV2ICsEIFRNCEnTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Error Indication from RNC eNodeB."
+     ::= { jnxMbgSgwGtpIfStatsEntry 178 }
+
+jnxMbgSgwIfGtpV2ICsSemErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpIfStatsEntry 179 }
+
+jnxMbgSgwIfGtpV2ICsSemErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Semantic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpIfStatsEntry 180 }
+
+jnxMbgSgwIfGtpV2ICsSynErTADRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpIfStatsEntry 181 }
+
+jnxMbgSgwIfGtpV2ICsSynErTADTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Syntactic Error in TAD Operation."
+     ::= { jnxMbgSgwGtpIfStatsEntry 182 }
+
+jnxMbgSgwIfGtpV2ICsRMValRcvRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Reserved Message Value Received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 183 }
+
+jnxMbgSgwIfGtpV2ICsRMValRcvTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Reserved Message Value Received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 184 }
+
+jnxMbgSgwIfGtpV2ICsRPrNtRspRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Remote peer not responding."
+     ::= { jnxMbgSgwGtpIfStatsEntry 185 }
+
+jnxMbgSgwIfGtpV2ICsRPrNtRspTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Remote peer not responding."
+     ::= { jnxMbgSgwGtpIfStatsEntry 186 }
+
+jnxMbgSgwIfGtpV2ICsColNWReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Collision with network initiated request."
+     ::= { jnxMbgSgwGtpIfStatsEntry 187 }
+
+jnxMbgSgwIfGtpV2ICsColNWReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Collision with network initiated request."
+     ::= { jnxMbgSgwGtpIfStatsEntry 188 }
+
+jnxMbgSgwIfGtpV2ICsUnPgUESusRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Unable to page UE due to suspension."
+     ::= { jnxMbgSgwGtpIfStatsEntry 189 }
+
+jnxMbgSgwIfGtpV2ICsUnPgUESusTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Unable to page UE due to suspension."
+     ::= { jnxMbgSgwGtpIfStatsEntry 190 }
+
+jnxMbgSgwIfGtpV2ICsInvTotLenRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid total len."
+     ::= { jnxMbgSgwGtpIfStatsEntry 191 }
+
+jnxMbgSgwIfGtpV2ICsInvTotLenTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid total len."
+     ::= { jnxMbgSgwGtpIfStatsEntry 192 }
+
+jnxMbgSgwIfGtpV2ICsDtForNtSupRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Data forwarding not supported."
+     ::= { jnxMbgSgwGtpIfStatsEntry 193 }
+
+jnxMbgSgwIfGtpV2ICsDtForNtSupTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Data forwarding not supported."
+     ::= { jnxMbgSgwGtpIfStatsEntry 194 }
+
+jnxMbgSgwIfGtpV2ICsInReFRePrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgSgwGtpIfStatsEntry 195 }
+
+jnxMbgSgwIfGtpV2ICsInReFRePrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid Reply from Remote peer."
+     ::= { jnxMbgSgwGtpIfStatsEntry 196 }
+
+jnxMbgSgwIfGtpV2ICsInvPrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets received with cause Invalid peer."
+     ::= { jnxMbgSgwGtpIfStatsEntry 197 }
+
+jnxMbgSgwIfGtpV2ICsInvPrTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets sent with cause Invalid peer."
+     ::= { jnxMbgSgwGtpIfStatsEntry 198 }
+
+jnxMbgSgwIfGtpV1ProtocolErrRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv1 Protocol Errors Received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 199 }
+
+jnxMbgSgwIfGtpV1UnSupMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv1 Unsupported Messages received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 200 }
+
+jnxMbgSgwIfGtpV1T3RespTmrExpRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 T3 timer expiries Received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 201 }
+
+jnxMbgSgwIfGtpV1EndMarkerRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 end marker packets received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 202 }
+
+jnxMbgSgwIfGtpV1EndMarkerTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 end marker packets sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 203 }
+
+jnxMbgSgwIfGtpV1EchoReqRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo request packets received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 204 }
+
+jnxMbgSgwIfGtpV1EchoReqTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo request packets sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 205 }
+
+jnxMbgSgwIfGtpV1EchoRespRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo response packets received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 206 }
+
+jnxMbgSgwIfGtpV1EchoRespTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP V1 echo response packets sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 207 }
+
+jnxMbgSgwIfGtpV1ErrIndRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets V1 Error Indication packets received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 208 }
+
+jnxMbgSgwIfGtpV1ErrIndTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTP packets V1 Error Indication packets sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 209 }
+
+jnxMbgSgwIfSuspNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 210 } 
+
+jnxMbgSgwIfSuspNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Notification messages sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 211 } 
+
+jnxMbgSgwIfSuspAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 212 }
+
+jnxMbgSgwIfSuspAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Suspend Acknowledgement messages sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 213 }
+
+jnxMbgSgwIfResumeNotifRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 214 }
+    
+jnxMbgSgwIfResumeNotifTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Notification messages sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 215 }
+
+jnxMbgSgwIfResumeAckRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 216 }
+   
+jnxMbgSgwIfResumeAckTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Resume Acknowledgement messages sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 217 }
+
+jnxMbgSgwIfPiggybackMsgRx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 Piggyback messages received."
+     ::= { jnxMbgSgwGtpIfStatsEntry 218 }
+    
+jnxMbgSgwIfPiggybackMsgTx OBJECT-TYPE
+         SYNTAX      Counter64
+         MAX-ACCESS  read-only
+         STATUS      current
+         DESCRIPTION
+         "Number of GTPv2 S11 Piggyback messages sent."
+     ::= { jnxMbgSgwGtpIfStatsEntry 219 }
+
+
+jnxMbgSgwGtpNotificationVars   OBJECT IDENTIFIER ::= {
+                                             jnxMbgSgwGtpObjects 3 }
+jnxMbgSgwGtpPeerName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "GTP Peer Name/IP"
+   ::= { jnxMbgSgwGtpNotificationVars 1 }
+
+jnxMbgSgwGtpAlarmStatCounter OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION
+    "Current Value of (Alarm) Statistics Counter
+     eg: in jnxMbgSgwGtpPrDNTPerPrAlrmActv it spefies the number
+         of times peer is down with in the monitoring interval"
+   ::= { jnxMbgSgwGtpNotificationVars 2 }
+
+jnxMbgSgwGtpInterfaceType OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "GTP Interface Type which can be one of S5/S8/S11/S1U/S12/S4"
+   ::= { jnxMbgSgwGtpNotificationVars 3 }
+
+jnxMbgSgwGtpGwName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the gateway name"
+    ::= { jnxMbgSgwGtpNotificationVars 4 }
+
+jnxMbgSgwGtpGwIndex OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Current Gateway ID value"
+    ::= { jnxMbgSgwGtpNotificationVars 5 }
+
+jnxMbgSgwGtpPeerGwUpNotif NOTIFICATION-TYPE
+     OBJECTS          { jnxMbgSgwGtpGwIndex,
+                        jnxMbgSgwGtpGwName,
+                        jnxMbgSgwGtpInterfaceType,
+                        jnxMbgSgwGtpPeerName }
+     STATUS      current
+     DESCRIPTION
+     "GTPC Peer UP Notification. This trap is sent when a new peer is added
+       or an existing peer goes down and comes back up."
+    ::= { jnxMbgSgwGtpNotifications 1 }
+
+jnxMbgSgwGtpPeerGwDnNotif NOTIFICATION-TYPE
+    OBJECTS          { jnxMbgSgwGtpGwIndex,
+                       jnxMbgSgwGtpGwName,
+                       jnxMbgSgwGtpInterfaceType,
+                       jnxMbgSgwGtpPeerName }
+    STATUS      current
+    DESCRIPTION
+     "GTPC Peer Down Notification. This trap is sent when a peer connection 
+      goes down."
+    ::= { jnxMbgSgwGtpNotifications 2 }
+
+jnxMbgSgwGtpPrDnTPerPrAlrmActv NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSgwGtpGwIndex,
+                  jnxMbgSgwGtpGwName,
+                  jnxMbgSgwGtpInterfaceType,
+                  jnxMbgSgwGtpPeerName,
+                  jnxMbgSgwGtpAlarmStatCounter }
+    STATUS          current
+    DESCRIPTION
+        "Peer down Threshold trap Active. This is sent when a peer connection
+         flaps for more than a higher threshold number of times with in a
+         monitor interval."
+    ::= { jnxMbgSgwGtpNotifications 3 }
+
+jnxMbgSgwGtpPrDnTPerPrAlrmClr NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSgwGtpGwIndex,
+                  jnxMbgSgwGtpGwName,
+                  jnxMbgSgwGtpInterfaceType,
+                  jnxMbgSgwGtpPeerName,
+                  jnxMbgSgwGtpAlarmStatCounter }
+    STATUS          current
+    DESCRIPTION
+        "Peer down Threshold trap Cleared. This is sent when the number of 
+         times a peer connection flaps in a monitor interval come down below
+         the lower threshold."
+    ::= { jnxMbgSgwGtpNotifications 4 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-sgw-mfwd.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-sgw-mfwd.txt
@@ -1,0 +1,85 @@
+-- ********************************************************************
+-- Juniper Mobile Gateway SGW MFWD(Mobile Packet Forwarding objects MIB.
+--
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- ********************************************************************
+
+JUNIPER-MOBILE-GW-SGW-MFWD-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE,
+    Counter64, Unsigned32, Gauge32 FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, 
+    TruthValue                     FROM SNMPv2-TC
+    EnabledStatus                  FROM JUNIPER-MIMSTP-MIB
+    jnxMobileGatewaySgw            FROM JUNIPER-MBG-SMI
+    jnxMbgGwName                   FROM JUNIPER-MOBILE-GATEWAYS;
+
+jnxMbgSgwMfwdMib MODULE-IDENTITY
+    LAST-UPDATED "201108041200Z" -- Aug 04, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to SGW MFWD 
+         (Serving Gateway Mobile Packet Forwarding Daemon) "
+    ::= { jnxMobileGatewaySgw 7 }
+
+jnxMbgSgwMfwdNotifications OBJECT IDENTIFIER
+    ::= { jnxMbgSgwMfwdMib 0 }
+
+jnxMbgSgwMfwdNotificationVars  OBJECT IDENTIFIER
+    ::= { jnxMbgSgwMfwdMib 1 }
+
+jnxMbgSgwMfwdServicePicName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (8..15))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+    "This identifies the session-pic, in the form ms-a/b/0, 
+     where <a> is the slot and <b> could be either 0 or 1."
+   ::= { jnxMbgSgwMfwdNotificationVars 1 }
+
+jnxMbgSgwMfwdBufMemLimit OBJECT-TYPE
+    SYNTAX        Gauge32
+    UNITS         "percent"
+    MAX-ACCESS    accessible-for-notify
+    STATUS        current
+    DESCRIPTION 
+        "This indicates the percentage of total buffer memory being used"
+    ::= { jnxMbgSgwMfwdNotificationVars 2 }
+
+jnxMbgSgwMfwdBufMemThresRaise NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwName,
+                  jnxMbgSgwMfwdServicePicName,
+                  jnxMbgSgwMfwdBufMemLimit }
+
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the high memory buffering threshold 
+         for MFWD has reached at the SPIC level. 
+         The gateway name, SPIC name and memory buffer threshold will be 
+         displayed."
+    ::= { jnxMbgSgwMfwdNotifications 1 }
+
+jnxMbgSgwMfwdBufMemThresClear NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgGwName,
+                  jnxMbgSgwMfwdServicePicName,
+                  jnxMbgSgwMfwdBufMemLimit }
+
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the low memory buffering threshold 
+         for MFWD has reached at the SPIC level. 
+         The gateway name, SPIC name and memory buffer threshold will be 
+         displayed."
+    ::= { jnxMbgSgwMfwdNotifications 2 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateway-sm-ip-pool.txt
+++ b/mibs/junos/mib-jnx-mobile-gateway-sm-ip-pool.txt
@@ -1,0 +1,656 @@
+--
+-- Juniper Mobile Gateway Subscriber Management IP pool objects MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAY-SM-IP-POOL-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+Counter64, Unsigned32, Gauge32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY, OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString
+        FROM SNMPv2-TC
+
+    InetAddressType, InetAddress, InetAddressPrefixLength
+        FROM INET-ADDRESS-MIB
+
+    jnxMobileGatewayMibRoot	
+        FROM JUNIPER-SMI
+
+    jnxMbgGwIndex, jnxMbgGwName
+        FROM JUNIPER-MOBILE-GATEWAYS;
+
+jnxMobileGatewayPgwSMIPPoolMib MODULE-IDENTITY
+    LAST-UPDATED "201111151200Z" -- Nov 15, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to Mobile-Edge Subscriber
+         Management IP pool Services"
+    REVISION "201101131200Z" -- Jan 13, 2011, 12:00:00
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewayMibRoot 5 }
+
+jnxMbgSMIPPoolNotifications          OBJECT IDENTIFIER ::= 
+                                         { jnxMobileGatewayPgwSMIPPoolMib 0 }
+jnxMbgSMIPPoolObjects                OBJECT IDENTIFIER ::= 
+                                         { jnxMobileGatewayPgwSMIPPoolMib 1 }
+jnxMbgSMIPPoolNotificationVars       OBJECT IDENTIFIER ::= 
+                                         { jnxMbgSMIPPoolObjects 2 }
+
+--
+-- Subscriber Management Address Pool Object definitions
+--
+
+jnxMbgIPPoolTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgIPPoolEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The table exposes the local address pools attributes and
+        their statistics.
+
+        This table contains information about local address pools only."
+    ::= { jnxMbgSMIPPoolObjects 3 }
+
+jnxMbgIPPoolEntry OBJECT-TYPE
+    SYNTAX      JnxMbgIPPoolEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a single address range or prefix entry 
+         in the pool. It is indexed by Pool Id."
+    INDEX       { jnxMbgIPPoolId }
+    ::= { jnxMbgIPPoolTable 1 }
+
+JnxMbgIPPoolEntry ::= SEQUENCE {
+    jnxMbgIPPoolId                Unsigned32,
+    jnxMbgIPPoolLogicalSystem     DisplayString,
+    jnxMbgIPPoolRoutingInstance   DisplayString,
+    jnxMbgIPPoolName              DisplayString,
+    jnxMbgIPPoolType              InetAddressType,
+    jnxMbgIPPoolFree              Gauge32,
+    jnxMbgIPPoolInUse             Gauge32,
+    jnxMbgIPPoolUtil              Gauge32 
+}
+
+jnxMbgIPPoolId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A Pool Id which identifies a pool on the mobile-gateway."
+    ::= { jnxMbgIPPoolEntry 1 }
+
+jnxMbgIPPoolLogicalSystem OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A name which identifies the logical-system to which the address 
+         pool belongs on the mobile gateway."
+    ::= { jnxMbgIPPoolEntry 2 }
+
+jnxMbgIPPoolRoutingInstance OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A name which identifies the routing instance to which the address 
+         pool belongs on the mobile gateway."
+    ::= { jnxMbgIPPoolEntry 3 }
+
+jnxMbgIPPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A name which identifies the pool on the mobile-gateway."
+    ::= { jnxMbgIPPoolEntry 4 }
+
+jnxMbgIPPoolType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The type configured for this pool on the mobile gateway.
+         Types supported are Ipv4(1) or IPv6(2)."
+    ::= { jnxMbgIPPoolEntry 5 }
+
+jnxMbgIPPoolFree OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of free addresses in this pool."
+    ::= { jnxMbgIPPoolEntry 6 }
+
+jnxMbgIPPoolInUse OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of used addresses in this pool."
+    ::= { jnxMbgIPPoolEntry 7 }
+
+jnxMbgIPPoolUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "percent"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Percentage utilization for this pool."
+    ::= { jnxMbgIPPoolEntry 8 }
+
+jnxMbgIPPoolRangeTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgIPPoolRangeEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+       "The table exposes the local address pool range's attributes and
+       their statistics.
+
+        This table contains information about local address pools only."
+    ::= { jnxMbgSMIPPoolObjects 4 }
+
+jnxMbgIPPoolRangeEntry OBJECT-TYPE
+    SYNTAX      JnxMbgIPPoolRangeEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry representing a address ranges in the pool. It is
+         indexed by the Gateway Index, Logical System Id,
+         Routing Instance Id, Pool Id and Range Id."
+    INDEX       { jnxMbgIPPoolId,
+                  jnxMbgIPPoolRangeName }
+    ::= { jnxMbgIPPoolRangeTable 1 }
+
+
+JnxMbgIPPoolRangeEntry ::= SEQUENCE {
+    jnxMbgIPPoolRangeName         DisplayString,
+    jnxMbgIPPoolRangeType         InetAddressType,
+    jnxMbgIPPoolRangeFree         Gauge32,
+    jnxMbgIPPoolRangeInUse        Gauge32,
+    jnxMbgIPPoolRangeUtil         Gauge32
+}
+
+jnxMbgIPPoolRangeName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..64))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The name of the local IP address pool range"
+    ::= { jnxMbgIPPoolRangeEntry 1 }
+
+jnxMbgIPPoolRangeType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The type configured for this range on the mobile gateway.
+         Types supported are Ipv4(1) or IPv6(2)."
+    ::= { jnxMbgIPPoolRangeEntry 2 }
+
+jnxMbgIPPoolRangeFree OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of free addresses in this range."
+    ::= { jnxMbgIPPoolRangeEntry 3 }
+
+jnxMbgIPPoolRangeInUse OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Total number of used addresses in this range."
+    ::= { jnxMbgIPPoolRangeEntry 4 }
+
+jnxMbgIPPoolRangeUtil OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "percent"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Percentage utilization for this range."
+    ::= { jnxMbgIPPoolRangeEntry 5 }
+
+--
+-- Deprecated OIDs
+--
+
+jnxMbgSMIPPoolTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF JnxMbgSMIPPoolEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+       "The table lists local address pools and their statistics"
+    ::= { jnxMbgSMIPPoolObjects 1 }
+
+jnxMbgSMIPPoolEntry OBJECT-TYPE
+    SYNTAX      JnxMbgSMIPPoolEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "An entry representing a single address range or prefix entry 
+         in the pool"
+    INDEX       { jnxMbgSMIPPoolLogicalSystem, 
+                  jnxMbgSMIPPoolRoutingInstance,
+                  jnxMbgSMIPPoolName }
+    ::= { jnxMbgSMIPPoolTable 1 }
+
+JnxMbgSMIPPoolEntry ::= SEQUENCE {
+    jnxMbgSMIPPoolLogicalSystem     DisplayString,
+    jnxMbgSMIPPoolRoutingInstance   DisplayString,
+    jnxMbgSMIPPoolName              DisplayString,
+    jnxMbgSMIPPoolType              InetAddressType,
+    jnxMbgSMIPPoolFree              Unsigned32,
+    jnxMbgSMIPPoolInUse             Unsigned32,
+    jnxMbgSMIPPoolUtil              Unsigned32 
+}
+
+jnxMbgSMIPPoolLogicalSystem OBJECT-TYPE 
+    SYNTAX      DisplayString (SIZE (1..64))
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A name which identifies the logical-system to which the address 
+         pool belongs."
+    ::= { jnxMbgSMIPPoolEntry 2 }
+
+jnxMbgSMIPPoolRoutingInstance OBJECT-TYPE 
+    SYNTAX      DisplayString (SIZE (1..128))
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A name which identifies the routing instance to which the address 
+         pool belongs."
+    ::= { jnxMbgSMIPPoolEntry 3 }
+
+jnxMbgSMIPPoolName OBJECT-TYPE 
+    SYNTAX      DisplayString (SIZE (1..64))
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+        "A name which identifies this pool on the mobile-gateway."
+    ::= { jnxMbgSMIPPoolEntry 1 }
+
+jnxMbgSMIPPoolType OBJECT-TYPE 
+    SYNTAX      InetAddressType 
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Indicates whether this pool entry is of type ipv4 or ipv6."
+    ::= { jnxMbgSMIPPoolEntry 4 }
+
+jnxMbgSMIPPoolFree OBJECT-TYPE 
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total number of free addresses in this pool entry."
+    ::= { jnxMbgSMIPPoolEntry 5 }
+
+jnxMbgSMIPPoolInUse OBJECT-TYPE 
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Total number of used addresses in this pool entry."
+    ::= { jnxMbgSMIPPoolEntry 6 }
+
+jnxMbgSMIPPoolUtil OBJECT-TYPE 
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Percentage utilization for this pool entry."
+    ::= { jnxMbgSMIPPoolEntry 7 }
+
+--
+-- Objects used in Notifications
+--
+
+jnxMbgSMIPPoolThresholdPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the address pool on the mobile-gateway
+         for which the threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 1 }
+
+jnxMbgSMIPPoolThresholdLSName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the logical-system on the mobile-gateway
+         in which the address pool threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 2 }
+
+jnxMbgSMIPPoolThresholdRIName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the routing instance on the mobile-gateway
+         in which the address pool threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 3 }
+
+jnxMbgSMIPPoolConfiguredThreshold OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "The threshold value configured for an address pool on the mobile 
+         gateway exceeding which a notification is generated."
+    ::= { jnxMbgSMIPPoolNotificationVars 4 }
+
+jnxMbgSMIPPoolCurrentThreshold OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "The current threshold value for an address pool on the mobile 
+         gateway. This can be equal to or greater than the configured
+         threshold value."
+    ::= { jnxMbgSMIPPoolNotificationVars 5 }
+
+jnxMbgSMIPPoolMMPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the address pool on the mobile-gateway
+         which underwent a change in the maintenance-mode state."
+    ::= { jnxMbgSMIPPoolNotificationVars 6 }
+
+jnxMbgSMIPPoolMMLSName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the logical-system on the mobile-gateway
+         which underwent a change in the maintenance-mode state."
+    ::= { jnxMbgSMIPPoolNotificationVars 7 }
+
+jnxMbgSMIPPoolMMRIName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the routing instance on the mobile-gateway
+         which underwent a change in the maintenance-mode state."
+    ::= { jnxMbgSMIPPoolNotificationVars 8 }
+
+jnxMbgSMIPPoolPrevMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgSMIPPoolNotificationVars 9 }
+
+jnxMbgSMIPPoolNewMMState OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A string that indicates the maintenance-mode state ."
+    ::= { jnxMbgSMIPPoolNotificationVars 10 }
+
+jnxMbgSMIPRangeHiThresRangeName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the address pool's range on the mobile-gateway
+         for which the threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 11 }
+
+jnxMbgSMIPRangeHiThresPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the address pool on the mobile-gateway, whose
+         range threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 12 }
+
+jnxMbgSMIPRangeHiLSName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the logical-system on the mobile-gateway
+         in which the address range threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 13 }
+
+jnxMbgSMIPRangeHiRIName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the routing instance on the mobile-gateway
+         in which the address range threshold was exceeded."
+    ::= { jnxMbgSMIPPoolNotificationVars 14 }
+
+jnxMbgSMIPRangeHiCfgThres OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The threshold value configured for an address pool range on the mobile 
+         gateway exceeding which a notification is generated."
+    ::= { jnxMbgSMIPPoolNotificationVars 15 }
+
+jnxMbgSMIPRangeHiCurrUtil OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The current threshold value for an address pool range on the mobile 
+         gateway. This can be equal to or greater than the configured
+         threshold value."
+    ::= { jnxMbgSMIPPoolNotificationVars 16 }
+
+jnxMbgSMIPRangeLowThresRangeName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the address pool's range on the mobile-gateway
+         for which the low threshold was reached."
+    ::= { jnxMbgSMIPPoolNotificationVars 17 }
+
+jnxMbgSMIPRangeLowThresPoolName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the address pool on the mobile-gateway, whose
+         range low threshold was reached."
+    ::= { jnxMbgSMIPPoolNotificationVars 18 }
+
+jnxMbgSMIPRangeLowLSName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the logical-system on the mobile-gateway
+         in which the address range low threshold was reached."
+    ::= { jnxMbgSMIPPoolNotificationVars 19 }
+
+jnxMbgSMIPRangeLowRIName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The name which identifies the routing instance on the mobile-gateway
+         in which the address range low threshold was reached."
+    ::= { jnxMbgSMIPPoolNotificationVars 20 }
+
+jnxMbgSMIPRangeLowCfgThres OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The threshold value configured for an address pool range on the mobile 
+         gateway reaching which a notification is generated."
+    ::= { jnxMbgSMIPPoolNotificationVars 21 }
+
+jnxMbgSMIPRangeLowCurrUtil OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The current threshold value for an address pool range on the mobile 
+         gateway. This can be equal to or greater than the configured
+         threshold value."
+    ::= { jnxMbgSMIPPoolNotificationVars 22 }
+
+jnxMbgSMIPPoolHTCfgThres OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The threshold value configured for an address pool on the mobile gateway 
+         exceeding which a notification is generated."
+    ::= { jnxMbgSMIPPoolNotificationVars 23 }
+
+jnxMbgSMIPPoolCurrUtil OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The current utilization value for an address pool on the mobile 
+         gateway. This can be equal to or greater than the configured
+         threshold value."
+    ::= { jnxMbgSMIPPoolNotificationVars 24 }
+
+jnxMbgSMIPPoolLTCfgThres OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "percent"
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The threshold value configured for an address pool on the mobile gateway
+         reaching which a notification is generated."
+    ::= { jnxMbgSMIPPoolNotificationVars 25 }
+
+--
+-- Notifications
+--
+
+jnxMbgSMIPPoolThresholdExceeded NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSMIPPoolThresholdPoolName,
+                  jnxMbgSMIPPoolThresholdLSName,
+                  jnxMbgSMIPPoolThresholdRIName,
+                  jnxMbgSMIPPoolConfiguredThreshold,
+                  jnxMbgSMIPPoolCurrentThreshold }
+    STATUS      deprecated
+    DESCRIPTION
+        "This notification signifies that the number of addresses allocated
+         from a given address pool has exceeded a pre-configured threshold 
+         value."
+    ::= { jnxMbgSMIPPoolNotifications 1 }
+
+jnxMbgSMIPPoolMMStateChange NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSMIPPoolMMPoolName,
+                  jnxMbgSMIPPoolMMLSName,
+                  jnxMbgSMIPPoolMMRIName,
+                  jnxMbgSMIPPoolPrevMMState,
+                  jnxMbgSMIPPoolNewMMState }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates that the pool name indicated by  
+         LS-name, RI-name and pool-name undergoes a change in the
+         maintenance-mode state."
+    ::= { jnxMbgSMIPPoolNotifications 2 }
+
+jnxMbgSMIPRangeHighThresExcd NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSMIPRangeHiThresRangeName,
+                  jnxMbgSMIPRangeHiThresPoolName,
+                  jnxMbgSMIPRangeHiLSName,
+                  jnxMbgSMIPRangeHiRIName,
+                  jnxMbgSMIPRangeHiCfgThres,
+                  jnxMbgSMIPRangeHiCurrUtil }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates that the range name that exceeded 
+         higher threshold."
+    ::= { jnxMbgSMIPPoolNotifications 3 }
+
+jnxMbgSMIPRangeLowThresRchd NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSMIPRangeLowThresRangeName,
+                  jnxMbgSMIPRangeLowThresPoolName,
+                  jnxMbgSMIPRangeLowLSName,
+                  jnxMbgSMIPRangeLowRIName,
+                  jnxMbgSMIPRangeLowCfgThres,
+                  jnxMbgSMIPRangeLowCurrUtil }
+    STATUS      current
+    DESCRIPTION
+        "This notification indicates that the range name that reached  
+         lower threshold."
+    ::= { jnxMbgSMIPPoolNotifications 4 }
+
+jnxMbgSMIPPoolHighThresExcd NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSMIPPoolThresholdPoolName,
+                  jnxMbgSMIPPoolThresholdLSName,
+                  jnxMbgSMIPPoolThresholdRIName,
+                  jnxMbgSMIPPoolHTCfgThres,
+                  jnxMbgSMIPPoolCurrUtil }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the number of addresses allocated
+         from a given address pool has exceeded a pre-configured threshold 
+         value."
+    ::= { jnxMbgSMIPPoolNotifications 5 }
+
+jnxMbgSMIPPoolLowThresRchd NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgSMIPPoolThresholdPoolName,
+                  jnxMbgSMIPPoolThresholdLSName,
+                  jnxMbgSMIPPoolThresholdRIName,
+                  jnxMbgSMIPPoolLTCfgThres,
+                  jnxMbgSMIPPoolCurrUtil }
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the number of addresses allocated
+         from a given address pool has reached the lower threshold value."
+    ::= { jnxMbgSMIPPoolNotifications 6 }
+
+jnxMbgIPPoolExhausted NOTIFICATION-TYPE
+    OBJECTS     { jnxMbgIPPoolLogicalSystem,
+                  jnxMbgIPPoolRoutingInstance,
+                  jnxMbgIPPoolName}
+    STATUS      current
+    DESCRIPTION
+        "This notification signifies that the given pool has exhausted all its
+         addresses and there are no free addresses left."
+
+    ::= { jnxMbgSMIPPoolNotifications 7 }
+
+END

--- a/mibs/junos/mib-jnx-mobile-gateways.txt
+++ b/mibs/junos/mib-jnx-mobile-gateways.txt
@@ -1,0 +1,101 @@
+--
+-- Juniper Mobile Gateways objects MIB.
+--
+-- Copyright (c) 2011-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-MOBILE-GATEWAYS DEFINITIONS ::= BEGIN
+
+IMPORTS
+    Counter64, IpAddress, Integer32, Counter32, Unsigned32,
+    NOTIFICATION-TYPE, MODULE-IDENTITY,OBJECT-TYPE
+        FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+        FROM SNMPv2-TC
+
+    Ipv6AddressPrefix, Ipv6AddressIfIdentifier, Ipv6Address
+        FROM IPV6-TC
+
+    InetAddressType, InetAddress, InetPortNumber, InetAddressPrefixLength
+        FROM INET-ADDRESS-MIB
+
+    EnabledStatus
+        FROM JUNIPER-MIMSTP-MIB
+
+        jnxMobileGatewayMibRoot
+            FROM JUNIPER-SMI;
+
+--
+-- This will be used as a root for MIBs common for both PGW and SGW.
+--
+
+jnxMobileGateways MODULE-IDENTITY
+    LAST-UPDATED "201101031200Z" -- Jan 03, 2011, 12:00:00 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+    DESCRIPTION
+        "This module defines objects pertaining to Mobile-Edge Gateways"
+    REVISION "201101031200Z" -- Jan 03, 2011, 12:00:00
+    DESCRIPTION "Initial version"
+
+    ::= { jnxMobileGatewayMibRoot 4 }
+
+jnxMbgGwIndexTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF JnxMbgGwIndexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry corresponds to a mobile gateway "
+  ::= { jnxMobileGateways 1 }
+
+jnxMbgGwIndexEntry OBJECT-TYPE
+    SYNTAX      JnxMbgGwIndexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A specification of the mobile gateway"
+    INDEX     { jnxMbgGwIndex }
+
+    ::= { jnxMbgGwIndexTable 1}
+
+JnxMbgGwIndexEntry ::= SEQUENCE {
+    jnxMbgGwIndex          Unsigned32,
+    jnxMbgGwName           DisplayString,
+    jnxMbgGwType           DisplayString
+}
+
+jnxMbgGwIndex   OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Gateway Index."
+    ::= { jnxMbgGwIndexEntry 1 }
+
+jnxMbgGwName   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Gateway Name."
+    ::= { jnxMbgGwIndexEntry 2 }
+
+jnxMbgGwType   OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+    "Gateway type: PGW/SGW."
+    ::= { jnxMbgGwIndexEntry 3 }
+
+
+END

--- a/mibs/junos/mib-jnx-mpls.txt
+++ b/mibs/junos/mib-jnx-mpls.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Multi-Protocol Label Switched Paths MIB
 --
--- Copyright (c) 1998-2004, 2006-2007, Juniper Networks, Inc.
+-- Copyright (c) 1998-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -561,7 +561,10 @@ MplsLspInfoEntry ::=
         mplsPathInfoExclude         Integer32,
         mplsPathInfoSetupPriority   INTEGER,
         mplsPathInfoHoldPriority    INTEGER,
-        mplsPathInfoProperties      INTEGER
+        mplsPathInfoProperties      INTEGER,
+        mplsLspInfoAggrOctets       Counter64,
+        mplsLspInfoAggrPackets      Counter64,
+        mplsPathInfoRecordRouteWithLabels     OCTET STRING
     }
 
 mplsLspInfoName OBJECT-TYPE
@@ -881,7 +884,51 @@ mplsPathInfoProperties OBJECT-TYPE
 	 unless mplsPathInfoName is not empty"
     ::= { mplsLspInfoEntry 27 }
 
+mplsLspInfoAggrOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of octets that have beeen forwarded over
+         current LSP. This is an aggregate count of octets
+         forwarded over all LSP instances from the time
+         LSP was up. The number reported is not realtime, may
+         be subject to several minutes delay.  The delay is
+         controllable by mpls statistics gathering interval,
+         which by default is once every 5 minutes.  If mpls
+         statistics gathering is not enabled, this number will
+         not increment."
+    ::= { mplsLspInfoEntry 28 }
 
+mplsLspInfoAggrPackets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The number of packets that have been forwarded over
+         current LSP. This is an aggregate count of packets
+         forwarded over all LSP instances from the time
+         LSP was up. The number reported is not realtime, may
+         be subject to several minutes delay. The delay is
+         controllable by mpls statistics gathering interval,
+         which by default is once every 5 minutes. If mpls
+         statistics gathering is not enabled, this number will
+         not increment."
+    ::= { mplsLspInfoEntry 29 }
+
+mplsPathInfoRecordRouteWithLabels OBJECT-TYPE
+    SYNTAX     OCTET STRING (SIZE (0..1024))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The route actually used for this path, as
+         recorded by the signaling protocol.
+         This field is a displayable string in the
+         format of XXX.XXX.XXX.XXX <flag/label> <space>
+         repeated for each address.
+         This field is meaningless unless mplsPathInfoName is
+         not empty"
+   ::= { mplsLspInfoEntry 30 }
 
 --
 -- definition of MPLS traps
@@ -997,3 +1044,4 @@ mplsPathInfoProperties OBJECT-TYPE
         ::= { mplsLspTraps 5 }
 
 END
+

--- a/mibs/junos/mib-jnx-optics.txt
+++ b/mibs/junos/mib-jnx-optics.txt
@@ -1,0 +1,2746 @@
+--
+-- Juniper Enterprise Specific MIB: Optics management 
+--
+-- Copyright (c) 2012-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-IFOPTICS-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, TimeTicks, NOTIFICATION-TYPE,
+    Unsigned32, Counter32, Integer32
+        FROM SNMPv2-SMI
+    DateAndTime, TEXTUAL-CONVENTION, TruthValue 
+        FROM SNMPv2-TC
+    ifIndex, ifDescr
+        FROM IF-MIB
+    jnxOpticsMibRoot, jnxOpticsNotifications
+        FROM JUNIPER-SMI;
+
+jnxIfOpticsMib MODULE-IDENTITY
+    LAST-UPDATED "201201261414Z" -- Thu Jan 26 14:14:51 PST 2012
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This MIB module defines objects used for managing the
+             Optics interface for Juniper products."
+    REVISION      "201201260000Z"
+    DESCRIPTION
+               "Added Optics Config, Alarms and PM data."
+    REVISION      "201201260000Z"
+    DESCRIPTION
+               "Initial revision."
+    ::= { jnxOpticsMibRoot 1 }
+
+--
+-- Textual Conventions
+--
+JnxOpticsLocation  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Near End or Far End "
+    SYNTAX       INTEGER {
+        jnxNearEnd(1),
+        jnxFarEnd(2)
+    }
+
+JnxOpticsDirection  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Indicates the direction as Rx/Tx or bi-directional."
+    SYNTAX       INTEGER {
+        jnxTxDir(1),
+        jnxRxDir(2),
+        jnxBiDir(3)
+    }
+
+
+JnxOpticsSeverity  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Severity of the Notification"
+    SYNTAX       INTEGER {
+        jnxCritical(1),
+        jnxMajor(2),
+        jnxMinor(3),
+        jnxInfo(4)
+    }
+
+JnxOpticsServiceStateAction  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  " Notification's action on the service state"
+    SYNTAX       INTEGER {
+                     jnxNotSupported(0),
+                     jnxNonServiceAffecting(1),
+                     jnxServiceAffecting(2)
+                 }
+
+
+JnxOpticsChannelSpacing ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Channel spacing
+           1 - 100  Ghz
+           2 - 50   GHz
+           3 - 25   GHz
+           4 - 12.5 GHz
+           5 - 6.25 Ghz "
+    SYNTAX  INTEGER {
+        spacing100Ghz(1),
+        spacing50Ghz(2),
+        spacing25Ghz(3),
+        spacing12point5Ghz(4),
+        spacing6point5Ghz(5)
+    }
+
+
+--
+-- All the notifications related to the optics module
+--
+JnxOpticsNotificationId  ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Optic alarm types"
+    SYNTAX       INTEGER {
+        jnxOpticsLOS(1),                  -- input loss of signal
+        jnxOpticsWavelenthLockErr(2),     -- wavelength lock
+        jnxOpticsPowerHighAlarm(3),       -- Tx high power alarm
+        jnxOpticsPowerLowAlarm(4),        -- Tx low power alarm
+        jnxOpticsBiasCurrentHighAlarm(5), -- Bias Current High
+        jnxOpticsBiasCurrentLowAlarm(6),  -- Bias Current Low
+        jnxOpticsTemperatureHighAlarm(7), -- Temperature High
+        jnxOpticsTemperaturelowAlarm(8),  -- Temperature low
+        jnxOpticsTxPLLLockAlarm(9),       -- Tx PLL Lock
+        jnxOpticsRxPLLLockAlarm(10),      -- Rx PLL Lock
+        jnxOpticsAvgPowerAlarm(11),       -- Avg Power
+        jnxOpticsRxLossAvgPowerAlarm(12), -- Rx Loss Avg Power
+        jnxOpticsLossofACPowerAlarm(13),  -- Loss of AC Power
+        jnxOpticsTxPowerHighThreshAlert(14), -- Tx Power High TCA
+        jnxOpticsTxPowerLowThreshAlert(15),  -- Tx Power Low TCA
+        jnxOpticsRxPowerHighThreshAlert(16), -- Rx Power High TCA
+        jnxOpticsRxPowerLowThreshAlert(17),  -- Rx Power Low TCA
+        jnxOpticsModuleTempHighThreshAlert(18),    -- Temp High TCA
+        jnxOpticsModuleTempLowThreshAlert(19),     -- Temp Low TCA
+        jnxOptics24HourTxPowerHighThreshAlert(20), -- 24 HourTxPowerHigh TCA
+        jnxOptics24HourTxPowerLowThreshAlert(21),  -- 24 HourTxPowerLow TCA
+        jnxOptics24HourRxPowerHighThreshAlert(22), -- 24 HourRxPowerHigh TCA
+        jnxOptics24HourRxPowerLowThreshAlert(23),  -- 24 HourRxPowerLow TCA
+        jnxOptics24HourModuleTempHighThreshAlert(24), -- 24 Hour Temp High TCA
+        jnxOptics24HourModuleTempLowThreshAlert(25),  -- 24 Hour Temp Low TCA
+        jnxOpticsRxPowerHighAlarm(26),                -- Rx high power alarm
+        jnxOpticsRxPowerLowAlarm(27),                 -- Rx high power alarm
+        jnxOpticsTxPowerHighWarning(28),              -- Rx high power warning
+        jnxOpticsTxPowerLowWarning(29),               -- Rx high power warning
+        jnxOpticsRxPowerHighWarning(30),              -- Rx high power warning
+        jnxOpticsRxPowerLowWarning(31),               -- Rx high power warning
+        jnxOpticsModuleTempHighWarning(32),           -- Mod temp high warning
+        jnxOpticsModuleTempLowWarning(33),            -- Mod temp low warning
+        jnxOpticsRxCarrierFreqHigh(34),               -- rx Carrier freq high
+                                                      -- warning
+        jnxOpticsRxCarrierFreqLow(35),                -- rx Carrier freq low
+                                                      -- warning
+        jnxOpticsChromaticDispHighWarning(36),        -- CD high warning
+        jnxOpticsChromaticDispLowWarning(37),         -- CD low warning
+        jnxOpticsQLowWarning(38),                     -- Q low warning
+        jnxOpticsOSNRLowWarning(39),                  -- OSNR low warning
+        jnxOpticsCarrierFreqHighAlert(40),            --  Carrier freq high
+                                                      -- TCA
+        jnxOpticsCarrierFreqLowAlert(41),             -- Carrier freq Low
+                                                      -- TCA
+        jnxOptics24HourCarrierFreqHighAlert(42),      -- Carrier freq high
+                                                      -- TCA 24Hour
+        jnxOptics24HourCarrierFreqLowAlert(43)        -- Carrier freq Low
+                                                      -- TCA 24Hour
+    }
+
+
+
+
+jnxOptics                       OBJECT IDENTIFIER ::= { jnxIfOpticsMib 1 }
+jnxOpticsPerformanceMonitoring  OBJECT IDENTIFIER ::= { jnxIfOpticsMib 2 }
+jnxOpticsAlarm                  OBJECT IDENTIFIER ::= { jnxIfOpticsMib 3 }
+
+--
+-- Optics config table
+--
+jnxOpticsConfigTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxOpticsConfigEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+            "Information about the optics config Table. "
+        ::= { jnxOptics 1 }
+
+jnxOpticsConfigEntry OBJECT-TYPE
+        SYNTAX     JnxOpticsConfigEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+            "A conceptual row that contains information about the optics
+             config Table."
+        INDEX   { jnxOpticsConfigContainerIndex, jnxOpticsConfigL1Index,
+                  jnxOpticsConfigL2Index, jnxOpticsConfigL3Index }
+        ::= { jnxOpticsConfigTable 1 }
+
+JnxOpticsConfigEntry ::=
+    SEQUENCE {
+        jnxOpticsConfigContainerIndex            
+                                 Integer32,
+        jnxOpticsConfigL1Index                    
+                                 Integer32,
+        jnxOpticsConfigL2Index                   
+                                 Integer32,
+        jnxOpticsConfigL3Index                    
+                                 Integer32,
+        jnxOpticsType                             
+                                 Integer32, 
+        jnxLaserEnable                     
+                                 TruthValue,
+        jnxWavelength                     
+                                 Unsigned32,
+        jnxSpacing                         
+                                 JnxOpticsChannelSpacing,
+        jnxModulation                      
+                                 Unsigned32,
+        jnxTxOpticalPower                  
+                                 Integer32,
+        jnxRxOpticalPower                  
+                                 Integer32,
+        jnxModuleTempHighThresh  
+                                 Integer32,
+        jnxModuleTempLowThresh   
+                                 Integer32,
+        jnxTxPowerHighThresh
+                                 Integer32,
+        jnxTxPowerLowThresh
+                                 Integer32,
+        jnxRxPowerHighThresh
+                                 Integer32,
+        jnxRxPowerLowThresh
+                                 Integer32,
+        jnx24HourModuleTempHighThresh
+                                 Integer32,
+        jnx24HourModuleTempLowThresh
+                                 Integer32,
+        jnx24HourTxPowerHighThresh
+                                 Integer32,
+        jnx24HourTxPowerLowThresh
+                                 Integer32,
+        jnx24HourRxPowerHighThresh
+                                 Integer32,
+        jnx24HourRxPowerLowThresh
+                                 Integer32,
+        jnxRxLosPowerWarningThresh
+                                 Integer32,
+        jnxRxLosPowerAlarmThresh
+                                 Integer32,
+        jnxOpticsCurrentStatus
+                                 BITS,
+        jnxTxPowerHighEnableTCA
+                                 TruthValue,
+        jnxTxPowerLowEnableTCA
+                                 TruthValue,
+        jnxRxPowerHighEnableTCA
+                                 TruthValue,
+        jnxRxPowerLowEnableTCA
+                                 TruthValue,
+        jnxModuleTempHighEnableTCA
+                                 TruthValue,
+        jnxModuleTempLowEnableTCA
+                                 TruthValue,
+        jnxCarFreqOffsetHighEnableTCA
+                                 TruthValue,
+        jnxCarFreqOffsetLowEnableTCA
+                                 TruthValue,
+        jnxCarFreqOffsetHighThresh
+                                 Integer32,
+        jnx24HourCarFreqOffsetHighThresh
+                                 Integer32,
+        jnxCarFreqOffsetLowThresh
+                                 Integer32,
+        jnx24HourCarFreqOffsetLowThresh
+                                 Integer32
+    }
+
+    jnxOpticsConfigContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The associated jnxContentsContainerIndex  - eg shelf.."
+        ::= { jnxOpticsConfigEntry 1 }
+
+    jnxOpticsConfigL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The level one index associated with this subject ... eg fpc
+             slot."
+        ::= { jnxOpticsConfigEntry 2 }
+
+    jnxOpticsConfigL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The level two index associated with this subject .. eg pic
+             slot."
+        ::= { jnxOpticsConfigEntry 3 }
+
+    jnxOpticsConfigL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The level three index associated with this subject.. eg port."
+        ::= { jnxOpticsConfigEntry 4 }
+
+    jnxOpticsType OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            " 0 - none 
+              1 - SFP
+              2 - XFP
+              3 - SFP+
+              4 - XFP+
+              5 - CFP
+              6 - CFP+  
+              7 - Non pluggable "
+        ::= { jnxOpticsConfigEntry 5 }
+
+
+    jnxLaserEnable OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " 0 - laser off
+              1 - laser on "
+        ::= { jnxOpticsConfigEntry 6 }
+
+    jnxWavelength OBJECT-TYPE
+        SYNTAX          Unsigned32
+        UNITS           "0.01 nm" 
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "The transmit wavelength of the laser."
+        ::= { jnxOpticsConfigEntry 7 }
+
+    jnxSpacing OBJECT-TYPE
+        SYNTAX          JnxOpticsChannelSpacing 
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "A minimum nominal difference in frequency (GHz) between two
+             adjacent channels."
+        ::= { jnxOpticsConfigEntry 8 }
+
+    jnxModulation OBJECT-TYPE
+        SYNTAX          Unsigned32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Modulation 
+             Unknown - (1),
+             NonPSK  - (2),
+             ODB     - (3),
+             DPSK    - (4),
+             QPSK    - (5),
+             DQPSK   - (6),
+             DPQPSK  - (7),
+             16QAM   - (8),
+             64QAM  -  (9),
+             256QAM -  (10)
+            "
+        ::= { jnxOpticsConfigEntry 9 }
+
+    jnxTxOpticalPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Transmit optical power."
+        ::= { jnxOpticsConfigEntry 10 }
+
+    jnxRxOpticalPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive optical power."
+        ::= { jnxOpticsConfigEntry 11 }
+
+    jnxModuleTempHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "Celsius (0.01 degrees C)"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "High module temerature in degree fahrenheit for a 15 minute period 
+             above which a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 12 }
+
+    jnxModuleTempLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "Celsius (0.01 degrees C)"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION  
+            "Low module temerature in degree fahrenheit for a 15 minute period
+             above which a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 13 }
+
+    jnxTxPowerHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Tx power for a 15 minute period above which 
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 14 }
+
+    jnxTxPowerLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Tx Power for a 15 minute period below which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 15 }
+
+    jnxRxPowerHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Rx power for a 15 minute period above which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 16 }
+
+    jnxRxPowerLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Rx Power for a 15 minute period below which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 17 }
+
+    jnx24HourModuleTempHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "Celsius (0.01 degrees C)"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "High module temerature in degree fahrenheit for a 24 hour period
+             above which a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 18 }
+
+    jnx24HourModuleTempLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "Celsius (0.01 degrees C)"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Low module temerature in degree fahrenheit for a 24 hour period
+             above which a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 19 }
+
+    jnx24HourTxPowerHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Tx power for a 24 hour period above which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 20 }
+
+    jnx24HourTxPowerLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Tx for a 24 hour period Power below which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 21 }
+
+    jnx24HourRxPowerHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Rx power for a 24 hour period above which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 22 }
+
+    jnx24HourRxPowerLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Rx Power for a 24 hour period below which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 23 }
+
+    jnxRxLosPowerWarningThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Rx Power warning threshold for seeting the optical LOS 
+             warning. "
+        ::= { jnxOpticsConfigEntry 24 }
+
+    jnxRxLosPowerAlarmThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Rx Power alarm threshold for seeting the optical LOS 
+             warning. "
+        ::= { jnxOpticsConfigEntry 25 }
+
+    jnxOpticsCurrentStatus OBJECT-TYPE
+        SYNTAX          BITS {
+                            opticalLos(1),       
+                            wavelenthLockErr(2),
+                            powerHighAlarm(3),
+                            powerLowAlarm(4),
+                            biasCurrentHighAlarm(5),
+                            biasCurrentLowAlarm(6),
+                            temperatureHighAlarm(7),
+                            temperaturelowAlarm(8),
+                            txPLLLockAlarm(9),
+                            rxPLLLockAlarm(10),
+                            avgPowerAlarm(11),
+                            rxLossAvgPowerAlarm(12),
+                            lossofACPowerAlarm(13),
+                            txPowerHighThreshAlert(14),
+                            txPowerLowThreshAlert(15),
+                            rxPowerHighThreshAlert(16),
+                            rxPowerLowThreshAlert(17),
+                            moduleTempHighThreshAlert(18),
+                            moduleTempLowThreshAlert(19),
+                            txPowerHigh24HourThreshAlert(20),
+                            txPowerLow24HourThreshAlert(21),
+                            rxPowerHigh24HourThreshAlert(22),
+                            rxPowerLow24HourThreshAlert(23),
+                            moduleTempHigh24HourThreshAlert(24),
+                            moduleTempLow24HourThreshAlert(25),
+                            powerRxHighAlarm(26),
+                            powerRxLowAlarm(27),
+                            powerTxHighWarning(28),
+                            powerTxLowWarning(29),
+                            powerRxHighWarning(30),
+                            powerRxLowWarning(31),
+                            temperatureHighWarning(32),
+                            temperaturelowWarning(33)
+                        }
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            " "
+        ::= { jnxOpticsConfigEntry 26 }
+
+    jnxTxPowerHighEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Tx Power High TCA."
+        ::= { jnxOpticsConfigEntry 27 }
+
+    jnxTxPowerLowEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Tx Power Low TCA."
+        ::= { jnxOpticsConfigEntry 28 }
+
+    jnxRxPowerHighEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Rx Power High TCA."
+        ::= { jnxOpticsConfigEntry 29 }
+
+    jnxRxPowerLowEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Rx Power Low TCA."
+        ::= { jnxOpticsConfigEntry 30 }
+
+    jnxModuleTempHighEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Module Temp High TCA."
+        ::= { jnxOpticsConfigEntry 31 }
+
+    jnxModuleTempLowEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Module Temp Low TCA."
+        ::= { jnxOpticsConfigEntry 32 }
+
+
+    jnxCarFreqOffsetHighEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the Carrier Frequency Offset High TCA."
+        ::= { jnxOpticsConfigEntry 33 }
+
+    jnxCarFreqOffsetLowEnableTCA OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            " Enable/Disable for the CarrierFreqOffetLow TCA's."
+        ::= { jnxOpticsConfigEntry 34 }
+
+    jnxCarFreqOffsetHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Carrier frequency offset for a 15 minute period above which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 35 }
+
+    jnx24HourCarFreqOffsetHighThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Carrier frequency offset for a 24 Hour period above which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 36 }
+
+    jnxCarFreqOffsetLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Carrier frequency offset for a 15 minute period Low which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 37 }
+
+    jnx24HourCarFreqOffsetLowThresh OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "Carrier frequency offset for a 24 Hour period Low which
+             a Threshold Crossing Alert (TCA) should be sent.
+             Only one TCA will be sent per period ."
+        ::= { jnxOpticsConfigEntry 38 }
+
+
+--
+-- Tracetone config
+--
+jnxOpticsTraceToneCfgTable   OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxOpticsTraceToneCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+            "Information about the optics tests."
+        ::= { jnxOptics 2 }
+
+jnxOpticsTraceToneCfgEntry OBJECT-TYPE
+        SYNTAX     JnxOpticsTraceToneCfgEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+            "Information about the optics FRU's."
+        INDEX   { jnxOpticsTraceToneCfgContainerIndex,
+                  jnxOpticsTraceToneCfgL1Index,
+                  jnxOpticsTraceToneCfgL2Index,
+                  jnxOpticsTraceToneCfgL3Index }
+        ::= { jnxOpticsTraceToneCfgTable 1 }
+
+JnxOpticsTraceToneCfgEntry ::=
+    SEQUENCE {
+            jnxOpticsTraceToneCfgContainerIndex            Integer32,
+            jnxOpticsTraceToneCfgL1Index                   Integer32,
+            jnxOpticsTraceToneCfgL2Index                   Integer32,
+            jnxOpticsTraceToneCfgL3Index                   Integer32,
+            jnxOpticsTraceToneCfgTxEnable                  TruthValue,
+            jnxOpticsTraceToneCfgRxEnable                  TruthValue,
+            jnxOpticsTraceToneCfgDestId                    OCTET STRING,
+            jnxOpticsTraceToneCfgTxMsg                     OCTET STRING,
+            jnxOpticsTraceToneCfgRxMsg                     OCTET STRING
+    }
+
+
+    jnxOpticsTraceToneCfgContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The associated jnxContentsContainerIndex  - eg shelf.."
+        ::= { jnxOpticsTraceToneCfgEntry 1 }
+
+    jnxOpticsTraceToneCfgL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The level one index associated with this subject ... eg fpc
+             slot."
+        ::= { jnxOpticsTraceToneCfgEntry 2 }
+
+    jnxOpticsTraceToneCfgL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The level two index associated with this subject .. eg pic
+             slot."
+        ::= { jnxOpticsTraceToneCfgEntry 3 }
+
+    jnxOpticsTraceToneCfgL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+            "The level three index associated with this subject..
+             eg port."
+        ::= { jnxOpticsTraceToneCfgEntry 4 }
+
+    jnxOpticsTraceToneCfgTxEnable OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "This will enable/disable the transmit Trace tone feature."
+        ::= { jnxOpticsTraceToneCfgEntry 5 }
+
+    jnxOpticsTraceToneCfgRxEnable OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "This will enable/disable the receive Trace tone feature."
+        ::= { jnxOpticsTraceToneCfgEntry 6 }
+
+    jnxOpticsTraceToneCfgDestId OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "This is the destination Id of the link
+             ID/ the chassis and the blade.
+             The transmit messages will also have the src id
+             which is this chassis id and this port info."
+        ::= { jnxOpticsTraceToneCfgEntry 7 }
+
+    jnxOpticsTraceToneCfgTxMsg OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+            "This will be the transmit data in the tracetone message."
+        ::= { jnxOpticsTraceToneCfgEntry 8 }
+
+    jnxOpticsTraceToneCfgRxMsg  OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "This will be the receive data in the trace tone message."
+        ::= { jnxOpticsTraceToneCfgEntry 9 }
+
+--
+-- Notification Trigger Table
+--
+jnxOpticsNotificationTrigDefaultHoldtimeUp OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect to
+                   persist before it is declared an alarm.
+                "
+       ::= { jnxOptics 3 }
+
+jnxOpticsNotificationTrigDefaultHoldtimeDown OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect to
+                   absent before the alarm is cleared.
+                "
+       ::= { jnxOptics 4 }
+
+--
+-- Table to configure individual optics notifications 
+--
+jnxOpticsNotificationTrigTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxOpticsNotificationTrigEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                "Information about the otn Alarm/Alart/Info trigger table. "
+        ::= { jnxOptics 5 }
+
+jnxOpticsNotificationTrigEntry OBJECT-TYPE
+        SYNTAX     JnxOpticsNotificationTrigEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that contains information about the Otn
+                  Alarm Trigger Table.
+                 "
+        INDEX   { jnxOpticsNotificationTrigContainerIndex,
+                  jnxOpticsNotificationTrigL1Index,
+                  jnxOpticsNotificationTrigL2Index,
+                  jnxOpticsNotificationTrigL3Index,
+                  jnxOpticsNotificationTrigAlmId }
+        ::= { jnxOpticsNotificationTrigTable 1 }
+
+JnxOpticsNotificationTrigEntry ::=
+    SEQUENCE {
+            jnxOpticsNotificationTrigContainerIndex
+                                Integer32,
+            jnxOpticsNotificationTrigL1Index
+                                Integer32,
+            jnxOpticsNotificationTrigL2Index
+                                Integer32,
+            jnxOpticsNotificationTrigL3Index
+                                Integer32,
+            jnxOpticsNotificationTrigAlmId
+                                JnxOpticsNotificationId,
+            jnxOpticsNotificationTrigSeverity
+                                JnxOpticsSeverity,
+            jnxOpticsNotificationTrigIgnore
+                                TruthValue,
+            jnxOpticsNotificationTrigHoldtimeUp
+                                Integer32,
+            jnxOpticsNotificationTrigHoldtimeDown
+                                Integer32,
+            jnxOpticsTrigServiceStateAction
+                                JnxOpticsServiceStateAction
+    }
+
+    jnxOpticsNotificationTrigContainerIndex OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The associated jnxContentsContainerIndex  - eg shelf."
+        ::= { jnxOpticsNotificationTrigEntry 1 }
+
+    jnxOpticsNotificationTrigL1Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level one index associated with this subject ... eg fpc
+                 slot."
+        ::= { jnxOpticsNotificationTrigEntry 2 }
+
+    jnxOpticsNotificationTrigL2Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level two index associated with this subject .. eg pic
+                 slot."
+        ::= { jnxOpticsNotificationTrigEntry 3 }
+
+    jnxOpticsNotificationTrigL3Index OBJECT-TYPE
+        SYNTAX          Integer32 (1..1024)
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "The level three index associated with this subject..
+                 eg port.
+                "
+        ::= { jnxOpticsNotificationTrigEntry 4 }
+
+    jnxOpticsNotificationTrigAlmId OBJECT-TYPE
+        SYNTAX          JnxOpticsNotificationId
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION
+                "
+                 This will be the type of Alarm as defined by 
+                 JnxOpticsNotificationId
+                "
+        ::= { jnxOpticsNotificationTrigEntry 5 }
+
+    jnxOpticsNotificationTrigSeverity OBJECT-TYPE
+        SYNTAX          JnxOpticsSeverity
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                 This will be the Severity of the Notification.
+                "
+        ::= { jnxOpticsNotificationTrigEntry 6 }
+
+    jnxOpticsNotificationTrigIgnore OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will ignore the alarm when set.
+                "
+        ::= { jnxOpticsNotificationTrigEntry 7 }
+
+
+    jnxOpticsNotificationTrigHoldtimeUp OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) for the defect to
+                   persist before it is declared an alarm.
+                "
+        ::= { jnxOpticsNotificationTrigEntry 8 }
+
+    jnxOpticsNotificationTrigHoldtimeDown OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+                "
+                   This object will indicate the time (ms) the defect is
+                   absent before the alarm is cleared.
+                "
+        ::= { jnxOpticsNotificationTrigEntry 9 }
+
+    jnxOpticsTrigServiceStateAction OBJECT-TYPE
+        SYNTAX          JnxOpticsServiceStateAction
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+                "
+                   This will indicate whether this alarm is service affecting
+                   or not .
+                "
+        ::= { jnxOpticsNotificationTrigEntry 10 }
+
+
+
+
+
+--
+-- Optical PM data
+-- 
+jnxOpticsPMCurrentTable OBJECT-TYPE
+     SYNTAX     SEQUENCE OF JnxOpticsPMCurrentEntry
+     MAX-ACCESS not-accessible
+     STATUS     current
+     DESCRIPTION
+         "A table of current PM entries."
+
+     ::= { jnxOpticsPerformanceMonitoring 1 }
+
+jnxOpticsPMCurrentEntry  OBJECT-TYPE
+     SYNTAX     JnxOpticsPMCurrentEntry
+     MAX-ACCESS not-accessible
+     STATUS     current
+     DESCRIPTION
+         "A conceptual row that contains information about the PM Current
+          Table."
+     INDEX    { ifIndex }
+     ::= { jnxOpticsPMCurrentTable 1 }
+
+JnxOpticsPMCurrentEntry  ::= SEQUENCE {
+        jnxPMCurChromaticDispersion      
+                            Integer32,
+        jnxPMCurDiffGroupDelay   
+                            Integer32,
+        jnxPMCurPolarizationState        
+                            Integer32,
+        jnxPMCurPolarDepLoss
+                            Integer32,
+        jnxPMCurQ                        
+                            Integer32,
+        jnxPMCurSNR                      
+                            Integer32,
+        jnxPMCurTxOutputPower            
+                            Integer32,
+        jnxPMCurRxInputPower             
+                            Integer32,
+        jnxPMCurMinChromaticDispersion
+                            Integer32,
+        jnxPMCurMaxChromaticDispersion
+                            Integer32,
+        jnxPMCurAvgChromaticDispersion
+                            Integer32,
+        jnxPMCurMinDiffGroupDelay
+                            Integer32,
+        jnxPMCurMaxDiffGroupDelay
+                            Integer32,
+        jnxPMCurAvgDiffGroupDelay
+                            Integer32,
+        jnxPMCurMinPolarState
+                            Integer32,
+        jnxPMCurMaxPolarState
+                            Integer32,
+        jnxPMCurAvgPolarState
+                            Integer32,
+        jnxPMCurMinPolarDepLoss
+                            Integer32,
+        jnxPMCurMaxPolarDepLoss
+                            Integer32,
+        jnxPMCurAvgPolarDepLoss
+                            Integer32,
+        jnxPMCurMinQ
+                            Integer32,
+        jnxPMCurMaxQ
+                            Integer32,
+        jnxPMCurAvgQ
+                            Integer32,
+        jnxPMCurMinSNR
+                            Integer32,
+        jnxPMCurMaxSNR
+                            Integer32,
+        jnxPMCurAvgSNR
+                            Integer32,
+        jnxPMCurMinTxOutputPower
+                            Integer32,
+        jnxPMCurMaxTxOutputPower
+                            Integer32,
+        jnxPMCurAvgTxOutputPower
+                            Integer32,
+        jnxPMCurMinRxInputPower
+                            Integer32,
+        jnxPMCurMaxRxInputPower
+                            Integer32,
+        jnxPMCurAvgRxInputPower
+                            Integer32,
+        jnxPMCurSuspectedFlag
+                            TruthValue,
+       jnxPMCurSuspectReason
+                            Integer32,
+        jnxPMCurTxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurMinTxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurMaxTxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurAvgTxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurTemperature
+                            Integer32,
+        jnxPMCurMinTemperature
+                            Integer32,
+        jnxPMCurMaxTemperature
+                            Integer32,
+        jnxPMCurAvgTemperature
+                            Integer32,
+        jnxPMCurCarFreqOffset
+                            Integer32,
+        jnxPMCurMinCarFreqOffset
+                            Integer32,
+        jnxPMCurMaxCarFreqOffset
+                            Integer32,
+        jnxPMCurAvgCarFreqOffset
+                            Integer32,
+        jnxPMCurRxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurMinRxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurMaxRxLaserBiasCurrent
+                            Integer32,
+        jnxPMCurAvgRxLaserBiasCurrent
+                            Integer32
+    }
+
+    jnxPMCurChromaticDispersion OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+              port"
+        ::= { jnxOpticsPMCurrentEntry 1 }
+
+    jnxPMCurDiffGroupDelay OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential group delay "
+        ::= { jnxOpticsPMCurrentEntry 2 }
+
+    jnxPMCurPolarizationState OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            " Polarization state "
+        ::= { jnxOpticsPMCurrentEntry 3 }
+
+    jnxPMCurPolarDepLoss OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "The polarisation dependent loss (PDL) is the difference (in dB)
+             between the maximum and minimum values of the channel insertion
+             loss (or gain) of the black-link from point SS to RS due to a
+             variation of the state of polarization (SOP) over all SOPs"
+        ::= { jnxOpticsPMCurrentEntry 4 }
+
+    jnxPMCurQ OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "'Q' factor estimated at Rx Transceiver port "
+        ::= { jnxOpticsPMCurrentEntry 5 }
+
+    jnxPMCurSNR OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR - signal to noise ratio"
+        ::= { jnxOpticsPMCurrentEntry 6 }
+
+    jnxPMCurTxOutputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "TxOutputPower  - transmit output power "
+        ::= { jnxOpticsPMCurrentEntry 7 }
+
+    jnxPMCurRxInputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "RxInputPower   - receive output power"
+        ::= { jnxOpticsPMCurrentEntry 8 }
+
+    jnxPMCurMinChromaticDispersion OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min Residual Chromatic Dispersion measured at Rx Transceiver
+              port"
+        ::= { jnxOpticsPMCurrentEntry 9 }
+
+    jnxPMCurMaxChromaticDispersion OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max Residual Chromatic Dispersion measured at Rx Transceiver
+              port"
+        ::= { jnxOpticsPMCurrentEntry 10 }
+
+    jnxPMCurAvgChromaticDispersion OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Residual Chromatic Dispersion measured at Rx Transceiver
+              port"
+        ::= { jnxOpticsPMCurrentEntry 11 }
+
+    jnxPMCurMinDiffGroupDelay OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min Differential group delay "
+        ::= { jnxOpticsPMCurrentEntry 12 }
+
+    jnxPMCurMaxDiffGroupDelay OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max Differential group delay "
+        ::= { jnxOpticsPMCurrentEntry 13 }
+
+    jnxPMCurAvgDiffGroupDelay OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Differential group delay "
+        ::= { jnxOpticsPMCurrentEntry 14 }
+
+    jnxPMCurMinPolarState OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min Polarization state "
+        ::= { jnxOpticsPMCurrentEntry 15 }
+
+    jnxPMCurMaxPolarState OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max Polarization state "
+        ::= { jnxOpticsPMCurrentEntry 16 }
+
+    jnxPMCurAvgPolarState OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Avg Polarization state "
+        ::= { jnxOpticsPMCurrentEntry 17 }
+
+    jnxPMCurMinPolarDepLoss OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min - The polarisation dependent loss (PDL)"
+        ::= { jnxOpticsPMCurrentEntry 18 }
+
+    jnxPMCurMaxPolarDepLoss OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max - The polarisation dependent loss (PDL)"
+        ::= { jnxOpticsPMCurrentEntry 19 }
+
+    jnxPMCurAvgPolarDepLoss OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Avg - The polarisation dependent loss (PDL)"
+        ::= { jnxOpticsPMCurrentEntry 20 }
+
+    jnxPMCurMinQ OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min 'Q' factor estimated at Rx Transceiver port "
+        ::= { jnxOpticsPMCurrentEntry 21 }
+
+    jnxPMCurMaxQ OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max 'Q' factor estimated at Rx Transceiver port "
+        ::= { jnxOpticsPMCurrentEntry 22 }
+
+    jnxPMCurAvgQ OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Avg 'Q' factor estimated at Rx Transceiver port "
+        ::= { jnxOpticsPMCurrentEntry 23 }
+
+    jnxPMCurMinSNR OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min SNR - signal to noise ratio"
+        ::= { jnxOpticsPMCurrentEntry 24 }
+
+    jnxPMCurMaxSNR OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max SNR - signal to noise ratio"
+        ::= { jnxOpticsPMCurrentEntry 25 }
+
+    jnxPMCurAvgSNR OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Avg SNR - signal to noise ratio"
+        ::= { jnxOpticsPMCurrentEntry 26 }
+
+    jnxPMCurMinTxOutputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min TxOutputPower  - transmit output power "
+        ::= { jnxOpticsPMCurrentEntry 27 }
+
+    jnxPMCurMaxTxOutputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max TxOutputPower  - transmit output power "
+        ::= { jnxOpticsPMCurrentEntry 28 }
+
+    jnxPMCurAvgTxOutputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Avg TxOutputPower  - transmit output power "
+        ::= { jnxOpticsPMCurrentEntry 29 }
+
+    jnxPMCurMinRxInputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Min RxInputPower   - receive output power"
+        ::= { jnxOpticsPMCurrentEntry 30 }
+
+    jnxPMCurMaxRxInputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Max RxInputPower   - receive output power"
+        ::= { jnxOpticsPMCurrentEntry 31 }
+
+    jnxPMCurAvgRxInputPower OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Avg RxInputPower   - receive output power"
+        ::= { jnxOpticsPMCurrentEntry 32 }
+
+    jnxPMCurSuspectedFlag OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "If true, the data in this entry may be unreliable."
+        ::= { jnxOpticsPMCurrentEntry 33 }
+
+    jnxPMCurSuspectReason OBJECT-TYPE
+        SYNTAX      Integer32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "If SuspectedFlag is true, the reson for the PM data being suspect.
+              0 - not applicable
+              1 - unknown
+              2 - new object
+              3 - interface disabled
+              4 - clock shift detected
+              5 - cleared by user
+              6 - interval too short secs < 890
+              7 - interval too long secs > 910
+              8 - near end unavailable
+              9 - far end unavailable
+             10 - partial data
+             11 - missing intervals due to restarts
+            "
+        ::= { jnxOpticsPMCurrentEntry 34 }
+
+    jnxPMCurTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Trasmit LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 35 }
+
+    jnxPMCurMinTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum trasmit LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 36 }
+
+    jnxPMCurMaxTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum trasmit LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 37 }
+
+    jnxPMCurAvgTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 38 }
+
+
+    jnxPMCurTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Temperature  measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 39 }
+
+    jnxPMCurMinTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum   Temperature  measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 40 }
+
+    jnxPMCurMaxTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum Temperature measure  at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 41 }
+
+    jnxPMCurAvgTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Temperature measure  at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 42 }
+
+
+    jnxPMCurCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 43 }
+
+    jnxPMCurMinCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 44 }
+
+    jnxPMCurMaxCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 45 }
+
+    jnxPMCurAvgCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Carrier frequency offset measured at Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 46 }
+
+    jnxPMCurRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Received LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 47 }
+
+    jnxPMCurMinRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Received Minimum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 48 }
+
+    jnxPMCurMaxRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Received Maximum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 49 }
+
+    jnxPMCurAvgRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Received Average LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMCurrentEntry 50 }
+
+
+--
+-- PM Interval Table
+--
+
+jnxOpticsPMIntervalTable OBJECT-TYPE
+     SYNTAX     SEQUENCE OF JnxOpticsPMIntervalEntry
+     MAX-ACCESS not-accessible
+     STATUS     current
+     DESCRIPTION
+         "A table of current PM  entries."
+     ::= { jnxOpticsPerformanceMonitoring 2 }
+
+jnxOpticsPMIntervalEntry  OBJECT-TYPE
+     SYNTAX     JnxOpticsPMIntervalEntry
+     MAX-ACCESS not-accessible
+     STATUS     current
+     DESCRIPTION
+         "A conceptual row that contains information about the PM Interval
+          Table."
+     INDEX    { ifIndex, jnxOpticsPMIntervalNumber }
+     ::= { jnxOpticsPMIntervalTable 1 }
+
+JnxOpticsPMIntervalEntry  ::= SEQUENCE {
+        jnxOpticsPMIntervalNumber                      
+                             Unsigned32,
+        jnxPMIntMinChromaticDispersion      
+                             Integer32,
+        jnxPMIntMaxChromaticDispersion      
+                             Integer32,
+        jnxPMIntAvgChromaticDispersion      
+                             Integer32,
+        jnxPMIntMinDiffGroupDelay   
+                             Integer32,
+        jnxPMIntMaxDiffGroupDelay   
+                             Integer32,
+        jnxPMIntAvgDiffGroupDelay   
+                             Integer32,
+        jnxPMIntMinPolarState        
+                             Integer32,
+        jnxPMIntMaxPolarState        
+                             Integer32,
+        jnxPMIntAvgPolarState        
+                             Integer32,
+        jnxPMIntMinPolarDependentLoss
+                             Integer32,
+        jnxPMIntMaxPolarDependentLoss
+                             Integer32,
+        jnxPMIntAvgPolarDependentLoss
+                             Integer32,
+        jnxPMIntMinQ                        
+                             Integer32,
+        jnxPMIntMaxQ                        
+                             Integer32,
+        jnxPMIntAvgQ                        
+                             Integer32,
+        jnxPMIntMinSNR                      
+                             Integer32,
+        jnxPMIntMaxSNR                      
+                             Integer32,
+        jnxPMIntAvgSNR                      
+                             Integer32,
+        jnxPMIntMinTxOutputPower            
+                             Integer32,
+        jnxPMIntMaxTxOutputPower            
+                             Integer32,
+        jnxPMIntAvgTxOutputPower            
+                             Integer32,
+        jnxPMIntMinRxInputPower              
+                             Integer32,
+        jnxPMIntMaxRxInputPower             
+                             Integer32,
+        jnxPMIntAvgRxInputPower             
+                             Integer32,
+        jnxPMIntTimeStamp
+                             DateAndTime,
+        jnxPMIntSuspectedFlag
+                             TruthValue,
+        jnxPMIntSuspectReason
+                             Integer32,
+        jnxPMIntMinTxLaserBiasCurrent
+                            Integer32,
+        jnxPMIntMaxTxLaserBiasCurrent
+                            Integer32,
+        jnxPMIntAvgTxLaserBiasCurrent
+                            Integer32,
+        jnxPMIntMinTemperature
+                            Integer32,
+        jnxPMIntMaxTemperature
+                            Integer32,
+        jnxPMIntAvgTemperature
+                            Integer32,
+        jnxPMIntMinCarFreqOffset
+                            Integer32,
+        jnxPMIntMaxCarFreqOffset
+                            Integer32,
+        jnxPMIntAvgCarFreqOffset
+                            Integer32,
+        jnxPMIntMinRxLaserBiasCurrent
+                            Integer32,
+        jnxPMIntMaxRxLaserBiasCurrent
+                            Integer32,
+        jnxPMIntAvgRxLaserBiasCurrent
+                            Integer32
+    }
+
+    jnxOpticsPMIntervalNumber OBJECT-TYPE
+        SYNTAX         Unsigned32(1..96)
+        MAX-ACCESS     not-accessible
+        STATUS         current
+        DESCRIPTION
+            "This is the 15 mintute interavl number."
+        ::= { jnxOpticsPMIntervalEntry 1 }
+
+    jnxPMIntMinChromaticDispersion OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+             port - min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 2 }
+
+    jnxPMIntMaxChromaticDispersion OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+             port - max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 3 }
+
+    jnxPMIntAvgChromaticDispersion OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+             port - average in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 4 }
+
+    jnxPMIntMinDiffGroupDelay OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential group delay measured at Rx Transceiver
+             port -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 5 }
+
+    jnxPMIntMaxDiffGroupDelay OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential group delay measured at Rx Transceiver
+             port -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 6 }
+
+    jnxPMIntAvgDiffGroupDelay OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential group delay measured at Rx Transceiver
+             port -- average in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 7 }
+
+    jnxPMIntMinPolarState OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization state -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 8 }
+
+    jnxPMIntMaxPolarState OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization state -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 9 }
+
+    jnxPMIntAvgPolarState OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization state -- average in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 10 }
+
+    jnxPMIntMinPolarDependentLoss OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization Dependent Loss -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 11 }
+
+    jnxPMIntMaxPolarDependentLoss OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization Dependent Loss -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 12 }
+
+    jnxPMIntAvgPolarDependentLoss OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization Dependent Loss  -- average in the 15 minute
+              interval"
+        ::= { jnxOpticsPMIntervalEntry 13 }
+
+    jnxPMIntMinQ OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Q -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 14 }
+
+    jnxPMIntMaxQ OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Q -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 15 }
+
+    jnxPMIntAvgQ OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Q -- Avg in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 16 }
+
+    jnxPMIntMinSNR OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 17 }
+
+    jnxPMIntMaxSNR OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 18 }
+
+    jnxPMIntAvgSNR OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR -- avg in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 19 }
+
+    jnxPMIntMinTxOutputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "TxOutputPower -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 20 }
+
+    jnxPMIntMaxTxOutputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "TxOutputPower  -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 21 }
+
+    jnxPMIntAvgTxOutputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     
+            "TxOutputPower  -- average in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 22 }
+
+    jnxPMIntMinRxInputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "RxInputPower -- min in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 23}
+
+    jnxPMIntMaxRxInputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     
+            "RxInputPower  -- max in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 24 }
+
+    jnxPMIntAvgRxInputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS           "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "RxInputPower  -- average in the 15 minute interval"
+        ::= { jnxOpticsPMIntervalEntry 25 }
+
+    jnxPMIntTimeStamp OBJECT-TYPE
+        SYNTAX      DateAndTime
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Time stamp PM interval"
+        ::= { jnxOpticsPMIntervalEntry 26 }
+
+    jnxPMIntSuspectedFlag OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "If true, the data in this entry may be unreliable."
+        ::= { jnxOpticsPMIntervalEntry 27 }
+
+    jnxPMIntSuspectReason OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "If SuspectedFlag is true, the reson for the PM data being suspect.
+              0 - not applicable
+              1 - unknown
+              2 - new object
+              3 - interface disabled
+              4 - clock shift detected
+              5 - cleared by user
+              6 - interval too short secs < 890
+              7 - interval too long secs > 910
+              8 - near end unavailable
+              9 - far end unavailable
+             10 - partial data
+             11 - missing intervals due to restarts
+            "
+        ::= { jnxOpticsPMIntervalEntry 28 }
+
+    jnxPMIntMinTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Transmit Minimum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 29 }
+
+    jnxPMIntMaxTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Transmit Maximum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 30 }
+
+    jnxPMIntAvgTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Transmit Average LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 31 }
+
+   jnxPMIntMinTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum   Temperature  measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 32 }
+
+    jnxPMIntMaxTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum Temperature measure  at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 33 }
+
+    jnxPMIntAvgTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Temperature measure  at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 34 }
+
+    jnxPMIntMinCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "Mhz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 35 }
+
+    jnxPMIntMaxCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 36 }
+
+    jnxPMIntAvgCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 37 }
+
+    jnxPMIntMinRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive Minimum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 38 }
+
+    jnxPMIntMaxRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive Maximum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 39 }
+
+    jnxPMIntAvgRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive Average LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMIntervalEntry 40 }
+
+
+--
+-- Cur/Prev Day Table
+--
+jnxOpticsPMDayTable OBJECT-TYPE
+     SYNTAX     SEQUENCE OF JnxOpticsPMDayEntry
+     MAX-ACCESS not-accessible
+     STATUS     current
+     DESCRIPTION
+         "A table of current PM Day entries."
+
+     ::= { jnxOpticsPerformanceMonitoring 3 }
+
+jnxOpticsPMDayEntry  OBJECT-TYPE
+     SYNTAX     JnxOpticsPMDayEntry
+     MAX-ACCESS not-accessible
+     STATUS     current
+     DESCRIPTION
+         "A conceptual row that contains information about the PM Day
+          Table"
+     INDEX    { ifIndex, jnxOpticsPMDayIndex }
+     ::= { jnxOpticsPMDayTable 1 }
+
+JnxOpticsPMDayEntry  ::= SEQUENCE {
+        jnxOpticsPMDayIndex                       
+                                           Unsigned32,
+        jnxPMDayMinChromaticDispersion      
+                                           Integer32,
+        jnxPMDayMaxChromaticDispersion      
+                                           Integer32,
+        jnxPMDayAvgChromaticDispersion      
+                                           Integer32,
+        jnxPMDayMinDiffGroupDelay   
+                                           Integer32,
+        jnxPMDayMaxDiffGroupDelay   
+                                           Integer32,
+        jnxPMDayAvgDiffGroupDelay   
+                                           Integer32,
+        jnxPMDayMinPolarState        
+                                           Integer32,
+        jnxPMDayMaxPolarState        
+                                           Integer32,
+        jnxPMDayAvgPolarState        
+                                           Integer32,
+        jnxPMDayMinPolarDependentLoss
+                                           Integer32,
+        jnxPMDayMaxPolarDependentLoss
+                                           Integer32,
+        jnxPMDayAvgPolarDependentLoss
+                                           Integer32,
+        jnxPMDayMinQ                        
+                                           Integer32,
+        jnxPMDayMaxQ                        
+                                           Integer32,
+        jnxPMDayAvgQ                        
+                                           Integer32,
+        jnxPMDayMinSNR                      
+                                           Integer32,
+        jnxPMDayMaxSNR                      
+                                           Integer32,
+        jnxPMDayAvgSNR                      
+                                           Integer32,
+        jnxPMDayMinTxOutputPower            
+                                           Integer32,
+        jnxPMDayMaxTxOutputPower            
+                                           Integer32,
+        jnxPMDayAvgTxOutputPower            
+                                           Integer32,
+        jnxPMDayMinRxInputPower             
+                                           Integer32,
+        jnxPMDayMaxRxInputPower             
+                                           Integer32,
+        jnxPMDayAvgRxInputPower             
+                                           Integer32,
+        jnxPMDayTimeStamp
+                                           DateAndTime,
+        jnxPMDaySuspectedFlag
+                                           TruthValue,
+        jnxPMDaySuspectReason
+                                           Integer32,
+        jnxPMDayMinTxLaserBiasCurrent
+                                           Integer32,
+        jnxPMDayMaxTxLaserBiasCurrent
+                                           Integer32,
+        jnxPMDayAvgTxLaserBiasCurrent
+                                           Integer32,
+        jnxPMDayMinTemperature
+                                           Integer32,
+        jnxPMDayMaxTemperature
+                                           Integer32,
+        jnxPMDayAvgTemperature
+                                           Integer32,
+        jnxPMDayMinCarFreqOffset
+                                           Integer32,
+        jnxPMDayMaxCarFreqOffset
+                                           Integer32,
+        jnxPMDayAvgCarFreqOffset
+                                           Integer32,
+        jnxPMDayMinRxLaserBiasCurrent
+                                           Integer32,
+        jnxPMDayMaxRxLaserBiasCurrent
+                                           Integer32,
+        jnxPMDayAvgRxLaserBiasCurrent
+                                           Integer32
+
+    }
+
+    jnxOpticsPMDayIndex OBJECT-TYPE
+        SYNTAX         Unsigned32(1..2)
+        MAX-ACCESS     not-accessible
+        STATUS         current
+        DESCRIPTION
+            "This is 1 - cur day/ 2 - prev day "
+        ::= { jnxOpticsPMDayEntry 1 }
+
+    jnxPMDayMinChromaticDispersion OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+             port - min in the day"
+        ::= { jnxOpticsPMDayEntry 2 }
+
+    jnxPMDayMaxChromaticDispersion OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+             port - max in the day"
+        ::= { jnxOpticsPMDayEntry 3 }
+
+    jnxPMDayAvgChromaticDispersion OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps/nm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Residual Chromatic Dispersion measured at Rx Transceiver
+             port - average in the day"
+        ::= { jnxOpticsPMDayEntry 4 }
+
+    jnxPMDayMinDiffGroupDelay OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential Group Delay measured at Rx Transceiver
+             port -- min in the day"
+        ::= { jnxOpticsPMDayEntry 5 }
+
+    jnxPMDayMaxDiffGroupDelay OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential Group Delay measured at Rx Transceiver
+             port -- max in the day"
+        ::= { jnxOpticsPMDayEntry 6 }
+
+    jnxPMDayAvgDiffGroupDelay OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "ps"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Differential Group Delay measured at Rx Transceiver
+             port -- average in the day"
+        ::= { jnxOpticsPMDayEntry 7 }
+
+    jnxPMDayMinPolarState OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization state -- min in the day"
+        ::= { jnxOpticsPMDayEntry 8 }
+
+    jnxPMDayMaxPolarState OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization state -- max in the day"
+        ::= { jnxOpticsPMDayEntry 9 }
+
+    jnxPMDayAvgPolarState OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "rad/s"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization state -- average in the day"
+        ::= { jnxOpticsPMDayEntry 10 }
+
+    jnxPMDayMinPolarDependentLoss OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization Dependent Loss -- min in the day"
+        ::= { jnxOpticsPMDayEntry 11 }
+
+    jnxPMDayMaxPolarDependentLoss OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization Dependent Loss -- max in the day"
+        ::= { jnxOpticsPMDayEntry 12 }
+
+    jnxPMDayAvgPolarDependentLoss OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Polarization Dependent Loss  -- average in the day
+             interval"
+        ::= { jnxOpticsPMDayEntry 13 }
+
+
+    jnxPMDayMinQ OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Q -- min in the day"
+        ::= { jnxOpticsPMDayEntry 14 }
+
+    jnxPMDayMaxQ OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Q -- max in the day"
+        ::= { jnxOpticsPMDayEntry 15 }
+
+    jnxPMDayAvgQ OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Q -- Avg in the day"
+        ::= { jnxOpticsPMDayEntry 16 }
+
+    jnxPMDayMinSNR OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR -- min in the day"
+        ::= { jnxOpticsPMDayEntry 17 }
+
+    jnxPMDayMaxSNR OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR -- max in the day"
+        ::= { jnxOpticsPMDayEntry 18 }
+
+    jnxPMDayAvgSNR OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.1 dB"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "SNR -- avg in the day"
+        ::= { jnxOpticsPMDayEntry 19 }
+
+    jnxPMDayMinTxOutputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "TxOutputPower -- min in the day"
+        ::= { jnxOpticsPMDayEntry 20 }
+
+    jnxPMDayMaxTxOutputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "TxOutputPower  -- max in the day."
+        ::= { jnxOpticsPMDayEntry 21 }
+
+    jnxPMDayAvgTxOutputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "TxOutputPower  -- average in the day."
+        ::= { jnxOpticsPMDayEntry 22 }
+
+    jnxPMDayMinRxInputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "RxInputPower -- min in the day."
+        ::= { jnxOpticsPMDayEntry 23}
+
+    jnxPMDayMaxRxInputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "RxInputPower  -- max in the day."
+        ::= { jnxOpticsPMDayEntry 24 }
+
+    jnxPMDayAvgRxInputPower OBJECT-TYPE
+        SYNTAX         Integer32
+        UNITS          "0.01 dbm"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "RxInputPower  -- average in the day."
+        ::= { jnxOpticsPMDayEntry 25 }
+
+    jnxPMDayTimeStamp OBJECT-TYPE
+        SYNTAX      DateAndTime
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Time for the Day."
+        ::= { jnxOpticsPMDayEntry 26 }
+
+    jnxPMDaySuspectedFlag OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "If true, the data in this entry may be unreliable."
+        ::= { jnxOpticsPMDayEntry 27 }
+
+    jnxPMDaySuspectReason OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "If SuspectedFlag is true, the reson for the PM data being suspect.
+              0 - not applicable
+              1 - unknown
+              2 - new object
+              3 - interface disabled
+              4 - clock shift detected
+              5 - cleared by user
+              6 - partial data
+              7 - one or more intervals are invaild
+            "
+        ::= { jnxOpticsPMDayEntry 28 }
+
+    jnxPMDayMinTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Transmit LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 29 }
+
+    jnxPMDayMaxTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Transmit Minimum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 30 }
+
+    jnxPMDayAvgTxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Transmit Maximum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 31 }
+
+   jnxPMDayMinTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum   Temperature  measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 32 }
+
+    jnxPMDayMaxTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum Temperature measure  at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 33 }
+
+    jnxPMDayAvgTemperature OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 Celcius"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Temperature measure  at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 34 }
+
+    jnxPMDayMinCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "Mhz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Minimum Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 35 }
+
+    jnxPMDayMaxCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Maximum Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 36 }
+
+    jnxPMDayAvgCarFreqOffset OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "MHz"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Average Carrier frequency offset measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 37 }
+
+   jnxPMDayMinRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 38 }
+
+    jnxPMDayMaxRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive Minimum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 39 }
+
+    jnxPMDayAvgRxLaserBiasCurrent OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           ".1 mA"
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION
+            "Receive Maximum LaserBiasCurrent measured at  Transceiver port"
+        ::= { jnxOpticsPMDayEntry 40 }
+
+
+
+
+--
+-- Optics Alarm/Alert  Table
+--
+jnxOpticsNotificationTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF JnxOpticsNotificationEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+         "A table of Notification entries."
+    ::= { jnxOpticsAlarm 1 }
+
+jnxOpticsNotificationEntry OBJECT-TYPE
+    SYNTAX     JnxOpticsNotificationEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+        "A conceptual entry in the Notification table."
+    INDEX { ifIndex, jnxOpticsNotificationLocation,
+            jnxOpticsNotificationDirection
+    }
+    ::= { jnxOpticsNotificationTable 1 }
+
+JnxOpticsNotificationEntry ::= SEQUENCE {
+        jnxOpticsNotificationLocation
+                            JnxOpticsLocation,
+        jnxOpticsNotificationDirection
+                            JnxOpticsDirection,
+        jnxOpticsNotificationSeverity
+                            JnxOpticsSeverity,
+        jnxOpticsLastNotificationId
+                            JnxOpticsNotificationId,
+        jnxOpticsNotificationDate         
+                            DateAndTime
+    }
+
+    jnxOpticsNotificationLocation OBJECT-TYPE
+        SYNTAX      JnxOpticsLocation 
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "The object identifies indicates if this entry was for
+             Near end/Far end."
+        ::= { jnxOpticsNotificationEntry 1 }
+
+    jnxOpticsNotificationDirection OBJECT-TYPE
+        SYNTAX      JnxOpticsDirection
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "The object identifies indicates if this entry was for
+             for the Tx/Rx or both."
+        ::= { jnxOpticsNotificationEntry 2 }
+
+    jnxOpticsLastNotificationId OBJECT-TYPE
+        SYNTAX      JnxOpticsNotificationId
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "The object identifies the OTN alarm that most recently
+             was set or cleared."
+        ::= { jnxOpticsNotificationEntry 3 }
+
+    jnxOpticsNotificationSeverity  OBJECT-TYPE
+        SYNTAX          JnxOpticsSeverity
+        MAX-ACCESS      accessible-for-notify
+        STATUS          current
+        DESCRIPTION
+            "The object identifies the severity of the last  alarm/alert
+             that most recently was set or cleared."
+        ::= { jnxOpticsNotificationEntry 4 }
+	
+    jnxOpticsNotificationDate OBJECT-TYPE
+        SYNTAX      DateAndTime
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "This specifies the date and time when this alarm occurred."
+        ::= { jnxOpticsNotificationEntry 5 }
+
+--
+-- Clear PM's for Interfaces
+--
+
+
+-- Clear for all Performance monitoring counters on this interface
+--
+jnxOpticsClearAllPMs OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+                " To clear all optics Performance monitoring counters on all
+                  interfaces. "
+        ::= { jnxOptics  6 }
+
+
+jnxOpticsClearIfPMsTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF JnxOpticsClearIfPMsEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                " To clear optics Performance monitoring counters on this
+                  interfaces "
+        INDEX       { ifIndex }
+        ::= { jnxOptics  7 }
+
+jnxOpticsClearIfPMsEntry OBJECT-TYPE
+        SYNTAX     JnxOpticsClearIfPMsEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+                 "A conceptual row that s used to clear the Optics PM Table."
+        INDEX   { ifIndex }
+        ::= { jnxOpticsClearIfPMsTable 1 }
+
+JnxOpticsClearIfPMsEntry ::=
+    SEQUENCE {
+            jnxOpticsClearCurrent
+                             TruthValue,
+            jnxOpticsClearInterfaceInterval
+                             TruthValue,
+            jnxOpticsClearInterfaceDay
+                             TruthValue,
+            jnxOpticsClearInterfaceAll
+                             TruthValue
+    }
+
+    jnxOpticsClearCurrent OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1- to clear all the Current Optics PM's for this interface
+               "
+        ::= { jnxOpticsClearIfPMsEntry 1 }
+
+    jnxOpticsClearInterfaceInterval OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1- to clear all the Optics PM's intervals(1-96) for this
+                 interface
+               "
+        ::= { jnxOpticsClearIfPMsEntry 2 }
+
+    jnxOpticsClearInterfaceDay OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1 - to clear all the Current Day and Previous Day Optics PM's
+                     for this interface
+               "
+        ::= { jnxOpticsClearIfPMsEntry 3 }
+
+    jnxOpticsClearInterfaceAll OBJECT-TYPE
+        SYNTAX          TruthValue
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION
+               " 1 - to clear all the  Optics PM's for this interface
+               "
+        ::= { jnxOpticsClearIfPMsEntry 4 }
+
+
+
+--
+-- Alarm/Alert Notifications
+--
+
+jnxOpticsNotificationPrefix   OBJECT IDENTIFIER ::=
+                                         { jnxOpticsNotifications 0 }
+
+    jnxOpticsNotificationSet NOTIFICATION-TYPE
+        OBJECTS { 
+            jnxOpticsNotificationLocation,
+            jnxOpticsNotificationDirection,
+            ifDescr,
+            jnxOpticsLastNotificationId, 
+            jnxOpticsNotificationSeverity,
+            jnxOpticsNotificationDate
+        }
+        STATUS  current
+        DESCRIPTION
+            "Notification of a recently set optics alarm."
+        ::= { jnxOpticsNotificationPrefix 1 }
+
+    jnxOpticsNotificationCleared NOTIFICATION-TYPE
+        OBJECTS { 
+            jnxOpticsNotificationLocation,
+            jnxOpticsNotificationDirection,
+            ifDescr,
+            jnxOpticsLastNotificationId, 
+            jnxOpticsNotificationSeverity,
+            jnxOpticsNotificationDate
+        }
+        STATUS  current
+        DESCRIPTION
+            "Notification of a recently cleared optics alarm."
+        ::= { jnxOpticsNotificationPrefix 2 }
+
+
+END

--- a/mibs/junos/mib-jnx-optif.txt
+++ b/mibs/junos/mib-jnx-optif.txt
@@ -1,0 +1,7204 @@
+JNX-OPT-IF-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Gauge32, Integer32,
+    Unsigned32, transmission
+        FROM SNMPv2-SMI
+        TEXTUAL-CONVENTION, RowPointer, RowStatus, TruthValue
+        FROM SNMPv2-TC
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    jnxoptIfMibRoot
+        FROM JUNIPER-SMI
+    ifIndex
+        FROM IF-MIB;
+
+
+--This is the MIB module for the OTN Interface objects. 
+
+
+jnxoptIfMibModule MODULE-IDENTITY 
+    LAST-UPDATED "200308130000Z" 
+    ORGANIZATION "IETF AToM MIB Working Group" 
+    CONTACT-INFO
+            "WG charter: 
+             http://www.ietf.org/html.charters/atommib-charter.html
+
+             Mailing Lists: 
+             General Discussion: atommib@research.telcordia.com 
+             To Subscribe: atommib-request@research.telcordia.com 
+             RFC 3591 Optical Interface Type MIB September 2003
+             Editor: Hing-Kam Lam
+             Postal: Lucent Technologies, Room 4C-616 
+                     101 Crawfords Corner Road 
+                     Holmdel, NJ 07733
+
+              Tel: +1 732 949 8338 
+             Email: hklam@lucent.com" 
+    DESCRIPTION 
+        "The MIB module to describe pre-OTN and OTN interfaces.
+         Copyright (C) The Internet Society (2003). This version 
+         of this MIB module is part of RFC 3591; see the RFC 
+         itself for full legal notices."
+
+    REVISION "200308130000Z" 
+    DESCRIPTION 
+        "Initial version, published as RFC 3591." 
+    ::={ jnxoptIfMibRoot 1 } 
+
+
+-- textual conventions 
+
+
+JnxoptIfAcTI ::= TEXTUAL-CONVENTION 
+    STATUS       current 
+    DESCRIPTION
+         "The trace identifier (TI) accepted at the receiver." 
+    SYNTAX       OCTET STRING (SIZE(64)) 
+
+
+JnxoptIfBitRateK ::= TEXTUAL-CONVENTION 
+    STATUS      current 
+    DESCRIPTION
+         "Indicates the index that is used to 
+          represent a supported bit rate and the different 
+          versions of OPUk, ODUk and OTUk. 
+          Allowed values of k are defined in ITU-T G.709. 
+          Currently allowed values in G.709 are:
+           k=1 represents an approximate bit rate of 2.5 Gbit/s, 
+          k=2 represents an approximate bit rate of 10 Gbit/s, 
+          k=3 represents an approximate bit rate of 40 Gbit/s."
+    SYNTAX      Integer32 
+
+JnxoptIfDEGM ::= TEXTUAL-CONVENTION 
+    STATUS      current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a Degraded Signal 
+      defect (dDEG). A dDEG shall be declared if JnxoptIfDEGM 
+      consecutive bad PM Seconds are detected."
+    SYNTAX      Unsigned32 (2..10) 
+
+
+JnxoptIfDEGThr ::= TEXTUAL-CONVENTION 
+    STATUS     current 
+    DESCRIPTION 
+      "Indicates the threshold level for declaring a performance 
+      monitoring (PM) Second to be bad. A PM Second is declared bad if 
+      the percentage of detected errored blocks in that second is 
+      greater than or equal to JnxoptIfDEGThr." 
+    SYNTAX     Unsigned32 (1..100) 
+
+
+JnxoptIfDirectionality ::= TEXTUAL-CONVENTION 
+    STATUS    current 
+    DESCRIPTION 
+      "Indicates the directionality of an entity." 
+    SYNTAX    INTEGER { 
+         sink(1), 
+         source(2), 
+         bidirectional(3) 
+    } 
+
+
+JnxoptIfSinkOrSource ::= TEXTUAL-CONVENTION 
+    STATUS    current 
+    DESCRIPTION 
+      "Indicates the directionality of an entity 
+      that is allowed only to be a source or sink." 
+    SYNTAX    INTEGER { 
+         sink(1), 
+         source(2) 
+    } 
+
+
+JnxoptIfExDAPI ::= TEXTUAL-CONVENTION 
+    STATUS current 
+    DESCRIPTION 
+      "The Destination Access Point Identifier (DAPI) 
+      expected by the receiver." 
+    SYNTAX OCTET STRING (SIZE(16)) 
+
+
+JnxoptIfExSAPI ::= TEXTUAL-CONVENTION 
+    STATUS current 
+    DESCRIPTION 
+      "The Source Access Point Identifier (SAPI) 
+      expected by the receiver." 
+    SYNTAX OCTET STRING (SIZE(16)) 
+
+
+JnxoptIfIntervalNumber ::= TEXTUAL-CONVENTION 
+    STATUS current 
+    DESCRIPTION 
+      "Uniquely identifies a 15-minute interval. The interval 
+      identified by 1 is the most recently completed interval, and 
+      the interval identified by n is the interval immediately 
+      preceding the one identified by n-1." 
+    SYNTAX Unsigned32 (1..96) 
+
+
+JnxoptIfTIMDetMode ::= TEXTUAL-CONVENTION 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function."
+    SYNTAX INTEGER { 
+        off(1), 
+        dapi(2), 
+        sapi(3), 
+        both(4) 
+    } 
+
+
+JnxoptIfTxTI ::= TEXTUAL-CONVENTION 
+    STATUS current 
+    DESCRIPTION
+      "The trace identifier (TI) transmitted." 
+    SYNTAX OCTET STRING (SIZE(64)) 
+
+
+-- object groups 
+
+
+jnxoptIfObjects OBJECT IDENTIFIER ::= { jnxoptIfMibModule 1 } 
+jnxoptIfConfs OBJECT IDENTIFIER ::= { jnxoptIfMibModule 2 } 
+
+
+jnxoptIfOTMn OBJECT IDENTIFIER ::= { jnxoptIfObjects 1 } 
+jnxoptIfPerfMon OBJECT IDENTIFIER ::= { jnxoptIfObjects 2 } 
+jnxoptIfOTSn OBJECT IDENTIFIER ::= { jnxoptIfObjects 3 } 
+jnxoptIfOMSn OBJECT IDENTIFIER ::= { jnxoptIfObjects 4 } 
+jnxoptIfOChGroup OBJECT IDENTIFIER ::= { jnxoptIfObjects 5 } 
+jnxoptIfOCh OBJECT IDENTIFIER ::= { jnxoptIfObjects 6 } 
+
+
+jnxoptIfOTUk OBJECT IDENTIFIER ::= { jnxoptIfObjects 7 } 
+jnxoptIfODUk OBJECT IDENTIFIER ::= { jnxoptIfObjects 8 } 
+jnxoptIfODUkT OBJECT IDENTIFIER ::= { jnxoptIfObjects 9 } 
+
+
+jnxoptIfGroups OBJECT IDENTIFIER ::= { jnxoptIfConfs 1 } 
+jnxoptIfCompl OBJECT IDENTIFIER ::= { jnxoptIfConfs 2 } 
+
+
+-- the jnxoptIfOTMn group 
+-- This group defines the OTM structure information of an 
+-- optical interface. 
+
+
+-- OTMn Table 
+
+
+jnxoptIfOTMnTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTMnEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTMn structure information." 
+    ::= { jnxoptIfOTMn 1 } 
+
+
+jnxoptIfOTMnEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTMnEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains the OTMn structure 
+      information of an optical interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTMnTable 1 } 
+
+
+JnxoptIfOTMnEntry ::= 
+    SEQUENCE { 
+        jnxoptIfOTMnOrder Unsigned32, 
+        jnxoptIfOTMnReduced TruthValue, 
+        jnxoptIfOTMnBitRates BITS, 
+        jnxoptIfOTMnInterfaceType SnmpAdminString, 
+        jnxoptIfOTMnTcmMax Unsigned32, 
+        jnxoptIfOTMnOpticalReach INTEGER 
+    } 
+
+
+jnxoptIfOTMnOrder OBJECT-TYPE 
+    SYNTAX Unsigned32 (1..900) 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "This object indicates the order of the OTM, which 
+      represents the maximum number of wavelengths that can be 
+      supported at the bit rate(s) supported on the interface." 
+    ::= { jnxoptIfOTMnEntry 1 } 
+
+
+jnxoptIfOTMnReduced OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "This object indicates whether a reduced or full 
+      functionality is supported at the interface. A value of 
+      true means reduced. A value of false means full." 
+    ::= { jnxoptIfOTMnEntry 2 } 
+
+
+jnxoptIfOTMnBitRates OBJECT-TYPE 
+    SYNTAX BITS { bitRateK1(0), bitRateK2(1), bitRateK3(2) } 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "This attribute is a bit map representing the bit 
+      rate or set of bit rates supported on the interface. 
+      The meaning of each bit position is as follows:
+      bitRateK1(0) is set if the 2.5 Gbit/s rate is supported 
+      bitRateK2(1) is set if the 10 Gbit/s rate is supported 
+      bitRateK3(2) is set if the 40 Gbit/s rate is supported
+      Note that each bit position corresponds to one possible 
+      value of the type JnxoptIfBitRateK. 
+      The default value of this attribute is system specific."
+    ::= { jnxoptIfOTMnEntry 3 } 
+
+
+jnxoptIfOTMnInterfaceType OBJECT-TYPE 
+    SYNTAX SnmpAdminString 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "This object identifies the type of interface. The value of 
+      this attribute will affect the behavior of the OTM with 
+      respect to presence/absence of OTM Overhead Signal (OOS) 
+      processing and TCM activation. For an IrDI interface, 
+      there is no OOS processing and TCM activation is limited 
+      to n levels as specified by a TCM level threshold.
+      This object contains two fields that are separated by 
+      whitespace. The possible values are: 
+      field 1: one of the 4-character ASCII strings 
+      'IrDI' or 'IaDI'
+      field 2: free-form text consisting of printable 
+      UTF-8 encoded characters
+      Note that field 2 is optional. If it is not present then there 
+      is no requirement for trailing whitespace after field 1.
+      The default values are as follows: 
+      field 1: 'IaDI' field 2: an empty string."
+    ::= { jnxoptIfOTMnEntry 4 } 
+
+
+jnxoptIfOTMnTcmMax OBJECT-TYPE 
+    SYNTAX Unsigned32 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION 
+      "This object identifies the maximum number of TCM 
+      levels allowed for any Optical Channel contained 
+      in this OTM. A new TCM activation will be rejected 
+      if the requested level is greater than the threshold. 
+      If InterfaceType object specifies a type of 'IaDI' 
+      for this OTM, then this attribute is irrelevant.
+      Possible values: unsigned integers in the range 
+      from 0 to 6 inclusive. 
+      Default value: 3."
+    ::= { jnxoptIfOTMnEntry 5 } 
+
+
+jnxoptIfOTMnOpticalReach OBJECT-TYPE 
+    SYNTAX INTEGER { intraOffice(1), shortHaul(2), longHaul(3),
+                     veryLongHaul(4), ultraLongHaul(5) } 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "This object indicates the length the optical signal 
+      may travel before requiring termination or regeneration. 
+      The meaning of the enumeration are:
+      intraOffice(1) - intra-office (as defined in ITU-T G.957) 
+      shortHaul(2) - short haul (as defined in ITU-T G.957) 
+      longHaul(3) - long haul (as defined in ITU-T G.957) 
+      veryLongHaul(4) - very long haul (as defined in ITU-T G.691) 
+      ultraLongHaul(5)- ultra long haul (as defined in ITU-T G.691)"
+    ::= { jnxoptIfOTMnEntry 6 } 
+
+
+-- the jnxoptIfPerfMon group 
+-- This group defines performance monitoring objects for all 
+-- layers. 
+
+-- PM interval table 
+
+jnxoptIfPerfMonIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfPerfMonIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of 15-minute performance monitoring interval 
+      information." 
+    ::= { jnxoptIfPerfMon 1 } 
+
+
+jnxoptIfPerfMonIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfPerfMonIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains 15-minute performance
+       monitoring interval information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfPerfMonIntervalTable 1 } 
+
+
+JnxoptIfPerfMonIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfPerfMonCurrentTimeElapsed Gauge32, 
+        jnxoptIfPerfMonCurDayTimeElapsed Gauge32,
+        jnxoptIfPerfMonIntervalNumIntervals Unsigned32, 
+        jnxoptIfPerfMonIntervalNumInvalidIntervals Unsigned32 
+    } 
+
+jnxoptIfPerfMonCurrentTimeElapsed OBJECT-TYPE 
+    SYNTAX Gauge32 (0..900) 
+    UNITS "seconds" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Number of seconds elapsed in the current 15-minute 
+      performance monitoring interval. 
+      If, for some reason, such as an adjustment in the NE's 
+      time-of-day clock, the number of seconds elapsed exceeds 
+      the maximum value, then the maximum value will be returned."
+    ::= { jnxoptIfPerfMonIntervalEntry 1 } 
+
+
+jnxoptIfPerfMonCurDayTimeElapsed OBJECT-TYPE 
+    SYNTAX Gauge32 (0..86400) 
+    UNITS "seconds" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Number of seconds elapsed in the current 24-hour interval 
+      performance monitoring period. 
+      If, for some reason, such as an adjustment in the NE 
+      time-of-day clock, the number of seconds elapsed exceeds 
+      the maximum value, then the maximum value will be returned."
+    ::= { jnxoptIfPerfMonIntervalEntry 2 } 
+
+
+jnxoptIfPerfMonIntervalNumIntervals OBJECT-TYPE 
+    SYNTAX Unsigned32 (0..96) 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The number of 15-minute intervals for which performance 
+      monitoring data is available. The number is the same for all 
+      the associated sub layers of the interface. 
+      An optical interface must be capable of supporting at least
+      n intervals, where n is defined as follows: 
+      The minimum value of n is 4. 
+      The default of n is 32. 
+      The maximum value of n is 96.
+       The value of this object will be n unless performance 
+      monitoring was (re-)started for the interface within the last 
+      (n*15) minutes, in which case the value will be the number of 
+      complete 15-minute intervals since measurement was 
+      (re-)started."
+    ::= { jnxoptIfPerfMonIntervalEntry 3 } 
+
+
+jnxoptIfPerfMonIntervalNumInvalidIntervals OBJECT-TYPE 
+    SYNTAX Unsigned32 (0..96) 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The number of intervals in the range from 0 to 
+      jnxoptIfPerfMonIntervalNumIntervals for which no performance 
+      monitoring data is available and/or the data is invalid."
+    ::= { jnxoptIfPerfMonIntervalEntry 4 } 
+
+
+-- the jnxoptIfOTSn group 
+-- This group handles the configuration and performance 
+-- monitoring objects for OTS layers. 
+
+
+-- OTSn config table 
+
+jnxoptIfOTSnConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTSn configuration information." 
+    ::= { jnxoptIfOTSn 1 } 
+
+
+jnxoptIfOTSnConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnConfigTable 1 } 
+
+
+JnxoptIfOTSnConfigEntry ::= 
+    SEQUENCE { 
+        jnxoptIfOTSnDirectionality               JnxoptIfDirectionality, 
+        jnxoptIfOTSnAprStatus                    SnmpAdminString, 
+        jnxoptIfOTSnAprControl                   SnmpAdminString, 
+        jnxoptIfOTSnTraceIdentifierTransmitted   JnxoptIfTxTI, 
+        jnxoptIfOTSnDAPIExpected                 JnxoptIfExDAPI, 
+        jnxoptIfOTSnSAPIExpected                 JnxoptIfExSAPI, 
+        jnxoptIfOTSnTraceIdentifierAccepted      JnxoptIfAcTI, 
+        jnxoptIfOTSnTIMDetMode                   JnxoptIfTIMDetMode, 
+        jnxoptIfOTSnTIMActEnabled                TruthValue, 
+        jnxoptIfOTSnCurrentStatus                BITS 
+    } 
+
+
+jnxoptIfOTSnDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+     "Indicates the directionality of the entity." 
+    ::= { jnxoptIfOTSnConfigEntry 1 } 
+
+
+jnxoptIfOTSnAprStatus OBJECT-TYPE 
+    SYNTAX SnmpAdminString 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "This attribute indicates the status of the Automatic 
+      Power Reduction (APR) function of the entity. Valid 
+      values are 'on' and 'off'." 
+    ::= { jnxoptIfOTSnConfigEntry 2 } 
+
+
+jnxoptIfOTSnAprControl OBJECT-TYPE 
+    SYNTAX SnmpAdminString 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION 
+      "This object is a UTF-8 encoded string that specifies Automatic 
+      Power Reduction (APR) control actions requested of this entity 
+      (when written) and that returns the current APR control state 
+      of this entity (when read). The values are implementation-defined. 
+      Any implementation that instantiates this object must document the 
+      set of values that it allows to be written, the set of values 
+      that it will return, and what each of those values means." 
+    ::= { jnxoptIfOTSnConfigEntry 3 } 
+
+
+jnxoptIfOTSnTraceIdentifierTransmitted OBJECT-TYPE 
+    SYNTAX JnxoptIfTxTI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The trace identifier transmitted. 
+      This object is applicable when jnxoptIfOTSnDirectionality has the 
+      value source(2) or bidirectional(3). 
+      This object does not apply to reduced-capability systems (i.e., 
+      those for which jnxoptIfOTMnReduced has the value true(1)) or 
+      at IrDI interfaces (i.e., when jnxoptIfOTMnInterfaceType field 1 
+      has the value 'IrDI'). 
+      If no value is ever set by a management entity for the object 
+      jnxoptIfOTSnTraceIdentifierTransmitted, system-specific default 
+      value will be used. Any implementation that instantiates this 
+      object must document the system-specific default value or how it 
+      is derived."
+    ::= { jnxoptIfOTSnConfigEntry 4 } 
+
+
+jnxoptIfOTSnDAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExDAPI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The DAPI expected by the receiver. 
+      This object is applicable when jnxoptIfOTSnDirectionality has the 
+      value sink(1) or bidirectional(3). It has no effect if 
+      jnxoptIfOTSnTIMDetMode has the value off(1) or sapi(3). 
+      This object does not apply to reduced-capability systems (i.e., 
+      those for which jnxoptIfOTMnReduced has the value true(1)) or 
+      at IrDI interfaces (i.e., when jnxoptIfOTMnInterfaceType field 1 
+      has the value 'IrDI')."
+    ::= { jnxoptIfOTSnConfigEntry 5 } 
+
+
+jnxoptIfOTSnSAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExSAPI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+     "The SAPI expected by the receiver. 
+      This object is applicable when jnxoptIfOTSnDirectionality has the 
+      value sink(1) or bidirectional(3). It has no effect if 
+      jnxoptIfOTSnTIMDetMode has the value off(1) or dapi(2). 
+      This object does not apply to reduced-capability systems (i.e., 
+      those for which jnxoptIfOTMnReduced has the value true(1)) or 
+      at IrDI interfaces (i.e., when jnxoptIfOTMnInterfaceType field 1 
+      has the value 'IrDI')."
+    ::= { jnxoptIfOTSnConfigEntry 6 } 
+
+
+jnxoptIfOTSnTraceIdentifierAccepted OBJECT-TYPE 
+    SYNTAX JnxoptIfAcTI 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The actual trace identifier received. 
+      This object is applicable when jnxoptIfOTSnDirectionality has the 
+      value sink(1) or bidirectional(3). Its value is unspecified 
+      if jnxoptIfOTSnCurrentStatus has either or both of the 
+      losO(5) and los(6) bits set. 
+      This object does not apply to reduced-capability systems (i.e., 
+      those for which jnxoptIfOTMnReduced has the value true(1)) or 
+      at IrDI interfaces (i.e., when jnxoptIfOTMnInterfaceType field 1 
+      has the value 'IrDI')."
+    ::= { jnxoptIfOTSnConfigEntry 7 } 
+
+
+jnxoptIfOTSnTIMDetMode OBJECT-TYPE 
+    SYNTAX JnxoptIfTIMDetMode 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function. This object is applicable 
+      when jnxoptIfOTSnDirectionality has the value sink(1) 
+      or bidirectional(3). The default value is off(1). 
+      This object does not apply to reduced-capability systems (i.e., 
+      those for which jnxoptIfOTMnReduced has the value true(1)) or 
+      at IrDI interfaces (i.e., when jnxoptIfOTMnInterfaceType field 1 
+      has the value 'IrDI'). 
+      The default value of this object is off(1)."
+    ::= { jnxoptIfOTSnConfigEntry 8 } 
+
+
+jnxoptIfOTSnTIMActEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+     "Indicates whether the Trace Identifier Mismatch (TIM) 
+      Consequent Action function is enabled. This object 
+      is applicable when jnxoptIfOTSnDirectionality has the 
+      value sink(1) or bidirectional(3). It has no effect 
+      when the value of jnxoptIfOTSnTIMDetMode is off(1). 
+      This object does not apply to reduced-capability systems (i.e., 
+      those for which jnxoptIfOTMnReduced has the value true(1)) or 
+      at IrDI interfaces (i.e., when jnxoptIfOTMnInterfaceType field 1 
+      has the value 'IrDI'). 
+      The default value of this object is false(2)."
+    ::= { jnxoptIfOTSnConfigEntry 9 } 
+
+
+jnxoptIfOTSnCurrentStatus OBJECT-TYPE 
+     SYNTAX BITS { 
+        bdiP(0), 
+        bdiO(1), 
+        bdi(2), 
+        tim(3), 
+        losP(4), 
+        losO(5), 
+        los(6) 
+    }
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+     "Indicates the defect condition of the entity, if any. 
+      This object is applicable when jnxoptIfOTSnDirectionality 
+      has the value sink(1) or bidirectional(3). In 
+      reduced-capability systems or at IrDI interfaces 
+      the only bit position that may be set is los(6)."
+    ::= { jnxoptIfOTSnConfigEntry 10 } 
+
+
+-- OTSn sink current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+jnxoptIfOTSnSinkCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTSn sink performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOTSn 2 } 
+
+
+jnxoptIfOTSnSinkCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn sink performance 
+      monitoring information of an interface for the current 
+      15-minute interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnSinkCurrentTable 1 } 
+
+
+JnxoptIfOTSnSinkCurrentEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSinkCurrentSuspectedFlag             TruthValue, 
+        jnxoptIfOTSnSinkCurrentInputPower                Integer32, 
+        jnxoptIfOTSnSinkCurrentLowInputPower             Integer32, 
+        jnxoptIfOTSnSinkCurrentHighInputPower            Integer32, 
+        jnxoptIfOTSnSinkCurrentLowerInputPowerThreshold  Integer32, 
+        jnxoptIfOTSnSinkCurrentUpperInputPowerThreshold  Integer32, 
+        jnxoptIfOTSnSinkCurrentOutputPower               Integer32, 
+        jnxoptIfOTSnSinkCurrentLowOutputPower            Integer32, 
+        jnxoptIfOTSnSinkCurrentHighOutputPower           Integer32,
+        jnxoptIfOTSnSinkCurrentLowerOutputPowerThreshold Integer32, 
+        jnxoptIfOTSnSinkCurrentUpperOutputPowerThreshold Integer32 
+    } 
+
+
+jnxoptIfOTSnSinkCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 1 } 
+
+
+jnxoptIfOTSnSinkCurrentInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the input." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 2 } 
+
+
+jnxoptIfOTSnSinkCurrentLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 3 } 
+
+
+jnxoptIfOTSnSinkCurrentHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 4 } 
+
+
+jnxoptIfOTSnSinkCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on input power. If 
+      jnxoptIfOTSnSinkCurrentInputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+     ::= { jnxoptIfOTSnSinkCurrentEntry 5 } 
+
+
+jnxoptIfOTSnSinkCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on input power. If 
+      jnxoptIfOTSnSinkCurrentInputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+     ::= { jnxoptIfOTSnSinkCurrentEntry 6 } 
+
+
+jnxoptIfOTSnSinkCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 7 } 
+
+
+jnxoptIfOTSnSinkCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 8 } 
+
+
+jnxoptIfOTSnSinkCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSinkCurrentEntry 9 } 
+
+
+jnxoptIfOTSnSinkCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on output power. If 
+      jnxoptIfOTSnSinkCurrentOutputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOTSnSinkCurrentEntry 10 } 
+
+
+jnxoptIfOTSnSinkCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on output power. If 
+      jnxoptIfOTSnSinkCurrentOutputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOTSnSinkCurrentEntry 11 } 
+
+
+-- OTSn sink interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOTSnSinkIntervalTable OBJECT-TYPE 
+   SYNTAX SEQUENCE OF JnxoptIfOTSnSinkIntervalEntry 
+   MAX-ACCESS not-accessible 
+   STATUS current 
+   DESCRIPTION
+     "A table of historical OTSn sink performance monitoring 
+     information." 
+   ::= { jnxoptIfOTSn 3 } 
+
+
+jnxoptIfOTSnSinkIntervalEntry OBJECT-TYPE 
+   SYNTAX JnxoptIfOTSnSinkIntervalEntry 
+   MAX-ACCESS not-accessible 
+   STATUS current 
+   DESCRIPTION
+     "A conceptual row that contains OTSn sink performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+   INDEX { ifIndex, jnxoptIfOTSnSinkIntervalNumber } 
+   ::= { jnxoptIfOTSnSinkIntervalTable 1 } 
+
+JnxoptIfOTSnSinkIntervalEntry ::=
+
+    SEQUENCE { 
+        jnxoptIfOTSnSinkIntervalNumber          JnxoptIfIntervalNumber, 
+        jnxoptIfOTSnSinkIntervalSuspectedFlag   TruthValue, 
+        jnxoptIfOTSnSinkIntervalLastInputPower  Integer32, 
+        jnxoptIfOTSnSinkIntervalLowInputPower   Integer32, 
+        jnxoptIfOTSnSinkIntervalHighInputPower  Integer32, 
+        jnxoptIfOTSnSinkIntervalLastOutputPower Integer32, 
+        jnxoptIfOTSnSinkIntervalLowOutputPower  Integer32, 
+        jnxoptIfOTSnSinkIntervalHighOutputPower Integer32
+    } 
+
+
+jnxoptIfOTSnSinkIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 1 } 
+
+
+jnxoptIfOTSnSinkIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 2 } 
+
+
+jnxoptIfOTSnSinkIntervalLastInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 3 } 
+
+
+jnxoptIfOTSnSinkIntervalLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 4 } 
+
+
+
+jnxoptIfOTSnSinkIntervalHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 5 } 
+
+
+jnxoptIfOTSnSinkIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 6 } 
+
+
+jnxoptIfOTSnSinkIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 7 } 
+
+ 
+jnxoptIfOTSnSinkIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOTSnSinkIntervalEntry 8 } 
+
+
+-- OTSn sink current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOTSnSinkCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of OTSn sink performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOTSn 4 } 
+
+
+jnxoptIfOTSnSinkCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn sink performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnSinkCurDayTable 1 } 
+ 
+
+JnxoptIfOTSnSinkCurDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSinkCurDaySuspectedFlag TruthValue, 
+        jnxoptIfOTSnSinkCurDayLowInputPower Integer32, 
+        jnxoptIfOTSnSinkCurDayHighInputPower Integer32, 
+        jnxoptIfOTSnSinkCurDayLowOutputPower Integer32, 
+        jnxoptIfOTSnSinkCurDayHighOutputPower Integer32 
+    } 
+
+
+jnxoptIfOTSnSinkCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSinkCurDayEntry 1 } 
+
+
+jnxoptIfOTSnSinkCurDayLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkCurDayEntry 2 } 
+
+
+jnxoptIfOTSnSinkCurDayHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The highest optical power monitored at the input during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkCurDayEntry 3 } 
+ 
+
+jnxoptIfOTSnSinkCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkCurDayEntry 4 } 
+
+
+jnxoptIfOTSnSinkCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkCurDayEntry 5 } 
+ 
+
+-- OTSn sink previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOTSnSinkPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTSn sink performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOTSn 5 } 
+
+
+jnxoptIfOTSnSinkPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn sink performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnSinkPrevDayTable 1 } 
+
+
+
+
+JnxoptIfOTSnSinkPrevDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSinkPrevDaySuspectedFlag      TruthValue, 
+        jnxoptIfOTSnSinkPrevDayLastInputPower     Integer32, 
+        jnxoptIfOTSnSinkPrevDayLowInputPower      Integer32, 
+        jnxoptIfOTSnSinkPrevDayHighInputPower     Integer32, 
+        jnxoptIfOTSnSinkPrevDayLastOutputPower    Integer32, 
+        jnxoptIfOTSnSinkPrevDayLowOutputPower     Integer32, 
+        jnxoptIfOTSnSinkPrevDayHighOutputPower    Integer32 
+    } 
+
+
+jnxoptIfOTSnSinkPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 1 } 
+
+
+jnxoptIfOTSnSinkPrevDayLastInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 2 } 
+
+
+jnxoptIfOTSnSinkPrevDayLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 3 } 
+
+
+jnxoptIfOTSnSinkPrevDayHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 4 } 
+
+
+
+jnxoptIfOTSnSinkPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 5 } 
+
+
+jnxoptIfOTSnSinkPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 6 } 
+
+
+jnxoptIfOTSnSinkPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSinkPrevDayEntry 7 } 
+
+
+-- OTSn source current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOTSnSrcCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTSn source performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOTSn 6 } 
+ 
+
+jnxoptIfOTSnSrcCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains OTSn source performance 
+      monitoring information of an interface for the current
+      15-minute interval." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnSrcCurrentTable 1 } 
+
+
+JnxoptIfOTSnSrcCurrentEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSrcCurrentSuspectedFlag             TruthValue,
+        jnxoptIfOTSnSrcCurrentOutputPower               Integer32, 
+        jnxoptIfOTSnSrcCurrentLowOutputPower            Integer32, 
+        jnxoptIfOTSnSrcCurrentHighOutputPower           Integer32,
+        jnxoptIfOTSnSrcCurrentLowerOutputPowerThreshold Integer32, 
+        jnxoptIfOTSnSrcCurrentUpperOutputPowerThreshold Integer32, 
+        jnxoptIfOTSnSrcCurrentInputPower                Integer32, 
+        jnxoptIfOTSnSrcCurrentLowInputPower             Integer32,
+        jnxoptIfOTSnSrcCurrentHighInputPower            Integer32, 
+        jnxoptIfOTSnSrcCurrentLowerInputPowerThreshold  Integer32, 
+        jnxoptIfOTSnSrcCurrentUpperInputPowerThreshold  Integer32
+    } 
+
+
+jnxoptIfOTSnSrcCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 1 } 
+
+
+jnxoptIfOTSnSrcCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 2 } 
+
+
+jnxoptIfOTSnSrcCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current
+    DESCRIPTION 
+      "The lowest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 3 } 
+
+
+
+jnxoptIfOTSnSrcCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 4 } 
+
+
+jnxoptIfOTSnSrcCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on output power. If 
+      jnxoptIfOTSnSrcCurrentOutputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOTSnSrcCurrentEntry 5 } 
+
+
+jnxoptIfOTSnSrcCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on output power. If 
+      jnxoptIfOTSnSrcCurrentOutputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOTSnSrcCurrentEntry 6 } 
+
+
+jnxoptIfOTSnSrcCurrentInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the input." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 7 } 
+
+
+jnxoptIfOTSnSrcCurrentLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current
+    DESCRIPTION 
+      "The lowest optical power monitored at the input during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 8 } 
+ 
+
+jnxoptIfOTSnSrcCurrentHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOTSnSrcCurrentEntry 9 } 
+
+
+jnxoptIfOTSnSrcCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on input power. If 
+      jnxoptIfOTSnSrcCurrentInputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOTSnSrcCurrentEntry 10 } 
+
+
+jnxoptIfOTSnSrcCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on input power. If 
+      jnxoptIfOTSnSrcCurrentInputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOTSnSrcCurrentEntry 11 } 
+
+
+-- OTSn source interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOTSnSrcIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of historical OTSn source performance monitoring 
+      information." 
+    ::= { jnxoptIfOTSn 7 } 
+
+
+jnxoptIfOTSnSrcIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn source performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOTSnSrcIntervalNumber } 
+    ::= { jnxoptIfOTSnSrcIntervalTable 1 } 
+ 
+
+JnxoptIfOTSnSrcIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSrcIntervalNumber          JnxoptIfIntervalNumber, 
+        jnxoptIfOTSnSrcIntervalSuspectedFlag   TruthValue, 
+        jnxoptIfOTSnSrcIntervalLastOutputPower Integer32, 
+        jnxoptIfOTSnSrcIntervalLowOutputPower  Integer32, 
+        jnxoptIfOTSnSrcIntervalHighOutputPower Integer32, 
+        jnxoptIfOTSnSrcIntervalLastInputPower  Integer32, 
+        jnxoptIfOTSnSrcIntervalLowInputPower   Integer32, 
+        jnxoptIfOTSnSrcIntervalHighInputPower  Integer32 
+    } 
+
+
+jnxoptIfOTSnSrcIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 1 } 
+
+
+jnxoptIfOTSnSrcIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 2 } 
+
+
+jnxoptIfOTSnSrcIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 3 } 
+
+
+
+jnxoptIfOTSnSrcIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 4 } 
+
+
+jnxoptIfOTSnSrcIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 5 } 
+
+
+jnxoptIfOTSnSrcIntervalLastInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 6 } 
+ 
+
+jnxoptIfOTSnSrcIntervalLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 7 } 
+
+
+jnxoptIfOTSnSrcIntervalHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOTSnSrcIntervalEntry 8 } 
+
+
+-- OTSn source current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOTSnSrcCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTSn source performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOTSn 8 } 
+
+
+jnxoptIfOTSnSrcCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn source performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnSrcCurDayTable 1 } 
+
+
+JnxoptIfOTSnSrcCurDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSrcCurDaySuspectedFlag   TruthValue, 
+        jnxoptIfOTSnSrcCurDayLowOutputPower  Integer32, 
+        jnxoptIfOTSnSrcCurDayHighOutputPower Integer32, 
+        jnxoptIfOTSnSrcCurDayLowInputPower   Integer32, 
+        jnxoptIfOTSnSrcCurDayHighInputPower  Integer32 
+    } 
+
+
+jnxoptIfOTSnSrcCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSrcCurDayEntry 1 } 
+
+
+jnxoptIfOTSnSrcCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The lowest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcCurDayEntry 2 } 
+
+
+jnxoptIfOTSnSrcCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcCurDayEntry 3 } 
+
+
+jnxoptIfOTSnSrcCurDayLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcCurDayEntry 4 } 
+
+
+jnxoptIfOTSnSrcCurDayHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcCurDayEntry 5 } 
+
+
+-- OTSn source previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOTSnSrcPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTSnSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTSn source performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOTSn 9 } 
+
+
+
+jnxoptIfOTSnSrcPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTSnSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTSn source performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTSnSrcPrevDayTable 1 } 
+
+
+JnxoptIfOTSnSrcPrevDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTSnSrcPrevDaySuspectedFlag   TruthValue, 
+        jnxoptIfOTSnSrcPrevDayLastOutputPower Integer32, 
+        jnxoptIfOTSnSrcPrevDayLowOutputPower  Integer32, 
+        jnxoptIfOTSnSrcPrevDayHighOutputPower Integer32, 
+        jnxoptIfOTSnSrcPrevDayLastInputPower  Integer32, 
+        jnxoptIfOTSnSrcPrevDayLowInputPower   Integer32, 
+        jnxoptIfOTSnSrcPrevDayHighInputPower  Integer32 
+    } 
+
+
+jnxoptIfOTSnSrcPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 1 } 
+
+
+jnxoptIfOTSnSrcPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+       previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 2 } 
+
+
+jnxoptIfOTSnSrcPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 3 } 
+
+
+jnxoptIfOTSnSrcPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 4 } 
+
+
+jnxoptIfOTSnSrcPrevDayLastInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 5 } 
+   
+
+jnxoptIfOTSnSrcPrevDayLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 6 } 
+
+
+jnxoptIfOTSnSrcPrevDayHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOTSnSrcPrevDayEntry 7 } 
+
+
+-- the jnxoptIfOMSn group 
+-- This group handles the configuration and performance monitoring 
+-- information for OMS layers. 
+
+
+-- OMSn config table 
+
+
+
+jnxoptIfOMSnConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OMSn configuration information." 
+    ::= { jnxoptIfOMSn 1 } 
+
+
+jnxoptIfOMSnConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnConfigTable 1 } 
+
+
+JnxoptIfOMSnConfigEntry ::=
+    SEQUENCE { 
+        jnxoptIfOMSnDirectionality JnxoptIfDirectionality, 
+        jnxoptIfOMSnCurrentStatus  BITS 
+    } 
+
+
+jnxoptIfOMSnDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the directionality of the entity." 
+    ::= { jnxoptIfOMSnConfigEntry 1 } 
+
+
+jnxoptIfOMSnCurrentStatus OBJECT-TYPE
+    SYNTAX BITS { 
+       ssfP(0), 
+       ssfO(1), 
+       ssf(2), 
+       bdiP(3), 
+       bdiO(4), 
+       bdi(5), 
+       losP(6) 
+    }
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the defect condition of the entity, if any. 
+      This object is applicable only to full capability 
+      systems whose interface type is IaDI and for which 
+      jnxoptIfOMSnDirectionality has the value sink(1) or 
+      bidirectional(3)." 
+    ::= { jnxoptIfOMSnConfigEntry 2 } 
+
+
+-- OMSn sink current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOMSnSinkCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OMSn sink performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOMSn 2 } 
+
+
+jnxoptIfOMSnSinkCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn sink performance 
+      monitoring information of an interface for the current
+      15-minute interval." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnSinkCurrentTable 1 } 
+
+
+JnxoptIfOMSnSinkCurrentEntry ::=
+    SEQUENCE { 
+        jnxoptIfOMSnSinkCurrentSuspectedFlag              TruthValue,
+        jnxoptIfOMSnSinkCurrentAggregatedInputPower       Integer32,
+        jnxoptIfOMSnSinkCurrentLowAggregatedInputPower    Integer32,
+        jnxoptIfOMSnSinkCurrentHighAggregatedInputPower   Integer32,
+        jnxoptIfOMSnSinkCurrentLowerInputPowerThreshold   Integer32,
+        jnxoptIfOMSnSinkCurrentUpperInputPowerThreshold   Integer32,
+        jnxoptIfOMSnSinkCurrentOutputPower                Integer32,
+        jnxoptIfOMSnSinkCurrentLowOutputPower             Integer32,
+        jnxoptIfOMSnSinkCurrentHighOutputPower            Integer32,
+        jnxoptIfOMSnSinkCurrentLowerOutputPowerThreshold  Integer32,
+        jnxoptIfOMSnSinkCurrentUpperOutputPowerThreshold  Integer32
+    } 
+
+
+jnxoptIfOMSnSinkCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSinkCurrentEntry 1 } 
+
+
+jnxoptIfOMSnSinkCurrentAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The aggregated optical power of all the DWDM input 
+      channels." 
+    ::= { jnxoptIfOMSnSinkCurrentEntry 2 } 
+
+
+jnxoptIfOMSnSinkCurrentLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels during the current 15-minute interval." 
+    ::= { jnxoptIfOMSnSinkCurrentEntry 3 } 
+
+
+jnxoptIfOMSnSinkCurrentHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels during the current 15-minute interval." 
+    ::= { jnxoptIfOMSnSinkCurrentEntry 4 } 
+
+
+jnxoptIfOMSnSinkCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on aggregated input power. If 
+      jnxoptIfOMSnSinkCurrentAggregatedInputPower drops to this value 
+      or below, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSinkCurrentEntry 5 } 
+
+
+jnxoptIfOMSnSinkCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on aggregated input power. If 
+      jnxoptIfOMSnSinkCurrentAggregatedInputPower reaches or exceeds 
+      this value, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSinkCurrentEntry 6 } 
+
+
+jnxoptIfOMSnSinkCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output." 
+      ::= { jnxoptIfOMSnSinkCurrentEntry 7 } 
+  
+
+jnxoptIfOMSnSinkCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output 
+      during the current 15-minute interval." 
+    ::= { jnxoptIfOMSnSinkCurrentEntry 8 } 
+
+
+jnxoptIfOMSnSinkCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output 
+      during the current 15-minute interval." 
+    ::= { jnxoptIfOMSnSinkCurrentEntry 9 } 
+
+
+jnxoptIfOMSnSinkCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on output power. If 
+      jnxoptIfOMSnSinkCurrentOutputPower drops to this value 
+      or below, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSinkCurrentEntry 10 } 
+
+
+jnxoptIfOMSnSinkCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on output power. If 
+      jnxoptIfOMSnSinkCurrentOutputPower reaches or exceeds 
+      this value, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSinkCurrentEntry 11 } 
+
+
+-- OMSn sink interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOMSnSinkIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSinkIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of historical OMSn sink performance monitoring 
+      information." 
+    ::= { jnxoptIfOMSn 3 } 
+
+
+jnxoptIfOMSnSinkIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSinkIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn sink performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOMSnSinkIntervalNumber } 
+    ::= { jnxoptIfOMSnSinkIntervalTable 1 } 
+  
+
+JnxoptIfOMSnSinkIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfOMSnSinkIntervalNumber                   JnxoptIfIntervalNumber,
+        jnxoptIfOMSnSinkIntervalSuspectedFlag            TruthValue,
+        jnxoptIfOMSnSinkIntervalLastAggregatedInputPower Integer32,
+        jnxoptIfOMSnSinkIntervalLowAggregatedInputPower  Integer32,
+        jnxoptIfOMSnSinkIntervalHighAggregatedInputPower Integer32,
+        jnxoptIfOMSnSinkIntervalLastOutputPower          Integer32,
+        jnxoptIfOMSnSinkIntervalLowOutputPower           Integer32,
+        jnxoptIfOMSnSinkIntervalHighOutputPower          Integer32
+    } 
+
+
+jnxoptIfOMSnSinkIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 1 } 
+
+
+jnxoptIfOMSnSinkIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 2 } 
+
+
+jnxoptIfOMSnSinkIntervalLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power of all the DWDM input 
+      channels during the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 3 } 
+
+
+jnxoptIfOMSnSinkIntervalLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels during the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 4 } 
+
+
+jnxoptIfOMSnSinkIntervalHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels during the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 5 } 
+
+
+jnxoptIfOMSnSinkIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The last optical power at the output 
+      during the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 6 } 
+
+
+jnxoptIfOMSnSinkIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power at the output 
+      during the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 7 } 
+
+
+jnxoptIfOMSnSinkIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power at the output 
+      during the interval." 
+    ::= { jnxoptIfOMSnSinkIntervalEntry 8 } 
+
+
+-- OMSn sink current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOMSnSinkCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OMSn sink performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOMSn 4 } 
+
+
+jnxoptIfOMSnSinkCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn sink performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnSinkCurDayTable 1 } 
+ 
+
+JnxoptIfOMSnSinkCurDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOMSnSinkCurDaySuspectedFlag             TruthValue,
+        jnxoptIfOMSnSinkCurDayLowAggregatedInputPower   Integer32,
+        jnxoptIfOMSnSinkCurDayHighAggregatedInputPower  Integer32,
+        jnxoptIfOMSnSinkCurDayLowOutputPower            Integer32,
+        jnxoptIfOMSnSinkCurDayHighOutputPower           Integer32
+    } 
+
+
+jnxoptIfOMSnSinkCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+      ::= { jnxoptIfOMSnSinkCurDayEntry 1 } 
+  
+
+jnxoptIfOMSnSinkCurDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels during the current 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkCurDayEntry 2 } 
+
+
+jnxoptIfOMSnSinkCurDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels during the current 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkCurDayEntry 3 } 
+
+
+jnxoptIfOMSnSinkCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power at the output 
+      during the current 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkCurDayEntry 4 } 
+
+
+
+jnxoptIfOMSnSinkCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power at the output 
+      during the current 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkCurDayEntry 5 } 
+
+
+-- OMSn sink previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOMSnSinkPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OMSn sink performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOMSn 5 } 
+
+
+jnxoptIfOMSnSinkPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn sink performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnSinkPrevDayTable 1 } 
+
+
+JnxoptIfOMSnSinkPrevDayEntry ::=
+    SEQUENCE { 
+       jnxoptIfOMSnSinkPrevDaySuspectedFlag             TruthValue,
+       jnxoptIfOMSnSinkPrevDayLastAggregatedInputPower  Integer32,
+       jnxoptIfOMSnSinkPrevDayLowAggregatedInputPower   Integer32,
+       jnxoptIfOMSnSinkPrevDayHighAggregatedInputPower  Integer32,
+       jnxoptIfOMSnSinkPrevDayLastOutputPower           Integer32,
+       jnxoptIfOMSnSinkPrevDayLowOutputPower            Integer32,
+       jnxoptIfOMSnSinkPrevDayHighOutputPower           Integer32
+    } 
+ 
+
+jnxoptIfOMSnSinkPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 1 } 
+
+
+jnxoptIfOMSnSinkPrevDayLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power of all the DWDM input 
+      channels during the previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 2 } 
+
+
+jnxoptIfOMSnSinkPrevDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels during the previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 3 } 
+
+
+jnxoptIfOMSnSinkPrevDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels during the previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 4 } 
+
+
+jnxoptIfOMSnSinkPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power at the output 
+      during the previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 5 } 
+
+
+jnxoptIfOMSnSinkPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power at the output 
+      during the previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 6 } 
+
+
+jnxoptIfOMSnSinkPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power at the output 
+      during the previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSinkPrevDayEntry 7 } 
+
+
+-- OMSn source current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOMSnSrcCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OMSn source performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOMSn 6 } 
+
+
+jnxoptIfOMSnSrcCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn source performance 
+      monitoring information of an interface for the current
+      15-minute interval." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnSrcCurrentTable 1 } 
+ 
+JnxoptIfOMSnSrcCurrentEntry ::= 
+    SEQUENCE { 
+        jnxoptIfOMSnSrcCurrentSuspectedFlag              TruthValue,
+        jnxoptIfOMSnSrcCurrentOutputPower                Integer32,
+        jnxoptIfOMSnSrcCurrentLowOutputPower             Integer32,
+        jnxoptIfOMSnSrcCurrentHighOutputPower            Integer32,
+        jnxoptIfOMSnSrcCurrentLowerOutputPowerThreshold  Integer32,
+        jnxoptIfOMSnSrcCurrentUpperOutputPowerThreshold  Integer32,
+        jnxoptIfOMSnSrcCurrentAggregatedInputPower       Integer32,
+        jnxoptIfOMSnSrcCurrentLowAggregatedInputPower    Integer32,
+        jnxoptIfOMSnSrcCurrentHighAggregatedInputPower   Integer32,
+        jnxoptIfOMSnSrcCurrentLowerInputPowerThreshold   Integer32,
+        jnxoptIfOMSnSrcCurrentUpperInputPowerThreshold   Integer32 
+    }  
+
+
+jnxoptIfOMSnSrcCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSrcCurrentEntry 1 } 
+
+
+jnxoptIfOMSnSrcCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output." 
+    ::= { jnxoptIfOMSnSrcCurrentEntry 2 } 
+
+
+jnxoptIfOMSnSrcCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 15-minute interval." 
+      ::= { jnxoptIfOMSnSrcCurrentEntry 3 } 
+  
+
+jnxoptIfOMSnSrcCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOMSnSrcCurrentEntry 4 } 
+
+
+jnxoptIfOMSnSrcCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on output power. If 
+      jnxoptIfOMSnSrcCurrentOutputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSrcCurrentEntry 5 } 
+
+
+jnxoptIfOMSnSrcCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on output power. If 
+      jnxoptIfOMSnSrcCurrentOutputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSrcCurrentEntry 6 } 
+
+
+jnxoptIfOMSnSrcCurrentAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The aggregated optical power at the input." 
+    ::= { jnxoptIfOMSnSrcCurrentEntry 7 } 
+  
+
+jnxoptIfOMSnSrcCurrentLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power at the input 
+      during the current 15-minute interval." 
+    ::= { jnxoptIfOMSnSrcCurrentEntry 8 } 
+
+
+jnxoptIfOMSnSrcCurrentHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power at the input 
+      during the current 15-minute interval." 
+    ::= { jnxoptIfOMSnSrcCurrentEntry 9 } 
+
+
+jnxoptIfOMSnSrcCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on aggregated input power. If 
+      jnxoptIfOMSnSrcCurrentAggregatedInputPower drops to this value 
+      or below, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSrcCurrentEntry 10 } 
+
+
+jnxoptIfOMSnSrcCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on aggregated input power. If 
+      jnxoptIfOMSnSrcCurrentAggregatedInputPower reaches or exceeds 
+      this value, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOMSnSrcCurrentEntry 11 } 
+
+
+-- OMSn source interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOMSnSrcIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of historical OMSn source performance monitoring 
+      information." 
+    ::= { jnxoptIfOMSn 7 } 
+
+
+jnxoptIfOMSnSrcIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn source performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOMSnSrcIntervalNumber } 
+    ::= { jnxoptIfOMSnSrcIntervalTable 1 } 
+ 
+
+JnxoptIfOMSnSrcIntervalEntry ::= 
+    SEQUENCE { 
+        jnxoptIfOMSnSrcIntervalNumber                   JnxoptIfIntervalNumber,
+        jnxoptIfOMSnSrcIntervalSuspectedFlag            TruthValue,
+        jnxoptIfOMSnSrcIntervalLastOutputPower          Integer32,
+        jnxoptIfOMSnSrcIntervalLowOutputPower           Integer32,
+        jnxoptIfOMSnSrcIntervalHighOutputPower          Integer32,
+        jnxoptIfOMSnSrcIntervalLastAggregatedInputPower Integer32,
+        jnxoptIfOMSnSrcIntervalLowAggregatedInputPower  Integer32,
+        jnxoptIfOMSnSrcIntervalHighAggregatedInputPower Integer32
+    }
+ 
+jnxoptIfOMSnSrcIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 1 } 
+
+jnxoptIfOMSnSrcIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 2 } 
+
+
+jnxoptIfOMSnSrcIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 3 } 
+
+
+jnxoptIfOMSnSrcIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 4 } 
+
+
+jnxoptIfOMSnSrcIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 5 } 
+
+
+jnxoptIfOMSnSrcIntervalLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power at the input 
+      during the interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 6 } 
+
+
+jnxoptIfOMSnSrcIntervalLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power at the input 
+      during the interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 7 } 
+
+
+jnxoptIfOMSnSrcIntervalHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power at the input 
+      during the interval." 
+    ::= { jnxoptIfOMSnSrcIntervalEntry 8 } 
+
+
+-- OMSn source current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOMSnSrcCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of OMSn source performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOMSn 8 } 
+
+
+jnxoptIfOMSnSrcCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn source performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnSrcCurDayTable 1 } 
+
+
+JnxoptIfOMSnSrcCurDayEntry ::=
+    SEQUENCE { 
+       jnxoptIfOMSnSrcCurDaySuspectedFlag             TruthValue,
+       jnxoptIfOMSnSrcCurDayLowOutputPower            Integer32,
+       jnxoptIfOMSnSrcCurDayHighOutputPower           Integer32,
+       jnxoptIfOMSnSrcCurDayLowAggregatedInputPower   Integer32,
+       jnxoptIfOMSnSrcCurDayHighAggregatedInputPower  Integer32
+    } 
+ 
+
+jnxoptIfOMSnSrcCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSrcCurDayEntry 1 } 
+
+
+jnxoptIfOMSnSrcCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcCurDayEntry 2 } 
+
+
+jnxoptIfOMSnSrcCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The highest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcCurDayEntry 3 } 
+
+
+jnxoptIfOMSnSrcCurDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power at the input 
+      during the current 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcCurDayEntry 4 } 
+
+
+jnxoptIfOMSnSrcCurDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power at the input 
+      during the current 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcCurDayEntry 5 } 
+ 
+
+-- OMSn source previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOMSnSrcPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOMSnSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OMSn source performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOMSn 9 } 
+ 
+
+jnxoptIfOMSnSrcPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOMSnSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OMSn source performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOMSnSrcPrevDayTable 1 } 
+
+
+
+JnxoptIfOMSnSrcPrevDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOMSnSrcPrevDaySuspectedFlag             TruthValue,
+        jnxoptIfOMSnSrcPrevDayLastOutputPower           Integer32,
+        jnxoptIfOMSnSrcPrevDayLowOutputPower            Integer32,
+        jnxoptIfOMSnSrcPrevDayHighOutputPower           Integer32,
+        jnxoptIfOMSnSrcPrevDayLastAggregatedInputPower  Integer32,
+        jnxoptIfOMSnSrcPrevDayLowAggregatedInputPower   Integer32,
+        jnxoptIfOMSnSrcPrevDayHighAggregatedInputPower  Integer32
+    }   
+
+
+jnxoptIfOMSnSrcPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 1 } 
+
+
+jnxoptIfOMSnSrcPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 2 } 
+
+
+jnxoptIfOMSnSrcPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 3 } 
+
+
+jnxoptIfOMSnSrcPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 4 } 
+
+
+
+jnxoptIfOMSnSrcPrevDayLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 5 } 
+
+
+jnxoptIfOMSnSrcPrevDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 6 } 
+
+
+jnxoptIfOMSnSrcPrevDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOMSnSrcPrevDayEntry 7 } 
+
+
+-- the jnxoptIfOChGroup group 
+-- This group handles the configuration and performance monitoring 
+-- information for OChGroup layers. 
+
+
+-- OChGroup config table 
+
+
+jnxoptIfOChGroupConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OChGroup configuration information." 
+    ::= { jnxoptIfOChGroup 1 } 
+
+
+jnxoptIfOChGroupConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains OChGroup configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupConfigTable 1 } 
+  
+
+JnxoptIfOChGroupConfigEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChGroupDirectionality JnxoptIfDirectionality 
+    } 
+
+
+jnxoptIfOChGroupDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the directionality of the entity." 
+    ::= { jnxoptIfOChGroupConfigEntry 1 } 
+
+
+-- OChGroup sink current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOChGroupSinkCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OChGroup sink performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOChGroup 2 } 
+
+
+jnxoptIfOChGroupSinkCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup sink performance 
+      monitoring information of an interface for the current
+      15-minute interval." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupSinkCurrentTable 1 } 
+
+JnxoptIfOChGroupSinkCurrentEntry ::= 
+    SEQUENCE { 
+        jnxoptIfOChGroupSinkCurrentSuspectedFlag              TruthValue,
+        jnxoptIfOChGroupSinkCurrentAggregatedInputPower       Integer32,
+        jnxoptIfOChGroupSinkCurrentLowAggregatedInputPower    Integer32,
+        jnxoptIfOChGroupSinkCurrentHighAggregatedInputPower   Integer32,
+        jnxoptIfOChGroupSinkCurrentLowerInputPowerThreshold   Integer32,
+        jnxoptIfOChGroupSinkCurrentUpperInputPowerThreshold   Integer32,
+        jnxoptIfOChGroupSinkCurrentOutputPower                Integer32,
+        jnxoptIfOChGroupSinkCurrentLowOutputPower             Integer32,
+        jnxoptIfOChGroupSinkCurrentHighOutputPower            Integer32,
+        jnxoptIfOChGroupSinkCurrentLowerOutputPowerThreshold  Integer32,
+        jnxoptIfOChGroupSinkCurrentUpperOutputPowerThreshold  Integer32
+    } 
+
+
+jnxoptIfOChGroupSinkCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 1 } 
+
+
+jnxoptIfOChGroupSinkCurrentAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The aggregated optical power of all the DWDM input 
+      channels in the OChGroup." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 2 } 
+
+
+jnxoptIfOChGroupSinkCurrentLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 3 } 
+
+
+jnxoptIfOChGroupSinkCurrentHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 4 } 
+
+
+
+
+jnxoptIfOChGroupSinkCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on aggregated input power. If 
+      jnxoptIfOChGroupSinkCurrentAggregatedInputPower drops to this value 
+      or below, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 5 } 
+
+
+jnxoptIfOChGroupSinkCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on aggregated input power. If 
+      jnxoptIfOChGroupSinkCurrentAggregatedInputPower reaches or exceeds 
+      this value, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 6 } 
+
+
+jnxoptIfOChGroupSinkCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output 
+      in the OChGroup." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 7 } 
+
+
+jnxoptIfOChGroupSinkCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output 
+      in the OChGroup during the current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 8 } 
+
+
+jnxoptIfOChGroupSinkCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The highest optical power monitored at the output 
+      in the OChGroup during the current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 9 } 
+
+
+jnxoptIfOChGroupSinkCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on the output power. If 
+      jnxoptIfOChGroupSinkCurrentOutputPower drops to this value 
+      or below, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 10 } 
+
+
+jnxoptIfOChGroupSinkCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on the output power. If 
+      jnxoptIfOChGroupSinkCurrentOutputPower reaches or exceeds 
+      this value, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSinkCurrentEntry 11 } 
+
+
+-- OChGroup sink interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOChGroupSinkIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSinkIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of historical OChGroup sink performance monitoring 
+      information." 
+    ::= { jnxoptIfOChGroup 3 } 
+
+
+jnxoptIfOChGroupSinkIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSinkIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup sink performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOChGroupSinkIntervalNumber } 
+    ::= { jnxoptIfOChGroupSinkIntervalTable 1 } 
+
+
+JnxoptIfOChGroupSinkIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChGroupSinkIntervalNumber           JnxoptIfIntervalNumber,
+        jnxoptIfOChGroupSinkIntervalSuspectedFlag            TruthValue,
+        jnxoptIfOChGroupSinkIntervalLastAggregatedInputPower Integer32,
+        jnxoptIfOChGroupSinkIntervalLowAggregatedInputPower  Integer32,
+        jnxoptIfOChGroupSinkIntervalHighAggregatedInputPower Integer32,
+        jnxoptIfOChGroupSinkIntervalLastOutputPower          Integer32,
+        jnxoptIfOChGroupSinkIntervalLowOutputPower           Integer32,
+        jnxoptIfOChGroupSinkIntervalHighOutputPower          Integer32
+    }   
+
+
+jnxoptIfOChGroupSinkIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 1 } 
+
+
+jnxoptIfOChGroupSinkIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 2 } 
+
+
+jnxoptIfOChGroupSinkIntervalLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 3 } 
+  
+
+jnxoptIfOChGroupSinkIntervalLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 4 } 
+
+
+jnxoptIfOChGroupSinkIntervalHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 5 } 
+ 
+
+jnxoptIfOChGroupSinkIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output 
+      in the OChGroup during the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 6 } 
+
+
+jnxoptIfOChGroupSinkIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output 
+      in the OChGroup during the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 7 } 
+
+
+jnxoptIfOChGroupSinkIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output 
+      in the OChGroup during the interval." 
+    ::= { jnxoptIfOChGroupSinkIntervalEntry 8 } 
+
+
+-- OChGroup sink current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChGroupSinkCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OChGroup sink performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOChGroup 4 } 
+
+
+jnxoptIfOChGroupSinkCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup sink performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupSinkCurDayTable 1 } 
+
+
+JnxoptIfOChGroupSinkCurDayEntry ::=
+     SEQUENCE { 
+         jnxoptIfOChGroupSinkCurDaySuspectedFlag             TruthValue,
+         jnxoptIfOChGroupSinkCurDayLowAggregatedInputPower   Integer32,
+         jnxoptIfOChGroupSinkCurDayHighAggregatedInputPower  Integer32,
+         jnxoptIfOChGroupSinkCurDayLowOutputPower            Integer32,
+         jnxoptIfOChGroupSinkCurDayHighOutputPower           Integer32
+    } 
+
+
+jnxoptIfOChGroupSinkCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSinkCurDayEntry 1 } 
+
+
+jnxoptIfOChGroupSinkCurDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkCurDayEntry 2 } 
+ 
+
+jnxoptIfOChGroupSinkCurDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkCurDayEntry 3 } 
+
+
+jnxoptIfOChGroupSinkCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output 
+      in the OChGroup during the current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkCurDayEntry 4 } 
+
+
+jnxoptIfOChGroupSinkCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output 
+      in the OChGroup during the current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkCurDayEntry 5 } 
+  
+
+-- OChGroup sink previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChGroupSinkPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OChGroup sink performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroup 5 } 
+
+
+jnxoptIfOChGroupSinkPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup sink performance 
+      monitoring information of an interface for the previous 
+      24-hour interval." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupSinkPrevDayTable 1 } 
+
+
+JnxoptIfOChGroupSinkPrevDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChGroupSinkPrevDaySuspectedFlag             TruthValue,
+        jnxoptIfOChGroupSinkPrevDayLastAggregatedInputPower  Integer32,
+        jnxoptIfOChGroupSinkPrevDayLowAggregatedInputPower   Integer32,
+        jnxoptIfOChGroupSinkPrevDayHighAggregatedInputPower  Integer32,
+        jnxoptIfOChGroupSinkPrevDayLastOutputPower           Integer32,
+        jnxoptIfOChGroupSinkPrevDayLowOutputPower            Integer32,
+        jnxoptIfOChGroupSinkPrevDayHighOutputPower           Integer32
+    }   
+
+
+jnxoptIfOChGroupSinkPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 1 } 
+
+
+jnxoptIfOChGroupSinkPrevDayLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 2 } 
+
+
+jnxoptIfOChGroupSinkPrevDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 3 } 
+  
+
+jnxoptIfOChGroupSinkPrevDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The highest aggregated optical power of all the DWDM input 
+      channels in the OChGroup during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 4 } 
+
+
+jnxoptIfOChGroupSinkPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output 
+      in the OChGroup during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 5 } 
+  
+
+jnxoptIfOChGroupSinkPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output 
+      in the OChGroup during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 6 } 
+
+
+jnxoptIfOChGroupSinkPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output 
+      in the OChGroup during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSinkPrevDayEntry 7 } 
+ 
+
+-- OChGroup source current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOChGroupSrcCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OChGroup source performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOChGroup 6 } 
+  
+
+jnxoptIfOChGroupSrcCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup source performance 
+      monitoring information of an interface for the current 
+      15-minute interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupSrcCurrentTable 1 } 
+
+
+JnxoptIfOChGroupSrcCurrentEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChGroupSrcCurrentSuspectedFlag              TruthValue,
+        jnxoptIfOChGroupSrcCurrentOutputPower                Integer32,
+        jnxoptIfOChGroupSrcCurrentLowOutputPower             Integer32,
+        jnxoptIfOChGroupSrcCurrentHighOutputPower            Integer32,
+        jnxoptIfOChGroupSrcCurrentLowerOutputPowerThreshold  Integer32,
+        jnxoptIfOChGroupSrcCurrentUpperOutputPowerThreshold  Integer32,
+        jnxoptIfOChGroupSrcCurrentAggregatedInputPower       Integer32,
+        jnxoptIfOChGroupSrcCurrentLowAggregatedInputPower    Integer32,
+        jnxoptIfOChGroupSrcCurrentHighAggregatedInputPower   Integer32,
+        jnxoptIfOChGroupSrcCurrentLowerInputPowerThreshold   Integer32,
+        jnxoptIfOChGroupSrcCurrentUpperInputPowerThreshold   Integer32 
+    } 
+ 
+
+jnxoptIfOChGroupSrcCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 1 } 
+
+
+jnxoptIfOChGroupSrcCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 2 } 
+  
+
+jnxoptIfOChGroupSrcCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The lowest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 3 } 
+
+
+jnxoptIfOChGroupSrcCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 4 } 
+ 
+
+jnxoptIfOChGroupSrcCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on output power. If 
+      jnxoptIfOChGroupSrcCurrentOutputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 5 } 
+
+
+jnxoptIfOChGroupSrcCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on output power. If 
+      jnxoptIfOChGroupSrcCurrentOutputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 6 } 
+
+
+jnxoptIfOChGroupSrcCurrentAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The aggregated optical power monitored at the input." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 7 } 
+   
+
+jnxoptIfOChGroupSrcCurrentLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power monitored at the input 
+      during the current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 8 } 
+
+
+jnxoptIfOChGroupSrcCurrentHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power monitored at the input 
+      during the current 15-minute interval." 
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 9 } 
+
+
+jnxoptIfOChGroupSrcCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on input power. If 
+      jnxoptIfOChGroupSrcCurrentAggregatedInputPower drops to this value 
+      or below, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 10 } 
+
+
+jnxoptIfOChGroupSrcCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on input power. If 
+      jnxoptIfOChGroupSrcCurrentAggregatedInputPower reaches or exceeds 
+      this value, a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChGroupSrcCurrentEntry 11 } 
+
+
+-- OChGroup source interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOChGroupSrcIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of historical OChGroup source performance monitoring 
+      information." 
+    ::= { jnxoptIfOChGroup 7 } 
+
+
+jnxoptIfOChGroupSrcIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup source performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOChGroupSrcIntervalNumber } 
+    ::= { jnxoptIfOChGroupSrcIntervalTable 1 } 
+
+
+JnxoptIfOChGroupSrcIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChGroupSrcIntervalNumber               JnxoptIfIntervalNumber,
+        jnxoptIfOChGroupSrcIntervalSuspectedFlag            TruthValue,
+        jnxoptIfOChGroupSrcIntervalLastOutputPower          Integer32,
+        jnxoptIfOChGroupSrcIntervalLowOutputPower           Integer32,
+        jnxoptIfOChGroupSrcIntervalHighOutputPower          Integer32,
+        jnxoptIfOChGroupSrcIntervalLastAggregatedInputPower Integer32,
+        jnxoptIfOChGroupSrcIntervalLowAggregatedInputPower  Integer32,
+        jnxoptIfOChGroupSrcIntervalHighAggregatedInputPower Integer32 
+     } 
+
+
+jnxoptIfOChGroupSrcIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 1 } 
+
+
+jnxoptIfOChGroupSrcIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 2 } 
+
+
+jnxoptIfOChGroupSrcIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The last optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 3 } 
+
+
+jnxoptIfOChGroupSrcIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 4 } 
+
+
+jnxoptIfOChGroupSrcIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 5 } 
+
+
+jnxoptIfOChGroupSrcIntervalLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power monitored at the input 
+      during the interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 6 } 
+ 
+
+jnxoptIfOChGroupSrcIntervalLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power monitored at the input 
+      during the interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 7 } 
+
+
+jnxoptIfOChGroupSrcIntervalHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power monitored at the input 
+      during the interval." 
+    ::= { jnxoptIfOChGroupSrcIntervalEntry 8 } 
+
+
+-- OChGroup source current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChGroupSrcCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OChGroup source performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOChGroup 8 } 
+
+
+jnxoptIfOChGroupSrcCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup source performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupSrcCurDayTable 1 } 
+
+
+JnxoptIfOChGroupSrcCurDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChGroupSrcCurDaySuspectedFlag             TruthValue,
+        jnxoptIfOChGroupSrcCurDayLowOutputPower            Integer32,
+        jnxoptIfOChGroupSrcCurDayHighOutputPower           Integer32,
+        jnxoptIfOChGroupSrcCurDayLowAggregatedInputPower   Integer32,
+        jnxoptIfOChGroupSrcCurDayHighAggregatedInputPower  Integer32
+    } 
+
+
+jnxoptIfOChGroupSrcCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSrcCurDayEntry 1 } 
+
+
+jnxoptIfOChGroupSrcCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcCurDayEntry 2 } 
+
+
+jnxoptIfOChGroupSrcCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcCurDayEntry 3 } 
+
+
+jnxoptIfOChGroupSrcCurDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power monitored at the input 
+      during the current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcCurDayEntry 4 } 
+
+
+jnxoptIfOChGroupSrcCurDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power monitored at the input 
+      during the current 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcCurDayEntry 5 } 
+
+
+-- OChGroup source previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChGroupSrcPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChGroupSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of OChGroup source performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroup 9 } 
+
+
+jnxoptIfOChGroupSrcPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChGroupSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OChGroup source performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChGroupSrcPrevDayTable 1 } 
+
+
+JnxoptIfOChGroupSrcPrevDayEntry ::=
+
+
+    SEQUENCE { 
+        jnxoptIfOChGroupSrcPrevDaySuspectedFlag            TruthValue, 
+        jnxoptIfOChGroupSrcPrevDayLastOutputPower          Integer32, 
+        jnxoptIfOChGroupSrcPrevDayLowOutputPower           Integer32, 
+        jnxoptIfOChGroupSrcPrevDayHighOutputPower          Integer32, 
+        jnxoptIfOChGroupSrcPrevDayLastAggregatedInputPower Integer32, 
+        jnxoptIfOChGroupSrcPrevDayLowAggregatedInputPower  Integer32, 
+        jnxoptIfOChGroupSrcPrevDayHighAggregatedInputPower Integer32 
+    } 
+
+
+jnxoptIfOChGroupSrcPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 1 } 
+
+
+jnxoptIfOChGroupSrcPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 2 } 
+
+
+jnxoptIfOChGroupSrcPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 3 } 
+
+
+jnxoptIfOChGroupSrcPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 4 } 
+
+
+jnxoptIfOChGroupSrcPrevDayLastAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last aggregated optical power monitored at the input 
+      during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 5 } 
+
+
+jnxoptIfOChGroupSrcPrevDayLowAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest aggregated optical power monitored at the input 
+      during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 6 } 
+
+
+jnxoptIfOChGroupSrcPrevDayHighAggregatedInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest aggregated optical power monitored at the input 
+      during the previous 24-hour interval." 
+    ::= { jnxoptIfOChGroupSrcPrevDayEntry 7 } 
+
+
+-- the jnxoptIfOCh group 
+
+
+-- This group handles the configuration and 
+-- performance monitoring information for OCh layers. 
+
+
+-- OCh config table 
+
+
+jnxoptIfOChConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh configuration information." 
+    ::= { jnxoptIfOCh 1 } 
+
+
+jnxoptIfOChConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChConfigTable 1 } 
+ 
+
+JnxoptIfOChConfigEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChDirectionality JnxoptIfDirectionality, 
+        jnxoptIfOChCurrentStatus  BITS  
+    } 
+
+
+jnxoptIfOChDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the directionality of the entity." 
+    ::= { jnxoptIfOChConfigEntry 1 } 
+
+
+jnxoptIfOChCurrentStatus OBJECT-TYPE
+    SYNTAX BITS { 
+        losP(0), 
+        los(1), 
+        oci(2), 
+        ssfP(3), 
+        ssfO(4), 
+        ssf(5) 
+    }
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the defect condition of the entity, if any. 
+      This object is applicable when jnxoptIfOChDirectionality 
+      has the value sink(1) or bidirectional(3). 
+      In full-capability systems the bit position los(1) is not used. 
+      In reduced-capability systems or at IrDI interfaces only 
+      the bit positions los(1) and ssfP(3) are used."
+    ::= { jnxoptIfOChConfigEntry 2 } 
+
+
+-- OCh sink current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOChSinkCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh sink performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOCh 2 } 
+
+
+jnxoptIfOChSinkCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSinkCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh sink performance 
+      monitoring information for an interface for the current 
+      15-minute interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChSinkCurrentTable 1 } 
+
+
+JnxoptIfOChSinkCurrentEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSinkCurrentSuspectedFlag            TruthValue, 
+        jnxoptIfOChSinkCurrentInputPower               Integer32, 
+        jnxoptIfOChSinkCurrentLowInputPower            Integer32, 
+        jnxoptIfOChSinkCurrentHighInputPower           Integer32, 
+        jnxoptIfOChSinkCurrentLowerInputPowerThreshold Integer32, 
+        jnxoptIfOChSinkCurrentUpperInputPowerThreshold Integer32 
+    } 
+
+
+jnxoptIfOChSinkCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSinkCurrentEntry 1 } 
+
+
+jnxoptIfOChSinkCurrentInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the input." 
+    ::= { jnxoptIfOChSinkCurrentEntry 2 } 
+
+
+jnxoptIfOChSinkCurrentLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOChSinkCurrentEntry 3 } 
+
+
+jnxoptIfOChSinkCurrentHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOChSinkCurrentEntry 4 } 
+
+
+jnxoptIfOChSinkCurrentLowerInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on input power. If 
+      jnxoptIfOChSinkCurrentInputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChSinkCurrentEntry 5 } 
+
+
+jnxoptIfOChSinkCurrentUpperInputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on input power. If 
+      jnxoptIfOChSinkCurrentInputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChSinkCurrentEntry 6 } 
+
+
+-- OCh sink interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOChSinkIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSinkIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of historical OCh sink performance monitoring 
+      information." 
+    ::= { jnxoptIfOCh 3 } 
+
+
+jnxoptIfOChSinkIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSinkIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh sink performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOChSinkIntervalNumber } 
+    ::= { jnxoptIfOChSinkIntervalTable 1 } 
+
+
+JnxoptIfOChSinkIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSinkIntervalNumber          JnxoptIfIntervalNumber,
+        jnxoptIfOChSinkIntervalSuspectedFlag   TruthValue,
+        jnxoptIfOChSinkIntervalLastInputPower  Integer32,
+        jnxoptIfOChSinkIntervalLowInputPower   Integer32,
+        jnxoptIfOChSinkIntervalHighInputPower  Integer32
+    } 
+
+
+jnxoptIfOChSinkIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOChSinkIntervalEntry 1 } 
+  
+
+jnxoptIfOChSinkIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSinkIntervalEntry 2 } 
+ 
+
+jnxoptIfOChSinkIntervalLastInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOChSinkIntervalEntry 3 } 
+
+
+jnxoptIfOChSinkIntervalLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOChSinkIntervalEntry 4 } 
+
+
+jnxoptIfOChSinkIntervalHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      interval." 
+    ::= { jnxoptIfOChSinkIntervalEntry 5 } 
+
+
+-- OCh sink current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChSinkCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh sink performance monitoring information for 
+      the current 24-hour interval." 
+    ::= { jnxoptIfOCh 4 } 
+
+
+jnxoptIfOChSinkCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSinkCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh sink performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChSinkCurDayTable 1 } 
+
+
+JnxoptIfOChSinkCurDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSinkCurDaySuspectedFlag   TruthValue,
+        jnxoptIfOChSinkCurDayLowInputPower   Integer32,
+        jnxoptIfOChSinkCurDayHighInputPower  Integer32 
+    } 
+
+
+jnxoptIfOChSinkCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSinkCurDayEntry 1 } 
+
+
+jnxoptIfOChSinkCurDayLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOChSinkCurDayEntry 2 } 
+
+
+jnxoptIfOChSinkCurDayHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+    "The highest optical power monitored at the input during the 
+    current 24-hour interval." 
+    ::= { jnxoptIfOChSinkCurDayEntry 3 } 
+
+
+
+-- OCh sink previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChSinkPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh sink performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOCh 5 } 
+
+
+jnxoptIfOChSinkPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSinkPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh sink performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChSinkPrevDayTable 1 } 
+
+
+JnxoptIfOChSinkPrevDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSinkPrevDaySuspectedFlag   TruthValue,
+        jnxoptIfOChSinkPrevDayLastInputPower  Integer32,
+        jnxoptIfOChSinkPrevDayLowInputPower   Integer32,
+        jnxoptIfOChSinkPrevDayHighInputPower  Integer32 
+    }   
+
+
+jnxoptIfOChSinkPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSinkPrevDayEntry 1 } 
+
+
+jnxoptIfOChSinkPrevDayLastInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChSinkPrevDayEntry 2 } 
+
+
+jnxoptIfOChSinkPrevDayLowInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChSinkPrevDayEntry 3 } 
+
+
+jnxoptIfOChSinkPrevDayHighInputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the input during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChSinkPrevDayEntry 4 } 
+
+
+-- OCh source current table 
+-- Contains data for the current 15-minute performance monitoring 
+-- interval. 
+
+
+jnxoptIfOChSrcCurrentTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh source performance monitoring information for 
+      the current 15-minute interval." 
+    ::= { jnxoptIfOCh 6 } 
+
+
+jnxoptIfOChSrcCurrentEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSrcCurrentEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh source performance 
+      monitoring information of an interface for the current 
+      15-minute interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChSrcCurrentTable 1 } 
+
+
+JnxoptIfOChSrcCurrentEntry ::= 
+    SEQUENCE {    
+        jnxoptIfOChSrcCurrentSuspectedFlag              TruthValue,
+        jnxoptIfOChSrcCurrentOutputPower                Integer32,
+        jnxoptIfOChSrcCurrentLowOutputPower             Integer32,
+        jnxoptIfOChSrcCurrentHighOutputPower            Integer32,
+        jnxoptIfOChSrcCurrentLowerOutputPowerThreshold  Integer32,
+        jnxoptIfOChSrcCurrentUpperOutputPowerThreshold  Integer32 
+    } 
+
+
+jnxoptIfOChSrcCurrentSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSrcCurrentEntry 1 } 
+
+
+jnxoptIfOChSrcCurrentOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The optical power monitored at the output." 
+    ::= { jnxoptIfOChSrcCurrentEntry 2 } 
+
+
+jnxoptIfOChSrcCurrentLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 15-minute interval." 
+   ::= { jnxoptIfOChSrcCurrentEntry 3 } 
+
+
+jnxoptIfOChSrcCurrentHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 15-minute interval." 
+    ::= { jnxoptIfOChSrcCurrentEntry 4 } 
+
+
+jnxoptIfOChSrcCurrentLowerOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The lower limit threshold on output power. If 
+      jnxoptIfOChSrcCurrentOutputPower drops to this value or below, 
+      a Threshold Crossing Alert (TCA) should be sent."
+    ::= { jnxoptIfOChSrcCurrentEntry 5 } 
+
+
+jnxoptIfOChSrcCurrentUpperOutputPowerThreshold OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The upper limit threshold on output power. If 
+      jnxoptIfOChSrcCurrentOutputPower reaches or exceeds this value, 
+      a Threshold Crossing Alert (TCA) should be sent."
+      ::= { jnxoptIfOChSrcCurrentEntry 6 } 
+
+
+-- OCh source interval table 
+-- Contains data for previous 15-minute performance monitoring 
+-- intervals. 
+
+
+jnxoptIfOChSrcIntervalTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of historical OCh source performance monitoring 
+      information." 
+    ::= { jnxoptIfOCh 7 } 
+
+
+jnxoptIfOChSrcIntervalEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSrcIntervalEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh source performance 
+      monitoring information of an interface during a particular 
+      historical interval."
+    INDEX { ifIndex, jnxoptIfOChSrcIntervalNumber } 
+    ::= { jnxoptIfOChSrcIntervalTable 1 } 
+
+
+JnxoptIfOChSrcIntervalEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSrcIntervalNumber           JnxoptIfIntervalNumber,
+        jnxoptIfOChSrcIntervalSuspectedFlag    TruthValue,
+        jnxoptIfOChSrcIntervalLastOutputPower  Integer32,
+        jnxoptIfOChSrcIntervalLowOutputPower   Integer32,
+        jnxoptIfOChSrcIntervalHighOutputPower  Integer32
+    } 
+
+
+jnxoptIfOChSrcIntervalNumber OBJECT-TYPE 
+    SYNTAX JnxoptIfIntervalNumber 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Uniquely identifies the interval." 
+    ::= { jnxoptIfOChSrcIntervalEntry 1 } 
+
+
+jnxoptIfOChSrcIntervalSuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSrcIntervalEntry 2 } 
+
+
+jnxoptIfOChSrcIntervalLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOChSrcIntervalEntry 3 } 
+
+
+jnxoptIfOChSrcIntervalLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOChSrcIntervalEntry 4 } 
+
+
+jnxoptIfOChSrcIntervalHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      interval." 
+    ::= { jnxoptIfOChSrcIntervalEntry 5 } 
+ 
+
+-- OCh source current day table 
+-- Contains data for the current 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChSrcCurDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh source performance monitoring information for 
+      the current 24-hour interval." 
+      ::= { jnxoptIfOCh 8 } 
+
+
+jnxoptIfOChSrcCurDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSrcCurDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh source performance 
+      monitoring information of an interface for the current 
+      24-hour interval."
+     INDEX { ifIndex } 
+   ::= { jnxoptIfOChSrcCurDayTable 1 } 
+ 
+
+JnxoptIfOChSrcCurDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSrcCurDaySuspectedFlag   TruthValue, 
+        jnxoptIfOChSrcCurDayLowOutputPower  Integer32, 
+        jnxoptIfOChSrcCurDayHighOutputPower Integer32 
+    } 
+
+
+jnxoptIfOChSrcCurDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSrcCurDayEntry 1 } 
+ 
+
+jnxoptIfOChSrcCurDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOChSrcCurDayEntry 2 } 
+
+
+jnxoptIfOChSrcCurDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+      current 24-hour interval." 
+    ::= { jnxoptIfOChSrcCurDayEntry 3 } 
+
+
+-- OCh source previous day table 
+-- Contains data for the previous 24-hour performance 
+-- monitoring interval. 
+
+
+jnxoptIfOChSrcPrevDayTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOChSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OCh source performance monitoring information for 
+      the previous 24-hour interval." 
+    ::= { jnxoptIfOCh 9 } 
+
+
+jnxoptIfOChSrcPrevDayEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOChSrcPrevDayEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OCh source performance 
+      monitoring information of an interface for the previous 
+      24-hour interval."
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOChSrcPrevDayTable 1 } 
+
+
+JnxoptIfOChSrcPrevDayEntry ::=
+    SEQUENCE { 
+        jnxoptIfOChSrcPrevDaySuspectedFlag    TruthValue,
+        jnxoptIfOChSrcPrevDayLastOutputPower  Integer32,
+        jnxoptIfOChSrcPrevDayLowOutputPower   Integer32,
+        jnxoptIfOChSrcPrevDayHighOutputPower  Integer32
+    } 
+
+
+jnxoptIfOChSrcPrevDaySuspectedFlag OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "If true, the data in this entry may be unreliable." 
+    ::= { jnxoptIfOChSrcPrevDayEntry 1 } 
+
+
+jnxoptIfOChSrcPrevDayLastOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The last optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChSrcPrevDayEntry 2 } 
+
+
+jnxoptIfOChSrcPrevDayLowOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The lowest optical power monitored at the output during the 
+      previous 24-hour interval." 
+    ::= { jnxoptIfOChSrcPrevDayEntry 3 } 
+
+
+jnxoptIfOChSrcPrevDayHighOutputPower OBJECT-TYPE 
+    SYNTAX Integer32 
+    UNITS "0.1 dbm" 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The highest optical power monitored at the output during the 
+       previous 24-hour interval." 
+    ::= { jnxoptIfOChSrcPrevDayEntry 4 } 
+  
+
+-- the jnxoptIfOTUk group 
+-- This group handles the configuration 
+-- information for OTUk layers. 
+
+
+-- OTUk config table 
+
+
+jnxoptIfOTUkConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfOTUkConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of OTUk configuration information." 
+    ::= { jnxoptIfOTUk 1 } 
+
+
+
+jnxoptIfOTUkConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfOTUkConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains OTUk configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfOTUkConfigTable 1 } 
+
+
+JnxoptIfOTUkConfigEntry ::=
+    SEQUENCE { 
+        jnxoptIfOTUkDirectionality              JnxoptIfDirectionality,
+        jnxoptIfOTUkBitRateK                    JnxoptIfBitRateK,
+        jnxoptIfOTUkTraceIdentifierTransmitted  JnxoptIfTxTI,
+        jnxoptIfOTUkDAPIExpected                JnxoptIfExDAPI,
+        jnxoptIfOTUkSAPIExpected                JnxoptIfExSAPI,
+        jnxoptIfOTUkTraceIdentifierAccepted     JnxoptIfAcTI,
+        jnxoptIfOTUkTIMDetMode                  JnxoptIfTIMDetMode,
+        jnxoptIfOTUkTIMActEnabled               TruthValue,
+        jnxoptIfOTUkDEGThr                      JnxoptIfDEGThr,
+        jnxoptIfOTUkDEGM                        JnxoptIfDEGM,
+        jnxoptIfOTUkSinkAdaptActive             TruthValue,
+        jnxoptIfOTUkSourceAdaptActive           TruthValue,
+        jnxoptIfOTUkSinkFECEnabled              TruthValue,
+        jnxoptIfOTUkCurrentStatus               BITS
+    } 
+
+
+jnxoptIfOTUkDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the directionality of the entity." 
+    ::= { jnxoptIfOTUkConfigEntry 1 } 
+
+
+jnxoptIfOTUkBitRateK OBJECT-TYPE 
+    SYNTAX JnxoptIfBitRateK 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the bit rate of the entity." 
+    ::= { jnxoptIfOTUkConfigEntry 2 } 
+
+
+jnxoptIfOTUkTraceIdentifierTransmitted OBJECT-TYPE 
+    SYNTAX JnxoptIfTxTI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The trace identifier transmitted. 
+      This object is applicable when jnxoptIfOTUkDirectionality 
+      has the value source(2) or bidirectional(3). It must not 
+      be instantiated in rows where jnxoptIfOTUkDirectionality 
+      has the value sink(1). 
+      If no value is ever set by a management entity for this 
+      object, system-specific default value will be used. 
+      Any implementation that instantiates this object must 
+      document the system-specific default value or how it 
+      is derived."
+    ::= { jnxoptIfOTUkConfigEntry 3 } 
+
+
+jnxoptIfOTUkDAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExDAPI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The DAPI expected by the receiver. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      This object has no effect when jnxoptIfOTUkTIMDetMode has 
+      the value off(1)."
+    ::= { jnxoptIfOTUkConfigEntry 4 } 
+
+
+jnxoptIfOTUkSAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExSAPI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The SAPI expected by the receiver. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      This object has no effect when jnxoptIfOTUkTIMDetMode has 
+      the value off(1)."
+    ::= { jnxoptIfOTUkConfigEntry 5 } 
+
+
+jnxoptIfOTUkTraceIdentifierAccepted OBJECT-TYPE 
+    SYNTAX JnxoptIfAcTI 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The actual trace identifier accepted. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      The value of this object is unspecified when 
+      jnxoptIfOTUkCurrentStatus indicates a near-end defect 
+      (i.e., ssf(3), lof(4), ais(5), lom(6)) that prevents 
+      extraction of the trace message."
+    ::= { jnxoptIfOTUkConfigEntry 6 } 
+
+
+jnxoptIfOTUkTIMDetMode OBJECT-TYPE 
+    SYNTAX JnxoptIfTIMDetMode 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      The default value of this object is off(1)." 
+    ::= { jnxoptIfOTUkConfigEntry 7 } 
+
+
+jnxoptIfOTUkTIMActEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates whether the Trace Identifier Mismatch (TIM) 
+      Consequent Action function is enabled. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      This object has no effect when jnxoptIfOTUkTIMDetMode has 
+      the value off(1). 
+      The default value of this object is false(2)." 
+    ::= { jnxoptIfOTUkConfigEntry 8 } 
+
+
+jnxoptIfOTUkDEGThr OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGThr 
+    UNITS "percentage" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the threshold level for declaring a performance 
+      monitoring (PM) Second to be bad. A PM Second is declared bad if 
+      the percentage of detected errored blocks in that second is 
+      greater than or equal to jnxoptIfOTUkDEGThr. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      The default value of this object is Severely Errored Second 
+      (SES) Estimator (See ITU-T G.7710)."
+    ::= { jnxoptIfOTUkConfigEntry 9 } 
+
+
+jnxoptIfOTUkDEGM OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGM 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a Degraded Signal 
+      defect (dDEG). A dDEG shall be declared if jnxoptIfOTUkDEGM 
+      consecutive bad PM Seconds are detected. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      The default value of this object is 7 (See ITU-T G.7710)."
+    ::= { jnxoptIfOTUkConfigEntry 10 } 
+
+
+jnxoptIfOTUkSinkAdaptActive OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates whether the sink adaptation function is activated or 
+      not. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      The default value of this object is false(2)."
+    ::= { jnxoptIfOTUkConfigEntry 11 } 
+
+
+jnxoptIfOTUkSourceAdaptActive OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates whether the source adaptation function is activated or 
+      not. 
+      This object is only applicable to the source function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value source(2) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value sink(1). 
+      The default value of this object is false(2)." 
+    ::= { jnxoptIfOTUkConfigEntry 12 } 
+
+
+jnxoptIfOTUkSinkFECEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION 
+      "If Forward Error Correction (FEC) is supported, this object 
+      indicates whether FEC at the OTUk sink adaptation function is 
+      enabled or not. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2). 
+      The default value of this object is true(1)." 
+    ::= { jnxoptIfOTUkConfigEntry 13 } 
+
+
+jnxoptIfOTUkCurrentStatus OBJECT-TYPE 
+    SYNTAX BITS { 
+        tim(0), 
+        deg(1), 
+        bdi(2), 
+        ssf(3), 
+        lof(4), 
+        ais(5), 
+        lom(6) 
+    } 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the defect condition of the entity, if any. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfOTUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfOTUkDirectionality has the value source(2)." 
+    ::= { jnxoptIfOTUkConfigEntry 14 } 
+
+
+-- GCC0 config table 
+
+
+jnxoptIfGCC0ConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfGCC0ConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of GCC0 configuration information." 
+    ::= { jnxoptIfOTUk 2 } 
+
+
+jnxoptIfGCC0ConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfGCC0ConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains GCC0 configuration 
+      information of an interface. Each instance must 
+      correspond to an instance of jnxoptIfOTUkConfigEntry. 
+      Separate source and/or sink instances may exist 
+      for a given ifIndex value, or a single bidirectional 
+      instance may exist, but a bidirectional instance may 
+      not coexist with a source or sink instance. 
+      Instances of this conceptual row persist across 
+      agent restarts."
+    INDEX { ifIndex, jnxoptIfGCC0Directionality } 
+    ::= { jnxoptIfGCC0ConfigTable 1 } 
+
+
+JnxoptIfGCC0ConfigEntry ::=
+    SEQUENCE { 
+        jnxoptIfGCC0Directionality JnxoptIfDirectionality, 
+        jnxoptIfGCC0Application    SnmpAdminString, 
+        jnxoptIfGCC0RowStatus      RowStatus 
+    } 
+
+
+jnxoptIfGCC0Directionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the directionality of the entity. 
+      The values source(2) and bidirectional(3) are 
+      not allowed if the corresponding instance of 
+      jnxoptIfOTUkDirectionality has the value sink(1). 
+      The values sink(1) and bidirectional(3) are 
+      not allowed if the corresponding instance of 
+      jnxoptIfOTUkDirectionality has the value source(2)."
+    ::= { jnxoptIfGCC0ConfigEntry 1 } 
+
+
+jnxoptIfGCC0Application OBJECT-TYPE 
+    SYNTAX SnmpAdminString 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the application transported by the GCC0 entity. 
+      Example applications are ECC, User data channel.
+      The value of this object may not be changed when 
+      jnxoptIfGCC0RowStatus has the value active(1)." 
+    ::= { jnxoptIfGCC0ConfigEntry 2 } 
+
+
+jnxoptIfGCC0RowStatus OBJECT-TYPE 
+    SYNTAX RowStatus 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "This columnar object is used for creating and deleting a 
+      conceptual row of the jnxoptIfGCC0 config table. 
+      It is used to model the addGCC0Access and removeGCC0Access 
+      operations of an OTUk_TTP for GCC0 access control as defined 
+      in G.874.1. Setting RowStatus to createAndGo or createAndWait 
+      implies addGCC0Access. Setting RowStatus to destroy implies 
+      removeGCC0Access."
+    ::= { jnxoptIfGCC0ConfigEntry 3 } 
+
+
+-- the jnxoptIfODUk group 
+-- This group handles the configuration information 
+-- for the ODUk layers. 
+
+
+-- ODUk config table 
+
+
+jnxoptIfODUkConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfODUkConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of ODUk configuration information." 
+    ::= { jnxoptIfODUk 1 } 
+
+
+jnxoptIfODUkConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfODUkConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains ODUk configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfODUkConfigTable 1 } 
+
+
+JnxoptIfODUkConfigEntry ::=
+    SEQUENCE { 
+       jnxoptIfODUkDirectionality              JnxoptIfDirectionality,
+       jnxoptIfODUkBitRateK                    JnxoptIfBitRateK,
+       jnxoptIfODUkTcmFieldsInUse              BITS,
+       jnxoptIfODUkPositionSeqCurrentSize      Unsigned32,
+       jnxoptIfODUkTtpPresent                  TruthValue 
+    } 
+
+
+jnxoptIfODUkDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfDirectionality 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the directionality of the entity." 
+    ::= { jnxoptIfODUkConfigEntry 1 } 
+ 
+
+jnxoptIfODUkBitRateK OBJECT-TYPE 
+    SYNTAX JnxoptIfBitRateK 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the bit rate of the entity." 
+    ::= { jnxoptIfODUkConfigEntry 2 } 
+
+
+jnxoptIfODUkTcmFieldsInUse OBJECT-TYPE 
+    SYNTAX BITS { 
+        tcmField1(0),
+        tcmField2(1),
+        tcmField3(2),
+        tcmField4(3),
+        tcmField5(4),
+        tcmField6(5)
+    } 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the TCM field(s) that are currently in use. 
+      The positions of the bits correspond to the TCM fields. 
+      A bit that is set to 1 means that the corresponding TCM 
+      field is used. This object will be updated when rows are 
+      created in or deleted from the jnxoptIfODUkTConfigTable, or 
+      the jnxoptIfODUkTNimConfigTable." 
+    ::= { jnxoptIfODUkConfigEntry 3 } 
+
+
+jnxoptIfODUkPositionSeqCurrentSize OBJECT-TYPE 
+    SYNTAX Unsigned32 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "This variable indicates the current size of the position 
+      sequence (i.e., number of TCM function and/or GCC12 
+      access that have been created in the ODUk interface). 
+      When the value of this variable is greater than zero, 
+      it means that one or more TCM function and/or GCC12 
+      access have been created in the ODUk interface. In this 
+      case, there will be as many rows in the 
+      jnxoptIfODUkPositionSeqTable as the value of 
+      jnxoptIfODUkPositionSeqCurrentSize corresponding to this 
+      ODUk interface, one row for each TCM function or GCC12 
+      access. The position of the TCM function and/or 
+      GCC12 access within the sequence is indicated by the 
+      jnxoptIfODUkPositionSeqPosition variable in 
+      jnxoptIfODUkPositionSeqTable. 
+      The jnxoptIfODUkPositionSeqTable also provides pointers 
+      to the corresponding TCM function (jnxoptIfODUkT) and 
+      GCC12 access (jnxoptIfGCC12) entities."
+    ::= { jnxoptIfODUkConfigEntry 4 } 
+
+
+jnxoptIfODUkTtpPresent OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "This object has the value true(1) if the ifEntry under which 
+      it is instantiated contains an ODUk Trail Termination Point, 
+      i.e., is the endpoint of an ODUk path. In that case there 
+      will be a corresponding row in the ODUk TTP config table and 
+      it will not be possible to create corresponding rows in the 
+      ODUk NIM config table. This object has the value false(2) 
+      if the ifEntry under which it is instantiated contains an 
+      intermediate ODUk Connection Termination Point. In that case 
+      there is no corresponding row in the ODUk TTP config table, 
+      but it will be possible to create corresponding rows in the 
+      ODUk NIM config table. This object also affects the allowable 
+      options in rows created in the GCC12 config table and in the 
+      ODUkT config table, as specified in the DESCRIPTION clauses 
+      of the columns in those tables." 
+    ::= { jnxoptIfODUkConfigEntry 5 } 
+
+
+-- ODUk Trail Termination Point (TTP) config table 
+
+
+jnxoptIfODUkTtpConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfODUkTtpConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of ODUk TTP configuration information." 
+    ::= { jnxoptIfODUk 2 } 
+ 
+
+jnxoptIfODUkTtpConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfODUkTtpConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains ODUk TTP configuration
+      information of an interface." 
+    INDEX { ifIndex } 
+    ::= { jnxoptIfODUkTtpConfigTable 1 } 
+
+
+JnxoptIfODUkTtpConfigEntry ::=
+    SEQUENCE { 
+        jnxoptIfODUkTtpTraceIdentifierTransmitted  JnxoptIfTxTI,
+        jnxoptIfODUkTtpDAPIExpected                JnxoptIfExDAPI,
+        jnxoptIfODUkTtpSAPIExpected                JnxoptIfExSAPI,
+        jnxoptIfODUkTtpTraceIdentifierAccepted     JnxoptIfAcTI,
+        jnxoptIfODUkTtpTIMDetMode                  JnxoptIfTIMDetMode,
+        jnxoptIfODUkTtpTIMActEnabled               TruthValue,
+        jnxoptIfODUkTtpDEGThr                      JnxoptIfDEGThr,
+        jnxoptIfODUkTtpDEGM                        JnxoptIfDEGM,
+        jnxoptIfODUkTtpCurrentStatus               BITS
+    } 
+ 
+
+jnxoptIfODUkTtpTraceIdentifierTransmitted OBJECT-TYPE 
+    SYNTAX JnxoptIfTxTI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The trace identifier transmitted. 
+      This object is applicable when jnxoptIfODUkDirectionality 
+      has the value source(2) or bidirectional(3). It must not 
+      be instantiated in rows where jnxoptIfODUkDirectionality 
+      has the value sink(1). 
+      If no value is ever set by a management entity for this 
+      object, system-specific default value will be used. 
+      Any implementation that instantiates this object must 
+      document the system-specific default value or how it 
+      is derived."
+   ::= { jnxoptIfODUkTtpConfigEntry 1 } 
+
+
+jnxoptIfODUkTtpDAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExDAPI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The DAPI expected by the receiver. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      This object has no effect when jnxoptIfODUkTtpTIMDetMode has 
+      the value off(1)."
+    ::= { jnxoptIfODUkTtpConfigEntry 2 } 
+
+
+
+jnxoptIfODUkTtpSAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExSAPI 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "The SAPI expected by the receiver. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      This object has no effect when jnxoptIfODUkTtpTIMDetMode has 
+      the value off(1)."
+    ::= { jnxoptIfODUkTtpConfigEntry 3 } 
+
+
+jnxoptIfODUkTtpTraceIdentifierAccepted OBJECT-TYPE 
+    SYNTAX JnxoptIfAcTI 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The actual trace identifier accepted. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      The value of this object is unspecified when 
+      jnxoptIfODUkTtpCurrentStatus indicates a near-end defect 
+      (i.e., oci(0), lck(1), ssf(5)) that prevents extraction 
+      of the trace message."
+    ::= { jnxoptIfODUkTtpConfigEntry 4 } 
+
+
+jnxoptIfODUkTtpTIMDetMode OBJECT-TYPE 
+    SYNTAX JnxoptIfTIMDetMode 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      The default value of this object is off(1)."
+    ::= { jnxoptIfODUkTtpConfigEntry 5 } 
+
+
+jnxoptIfODUkTtpTIMActEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates whether the Trace Identifier Mismatch (TIM) 
+      Consequent Action function is enabled. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      This object has no effect when jnxoptIfODUkTtpTIMDetMode has 
+      the value off(1). 
+      The default value of this object is false(2)."
+    ::= { jnxoptIfODUkTtpConfigEntry 6 } 
+
+
+jnxoptIfODUkTtpDEGThr OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGThr 
+    UNITS "percentage" 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a performance 
+      monitoring (PM) Second to be bad. A PM Second is declared bad if 
+      the percentage of detected errored blocks in that second is 
+      greater than or equal to jnxoptIfODUkDEGThr. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      The default value of this object is Severely Errored Second 
+      (SES) Estimator (See ITU-T G.7710)."
+    ::= { jnxoptIfODUkTtpConfigEntry 7 } 
+
+
+jnxoptIfODUkTtpDEGM OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGM 
+    MAX-ACCESS read-write 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a Degraded Signal 
+      defect (dDEG). A dDEG shall be declared if jnxoptIfODUkDEGM 
+      consecutive bad PM Seconds are detected. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2). 
+      The default value of this object is 7 (See ITU-T G.7710)."
+    ::= { jnxoptIfODUkTtpConfigEntry 8 } 
+
+
+jnxoptIfODUkTtpCurrentStatus OBJECT-TYPE 
+    SYNTAX BITS { 
+        oci(0),
+        lck(1),
+        tim(2),
+        deg(3),
+        bdi(4),
+        ssf(5)
+    }
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the defect condition of the entity, if any. 
+      This object is only applicable to the sink function, i.e., 
+      only when jnxoptIfODUkDirectionality has the value sink(1) 
+      or bidirectional(3). It must not be instantiated in rows 
+      where jnxoptIfODUkDirectionality has the value source(2)."
+    ::= { jnxoptIfODUkTtpConfigEntry 9 } 
+
+
+-- ODUk Position Sequence table 
+
+
+jnxoptIfODUkPositionSeqTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfODUkPositionSeqEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of ODUk Position Sequence information." 
+    ::= { jnxoptIfODUk 3 } 
+
+
+jnxoptIfODUkPositionSeqEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfODUkPositionSeqEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains ODUk position sequence 
+      information of an ODUk interface. The ODUk interface 
+      is identified by the ifIndex. Associated with each 
+      ODUk interface there may be one of more conceptual 
+      rows in the jnxoptIfODUkPositionSeqTable. Each row 
+      represents a TCM or GCC12 access function within the 
+      associated ODUk interface. Rows of the 
+      jnxoptIfODUkPositionSeqTable table are created/deleted 
+      as the result of the creation/deletion of the jnxoptIfODUkT 
+      or jnxoptIfGCC12 entities." 
+    INDEX { ifIndex, jnxoptIfODUkPositionSeqIndex } 
+    ::= { jnxoptIfODUkPositionSeqTable 1 } 
+
+
+JnxoptIfODUkPositionSeqEntry ::= 
+    SEQUENCE { 
+        jnxoptIfODUkPositionSeqIndex            Unsigned32,
+        jnxoptIfODUkPositionSeqPosition         Unsigned32,
+        jnxoptIfODUkPositionSeqPointer          RowPointer 
+    } 
+
+
+jnxoptIfODUkPositionSeqIndex OBJECT-TYPE 
+    SYNTAX Unsigned32 (1..4294967295) 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "This variable identifies a row in the 
+      jnxoptIfODUkPositionSeqTable Table. 
+      Each row of the jnxoptIfODUkPositionSeqTable Table 
+      represents a TCM or GCC12 access function within the 
+      associated ODUk interface."
+    ::= { jnxoptIfODUkPositionSeqEntry 1 } 
+
+
+jnxoptIfODUkPositionSeqPosition OBJECT-TYPE 
+    SYNTAX Unsigned32 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "This variable indicates the position of the TCM or 
+      GCC12 access function within the sequence of TCMs & 
+      GCC12 access functions of the associated ODUk 
+      interface. The TCM or GCC12 presented by this row is 
+      referenced by the jnxoptIfODUkPositionSeqPointer variable."
+    ::= { jnxoptIfODUkPositionSeqEntry 2 } 
+
+
+jnxoptIfODUkPositionSeqPointer OBJECT-TYPE 
+    SYNTAX RowPointer 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "This variable identifies the TCM or GCC12 access function 
+      by pointing to the corresponding jnxoptIfODUkT or jnxoptIfGCC12 
+      entity."
+    ::= { jnxoptIfODUkPositionSeqEntry 3 } 
+
+
+-- ODUk Non-intrusive monitoring (Nim) config table 
+
+
+jnxoptIfODUkNimConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfODUkNimConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of ODUkNim configuration information." 
+    ::= { jnxoptIfODUk 4 } 
+
+
+jnxoptIfODUkNimConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfODUkNimConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains ODUkNim configuration 
+      information of an interface. Each instance must 
+      correspond to an instance of jnxoptIfODUkConfigEntry 
+      for which jnxoptIfODUkTtpPresent has the value false(2).
+      Instances of this conceptual row persist across 
+      agent restarts, and read-create columns other 
+      than the status column may be modified while the 
+      row is active."
+    INDEX { ifIndex, jnxoptIfODUkNimDirectionality }
+    ::= { jnxoptIfODUkNimConfigTable 1 } 
+
+
+JnxoptIfODUkNimConfigEntry ::= 
+    SEQUENCE { 
+        jnxoptIfODUkNimDirectionality              JnxoptIfSinkOrSource,
+        jnxoptIfODUkNimDAPIExpected                JnxoptIfExDAPI,
+        jnxoptIfODUkNimSAPIExpected                JnxoptIfExSAPI,
+        jnxoptIfODUkNimTraceIdentifierAccepted     JnxoptIfAcTI,
+        jnxoptIfODUkNimTIMDetMode                  JnxoptIfTIMDetMode,
+        jnxoptIfODUkNimTIMActEnabled               TruthValue,
+        jnxoptIfODUkNimDEGThr                      JnxoptIfDEGThr,
+        jnxoptIfODUkNimDEGM                        JnxoptIfDEGM,
+        jnxoptIfODUkNimCurrentStatus               BITS,
+        jnxoptIfODUkNimRowStatus                   RowStatus 
+    } 
+
+
+jnxoptIfODUkNimDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfSinkOrSource 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "Specifies the monitor point for the ODUk Path non-intrusive 
+      monitoring function. The value source(2) is not allowed 
+      if the corresponding instance of jnxoptIfODUkDirectionality 
+      has the value sink(1), and the value sink(1) is not allowed 
+      if the corresponding instance of jnxoptIfODUkDirectionality 
+      has the value source(2). Either the value sink(1) or 
+      source(2) is allowed if the corresponding instance of 
+      jnxoptIfODUkDirectionality has the value bidirectional(3).
+      The value sink(1) means monitoring at the sink direction 
+      path signal of the ODUk CTP.
+      The value source(2) means monitoring at the source direction 
+      path signal of the ODUk CTP. Monitoring the source direction 
+      of an ODUk CTP is necessary in those cases where the ODUk CTP 
+      is at an SNCP (Subnetwork Connection Protection) end (e.g., see 
+      Figure I.1.2/G.874.1). If one would like to get the performance 
+      of the protected connection, one cannot use the NIM function 
+      at both ODUk CTP sinks (before the matrix), instead one should 
+      monitor the signal at the source ODUk CTP after the matrix."
+    ::= { jnxoptIfODUkNimConfigEntry 1 } 
+
+
+jnxoptIfODUkNimDAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExDAPI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "The DAPI expected by the receiver. 
+      This object has no effect if jnxoptIfODUkNimTIMDetMode has 
+      the value off(1) or sapi(3)."
+    ::= { jnxoptIfODUkNimConfigEntry 2 } 
+
+
+jnxoptIfODUkNimSAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExSAPI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "The SAPI expected by the receiver. 
+      This object has no effect if jnxoptIfODUkNimTIMDetMode has 
+      the value off(1) or dapi(2)."
+    ::= { jnxoptIfODUkNimConfigEntry 3 } 
+
+
+jnxoptIfODUkNimTraceIdentifierAccepted OBJECT-TYPE 
+    SYNTAX JnxoptIfAcTI 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The actual trace identifier accepted. The value of 
+      this object is unspecified if jnxoptIfODUkNimCurrentStatus 
+      has any of the bit positions oci(0), lck(1), or ssf(5) 
+      set or if jnxoptIfODUkNimRowStatus has any value other 
+      than active(1)."
+    ::= { jnxoptIfODUkNimConfigEntry 4 } 
+
+
+jnxoptIfODUkNimTIMDetMode OBJECT-TYPE 
+    SYNTAX JnxoptIfTIMDetMode 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function." 
+    ::= { jnxoptIfODUkNimConfigEntry 5 } 
+
+
+jnxoptIfODUkNimTIMActEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates whether the Trace Identifier Mismatch (TIM) 
+      Consequent Action function is enabled." 
+    ::= { jnxoptIfODUkNimConfigEntry 6 } 
+
+
+jnxoptIfODUkNimDEGThr OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGThr 
+    UNITS "percentage" 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the threshold level for declaring a performance 
+      monitoring (PM) Second to be bad. A PM Second is declared bad 
+      if the percentage of detected errored blocks in that second is 
+      greater than or equal to jnxoptIfODUkNimDEGThr." 
+    ::= { jnxoptIfODUkNimConfigEntry 7 } 
+
+
+jnxoptIfODUkNimDEGM OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGM 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the threshold level for declaring a Degraded Signal 
+      defect (dDEG). A dDEG shall be declared if jnxoptIfODUkNimDEGM 
+      consecutive bad PM Seconds are detected." 
+    ::= { jnxoptIfODUkNimConfigEntry 8 } 
+
+
+jnxoptIfODUkNimCurrentStatus OBJECT-TYPE 
+    SYNTAX BITS { 
+        oci(0), 
+        lck(1), 
+        tim(2), 
+        deg(3), 
+        bdi(4), 
+        ssf(5) 
+    } 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the defect condition of the entity, if 
+      any. The value of this object is unspecified if 
+      jnxoptIfODUkNimRowStatus has any value other than 
+      active(1)." 
+    ::= { jnxoptIfODUkNimConfigEntry 9 } 
+
+
+jnxoptIfODUkNimRowStatus OBJECT-TYPE 
+    SYNTAX RowStatus 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "This columnar object is used for creating and deleting 
+      a conceptual row of the jnxoptIfODUkNim config table. 
+      It is used to model the activateNim and deactivateNim 
+      operations of an OTUk_CTP for non-intrusive monitoring 
+      control as defined in G.874.1. Setting RowStatus to 
+      createAndGo or createAndWait implies activateNim. 
+      Setting RowStatus to destroy implies deactivateNim."
+    ::= { jnxoptIfODUkNimConfigEntry 10 } 
+
+
+-- GCC12 config table 
+
+
+jnxoptIfGCC12ConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfGCC12ConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of GCC12 configuration information. 
+      The GCC function processes the GCC overhead bytes passing 
+      through them but leave the remainder of the ODUk overhead 
+      and payload data alone."
+    ::= { jnxoptIfODUk 5 } 
+
+
+jnxoptIfGCC12ConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfGCC12ConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains GCC12 configuration 
+      information of an interface. Each instance must 
+      correspond to an instance of jnxoptIfODUkConfigEntry. 
+      Separate instances providing GCC1-only access and 
+      GCC2-only access may exist for a given ifIndex value, 
+      or a single instance providing GCC1 + GCC2 may exist, 
+      but a GCC1 + GCC2 instance may not coexist with a 
+      GCC1-only or GCC2-only instance.
+      Instances of this conceptual row persist across agent
+      restarts." 
+    INDEX { ifIndex, jnxoptIfGCC12Codirectional, jnxoptIfGCC12GCCAccess } 
+    ::= { jnxoptIfGCC12ConfigTable 1 } 
+
+
+JnxoptIfGCC12ConfigEntry ::= 
+    SEQUENCE { 
+        jnxoptIfGCC12Codirectional      TruthValue,
+        jnxoptIfGCC12GCCAccess          INTEGER,
+        jnxoptIfGCC12GCCPassThrough     TruthValue,
+        jnxoptIfGCC12Application        SnmpAdminString,
+        jnxoptIfGCC12RowStatus          RowStatus
+    } 
+
+
+jnxoptIfGCC12Codirectional OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the directionality of the GCC12 termination with 
+      respect to the associated ODUk CTP. The value true(1) means 
+      that the sink part of the GCC12 extracts COMMS data from the 
+      signal at the input to the ODUk CTP sink and the source part 
+      of the GCC12 inserts COMMS data into the signal at the output 
+      of the ODUk CTP source. The value false(2) means that the 
+      sink part of the GCC12 extracts COMMS data from the signal at 
+      the output of the ODUk CTP source and the source part of the 
+      GCC12 inserts COMMS data into the signal at the input of the 
+      ODUk CTP sink. This attribute may assume either value when 
+      the corresponding instance of jnxoptIfODUkTtpPresent has the 
+      value false(2). When the value of the corresponding instance 
+      of jnxoptIfODUkTtpPresent is true(1) then the only value allowed 
+      for this attribute is true(1)." 
+    ::= { jnxoptIfGCC12ConfigEntry 1 } 
+
+
+jnxoptIfGCC12GCCAccess OBJECT-TYPE 
+    SYNTAX INTEGER { 
+        gcc1 (1), 
+        gcc2 (2), 
+        gcc1and2 (3) 
+    } 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the GCC access represented by the entity." 
+    ::= { jnxoptIfGCC12ConfigEntry 2 } 
+
+
+jnxoptIfGCC12GCCPassThrough OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Controls whether the selected GCC overhead bytes are passed 
+      through or modified. The value true(1) means that the selected 
+      GCC overhead bytes are passed through unmodified from the ODUk 
+      CTP input to the ODUk CTP output. The value false(2) means that 
+      the selected GCC overhead bytes are set to zero at the ODUk CTP 
+      output after the extraction of the COMMS data. This object has 
+      no effect if the corresponding instance of jnxoptIfODUkTtpPresent 
+      has the value true(1).
+      The value of this object may not be changed when 
+      jnxoptIfGCC12RowStatus has the value active(1)." 
+    ::= { jnxoptIfGCC12ConfigEntry 3 } 
+
+
+jnxoptIfGCC12Application OBJECT-TYPE 
+    SYNTAX SnmpAdminString 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the application transported by the GCC12 entity. 
+      Example applications are ECC, User data channel.
+      The value of this object may not be changed when 
+      jnxoptIfGCC12RowStatus has the value active(1)." 
+    ::= { jnxoptIfGCC12ConfigEntry 4 } 
+
+
+jnxoptIfGCC12RowStatus OBJECT-TYPE 
+    SYNTAX RowStatus 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "This columnar object is used for creating and deleting 
+      a conceptual row of the jnxoptIfGCC12 config table. It is 
+      used to model the addGCC12Access and removeGCC12Access 
+      operations of an ODUk_CTP or ODUk_TTP for GCC12 access 
+      control as defined in G.874.1. Setting RowStatus to 
+      createAndGo or createAndWait implies addGCC12Access. 
+      Setting RowStatus to destroy implies removeGCC12Access. 
+      Successful addition/removal of the GCC12 access function 
+      will result in updating the 
+      jnxoptIfODUkPositionSeqCurrentSize variable and the 
+      jnxoptIfODUkPositionSeqTable table of the associated 
+      ODUk entry in the jnxoptIfODUkConfigTable." 
+    ::= { jnxoptIfGCC12ConfigEntry 5 } 
+
+
+-- the jnxoptIfODUkT group 
+-- This group handles the configuration information 
+-- for the ODUkT layers. 
+
+
+-- ODUkT config table 
+
+
+jnxoptIfODUkTConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfODUkTConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A table of ODUkT configuration information." 
+    ::= { jnxoptIfODUkT 1 } 
+
+
+jnxoptIfODUkTConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfODUkTConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "A conceptual row that contains ODUkT configuration 
+      information of an interface. Each instance must 
+      correspond to an instance of jnxoptIfODUkConfigEntry. 
+      Rows in this table are mutually exclusive with rows 
+      in the ODUkT NIM config table -- in other words, this 
+      row object may not be instantiated for a given pair 
+      of ifIndex and TCM field values if a corresponding 
+      instance of jnxoptIfODUkTNimConfigEntry already exists.
+      Instances of this conceptual row persist across agent 
+      restarts. Except where noted otherwise, read-create 
+      columns other than the status column may be modified 
+      while the row is active."
+    INDEX { ifIndex, jnxoptIfODUkTTcmField, jnxoptIfODUkTCodirectional }
+    ::= { jnxoptIfODUkTConfigTable 1 } 
+
+JnxoptIfODUkTConfigEntry ::= 
+    SEQUENCE { 
+        jnxoptIfODUkTTcmField                    Unsigned32,
+        jnxoptIfODUkTCodirectional               TruthValue,
+        jnxoptIfODUkTTraceIdentifierTransmitted  JnxoptIfTxTI,
+        jnxoptIfODUkTDAPIExpected                JnxoptIfExDAPI,
+        jnxoptIfODUkTSAPIExpected                JnxoptIfExSAPI,
+        jnxoptIfODUkTTraceIdentifierAccepted     JnxoptIfAcTI,
+        jnxoptIfODUkTTIMDetMode                  JnxoptIfTIMDetMode,
+        jnxoptIfODUkTTIMActEnabled               TruthValue,
+        jnxoptIfODUkTDEGThr                      JnxoptIfDEGThr,
+        jnxoptIfODUkTDEGM                        JnxoptIfDEGM,
+        jnxoptIfODUkTSinkMode                    INTEGER,
+        jnxoptIfODUkTSinkLockSignalAdminState    INTEGER,
+        jnxoptIfODUkTSourceLockSignalAdminState  INTEGER,
+        jnxoptIfODUkTCurrentStatus               BITS,
+        jnxoptIfODUkTRowStatus                   RowStatus 
+    } 
+
+
+jnxoptIfODUkTTcmField OBJECT-TYPE 
+    SYNTAX Unsigned32 (1..6) 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the tandem connection monitoring 
+      field of the ODUk OH. Valid values are 
+      integers from 1 to 6." 
+    ::= { jnxoptIfODUkTConfigEntry 1 } 
+
+
+jnxoptIfODUkTCodirectional OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the directionality of the ODUkT termination point with 
+      respect to the associated ODUk CTP. The value true(1) means 
+      that the sink part of the ODUkT TP extracts TCM data from the 
+      signal at the input to the ODUk CTP sink and the source part 
+      of the ODUkT TP inserts TCM data into the signal at the output 
+      of the ODUk CTP source. The value false(2) means that the 
+      sink part of the ODUkT TP extracts TCM data from the signal at 
+      the output of the ODUk CTP source and the source part of the 
+      ODUkT TP inserts TCM data into the signal at the input of the 
+      ODUk CTP sink. This attribute may assume either value when 
+      the corresponding instance of jnxoptIfODUkTtpPresent has the 
+      value false(2). When the value of the corresponding instance 
+      of jnxoptIfODUkTtpPresent is true(1) then the only value allowed 
+      for this attribute is true(1)." 
+    ::= { jnxoptIfODUkTConfigEntry 2 } 
+
+
+jnxoptIfODUkTTraceIdentifierTransmitted OBJECT-TYPE 
+    SYNTAX JnxoptIfTxTI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "The trace identifier transmitted. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value false(2), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value true(1). 
+      It must not be instantiated in rows for all other cases." 
+    ::= { jnxoptIfODUkTConfigEntry 3 } 
+
+
+jnxoptIfODUkTDAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExDAPI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "The DAPI expected by the receiver. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      This object has no effect when jnxoptIfODUkTTIMDetMode has 
+      the value off(1)."
+    ::= { jnxoptIfODUkTConfigEntry 4 } 
+
+
+jnxoptIfODUkTSAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExSAPI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "The SAPI expected by the receiver. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      This object has no effect when jnxoptIfODUkTTIMDetMode has 
+      the value off(1)."
+    ::= { jnxoptIfODUkTConfigEntry 5 } 
+
+
+jnxoptIfODUkTTraceIdentifierAccepted OBJECT-TYPE 
+    SYNTAX JnxoptIfAcTI 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "The actual trace identifier accepted. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      The value of this object is unspecified when 
+      jnxoptIfODUkTCurrentStatus indicates a near-end defect 
+      (i.e., oci(0), lck(1), ssf(5)) that prevents extraction 
+      of the trace message." 
+    ::= { jnxoptIfODUkTConfigEntry 6 } 
+
+
+jnxoptIfODUkTTIMDetMode OBJECT-TYPE 
+    SYNTAX JnxoptIfTIMDetMode 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      The default value of this object is off(1)."
+    ::= { jnxoptIfODUkTConfigEntry 7 } 
+
+
+jnxoptIfODUkTTIMActEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates whether the Trace Identifier Mismatch (TIM) 
+      Consequent Action function is enabled. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      This object has no effect when jnxoptIfODUkTTIMDetMode has 
+      the value off(1). 
+      The default value of this object is false(2)."
+    ::= { jnxoptIfODUkTConfigEntry 8 } 
+
+
+jnxoptIfODUkTDEGThr OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGThr 
+    UNITS "percentage" 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a performance 
+      monitoring (PM) Second to be bad. A PM Second is declared bad if 
+      the percentage of detected errored blocks in that second is 
+      greater than or equal to jnxoptIfODUkTDEGThr. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      The default value of this object is Severely Errored Second 
+      (SES) Estimator (See ITU-T G.7710)."
+    ::= { jnxoptIfODUkTConfigEntry 9 } 
+
+
+jnxoptIfODUkTDEGM OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGM 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a Degraded Signal 
+      defect (dDEG). A dDEG shall be declared if jnxoptIfODUkTDEGM 
+      consecutive bad PM Seconds are detected. 
+      This object is applicable only to the following three cases.
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases. 
+      The default value of this object is 7 (See ITU-T G.7710)."
+    ::= { jnxoptIfODUkTConfigEntry 10 } 
+
+
+jnxoptIfODUkTSinkMode OBJECT-TYPE
+    SYNTAX INTEGER { 
+        operational (1), 
+        monitor (2) 
+    }
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "This variable specifies the TCM mode at the entity. 
+      The value operational(1) means that TCM Overhead (TCMOH) 
+      processes (see ITU-T G.798) shall be 
+      performed and consequent actions for AIS, Trail 
+      Signal Fail (TSF), Trail Signal Degraded (TSD) shall be 
+      initiated in case of defects. 
+      The value monitor(2) means that TCMOH processes shall be 
+      performed but consequent actions for AIS, Trail 
+      Server Failure (TSF), Trail Server Degraded (TSD) shall _not_ be 
+      initiated in case of defects. 
+      This object is applicable only when the value of 
+      jnxoptIfODUkTtpPresent is false(2) and also either one of the 
+      following three cases holds:
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases." 
+    ::= { jnxoptIfODUkTConfigEntry 11 } 
+
+
+jnxoptIfODUkTSinkLockSignalAdminState OBJECT-TYPE 
+    SYNTAX INTEGER { 
+        locked(1), 
+        normal(2) 
+    } 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Provides the capability to provision the LOCK signal, which 
+      is one of the ODUk maintenance signals, at the ODUKT sink. When 
+      a Tandem Connection endpoint is set to admin state locked, 
+      it inserts the ODUk-LCK signal in the sink direction.
+      This object is applicable only when the value of 
+      jnxoptIfODUkTtpPresent is false(2) and also either one of the 
+      following three cases holds:
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases." 
+    ::= { jnxoptIfODUkTConfigEntry 12 } 
+
+
+jnxoptIfODUkTSourceLockSignalAdminState OBJECT-TYPE 
+    SYNTAX INTEGER { 
+        locked(1), 
+        normal(2) 
+    } 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Provides the capability to provision the LOCK signal, which 
+      is one of the ODUk maintenance signals, at the source. 
+      When a Tandem Connection endpoint is set to admin state 
+      locked, it inserts the ODUk-LCK signal in the source 
+      direction. 
+      This object is applicable only when either one of the 
+      following three cases holds:
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value false(2), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value true(1). 
+      It must not be instantiated in rows for all other cases." 
+    ::= { jnxoptIfODUkTConfigEntry 13 } 
+
+
+jnxoptIfODUkTCurrentStatus OBJECT-TYPE
+    SYNTAX BITS { 
+        oci(0), 
+        lck(1), 
+        tim(2), 
+        deg(3), 
+        bdi(4), 
+        ssf(5) 
+    }
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the defect condition of the entity, if any. 
+      This object is applicable only when either one of the 
+      following three cases holds:
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It must not be instantiated in rows for all other cases." 
+    ::= { jnxoptIfODUkTConfigEntry 14 } 
+
+
+jnxoptIfODUkTRowStatus OBJECT-TYPE 
+    SYNTAX RowStatus 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "This columnar object is used for creating and deleting a 
+      conceptual row of the jnxoptIfODUkT config table. 
+      It is used to model the addTCM and removeTCM operations of an 
+      ODUk_CTP or ODUk_TTP for Tandem connection monitoring as defined 
+      in ITU-T G.874.1. 
+      Setting RowStatus to createAndGo or createAndWait implies addTCM. 
+      Setting RowStatus to destroy implies removeTCM. 
+      Successful addition/removal of TCM will result in updating the 
+      jnxoptIfODUkTcmFieldsInUse and jnxoptIfODUkPositionSeqCurrentSize 
+      variables and the jnxoptIfODUkPositionSeqTable table of the 
+      associated ODUk entry in the jnxoptIfODUkConfigTable." 
+    ::= { jnxoptIfODUkTConfigEntry 15 } 
+
+
+-- ODUkT Non-intrusive monitoring (Nim) config table 
+
+
+jnxoptIfODUkTNimConfigTable OBJECT-TYPE 
+    SYNTAX SEQUENCE OF JnxoptIfODUkTNimConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A table of ODUkTNim configuration information." 
+    ::= { jnxoptIfODUkT 2 } 
+
+
+jnxoptIfODUkTNimConfigEntry OBJECT-TYPE 
+    SYNTAX JnxoptIfODUkTNimConfigEntry 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION 
+      "A conceptual row that contains ODUkTNim configuration 
+      information of an interface. Each instance must 
+      correspond to an instance of jnxoptIfODUkConfigEntry. 
+      Rows in this table are mutually exclusive with rows 
+      in the ODUkT config table -- in other words, this 
+      row object may not be instantiated for a given pair 
+      of ifIndex and TCM field values if a corresponding 
+      instance of jnxoptIfODUkTConfigEntry already exists.
+      Instances of this conceptual row persist across 
+      agent restarts, and read-create columns other 
+      than the status column may be modified while the 
+      row is active."
+    INDEX {ifIndex, jnxoptIfODUkTNimTcmField, jnxoptIfODUkTNimDirectionality}
+    ::= { jnxoptIfODUkTNimConfigTable 1 } 
+
+JnxoptIfODUkTNimConfigEntry ::= 
+    SEQUENCE { 
+        jnxoptIfODUkTNimTcmField                    Unsigned32,
+        jnxoptIfODUkTNimDirectionality              JnxoptIfSinkOrSource,
+        jnxoptIfODUkTNimDAPIExpected                JnxoptIfExDAPI,
+        jnxoptIfODUkTNimSAPIExpected                JnxoptIfExSAPI,
+        jnxoptIfODUkTNimTraceIdentifierAccepted     JnxoptIfAcTI,
+        jnxoptIfODUkTNimTIMDetMode                  JnxoptIfTIMDetMode,
+        jnxoptIfODUkTNimTIMActEnabled               TruthValue,
+        jnxoptIfODUkTNimDEGThr                      JnxoptIfDEGThr,
+        jnxoptIfODUkTNimDEGM                        JnxoptIfDEGM,
+        jnxoptIfODUkTNimCurrentStatus               BITS,
+        jnxoptIfODUkTNimRowStatus                   RowStatus
+    } 
+
+
+jnxoptIfODUkTNimTcmField OBJECT-TYPE 
+    SYNTAX Unsigned32 (1..6) 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the tandem connection monitoring 
+      field of the ODUk OH on which non-intrusive monitoring 
+      is performed. Valid values are 
+      integers from 1 to 6."
+    ::= { jnxoptIfODUkTNimConfigEntry 1 } 
+
+
+jnxoptIfODUkTNimDirectionality OBJECT-TYPE 
+    SYNTAX JnxoptIfSinkOrSource 
+    MAX-ACCESS not-accessible 
+    STATUS current 
+    DESCRIPTION
+      "Specifies the monitor point for the ODUk TCM non-intrusive 
+      monitoring function. The value source(2) is not allowed 
+      if the corresponding instance of jnxoptIfODUkDirectionality 
+      has the value sink(1), and the value sink(1) is not allowed 
+      if the corresponding instance of jnxoptIfODUkDirectionality 
+      has the value source(2). Either the value sink(1) or 
+      source(2) is allowed if the corresponding instance of 
+      jnxoptIfODUkDirectionality has the value bidirectional(3). 
+      The value sink(1) means monitoring at the sink direction 
+      TCM signal of the ODUk CTP. 
+      The value source(2) means monitoring at the source direction 
+      path signal of the ODUk CTP."
+    ::= { jnxoptIfODUkTNimConfigEntry 2 } 
+
+
+jnxoptIfODUkTNimDAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExDAPI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "The DAPI expected by the receiver. 
+      This object has no effect if jnxoptIfODUkTNimTIMDetMode has 
+      the value off(1) or sapi(3)."
+    ::= { jnxoptIfODUkTNimConfigEntry 3 } 
+
+
+jnxoptIfODUkTNimSAPIExpected OBJECT-TYPE 
+    SYNTAX JnxoptIfExSAPI 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "The SAPI expected by the receiver. 
+      This object has no effect if jnxoptIfODUkTNimTIMDetMode has 
+      the value off(1) or dapi(2)." 
+    ::= { jnxoptIfODUkTNimConfigEntry 4 } 
+
+
+jnxoptIfODUkTNimTraceIdentifierAccepted OBJECT-TYPE 
+    SYNTAX JnxoptIfAcTI 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "The actual trace identifier accepted. The value of 
+      this object is unspecified if jnxoptIfODUkTNimCurrentStatus 
+      has any of the bit positions oci(0), lck(1), or ssf(5) 
+      set or if jnxoptIfODUkTNimRowStatus has any value other 
+      than active(1)." 
+    ::= { jnxoptIfODUkTNimConfigEntry 5 } 
+
+
+jnxoptIfODUkTNimTIMDetMode OBJECT-TYPE 
+    SYNTAX JnxoptIfTIMDetMode 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the mode of the Trace Identifier Mismatch (TIM) 
+      Detection function." 
+    ::= { jnxoptIfODUkTNimConfigEntry 6 } 
+
+
+jnxoptIfODUkTNimTIMActEnabled OBJECT-TYPE 
+    SYNTAX TruthValue 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates whether the Trace Identifier Mismatch (TIM) 
+      Consequent Action function is enabled." 
+    ::= { jnxoptIfODUkTNimConfigEntry 7 } 
+
+
+jnxoptIfODUkTNimDEGThr OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGThr 
+    UNITS "percentage" 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the threshold level for declaring a performance 
+      monitoring (PM) Second to be bad. A PM Second is declared bad if 
+      the percentage of detected errored blocks in that second is 
+      greater than or equal to jnxoptIfODUkTNimDEGThr." 
+    ::= { jnxoptIfODUkTNimConfigEntry 8 } 
+
+
+jnxoptIfODUkTNimDEGM OBJECT-TYPE 
+    SYNTAX JnxoptIfDEGM 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION
+      "Indicates the threshold level for declaring a Degraded Signal 
+      defect (dDEG). A dDEG shall be declared if jnxoptIfODUkTNimDEGM 
+      consecutive bad PM Seconds are detected."
+    ::= { jnxoptIfODUkTNimConfigEntry 9 } 
+
+
+jnxoptIfODUkTNimCurrentStatus OBJECT-TYPE 
+    SYNTAX BITS { 
+        oci(0), 
+        lck(1), 
+        tim(2), 
+        deg(3), 
+        bdi(4), 
+        ssf(5) 
+    } 
+    MAX-ACCESS read-only 
+    STATUS current 
+    DESCRIPTION 
+      "Indicates the defect condition of the entity, if any. 
+      The value of this object is unspecified if 
+      jnxoptIfODUkTNimRowStatus has any value other than 
+      active(1)." 
+    ::= { jnxoptIfODUkTNimConfigEntry 10 } 
+
+
+jnxoptIfODUkTNimRowStatus OBJECT-TYPE 
+    SYNTAX RowStatus 
+    MAX-ACCESS read-create 
+    STATUS current 
+    DESCRIPTION 
+      "This columnar object is used for creating and deleting a 
+      conceptual row of the jnxoptIfODUkTNim config table. 
+      It is used to model the addTCM and removeTCM operations of an 
+      ODUk_CTP or ODUk_TTP for non-intrusive Tandem connection 
+      monitoring as defined in ITU-T G.874.1. 
+      Setting RowStatus to createAndGo or createAndWait implies addTCM. 
+      Setting RowStatus to destroy implies removeTCM. 
+      Successful addition/removal of Nim TCM will result in updating 
+      the jnxoptIfODUkPositionSeqCurrentSize variable and the 
+      jnxoptIfODUkPositionSeqTable table of the associated ODUk entry 
+      in the jnxoptIfODUkConfigTable." 
+    ::= { jnxoptIfODUkTNimConfigEntry 11 } 
+
+
+-- units of conformance 
+
+
+jnxoptIfOTMnGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTMnOrder,
+        jnxoptIfOTMnReduced,
+        jnxoptIfOTMnBitRates,
+        jnxoptIfOTMnInterfaceType,
+        jnxoptIfOTMnTcmMax,
+         jnxoptIfOTMnOpticalReach
+    }
+    STATUS current 
+    DESCRIPTION 
+      "A collection of OTMn structure information objects." 
+    ::= { jnxoptIfGroups 1 } 
+
+
+jnxoptIfPerfMonGroup OBJECT-GROUP 
+    OBJECTS {     
+        jnxoptIfPerfMonCurrentTimeElapsed,
+        jnxoptIfPerfMonCurDayTimeElapsed,
+        jnxoptIfPerfMonIntervalNumIntervals,
+        jnxoptIfPerfMonIntervalNumInvalidIntervals
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of performance monitoring interval objects." 
+    ::= { jnxoptIfGroups 2 } 
+ 
+
+jnxoptIfOTSnCommonGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnDirectionality 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OTSn interfaces." 
+    ::= { jnxoptIfGroups 3 } 
+
+
+jnxoptIfOTSnSourceGroupFull OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnTraceIdentifierTransmitted 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+       applicable to full-functionality/IaDI OTSn 
+       interfaces that support source functions." 
+    ::= { jnxoptIfGroups 4 } 
+
+
+jnxoptIfOTSnAPRStatusGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnAprStatus 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of objects applicable to 
+      OTSn interfaces that support Automatic 
+      Power Reduction functions." 
+    ::= { jnxoptIfGroups 5 } 
+
+jnxoptIfOTSnAPRControlGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnAprControl 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of objects applicable to 
+      OTSn interfaces that provide Automatic 
+      Power Reduction control functions." 
+    ::= { jnxoptIfGroups 6 } 
+ 
+jnxoptIfOTSnSinkGroupBasic OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnCurrentStatus 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OTSn interfaces that 
+      support sink functions." 
+    ::= { jnxoptIfGroups 7 } 
+
+jnxoptIfOTSnSinkGroupFull OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnDAPIExpected, 
+        jnxoptIfOTSnSAPIExpected, 
+        jnxoptIfOTSnTraceIdentifierAccepted, 
+        jnxoptIfOTSnTIMDetMode, 
+        jnxoptIfOTSnTIMActEnabled 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to full-functionality/IaDI OTSn 
+      interfaces that support sink functions." 
+    ::= { jnxoptIfGroups 8 } 
+   
+jnxoptIfOTSnSinkPreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnSinkCurrentSuspectedFlag,
+        jnxoptIfOTSnSinkCurrentInputPower,
+        jnxoptIfOTSnSinkCurrentLowInputPower,
+        jnxoptIfOTSnSinkCurrentHighInputPower,
+        jnxoptIfOTSnSinkCurrentOutputPower,
+        jnxoptIfOTSnSinkCurrentLowOutputPower,
+        jnxoptIfOTSnSinkCurrentHighOutputPower,
+        jnxoptIfOTSnSinkIntervalSuspectedFlag,
+        jnxoptIfOTSnSinkIntervalLastInputPower,
+        jnxoptIfOTSnSinkIntervalLowInputPower,
+        jnxoptIfOTSnSinkIntervalHighInputPower,
+        jnxoptIfOTSnSinkIntervalLastOutputPower,
+        jnxoptIfOTSnSinkIntervalLowOutputPower,
+        jnxoptIfOTSnSinkIntervalHighOutputPower,
+        jnxoptIfOTSnSinkCurDaySuspectedFlag,
+        jnxoptIfOTSnSinkCurDayLowInputPower,
+        jnxoptIfOTSnSinkCurDayHighInputPower,
+        jnxoptIfOTSnSinkCurDayLowOutputPower,
+        jnxoptIfOTSnSinkCurDayHighOutputPower,
+        jnxoptIfOTSnSinkPrevDaySuspectedFlag,
+        jnxoptIfOTSnSinkPrevDayLastInputPower,
+        jnxoptIfOTSnSinkPrevDayLowInputPower,
+        jnxoptIfOTSnSinkPrevDayHighInputPower,
+        jnxoptIfOTSnSinkPrevDayLastOutputPower,
+        jnxoptIfOTSnSinkPrevDayLowOutputPower,
+        jnxoptIfOTSnSinkPrevDayHighOutputPower
+     }
+     STATUS current
+     DESCRIPTION
+       "A collection of pre-OTN performance monitoring 
+       objects applicable to OTSn interfaces that 
+       support sink functions."
+     ::= { jnxoptIfGroups 9 } 
+
+
+jnxoptIfOTSnSinkPreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnSinkCurrentLowerInputPowerThreshold,
+        jnxoptIfOTSnSinkCurrentUpperInputPowerThreshold,
+        jnxoptIfOTSnSinkCurrentLowerOutputPowerThreshold,
+        jnxoptIfOTSnSinkCurrentUpperOutputPowerThreshold
+    }
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OTSn interfaces 
+      that support sink functions." 
+    ::= { jnxoptIfGroups 10 } 
+
+
+jnxoptIfOTSnSourcePreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnSrcCurrentSuspectedFlag,
+        jnxoptIfOTSnSrcCurrentOutputPower,
+        jnxoptIfOTSnSrcCurrentLowOutputPower,
+        jnxoptIfOTSnSrcCurrentHighOutputPower,
+        jnxoptIfOTSnSrcCurrentInputPower,
+        jnxoptIfOTSnSrcCurrentLowInputPower,
+        jnxoptIfOTSnSrcCurrentHighInputPower,
+        jnxoptIfOTSnSrcIntervalSuspectedFlag,
+        jnxoptIfOTSnSrcIntervalLastOutputPower,
+        jnxoptIfOTSnSrcIntervalLowOutputPower,
+        jnxoptIfOTSnSrcIntervalHighOutputPower,
+        jnxoptIfOTSnSrcIntervalLastInputPower,
+        jnxoptIfOTSnSrcIntervalLowInputPower,
+        jnxoptIfOTSnSrcIntervalHighInputPower,
+        jnxoptIfOTSnSrcCurDaySuspectedFlag,
+        jnxoptIfOTSnSrcCurDayLowOutputPower,
+        jnxoptIfOTSnSrcCurDayHighOutputPower,
+        jnxoptIfOTSnSrcCurDayLowInputPower,
+        jnxoptIfOTSnSrcCurDayHighInputPower,
+        jnxoptIfOTSnSrcPrevDaySuspectedFlag,
+        jnxoptIfOTSnSrcPrevDayLastOutputPower,
+        jnxoptIfOTSnSrcPrevDayLowOutputPower,
+        jnxoptIfOTSnSrcPrevDayHighOutputPower,
+        jnxoptIfOTSnSrcPrevDayLastInputPower,
+        jnxoptIfOTSnSrcPrevDayLowInputPower,
+        jnxoptIfOTSnSrcPrevDayHighInputPower
+    }
+    STATUS current
+    DESCRIPTION
+      "A collection of pre-OTN performance monitoring 
+      objects applicable to OTSn interfaces that 
+      support source functions."
+    ::= { jnxoptIfGroups 11 } 
+
+
+jnxoptIfOTSnSourcePreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOTSnSrcCurrentLowerOutputPowerThreshold,
+        jnxoptIfOTSnSrcCurrentUpperOutputPowerThreshold,
+        jnxoptIfOTSnSrcCurrentLowerInputPowerThreshold,
+        jnxoptIfOTSnSrcCurrentUpperInputPowerThreshold
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OTSn interfaces 
+      that support source functions." 
+    ::= { jnxoptIfGroups 12 } 
+
+
+jnxoptIfOMSnCommonGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOMSnDirectionality 
+    }
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OMSn interfaces." 
+    ::= { jnxoptIfGroups 13 } 
+
+
+jnxoptIfOMSnSinkGroupBasic OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOMSnCurrentStatus 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OMSn interfaces that 
+      support sink functions." 
+    ::= { jnxoptIfGroups 14 } 
+
+
+jnxoptIfOMSnSinkPreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOMSnSinkCurrentSuspectedFlag,
+        jnxoptIfOMSnSinkCurrentAggregatedInputPower,
+        jnxoptIfOMSnSinkCurrentLowAggregatedInputPower,
+        jnxoptIfOMSnSinkCurrentHighAggregatedInputPower,
+        jnxoptIfOMSnSinkCurrentOutputPower,
+        jnxoptIfOMSnSinkCurrentLowOutputPower,
+        jnxoptIfOMSnSinkCurrentHighOutputPower,
+        jnxoptIfOMSnSinkIntervalSuspectedFlag,
+        jnxoptIfOMSnSinkIntervalLastAggregatedInputPower,
+        jnxoptIfOMSnSinkIntervalLowAggregatedInputPower,
+        jnxoptIfOMSnSinkIntervalHighAggregatedInputPower,
+        jnxoptIfOMSnSinkIntervalLastOutputPower,
+        jnxoptIfOMSnSinkIntervalLowOutputPower,
+        jnxoptIfOMSnSinkIntervalHighOutputPower,
+        jnxoptIfOMSnSinkCurDaySuspectedFlag,
+        jnxoptIfOMSnSinkCurDayLowAggregatedInputPower,
+        jnxoptIfOMSnSinkCurDayHighAggregatedInputPower,
+        jnxoptIfOMSnSinkCurDayLowOutputPower,
+        jnxoptIfOMSnSinkCurDayHighOutputPower,
+        jnxoptIfOMSnSinkPrevDaySuspectedFlag,
+        jnxoptIfOMSnSinkPrevDayLastAggregatedInputPower,
+        jnxoptIfOMSnSinkPrevDayLowAggregatedInputPower,
+        jnxoptIfOMSnSinkPrevDayHighAggregatedInputPower,
+        jnxoptIfOMSnSinkPrevDayLastOutputPower,
+        jnxoptIfOMSnSinkPrevDayLowOutputPower,
+        jnxoptIfOMSnSinkPrevDayHighOutputPower
+    } 
+    STATUS current 
+    DESCRIPTION
+      "A collection of pre-OTN performance monitoring 
+      objects applicable to OMSn interfaces that 
+      support sink functions."
+    ::= { jnxoptIfGroups 15 } 
+
+
+jnxoptIfOMSnSinkPreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOMSnSinkCurrentLowerInputPowerThreshold,
+        jnxoptIfOMSnSinkCurrentUpperInputPowerThreshold,
+        jnxoptIfOMSnSinkCurrentLowerOutputPowerThreshold,
+        jnxoptIfOMSnSinkCurrentUpperOutputPowerThreshold 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OMSn interfaces 
+      that support sink functions." 
+    ::= { jnxoptIfGroups 16 } 
+
+
+jnxoptIfOMSnSourcePreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOMSnSrcCurrentSuspectedFlag,
+        jnxoptIfOMSnSrcCurrentOutputPower,
+        jnxoptIfOMSnSrcCurrentLowOutputPower,
+        jnxoptIfOMSnSrcCurrentHighOutputPower,
+        jnxoptIfOMSnSrcCurrentAggregatedInputPower,
+        jnxoptIfOMSnSrcCurrentLowAggregatedInputPower,
+        jnxoptIfOMSnSrcCurrentHighAggregatedInputPower,
+        jnxoptIfOMSnSrcIntervalSuspectedFlag,
+        jnxoptIfOMSnSrcIntervalLastOutputPower,
+        jnxoptIfOMSnSrcIntervalLowOutputPower,
+        jnxoptIfOMSnSrcIntervalHighOutputPower,
+        jnxoptIfOMSnSrcIntervalLastAggregatedInputPower,
+        jnxoptIfOMSnSrcIntervalLowAggregatedInputPower,
+        jnxoptIfOMSnSrcIntervalHighAggregatedInputPower,
+        jnxoptIfOMSnSrcCurDaySuspectedFlag,
+        jnxoptIfOMSnSrcCurDayLowOutputPower,
+        jnxoptIfOMSnSrcCurDayHighOutputPower,
+        jnxoptIfOMSnSrcCurDayLowAggregatedInputPower,
+        jnxoptIfOMSnSrcCurDayHighAggregatedInputPower,
+        jnxoptIfOMSnSrcPrevDaySuspectedFlag,
+        jnxoptIfOMSnSrcPrevDayLastOutputPower,
+        jnxoptIfOMSnSrcPrevDayLowOutputPower,
+        jnxoptIfOMSnSrcPrevDayHighOutputPower,
+        jnxoptIfOMSnSrcPrevDayLastAggregatedInputPower,
+        jnxoptIfOMSnSrcPrevDayLowAggregatedInputPower,
+        jnxoptIfOMSnSrcPrevDayHighAggregatedInputPower 
+    }
+    STATUS current
+    DESCRIPTION
+      "A collection of pre-OTN performance monitoring 
+       objects applicable to OMSn interfaces that 
+       support source functions."
+    ::= { jnxoptIfGroups 17 } 
+
+
+jnxoptIfOMSnSourcePreOtnPMThresholdGroup OBJECT-GROUP 
+     OBJECTS { 
+         jnxoptIfOMSnSrcCurrentLowerOutputPowerThreshold,
+         jnxoptIfOMSnSrcCurrentUpperOutputPowerThreshold,
+         jnxoptIfOMSnSrcCurrentLowerInputPowerThreshold,
+         jnxoptIfOMSnSrcCurrentUpperInputPowerThreshold 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OMSn interfaces that 
+      that support source functions." 
+    ::= { jnxoptIfGroups 18 } 
+  
+
+jnxoptIfOChGroupCommonGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChGroupDirectionality 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OChGroup interfaces." 
+    ::= { jnxoptIfGroups 19 } 
+
+
+jnxoptIfOChGroupSinkPreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChGroupSinkCurrentSuspectedFlag,
+        jnxoptIfOChGroupSinkCurrentAggregatedInputPower,
+        jnxoptIfOChGroupSinkCurrentLowAggregatedInputPower,
+        jnxoptIfOChGroupSinkCurrentHighAggregatedInputPower,
+        jnxoptIfOChGroupSinkCurrentOutputPower,
+        jnxoptIfOChGroupSinkCurrentLowOutputPower,
+        jnxoptIfOChGroupSinkCurrentHighOutputPower,
+        jnxoptIfOChGroupSinkIntervalSuspectedFlag,
+        jnxoptIfOChGroupSinkIntervalLastAggregatedInputPower,
+        jnxoptIfOChGroupSinkIntervalLowAggregatedInputPower,
+        jnxoptIfOChGroupSinkIntervalHighAggregatedInputPower,
+        jnxoptIfOChGroupSinkIntervalLastOutputPower,
+        jnxoptIfOChGroupSinkIntervalLowOutputPower,
+        jnxoptIfOChGroupSinkIntervalHighOutputPower,
+        jnxoptIfOChGroupSinkCurDaySuspectedFlag,
+        jnxoptIfOChGroupSinkCurDayLowAggregatedInputPower,
+        jnxoptIfOChGroupSinkCurDayHighAggregatedInputPower,
+        jnxoptIfOChGroupSinkCurDayLowOutputPower,
+        jnxoptIfOChGroupSinkCurDayHighOutputPower,
+        jnxoptIfOChGroupSinkPrevDaySuspectedFlag,
+        jnxoptIfOChGroupSinkPrevDayLastAggregatedInputPower,
+        jnxoptIfOChGroupSinkPrevDayLowAggregatedInputPower,
+        jnxoptIfOChGroupSinkPrevDayHighAggregatedInputPower,
+        jnxoptIfOChGroupSinkPrevDayLastOutputPower,
+        jnxoptIfOChGroupSinkPrevDayLowOutputPower,
+        jnxoptIfOChGroupSinkPrevDayHighOutputPower 
+    }
+    STATUS current
+    DESCRIPTION
+      "A collection of pre-OTN performance monitoring 
+      objects applicable to OChGroup interfaces that 
+      support sink functions."
+    ::= { jnxoptIfGroups 20 } 
+
+
+jnxoptIfOChGroupSinkPreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChGroupSinkCurrentLowerInputPowerThreshold,
+        jnxoptIfOChGroupSinkCurrentUpperInputPowerThreshold,
+        jnxoptIfOChGroupSinkCurrentLowerOutputPowerThreshold,
+        jnxoptIfOChGroupSinkCurrentUpperOutputPowerThreshold
+ 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OChGroup interfaces 
+      that support sink functions." 
+    ::= { jnxoptIfGroups 21 } 
+
+
+jnxoptIfOChGroupSourcePreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChGroupSrcCurrentSuspectedFlag,
+        jnxoptIfOChGroupSrcCurrentOutputPower,
+        jnxoptIfOChGroupSrcCurrentLowOutputPower,
+        jnxoptIfOChGroupSrcCurrentHighOutputPower,
+        jnxoptIfOChGroupSrcCurrentAggregatedInputPower,
+        jnxoptIfOChGroupSrcCurrentLowAggregatedInputPower,
+        jnxoptIfOChGroupSrcCurrentHighAggregatedInputPower,
+        jnxoptIfOChGroupSrcIntervalSuspectedFlag,
+        jnxoptIfOChGroupSrcIntervalLastOutputPower,
+        jnxoptIfOChGroupSrcIntervalLowOutputPower,
+        jnxoptIfOChGroupSrcIntervalHighOutputPower,
+        jnxoptIfOChGroupSrcIntervalLastAggregatedInputPower,
+        jnxoptIfOChGroupSrcIntervalLowAggregatedInputPower,
+        jnxoptIfOChGroupSrcIntervalHighAggregatedInputPower,
+        jnxoptIfOChGroupSrcCurDaySuspectedFlag,
+        jnxoptIfOChGroupSrcCurDayLowOutputPower,
+        jnxoptIfOChGroupSrcCurDayHighOutputPower,
+        jnxoptIfOChGroupSrcCurDayLowAggregatedInputPower,
+        jnxoptIfOChGroupSrcCurDayHighAggregatedInputPower,
+        jnxoptIfOChGroupSrcPrevDaySuspectedFlag,
+        jnxoptIfOChGroupSrcPrevDayLastOutputPower,
+        jnxoptIfOChGroupSrcPrevDayLowOutputPower,
+        jnxoptIfOChGroupSrcPrevDayHighOutputPower,
+        jnxoptIfOChGroupSrcPrevDayLastAggregatedInputPower,
+        jnxoptIfOChGroupSrcPrevDayLowAggregatedInputPower,
+        jnxoptIfOChGroupSrcPrevDayHighAggregatedInputPower
+    }
+    STATUS current
+    DESCRIPTION
+      "A collection of pre-OTN performance monitoring 
+      objects applicable to OChGroup interfaces that 
+      support source functions."
+    ::= { jnxoptIfGroups 22 } 
+
+
+jnxoptIfOChGroupSourcePreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChGroupSrcCurrentLowerOutputPowerThreshold,
+        jnxoptIfOChGroupSrcCurrentUpperOutputPowerThreshold,
+        jnxoptIfOChGroupSrcCurrentLowerInputPowerThreshold,
+        jnxoptIfOChGroupSrcCurrentUpperInputPowerThreshold 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OChGroup interfaces that 
+      that support source functions." 
+    ::= { jnxoptIfGroups 23 } 
+
+
+jnxoptIfOChCommonGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChDirectionality 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OCh interfaces." 
+    ::= { jnxoptIfGroups 24 } 
+
+
+
+jnxoptIfOChSinkGroupBasic OBJECT-GROUP 
+    OBJECTS { 
+         jnxoptIfOChCurrentStatus 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all OCh interfaces that 
+      support sink functions." 
+    ::= { jnxoptIfGroups 25 } 
+
+
+jnxoptIfOChSinkPreOtnPMGroup OBJECT-GROUP 
+    OBJECTS {     
+        jnxoptIfOChSinkCurrentSuspectedFlag,
+        jnxoptIfOChSinkCurrentInputPower,
+        jnxoptIfOChSinkCurrentLowInputPower,
+        jnxoptIfOChSinkCurrentHighInputPower,
+        jnxoptIfOChSinkIntervalSuspectedFlag,
+        jnxoptIfOChSinkIntervalLastInputPower,
+        jnxoptIfOChSinkIntervalLowInputPower,
+        jnxoptIfOChSinkIntervalHighInputPower,
+        jnxoptIfOChSinkCurDaySuspectedFlag,
+        jnxoptIfOChSinkCurDayLowInputPower,
+        jnxoptIfOChSinkCurDayHighInputPower,
+        jnxoptIfOChSinkPrevDaySuspectedFlag,
+        jnxoptIfOChSinkPrevDayLastInputPower,
+        jnxoptIfOChSinkPrevDayLowInputPower,
+        jnxoptIfOChSinkPrevDayHighInputPower 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      objects applicable to OCh interfaces that 
+      support sink functions." 
+    ::= { jnxoptIfGroups 26 } 
+
+
+jnxoptIfOChSinkPreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChSinkCurrentLowerInputPowerThreshold, 
+        jnxoptIfOChSinkCurrentUpperInputPowerThreshold 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OCh interfaces 
+      that support sink functions." 
+    ::= { jnxoptIfGroups 27 } 
+
+jnxoptIfOChSourcePreOtnPMGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChSrcCurrentSuspectedFlag,
+        jnxoptIfOChSrcCurrentOutputPower,
+        jnxoptIfOChSrcCurrentLowOutputPower,
+        jnxoptIfOChSrcCurrentHighOutputPower,
+        jnxoptIfOChSrcIntervalSuspectedFlag,
+        jnxoptIfOChSrcIntervalLastOutputPower,
+        jnxoptIfOChSrcIntervalLowOutputPower,
+        jnxoptIfOChSrcIntervalHighOutputPower,
+        jnxoptIfOChSrcCurDaySuspectedFlag,
+        jnxoptIfOChSrcCurDayLowOutputPower,
+        jnxoptIfOChSrcCurDayHighOutputPower,
+        jnxoptIfOChSrcPrevDaySuspectedFlag,
+        jnxoptIfOChSrcPrevDayLastOutputPower,
+        jnxoptIfOChSrcPrevDayLowOutputPower,
+        jnxoptIfOChSrcPrevDayHighOutputPower 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      objects applicable to OCh interfaces that 
+      support source functions." 
+    ::= { jnxoptIfGroups 28 } 
+
+
+jnxoptIfOChSourcePreOtnPMThresholdGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfOChSrcCurrentLowerOutputPowerThreshold, 
+        jnxoptIfOChSrcCurrentUpperOutputPowerThreshold 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of pre-OTN performance monitoring 
+      threshold objects applicable to OCh interfaces 
+      that support source functions." 
+    ::= { jnxoptIfGroups 29 } 
+
+
+jnxoptIfOTUkCommonGroup OBJECT-GROUP 
+   OBJECTS { 
+       jnxoptIfOTUkDirectionality, 
+       jnxoptIfOTUkBitRateK 
+   } 
+   STATUS current 
+   DESCRIPTION 
+     "A collection of configuration objects 
+     applicable to all OTUk interfaces." 
+   ::= { jnxoptIfGroups 30 } 
+
+
+
+jnxoptIfOTUkSourceGroup OBJECT-GROUP
+    OBJECTS { 
+        jnxoptIfOTUkTraceIdentifierTransmitted, 
+        jnxoptIfOTUkSourceAdaptActive 
+    }
+    STATUS current 
+    DESCRIPTION
+      "A collection of configuration objects 
+      applicable to OTUk interfaces that 
+      support source functions."
+    ::= { jnxoptIfGroups 31 } 
+
+
+jnxoptIfOTUkSinkGroup OBJECT-GROUP
+    OBJECTS { 
+         jnxoptIfOTUkDAPIExpected,
+        jnxoptIfOTUkSAPIExpected,
+        jnxoptIfOTUkTraceIdentifierAccepted,
+        jnxoptIfOTUkTIMDetMode,
+        jnxoptIfOTUkTIMActEnabled,
+        jnxoptIfOTUkDEGThr,
+        jnxoptIfOTUkDEGM,
+        jnxoptIfOTUkSinkAdaptActive,
+        jnxoptIfOTUkSinkFECEnabled,
+        jnxoptIfOTUkCurrentStatus 
+    }
+    STATUS current 
+    DESCRIPTION
+      "A collection of configuration objects 
+      applicable to OTUk interfaces that 
+      support sink functions."
+    ::= { jnxoptIfGroups 32 } 
+
+
+jnxoptIfGCC0Group OBJECT-GROUP
+    OBJECTS { 
+        jnxoptIfGCC0Application, 
+        jnxoptIfGCC0RowStatus 
+    }
+    STATUS current 
+    DESCRIPTION 
+      "A collection of GCC0 configuration objects." 
+    ::= { jnxoptIfGroups 33 } 
+
+
+jnxoptIfODUkGroup OBJECT-GROUP
+   OBJECTS { 
+        jnxoptIfODUkDirectionality,
+        jnxoptIfODUkBitRateK,
+        jnxoptIfODUkTcmFieldsInUse,
+        jnxoptIfODUkPositionSeqCurrentSize,
+        jnxoptIfODUkPositionSeqPosition,
+        jnxoptIfODUkPositionSeqPointer,
+        jnxoptIfODUkTtpPresent
+    }
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all ODUk interfaces." 
+    ::= { jnxoptIfGroups 34 } 
+
+
+jnxoptIfODUkTtpSourceGroup OBJECT-GROUP
+    OBJECTS { 
+        jnxoptIfODUkTtpTraceIdentifierTransmitted 
+    }
+    STATUS current 
+    DESCRIPTION
+      "A collection of configuration objects 
+      applicable to all interfaces that support 
+      ODUk trail termination source functions."
+    ::= { jnxoptIfGroups 35 } 
+
+
+jnxoptIfODUkTtpSinkGroup OBJECT-GROUP
+     OBJECTS { 
+        jnxoptIfODUkTtpDAPIExpected,
+        jnxoptIfODUkTtpSAPIExpected,
+        jnxoptIfODUkTtpTraceIdentifierAccepted,
+        jnxoptIfODUkTtpTIMDetMode,
+        jnxoptIfODUkTtpTIMActEnabled,
+        jnxoptIfODUkTtpDEGThr,
+        jnxoptIfODUkTtpDEGM,
+        jnxoptIfODUkTtpCurrentStatus 
+    }
+    STATUS current 
+    DESCRIPTION
+      "A collection of ODUk configuration objects 
+      applicable to all interfaces that support 
+      ODUk trail termination sink functions."
+    ::= { jnxoptIfGroups 36 } 
+
+
+jnxoptIfODUkNimGroup OBJECT-GROUP
+     OBJECTS { 
+        jnxoptIfODUkNimDAPIExpected,
+        jnxoptIfODUkNimSAPIExpected,
+        jnxoptIfODUkNimTraceIdentifierAccepted,
+        jnxoptIfODUkNimTIMDetMode,
+        jnxoptIfODUkNimTIMActEnabled,
+        jnxoptIfODUkNimDEGThr,
+        jnxoptIfODUkNimDEGM,
+        jnxoptIfODUkNimCurrentStatus,
+        jnxoptIfODUkNimRowStatus
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of ODUk Nim configuration objects." 
+    ::= { jnxoptIfGroups 37 } 
+
+jnxoptIfGCC12Group OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfGCC12GCCPassThrough, 
+        jnxoptIfGCC12Application, 
+        jnxoptIfGCC12RowStatus 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of GCC12 configuration objects." 
+    ::= { jnxoptIfGroups 38 } 
+
+jnxoptIfODUkTCommonGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfODUkTRowStatus 
+    } 
+    STATUS current 
+    DESCRIPTION 
+     "A collection of configuration objects 
+     applicable to all ODUkT instances." 
+    ::= { jnxoptIfGroups 39 } 
+
+jnxoptIfODUkTSourceGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfODUkTTraceIdentifierTransmitted, 
+        jnxoptIfODUkTSourceLockSignalAdminState 
+    } 
+    STATUS current 
+    DESCRIPTION 
+      "A collection of configuration objects 
+      applicable to all ODUkT instances 
+      that provide source functions." 
+    ::= { jnxoptIfGroups 40 } 
+
+jnxoptIfODUkTSinkGroup OBJECT-GROUP 
+    OBJECTS { 
+        jnxoptIfODUkTDAPIExpected,
+        jnxoptIfODUkTSAPIExpected,
+        jnxoptIfODUkTTraceIdentifierAccepted,
+        jnxoptIfODUkTTIMDetMode,
+        jnxoptIfODUkTTIMActEnabled,
+        jnxoptIfODUkTDEGThr,
+        jnxoptIfODUkTDEGM,
+        jnxoptIfODUkTCurrentStatus
+    }
+    STATUS current
+    DESCRIPTION
+      "A collection of configuration objects 
+      applicable to all ODUkT instances 
+      that provide sink functions."
+    ::= { jnxoptIfGroups 41 } 
+
+
+jnxoptIfODUkTSinkGroupCtp OBJECT-GROUP 
+   OBJECTS { 
+       jnxoptIfODUkTSinkMode, 
+       jnxoptIfODUkTSinkLockSignalAdminState 
+   } 
+   STATUS current 
+   DESCRIPTION 
+     "A collection of configuration objects 
+     applicable to ODUkT instances not 
+     colocated with an ODUk TTP that 
+     provide sink functions." 
+   ::= { jnxoptIfGroups 42 } 
+
+
+jnxoptIfODUkTNimGroup OBJECT-GROUP 
+   OBJECTS { 
+       jnxoptIfODUkTNimDAPIExpected,
+       jnxoptIfODUkTNimSAPIExpected,
+       jnxoptIfODUkTNimTraceIdentifierAccepted,
+       jnxoptIfODUkTNimTIMDetMode,
+       jnxoptIfODUkTNimTIMActEnabled,
+       jnxoptIfODUkTNimDEGThr,
+       jnxoptIfODUkTNimDEGM,
+       jnxoptIfODUkTNimCurrentStatus,
+       jnxoptIfODUkTNimRowStatus 
+   } 
+   STATUS current 
+   DESCRIPTION 
+   "A collection of ODUkT Nim configuration objects." 
+   ::= { jnxoptIfGroups 43 } 
+
+
+-- compliance specifications 
+
+
+jnxoptIfOtnConfigCompl MODULE-COMPLIANCE 
+    STATUS current 
+    DESCRIPTION 
+      "Implementation requirements for the OTN configuration 
+      functions defined in this MIB module." 
+    MODULE -- this module
+    MANDATORY-GROUPS { 
+        jnxoptIfOTMnGroup, 
+        jnxoptIfOTSnCommonGroup 
+    }
+
+
+GROUP jnxoptIfOTSnSourceGroupFull
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) for which the corresponding 
+      instance of jnxoptIfOTSnDirectionality has the value 
+      source(2) or bidirectional(3), the corresponding 
+      instance of jnxoptIfOTMnReduced has the value false(2), 
+      and the corresponding instance of jnxoptIfOTMnInterfaceType 
+      specifies an OTMn interface type of 'IaDI'."
+
+
+GROUP jnxoptIfOTSnAPRStatusGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) that support Automatic Power 
+      Reduction functions."
+
+GROUP jnxoptIfOTSnAPRControlGroup
+    DESCRIPTION
+      "This group is optional, but is recommended for interfaces 
+      of ifType opticalTransport(196) that provide Automatic 
+      Power Reduction control functions."
+
+
+GROUP jnxoptIfOTSnSinkGroupBasic
+     DESCRIPTION
+       "This group is mandatory for interfaces of ifType 
+       opticalTransport(196) for which the corresponding 
+       instance of jnxoptIfOTSnDirectionality has the value 
+       sink(1) or bidirectional(3)."
+
+GROUP jnxoptIfOTSnSinkGroupFull
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) for which the corresponding 
+      instance of jnxoptIfOTSnDirectionality has the value 
+      sink(1) or bidirectional(3), the corresponding 
+      instance of jnxoptIfOTMnReduced has the value false(2), 
+      and the corresponding instance of jnxoptIfOTMnInterfaceType 
+      specifies an OTMn interface type of 'IaDI'."
+
+
+GROUP jnxoptIfOMSnCommonGroup 
+    DESCRIPTION 
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) that support access to the OMS 
+      overhead information within the OTN Supervisory Channel."
+
+GROUP jnxoptIfOMSnSinkGroupBasic
+    DESCRIPTION
+     "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) that support access to the OMS Overhead 
+      information within the OSC (OTN Supervisory Channel) 
+      for which the corresponding 
+      instance of jnxoptIfOMSnDirectionality has the value 
+      sink(1) or bidirectional(3)."
+
+
+GROUP jnxoptIfOChGroupCommonGroup 
+    DESCRIPTION 
+      "This group is mandatory for interfaces of ifType 
+      opticalChannelGroup(219)."
+
+
+GROUP jnxoptIfOChCommonGroup 
+   DESCRIPTION 
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(195)."
+
+
+GROUP jnxoptIfOChSinkGroupBasic
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) for which the corresponding 
+      instance of jnxoptIfOChDirectionality has the value 
+      sink(1) or bidirectional(3)."
+
+
+GROUP jnxoptIfOTUkCommonGroup 
+    DESCRIPTION 
+       "This group is mandatory for interfaces of ifType 
+       opticalChannel(195) that support OTUk layer functions."
+
+
+GROUP jnxoptIfOTUkSourceGroup
+     DESCRIPTION
+       "This group is mandatory for interfaces of ifType 
+       opticalChannel(195) that support OTUk layer functions 
+       and for which the corresponding instance of 
+       jnxoptIfOTUkDirectionality has the value source(2) or 
+       bidirectional(3)."
+
+
+GROUP jnxoptIfOTUkSinkGroup
+     DESCRIPTION
+       "This group is mandatory for interfaces of ifType 
+       opticalChannel(195) that support OTUk layer functions 
+       and for which the corresponding instance of 
+       jnxoptIfOTUkDirectionality has the value sink(1) or
+       bidirectional(3)."
+
+GROUP jnxoptIfGCC0Group
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support GCC0 access functions. 
+      It may be implemented only if the jnxoptIfOTUkCommonGroup 
+      is also implemented."
+
+
+GROUP jnxoptIfODUkGroup 
+    DESCRIPTION 
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support ODUk layer functions."
+
+
+GROUP jnxoptIfODUkTtpSourceGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) for which the corresponding 
+      instance of jnxoptIfODUkTtpPresent has the value 
+      true(1) and for which the corresponding instance of 
+      jnxoptIfODUkDirectionality has the value source(2) or 
+      bidirectional(3). It may be implemented only if the 
+      jnxoptIfODUkGroup is also implemented."
+
+
+GROUP jnxoptIfODUkTtpSinkGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) for which the corresponding 
+      instance of jnxoptIfODUkTtpPresent has the value 
+      true(1) and for which the corresponding instance of 
+      jnxoptIfODUkDirectionality has the value sink(1) or 
+      bidirectional(3). It may be implemented only if the 
+      jnxoptIfODUkGroup is also implemented."
+
+
+GROUP jnxoptIfODUkNimGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) for which the corresponding 
+      instance of jnxoptIfODUkTtpPresent has the value 
+      false(2). It may be implemented only if the 
+      jnxoptIfODUkGroup is also implemented."
+
+
+GROUP jnxoptIfGCC12Group
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support GCC12 access functions. 
+      It may be implemented only if the jnxoptIfODUkGroup 
+      is also implemented."
+
+
+GROUP jnxoptIfODUkTCommonGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support intrusive 
+      tandem connection monitoring. It may be implemented 
+      only if the jnxoptIfODUkGroup is also implemented."
+
+
+GROUP jnxoptIfODUkTSourceGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support intrusive 
+      tandem connection monitoring and for which
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value false(2), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value true(1). 
+      It may be implemented only if the jnxoptIfODUkGroup is 
+      also implemented."
+
+
+GROUP jnxoptIfODUkTSinkGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support intrusive 
+      tandem connection monitoring and for which
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It may be implemented only if the jnxoptIfODUkGroup is 
+      also implemented."
+
+
+GROUP jnxoptIfODUkTSinkGroupCtp
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support intrusive 
+      tandem connection monitoring and for which 
+      jnxoptIfODUkTtpPresent is false(2) and
+      (i) jnxoptIfODUkDirectionality has the value bidirectional(3), or 
+      (ii) jnxoptIfODUkDirectionality has the value sink(1) and 
+      jnxoptIfODUkTCodirectional has the value true(1), or 
+      (iii) jnxoptIfODUkDirectionality has the value source(3) and 
+      jnxoptIfODUkTCodirectional has the value false(2). 
+      It may be implemented only if the jnxoptIfODUkGroup and 
+      jnxoptIfODUkTSinkGroup are also implemented." 
+
+
+GROUP jnxoptIfODUkTNimGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support non-intrusive 
+      tandem connection monitoring. It may be implemented 
+      only if the jnxoptIfODUkGroup is also implemented."
+    ::= { jnxoptIfCompl 1 } 
+
+
+jnxoptIfPreOtnPMCompl MODULE-COMPLIANCE 
+    STATUS current 
+    DESCRIPTION 
+      "Implementation requirements for Pre-OTN performance 
+      monitoring functions defined in this MIB module."
+    MODULE -- this module
+    MANDATORY-GROUPS { 
+        jnxoptIfPerfMonGroup 
+    }
+
+GROUP jnxoptIfOTSnSinkPreOtnPMGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) that support OTSn sink 
+      functions (i.e., for which the corresponding instance 
+      of jnxoptIfOTSnDirectionality -- if implemented -- has 
+      the value sink(1) or bidirectional(3))."
+
+
+GROUP jnxoptIfOTSnSinkPreOtnPMThresholdGroup
+    DESCRIPTION
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOTSnSinkPreOtnPMGroup is a prerequisite for 
+      implementing this group."
+
+
+GROUP jnxoptIfOTSnSourcePreOtnPMGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalTransport(196) that support OTSn source 
+      functions (i.e., for which the corresponding instance 
+      of jnxoptIfOTSnDirectionality -- if implemented -- has 
+      the value source(2) or bidirectional(3))."
+
+
+GROUP jnxoptIfOTSnSourcePreOtnPMThresholdGroup 
+    DESCRIPTION
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOTSnSourcePreOtnPMGroup is a prerequisite for 
+      implementing this group "
+
+
+GROUP jnxoptIfOMSnSinkPreOtnPMGroup 
+   DESCRIPTION
+     "This group is optional. It may be implemented by systems 
+      with the necessary instrumentation on interfaces of ifType 
+      opticalTransport(196) that support OMSn sink functions 
+      (i.e., for which the corresponding instance of 
+      jnxoptIfOMSnDirectionality -- if implemented -- has the value 
+      sink(1) or bidirectional(3))."
+
+
+GROUP jnxoptIfOMSnSinkPreOtnPMThresholdGroup 
+   DESCRIPTION
+     "This group is mandatory if and only if TCA notifications 
+     are implemented. If the objects of this group are instantiated 
+     then the implementation must also provide, in an 
+     enterprise MIB, suitable TCA notification definitions and 
+     notification control objects. Implementation of the 
+     jnxoptIfOMSnSinkPreOtnPMGroup is a prerequisite for 
+     implementing this group "
+
+
+GROUP jnxoptIfOMSnSourcePreOtnPMGroup 
+    DESCRIPTION
+      "This group is optional. It may be implemented by systems 
+      with the necessary instrumentation on interfaces of ifType 
+      opticalTransport(196) that support OMSn source functions 
+      (i.e., for which the corresponding instance of 
+      jnxoptIfOMSnDirectionality -- if implemented -- has the value 
+      source(2) or bidirectional(3))."
+
+
+GROUP jnxoptIfOMSnSourcePreOtnPMThresholdGroup 
+    DESCRIPTION
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOMSnSourcePreOtnPMGroup is a prerequisite for 
+      implementing this group "
+
+
+GROUP jnxoptIfOChGroupSinkPreOtnPMGroup 
+    DESCRIPTION
+      "This group is optional. It may be implemented by systems 
+      with the necessary instrumentation on interfaces of ifType 
+      opticalChannelGroup(219) that support OChGroup sink functions 
+      (i.e., for which the corresponding instance of 
+      jnxoptIfOChGroupDirectionality -- if implemented -- has the value 
+      sink(1) or bidirectional(3))."
+
+
+GROUP jnxoptIfOChGroupSinkPreOtnPMThresholdGroup
+    DESCRIPTION
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOChGroupSinkPreOtnPMGroup is a prerequisite for 
+      implementing this group "
+
+
+GROUP jnxoptIfOChGroupSourcePreOtnPMGroup
+    DESCRIPTION
+      "This group is optional. It may be implemented by systems 
+      with the necessary instrumentation on interfaces of ifType 
+      opticalChannelGroup(219) that support OChGroup source functions 
+      (i.e., for which the corresponding instance of 
+      jnxoptIfOChGroupDirectionality -- if implemented -- has the value 
+      source(2) or bidirectional(3))."
+
+
+GROUP jnxoptIfOChGroupSourcePreOtnPMThresholdGroup
+    DESCRIPTION
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOChGroupSourcePreOtnPMGroup is a prerequisite for 
+      implementing this group "
+
+
+GROUP jnxoptIfOChSinkPreOtnPMGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support OCh sink functions 
+      (i.e., for which the corresponding instance of 
+      jnxoptIfOChDirectionality -- if implemented -- has the 
+      value sink(1) or bidirectional(3))."
+
+
+GROUP jnxoptIfOChSinkPreOtnPMThresholdGroup 
+    DESCRIPTION 
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOChSinkPreOtnPMGroup is a prerequisite for 
+      implementing this group "
+
+
+GROUP jnxoptIfOChSourcePreOtnPMGroup
+    DESCRIPTION
+      "This group is mandatory for interfaces of ifType 
+      opticalChannel(195) that support OCh source functions 
+      (i.e., for which the corresponding instance of 
+      jnxoptIfOChDirectionality -- if implemented -- has the 
+      value source(2) or bidirectional(3))."
+
+
+GROUP jnxoptIfOChSourcePreOtnPMThresholdGroup
+    DESCRIPTION
+      "This group is mandatory if and only if TCA notifications 
+      are implemented. If the objects of this group are instantiated 
+      then the implementation must also provide, in an 
+      enterprise MIB, suitable TCA notification definitions and 
+      notification control objects. Implementation of the 
+      jnxoptIfOChSourcePreOtnPMGroup is a prerequisite for 
+      implementing this group "
+    ::= { jnxoptIfCompl 2 } 
+
+
+END 
+
+
+
+
+
+
+

--- a/mibs/junos/mib-jnx-ospfv3mib.txt
+++ b/mibs/junos/mib-jnx-ospfv3mib.txt
@@ -26,7 +26,7 @@
             ;
     
     jnxOspfv3MIB MODULE-IDENTITY 
-            LAST-UPDATED "200608091200Z" 
+            LAST-UPDATED "201103301200Z" -- 30 March 2011 12:00:00 GMT 
             ORGANIZATION "IETF OSPF Working Group" 
             CONTACT-INFO 
                 "WG E-Mail: ospf@ietf.org 
@@ -56,14 +56,18 @@
              REVISION "200608091200Z" 
              DESCRIPTION -- RFC Editor assigns RFC xxxx 
                  "Initial version, published as RFC xxxx" 
- 
+
+             REVISION "201103301200Z" -- 30 March 2011 12:00:00 GMT
+             DESCRIPTION 
+                 "Deprecating all objects. New mib file rfc5643.mib 
+                  takes care of these objects." 
              ::= { jnxOspfv3Experiment 1 }                         -- *** JNX ***
  
     -- Texual conventions 
  
     JnxOspfv3UpToRefreshIntervalTc ::= TEXTUAL-CONVENTION 
              DISPLAY-HINT "d" 
-             STATUS        current 
+             STATUS        deprecated 
              DESCRIPTION 
                 "The values one might be able to configure for                  
                 variables bounded by the Refresh Interval" 
@@ -71,14 +75,14 @@
  
     JnxOspfv3DeadIntRangeTc ::= TEXTUAL-CONVENTION 
              DISPLAY-HINT "d" 
-             STATUS        current 
+             STATUS        deprecated 
              DESCRIPTION 
                 "The range, in seconds, of dead interval value." 
              SYNTAX      Integer32 (1..'FFFF'h) 
     
     JnxOspfv3RouterIdTc ::= TEXTUAL-CONVENTION 
              DISPLAY-HINT "d" 
-             STATUS      current 
+             STATUS      deprecated 
              DESCRIPTION 
                 "A 32-bit, unsigned integer uniquely identifying the 
                 router in the Autonomous System. To ensure uniqueness, 
@@ -89,14 +93,14 @@
  
     JnxOspfv3AreaIdTc ::= TEXTUAL-CONVENTION 
              DISPLAY-HINT "d" 
-             STATUS      current 
+             STATUS      deprecated 
              DESCRIPTION 
                 "An OSPFv3 Area Identifier" 
              SYNTAX      Unsigned32 (0..'FFFFFFFF'h) 
  
     JnxOspfv3IfInstIdTc ::= TEXTUAL-CONVENTION 
              DISPLAY-HINT "d" 
-             STATUS      current 
+             STATUS      deprecated 
              DESCRIPTION 
                 "An OSPFv3 interface instance ID" 
              SYNTAX      Integer32 (0..255) 
@@ -117,7 +121,7 @@
     jnxOspfv3RouterId OBJECT-TYPE 
             SYNTAX         JnxOspfv3RouterIdTc 
             MAX-ACCESS     read-write 
-            STATUS         current 
+            STATUS         deprecated 
             DESCRIPTION 
                 "A 32-bit integer uniquely identifying the 
                 router in the Autonomous System. To ensure 
@@ -130,7 +134,7 @@
     jnxOspfv3AdminStat OBJECT-TYPE 
             SYNTAX          Status 
             MAX-ACCESS      read-write 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The administrative status of OSPFv3 in the 
                 router. The value 'enabled' denotes that the 
@@ -142,7 +146,7 @@
     jnxOspfv3VersionNumber OBJECT-TYPE 
             SYNTAX          INTEGER { version3 (3) } 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The version number of OSPF for IPv6 is 3." 
             ::= { jnxOspfv3GeneralGroup 3 } 
@@ -150,7 +154,7 @@
     jnxOspfv3AreaBdrRtrStatus OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A flag to note whether this router is an area 
                 border router." 
@@ -162,7 +166,7 @@
     jnxOspfv3ASBdrRtrStatus OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-write 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A flag to note whether this router is  
                 configured as an Autonomous System border router." 
@@ -174,7 +178,7 @@
     jnxOspfv3AsScopeLsaCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of AS-Scope (e.g. AS-External) link state 
                 advertisements in the link state database." 
@@ -183,7 +187,7 @@
     jnxOspfv3AsScopeLsaCksumSum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32-bit unsigned sum of the LS checksums of 
                 the AS-scoped link state advertisements  
@@ -197,7 +201,7 @@
     jnxOspfv3OriginateNewLsas OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of new link-state advertisements 
                 that have been originated. This number is 
@@ -208,7 +212,7 @@
     jnxOspfv3RxNewLsas OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of link state advertisements  
                 received determined to be new instantiations. 
@@ -220,7 +224,7 @@
     jnxOspfv3ExtLsaCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of External(LS type 0x4005) in the  
                 link state database" 
@@ -230,7 +234,7 @@
     jnxOspfv3ExtAreaLsdbLimit OBJECT-TYPE 
             SYNTAX          Integer32 (-1..'7FFFFFFF'h) 
             MAX-ACCESS      read-write 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The maximum number of non-default  
                 AS-external-LSAs entries that can be stored in the 
@@ -256,7 +260,7 @@
                                  } 
                                          
             MAX-ACCESS      read-write 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A Bit Mask indicating whether the router is 
                 forwarding IPv6 multicast datagrams based on 
@@ -291,7 +295,7 @@
             SYNTAX          Unsigned32 
             UNITS           "seconds" 
             MAX-ACCESS      read-write 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of seconds that, after entering 
                 Overflow State, a router will attempt to leave 
@@ -304,7 +308,7 @@
     jnxOspfv3DemandExtensions OBJECT-TYPE 
             SYNTAX         TruthValue 
             MAX-ACCESS     read-write 
-            STATUS         current 
+            STATUS         deprecated 
             DESCRIPTION 
                 "The router's support for demand routing." 
             REFERENCE 
@@ -314,7 +318,7 @@
     jnxOspfv3ReferenceBandwidth OBJECT-TYPE  
            SYNTAX       Unsigned32  
            MAX-ACCESS   read-write  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Reference bandwidth in kilobits/second for  
               calculating default interface metrics. The  
@@ -327,7 +331,7 @@
                                   plannedAndUnplanned (3)  
                              } 
            MAX-ACCESS   read-write  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "The router's support for OSPF Graceful restart.  
               Options include: no restart support, only planned  
@@ -338,7 +342,7 @@
            SYNTAX       JnxOspfv3UpToRefreshIntervalTc 
            UNITS        "seconds"  
            MAX-ACCESS   read-write  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Configured OSPF Graceful restart timeout interval."  
            ::= { jnxOspfv3GeneralGroup 17 }  
@@ -349,7 +353,7 @@
                                   unplannedRestart (3)  
                                 }  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "The current status of OSPF Graceful restart capability."  
            ::= { jnxOspfv3GeneralGroup 18 }  
@@ -358,7 +362,7 @@
            SYNTAX       JnxOspfv3UpToRefreshIntervalTc 
            UNITS        "seconds"  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Remaining time in current OSPF Graceful restart  
               interval."  
@@ -372,7 +376,7 @@
                                   topologyChanged (5) 
                                 }  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Describes the outcome of the last attempt at a  
               Graceful restart. 
@@ -388,7 +392,7 @@
     jnxOspfv3NotificationEnable OBJECT-TYPE 
            SYNTAX TruthValue 
            MAX-ACCESS read-write 
-           STATUS current 
+           STATUS deprecated 
            DESCRIPTION 
                "If this object is set to true(1), then it enables 
                 the generation of OSPFv3 Notifications. If it is 
@@ -409,11 +413,13 @@
     jnxOspfv3AreaTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3AreaEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
-                "Information describing the configured  
+                "Information describing the configured 
                 parameters and cumulative statistics of the router's 
-                attached areas." 
+                attached areas. Marking this table and its objects 
+                deprecated as it is now implemented as a part of  
+                RFC 5643." 
             REFERENCE 
                 "OSPF Version 2, Section 6 The Area Data  
                 Structure" 
@@ -422,7 +428,7 @@
     jnxOspfv3AreaEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Information describing the configured  
                 parameters and cumulative statistics of one of the 
@@ -467,7 +473,7 @@
     jnxOspfv3AreaId OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A 32-bit integer uniquely identifying an area. 
                 Area ID 0 is used for the OSPFv3 backbone." 
@@ -482,7 +488,7 @@
                             importNssa(3)        -- not-so-stubby-area 
                             } 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether an area is a Stub area, NSSA, or 
                 standard area. AS-scope LSAs are not imported into Stub 
@@ -496,7 +502,7 @@
     jnxOspfv3AreaSpfRuns OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of times that the intra-area route 
                 table has been calculated using this area's 
@@ -507,7 +513,7 @@
     jnxOspfv3AreaBdrRtrCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The total number of area border routers 
                 reachable within this area. This is initially zero, 
@@ -517,7 +523,7 @@
     jnxOspfv3AreaAsBdrRtrCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The total number of Autonomous System border 
                 routers reachable within this area. This is 
@@ -528,7 +534,7 @@
     jnxOspfv3AreaScopeLsaCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The total number of Area-Scope link state  
                 advertisements in this area's link state  
@@ -538,7 +544,7 @@
     jnxOspfv3AreaScopeLsaCksumSum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32-bit unsigned sum of the Area-Scope link state 
                 advertisements' LS checksums contained in this 
@@ -554,7 +560,7 @@
                             sendAreaSummary(2) 
                             } 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The variable ospfv3AreaSummary controls the 
                 import of Inter-Area LSAs into stub and 
@@ -573,7 +579,7 @@
     jnxOspfv3AreaStatus OBJECT-TYPE 
             SYNTAX          RowStatus 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This object permits management of the table by 
                 facilitating actions such as row creation, 
@@ -587,7 +593,7 @@
     jnxOspfv3StubMetric OBJECT-TYPE 
             SYNTAX          BigMetric 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The metric value advertised for the default route 
                  into Stub and NSSA areas." 
@@ -596,7 +602,7 @@
     jnxOspfv3AreaNssaTranslatorRole OBJECT-TYPE 
             SYNTAX          INTEGER { always(1), candidate(2) } 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates an NSSA Border router's ability to 
                 perform NSSA translation of NSSA-LSAs into 
@@ -611,7 +617,7 @@
                             disabled(3) 
                             } 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates if and how an NSSA Border router is 
                  performing NSSA translation of NSSA-LSAs into  
@@ -628,7 +634,7 @@
             SYNTAX          Unsigned32 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of seconds after an elected translator 
                 determines its services are no longer required, that 
@@ -639,7 +645,7 @@
     jnxOspfv3AreaNssaTranslatorEvents OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates the number of Translator State changes 
                 that have occurred since the last boot-up." 
@@ -652,7 +658,7 @@
                             nonComparable (3)   -- external type 2 
                             } 
             MAX-ACCESS   read-create 
-            STATUS       current 
+            STATUS       deprecated 
             DESCRIPTION 
                "This variable displays the type of metric 
                advertised as a default route." 
@@ -668,15 +674,17 @@
     jnxOspfv3AsLsdbTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3AsLsdbEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
-                "The OSPFv3 Process's AS-Scope Link State Database." 
+                "The OSPFv3 Process's AS-Scope Link State Database. 
+                Marking this table and its objects deprecated as it is now 
+                implemented as a part of RFC 5643."
             ::= { jnxOspfv3Objects 3 } 
  
     jnxOspfv3AsLsdbEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3AsLsdbEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A single AS-Scope Link State Advertisement." 
             INDEX           { jnxOspfv3AsLsdbType, 
@@ -707,7 +715,7 @@
     jnxOspfv3AsLsdbType OBJECT-TYPE 
             SYNTAX          Unsigned32(0..'FFFFFFFF'h) 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The type of the link state advertisement. 
                 Each link state type has a separate  
@@ -718,7 +726,7 @@
     jnxOspfv3AsLsdbRouterId OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32 bit number that uniquely identifies the 
                 originating router in the Autonomous System." 
@@ -729,7 +737,7 @@
     jnxOspfv3AsLsdbLsid OBJECT-TYPE 
             SYNTAX          Unsigned32 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Link State ID is an LS Type Specific field 
                 containing a unique identifier; 
@@ -747,7 +755,7 @@
     jnxOspfv3AsLsdbSequence OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The sequence number field is a signed 32-bit 
                 integer. It is used to detect old and duplicate 
@@ -766,7 +774,7 @@
                                       -- unless DoNotAge bit is set 
             UNITS           "seconds" 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This field is the age of the link state  
                 advertisement in seconds." 
@@ -777,7 +785,7 @@
     jnxOspfv3AsLsdbChecksum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This field is the checksum of the complete 
                 contents of the advertisement, excepting the 
@@ -794,7 +802,7 @@
     jnxOspfv3AsLsdbAdvertisement OBJECT-TYPE 
             SYNTAX          OCTET STRING (SIZE (1..65535)) 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The entire Link State Advertisement, including 
                 its header." 
@@ -803,7 +811,7 @@
     jnxOspfv3AsLsdbTypeKnown OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether the LSA type is recognized by 
                 this Router." 
@@ -818,15 +826,17 @@
     jnxOspfv3AreaLsdbTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3AreaLsdbEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
-                "The OSPFv3 Process's Area-Scope Link State Database." 
+                "The OSPFv3 Process's Area-Scope Link State Database. 
+                Marking this table and its objects deprecated as it is 
+                now implemented as a part of RFC 5643."  
             ::= { jnxOspfv3Objects 4 } 
  
     jnxOspfv3AreaLsdbEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaLsdbEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A single Area-Scope Link State Advertisement." 
             INDEX           { jnxOspfv3AreaLsdbAreaId, 
@@ -859,7 +869,7 @@
     jnxOspfv3AreaLsdbAreaId OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32-bit identifier of the Area from which the 
                 LSA was received." 
@@ -870,7 +880,7 @@
     jnxOspfv3AreaLsdbType OBJECT-TYPE 
             SYNTAX          Unsigned32(0..'FFFFFFFF'h) 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The type of the link state advertisement. 
                 Each link state type has a separate 
@@ -881,7 +891,7 @@
     jnxOspfv3AreaLsdbRouterId OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32-bit number that uniquely identifies the 
                 originating router in the Autonomous System." 
@@ -892,7 +902,7 @@
     jnxOspfv3AreaLsdbLsid OBJECT-TYPE 
             SYNTAX          Unsigned32 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Link State ID is an LS Type Specific field 
                 containing a unique identifier; 
@@ -910,7 +920,7 @@
     jnxOspfv3AreaLsdbSequence OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The sequence number field is a signed 32-bit 
                 integer. It is used to detect old and  
@@ -928,7 +938,7 @@
                                       -- unless DoNotAge bit is set 
             UNITS           "seconds" 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This field is the age of the link state 
                 advertisement in seconds." 
@@ -939,7 +949,7 @@
     jnxOspfv3AreaLsdbChecksum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This field is the checksum of the complete 
                 contents of the advertisement, excepting the 
@@ -956,7 +966,7 @@
     jnxOspfv3AreaLsdbAdvertisement OBJECT-TYPE 
             SYNTAX          OCTET STRING (SIZE (1..65535)) 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The entire Link State Advertisement, including 
                 its header." 
@@ -965,7 +975,7 @@
     jnxOspfv3AreaLsdbTypeKnown OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether the LSA type is recognized 
                 by this Router." 
@@ -980,15 +990,17 @@
     jnxOspfv3LinkLsdbTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3LinkLsdbEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
-                "The OSPFv3 Process's Link-Scope Link State Database." 
+                "The OSPFv3 Process's Link-Scope Link State Database. 
+                Marking this table and its objects deprecated as it is 
+                now implemented as a part of RFC 5643." 
             ::= { jnxOspfv3Objects 5 } 
  
     jnxOspfv3LinkLsdbEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3LinkLsdbEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A single Link-Scope Link State Advertisement." 
             INDEX           { jnxOspfv3LinkLsdbIfIndex, 
@@ -1024,7 +1036,7 @@
     jnxOspfv3LinkLsdbIfIndex OBJECT-TYPE 
             SYNTAX         InterfaceIndex 
             MAX-ACCESS     not-accessible 
-            STATUS         current 
+            STATUS         deprecated 
             DESCRIPTION 
                 "The identifier of the link from which the LSA 
                 was received." 
@@ -1033,7 +1045,7 @@
     jnxOspfv3LinkLsdbIfInstId OBJECT-TYPE 
             SYNTAX         JnxOspfv3IfInstIdTc 
             MAX-ACCESS     not-accessible 
-            STATUS         current 
+            STATUS         deprecated 
             DESCRIPTION 
                 "The identifier of the interface instance from 
                 which the LSA was received." 
@@ -1042,7 +1054,7 @@
     jnxOspfv3LinkLsdbType OBJECT-TYPE 
             SYNTAX          Unsigned32(0..'FFFFFFFF'h) 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The type of the link state advertisement. 
                 Each link state type has a separate 
@@ -1053,7 +1065,7 @@
     jnxOspfv3LinkLsdbRouterId OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32 bit number that uniquely identifies the 
                 originating router in the Autonomous System." 
@@ -1064,7 +1076,7 @@
     jnxOspfv3LinkLsdbLsid OBJECT-TYPE 
             SYNTAX        Unsigned32 
             MAX-ACCESS    not-accessible 
-            STATUS        current 
+            STATUS        deprecated 
             DESCRIPTION 
                 "The Link State ID is an LS Type Specific field 
                 containing a unique identifier; 
@@ -1082,7 +1094,7 @@
     jnxOspfv3LinkLsdbSequence OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The sequence number field is a signed 32-bit 
                 integer. It is used to detect old and duplicate 
@@ -1100,7 +1112,7 @@
                                       -- unless DoNotAge bit is set 
             UNITS           "seconds" 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This field is the age of the link state 
                 advertisement in seconds." 
@@ -1111,7 +1123,7 @@
     jnxOspfv3LinkLsdbChecksum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This field is the checksum of the complete 
                 contents of the advertisement, excepting the 
@@ -1128,7 +1140,7 @@
     jnxOspfv3LinkLsdbAdvertisement OBJECT-TYPE 
             SYNTAX          OCTET STRING (SIZE (1..65535)) 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The entire Link State Advertisement, including 
                 its header." 
@@ -1137,7 +1149,7 @@
     jnxOspfv3LinkLsdbTypeKnown OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether the LSA type is recognized by this 
                  Router." 
@@ -1153,10 +1165,12 @@
     jnxOspfv3HostTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3HostEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The list of Hosts, and their metrics, that the 
-                router will advertise as host routes." 
+                router will advertise as host routes. Marking this 
+                table and its objects deprecated as it is now implemented 
+                as a part of RFC 5643."  
             REFERENCE 
                 "OSPF Version 2, Appendix C.6  Host route 
                 parameters" 
@@ -1165,7 +1179,7 @@
     jnxOspfv3HostEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3HostEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A metric to be advertised when a given host is 
                 reachable." 
@@ -1189,7 +1203,7 @@
     jnxOspfv3HostAddressType OBJECT-TYPE 
             SYNTAX          InetAddressType 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The address type of ospfv3HostAddress. Only IPv6 
                 addresses without zone index are expected." 
@@ -1202,7 +1216,7 @@
     jnxOspfv3HostAddress OBJECT-TYPE 
             SYNTAX          InetAddress (SIZE (16)) 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The IPv6 Address of the Host. Must be a Global 
                  address." 
@@ -1214,7 +1228,7 @@
     jnxOspfv3HostMetric OBJECT-TYPE 
             SYNTAX          Metric 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Metric to be advertised." 
             REFERENCE 
@@ -1225,7 +1239,7 @@
     jnxOspfv3HostStatus OBJECT-TYPE 
             SYNTAX          RowStatus 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This object permits management of the table by 
                 facilitating actions such as row creation, 
@@ -1239,7 +1253,7 @@
     jnxOspfv3HostAreaID OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Area the Host Entry is to be found within. 
                 By default, the area that a subsuming OSPFv3 
@@ -1253,10 +1267,12 @@
     jnxOspfv3IfTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3IfEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
-                "The OSPFv3 Interface Table describes the  
-                interfaces from the viewpoint of OSPFv3." 
+                "The OSPFv3 Interface Table describes the 
+                interfaces from the viewpoint of OSPFv3. Marking this table 
+                and its objects deprecated as it is now implemented as 
+                a part of RFC 5643." 
             REFERENCE 
                 "OSPF Version 2, Appendix C.3 Router interface 
                 parameters" 
@@ -1265,7 +1281,7 @@
     jnxOspfv3IfEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3IfEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The OSPFv3 Interface Entry describes one 
                 interface from the viewpoint of OSPFv3." 
@@ -1329,7 +1345,7 @@
     jnxOspfv3IfIndex OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The interface index of this OSPFv3 interface. 
                  It corresponds to the interface index of the 
@@ -1339,7 +1355,7 @@
     jnxOspfv3IfInstId OBJECT-TYPE 
             SYNTAX          JnxOspfv3IfInstIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Enables multiple interface instances of OSPFv3 
                 to be run over a single link. Each protocol 
@@ -1350,7 +1366,7 @@
     jnxOspfv3IfAreaId OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A 32-bit integer uniquely identifying the area 
                 to which the interface connects. Area ID 
@@ -1366,7 +1382,7 @@
                             pointToMultipoint(5) 
                             } 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The OSPFv3 interface type." 
             ::= { jnxOspfv3IfEntry 4 } 
@@ -1374,7 +1390,7 @@
     jnxOspfv3IfAdminStat OBJECT-TYPE 
             SYNTAX          Status 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The OSPFv3 interface's administrative status. 
                 The value formed on the interface, and the 
@@ -1387,7 +1403,7 @@
     jnxOspfv3IfRtrPriority OBJECT-TYPE 
             SYNTAX          DesignatedRouterPriority 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The priority of this interface. Used in 
                 multi-access networks, this field is used in 
@@ -1404,7 +1420,7 @@
             SYNTAX          JnxOspfv3UpToRefreshIntervalTc 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The estimated number of seconds it takes to 
                 transmit a link state update packet over this 
@@ -1416,7 +1432,7 @@
             SYNTAX          JnxOspfv3UpToRefreshIntervalTc 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of seconds between link state 
                 advertisement retransmissions, for adjacencies 
@@ -1430,7 +1446,7 @@
             SYNTAX          HelloRange 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The length of time, in seconds, between the 
                 Hello packets that the router sends on the 
@@ -1443,7 +1459,7 @@
             SYNTAX          JnxOspfv3DeadIntRangeTc 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of seconds that a router's Hello 
                 packets have not been seen before its  
@@ -1458,7 +1474,7 @@
             SYNTAX          Unsigned32 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The larger time interval, in seconds, between 
                 the Hello packets sent to an inactive  
@@ -1477,7 +1493,7 @@
                             otherDesignatedRouter(7) 
                             } 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The OSPFv3 Interface State." 
             ::= { jnxOspfv3IfEntry 12 } 
@@ -1485,7 +1501,7 @@
     jnxOspfv3IfDesignatedRouter OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Router ID of the Designated Router." 
             ::= { jnxOspfv3IfEntry 13 } 
@@ -1493,7 +1509,7 @@
     jnxOspfv3IfBackupDesignatedRouter OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Router ID of the Backup Designated 
                 Router." 
@@ -1502,7 +1518,7 @@
     jnxOspfv3IfEvents OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of times this OSPF interface has 
                 changed its state, or an error has occurred." 
@@ -1511,7 +1527,7 @@
      jnxOspfv3IfStatus OBJECT-TYPE 
             SYNTAX          RowStatus 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This object permits management of the table by 
                 facilitating actions such as row creation, 
@@ -1529,7 +1545,7 @@
                             unicast(3)    -- to each OSPFv3 neighbor 
                             } 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The way multicasts should forwarded on this 
                 interface; not forwarded, forwarded as data 
@@ -1544,7 +1560,7 @@
     jnxOspfv3IfDemand OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether Demand OSPFv3 procedures 
                 (hello suppression to FULL neighbors and 
@@ -1556,7 +1572,7 @@
     jnxOspfv3IfMetricValue OBJECT-TYPE 
             SYNTAX          Metric 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The metric assigned to this interface. 
                  The default value of the Metric is 
@@ -1568,7 +1584,7 @@
      jnxOspfv3IfLinkScopeLsaCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The total number of Link-Scope link state 
                 advertisements in this link's link state 
@@ -1578,7 +1594,7 @@
      jnxOspfv3IfLinkLsaCksumSum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32-bit unsigned sum of the Link-Scope link state 
                 advertisements' LS checksums contained in this 
@@ -1591,7 +1607,7 @@
     jnxOspfv3IfDemandNbrProbe OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                    "Indicates whether or not neighbor probing is 
                    enabled to determine whether or not the neighbor  
@@ -1604,7 +1620,7 @@
            SYNTAX       Unsigned32  
            UNITS        "seconds"  
            MAX-ACCESS   read-create 
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "The number of consecutive LSA retransmissions before 
               the neighbor is deemed inactive and the neighbor  
@@ -1617,7 +1633,7 @@
            SYNTAX       Unsigned32  
            UNITS        "seconds"  
            MAX-ACCESS   read-create 
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Defines how often the neighbor will be probed."  
            DEFVAL          { 120 } 
@@ -1633,10 +1649,11 @@
     jnxOspfv3VirtIfTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3VirtIfEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Information about this router's virtual 
-                interfaces." 
+                interfaces. Marking this table and its objects 
+                deprecated as it is now implemented as a part of RFC 5643."  
             REFERENCE 
                 "OSPF Version 2, Appendix C.4 Virtual link 
                 parameters" 
@@ -1645,7 +1662,7 @@
     jnxOspfv3VirtIfEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3VirtIfEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Information about a single Virtual Interface." 
             INDEX           { jnxOspfv3VirtIfAreaId, 
@@ -1685,7 +1702,7 @@
     jnxOspfv3VirtIfAreaId OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Transit Area that the Virtual Link 
                 traverses. By definition, this is not 
@@ -1695,7 +1712,7 @@
     jnxOspfv3VirtIfNeighbor OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Router ID of the Virtual Neighbor." 
             ::= { jnxOspfv3VirtIfEntry 2 } 
@@ -1703,7 +1720,7 @@
     jnxOspfv3VirtIfIndex OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The local interface index assigned to this 
                 OSPFv3 virtual interface. It is advertised in 
@@ -1714,7 +1731,7 @@
     jnxOspfv3VirtIfInstId OBJECT-TYPE 
             SYNTAX          JnxOspfv3IfInstIdTc 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Specifies the interface instance ID to be used 
                 for the virtual interface. This ID has local link 
@@ -1726,7 +1743,7 @@
             SYNTAX          JnxOspfv3UpToRefreshIntervalTc 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The estimated number of seconds it takes to 
                 transmit a link state update packet over this 
@@ -1738,7 +1755,7 @@
             SYNTAX          JnxOspfv3UpToRefreshIntervalTc 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of seconds between link state 
                 advertisement retransmissions, for adjacencies 
@@ -1754,7 +1771,7 @@
             SYNTAX          HelloRange 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The length of time, in seconds, between the 
                 Hello packets that the router sends on the 
@@ -1767,7 +1784,7 @@
             SYNTAX          JnxOspfv3DeadIntRangeTc 
             UNITS           "seconds" 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of seconds that a router's Hello 
                 packets have not been seen before its 
@@ -1784,7 +1801,7 @@
                             pointToPoint(4) 
                             } 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "ospf virtual interface states. The same encoding 
                 as the ospfV3IfTable is used." 
@@ -1793,7 +1810,7 @@
     jnxOspfv3VirtIfEvents OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of state changes or error events on 
                 this Virtual Link" 
@@ -1802,7 +1819,7 @@
     jnxOspfv3VirtIfStatus OBJECT-TYPE 
             SYNTAX          RowStatus 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This object permits management of the table by 
                 facilitating actions such as row creation, 
@@ -1816,7 +1833,7 @@
     jnxOspfv3VirtIfLinkScopeLsaCount OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The total number of Link-Scope link state 
                 advertisements in this virtual link's link state 
@@ -1826,7 +1843,7 @@
     jnxOspfv3VirtIfLinkLsaCksumSum OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The 32-bit unsigned sum of the Link-Scope link-state 
                 advertisements' LS checksums contained in this 
@@ -1845,18 +1862,20 @@
     jnxOspfv3NbrTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3NbrEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A table of non-virtual neighbor information." 
             REFERENCE 
                 "OSPF Version 2, Section 10 The Neighbor Data 
-                Structure" 
+                Structure. Marking this table and its objects 
+                deprecated as it is now implemented as a part of 
+                RFC 5643." 
             ::= { jnxOspfv3Objects 9 } 
  
     jnxOspfv3NbrEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3NbrEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The information regarding a single neighbor." 
             REFERENCE 
@@ -1903,7 +1922,7 @@
     jnxOspfv3NbrIfIndex OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The local link ID of the link over which the 
                  neighbor can be reached." 
@@ -1912,7 +1931,7 @@
     jnxOspfv3NbrIfInstId OBJECT-TYPE 
             SYNTAX          JnxOspfv3IfInstIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Interface instance over which the neighbor 
                 can be reached. This ID has local link 
@@ -1922,7 +1941,7 @@
     jnxOspfv3NbrRtrId OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                "A 32-bit integer uniquely identifying the neighboring 
                router in the Autonomous System." 
@@ -1931,7 +1950,7 @@
     jnxOspfv3NbrAddressType OBJECT-TYPE 
             SYNTAX          InetAddressType 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The address type of ospfv3NbrAddress. Only IPv6 
                 addresses without zone index are expected." 
@@ -1940,7 +1959,7 @@
     jnxOspfv3NbrAddress OBJECT-TYPE 
             SYNTAX          InetAddress (SIZE (16)) 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The IPv6 address of the neighbor associated with 
                 the local link." 
@@ -1949,7 +1968,7 @@
     jnxOspfv3NbrOptions OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A Bit Mask corresponding to the neighbor's 
                 options field." 
@@ -1960,7 +1979,7 @@
     jnxOspfv3NbrPriority OBJECT-TYPE 
             SYNTAX          DesignatedRouterPriority 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The priority of this neighbor in the designated 
                 router election algorithm. The value 0 signifies 
@@ -1980,7 +1999,7 @@
                             full(8) 
                             } 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The State of the relationship with this 
                 Neighbor." 
@@ -1991,7 +2010,7 @@
     jnxOspfv3NbrEvents OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of times this neighbor relationship 
                 has changed state, or an error has occurred." 
@@ -2000,7 +2019,7 @@
     jnxOspfv3NbrLsRetransQLen OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The current length of the retransmission 
                 queue." 
@@ -2009,7 +2028,7 @@
     jnxOspfv3NbrHelloSuppressed OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether Hellos are being suppressed 
                 to the neighbor" 
@@ -2018,7 +2037,7 @@
     jnxOspfv3NbrIfId OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The interface ID that the neighbor advertises 
                 in its Hello Packets on this link, that is, the 
@@ -2031,7 +2050,7 @@
                                 }  
 
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Indicates whether the router is acting  
               as a Graceful restart helper for the neighbor."  
@@ -2041,7 +2060,7 @@
            SYNTAX       JnxOspfv3UpToRefreshIntervalTc 
            UNITS        "seconds"  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Remaining time in current OSPF Graceful restart  
               interval, if the router is acting as a restart  
@@ -2056,13 +2075,13 @@
                                   topologyChanged (5) 
                                 }  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Describes the outcome of the last attempt at acting  
               as a Graceful restart helper for the neighbor. 
     
               none:............no restart has yet been attempted. 
-              inProgress:......a restart attempt is currently underway. 
+              inProgress:......a restart attempt is currentlyly underway. 
               completed:.......the last restart completed successfully. 
               timedOut:........the last restart timed out. 
               topologyChanged:.the last restart was aborted due to 
@@ -2078,10 +2097,11 @@
     jnxOspfv3CfgNbrTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3CfgNbrEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A table of configured, non-virtual neighbor 
-                information." 
+                information. Marking this table and its objects 
+                deprecated as it is now implemented as a part of RFC 5643." 
             REFERENCE 
                 "OSPF Version 2, Section 10 The Neighbor Data 
                 Structure" 
@@ -2090,7 +2110,7 @@
     jnxOspfv3CfgNbrEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3CfgNbrEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The information regarding a single configured 
                 neighbor or neighbor discovered by lower-level 
@@ -2122,7 +2142,7 @@
     jnxOspfv3CfgNbrIfIndex OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The local link ID of the link over which the 
                  neighbor can be reached." 
@@ -2131,7 +2151,7 @@
     jnxOspfv3CfgNbrIfInstId OBJECT-TYPE 
             SYNTAX          JnxOspfv3IfInstIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Interface instance over which the neighbor 
                 can be reached. This ID has local link 
@@ -2141,7 +2161,7 @@
     jnxOspfv3CfgNbrAddressType OBJECT-TYPE 
             SYNTAX          InetAddressType 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The address type of ospfv3NbrAddress. Only IPv6 
                 addresses without zone index are expected." 
@@ -2150,7 +2170,7 @@
     jnxOspfv3CfgNbrAddress OBJECT-TYPE 
             SYNTAX          InetAddress (SIZE (16)) 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The IPv6 address of the neighbor associated with 
                 the local link." 
@@ -2159,7 +2179,7 @@
     jnxOspfv3CfgNbrPriority OBJECT-TYPE 
             SYNTAX          DesignatedRouterPriority 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The priority of this neighbor in the designated 
                 router election algorithm. The value 0 signifies 
@@ -2171,7 +2191,7 @@
     jnxOspfv3CfgNbrStatus OBJECT-TYPE 
             SYNTAX          RowStatus 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This object permits management of the table by 
                 facilitating actions such as row creation, 
@@ -2191,9 +2211,11 @@
     jnxOspfv3VirtNbrTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3VirtNbrEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
-                "A table of virtual neighbor information." 
+                "A table of virtual neighbor information. Marking this 
+                table and its objects deprecated as it is now 
+                implemented as a part of RFC 5643." 
             REFERENCE 
                 "OSPF Version 2, Section 15 Virtual Links" 
             ::= { jnxOspfv3Objects 11 } 
@@ -2201,7 +2223,7 @@
     jnxOspfv3VirtNbrEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3VirtNbrEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Virtual neighbor information." 
             INDEX           { jnxOspfv3VirtNbrArea, 
@@ -2244,7 +2266,7 @@
     jnxOspfv3VirtNbrArea OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Transit Area Identifier." 
             ::= { jnxOspfv3VirtNbrEntry 1 } 
@@ -2252,7 +2274,7 @@
     jnxOspfv3VirtNbrRtrId OBJECT-TYPE 
             SYNTAX          JnxOspfv3RouterIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A 32-bit integer uniquely identifying the 
                 neighboring router in the Autonomous System." 
@@ -2261,7 +2283,7 @@
     jnxOspfv3VirtNbrIfIndex OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The local interface ID for the virtual link over 
                 which the neighbor can be reached." 
@@ -2270,7 +2292,7 @@
     jnxOspfv3VirtNbrIfInstId OBJECT-TYPE 
             SYNTAX          JnxOspfv3IfInstIdTc 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The interface instance for the virtual link over 
                 which the neighbor can be reached." 
@@ -2279,7 +2301,7 @@
     jnxOspfv3VirtNbrAddressType OBJECT-TYPE 
             SYNTAX          InetAddressType 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The address type of ospfv3VirtNbrAddress. Only IPv6 
                 addresses without zone index are expected." 
@@ -2288,7 +2310,7 @@
     jnxOspfv3VirtNbrAddress OBJECT-TYPE 
             SYNTAX          InetAddress (SIZE (16)) 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The IPv6 address advertised by this Virtual Neighbor. 
                 It must be a Global scope address." 
@@ -2297,7 +2319,7 @@
     jnxOspfv3VirtNbrOptions OBJECT-TYPE 
             SYNTAX          Integer32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A Bit Mask corresponding to the neighbor's options 
                 field." 
@@ -2317,7 +2339,7 @@
                             full(8) 
                             } 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The state of the Virtual Neighbor Relationship." 
             ::= { jnxOspfv3VirtNbrEntry 8 } 
@@ -2325,7 +2347,7 @@
     jnxOspfv3VirtNbrEvents OBJECT-TYPE 
             SYNTAX          Counter32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The number of times this virtual link has 
                 changed its state, or an error has occurred." 
@@ -2334,7 +2356,7 @@
     jnxOspfv3VirtNbrLsRetransQLen OBJECT-TYPE 
             SYNTAX          Gauge32 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The current length of the retransmission 
                 queue." 
@@ -2343,7 +2365,7 @@
     jnxOspfv3VirtNbrHelloSuppressed OBJECT-TYPE 
             SYNTAX          TruthValue 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Indicates whether Hellos are being suppressed 
                 to the neighbor" 
@@ -2352,7 +2374,7 @@
     jnxOspfv3VirtNbrIfId OBJECT-TYPE 
             SYNTAX          InterfaceIndex 
             MAX-ACCESS      read-only 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The interface ID that the neighbor advertises 
                 in its Hello Packets on this virtual link, that is, 
@@ -2364,7 +2386,7 @@
                                   helping (2)  
                                 }  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Indicates whether the router is acting  
               as a Graceful restart helper for the neighbor."  
@@ -2374,7 +2396,7 @@
            SYNTAX       JnxOspfv3UpToRefreshIntervalTc 
            UNITS        "seconds"  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Remaining time in current OSPF Graceful restart  
               interval, if the router is acting as a restart  
@@ -2389,7 +2411,7 @@
                                   topologyChanged (5)  
                                 }  
            MAX-ACCESS   read-only  
-           STATUS       current  
+           STATUS       deprecated  
            DESCRIPTION  
               "Describes the outcome of the last attempt at acting  
                as a Graceful restart helper for the neighbor. 
@@ -2409,19 +2431,21 @@
     jnxOspfv3AreaAggregateTable OBJECT-TYPE 
             SYNTAX          SEQUENCE OF JnxOspfv3AreaAggregateEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A range of IPv6 prefixes specified by a 
                 prefix/prefix length pair. Note that if 
                 ranges are configured such that one range 
                 subsumes another range the most specific 
-                match is the preferred one." 
+                match is the preferred one. Marking this table 
+                and its objects deprecated as it is now implemented 
+                as part of RFC 5643." 
             ::= { jnxOspfv3Objects 12 } 
  
     jnxOspfv3AreaAggregateEntry OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaAggregateEntry 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "A range of IPv6 prefixes specified by a 
                 prefix/prefix length pair. Note that if 
@@ -2459,7 +2483,7 @@
     jnxOspfv3AreaAggregateAreaID OBJECT-TYPE 
             SYNTAX          JnxOspfv3AreaIdTc 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The Area the Address Aggregate is to be found 
                 within." 
@@ -2473,7 +2497,7 @@
                             nssaExternalLsa(8199)     -- 0x2007 
                             } 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The type of the Address Aggregate.  This field 
                 specifies the Area Lsdb type that this Address 
@@ -2486,7 +2510,7 @@
     jnxOspfv3AreaAggregatePrefixType OBJECT-TYPE 
             SYNTAX          InetAddressType 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The prefix type of ospfv3AreaAggregatePrefix. Only 
                 IPv6 addresses are expected." 
@@ -2495,7 +2519,7 @@
     jnxOspfv3AreaAggregatePrefix OBJECT-TYPE 
             SYNTAX          InetAddress (SIZE (0..16)) 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The IPv6 Prefix." 
             REFERENCE 
@@ -2506,7 +2530,7 @@
             SYNTAX          InetAddressPrefixLength (3..128) 
             UNITS           "bits" 
             MAX-ACCESS      not-accessible 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "The length of the prefix (in bits). A prefix can 
                 not be shorter than 3 bits." 
@@ -2517,7 +2541,7 @@
     jnxOspfv3AreaAggregateStatus OBJECT-TYPE 
             SYNTAX          RowStatus 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This object permits management of the table by 
                 facilitating actions such as row creation, 
@@ -2534,7 +2558,7 @@
                             doNotAdvertiseMatching(2) 
                             } 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "Prefixes subsumed by ranges either trigger the 
                 advertisement of the indicated aggregate 
@@ -2546,7 +2570,7 @@
     jnxOspfv3AreaAggregateRouteTag OBJECT-TYPE 
             SYNTAX          INTEGER 
             MAX-ACCESS      read-create 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This tag is advertised only in the summarized 
                  As-External LSA when summarizing from NSSA-LSA's to  
@@ -2577,7 +2601,7 @@
                         duplicateRouterId (9), 
                         noError (10) } 
         MAX-ACCESS   accessible-for-notify 
-        STATUS   current 
+        STATUS   deprecated 
         DESCRIPTION 
            "Potential types of configuration conflicts. 
            Used by the ospfv3ConfigError and  
@@ -2597,7 +2621,7 @@
                         lsAck (5), 
                         nullPacket (6) } 
         MAX-ACCESS   accessible-for-notify 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "OSPFv3 packet types. When the last value of a notification 
            using this object is needed, but no notifications of 
@@ -2608,7 +2632,7 @@
     jnxOspfv3PacketSrc      OBJECT-TYPE 
             SYNTAX       InetAddress 
             MAX-ACCESS   accessible-for-notify 
-            STATUS       current 
+            STATUS       deprecated 
             DESCRIPTION 
                "The IPv6 address of an inbound packet that cannot 
                be identified by a neighbor instance. When 
@@ -2628,7 +2652,7 @@
         OBJECTS { jnxOspfv3RouterId,  -- The originator of the notification 
                   jnxOspfv3VirtIfState  -- The new state 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3VirtIfStateChange notification signifies that there 
            has been a change in the state of an OSPFv3 virtual 
@@ -2644,7 +2668,7 @@
                                     -- the notification 
                   jnxOspfv3NbrState    -- The new state 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3NbrStateChange notification signifies that 
            there has been a change in the state of a 
@@ -2664,7 +2688,7 @@
         OBJECTS { jnxOspfv3RouterId, -- The originator of the notification 
                   jnxOspfv3VirtNbrState  -- The new state 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3VirtNbrStateChange notification signifies 
            that there has been a change in the state of an OSPFv3 
@@ -2681,7 +2705,7 @@
            jnxOspfv3ConfigErrorType, -- Type of error 
            jnxOspfv3PacketType       -- Type of packet 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3IfConfigError notification signifies that a 
            packet has been received on a non-virtual 
@@ -2698,7 +2722,7 @@
            jnxOspfv3ConfigErrorType, -- Type of error 
            jnxOspfv3PacketType 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3VirtIfConfigError notification signifies that a 
            packet has been received on a virtual interface 
@@ -2716,7 +2740,7 @@
            jnxOspfv3PacketSrc,       -- The source IPv6 address 
            jnxOspfv3PacketType       -- Type of packet 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3IfRxBadPacket notification signifies that an 
            ospfv3 packet that cannot be parsed has been received on a 
@@ -2728,7 +2752,7 @@
           jnxOspfv3VirtIfState,      -- State of the interface 
           jnxOspfv3PacketType        -- Type of packet 
           } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3VirtIfRxBadPacket notification signifies 
            that an OSPFv3 packet that cannot be parsed has been received 
@@ -2740,7 +2764,7 @@
         OBJECTS { jnxOspfv3RouterId, -- The originator of the notification 
            jnxOspfv3ExtAreaLsdbLimit -- Limit on External LSAs 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3LsdbOverflow notification signifies that the 
            number of LSAs in the router's link-state 
@@ -2751,7 +2775,7 @@
         OBJECTS { jnxOspfv3RouterId, -- The originator of the notification 
            jnxOspfv3ExtAreaLsdbLimit 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3LsdbApproachingOverflow notification signifies 
            that the number of LSAs in the router's 
@@ -2763,7 +2787,7 @@
         OBJECTS { jnxOspfv3RouterId, -- The originator of the notification 
            jnxOspfv3IfState   -- The new state 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3IfStateChange notification signifies that there 
            has been a change in the state of a non-virtual 
@@ -2778,7 +2802,7 @@
         OBJECTS { jnxOspfv3RouterId, -- The originator of the notification 
            jnxOspfv3AreaNssaTranslatorState  -- new state 
            } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3NssaTranslatorStatusChange notification 
            indicates that there has been a change in the router's 
@@ -2794,7 +2818,7 @@
                   jnxOspfv3RestartInterval, 
                   jnxOspfv3RestartExitRc 
                 } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3RestartStatusChange notification signifies that 
            there has been a change in the graceful restart 
@@ -2809,7 +2833,7 @@
                   jnxOspfv3NbrRestartHelperAge, 
                   jnxOspfv3NbrRestartHelperExitRc 
                 } 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3NbrRestartHelperStatusChange notification 
            signifies that there has been a change in the 
@@ -2825,7 +2849,7 @@
                   jnxOspfv3VirtNbrRestartHelperExitRc 
                 } 
 
-        STATUS       current 
+        STATUS       deprecated 
         DESCRIPTION 
            "An ospfv3VirtNbrRestartHelperStatusChange 
            notification signifies that there has been a 
@@ -2845,7 +2869,7 @@
     -- compliance statements 
  
     jnxOspfv3Compliance MODULE-COMPLIANCE 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION     "The compliance statement" 
             MODULE          -- this module 
             MANDATORY-GROUPS { 
@@ -2882,13 +2906,17 @@
                 support attached hosts." 
  
             OBJECT          jnxOspfv3NbrAddressType 
-            SYNTAX          InetAddressType { ipv6(2) } 
+            SYNTAX          InetAddressType { 
+                                              ipv6(2) 
+                                            }
             DESCRIPTION 
                 "An implementation is only required to support IPv6 
                 address without zone index." 
  
             OBJECT          jnxOspfv3VirtNbrAddressType 
-            SYNTAX          InetAddressType { ipv6(2) } 
+            SYNTAX          InetAddressType { 
+                                              ipv6(2) 
+                                            }
             DESCRIPTION 
                 "An implementation is only required to support IPv6 
                 address without zone index." 
@@ -2921,7 +2949,7 @@
                             jnxOspfv3RestartExitRc, 
                             jnxOspfv3NotificationEnable 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used for managing/monitoring 
                 OSPFv3 global parameters." 
@@ -2945,7 +2973,7 @@
                             jnxOspfv3AreaNssaTranslatorEvents, 
                             jnxOspfv3AreaStubMetricType 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used for ospfv3 systems 
                 supporting areas." 
@@ -2959,7 +2987,7 @@
                             jnxOspfv3AsLsdbAdvertisement, 
                             jnxOspfv3AsLsdbTypeKnown 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used for ospfv3 systems 
                 that display their AS-scope link state database." 
@@ -2973,7 +3001,7 @@
                             jnxOspfv3AreaLsdbAdvertisement, 
                             jnxOspfv3AreaLsdbTypeKnown 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used for OSPFv3 systems 
                 that display their Area-scope link state database." 
@@ -2987,7 +3015,7 @@
                             jnxOspfv3LinkLsdbAdvertisement, 
                             jnxOspfv3LinkLsdbTypeKnown 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used for OSPFv3 systems 
                 that display their Link-scope link state database." 
@@ -2999,7 +3027,7 @@
                             jnxOspfv3HostStatus, 
                             jnxOspfv3HostAreaID 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used for OSPFv3 systems 
                 that support attached hosts." 
@@ -3030,7 +3058,7 @@
                             jnxOspfv3IfDemandNbrProbeRetxLimit,  
                             jnxOspfv3IfDemandNbrProbeInterval  
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These interface objects used for  
                 managing/monitoring OSPFv3 interfaces." 
@@ -3050,7 +3078,7 @@
                             jnxOspfv3VirtIfLinkScopeLsaCount, 
                             jnxOspfv3VirtIfLinkLsaCksumSum  
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These virtual interface objects are used for  
                 managing/monitoring OSPFv3 virtual interfaces." 
@@ -3071,7 +3099,7 @@
                             jnxOspfv3NbrRestartHelperAge,  
                             jnxOspfv3NbrRestartHelperExitRc 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These neighbor objects are used for 
                 managing/monitoring OSPFv3 neighbors." 
@@ -3082,7 +3110,7 @@
                             jnxOspfv3CfgNbrPriority, 
                             jnxOspfv3CfgNbrStatus 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These configured neighbor objects are used for 
                 managing/monitoring ospfv3 configured neighbors." 
@@ -3104,7 +3132,7 @@
                             jnxOspfv3VirtNbrRestartHelperAge,  
                             jnxOspfv3VirtNbrRestartHelperExitRc 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These virtual neighbor objects are used for 
                 managing/monitoring OSPFv3 virtual neighbors." 
@@ -3116,7 +3144,7 @@
                             jnxOspfv3AreaAggregateEffect, 
                             jnxOspfv3AreaAggregateRouteTag 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These area aggregate objects used required for 
                 aggregating OSPFv3 prefixes for summarization  
@@ -3129,7 +3157,7 @@
                             jnxOspfv3PacketType, 
                             jnxOspfv3PacketSrc 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "These objects are used to record notification 
                 parameters" 
@@ -3152,7 +3180,7 @@
                             jnxOspfv3NbrRestartHelperStatusChange, 
                             jnxOspfv3VirtNbrRestartHelperStatusChange 
                             } 
-            STATUS          current 
+            STATUS          deprecated 
             DESCRIPTION 
                 "This group is used for OSPFv3 notifications" 
             ::= { jnxOspfv3Groups 14 } 

--- a/mibs/junos/mib-jnx-p2mp.txt
+++ b/mibs/junos/mib-jnx-p2mp.txt
@@ -1,0 +1,1343 @@
+   JNX-MPLS-TE-P2MP-STD-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+      Unsigned32, Counter32, Counter64, TimeTicks
+         FROM SNMPv2-SMI                                    -- RFC 2578
+      MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+         FROM SNMPv2-CONF                                   -- RFC 2580
+      TruthValue, RowStatus, StorageType, TimeStamp
+         FROM SNMPv2-TC                                     -- RFC 2579
+      mplsStdMIB, MplsPathIndexOrZero
+         FROM MPLS-TC-STD-MIB                               -- RFC 3811
+      MplsIndexType
+         FROM MPLS-LSR-STD-MIB                              -- RFC 3813
+      mplsTunnelIndex, mplsTunnelInstance, mplsTunnelIngressLSRId,
+      mplsTunnelEgressLSRId
+         FROM MPLS-TE-STD-MIB                               -- RFC 3812
+      IndexInteger, IndexIntegerNextFree
+         FROM DIFFSERV-MIB                                  -- RFC 3289
+      InetAddress, InetAddressType
+         FROM INET-ADDRESS-MIB                              -- RFC 4001
+      jnxP2mpExperiment                                     -- *** JNX ***
+         FROM JUNIPER-EXPERIMENT-MIB                        -- *** JNX ***
+      ;
+
+   jnxMplsTeP2mpStdMIB MODULE-IDENTITY
+      LAST-UPDATED "200904170000Z"  -- April 17, 2009
+      ORGANIZATION
+         "Multiprotocol Label Switching (MPLS) Working Group"
+      CONTACT-INFO
+           "        Adrian Farrel
+                    Old Dog Consulting
+            Email:  adrian@olddog.co.uk
+
+                    Seisho Yasukawa
+                    NTT Corporation
+            Email:  s.yasukawa@hco.ntt.co.jp
+
+                    Thomas D. Nadeau
+                    British Telecom
+            Email:  tom.nadeau@bt.com
+
+                   Comments about this document should be emailed
+                   directly to the MPLS working group mailing list at
+                   mpls@lists.ietf.org"
+
+
+      DESCRIPTION
+           "Copyright (c) 2009 IETF Trust and the persons identified as
+            the document authors. All rights reserved.
+
+            This document is subject to BCP 78 and the IETF Trust's
+            Legal Provisions Relating to IETF Documents in effect on the
+            date of publication of this document
+            (http://trustee.ietf.org/license-info). Please review these
+            documents carefully, as they describe your rights and
+            restrictions with respect to this document.
+
+            The initial version of this MIB module was published in
+            RFC XXXX. For full legal notices see the RFC itself or see:
+            http://www.ietf.org/copyrights/ianamib.html
+-- RFC Editor. Please replace XXXX with the RFC number for this
+-- document and remove this note.
+
+            This MIB module contains managed object definitions
+            for Point-to-Multipoint (P2MP) MPLS Traffic Engineering (TE)
+            defined in:
+            1. Signaling Requirements for Point-to-Multipoint
+               Traffic-Engineered MPLS Label Switched Paths (LSPs),
+               S. Yasukawa, RFC 4461, April 2006.
+            2. Extensions to Resource Reservation Protocol - Traffic
+               Engineering (RSVP-TE) for Point-to-Multipoint TE Label
+               Switched Paths (LSPs), Aggarwal, R., Papadimitriou, D.,
+               and Yasukawa, S., RFC 4875, May 2007."
+
+      -- Revision history.
+
+      REVISION
+         "200904170000Z"  -- April 17, 2009
+      DESCRIPTION
+           "Initial version issued as part of RFC XXXX."
+-- RFC Editor. Please replace XXXX with the RFC number for this
+-- document and remove this note.
+
+      -- ::= { mplsStdMIB YYY }
+      ::= { jnxP2mpExperiment 1 }
+
+-- RFC Editor. Please replace YYY with the codepoint issued by IANA
+-- and remove this note.
+
+
+
+
+
+
+
+
+
+   -- Top level components of this MIB module.
+
+   -- notifications
+   jnxMplsTeP2mpNotifications OBJECT IDENTIFIER ::= { jnxMplsTeP2mpStdMIB 0 }
+   -- tables, scalars
+   jnxMplsTeP2mpScalars       OBJECT IDENTIFIER ::= { jnxMplsTeP2mpStdMIB 1 }
+   jnxMplsTeP2mpObjects       OBJECT IDENTIFIER ::= { jnxMplsTeP2mpStdMIB 2 }
+   -- conformance
+   jnxMplsTeP2mpConformance   OBJECT IDENTIFIER ::= { jnxMplsTeP2mpStdMIB 3 }
+
+   -- MPLS P2MP Tunnel scalars.
+
+   jnxMplsTeP2mpTunnelConfigured OBJECT-TYPE
+      SYNTAX        Unsigned32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "The number of P2MP tunnels configured on this device. A
+            tunnel is considered configured if the mplsTunnelRowStatus
+            in MPLS-TE-STD-MIB is active(1)."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpScalars 1 }
+
+   jnxMplsTeP2mpTunnelActive OBJECT-TYPE
+      SYNTAX        Unsigned32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "The number of P2MP tunnels active on this device. A
+            tunnel is considered active if the mplsTunnelOperStatus
+            in MPLS-TE-STD-MIB is up(1)."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpScalars 2 }
+
+   jnxMplsTeP2mpTunnelTotalMaxHops OBJECT-TYPE
+      SYNTAX        Unsigned32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "The maximum number of hops that can be specified for an
+            entire P2MP tunnel on this device. This object should be
+            used in conjunction with mplsTunnelMaxHops in
+
+
+            MPLS-TE-STD-MIB that is used in the context of P2MP tunnels
+            to express the maximum number of hops to any individual
+            destination of a P2MP tunnel that can be configured on this
+            device. mplsTeP2mpTunnelTotalMaxHops would normally be set
+            larger than or equal to mplsTunnelMaxHops."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpScalars 3 }
+
+   -- End of MPLS Tunnel scalars.
+
+   -- MPLS P2MP tunnel table.
+
+   jnxMplsTeP2mpTunnelTable OBJECT-TYPE
+      SYNTAX        SEQUENCE OF JnxMplsTeP2mpTunnelEntry
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "The mplsTeP2mpTunnelTable allows new P2MP MPLS tunnels to be
+            created between an LSR and one or more remote end-points,
+            and existing P2MP tunnels to be reconfigured or removed.
+
+            This table sparse augments mplsTunnelTable in
+            MPLS-TE-STD-MIB such that entries in that table can be
+            flagged as point-to-multipoint, and can be configured and
+            monitored appropriately."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpObjects 1 }
+
+   jnxMplsTeP2mpTunnelEntry OBJECT-TYPE
+      SYNTAX        JnxMplsTeP2mpTunnelEntry
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "An entry in this table represents a P2MP MPLS tunnel.
+            An entry can be created by a network administrator or by an
+            SNMP agent as instructed by an MPLS signaling protocol.
+
+            An entry in this table MUST correspond to an entry in the
+            mplsTunnelTable in MPLS-TE-STD-MIB. This table shares index
+            objects with that table and sparse augments that table.
+
+            Thus, an entry in this table can only be created at the same
+
+
+            time as or after a corresponding entry in mplsTunnelTable,
+            and an entry in mplsTunnelTable cannot be deleted while a
+            corresponding entry exists in this table.
+
+            This table entry includes a row status object, but
+            administrative and operational statuses should be taken from
+            mplsTunnelAdminStatus and mplsTunnelOperStatus in the
+            corresponding entry in mplsTunnelTable."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      INDEX {  mplsTunnelIndex,
+               mplsTunnelInstance,
+               mplsTunnelIngressLSRId,
+               mplsTunnelEgressLSRId
+            }
+      ::= { jnxMplsTeP2mpTunnelTable 1 }
+
+   JnxMplsTeP2mpTunnelEntry ::= SEQUENCE {
+         jnxMplsTeP2mpTunnelP2mpIntegrity      TruthValue,
+         jnxMplsTeP2mpTunnelBranchRole         INTEGER,
+         jnxMplsTeP2mpTunnelP2mpXcIndex        MplsIndexType,
+         jnxMplsTeP2mpTunnelRowStatus          RowStatus,
+         jnxMplsTeP2mpTunnelStorageType        StorageType
+   }
+
+   jnxMplsTeP2mpTunnelP2mpIntegrity OBJECT-TYPE
+      SYNTAX        TruthValue
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "Denotes whether or not P2MP Integrity is required for this
+            tunnel.
+
+            If P2MP integrity is operational on a P2MP tunnel then the
+            failure of the path to any of the tunnel destinations should
+            cause the teardown of the entire P2MP tunnel."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      DEFVAL { false }
+      ::= { jnxMplsTeP2mpTunnelEntry 2 }
+
+
+
+
+
+   jnxMplsTeP2mpTunnelBranchRole OBJECT-TYPE
+      SYNTAX        INTEGER { notBranch(1),
+                              branch(2),
+                              bud(3) }
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "This value supplements the value in the object
+            mplsTunnelRole in MPLS-TE-STD-MIB that indicates the role
+            of this LSR in the tunnel represented by this entry in
+            mplsTeP2mpTunnelTable.
+
+            mplsTunnelRole may take any of the values:
+               head(1),
+               transit(2),
+               tail(3),
+               headTail(4)
+
+            If this LSR is an ingress and there is exactly one
+            out-segment, mplsTunnelRole should contain the value
+            head(1), and mplsTeP2mpTunnelBranchRole should have the
+            value notBranch(1).
+
+            If this LSR is an ingress with more than one out segment,
+            mplsTunnelRole should contain the value head(1), and
+            mplsTeP2mpTunnelBranchRole should have the value branch(2).
+
+            If this LSR is an ingress, an egress, and there is one or
+            more out-segments, mplsTunnelRole should contain the value
+            headTail(4), and mplsTeP2mpTunnelBranchRole should have the
+            value bud(3).
+
+            If this LSR is a transit with exactly one out-segment,
+            mplsTunnelRole should contain the value transit(2), and
+            mplsTeP2mpTunnelBranchRole should have the value
+            notBranch(1).
+
+            If this LSR is a transit with more than one out-segment,
+            mplsTunnelRole should contain the value transit(2), and
+            mplsTeP2mpTunnelBranchRole should have the value branch(2).
+
+            If this LSR is a transit with one or more out-segments and
+            is also an egress, mplsTunnelRole should contain the value
+            transit(2), and mplsTeP2mpTunnelBranchRole should have the
+            value bud(3).
+
+            If this LSR is an egress with no out-segment and is not the
+            ingress, mplsTunnelRole should contain the value tail(3),
+
+
+            and mplsTeP2mpTunnelBranchRole should have the value
+            notBranch(1).
+
+            If this LSR is an egress and has one or more out-segments,
+            mplsTunnelRole should contain the value transit(1), and
+            mplsTeP2mpTunnelBranchRole should have the value bud(3)."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      DEFVAL { notBranch }
+      ::= { jnxMplsTeP2mpTunnelEntry 3 }
+
+   jnxMplsTeP2mpTunnelP2mpXcIndex OBJECT-TYPE
+      SYNTAX        MplsIndexType
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This object contains the value of mplsXCIndex, the primary
+            index of the mplsXCTable for all cross-connect entries for
+            this P2MP LSP.
+
+            If no XC entries have been created yet, this object must
+            return zero.
+
+            The set of entries in the mplsXCTable for this P2MP LSP can
+            be walked by reading Get-or-GetNext starting with the three
+            indexes to mplsXCTable set as:
+              mplsXCIndex            = the value of this object
+              mplsXCInSegmentIndex   = 0x0
+              mplsXCOutSegmentIndex  = 0x0"
+      REFERENCE
+           "RFC 3813 - Multiprotocol Label Switching (MPLS) Label
+            Switching (LSR) Router Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T.  Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpTunnelEntry 4 }
+
+   jnxMplsTeP2mpTunnelRowStatus OBJECT-TYPE
+      SYNTAX        RowStatus
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "This variable is used to create, modify, and/or delete a row
+            in this table.  When a row in this table is in active(1)
+            state, no objects in that row can be modified by the agent
+            except mplsTeP2mpTunnelRowStatus and
+            mplsTeP2mpTunnelStorageType.
+
+
+
+            This object and mplsTunnelRowStatus in the corresponding
+            entry in mplsTunnelTable in MPLS-TE-STD-MIB should be
+            managed together. No objects in a row in this table can be
+            modified when the mplsTunnelRowStatus object in the
+            corresponding row in mplsTunnelTable has value active(1).
+
+            Note that no admin or oper status objects are provided in
+            this table. The administrative and operational status of
+            P2MP tunnels is taken from the values of
+            mplsTunnelAdminStatus and mplsTunnelOperStatus in the
+            corresponding row mplsTunnelTable."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpTunnelEntry 5 }
+
+   jnxMplsTeP2mpTunnelStorageType OBJECT-TYPE
+      SYNTAX        StorageType
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "The storage type for this tunnel entry.
+            Conceptual rows having the value 'permanent' need not allow
+            write-access to any columnar objects in the row."
+      DEFVAL { volatile }
+      ::= { jnxMplsTeP2mpTunnelEntry 6 }
+
+   -- End of mplsTeP2mpTunnelTable
+
+   -- MPLS P2MP tunnel destination table.
+
+   jnxMplsTeP2mpTunnelSubGroupIDNext OBJECT-TYPE
+      SYNTAX        IndexIntegerNextFree (0..65535)
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This object contains an unused value for
+            mplsTeP2mpTunnelDestSubGroupID, or a zero to indicate that
+            none exists. Negative values are not allowed, as they do not
+            correspond to valid values of
+            mplsTeP2mpTunnelDestSubGroupID.
+
+            Note that this object offers an unused value for an
+            mplsTeP2mpTunnelDestSubGroupID value at the local LSR when
+            it is a sub-group originator. In other cases, the value of
+            mplsTeP2mpTunnelDestSubGroupID SHOULD be taken from the
+            received value signaled by the signaling protocol and
+
+
+            corresponds to the value in
+            mplsTeP2mpTunnelDestSrcSubGroupID."
+      ::= { jnxMplsTeP2mpObjects 2 }
+
+   jnxMplsTeP2mpTunnelDestTable OBJECT-TYPE
+      SYNTAX        SEQUENCE OF JnxMplsTeP2mpTunnelDestEntry
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "The mplsTeP2mpTunnelDestTable allows new destinations of
+            P2MP MPLS tunnels to be added to and removed from P2MP
+            tunnels."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpObjects 3 }
+
+   jnxMplsTeP2mpTunnelDestEntry OBJECT-TYPE
+      SYNTAX        JnxMplsTeP2mpTunnelDestEntry
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "An entry in this table represents a destination of a P2MP
+            MPLS tunnel. An entry can be created by a network
+            administrator or by an SNMP agent as instructed by an MPLS
+            signaling protocol.
+
+            Entries in this table share some index fields with the
+            mplsTeP2mpTunnelTable and the mplsTunnelTable in
+            MPLS-TE-STD-MIB. Entries in this table have no meaning
+            unless there is a corresponding entry in
+            mplsTeP2mpTunnelTable (which, itself, depends on a
+            corresponding entry in mplsTunnelTable).
+
+            Note that the same destination may be present more than once
+            if it is in more than one sub-group as reflected by the
+            mplsTeP2mpTunnelDestSrcSubGroupOriginType,
+            mplsTeP2mpTunnelDestSrcSubGroupOrigin,
+            mplsTeP2mpTunnelDestSrcSubGroupID,
+            mplsTeP2mpTunnelDestSubGroupOriginType,
+            mplsTeP2mpTunnelDestSubGroupOrigin, and
+            mplsTeP2mpTunnelDestSubGroupID, index objects.
+
+            Entries in this table may be created at any time. If created
+            before an entry in the mplsTeP2mpTunnelTable the entries
+            have no meaning, but may be kept ready for the creation of
+            the P2MP tunnel. If created after the entry in
+
+
+            mplsTeP2mpTunnelTable, entries in this table may reflect the
+            addition of destinations to active P2MP tunnels. For this
+            reason, entries in this table are equipped with row, admin,
+            and oper status objects. "
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      INDEX {  mplsTunnelIndex,
+               mplsTunnelInstance,
+               mplsTunnelIngressLSRId,
+               mplsTunnelEgressLSRId,
+               jnxMplsTeP2mpTunnelDestSrcSubGroupOriginType,
+               jnxMplsTeP2mpTunnelDestSrcSubGroupOrigin,
+               jnxMplsTeP2mpTunnelDestSrcSubGroupID,
+               jnxMplsTeP2mpTunnelDestSubGroupOriginType,
+               jnxMplsTeP2mpTunnelDestSubGroupOrigin,
+               jnxMplsTeP2mpTunnelDestSubGroupID,
+               jnxMplsTeP2mpTunnelDestDestinationType,
+               jnxMplsTeP2mpTunnelDestDestination
+            }
+      ::= { jnxMplsTeP2mpTunnelDestTable 1 }
+
+   JnxMplsTeP2mpTunnelDestEntry ::= SEQUENCE {
+         jnxMplsTeP2mpTunnelDestSrcSubGroupOriginType  InetAddressType,
+         jnxMplsTeP2mpTunnelDestSrcSubGroupOrigin      InetAddress,
+         jnxMplsTeP2mpTunnelDestSrcSubGroupID          IndexInteger,
+         jnxMplsTeP2mpTunnelDestSubGroupOriginType     InetAddressType,
+         jnxMplsTeP2mpTunnelDestSubGroupOrigin         InetAddress,
+         jnxMplsTeP2mpTunnelDestSubGroupID             IndexInteger,
+         jnxMplsTeP2mpTunnelDestDestinationType        InetAddressType,
+         jnxMplsTeP2mpTunnelDestDestination            InetAddress,
+         jnxMplsTeP2mpTunnelDestBranchOutSegment       MplsIndexType,
+         jnxMplsTeP2mpTunnelDestHopTableIndex          MplsPathIndexOrZero,
+         jnxMplsTeP2mpTunnelDestPathInUse              MplsPathIndexOrZero,
+         jnxMplsTeP2mpTunnelDestCHopTableIndex         MplsPathIndexOrZero,
+         jnxMplsTeP2mpTunnelDestARHopTableIndex        MplsPathIndexOrZero,
+         jnxMplsTeP2mpTunnelDestTotalUpTime            TimeTicks,
+         jnxMplsTeP2mpTunnelDestInstanceUpTime         TimeTicks,
+         jnxMplsTeP2mpTunnelDestPathChanges            Counter32,
+         jnxMplsTeP2mpTunnelDestLastPathChange         TimeTicks,
+         jnxMplsTeP2mpTunnelDestCreationTime           TimeStamp,
+         jnxMplsTeP2mpTunnelDestStateTransitions       Counter32,
+         jnxMplsTeP2mpTunnelDestDiscontinuityTime      TimeStamp,
+         jnxMplsTeP2mpTunnelDestAdminStatus            INTEGER,
+         jnxMplsTeP2mpTunnelDestOperStatus             INTEGER,
+         jnxMplsTeP2mpTunnelDestRowStatus              RowStatus,
+         jnxMplsTeP2mpTunnelDestStorageType            StorageType
+   }
+
+   jnxMplsTeP2mpTunnelDestSrcSubGroupOriginType OBJECT-TYPE
+      SYNTAX        InetAddressType
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "This object identifies the type of address carried in
+            mplsTeP2mpTunnelDestSrcSubGroupOrigin.
+
+            Since the object mplsTeP2mpTunnelDestSrcSubGroupOrigin must
+            conform to the protocol specification, this object must
+            return either ipv4(1) or ipv6(2) at a transit or egress LSR.
+
+            At an ingress LSR, there is no source sub-group and this
+            object should return the value unknown(0)."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 1 }
+
+   jnxMplsTeP2mpTunnelDestSrcSubGroupOrigin OBJECT-TYPE
+      SYNTAX        InetAddress (SIZE(0|4|16))
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "The TE Router ID (reachable and stable IP address) of the
+            originator of the P2MP sub-group as received on a Path
+            message by a transit or egress LSR.
+
+            This object is interpreted in the context of
+            mplsTeP2mpTunnelDestSrcSubGroupOriginType.
+
+            The value of the sub-group originator used on outgoing Path
+            messages is found in mplsTeP2mpTunnelDestSubGroupOrigin and
+            is copied from this object unless this LSR is responsible
+            for changing the sub-group ID.
+
+            At an ingress LSR there is no received Path message.
+            mplsTeP2mpTunnelDestSrcSubGroupOriginType should return
+            unknown(0), and this object should return a zero-length
+            string."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 2 }
+
+
+
+
+
+
+
+   jnxMplsTeP2mpTunnelDestSrcSubGroupID OBJECT-TYPE
+      SYNTAX        IndexInteger (0..65535)
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "The unique identifier assigned by the sub-group originator
+            for this sub-group of this P2MP tunnel as received on a Path
+            message by a transit or egress LSR.
+
+            The value of the sub-group identifier used on outgoing Path
+            messages is found in mplsTeP2mpTunnelDestSubGroupID and is
+            copied from this object unless this LSR is responsible for
+            changing the sub-group ID.
+
+            At an ingress LSR there is no received Path message, and
+            this object should return zero."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 3 }
+
+   jnxMplsTeP2mpTunnelDestSubGroupOriginType OBJECT-TYPE
+      SYNTAX        InetAddressType
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "This object identifies the type of address carried in
+            mplsTeP2mpTunnelDestSubGroupOrigin.
+
+            This object must return either ipv4(1) or ipv6(2) in keeping
+            with the protocol specification."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 4 }
+
+   jnxMplsTeP2mpTunnelDestSubGroupOrigin OBJECT-TYPE
+      SYNTAX        InetAddress (SIZE(4|16))
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "The TE Router ID (reachable and stable IP address) of the
+            originator of the P2MP sub-group. In many cases, this will
+            be the ingress LSR of the P2MP tunnel and will be the
+            received signaled value as available in
+            mplsTeP2mpTunnelDestSrcSubGroupOrigin.
+
+            When a signaling protocol is used, this object corresponds
+            to the Sub-Group Originator field in the SENDER_TEMPLATE
+
+
+            object.
+
+            This object is interpreted in the context of
+            mplsTeP2mpTunnelDestSubGroupOriginType."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 5 }
+
+   jnxMplsTeP2mpTunnelDestSubGroupID OBJECT-TYPE
+      SYNTAX        IndexInteger (1..65535)
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "The unique identifier assigned by the sub-group originator
+            for this sub-group of this P2MP tunnel.
+
+            An appropriate value for this object during row creation
+            when the sub-group origin in
+            mplsTeP2mpTunnelDestSubGroupOrigin is the local LSR can
+            be obtained by reading mplsTeP2mpTunnelSubGroupIDNext.
+
+            At an egress, there is no downstream sub-group ID. This
+            object should return the value received from upstream and
+            reported in mplsTeP2mpTunnelDestSrcSubGroupID."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 6 }
+
+   jnxMplsTeP2mpTunnelDestDestinationType OBJECT-TYPE
+      SYNTAX        InetAddressType
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "This object identifies the type of address carried in
+            mplsTeP2mpTunnelDestDestination.
+
+            This object forms part of the index of this table and can,
+            therefore, not return the value unknown(0). Similarly, since
+            the object mplsTeP2mpTunnelDestDestination must conform to
+            the protocol specification, this object must return either
+            ipv4(1) or ipv6(2)."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 7 }
+
+
+   jnxMplsTeP2mpTunnelDestDestination OBJECT-TYPE
+      SYNTAX        InetAddress (SIZE(4|16))
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "A single destination of this P2MP tunnel. That is, a
+            routable TE address of a leaf. This will often be the TE
+            Router ID of the leaf, but can be any interface address.
+
+            When a signaling protocol is used, this object corresponds
+            to the S2L Sub-LSP destination address field in the
+            S2L_SUB_LSP object.
+
+            This object is interpreted in the context of
+            mplsTeP2mpTunnelDestDestinationType."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 8 }
+
+   jnxMplsTeP2mpTunnelDestBranchOutSegment OBJECT-TYPE
+      SYNTAX        MplsIndexType
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This object identifies the outgoing branch from this LSR
+            towards the destination represented by this table entry. It
+            must be a unique identifier within the scope of this tunnel.
+
+            If MPLS-LSR-STD-MIB is implemented, this object should
+            contain an index into mplsOutSegmentTable.
+
+            If MPLS-LSR-STD-MIB is not implemented, the LSR should
+            assign a unique value to each branch of the tunnel.
+
+            The value of this object is also used as an index into
+            mplsTeP2mpTunnelBranchPerfTable."
+         ::= { jnxMplsTeP2mpTunnelDestEntry 9 }
+
+   jnxMplsTeP2mpTunnelDestHopTableIndex OBJECT-TYPE
+      SYNTAX        MplsPathIndexOrZero
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "Index into the mplsTunnelHopTable entry that specifies the
+            explicit route hops for this destination of the P2MP tunnel.
+
+
+            This object represents the configured route for the branch
+            of the P2MP tree to this destination and is meaningful only
+            at the head-end (ingress or root) of the P2MP tunnel. Note
+            that many such paths may be configured within the
+            mplsTunnelHopTable for each destination, and that the object
+            mplsTeP2mpTunnelDestPathInUse identifies which path has been
+            selected for use."
+      DEFVAL { 0 }
+      ::= { jnxMplsTeP2mpTunnelDestEntry 10 }
+
+   jnxMplsTeP2mpTunnelDestPathInUse OBJECT-TYPE
+      SYNTAX        MplsPathIndexOrZero
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "This value denotes the configured path that was chosen as
+            the explicit path to this destination of this P2MP tunnel.
+            This value reflects the secondary index into
+            mplsTunnelHopTable where the primary index comes from
+            mplsTeP2mpTunnelDestHopTableIndex.
+
+            The path indicated by this object might not exactly match
+            the one signaled and recorded in mplsTunnelCHopTable as
+            specific details of the path might be computed locally.
+
+            Similarly, the path might not match the actual path in use
+            as recorded in mplsTunnelARHopTable due to the fact that
+            some details of the path may have been resolved within the
+            network.
+
+            A value of zero denotes that no path is currently in use or
+            available."
+      DEFVAL { 0 }
+      ::= { jnxMplsTeP2mpTunnelDestEntry 11 }
+
+   jnxMplsTeP2mpTunnelDestCHopTableIndex OBJECT-TYPE
+      SYNTAX        MplsPathIndexOrZero
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Index into the mplsTunnelCHopTable that identifies the
+            explicit path for this destination of the P2MP tunnel.
+
+            This path is based on the chosen configured path identified
+            by mplsTeP2mpTunnelDestHopTableIndex and
+            mplsTeP2mpTunnelDestPathInUse, but may have been modified
+            and automatically updated by the agent when computed hops
+            become available or when computed hops get modified.
+
+
+            If this destination is the destination of the 'first S2L
+            sub-LSP' then this path will be signaled in the Explicit
+            Route Object. If this destination is the destination of a
+            'subsequent S2L sub-LSP' then this path will be signaled in
+            a Secondary Explicit Route Object."
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 12 }
+
+   jnxMplsTeP2mpTunnelDestARHopTableIndex OBJECT-TYPE
+      SYNTAX        MplsPathIndexOrZero
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Index into the mplsTunnelARHopTable that identifies the
+            actual hops traversed to this destination of the P2MP
+            tunnel. This is automatically updated by the agent when the
+            actual hops becomes available.
+
+            If this destination is the destination of the 'first S2L
+            sub-LSP' then this path will be signaled in the Recorded
+            Route Object. If this destination is the destination of a
+            'subsequent S2L sub-LSP' then this path will be signaled in
+            a Secondary Recorded Route Object."
+
+      REFERENCE
+           "RFC 4875 - Extensions to Resource Reservation Protocol -
+            Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+            Label Switched Paths (LSPs), R. Aggarwal, D. Papadimitriou,
+            and S. Yasukawa, May 2007."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 13 }
+
+   jnxMplsTeP2mpTunnelDestTotalUpTime OBJECT-TYPE
+      SYNTAX        TimeTicks
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This value represents the aggregate up time for all
+            instances of this tunnel to this destination, if this
+            information is available.
+
+            If this information is not available, this object MUST
+            return a value of 0."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 14 }
+
+
+
+   jnxMplsTeP2mpTunnelDestInstanceUpTime OBJECT-TYPE
+      SYNTAX        TimeTicks
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This value identifies the total time that the currently
+            active tunnel instance to this destination has had its
+            operational status (mplsTeP2mpTunnelDestOperStatus) set to
+            up(1) since it was last previously not up(1)."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 15 }
+
+   jnxMplsTeP2mpTunnelDestPathChanges OBJECT-TYPE
+      SYNTAX        Counter32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This object counts the number of times the actual path for
+            this destination of this P2MP tunnel instance has changed.
+            This object should be read in conjunction with
+            mplsTeP2mpTunnelDestDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 16 }
+
+   jnxMplsTeP2mpTunnelDestLastPathChange OBJECT-TYPE
+      SYNTAX        TimeTicks
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Specifies the time since the last change to the actual path
+           for this destination of this P2MP tunnel instance."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 17 }
+
+   jnxMplsTeP2mpTunnelDestCreationTime OBJECT-TYPE
+      SYNTAX        TimeStamp
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Specifies the value of sysUpTime when the first instance of
+            this tunnel came into existence for this destination. That
+            is, when the value of mplsTeP2mpTunnelDestOperStatus was
+            first set to up(1)."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 18 }
+
+   jnxMplsTeP2mpTunnelDestStateTransitions OBJECT-TYPE
+      SYNTAX        Counter32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "This object counts the number of times the status
+
+
+            (mplsTeP2mpTunnelDestOperStatus) of this tunnel instance to
+            this destination has changed.
+            This object should be read in conjunction with
+            mplsTeP2mpTunnelDestDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 19 }
+
+   jnxMplsTeP2mpTunnelDestDiscontinuityTime OBJECT-TYPE
+      SYNTAX      TimeStamp
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            any one or more of this row's Counter32 objects experienced
+            a discontinuity. If no such discontinuity has occurred since
+            the last re-initialization of the local management
+            subsystem, then this object contains a zero value."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 20 }
+
+   jnxMplsTeP2mpTunnelDestAdminStatus OBJECT-TYPE
+      SYNTAX       INTEGER {
+                      up(1),        -- ready to pass data
+                      down(2),      -- out of service
+                      testing(3)    -- in some test mode
+                    }
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "Indicates the desired operational status of this
+            destination of this P2MP tunnel."
+      DEFVAL { up }
+      ::= { jnxMplsTeP2mpTunnelDestEntry 21 }
+
+   jnxMplsTeP2mpTunnelDestOperStatus OBJECT-TYPE
+      SYNTAX        INTEGER {
+                      up(1),             -- ready to pass data
+                      down(2),           -- out of service
+                      testing(3),        -- in some test mode
+                      unknown(4),        -- status cannot be determined
+                      lowerLayerDown(7)  -- down due to the state of
+                                         -- lower layer interfaces
+                    }
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the actual operational status of this destination
+            of this P2MP tunnel. This object may be compared to
+            mplsTunnelOperStatus that includes two other values:
+              dormant(5)    -- some component is missing
+
+
+              notPresent(6) -- down due to the state of
+                            -- lower layer interfaces.
+            These states do not apply to an individual destination of a
+            P2MP MPLS-TE LSP and so are not included in this object."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 22 }
+
+   jnxMplsTeP2mpTunnelDestRowStatus OBJECT-TYPE
+      SYNTAX        RowStatus
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION
+           "This object is used to create, modify, and/or delete a row
+            in this table. When a row in this table is in active(1)
+            state, no objects in that row can be modified by SET
+            operations except mplsTeP2mpTunnelDestAdminStatus and
+            mplsTeP2mpTunnelDestStorageType."
+      ::= { jnxMplsTeP2mpTunnelDestEntry 23 }
+
+   jnxMplsTeP2mpTunnelDestStorageType OBJECT-TYPE
+      SYNTAX        StorageType
+      MAX-ACCESS    read-create
+      STATUS        current
+      DESCRIPTION  "The storage type for this table entry.
+
+                    Conceptual rows having the value 'permanent' need
+                    not allow write-access to any columnar objects in
+                    the row."
+      DEFVAL { volatile }
+      ::= { jnxMplsTeP2mpTunnelDestEntry 24 }
+
+   -- End of mplsTeP2mpTunnelDestTable
+
+   -- MPLS Tunnel Branch Performance Table.
+
+   jnxMplsTeP2mpTunnelBranchPerfTable  OBJECT-TYPE
+      SYNTAX        SEQUENCE OF JnxMplsTeP2mpTunnelBranchPerfEntry
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "This table provides per-tunnel branch MPLS performance
+            information.
+
+            This table is not valid for switching types other than
+            packet."
+
+
+      ::= { jnxMplsTeP2mpObjects 4 }
+
+   jnxMplsTeP2mpTunnelBranchPerfEntry OBJECT-TYPE
+      SYNTAX        JnxMplsTeP2mpTunnelBranchPerfEntry
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "An entry in this table is created by the LSR for each
+            downstream branch (out-segment) from this LSR for this P2MP
+            tunnel.
+
+            More than one destination as represented by an entry in the
+            mplsTeP2mpTunnelDestTable may be reached through a single
+            out-segment. More than one out-segment may belong to a
+            single P2MP tunnel represented by an entry in
+            mplsTeP2mpTunnelTable.
+
+            Each entry in the table is indexed by the four identifiers
+            of the P2MP tunnel, and the out-segment that identifies the
+            outgoing branch."
+      INDEX {  mplsTunnelIndex,
+               mplsTunnelInstance,
+               mplsTunnelIngressLSRId,
+               mplsTunnelEgressLSRId,
+               jnxMplsTeP2mpTunnelBranchPerfBranch
+            }
+      ::= { jnxMplsTeP2mpTunnelBranchPerfTable 1 }
+
+   JnxMplsTeP2mpTunnelBranchPerfEntry ::= SEQUENCE {
+         jnxMplsTeP2mpTunnelBranchPerfBranch        MplsIndexType,
+         jnxMplsTeP2mpTunnelBranchPerfPackets       Counter32,
+         jnxMplsTeP2mpTunnelBranchPerfHCPackets     Counter64,
+         jnxMplsTeP2mpTunnelBranchPerfErrors        Counter32,
+         jnxMplsTeP2mpTunnelBranchPerfBytes         Counter32,
+         jnxMplsTeP2mpTunnelBranchPerfHCBytes       Counter64,
+         jnxMplsTeP2mpTunnelBranchDiscontinuityTime TimeStamp
+   }
+
+   jnxMplsTeP2mpTunnelBranchPerfBranch OBJECT-TYPE
+      SYNTAX        MplsIndexType
+      MAX-ACCESS    not-accessible
+      STATUS        current
+      DESCRIPTION
+           "This object identifies an outgoing branch from this LSR
+            for this tunnel. Its value is unique within the context of
+            the tunnel.
+
+            If MPLS-LSR-STD-MIB is implemented, this object should
+
+
+            contain an index into mplsOutSegmentTable.
+
+            Under all circumstances, this object should contain
+            the same value as mplsTeP2mpTunnelDestBranchOutSegment for
+            destinations reached on this branch."
+         ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 1 }
+
+   jnxMplsTeP2mpTunnelBranchPerfPackets OBJECT-TYPE
+      SYNTAX        Counter32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Number of packets forwarded by the tunnel onto this branch.
+            This object should represents the 32-bit value of the least
+            significant part of the 64-bit value if both
+            mplsTeP2mpTunnelBranchPerfHCPackets is returned.
+            This object should be read in conjunction with
+            mplsTeP2mpTunnelBranchDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 2 }
+
+   jnxMplsTeP2mpTunnelBranchPerfHCPackets OBJECT-TYPE
+      SYNTAX        Counter64
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "High capacity counter for number of packets forwarded by the
+            tunnel onto this branch.
+            This object should be read in conjunction with
+            mplsTeP2mpTunnelBranchDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 3 }
+
+   jnxMplsTeP2mpTunnelBranchPerfErrors OBJECT-TYPE
+      SYNTAX        Counter32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Number of packets dropped because of errors or for other
+            reasons, that were supposed to be forwarded onto this
+            branch for this tunnel. This object should be read in
+            conjunction with mplsTeP2mpTunnelBranchDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 4 }
+
+   jnxMplsTeP2mpTunnelBranchPerfBytes OBJECT-TYPE
+      SYNTAX        Counter32
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Number of bytes forwarded by the tunnel onto this branch.
+
+
+            This object should represents the 32-bit value of the least
+            significant part of the 64-bit value if both
+            mplsTeP2mpTunnelBranchPerfHCBytes is returned.
+            This object should be read in conjunction with
+            mplsTeP2mpTunnelBranchDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 5 }
+
+   jnxMplsTeP2mpTunnelBranchPerfHCBytes OBJECT-TYPE
+      SYNTAX        Counter64
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "High capacity counter for number of bytes forwarded
+            by the tunnel onto this branch.
+            This object should be read in conjunction with
+            mplsTeP2mpTunnelBranchDiscontinuityTime."
+      ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 6 }
+
+   jnxMplsTeP2mpTunnelBranchDiscontinuityTime OBJECT-TYPE
+      SYNTAX      TimeStamp
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            any one or more of this row's Counter32 or Counter64 objects
+            experienced a discontinuity. If no such discontinuity has
+            occurred since the last re-initialization of the local
+            management subsystem, then this object contains a zero
+            value."
+      ::= { jnxMplsTeP2mpTunnelBranchPerfEntry 7 }
+
+   -- End of mplsTeP2mpTunnelBranchPerfTable
+
+   -- Notifications.
+
+   jnxMplsTeP2mpTunnelNotificationEnable OBJECT-TYPE
+      SYNTAX        TruthValue
+      MAX-ACCESS    read-write
+      STATUS        current
+      DESCRIPTION
+           "If this object is true(1), then it enables the generation of
+            mplsTeP2mpTunnelDestUp and mplsTeP2mpTunnelDestDown
+            notifications. Otherwise these notifications are not
+            emitted.
+
+            Note that when tunnels have large numbers of destinations,
+            setting this object to true(1) may result in the generation
+            of large numbers of notifications."
+
+
+      DEFVAL { false }
+      ::= { jnxMplsTeP2mpObjects 5 }
+
+   jnxMplsTeP2mpTunnelDestUp NOTIFICATION-TYPE
+      OBJECTS     {
+         jnxMplsTeP2mpTunnelDestAdminStatus,
+         jnxMplsTeP2mpTunnelDestOperStatus
+      }
+      STATUS      current
+      DESCRIPTION
+           "This notification is generated when a
+            mplsTeP2mpTunnelDestOperStatus object for one of the
+            destinations of one of the configured tunnels is about to
+            leave the down(2) state and transition into some other
+            state.  This other state is indicated by the included value
+            of mplsTeP2mpTunnelDestOperStatus.
+
+            This reporting of state transitions mirrors mplsTunnelUp."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpNotifications 1 }
+
+   jnxMplsTeP2mpTunnelDestDown NOTIFICATION-TYPE
+      OBJECTS     {
+         jnxMplsTeP2mpTunnelDestAdminStatus,
+         jnxMplsTeP2mpTunnelDestOperStatus
+      }
+      STATUS      current
+      DESCRIPTION
+           "This notification is generated when a
+            mplsTeP2mpTunnelDestOperStatus object for one of the
+            destinations of one of the configured tunnels is about to
+            enter the down(2) state from some other state. This other
+            state is indicated by the included value of
+            mplsTeP2mpTunnelDestOperStatus.
+
+            This reporting of state transitions mirrors mplsTunnelDown."
+      REFERENCE
+           "RFC 3812 - Multiprotocol Label Switching (MPLS) Traffic
+            Engineering (TE) Management Information Base (MIB),
+            Srinivasan, C., Viswanathan, A., and T. Nadeau, June 2004."
+      ::= { jnxMplsTeP2mpNotifications 2 }
+
+   -- End of notifications.
+
+
+
+
+
+   --****************************************************************
+   -- Module Conformance Statement
+   --****************************************************************
+
+   jnxMplsTeP2mpGroups
+      OBJECT IDENTIFIER ::= { jnxMplsTeP2mpConformance 1 }
+
+   jnxMplsTeP2mpCompliances
+      OBJECT IDENTIFIER ::= { jnxMplsTeP2mpConformance 2 }
+
+   --
+   -- Full Compliance
+   -- Compliance requirement for fully compliant implementations.
+   -- Such implementations allow configuration of P2MP tunnels at
+   -- head-end LSRs via SNMP, and monitoring of P2MP tunnels at all
+   -- LSRs via SNMP.
+   --
+
+   jnxMplsTeP2mpModuleFullCompliance MODULE-COMPLIANCE
+      STATUS       current
+      DESCRIPTION
+           "Compliance statement for agents that provide full support
+            for MPLS-TE-P2MP-STD-MIB. Such devices can be monitored and
+            also be configured using this MIB module.
+            The Module is implemented with support for read-create and
+            read-write. In other words, both monitoring and
+            configuration are available when using this
+            MODULE-COMPLIANCE."
+
+      MODULE -- this module
+
+      MANDATORY-GROUPS {
+         jnxMplsTeP2mpGeneralGroup,
+         jnxMplsTeP2mpNotifGroup,
+         jnxMplsTeP2mpScalarGroup
+      }
+
+      -- mplsTeP2mpTunnelTable
+
+      OBJECT       jnxMplsTeP2mpTunnelRowStatus
+      SYNTAX       RowStatus { active(1) }
+      WRITE-SYNTAX RowStatus { createAndGo(4), destroy(6) }
+      DESCRIPTION
+          "Support for createAndWait and notInService is not
+           required."
+
+   ::= { jnxMplsTeP2mpCompliances 1 }
+
+
+   jnxMplsTeP2mpModuleReadOnlyCompliance MODULE-COMPLIANCE
+      STATUS       current
+      DESCRIPTION
+           "Compliance statement for agents that provide read-only
+            support for MPLS-TE-P2MP-STD-MIB. Such devices can only be
+            monitored using this MIB module.
+            The Module is implemented with support for read-only. In
+            other words, only monitoring is available by implementing
+            this MODULE-COMPLIANCE."
+
+      MODULE -- this module
+
+      MANDATORY-GROUPS {
+         jnxMplsTeP2mpGeneralGroup,
+         jnxMplsTeP2mpScalarGroup,
+         jnxMplsTeP2mpNotifGroup
+      }
+
+      -- mplsTeP2mpTunnelTable
+
+      OBJECT      jnxMplsTeP2mpTunnelP2mpIntegrity
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+      OBJECT      jnxMplsTeP2mpTunnelBranchRole
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+      OBJECT      jnxMplsTeP2mpTunnelP2mpXcIndex
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+      OBJECT      jnxMplsTeP2mpTunnelRowStatus
+      SYNTAX      RowStatus { active(1) }
+      MIN-ACCESS  read-only
+      DESCRIPTION
+          "Write access is not required, and active(1) is the
+           only status that needs to be supported."
+
+      OBJECT      jnxMplsTeP2mpTunnelStorageType
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+      -- mplsTeP2mpTunnelDestTable
+
+      OBJECT      jnxMplsTeP2mpTunnelDestHopTableIndex
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+
+      OBJECT      jnxMplsTeP2mpTunnelDestPathInUse
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+      OBJECT      jnxMplsTeP2mpTunnelDestAdminStatus
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+      OBJECT      jnxMplsTeP2mpTunnelDestRowStatus
+      SYNTAX      RowStatus { active(1) }
+      MIN-ACCESS  read-only
+      DESCRIPTION
+          "Write access is not required, and active(1) is the
+           only status that needs to be supported."
+
+      OBJECT      jnxMplsTeP2mpTunnelDestStorageType
+      MIN-ACCESS  read-only
+      DESCRIPTION "Write access is not required."
+
+   ::= { jnxMplsTeP2mpCompliances 2 }
+
+   -- Units of conformance.
+
+   jnxMplsTeP2mpGeneralGroup OBJECT-GROUP
+      OBJECTS {
+         jnxMplsTeP2mpTunnelConfigured,
+         jnxMplsTeP2mpTunnelActive,
+         jnxMplsTeP2mpTunnelTotalMaxHops,
+         jnxMplsTeP2mpTunnelP2mpIntegrity,
+         jnxMplsTeP2mpTunnelBranchRole,
+         jnxMplsTeP2mpTunnelP2mpXcIndex,
+         jnxMplsTeP2mpTunnelRowStatus,
+         jnxMplsTeP2mpTunnelStorageType,
+         jnxMplsTeP2mpTunnelSubGroupIDNext,
+         --mplsTeP2mpTunnelDestSrcSubGroupOriginType,
+         --mplsTeP2mpTunnelDestSrcSubGroupOrigin,
+         --mplsTeP2mpTunnelDestSrcSubGroupID,
+         --mplsTeP2mpTunnelDestSubGroupOriginType,
+         --mplsTeP2mpTunnelDestSubGroupOrigin,
+         --mplsTeP2mpTunnelDestSubGroupID,
+         --mplsTeP2mpTunnelDestDestinationType,
+         --mplsTeP2mpTunnelDestDestination,
+         jnxMplsTeP2mpTunnelDestBranchOutSegment,
+         jnxMplsTeP2mpTunnelDestHopTableIndex,
+         jnxMplsTeP2mpTunnelDestPathInUse,
+         jnxMplsTeP2mpTunnelDestCHopTableIndex,
+         jnxMplsTeP2mpTunnelDestARHopTableIndex,
+         jnxMplsTeP2mpTunnelDestTotalUpTime,
+
+
+         jnxMplsTeP2mpTunnelDestInstanceUpTime,
+         jnxMplsTeP2mpTunnelDestPathChanges,
+         jnxMplsTeP2mpTunnelDestLastPathChange,
+         jnxMplsTeP2mpTunnelDestCreationTime,
+         jnxMplsTeP2mpTunnelDestStateTransitions,
+         jnxMplsTeP2mpTunnelDestDiscontinuityTime,
+         jnxMplsTeP2mpTunnelDestAdminStatus,
+         jnxMplsTeP2mpTunnelDestOperStatus,
+         jnxMplsTeP2mpTunnelDestRowStatus,
+         jnxMplsTeP2mpTunnelDestStorageType,
+         jnxMplsTeP2mpTunnelBranchPerfPackets,
+         jnxMplsTeP2mpTunnelBranchPerfHCPackets,
+         jnxMplsTeP2mpTunnelBranchPerfErrors,
+         jnxMplsTeP2mpTunnelBranchPerfBytes,
+         jnxMplsTeP2mpTunnelBranchPerfHCBytes,
+         jnxMplsTeP2mpTunnelBranchDiscontinuityTime,
+         jnxMplsTeP2mpTunnelNotificationEnable
+      }
+   STATUS  current
+   DESCRIPTION
+        "Collection of objects needed for MPLS P2MP."
+   ::= { jnxMplsTeP2mpGroups 1 }
+
+   jnxMplsTeP2mpNotifGroup NOTIFICATION-GROUP
+      NOTIFICATIONS {
+         jnxMplsTeP2mpTunnelDestUp,
+         jnxMplsTeP2mpTunnelDestDown
+      }
+   STATUS  current
+   DESCRIPTION
+        "Notifications implemented in this module."
+   ::= { jnxMplsTeP2mpGroups 2 }
+
+   jnxMplsTeP2mpScalarGroup OBJECT-GROUP
+      OBJECTS {
+         jnxMplsTeP2mpTunnelConfigured,
+         jnxMplsTeP2mpTunnelActive,
+         jnxMplsTeP2mpTunnelTotalMaxHops
+      }
+      STATUS  current
+      DESCRIPTION
+           "Scalar objects needed to implement P2MP MPLS tunnels."
+      ::= { jnxMplsTeP2mpGroups 3 }
+
+   END

--- a/mibs/junos/mib-jnx-pae-extension.txt
+++ b/mibs/junos/mib-jnx-pae-extension.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: PAE MIB Extension
 --
--- Copyright (c) 2007, Juniper Networks, Inc.
+-- Copyright (c) 2007-2008, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.

--- a/mibs/junos/mib-jnx-pfe.txt
+++ b/mibs/junos/mib-jnx-pfe.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: PFE MIB
 -- 
--- Copyright (c) 2006, Juniper Networks, Inc.
+-- Copyright (c) 2006-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -10,7 +10,8 @@
 JUNIPER-PFE-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
-    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Integer32
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, 
+    Counter32, Counter64, Integer32
         FROM SNMPv2-SMI
     DisplayString
         FROM SNMPv2-TC
@@ -18,7 +19,7 @@ IMPORTS
         FROM JUNIPER-SMI;
 
 jnxPfeMib MODULE-IDENTITY
-    LAST-UPDATED "201002070000Z" -- Sun Feb 07 00:00:00 2010 UTC
+    LAST-UPDATED "201109220000Z" -- Thu Sept 22 00:00:00 2011 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -30,9 +31,19 @@ jnxPfeMib MODULE-IDENTITY
     DESCRIPTION
             "The MIB provides PFE specific data."
 
+    REVISION      "201109090000Z"
+    DESCRIPTION
+               "Added new Table jnxPfeMemoryErrorsTable which gives parity and
+                ecc errors.
+                Added new Trap pfeMemoryErrors"
     REVISION      "201002070000Z"
     DESCRIPTION
                "Added new notification types."
+    REVISION      "201403120000Z"
+    DESCRIPTION 
+               "Added new Table jnxPfeNotifyGlParAccSec which counts
+                notifications for the packets parsed/processed by
+                access-security." 
     --REVISION      "201001070000Z"
     --DESCRIPTION
     --         "Added new notification types."
@@ -89,7 +100,8 @@ jnxPfeMib MODULE-IDENTITY
             jnxPfeNotifyGlPktGetFails   Counter32,
             jnxPfeNotifyGlDmaFails      Counter32,
             jnxPfeNotifyGlDmaTotals     Counter32,
-            jnxPfeNotifyGlUnknowns      Counter32
+            jnxPfeNotifyGlUnknowns      Counter32,
+            jnxPfeNotifyGlParAccSec     Counter32
 	}
 
     jnxPfeNotifyGlSlot OBJECT-TYPE
@@ -272,6 +284,15 @@ jnxPfeMib MODULE-IDENTITY
                 only."
         ::= { jnxPfeNotifyGlEntry 19 }
 
+    jnxPfeNotifyGlParAccSec OBJECT-TYPE
+        SYNTAX      Counter32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "Count of notifications for the packets parsed/processed by
+                access-security."
+        ::= { jnxPfeNotifyGlEntry 20 }       
+
     --
     -- This table provides Type specific PFE notification stats for each PFE 
     -- slot, exposing the data provided by the 'show pfe statistics 
@@ -404,5 +425,81 @@ jnxPfeMib MODULE-IDENTITY
                 "Count of notifications where the notification type in the 
                 message does not match any of the valid types."
         ::= { jnxPfeNotifyTypeEntry 6 }
+
+    --
+    -- This table provides error counters for each PFE
+    --
+    jnxPfeMemoryErrorsTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF JnxPfeMemoryErrorsEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This provides PFE memory errors"
+    ::= { jnxPfeNotification 3 }
+
+    jnxPfeMemoryErrorsEntry OBJECT-TYPE
+    SYNTAX          JnxPfeMemoryErrorsEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        ""
+        INDEX { jnxPfeFpcSlot, jnxPfeSlot }
+    ::= { jnxPfeMemoryErrorsTable 1 }
+
+    JnxPfeMemoryErrorsEntry ::=
+    SEQUENCE {
+            jnxPfeFpcSlot         Integer32,
+            jnxPfeSlot            Integer32,  
+            jnxPfeParityErrors    Counter64,
+            jnxPfeEccErrors       Counter64
+    }
+
+     jnxPfeFpcSlot OBJECT-TYPE
+        SYNTAX      Integer32 (0..2147483647)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "The FPC slot number for this set of PFE notification"
+        ::= { jnxPfeMemoryErrorsEntry 1 }
+
+    jnxPfeSlot OBJECT-TYPE
+        SYNTAX      Integer32 (0..2147483647)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+                "The pfe slot number for this set of errors"
+        ::= { jnxPfeMemoryErrorsEntry 2 }
+
+    jnxPfeParityErrors OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "The parity error count"
+        ::= { jnxPfeMemoryErrorsEntry 3 }
+
+    jnxPfeEccErrors OBJECT-TYPE
+        SYNTAX      Counter64
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "The ECC error count"
+        ::= { jnxPfeMemoryErrorsEntry 4 }
+     
+
+pfeMemoryErrorsNotificationPrefix OBJECT IDENTIFIER ::= { jnxPfeNotification 0 }
+
+pfeMemoryErrors NOTIFICATION-TYPE
+    OBJECTS {
+        jnxPfeParityErrors,
+        jnxPfeEccErrors
+    }
+    STATUS current
+    DESCRIPTION
+        "A pfeMemoryErrors notification is sent when the value
+        of jnxPfeParityErrors or jnxPfeEccErrors increases." 
+
+    ::= { pfeMemoryErrorsNotificationPrefix 1 }
+
 
 END

--- a/mibs/junos/mib-jnx-ping.txt
+++ b/mibs/junos/mib-jnx-ping.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Ping MIB
 -- 
--- Copyright (c) 2001-2007, Juniper Networks, Inc.
+-- Copyright (c) 2001-2012, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -32,7 +32,7 @@ IMPORTS
         FROM JUNIPER-SMI;
 
 jnxPingMIB MODULE-IDENTITY
-    LAST-UPDATED "200902010000Z" -- February 1 00:00:00 2005 UTC
+    LAST-UPDATED "200911180000Z" -- November 18 00:00:00 2009 UTC
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -47,6 +47,12 @@ jnxPingMIB MODULE-IDENTITY
              related entries in mib-2, pingMIB."
 
     -- revision history
+    REVISION "201109200000Z" -- September 20 00:00:00 2011 UTC
+    DESCRIPTION
+            "Updated the jnxPingCtlTargetPort description."
+    REVISION "200911180000Z" -- November 18 00:00:00 2009 UTC
+    DESCRIPTION
+            "Added jnxPingCtlEXseriesHWTimeStamp to jnxPingCtlTable."
     REVISION "200904200000Z" -- April 20 00:00:00 2009 UTC
     DESCRIPTION
             "Added jnxPingCtlTargetPort to jnxPingCtlTable."
@@ -158,7 +164,8 @@ JnxPingCtlEntry ::=
         jnxPingCtlJseriesHWTimeStamp     TruthValue,
         jnxPingCtlOneWayHWTimeStamp      TruthValue,
         jnxPingCtlMovAvgSize             Unsigned32,
-        jnxPingCtlMXseriesHWTimeStamp    TruthValue
+        jnxPingCtlMXseriesHWTimeStamp    TruthValue,
+        jnxPingCtlEXseriesHWTimeStamp    TruthValue
     }
 
 jnxPingCtlOwnerIndex OBJECT-TYPE
@@ -458,7 +465,8 @@ jnxPingCtlTargetPort  OBJECT-TYPE
     MAX-ACCESS  read-create
     STATUS      current
     DESCRIPTION
-        "The target UDP/TCP port used by the probe."
+        "The target UDP/TCP port used by the probe.
+         When ICMP ping is used, jnxPingCtlTargetPort value will be shown as 0."
     ::= { jnxPingCtlEntry 17 }
 
 jnxPingCtlJseriesHWTimeStamp  OBJECT-TYPE
@@ -515,6 +523,16 @@ jnxPingCtlMXseriesHWTimeStamp  OBJECT-TYPE
          For those routers, this object must have the value: false."
     DEFVAL { false }
     ::= { jnxPingCtlEntry 21 }
+
+jnxPingCtlEXseriesHWTimeStamp  OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+        "Use to enable the RPM Hardware Timestamp feature on EX-series switches.
+         For thoses, this object must have the value: false."
+    DEFVAL { false }
+    ::= { jnxPingCtlEntry 22 }
 
 
 

--- a/mibs/junos/mib-jnx-power-supply-unit.txt
+++ b/mibs/junos/mib-jnx-power-supply-unit.txt
@@ -1,0 +1,476 @@
+-- *****************************************************************
+-- Juniper Enterprise Specific MIB: JUNIPER-POWER-MANAGEMENT
+--
+-- Copyright (c) 2009-2010, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- *****************************************************************
+
+JUNIPER-POWER-SUPPLY-UNIT-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+        MODULE-IDENTITY, OBJECT-TYPE
+                FROM SNMPv2-SMI
+        TEXTUAL-CONVENTION, DisplayString, TruthValue
+                FROM SNMPv2-TC
+        jnxContentsContainerIndex, jnxContentsL1Index,
+        jnxContentsL2Index, jnxContentsL3Index
+                FROM JUNIPER-MIB
+        jnxPsuMIBRoot
+                FROM JUNIPER-SMI;
+
+jnxPsuMIB MODULE-IDENTITY
+    LAST-UPDATED "201010270000Z" -- Oct 27 00:00:00 2010 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "Juniper Technical Assistance Center
+         Juniper Networks, Inc.
+         1194 N. Mathilda Avenue
+         Sunnyvale, CA 94089
+         E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "The Juniper Supply Unit MIB definitions for enabling
+             power monitoring and management of a juniper device."
+
+    -- revision history
+    REVISION  "201001270000Z" -- January 27 00:00:00 2010 UTC
+    DESCRIPTION
+            "Initial revision."
+    REVISION  "201005130000Z" -- May 13 00:00:00 2010 UTC
+    DESCRIPTION
+            "Added new OIDs for power budget statistics which gives details of
+            Power reserved for Chassis and the Total power allocated to Chassis
+            including for each FPC. 
+            Added new Table jnxPsuFpcPowerTable which gives the Priority
+            assigned and Power allocated to each FPC."
+    REVISION  "201010270000Z" -- Oct 27 00:00:00 2010 UTC
+    DESCRIPTION
+            "Added new OIDs for power budget statistics which gives details of
+            Power reserved for System dynamically."
+
+    ::= { jnxPsuMIBRoot 1 }
+
+jnxPsuNotifications     OBJECT IDENTIFIER ::= { jnxPsuMIB 1 }
+jnxPsuObjects           OBJECT IDENTIFIER ::= { jnxPsuMIB 2 }
+
+--**********************************************************************
+-- PSU Scalar Objects 
+--**********************************************************************
+
+jnxPsuScalars           OBJECT IDENTIFIER ::= { jnxPsuObjects 1 }
+
+jnxPsuAvailableDeviceCount OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Gives the number of PSU units available online in the System."
+    ::= { jnxPsuScalars 1 }
+
+jnxPsuAvailableAveragePowerSupply OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Gives the total average power that the System can supply from the
+        available online units in Watts."
+    ::= { jnxPsuScalars 2 }
+
+jnxPsuAvailableMaxPowerSupply OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Gives the total maximum power that the System can supply from the 
+        available online units in Watts."
+    ::= { jnxPsuScalars 3 }
+
+jnxPsuRedundancy  OBJECT-TYPE
+    SYNTAX        INTEGER {
+                  nPlusNRedundancy(1),
+                  nPlusOneRedundancy(2),
+                  none(3)
+    }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "PSU power redundancy configuration."
+    ::= { jnxPsuScalars 4 }
+
+jnxPsuChassisPowerReserved OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Power reserved for Chassis in Watts."
+    ::= { jnxPsuScalars 5 }
+
+jnxPsuChassisPowerAllocated OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Total power allocated for chassis and all the FPCs in Watts."
+    ::= { jnxPsuScalars 6 }
+
+jnxPsuRedundantPowerAvailable OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Power(in Watts) that is still available for allocation
+        even while supporting redundancy with the present usage."
+    ::= { jnxPsuScalars 7 }
+
+jnxPsuTotalPowerAvailable OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Power(in Watts) which could be made available for further
+        allocation without supporting any redundancy with the present usage."
+::= { jnxPsuScalars 8 }
+
+jnxPsuChassisPowerConsumed OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Total power consumed by the entire system rounded to the nearest integer.
+         This is calculated using the PowerFactor, Current and Voltage values 
+         of each PSU that is online and connected to the System."
+    ::= { jnxPsuScalars 9 }
+
+jnxPsuTemperatureInflow OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Average inflow temperature calculated from all 
+        the available input sensors on the master RE."
+
+    ::= { jnxPsuScalars 10 }
+
+jnxPsuTemperatureOutflow OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Average outflow temperature calculated from all 
+        the available output sensors on the master RE."
+    ::= { jnxPsuScalars 11 }
+
+jnxPsuTemperatureInflowSamples OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of samples being taken while calculating
+        jnxPsuTemperatureInflow."
+
+    ::= { jnxPsuScalars 12 }
+
+jnxPsuTemperatureOutflowSamples OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of samples being taken while calculating
+        jnxPsuTemperatureOutflow."
+
+    ::= { jnxPsuScalars 13 }
+
+--**********************************************************************
+-- Device POWER
+--**********************************************************************
+
+jnxPsuTable  OBJECT-TYPE
+    SYNTAX        SEQUENCE OF JnxPsuEntry 
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION   "A list of power entries for each PSU component."
+    ::= { jnxPsuObjects 2 }
+
+jnxPsuEntry    OBJECT-TYPE
+    SYNTAX        JnxPsuEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION   "Defines an entry in jnxPsuTable. "
+    INDEX         { jnxContentsContainerIndex,
+                    jnxContentsL1Index,
+                    jnxContentsL2Index,
+                    jnxContentsL3Index }
+
+    ::= { jnxPsuTable 1 }
+
+JnxPsuEntry ::= 
+    SEQUENCE { 
+        jnxPsuAvgPower    INTEGER,
+        jnxPsuMaxPower    INTEGER,
+        jnxPsuMode        INTEGER,
+        jnxPsuOutletCount INTEGER
+    }
+
+jnxPsuAvgPower   	OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Buffer that contains the average power used, in Watts 
+                  for each component."
+    ::= { jnxPsuEntry 1 }
+                 
+jnxPsuMaxPower   	OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Buffer that contains the max power available, in Watts 
+                  for each component."
+    ::= { jnxPsuEntry 2 }
+
+jnxPsuMode   OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      single(1),
+                      three(3)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Mode for each PSU component."
+    ::= { jnxPsuEntry 3 }
+
+jnxPsuOutletCount OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "The number of outlets (regardless of their current state)
+                  present on this psu component, default is 0."
+    DEFVAL        { 0 }
+    ::= { jnxPsuEntry 4 }
+
+--**********************************************************************
+-- Environment
+--**********************************************************************
+
+jnxPsuEnvironmentTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF JnxPsuEnvironmentEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION   "A list of PSU Environment entries."
+    ::= { jnxPsuObjects 3 }
+
+jnxPsuEnvironmentEntry OBJECT-TYPE
+    SYNTAX       JnxPsuEnvironmentEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION  "Defines an entry in jnxPsuEnvironmentTable."
+    INDEX        { jnxContentsContainerIndex,
+                   jnxContentsL1Index,
+                   jnxContentsL2Index,
+                   jnxContentsL3Index }
+    ::= { jnxPsuEnvironmentTable 1 }
+
+JnxPsuEnvironmentEntry ::=
+    SEQUENCE {
+        jnxPsuThermalValue    INTEGER,
+        jnxPsuHumidityValue   INTEGER
+    }
+
+jnxPsuThermalValue  OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Temparature at each component in degrees Celsius rounded to
+                  the nearest integer."
+    ::= { jnxPsuEnvironmentEntry 1 }
+
+jnxPsuHumidityValue  OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Humidity at each component in percentage."
+    ::= { jnxPsuEnvironmentEntry 2 }
+
+--**********************************************************************
+-- OUTLETS
+--**********************************************************************
+
+jnxPsuOutletTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF JnxPsuOutletEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION   "Gives details of each Power outlet`s state,
+                   capacity to supply power, and other details."
+    ::= { jnxPsuObjects 4 }
+
+jnxPsuOutletEntry OBJECT-TYPE
+    SYNTAX       JnxPsuOutletEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION  "A value contained within the OutletEntry"
+    INDEX        { jnxContentsContainerIndex,
+                   jnxContentsL1Index,
+                   jnxContentsL2Index,
+                   jnxContentsL3Index }
+     ::= { jnxPsuOutletTable 1 }
+
+JnxPsuOutletEntry ::= 
+    SEQUENCE {
+	jnxPsuOutletName                     DisplayString,
+	jnxPsuOutletDescription              DisplayString,
+	jnxPsuOutletAvgPower                 INTEGER,
+	jnxPsuOutletMaxPower                 INTEGER,
+	jnxPsuOutletCurrent                  INTEGER,
+	jnxPsuOutletStatus                   INTEGER,
+	jnxPsuOutletVoltage                  INTEGER,
+	jnxPsuOutletPowerFactorValue         INTEGER,
+	jnxPsuOutletPowerConsumed            INTEGER
+    }
+
+jnxPsuOutletName  OBJECT-TYPE
+    SYNTAX        DisplayString(SIZE (0..15))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Outlet name associated to the power supply unit for 
+                   each PSU Component."
+    ::= { jnxPsuOutletEntry 1 }
+
+jnxPsuOutletDescription	OBJECT-TYPE
+    SYNTAX        DisplayString(SIZE (0..63))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Outlet description associated to the power supply unit for 
+                   each PSU Component."
+    ::= { jnxPsuOutletEntry 2 }
+
+jnxPsuOutletAvgPower OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Buffer that contains the average power used, in Watts for each component."
+    ::= { jnxPsuOutletEntry 3 }
+		 
+jnxPsuOutletMaxPower OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Buffer that contains the maximum power available, in Watts for each component."
+    ::= { jnxPsuOutletEntry 4 }
+		 
+jnxPsuOutletCurrent OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "PSU output current in milliamps rounded to the nearest
+                  integer."
+    ::= { jnxPsuOutletEntry 5 }
+                  
+jnxPsuOutletStatus  OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      off(0),
+                      on(1)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "The value of the operational status for the given outlet.
+                   This can also be used to set the outlet state"
+    ::= { jnxPsuOutletEntry 8 }
+
+jnxPsuOutletVoltage OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Output voltage in Volts rounded to the nearest integer."
+    ::= { jnxPsuOutletEntry 9 }
+
+--
+-- NOTE: jnxPsuOutletPowerFactorValue does NOT return the traditional
+-- "power factor", defined as real power in watts divided by apparent 
+-- power in volt-amperes.  Instead it returns "efficiency" which is  
+-- defined as power output divided by power input.
+--
+jnxPsuOutletPowerFactorValue OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Power factor percentage of each PSU (2k/3k).
+
+                  Algorithm for calculation of Power Factor is below.
+                  For PowerOut values that fall in between 618.93W and 915.24W,
+                  say 700W, the appropriate PF ranges from 0.910191 & 
+                  0.917994. Following linear equation could help deduce a
+                  fairly accurate input power value.
+ 
+                  Linear equation y = mx + b (where m is the slope and b is 
+                  the Y intercept)
+
+                  Slope m = (y2 - y1) / (x2 - x1)
+                  Y intercept  b = y - mx
+ 
+                  Plugging it all together for our example:
+ 
+                  m = (915.24 - 618.93) / (0.917994 - 0.910191) = 37973.86
+                  b = 915.24 - (37973.86 * 0.917994) = -33944.5
+ 
+                  for 700W (y), our efficiency (x) would then be:
+ 
+                  x = (700 - (-33944.5)) / 37973.86 = 0.912326 = 91%
+
+                  PowerIn = 700W /0.912326 = 767.26W "
+
+    ::= { jnxPsuOutletEntry 10 }
+
+jnxPsuOutletPowerConsumed OBJECT-TYPE
+    SYNTAX        INTEGER
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION   "Power Consumed by each outlet units in Watts."
+    ::= { jnxPsuOutletEntry 11 }
+
+                  
+--**********************************************************************
+-- FPC Power allocated information 
+--**********************************************************************
+
+jnxPsuFpcPowerTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF JnxPsuFpcPowerEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION   "A list of entries for each FPC(Flexible PIC Concentrator)
+                   giving it's assigned priority and power being allocated. 
+                   More information on FPCs can be found in JUNIPER-MIB."
+    ::= { jnxPsuObjects 5 }
+
+jnxPsuFpcPowerEntry OBJECT-TYPE
+    SYNTAX       JnxPsuFpcPowerEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION  "A value contained within the FpcPowerEntry"
+    INDEX        { jnxContentsContainerIndex,
+                   jnxContentsL1Index,
+                   jnxContentsL2Index,
+                   jnxContentsL3Index }
+     ::= { jnxPsuFpcPowerTable 1 }
+
+JnxPsuFpcPowerEntry ::=
+    SEQUENCE {
+            jnxPsuFpcPowerPriority               INTEGER,
+            jnxPsuFpcPowerAllocated              INTEGER
+          }
+      
+jnxPsuFpcPowerPriority OBJECT-TYPE
+     SYNTAX         INTEGER
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION    "The Power budget priority assigned to the FPC.
+                     Lower number means higher priority."
+     ::= { jnxPsuFpcPowerEntry 1 }
+
+jnxPsuFpcPowerAllocated OBJECT-TYPE
+    SYNTAX         INTEGER
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION    "The Power allocated to the FPC in Watts."
+    ::= { jnxPsuFpcPowerEntry 2 }
+
+END

--- a/mibs/junos/mib-jnx-ppp.txt
+++ b/mibs/junos/mib-jnx-ppp.txt
@@ -1,0 +1,3075 @@
+
+
+--
+-- Juniper Enterprise Specifics MIB
+-- 
+-- Copyright (c) 2010-2012, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JNX-PPP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32, IpAddress, TimeTicks, Unsigned32   
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, TruthValue, RowStatus
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    ifIndex, InterfaceIndex, InterfaceIndexOrZero
+        FROM IF-MIB
+    Ipv6AddressIfIdentifier
+        FROM IPV6-TC
+    jnxPppMibRoot
+        FROM JUNIPER-SMI ;                                  
+
+
+jnxPppMIB  MODULE-IDENTITY
+    LAST-UPDATED "201309190942Z"  -- 19-Sept-13 03:12 PM EST
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "       Juniper Networks, Inc.
+        Postal: 10 Technology Park Drive
+                Westford, MA  01886-3146
+                USA
+        Tel:    +1 978 589 5800
+        Email:  mib@Juniper.net"
+    DESCRIPTION
+        "The Point-to-Point Protocol (PPP) MIB for the Juniper enterprise."
+    -- Revision History
+
+    REVISION    "201309190000Z"  -- 19-Sept-13 03:12 PM EST - JUNOS 13.1 
+    DESCRIPTION 
+        "Updated the revision history and LAST-UPDATED field." 
+
+    REVISION    "201306130000Z"  -- 13-Jun-13 05:32 AM EST - JUNOS 13.1
+    DESCRIPTION
+        "Deprecated InterfaceIndex type and added InterfaceIndexOrZero type
+         for jnxPppNextIfIndex, jnxPppMlPppNextLinkIfIndex and
+         jnxPppMlPppNextNetworkIfIndex."
+     
+      REVISION    "201206080000Z"  -- 08-Jun-12 03:12 PM EST  - JUNOS 12.1 
+      DESCRIPTION 
+        "Changes are done to change all Data packet/octet counters from 
+         32 to 64 bit counter. 32 bit counters were too small for data 
+         packets/octects and were consumed too early. All old counters are 
+         deprecated and new counters are added." 
+
+    REVISION    "201111290000Z"  -- 29-Nov-11 03:12 PM EST  - JUNOS 11.4
+    DESCRIPTION
+        "Deprecated Integer32 type jnxPppLinkStatusLocalMagicNumber, 
+         jnxPppLinkStatusRemoteMagicNumber and added Unsigned32 type
+         jnxPppLinkStatusLocalMagicNumber1, jnxPppLinkStatusLocalMagicNumber1
+         under jnxPppLinkStatusTable"
+    
+    REVISION    "201007220942Z"  -- 22-Jul-10 03:12 PM EST  - JUNOS 11.0
+    DESCRIPTION
+        "Initial version."
+    ::= { jnxPppMibRoot 1 }
+
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Textual conventions
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+JnxPppAuthentication ::= TEXTUAL-CONVENTION
+    STATUS      deprecated
+    DESCRIPTION
+        "Specifies the type(s) of PPP authentication used, if any:
+          none      No authentication is negotiated.
+          pap       PAP negotiation only.
+          chap      CHAP negotiation only.
+          papChap   PAP negotiation is attempted first; if fails, attempt CHAP.
+          chapPap   CHAP negotiation is attempted first; if fails, attempt PAP."
+    SYNTAX      INTEGER {
+                    none (0),
+                    pap (1),
+                    chap (2),
+                    papChap (3),
+                    chapPap (4) }
+
+--+++++++++
+
+JnxPppMlPppBundleName ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "MLPPP Bundle name.  The bundle name is a characteristic of a MLPPP
+        network interface."
+    SYNTAX OCTET STRING (SIZE(1..60))
+
+
+--+++++
+
+JnxPppAuthentication2 ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "Specifies the type(s) of PPP authentication used, if any:
+          none      No authentication is negotiated.
+          pap       PAP negotiation.
+          chap      CHAP negotiation.
+          eap       EAP negotiation." 
+
+    SYNTAX      INTEGER {
+                    none (0),
+                    pap (1),
+                    chap (2),
+                    eap (3) }
+
+
+JnxNibbleConfig ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "A configuration variable comprised of nibbles i.e. 4 bits, such that 
+         a client can supply a list of 0 to 8 selections.  The least 
+         significant nibble is the first value of the list, and the most 
+         significant nibble is the last value.  The value in each field 
+         ranges from 0 to 15, however the first nibble with value 0 indicates
+         the end of the list.  Repetition of values is not allowed. 
+         Segregation of values in not allowed.
+
+         Example valid encoding:
+         0x00000321
+         0x00083E12
+
+         Not a valid encoding:
+         0x00000121 will return an error
+         0x01002001 will return an error."
+    SYNTAX INTEGER
+
+-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Managed objects
+-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+jnxPPPObjects        OBJECT IDENTIFIER ::= { jnxPppMIB 1 }
+
+--
+-- This MIB contains managed objects for PPP interfaces. Management objects are
+-- provided to query for an available interface index, and to create/delete 
+-- interfaces of this type. Creating/deleting this interface type using this 
+-- MIB has the side effect of creating/deleting corresponding entries in the
+-- Interface MIB ifTable/ifXTable, and in the Jnxper Enterprise Interface MIB
+-- jnxIfTable. 
+--This MIB acts as a supplement to IETF MIBs RFC1471 PPP-LCP-MIB .
+
+-- MIB object definitions are organized into the following
+-- Functional sections:
+--
+jnxPppLcp 	                OBJECT IDENTIFIER   ::= { jnxPPPObjects 1 }
+jnxPppSec            	        OBJECT IDENTIFIER   ::= { jnxPPPObjects 2 }     
+jnxPppIp                        OBJECT IDENTIFIER   ::= { jnxPPPObjects 3 }
+jnxPppOsi                       OBJECT IDENTIFIER   ::= { jnxPPPObjects 4 }
+jnxPppSession                   OBJECT IDENTIFIER   ::= { jnxPPPObjects 5 }
+jnxPppMlPpp                     OBJECT IDENTIFIER   ::= { jnxPPPObjects 6 }
+jnxPppSummary                   OBJECT IDENTIFIER   ::= { jnxPPPObjects 7 }
+jnxPppIpv6                      OBJECT IDENTIFIER   ::= { jnxPPPObjects 8 }
+jnxPppGlobalConfig              OBJECT IDENTIFIER   ::= { jnxPPPObjects 9 }
+
+
+
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- PPP LCP
+-- This section defines objects used to manage the PPP Link / LCP layer of PPP.
+-- The jnxPppLinkStatusTable complements RFC1471 pppLinkStatusTable, providing 
+--status indications regarding the operation of network protocols over each
+-- link. The addition/removal of a network protocol service is accomplished 
+-- outside this MIB. The jnxPppLinkConfigTable complements RFC1471 
+-- providing the ability to create/delete instances of PPP links and providing 
+-- for configuration of option parameter values (if any) not found in the 
+-- standard MIB, to be used during LCP negotiation.
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- The PPP Link Status Table
+--
+jnxPppLinkStatusTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppLinkStatusEntry
+    MAX-ACCESS                        not-accessible
+    STATUS                                   current
+    DESCRIPTION
+        "This table contains entries for PPP interfaces present in the system."
+    ::= { jnxPppLcp 1 }
+
+jnxPppLinkStatusEntry OBJECT-TYPE
+    SYNTAX                                JnxPppLinkStatusEntry
+    MAX-ACCESS                      not-accessible
+    STATUS                                 current
+    DESCRIPTION
+        "Each entry describes the characteristics of a PPP interface."
+    INDEX     { ifIndex }
+    ::= { jnxPppLinkStatusTable 1 }
+
+JnxPppLinkStatusEntry ::= SEQUENCE {
+    jnxPppLinkStatusTerminateReason               INTEGER,
+    jnxPppLinkStatusTerminateNegFailOption        INTEGER,
+    jnxPppLinkStatusInKeepaliveRequests           Counter32,                  
+    jnxPppLinkStatusOutKeepaliveRequests          Counter32,
+    jnxPppLinkStatusInKeepaliveReplies            Counter32,
+    jnxPppLinkStatusOutKeepaliveReplies           Counter32,
+    jnxPppLinkStatusKeepaliveFailures             Counter32,
+    jnxPppLinkStatusLocalMagicNumber              Integer32,
+    jnxPppLinkStatusRemoteMagicNumber             Integer32,
+    jnxPppLinkStatusLocalAuthentication           JnxPppAuthentication2,
+    jnxPppLinkStatusTunnelIfIndex                 InterfaceIndexOrZero,
+    jnxPppLinkStatuslcpRenegoTerminates           Counter32,
+    jnxPppLinkStatusLocalMagicNumber1             Unsigned32,
+    jnxPppLinkStatusRemoteMagicNumber1            Unsigned32}
+
+jnxPppLinkStatusTerminateReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    adminDisable(2),
+                    lowerLayerDown(3),
+                    noUpperInterface(4),
+                    authenticationFailure(5),
+                    peerTerminated(6),
+                    peerRenegotiated(7),
+                    maxRetriesExceeded(8),
+                    negotiationFailure(9),
+                    keepaliveFailure(10),
+                    sessionTimeout(11),
+                    inactivityTimeout(12),
+                    addressLeaseExpired(13),
+                    adminLogout(14),
+                    tunnelFailed(15),
+                    tunnelDisconnected(16),
+                    loopback(17) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reason the PPP link was terminated:
+            none                    None.
+            other                   Not specified.
+            adminDisable            Interface administratively disabled.
+            lowerLayerDown          Underlying interface is down.
+            noUpperInterface        No interface above PPP.
+            authenticationFailure   Authentication failed.
+            peerTerminated          Peer initiated termination.
+            peerRenegotiated        Peer initiated renegotiation.
+            maxRetriesExceeded      Maximum number of config retries exceeded.
+            negotiationFailure      Failed to negotiate LCP option.                    
+            keepaliveFailure        Keepalive failed.
+            sessionTimeout          Maximum session period expired.
+            inactivityTimeout       Maximum inactivity period expired.
+            addressLeaseExpired     Lease for network address expired.
+            adminLogout             Session administratively terminated.
+            tunnelFailed            Associated tunnel failed.
+            tunnelDisconnected      Associated tunnel disconnected.
+            loopback                Loopback detected."
+    ::= { jnxPppLinkStatusEntry 1 }
+
+jnxPppLinkStatusTerminateNegFailOption OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    localMru(2),
+                    remoteMru(3),
+                    localMagicNumber(4),
+                    remoteMagicNumber(5),
+                    localAuthentication(6),
+                    localToRemoteProtocolCompression(7),
+                    localToRemoteACCompression(8) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reports the PPP LCP option for which negotiation failed, 
+        when jnxPppLinkStatusTerminateReason has the value negotiationFailure."
+    ::= { jnxPppLinkStatusEntry 2 }
+
+jnxPppLinkStatusInKeepaliveRequests OBJECT-TYPE
+    SYNTAX            Counter32
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "Number of keepalive requests received."
+    ::= { jnxPppLinkStatusEntry 3 }
+
+jnxPppLinkStatusOutKeepaliveRequests OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of keepalive requests transmitted."
+    ::= { jnxPppLinkStatusEntry 4 }
+
+jnxPppLinkStatusInKeepaliveReplies OBJECT-TYPE
+    SYNTAX            Counter32
+    MAX-ACCESS   read-only
+    STATUS             current
+    DESCRIPTION
+        "Number of keepalive replies received."
+    ::= { jnxPppLinkStatusEntry 5 }
+
+jnxPppLinkStatusOutKeepaliveReplies OBJECT-TYPE
+    SYNTAX            Counter32
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "Number of keepalive replies transmitted."
+    ::= { jnxPppLinkStatusEntry 6 }
+
+jnxPppLinkStatusKeepaliveFailures OBJECT-TYPE
+    SYNTAX            Counter32
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "Number of keepalive failures detected."
+    ::= { jnxPppLinkStatusEntry 7 }
+
+jnxPppLinkStatusLocalMagicNumber OBJECT-TYPE
+    SYNTAX            Integer32
+    MAX-ACCESS         read-only
+    STATUS             deprecated
+    DESCRIPTION
+        "Magic number negotiated for the local side.
+         This has been deprecated and replaced by 
+         jnxPppLinkStatusLocalMagicNumber1"
+    ::= { jnxPppLinkStatusEntry 8 }
+
+jnxPppLinkStatusRemoteMagicNumber OBJECT-TYPE
+    SYNTAX            Integer32
+    MAX-ACCESS         read-only
+    STATUS             deprecated
+    DESCRIPTION
+        "Magic number negotiated for the remote side.
+         This has been deprecated and replaced by
+         jnxPppLinkStatusRemoteMagicNumber1"
+    ::= { jnxPppLinkStatusEntry 9 }
+
+jnxPppLinkStatusLocalAuthentication OBJECT-TYPE
+    SYNTAX            JnxPppAuthentication2
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "Authentication protocol negotiated for the local side."
+    ::= { jnxPppLinkStatusEntry 10 }
+
+jnxPppLinkStatusTunnelIfIndex OBJECT-TYPE
+    SYNTAX            InterfaceIndexOrZero
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "The ifIndex of an associated interface pertaining to a tunneling 
+        protocol, or zero if no such interface exists.The type of tunneling
+        interface can be identified from information in the entries in 
+        ifTable and jnxIfTable for this tunnel interface."
+    ::= { jnxPppLinkStatusEntry 11 }
+
+jnxPppLinkStatuslcpRenegoTerminates OBJECT-TYPE
+    SYNTAX            Counter32
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "Number of times lcp terminated due to peer exceeding max renegotiation 
+         attempts."
+    ::= { jnxPppLinkStatusEntry 12 }
+
+
+jnxPppLinkStatusLocalMagicNumber1 OBJECT-TYPE
+    SYNTAX             Unsigned32
+    MAX-ACCESS         read-only
+    STATUS             current
+    DESCRIPTION
+        "Magic number negotiated for the local side."
+    ::= { jnxPppLinkStatusEntry 13 }
+
+jnxPppLinkStatusRemoteMagicNumber1 OBJECT-TYPE
+    SYNTAX             Unsigned32
+    MAX-ACCESS         read-only
+    STATUS             current
+    DESCRIPTION
+        "Magic number negotiated for the remote side."
+    ::= { jnxPppLinkStatusEntry 14 }
+
+--
+-- The PPP Link Configuration Table
+--
+jnxPppLinkConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppLinkConfigEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "This table contains entries for PPP interfaces present in the system."
+    ::= { jnxPppLcp 2 }
+
+jnxPppLinkConfigEntry OBJECT-TYPE
+    SYNTAX             JnxPppLinkConfigEntry
+    MAX-ACCESS         not-accessible
+    STATUS             current
+    DESCRIPTION
+        "Each entry describes the characteristics of a PPP interface.
+        Creating or deleting entries in this table causes corresponding entries 
+        for be created or deleted in ifTable,ifXTable,jnxIfTable."
+   INDEX     { jnxPppLinkConfigIfIndex }
+    ::= { jnxPppLinkConfigTable 1 }
+
+JnxPppLinkConfigEntry ::= SEQUENCE {
+    jnxPppLinkConfigIfIndex                             InterfaceIndex,
+    jnxPppLinkConfigRowStatus                           RowStatus,
+    jnxPppLinkConfigLowerIfIndex                        InterfaceIndexOrZero,
+    jnxPppLinkConfigKeepalive                           Integer32,
+    jnxPppLinkConfigAuthentication                      JnxPppAuthentication,
+    jnxPppLinkConfigMaxAuthenRetries                    Integer32,
+    jnxPppLinkConfigStandardIfIndex                     InterfaceIndex,
+    jnxPppLinkConfigChapMinChallengeLength              Integer32,
+    jnxPppLinkConfigChapMaxChallengeLength              Integer32,
+    jnxPppLinkConfigPassiveMode                         INTEGER,
+    jnxPppLinkConfigAuthenticatorLogicalSystem          OCTET STRING,
+    jnxPppLinkConfigAuthenticatorRoutingInstance        OCTET STRING,
+    jnxPppLinkConfigAaaProfile                          OCTET STRING,
+    jnxPppLinkConfigAuthentication2                     JnxNibbleConfig,
+    jnxPppLinkConfigIgnoreMagicNumberMismatch           INTEGER,
+    jnxPppLinkConfigMaxLcpRenegotiation                 Integer32}
+
+jnxPppLinkConfigIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of the PPP interface.  When creating entries in this
+         table, suitable values for this object are determined by reading 
+         jnxPppNextIfIndex."
+    ::= { jnxPppLinkConfigEntry 1 }
+
+jnxPppLinkConfigRowStatus OBJECT-TYPE
+    SYNTAX            RowStatus
+    MAX-ACCESS         read-only
+    STATUS             current
+    DESCRIPTION
+       "Controls creation or deletion of entries in this table with READ-CREATE
+        maximum access according to the RowStatus textual convention,
+        constrained to support the following values only:
+            createAndGo
+            destroy
+        To create an entry in this table, the following entry objects MUST be
+         explicitly configured:
+            jnxPppLinkConfigRowStatus
+            jnxPppLinkConfigLowerIfIndex
+
+        In addition, when creating an entry the following conditions must hold:
+            A value for jnxPppLinkConfigIndex must have been determined 
+            previously, by reading jnxPppNextIfIndex.The interface identified 
+            by jnxPppLinkConfigLowerIfIndex must exist. A corresponding entry  
+           in Table or ifXTable or jnxIfTable is created or destroyed as a 
+             result of creating or destroying an entry in this table.
+
+         The following values can be read from this object:
+             active(1)"
+    ::= { jnxPppLinkConfigEntry 2 }
+
+jnxPppLinkConfigLowerIfIndex OBJECT-TYPE
+    SYNTAX            InterfaceIndexOrZero
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+       "The ifIndex of an interface over which this PPP interface is to be 
+       layered.A value of zero indicates no layering.  An implementation may
+      choose to require that a non-zero value be configured at entry creation."
+    ::= { jnxPppLinkConfigEntry 3 }
+
+jnxPppLinkConfigKeepalive OBJECT-TYPE
+    SYNTAX             Integer32 (0..64800)
+    UNITS               "seconds"
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "Keepalive interval in seconds.  A value of zero disables keepalive. 
+        Keepalive is performed using LCP Echo."
+    DEFVAL    { 30 }
+    ::= { jnxPppLinkConfigEntry 4 }
+
+jnxPppLinkConfigAuthentication OBJECT-TYPE
+    SYNTAX      JnxPppAuthentication
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Specifies the type(s) of authentication, if any, to be negotiated
+         with the peer:
+          none      No authentication is negotiated.
+          pap       PAP negotiation only.
+          chap      CHAP negotiation only.
+          papChap   PAP negotiation is attempted first; if fails, attempt CHAP.
+          chapPap   CHAP negotiation is attempted first; if fails, attempt PAP.
+
+        If authentication negotiation is not supported for this PPP interface, 
+        then any attempt to explicitely set this object if READ-CREATE maximum
+        access is supported will result in a notWritable error and it will be
+        implicitily set to the DEFVAL on row creation. Setting this object to
+        none(0) will set jnxPppLinkConfigAuthenticatorRouting Instance object
+        to an empty string.
+ This object returns a null(0) value on the get operation. New object 
+ jnxPppLinkConfigAuthentication2 will reflect the configured values. Setting
+ this object along with the jnxPppLinkConfigAuthentication2 object will return  
+ an inconsistentValue error."
+    DEFVAL    { none }
+    ::= { jnxPppLinkConfigEntry 5 }
+
+jnxPppLinkConfigMaxAuthenRetries OBJECT-TYPE
+    SYNTAX            Integer32 (0..7)
+    MAX-ACCESS         read-only
+    STATUS             current
+    DESCRIPTION
+        "The number of authentication retries permitted, in addition to a
+         failed initial attempt.  If all retries fail, the link is reset. 
+         If authentication negotiation is not supported for this PPP interface,
+         then any attempt to explicitely set this object  if READ-CREATE 
+         maximum access is supported will result in a notWritable error and
+         it will be implicitily set to the DEFVAL on row creation."
+    DEFVAL    { 0 }
+    ::= { jnxPppLinkConfigEntry 6 }
+
+jnxPppLinkConfigStandardIfIndex OBJECT-TYPE
+    SYNTAX            InterfaceIndex
+    MAX-ACCESS        read-only
+    STATUS            current
+    DESCRIPTION
+        "The ifIndex value for this interface in the standard PPP MIBs. 
+         The ifIndex value for PPP interfaces is not the same for both 
+         proprietary and standard MIB tables pertaining to PPP interface.
+        Therefore this value is provide to simply cross referencing 
+        standard PPP and proprietary PPP MIB information."
+    ::= { jnxPppLinkConfigEntry 7 }
+
+jnxPppLinkConfigChapMinChallengeLength OBJECT-TYPE
+    SYNTAX            Integer32 (8..63)
+    MAX-ACCESS        read-only
+    STATUS             current
+    DESCRIPTION
+        "Minimum value of the CHAP authenticator challenge length value.
+         This value is never greater than
+         jnxPppLinkConfigChapMaxChallengeLength."
+    DEFVAL    { 16 }
+    ::= { jnxPppLinkConfigEntry 8 }
+
+jnxPppLinkConfigChapMaxChallengeLength OBJECT-TYPE
+    SYNTAX            Integer32 (8..63)
+    MAX-ACCESS         read-only
+    STATUS             current
+    DESCRIPTION
+        "Maximum value of the CHAP authenticator challenge length value. 
+        This value is never less than  jnxPppLinkConfigChapMinChallengeLength."
+    DEFVAL    { 32 }
+    ::= { jnxPppLinkConfigEntry 9 }
+
+jnxPppLinkConfigPassiveMode OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS        read-only
+    STATUS             current
+    DESCRIPTION
+    "When enabled, LCP state machine is forced into passive mode on lower layer
+         UP message.  It adds compatibility with slow and buggy clients."
+    DEFVAL    { disable }
+    ::= { jnxPppLinkConfigEntry 10 }
+
+jnxPppLinkConfigAuthenticatorLogicalSystem OBJECT-TYPE
+    SYNTAX            OCTET STRING
+    MAX-ACCESS        read-only
+    STATUS             current
+    DESCRIPTION
+        "The name of the logical system to  be used for authentication on the
+         PPP interface.With READ-CREATE maximum access , setting this object 
+         statically binds the authenticating logical system with the PPP
+         interface.  If this object is not explicitly set or it is set to null
+         string, then this object is ignored and the virtual router used for
+         authentication is determined by other means. 
+         On a Set operation, if the value of this object is not null and does 
+         not correspond to an existing virtual router, then an
+         inconsistentValue error is returned. Setting this object to a non-null
+        string returns inconsistentValue error if jnxPppLinkConfigAuthentication
+        object is none(0) or not configured."
+    ::= { jnxPppLinkConfigEntry 11 }
+
+jnxPppLinkConfigAuthenticatorRoutingInstance OBJECT-TYPE
+    SYNTAX             OCTET STRING
+    MAX-ACCESS         read-only
+    STATUS             current
+    DESCRIPTION
+        "The name of the routing instancebe used for authentication on the 
+        PPP interface. With READ-CREATE maximum access, setting this object 
+        statically binds the authenticating routing instance with the PPP 
+        interface.If this object is not explicitly set or it is set to null
+        string, then this object is ignored and the virtual router used for
+        authentication is determined by other means.  On a Set operation,
+        if the value of this object is not null and does not correspond to
+       an existing virtual router, then an inconsistentValue error is returned.
+       Setting this object to a non-null string returns inconsistentValue error
+       if jnxPppLinkConfigAuthentication object is
+          none(0) or not configured."
+    ::= { jnxPppLinkConfigEntry 12 }
+
+
+jnxPppLinkConfigAaaProfile OBJECT-TYPE
+    SYNTAX            OCTET STRING
+    MAX-ACCESS        read-only
+    STATUS             current
+    DESCRIPTION
+        "The name of the AAA profile to be used for authentication on the
+         PPP interface. With READ-CREATE maximum access, setting this 
+         object statically binds the AAA profile with the PPP interface.
+         If this object is not explicitly set or it is set to null string, 
+         then this object is ignored.  On a Set operation, if the value of 
+         this object is not null and does not correspond to an existing
+         AAA profile, then an inconsistentValue error is returned."
+    ::= { jnxPppLinkConfigEntry 13 }
+
+jnxPppLinkConfigAuthentication2 OBJECT-TYPE
+    SYNTAX         JnxNibbleConfig
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+        "A configuration variable comprised of nibbles i.e. 4 bits, such
+         that a client can supply a list of 0 to 8 selections.  The least
+          significant nibble is the first value of the list, and the most
+          significant nibble is the last value.  The value in each field 
+          ranges from 0 to 15, however the first nibble with value 0 
+          indicates the end of the list.  Repetition of values is not allowed.
+          Segregation
+           of values is not allowed.
+
+         Valid Values are:
+         none - 0
+         pap  - 1
+         chap - 2
+         eap  - 3
+
+         Example valid encoding:
+         0x00000321
+         0x00000012
+
+         Not a valid encoding:
+         0x00000121
+         0x01002001
+
+         If authentication negotiation is not supported for this PPP interface
+        and with READ-CREATE maximum access ,any attempt to explicitly set this
+         object will result in a notWritable error and it will be implicitly 
+        set to the DEFVAL on row creation. Setting this object to null will set
+        jnxPppLinkConfigAuthenticatorRoutingInstance object to an empty string.
+        Setting this object along with the jnxPppLinkConfigAuthentication object
+         will return an inconsistentValue error."
+    DEFVAL    { 0 }
+    ::= { jnxPppLinkConfigEntry 14 }
+    
+jnxPppLinkConfigIgnoreMagicNumberMismatch OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+        "The ignore magic number mismatch option of the PPP interface determines
+         the action to be taken, when the peer has not negotiated any value yet 
+         sent null or invalid magic number in the LCP echo packets.
+         The two actions
+         that can be configured are:
+            1)	Ignore the mismatch and retain connection
+            2)	Disallow the mismatch and terminate connection"
+    DEFVAL    { disable }
+    ::= { jnxPppLinkConfigEntry 15 }
+
+jnxPppLinkConfigMaxLcpRenegotiation OBJECT-TYPE
+    SYNTAX      Integer32 (1..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum number of allowed lcp renegotiation attempts from peer."
+    DEFVAL    { 30 }
+    ::= { jnxPppLinkConfigEntry 16 }
+
+
+--
+-- IfIndex selection for creating new PPP interfaces in jnxPppLinkConfigTable.
+--
+-- NOTE: This object is placed after jnxPppLinkConfigTable so
+-- that jnxPppLinkStatusTable and jnxPppLinkConfigTable have the
+-- same relative MIB node positions below the jnxPppLcp node
+-- (jnxPppLcp.1 and jnxPppLcp.2, respectively) as their counterpart
+-- Status and Config tables in RFC1471.
+--
+jnxPppNextIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Coordinate ifIndex value allocation for entries in the 
+       jnxPppLinkConfigTable. A GET of this object returns the next available
+       ifIndex value to be used to create an entry in the associated interface
+       table; or zero, if no valid ifIndex value is available.This object
+       also returns a value of zero when it is the lexicographic successor
+       of a varbind presented in an SNMP GETNEXT or GETBULK request, for which
+       circumstance it is assumed that ifIndex allocation is unintended.
+       Successive GETs will typically return different values, thus avoiding
+       collisions among cooperating management clients seeking to create table
+       entries simultaneously."
+    ::= { jnxPppLcp 3 }
+
+
+
+
+-- ////////////////////////////////////////////////////////////////////////////
+-- PPP Security
+-- This section defines objects used to manage the PPP Security
+-- functionality of PPP.
+-- ////////////////////////////////////////////////////////////////////////////
+-- No objects are currently defined.
+-- ////////////////////////////////////////////////////////////////////////////
+-- PPP IP NCP
+-- This section defines objects used to manage the PPP Network Control Protocol
+-- for IP protocol operation (IPCP).
+-- /////////////////////////////////////////////////////////////////////////////
+-- The PPP IP Table
+jnxPppIpTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppIpEntry
+    MAX-ACCESS   not-accessible
+    STATUS             current
+    DESCRIPTION
+        "Table containing the IP parameters for the local PPP entity."
+    ::= { jnxPppIp 1 }
+
+jnxPppIpEntry OBJECT-TYPE
+    SYNTAX      JnxPppIpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "IPCP status information for a particular PPP link."
+    INDEX     { ifIndex }
+    ::= { jnxPppIpTable 1 }
+
+JnxPppIpEntry ::= SEQUENCE {
+    jnxPppIpServiceStatus                      INTEGER,
+    jnxPppIpTerminateReason                    INTEGER,
+    jnxPppIpTerminateNegFailOption             INTEGER,
+    jnxPppIpLocalIpAddress                     IpAddress,
+    jnxPppIpRemoteIpAddress                    IpAddress,
+    jnxPppIpRemotePrimaryDnsAddress            IpAddress,
+    jnxPppIpRemoteSecondaryDnsAddress          IpAddress,
+    jnxPppIpRemotePrimaryWinsAddress           IpAddress,
+    jnxPppIpRemoteSecondaryWinsAddress         IpAddress,
+    jnxPppIpNetworkStatusIpcpRenegoTerminates  Counter32}
+
+jnxPppIpServiceStatus OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates whether IP protocol service is operating over this PPP link.
+         Service is established on this link through means outside this MIB."
+    ::= { jnxPppIpEntry 1 }
+
+jnxPppIpTerminateReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    noService(2),
+                    admin(3),
+                    linkDown(4),
+                    peerTerminated(5),
+                    peerRenegotiated(6),
+                    maxRetriesExceeded(7),
+                    negotiationFailure(8) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reason the IPCP link was terminated:
+            none                    None.
+            other                   Not specified.
+            noService               No IP service configured on this PPP link.
+            admin                   Administratively disabled.
+            linkDown                Underlying link is down.
+            peerTerminated          Peer initiated termination.
+            peerRenegotiated        Peer initiated renegotiation.
+            maxRetriesExceeded      Maximum number of config retries exceeded.
+            negotiationFailure      Failed to negotiate IPCP option.  See                                
+             jnxPppIpTerminateNegFailOption."
+    ::= { jnxPppIpEntry 2 }
+
+jnxPppIpTerminateNegFailOption OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    localIpAddress(2),
+                    remoteIpAddress(3),
+                    remotePrimaryDnsAddress(4),
+                    remoteSecondaryDnsAddress(5),
+                    remotePrimaryWinsAddress(6),
+                    remoteSecondaryWinsAddress(7),
+                    localIpAddressMask(8),
+                    remoteIpAddressMask(9) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reports the PPP IPCP option for which negotiation failed, when 
+        jnxPppIpTerminateReason has the value 'negotiationFailure'."
+    ::= { jnxPppIpEntry 3 }
+
+jnxPppIpLocalIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "IP Address used by the local side."
+    ::= { jnxPppIpEntry 4 }
+
+jnxPppIpRemoteIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "IP Address used by the remote side."
+    ::= { jnxPppIpEntry 5 }
+
+jnxPppIpRemotePrimaryDnsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Primary DNS server used by the remote side."
+    ::= { jnxPppIpEntry 6 }
+
+jnxPppIpRemoteSecondaryDnsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Secondary DNS server used by the remote side."
+    ::= { jnxPppIpEntry 7 }
+
+jnxPppIpRemotePrimaryWinsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Primary WINS server used by the remote side."
+    ::= { jnxPppIpEntry 8 }
+
+jnxPppIpRemoteSecondaryWinsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Secondary WINS server used by the remote side."
+    ::= { jnxPppIpEntry 9 }
+
+jnxPppIpNetworkStatusIpcpRenegoTerminates OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of times ipcp terminated due to peer exceeding max 
+        renegotiation attempts."
+    ::= { jnxPppIpEntry 10 }
+
+--
+-- The PPP IP Config Table
+--
+jnxPppIpConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppIpConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table containing the IP parameters for the local PPP entity."
+    ::= { jnxPppIp 2 }
+
+jnxPppIpConfigEntry OBJECT-TYPE
+    SYNTAX      JnxPppIpConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "IPCP configuration information for a particular PPP link."
+    INDEX     { ifIndex }
+    ::= { jnxPppIpConfigTable 1 }
+
+JnxPppIpConfigEntry ::= SEQUENCE {
+    jnxPppIpConfigPeerDnsPriority      INTEGER,
+    jnxPppIpConfigPeerWinsPriority     INTEGER,
+    jnxPppIpConfigIpcpNetmask          INTEGER,
+    jnxPppIpConfigInitiateIp           INTEGER,
+    jnxPppIpConfigMaxIpcpRenegotiation Integer32,
+    jnxPppIpConfigPromptIpcpDnsOption  INTEGER,
+    jnxPppIpConfigIpcpLockout          INTEGER}
+
+jnxPppIpConfigPeerDnsPriority OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "When enabled, allows peer's DNS address to prevail in the event of a 
+        negotiation conflict; when disabled, the local PPP interface's DNS 
+        address prevails."
+    ::= { jnxPppIpConfigEntry 1 }
+
+jnxPppIpConfigPeerWinsPriority OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "When enabled, allows peer's WINS address to prevail in the event of a 
+        negotiation conflict; when disabled, the local PPP interface's WINS
+         address prevails."
+    ::= { jnxPppIpConfigEntry 2 }
+
+jnxPppIpConfigIpcpNetmask OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables the negotiation of the IPCP option netmask (0x90) during 
+        IPCP negotiation."
+    DEFVAL    { disable }
+    ::= { jnxPppIpConfigEntry 3 }
+
+jnxPppIpConfigInitiateIp OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables the initiation of negotiation of the IPCP."
+    DEFVAL    { disable }
+    ::= { jnxPppIpConfigEntry 4 }
+
+jnxPppIpConfigMaxIpcpRenegotiation OBJECT-TYPE
+    SYNTAX      Integer32 (1..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum number of allowed ipcp renegotiation attempts from peer."
+    DEFVAL    { 30 }
+    ::= { jnxPppIpConfigEntry 5 }
+
+jnxPppIpConfigPromptIpcpDnsOption OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Control prompting of IPCP DNS option to remote peer."
+    DEFVAL    { disable }
+    ::= { jnxPppIpConfigEntry 6 }
+
+jnxPppIpConfigIpcpLockout OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables IPCP lockout. It determines whether this NCP can be negotiated
+         when the interface is already running a different NCP. On enabling 
+         this option, the IPCP negotiation will be blocked after a different 
+         NCP service is up and waited for 10 seconds for IPCP initiation 
+         from peer."
+    DEFVAL    { disable }
+    ::= { jnxPppIpConfigEntry 7 }
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- PPP OSI NCP
+-- This section defines objects used to manage the PPP Network Control Protocol
+-- for OSI protocol operation (OSICP). The IETF does not define a standard MIB
+-- for managing an OSI NCP. For consistency, this MIB follows the model of 
+--- RFC1473 for IP NCP: 
+-- A status table reports the condition of the NCP state machine, and the outcome 
+--of option parameter negotiation (if any) when the OperStatus object has the
+-- value 'opened(1)'; a configuration table provides administrative control over
+-- the NCP state machine, and permits configuration of proposed option parameter
+-- values (if any) to be used during NCP negotiation.
+-- /////////////////////////////////////////////////////////////////////////////
+-- PPP OSI Status Table
+--
+jnxPppOsiTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppOsiEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table containing the OSI parameters for the local PPP entity."
+    ::= { jnxPppOsi 1 }
+
+jnxPppOsiEntry OBJECT-TYPE
+    SYNTAX      JnxPppOsiEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "OSICP status information for a particular PPP link."
+    INDEX     { ifIndex }
+    ::= { jnxPppOsiTable 1 }
+
+JnxPppOsiEntry ::= SEQUENCE {
+    jnxPppOsiServiceStatus          INTEGER,
+    jnxPppOsiOperStatus             INTEGER,
+    jnxPppOsiTerminateReason        INTEGER,
+    jnxPppOsiTerminateNegFailOption INTEGER,
+    jnxPppOsiLocalAlignNpdu         INTEGER,
+    jnxPppOsiRemoteAlignNpdu        INTEGER }
+
+jnxPppOsiServiceStatus OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates whether OSI protocol service is operating over this PPP link.
+         Service is established on this link through means outside this MIB."
+    ::= { jnxPppOsiEntry 1 }
+
+jnxPppOsiOperStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    opened(1),
+                    notOpened(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The operational status of the OSI network protocol.  If the value of
+         this object is up then the finite state machine for the OSI network
+          protocol has reached the Opened state."
+    ::= { jnxPppOsiEntry 2 }
+
+jnxPppOsiTerminateReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    noService(2),
+                    admin(3),
+                    linkDown(4),
+                    peerTerminated(5),
+                    peerRenegotiated(6),
+                    maxRetriesExceeded(7),
+                    negotiationFailure(8) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reason the OSICP link was terminated:
+            none                    None.
+            other                   Not specified.
+            noService               No OSI service configured on this PPP link.
+            admin                   Administratively disabled.
+            linkDown                Underlying link is down.
+            peerTerminated          Peer initiated termination.
+            peerRenegotiated        Peer initiated renegotiation.
+            maxRetriesExceeded      Maximum number of config retries exceeded.
+            negotiationFailure      Failed to negotiate IPCP option.  See
+                                    jnxPppOsiTerminateNegFailOption."
+    ::= { jnxPppOsiEntry 3 }
+
+jnxPppOsiTerminateNegFailOption OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    localAlignNpdu(2),
+                    remoteAlignNpdu(3) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reports the PPP OSICP option for which negotiation failed, when 
+        jnxPppOsiTerminateReason has the value 'negotiationFailure'."
+    ::= { jnxPppOsiEntry 4 }
+
+jnxPppOsiLocalAlignNpdu OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    oneModulo4(1),
+                    twoModulo4(2),
+                    threeModulo4(3),
+                    fourModulo4(4),
+                    even(254),
+                    odd(255) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Local alignment of network PDU:
+            none            No alignment specified.
+            oneModulo4      Alignment on first octet (out of four).
+            twoModulo4      Alignment on second octet (out of four).
+            threeModulo4    Alignment on third octet (out of four).
+            fourModulo4     Alignment on fourth octet (out of four).
+            even            Alignment on even-octet boundary.
+            odd             Alignment on odd-octet boundary."
+    ::= { jnxPppOsiEntry 5 }
+
+jnxPppOsiRemoteAlignNpdu OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    oneModulo4(1),
+                    twoModulo4(2),
+                    threeModulo4(3),
+                    fourModulo4(4),
+                    even(254),
+                    odd(255) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Remote alignment of network PDU.
+            none            No alignment specified.
+            oneModulo4      Alignment on first octet (out of four).
+            twoModulo4      Alignment on second octet (out of four).
+            threeModulo4    Alignment on third octet (out of four).
+            fourModulo4     Alignment on fourth octet (out of four).
+            even            Alignment on even-octet boundary.
+            odd             Alignment on odd-octet boundary."
+    ::= { jnxPppOsiEntry 6 }
+
+--
+-- The PPP OSI Configuration Table
+--
+jnxPppOsiConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppOsiConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table containing configuration variables for the OSICP for the 
+        local PPP entity."
+    ::= { jnxPppOsi 2 }
+
+jnxPppOsiConfigEntry   OBJECT-TYPE
+    SYNTAX      JnxPppOsiConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "OSICP information for a particular PPP link."
+    INDEX     { ifIndex }
+    ::= { jnxPppOsiConfigTable 1 }
+
+JnxPppOsiConfigEntry ::= SEQUENCE {
+    jnxPppOsiConfigAdminStatus  INTEGER }
+
+jnxPppOsiConfigAdminStatus   OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    open(1),
+                    close(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The immediate desired status of the OSI network protocol. 
+         Setting this object to open will inject an administrative open event
+          into the OSI network protocol's finite state machine.  Setting this
+           object to close will inject an administrative close event into the
+            OSI network protocol's finite state machine."
+    ::= { jnxPppOsiConfigEntry 1 }
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- PPP Session
+-- This section defines objects used to manage the PPP sessions.
+-- The jnxPppSessionTable provides status of each PPP session.
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- The PPP Session Table
+--
+jnxPppSessionTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppSessionEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for PPP interfaces present in the system."
+    ::= { jnxPppSession 1 }
+
+jnxPppSessionEntry OBJECT-TYPE
+    SYNTAX      JnxPppSessionEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry describes the characteristics of a PPP interface."
+    INDEX     { ifIndex }
+    ::= { jnxPppSessionTable 1 }
+
+JnxPppSessionEntry ::= SEQUENCE {
+    jnxPppSessionGrant                         TruthValue,
+    jnxPppSessionTerminateReason               INTEGER,
+    jnxPppSessionStartTime                     TimeTicks,
+    jnxPppSessionInOctets                      Counter32,
+    jnxPppSessionOutOctets                     Counter32,
+    jnxPppSessionInPackets                     Counter32,
+    jnxPppSessionOutPackets                    Counter32,
+    jnxPppSessionSessionTimeout                Integer32,
+    jnxPppSessionInactivityTimeout             Integer32,
+    jnxPppSessionAccountingInterval            Integer32,
+    jnxPppSessionRemoteIpAddress               IpAddress,
+    jnxPppSessionRemotePrimaryDnsAddress       IpAddress,
+    jnxPppSessionRemoteSecondaryDnsAddress     IpAddress,
+    jnxPppSessionRemotePrimaryWinsAddress      IpAddress,
+    jnxPppSessionRemoteSecondaryWinsAddress    IpAddress,
+    jnxPppSessionRemoteIpv6AddressIfIdentifier Ipv6AddressIfIdentifier,
+    jnxPppSessionInhibitIp                     INTEGER,
+    jnxPppSessionInhibitIpv6                   INTEGER,
+    jnxPppSessionInOctets64                    Counter64,
+    jnxPppSessionOutOctets64                   Counter64,
+    jnxPppSessionInPackets64                   Counter64,
+    jnxPppSessionOutPackets64                  Counter64}
+
+jnxPppSessionGrant OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates whether a session has been granted via the authentication
+        mechanism."
+    ::= { jnxPppSessionEntry 1 }
+
+jnxPppSessionTerminateReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    unknown(1),
+                    userRequest(2),
+                    keepaliveFailure(3),
+                    sessionTimeout(4),
+                    inactivityTimeout(5),
+                    adminDisable(6),
+                    lowerLayerDown(7),
+                    noUpperInterface(8),
+                    deny(9),
+                    noHardware(10),
+                    noResources(11),
+                    noInterface(12),
+                    challengeTimeout(13),
+                    requestTimeout(14),
+                    authenticatorTimeout(15),
+                    addressLeaseExpired(16),
+                    adminLogout(17),
+                    tunnelFailed(18) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The reason the session was terminated."
+    ::= { jnxPppSessionEntry 2 }
+
+jnxPppSessionStartTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The value of sysUpTime when this session last became active."
+    ::= { jnxPppSessionEntry 3 }
+
+jnxPppSessionInOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "octets"
+    MAX-ACCESS  read-only
+    STATUS      deprecated 
+    DESCRIPTION
+        "Number of octets received since this session last became active, as 
+        denoted by jnxPppSessionStartTime. This has been deprecated and 
+        replaced by jnxPppSessionInOctets64"
+    ::= { jnxPppSessionEntry 4 }
+
+jnxPppSessionOutOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "octets"
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of octets sent since this session last became active, as 
+        denoted by jnxPppSessionStartTime. This has been deprecated and
+        replaced by jnxPppSessionOutOctets64"
+    ::= { jnxPppSessionEntry 5 }
+
+jnxPppSessionInPackets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "packets"
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of packets received since this session last became active, as
+         denoted by jnxPppSessionStartTime. This has been deprecated and
+         replaced by jnxPppSessionInPackets64"
+    ::= { jnxPppSessionEntry 6 }
+
+jnxPppSessionOutPackets OBJECT-TYPE
+    SYNTAX      Counter32
+    UNITS       "packets"
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Number of packets sent since this session last became active, as 
+        denoted by jnxPppSessionStartTime. This has been deprecated and
+        replaced by jnxPppSessionOutPackets64"
+    ::= { jnxPppSessionEntry 7 }
+
+jnxPppSessionSessionTimeout OBJECT-TYPE
+    SYNTAX      Integer32 (0..2147483647)
+    UNITS       "milliseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum duration for the session, after which the session terminates
+         automatically."
+    ::= { jnxPppSessionEntry 8 }
+
+jnxPppSessionInactivityTimeout OBJECT-TYPE
+    SYNTAX      Integer32 (0..2147483647)
+    UNITS       "milliseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum inactivity duration for the session, after which the session
+         terminates automatically."
+    ::= { jnxPppSessionEntry 9 }
+
+jnxPppSessionAccountingInterval OBJECT-TYPE
+    SYNTAX      Integer32 (0..2147483647)
+    UNITS       "milliseconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Interval that must elapse between generation of accounting records
+         for this session."
+    ::= { jnxPppSessionEntry 10 }
+
+jnxPppSessionRemoteIpAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Remote IP address, obtained from the authentication service, to be 
+        used during IPCP negotiation with the remote side."
+    ::= { jnxPppSessionEntry 11 }
+
+jnxPppSessionRemotePrimaryDnsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Remote primary DNS IP address, obtained from the authentication 
+        service, to be used during IPCP negotiation with the remote side."
+    ::= { jnxPppSessionEntry 12 }
+
+jnxPppSessionRemoteSecondaryDnsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Remote secondary DNS IP address, obtained from the authentication 
+        service, to be used during IPCP negotiation with the remote side."
+    ::= { jnxPppSessionEntry 13 }
+
+jnxPppSessionRemotePrimaryWinsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Remote primary WINS IP address, obtained from the authentication
+         service, to be used during IPCP negotiation with the remote side."
+    ::= { jnxPppSessionEntry 14 }
+
+jnxPppSessionRemoteSecondaryWinsAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Remote secondary WINS IP address, obtained from the authentication
+         service, to be used during IPCP negotiation with the remote side."
+    ::= { jnxPppSessionEntry 15 }
+
+jnxPppSessionRemoteIpv6AddressIfIdentifier OBJECT-TYPE
+    SYNTAX      Ipv6AddressIfIdentifier
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "IPV6 Address Interface Identifier obtained from the authentication
+         service, to be used during IPCP negotiation with the remote side."
+    ::= { jnxPppSessionEntry 16 }
+
+jnxPppSessionInhibitIp OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates whether a session has had its IP service inhibited by the
+         authentication mechanism."
+    ::= { jnxPppSessionEntry 17 }
+
+jnxPppSessionInhibitIpv6 OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates whether a session has had its IPv6 service inhibited by the
+         authentication mechanism."
+    ::= { jnxPppSessionEntry 18 }
+
+jnxPppSessionInOctets64 OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of octets received since this session last became active, as 
+        denoted by jnxPppSessionStartTime."
+    ::= { jnxPppSessionEntry 19 }
+
+jnxPppSessionOutOctets64 OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "octets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of octets sent since this session last became active, as 
+        denoted by jnxPppSessionStartTime."
+    ::= { jnxPppSessionEntry 20 }
+
+jnxPppSessionInPackets64 OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received since this session last became active, as
+         denoted by jnxPppSessionStartTime."
+    ::= { jnxPppSessionEntry 21 }
+
+jnxPppSessionOutPackets64 OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "packets"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets sent since this session last became active, as 
+        denoted by jnxPppSessionStartTime."
+    ::= { jnxPppSessionEntry 22 }
+
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- Multi-Link PPP  (MLPPP)
+-- This section defines objects used to manage the MLPPP.
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- The MLPPP BundleTable
+--
+jnxPppMlPppBundleTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppMlPppBundleEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for MLPPP bundles present in the system."
+    ::= { jnxPppMlPpp 1 }
+
+jnxPppMlPppBundleEntry OBJECT-TYPE
+    SYNTAX      JnxPppMlPppBundleEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry describes the characteristics of a MLPPP bundle."
+    INDEX     { jnxPppMlPppBundleName }
+    ::= { jnxPppMlPppBundleTable 1 }
+
+JnxPppMlPppBundleEntry ::= SEQUENCE {
+    jnxPppMlPppBundleName           JnxPppMlPppBundleName,
+    jnxPppMlPppBundleRowStatus      RowStatus,
+    jnxPppMlPppBundleNetworkIfIndex InterfaceIndex }
+
+jnxPppMlPppBundleName OBJECT-TYPE
+    SYNTAX      JnxPppMlPppBundleName
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The administrative name of the MLPPP bundle associated with this
+         MLPPP network interface."
+    ::= { jnxPppMlPppBundleEntry 1 }
+
+jnxPppMlPppBundleRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The rowStatus for this entry.  The following sets are supported 
+        with read-create maximum access:
+             createAndGo(4),
+             destroy(6)
+
+         The following values can be read from this object:
+             active(1) "
+    ::= { jnxPppMlPppBundleEntry 2 }
+
+jnxPppMlPppBundleNetworkIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of this MLPPP network interface.  It is a valid ifIndex
+         even if there is no corresponding network interface instance in 
+         the jnxPppMlPppLinkConfigTable."
+    ::= { jnxPppMlPppBundleEntry 3 }
+
+--
+-- IfIndex selection for creating new MLPPP Link interfaces in
+-- jnxPppLinkConfigTable.
+--
+-- NOTE: This object is placed after jnxPppLinkConfigTable so that jnxPppLinkStatusTable and jnxPppLinkConfigTable have the same relative MIB node positions below the jnxPppLcp node (jnxPppLcp.1 and jnxPppLcp.2, respectively) as their counterpart Status and Config tables in RFC1471.
+
+jnxPppMlPppNextLinkIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Coordinate ifIndex value allocation for entries in 
+        jnxPppMlPppLinkConfigTable. A GET of this object returns the next 
+        available ifIndex value to be used to create an entry in the 
+        associated interface table; or zero, if no valid ifIndex value is
+        available.  This object also returns a value of zero when it is the
+        lexicographic successor of a varbind presented in an SNMP GETNEXT 
+        or GETBULK request, for which circumstance it is assumed that ifIndex
+        allocation is unintended. Successive GETs will typically return 
+        different values, thus avoiding collisions among cooperating management
+        clients seeking to create table entries simultaneously."
+    ::= { jnxPppMlPpp 2 }
+
+--
+-- The MLPPP Link Configuration Table
+--
+jnxPppMlPppLinkConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppMlPppLinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for MLPPP interfaces present in the system."
+    ::= { jnxPppMlPpp 3 }
+
+jnxPppMlPppLinkConfigEntry OBJECT-TYPE
+    SYNTAX      JnxPppMlPppLinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry describes the characteristics of MLPPP interface. 
+        With read-create maximum access,creating/deleting entries in this
+        table causes corresponding entries for be created/deleted in
+       ifTable/ifXTable/jnxIfTable."
+    INDEX     { jnxPppMlPppLinkConfigIfIndex }
+    ::= { jnxPppMlPppLinkConfigTable 1 }
+
+JnxPppMlPppLinkConfigEntry ::= SEQUENCE {
+    jnxPppMlPppLinkConfigIfIndex                      InterfaceIndex,
+    jnxPppMlPppLinkConfigLowerIfIndex                 InterfaceIndexOrZero,
+    jnxPppMlPppLinkConfigKeepalive                    Integer32,
+    jnxPppMlPppLinkConfigAuthentication               JnxPppAuthentication,
+    jnxPppMlPppLinkConfigMaxAuthenRetries             Integer32,
+    jnxPppMlPppLinkConfigRowStatus                    RowStatus,
+    jnxPppMlPppLinkConfigAaaProfile                   OCTET STRING,
+    jnxPppMlPppLinkConfigChapMinChallengeLength       Integer32,
+    jnxPppMlPppLinkConfigChapMaxChallengeLength       Integer32,
+    jnxPppMlPppLinkConfigPassiveMode                  INTEGER,
+    jnxPppMlPppLinkConfigAuthenticatorLogicalSystem   OCTET STRING,
+    jnxPppMlPppLinkConfigAuthenticatorRoutingInstance OCTET STRING,
+    jnxPppMlPppLinkConfigFragmentation                INTEGER,
+    jnxPppMlPppLinkConfigReassembly                   INTEGER,
+    jnxPppMlPppLinkConfigMaxReceiveReconstructedUnit  Integer32,
+    jnxPppMlPppLinkConfigFragmentSize                 Integer32,
+    jnxPppMlPppLinkConfigHashLinkSelection            INTEGER,
+    jnxPppMlPppLinkConfigAuthentication2              JnxNibbleConfig,
+    jnxPppMlPppLinkConfigIgnoreMagicNumberMismatch    INTEGER,
+    jnxPppMlPppLinkConfigMultilinkMulticlass          INTEGER,
+    jnxPppMlPppLinkConfigMultilinkMaxMultiClasses     INTEGER}
+
+jnxPppMlPppLinkConfigIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of the MLPPP interface.  When creating entries in this 
+        table, suitable values for this object are determined by reading 
+        jnxPppMlPppNextLinkIfIndex."
+    ::= { jnxPppMlPppLinkConfigEntry 1 }
+
+jnxPppMlPppLinkConfigLowerIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of an interface over which this PPP interface is to be 
+        layered.  A value of zero indicates no layering.  An implementation 
+        may choose to require that a non-zero value be configured at entry
+         creation."
+    ::= { jnxPppMlPppLinkConfigEntry 2 }
+
+jnxPppMlPppLinkConfigKeepalive OBJECT-TYPE
+    SYNTAX      Integer32 (0|10..64800)
+    UNITS       "seconds"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Keepalive interval in seconds.  A value of zero disables keepalive.
+         Keepalive is performed using LCP Echo."
+    DEFVAL    { 30 }
+    ::= { jnxPppMlPppLinkConfigEntry 4 }
+
+jnxPppMlPppLinkConfigAuthentication OBJECT-TYPE
+    SYNTAX      JnxPppAuthentication
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+        "Specifies the type(s) of authentication, if any, to be 
+        negotiated with the peer:
+          none      No authentication is negotiated.
+          pap       PAP negotiation only.
+          chap      CHAP negotiation only.
+          papChap   PAP negotiation is attempted first; if fails, attempt CHAP.
+          chapPap   CHAP negotiation is attempted first; if fails, attempt PAP.
+
+       If authentication negotiation is not supported for this MLPPP interface,
+       then any attempt to explicitely set this object will result in a 
+       notWritable error and it will be implicitily set to the DEFVAL on
+       row creation. 
+       This object returns a none (0) value on the get operation.
+       New object jnxPppMlPppLinkConfigAuthentication2 will reflect the configured 
+       values. Setting this object along with the jnxPppMlPppLinkConfigAuthentication2
+        object will return an inconsistentValue error."
+    DEFVAL    { none }
+    ::= { jnxPppMlPppLinkConfigEntry 5 }
+
+jnxPppMlPppLinkConfigMaxAuthenRetries OBJECT-TYPE
+    SYNTAX      Integer32 (0..7)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of authentication retries permitted, in addition to a
+         failed initial attempt.  If all retries fail, the link is reset."
+    DEFVAL    { 0 }
+    ::= { jnxPppMlPppLinkConfigEntry 6 }
+
+jnxPppMlPppLinkConfigRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with read-carete 
+        maximum access,according to the RowStatus textual convention, 
+        constrained to support the following values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST be 
+        explicitly configured:
+            jnxPppMlPppLinkConfigRowStatus
+            jnxPppMlPppLinkConfigLowerIfIndex
+        In addition, when creating an entry the following conditions must hold:
+            A value for jnxPppMlPppLinkConfigIndex must have been
+             determined previously, by reading jnxPppMlPppNextIfIndex. 
+             The interface identified by jnxPppMlPppLinkConfigLowerIfIndex
+             must exist.
+            A corresponding entry in ifTable/ifXTable/jnxIfTable is 
+            created/destroyed as a result of creating/destroying an entry in 
+            this table.
+
+        The following values can be read from this object:
+             active(1) "
+    ::= { jnxPppMlPppLinkConfigEntry 7 }
+
+jnxPppMlPppLinkConfigAaaProfile OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The name of the AAA profile to be used for authentication on the 
+        PPP interface.Setting this object statically binds the AAA profile
+        with the PPP interface. If this object is not explicitly set or it
+        is set to null string, then this object is ignored. On a Set operation,
+        if the value of this object is not null and does not correspond to an
+         existin AAA profile, then an inconsistentValue error is returned."
+    ::= { jnxPppMlPppLinkConfigEntry 8 }
+
+jnxPppMlPppLinkConfigChapMinChallengeLength OBJECT-TYPE
+    SYNTAX      Integer32 (8..63)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Minimum value of the CHAP authenticator challenge length value.
+       This value is never allowed to be set to a value greater than 
+       jnxPppMlPppLinkConfigChapMaxChallengeLength."
+    DEFVAL    { 16 }
+    ::= { jnxPppMlPppLinkConfigEntry 9 }
+
+jnxPppMlPppLinkConfigChapMaxChallengeLength OBJECT-TYPE
+    SYNTAX      Integer32 (8..63)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum value of the CHAP authenticator challenge length value."
+    DEFVAL    { 32 }
+    ::= { jnxPppMlPppLinkConfigEntry 10 }
+
+jnxPppMlPppLinkConfigPassiveMode OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "When enabled, LCP state machine is forced into passive mode on lower 
+        layer UP message.  It adds compatibility with slow and buggy clients."
+    DEFVAL    { disable }
+    ::= { jnxPppMlPppLinkConfigEntry 11 }
+
+jnxPppMlPppLinkConfigAuthenticatorLogicalSystem OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The name of the Logical System (Jnxper-ROUTER-MIB.jnxRouterName) to 
+        be used for authentication on the PPP interface.  Setting this object
+         statically binds the authenticating virtual router with the link interface.
+         With read-create maximum access, if this object is not explicitly set or 
+         it is set to null string, then this object is ignored and the
+          virtual router used for     authentication is determined by other means.
+            On a Set operation, if the value of this object is not null and does not
+             correspond to an existing virtual router, then an inconsistentValue
+              error is returned."
+    ::= { jnxPppMlPppLinkConfigEntry 12 }
+
+ jnxPppMlPppLinkConfigAuthenticatorRoutingInstance OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The name of the Routing Instance (Jnxper-ROUTER-MIB.jnxRouterName) 
+        to be used for authentication on the PPP interface.  Setting this 
+        object statically binds the authenticating virtual router with the 
+        link interface. With read-create maximum access, if this object is
+         not explicitly set or it is set to null string, then this object is
+          ignored and the virtual router used for     authentication is
+           determined by other means.  On a Set operation, if the value of
+            this object is not null and does not correspond to an existing
+             virtual router, then an inconsistentValue error is returned."
+    ::= { jnxPppMlPppLinkConfigEntry 13 }
+
+jnxPppMlPppLinkConfigFragmentation OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables MLPPP fragmentation.With read-create maximum access,
+        changing this object has an effect when the link is next restarted."
+    DEFVAL    { disable }
+    ::= { jnxPppMlPppLinkConfigEntry 14 }
+
+jnxPppMlPppLinkConfigReassembly OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables MLPPP reassembly. With read-create maximum access,
+         changing this object has an effect when the link is next restarted."
+    DEFVAL    { disable }
+    ::= { jnxPppMlPppLinkConfigEntry 15 }
+
+jnxPppMlPppLinkConfigMaxReceiveReconstructedUnit OBJECT-TYPE
+    SYNTAX      Integer32 (1|64..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Maximum Receive Reconstructed Unit (MRRU) that the local 
+        PPP entity will advertise to the remote entity.  If the value of
+        this variable is 1, then the MRRU is set to the local MRU value. 
+        With read-create maximum access, changing this object has an effect
+        when the link is next restarted."
+    DEFVAL    { 1 }
+    ::= { jnxPppMlPppLinkConfigEntry 16 }
+
+jnxPppMlPppLinkConfigFragmentSize OBJECT-TYPE
+    SYNTAX      Integer32 (1|128..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The size of fragments transmitted by the local PPP entity.
+        If the value of this variable is 1, then the fragment size is set to 
+        the link's MTU value. With read-create maximum access, 
+        changing this object has an effect when the link is next restarted."
+    DEFVAL    { 1 }
+    ::= { jnxPppMlPppLinkConfigEntry 17 }
+
+jnxPppMlPppLinkConfigHashLinkSelection OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables MLPPP hash-based link selection for non-best-effort traffic.
+        With read-create maximum access,changing this object has an effect
+         when the link is next restarted."
+    DEFVAL    { disable }
+    ::= { jnxPppMlPppLinkConfigEntry 18 }
+
+jnxPppMlPppLinkConfigAuthentication2 OBJECT-TYPE
+    SYNTAX      JnxNibbleConfig
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A configuration variable comprised of nibbles i.e. 4 bits, such 
+        that a client can supply a list of 0 to 8 selections.  The least
+         significant nibble is the first value of the list, and the most 
+         significant nibble is the last value.  The value in each field
+         ranges from 0 to 15, however the first nibble with value 0 indicates
+          the end of the list.  Repetition of values is not allowed. 
+          Segregation of values is not allowed.
+
+         Valid Values are:
+         none - 0
+         pap  - 1
+         chap - 2
+         eap  - 3
+
+         Example valid encoding:
+         0x00000321
+         0x00000012
+
+         Not a valid encoding:
+         0x00000121
+         0x01002001
+
+         If authentication negotiation is not supported for this PPP interface
+         and With read-create maximum access, then any attempt to explicitly 
+         set this object will result in a notWritable error and it will be 
+         implicitly set to the DEFVAL on row creation. Setting this object to 
+         null will set jnxPppMlPppLinkConfigAuthenticatorVirtualRouter object 
+         to an empty string.Setting this object along with the 
+         jnxPppMlPppLinkConfigAuthentication object will return an i
+         nconsistentValue error."
+    DEFVAL    { 0 }
+    ::= { jnxPppMlPppLinkConfigEntry 19 }
+    
+jnxPppMlPppLinkConfigIgnoreMagicNumberMismatch OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+       "The ignore magic number mismatch option of the PPP interface determines
+         the action to be taken, when the peer has not negotiated any value yet
+          sent null or invalid magic number in the LCP echo packets. The two 
+          actions that can be configured are:
+            1)	Ignore the mismatch and retain connection
+            2)	Disallow the mismatch and terminate connection"
+    DEFVAL    { disable }
+    ::= { jnxPppMlPppLinkConfigEntry 20 }
+
+jnxPppMlPppLinkConfigMultilinkMulticlass OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables Multiclass Multilink PPP (MCML). With read-create maximum
+         access,changing this object has an effect when the link is next
+          restarted."
+    DEFVAL    {disable}
+    ::= { jnxPppMlPppLinkConfigEntry 21 }
+
+jnxPppMlPppLinkConfigMultilinkMaxMultiClasses OBJECT-TYPE
+    SYNTAX      INTEGER (0..8)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum number of MCML classes to be negotiated.With read-create
+         maximum access,changing this object has an effect when the link
+          is next restarted."
+    DEFVAL    {0}
+    ::= { jnxPppMlPppLinkConfigEntry 22 }
+
+jnxPppMlPppNextNetworkIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Coordinate ifIndex value allocation for entries in
+        jnxPppMlPppNetworkConfigTable. A GET of this object returns the next
+        available ifIndex value to be used to create an entry in the associated
+        interface table; or zero, if no        valid ifIndex value is available.
+        This object also returns a value of zero when it is the lexicographic
+        successor of a varbind presented in an SNMP GETNEXT or GETBULK request,
+        for which circumstance it is assumed that ifIndex allocation 
+        is unintended. Successive GETs will typically return different values,
+         thus avoiding collisions among cooperating management clients seeking 
+         to create table entries simultaneously."
+    ::= { jnxPppMlPpp 4 }
+
+
+--
+-- The MLPPP Network Configuration Table
+--
+jnxPppMlPppNetworkConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppMlPppNetworkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for MLPPP network interfaces 
+        present in the system."
+    ::= { jnxPppMlPpp 5 }
+
+jnxPppMlPppNetworkConfigEntry OBJECT-TYPE
+    SYNTAX      JnxPppMlPppNetworkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry describes the characteristics of MLPPP interface.
+         With read-create maximum access,creating/deleting entries in 
+         this table causes corresponding entries for be created/deleted 
+         in ifTable/ifXTable/jnxIfTable."
+    INDEX     { jnxPppMlPppNetworkConfigIfIndex }
+    ::= { jnxPppMlPppNetworkConfigTable 1 }
+
+JnxPppMlPppNetworkConfigEntry ::= SEQUENCE {
+    jnxPppMlPppNetworkConfigIfIndex         InterfaceIndex,
+    jnxPppMlPppNetworkConfigLowerIfIndex    InterfaceIndex,
+    jnxPppMlPppNetworkBundleName            JnxPppMlPppBundleName,
+    jnxPppMlPppNetworkRowStatus             RowStatus }
+
+jnxPppMlPppNetworkConfigIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of the MLPPP network interface.  When creating entries
+         in this table, suitable values for this object are determined by 
+         reading jnxPppMlPppNextNetworkIfIndex."
+    ::= { jnxPppMlPppNetworkConfigEntry 1 }
+
+jnxPppMlPppNetworkConfigLowerIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of a PPP link interface over which this PPP network 
+        interface is to be layered.  On sets, the value of this object must 
+        equal on of the previously created PPP link interfaces created in 
+        the jnxPppMlPppLinkConfigTable.  On gets, the value of this object 
+        is the lexicographically least PPP link interface in a potential
+         bundle of PPP link interfaces."
+    ::= { jnxPppMlPppNetworkConfigEntry 2 }
+
+jnxPppMlPppNetworkBundleName OBJECT-TYPE
+    SYNTAX     JnxPppMlPppBundleName
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+        "The MLPPP bundle name administratively assigned."
+    ::= { jnxPppMlPppNetworkConfigEntry 3 }
+
+jnxPppMlPppNetworkRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with read-create
+         maximum access , according to the RowStatus textual convention,
+          constrained to support the following values only:
+            createAndGo
+            destroy
+        To create an entry in this table, the following entry objects MUST be 
+        explicitly configured:
+
+            jnxPppMlPppNetworkConfigLowerIfIndex
+            jnxPppMlPppNetworkBundleName
+            jnxPppMlPppNetworkConfigRowStatus
+
+        In addition, when creating an entry the following conditions must hold:
+           A value for jnxPppMlPppNetworkConfigIndex must have been determined
+            previously, by reading jnxPppMlPppNextNetworkIfIndex. The 
+            interface identified by jnxPppMlPppNetworkConfigLowerIfInde must 
+            exist by a creation request to the jnxPppMlPppLinkConfigTable.
+           The bundleName specified in jnxPppMlPppNetworkBundleName must have
+            been created first in the jnxPppMlPppBundleTable. A corresponding
+             entry in ifTable/ifXTable/jnxIfTable is created/destroyed as a 
+             result of creating/destroying an entry in this table.
+
+        The following values can be read from this object:
+             active(1) "
+    ::= { jnxPppMlPppNetworkConfigEntry 4 }
+
+
+--
+-- The MLPPP Link Bind Table
+--
+jnxPppMlPppLinkBindTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppMlPppLinkBindEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for MLPPP Link interface to MLPPP 
+        network interfaces bindings."
+    ::= { jnxPppMlPpp 6 }
+
+jnxPppMlPppLinkBindEntry OBJECT-TYPE
+    SYNTAX      JnxPppMlPppLinkBindEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry describes the MLPPP link interface to MLPPP network 
+        interface bindings."
+    INDEX     { jnxPppMlPppBindNetworkIfIndex,
+                jnxPppMlPppBindLinkIfIndex }
+    ::= { jnxPppMlPppLinkBindTable 1 }
+
+JnxPppMlPppLinkBindEntry ::= SEQUENCE {
+    jnxPppMlPppBindNetworkIfIndex   InterfaceIndex,
+    jnxPppMlPppBindLinkIfIndex      InterfaceIndex,
+    jnxPppMlPppBindRowStatus        RowStatus }
+
+jnxPppMlPppBindNetworkIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of the MLPPP network interface."
+    ::= { jnxPppMlPppLinkBindEntry 1 }
+
+jnxPppMlPppBindLinkIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of a MLPPP link interface bound by the MLPPP network
+         interface defined by jnxPppMlPppBindNetworkIfIndex."
+    ::= { jnxPppMlPppLinkBindEntry 2 }
+
+jnxPppMlPppBindRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with read-create
+         maximum access, according to the RowStatus textual convention, 
+         constrained to support the following values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST
+        be explicitly configured:
+            jnxPppMlPppBindRowStatus
+
+        In addition, when creating an entry the following conditions must hold:
+        The interfaces identified by jnxPppMlPppBindNetworkIfIndex and 
+        jnxPppMlPppBindLinkIfIndex must be created in the 
+        jnxPppMlPppNetworkConfigTable and jnxPppMlPppLinkConfigTable 
+        respectively. A MLPPP bundle must be associated with the 
+        jnxPppMlPppNetworkIfIndex and exist in the jnxPppMibPppBundleTable. 
+        A corresponding entry in ifStackTable is created/destroyed as a result
+         of creating/destroying an entry in this table.
+
+        The following values can be read from this object:
+             active(1) "
+    ::= { jnxPppMlPppLinkBindEntry 3 }
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- PPP Interface Summary Counts
+-- /////////////////////////////////////////////////////////////////////////////
+
+jnxPppSummaryPppInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces configured in the system."
+    ::= { jnxPppSummary 1 }
+
+jnxPppSummaryPppIpNCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number IP NCPs configured in the system."
+    ::= { jnxPppSummary 2 }
+
+jnxPppSummaryPppOsiNCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs configured in the system."
+    ::= { jnxPppSummary 3 }
+
+jnxPppSummaryPppIfAdminUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system that are
+         administratively configured to up(1)."
+    REFERENCE
+        "IF-MIB.ifAdminStatus"
+    ::= { jnxPppSummary 4 }
+
+jnxPppSummaryPppIfAdminDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system that are
+         administrateively configued to down(2)."
+    REFERENCE
+        "IF-MIB.ifAdminStatus"
+    ::= { jnxPppSummary 5 }
+
+jnxPppSummaryPppIfOperUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system with an 
+        operational state of up(1)."
+    REFERENCE
+        "IF-MIB.ifOperstatus"
+    ::= { jnxPppSummary 7 }
+
+jnxPppSummaryPppIfOperDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system with an 
+        operational state of down(2)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 8 }
+
+jnxPppSummaryPppIfOperDormant OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system with an
+         operational state of dormant(5)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 9 }
+
+jnxPppSummaryPppIfNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system with an 
+        operational state of notPresent(6)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 10 }
+
+jnxPppSummaryPppIfLowerLayerDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP interfaces in the system with an 
+        operational state of lowerLayerDown(7)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 11 }
+
+jnxPppSummaryPppIpNcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IP NCPs in the system with an
+         operational state of opened(1)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 12 }
+
+jnxPppSummaryPppIpNcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IP NCPs in the system with an 
+        operational state of not-opened(2)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 13 }
+
+jnxPppSummaryPppOsiNcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP OSI NCPs in the system with an 
+        operational state of opened."
+    ::= { jnxPppSummary 14 }
+
+jnxPppSummaryPppOsiNcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP OSI NCPs in the system with an 
+        operational state of closed."
+    ::= { jnxPppSummary 15 }
+
+jnxPppSummaryPppIfLastChangeTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The value of the sysUpTime at the time of the last PPP interface
+         creation or deletion in the system.  If the number of PPP interfaces has been unchanged since the last re-initialization of the system, then this object contains a zero value. "
+    ::= { jnxPppSummary 16 }
+
+jnxPppSummaryPppLinkInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces configured in the system."
+    ::= { jnxPppSummary 17 }
+
+jnxPppSummaryPppLinkIfAdminUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces in the system that are
+         administratively configured to up(1)."
+    REFERENCE
+        "IF-MIB.ifAdminStatus"
+    ::= { jnxPppSummary 18 }
+
+jnxPppSummaryPppLinkIfAdminDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces in the system that are
+         administrateively configued to down(2)."
+    REFERENCE
+        "IF-MIB.ifAdminStatus"
+    ::= { jnxPppSummary 19 }
+
+jnxPppSummaryPppLinkIfOperUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces in the system with an 
+        operational state of up(1)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 20 }
+
+jnxPppSummaryPppLinkIfOperDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces in the system with an
+         operational state of down(2)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 21 }
+
+jnxPppSummaryPppLinkIfOperDormant OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces in the system with an 
+        operational state of dormant(5)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 22 }
+
+jnxPppSummaryPppLinkIfNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP link interfaces in the system with an
+         operational state of notPresent(6)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 23 }
+
+jnxPppSummaryPppLinkIfLowerLayerDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP Link interfaces in the system with an 
+        operational state of lowerLayerDown(7)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 24 }
+
+jnxPppSummaryPppLinkIfLastChangeTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The value of the sysUpTime at the time of the last PPP Link interface
+         creation or deletion in the system.  If the number of PPP interfaces has been unchanged since the last re-initialization of the system, then this object contains a zero value. "
+    ::= { jnxPppSummary 25 }
+
+jnxPppSummaryPppNetworkInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces configured in the system."
+    ::= { jnxPppSummary 26 }
+
+jnxPppSummaryPppNetworkIpNCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number IP NCPs in the system configured on 
+        PPP network interfaces."
+    ::= { jnxPppSummary 27 }
+
+jnxPppSummaryPppNetworkOsiNCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system configured on 
+        PPP network interfaces."
+    ::= { jnxPppSummary 28 }
+
+jnxPppSummaryPppNetworkIfAdminUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system that are
+         administratively configured to up(1)."
+    REFERENCE
+        "IF-MIB.ifAdminStatus"
+    ::= { jnxPppSummary 29 }
+
+jnxPppSummaryPppNetworkIfAdminDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system that are 
+        administrateively configued to down(2)."
+    REFERENCE
+        "IF-MIB.ifAdminStatus"
+    ::= { jnxPppSummary 30 }
+
+jnxPppSummaryPppNetworkIfOperUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system with an
+         operational state of up(1)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 31 }
+
+jnxPppSummaryPppNetworkIfOperDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system with an 
+        operational state of down(2)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 32 }
+
+jnxPppSummaryPppNetworkIfOperDormant OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS   read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system with an
+         operational state of dormant(5)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 33 }
+
+jnxPppSummaryPppNetworkIfNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system with an
+         operational state of notPresent(6)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 34 }
+
+jnxPppSummaryPppNetworkIfLowerLayerDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP network interfaces in the system with an
+         operational state of lowerLayerDown(7)."
+    REFERENCE
+        "IF-MIB.ifOperStatus"
+    ::= { jnxPppSummary 35 }
+
+jnxPppSummaryPppNetworkIpNcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IP NCPs in the system with an operational 
+        state of opened(1)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 36 }
+
+jnxPppSummaryPppNetworkIpNcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IP NCPs in the system with an operational 
+        state of not-opened(2)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 37 }
+
+jnxPppSummaryPppNetworkOsiNcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP OSI NCPs in the system with an operational 
+        state of opened."
+    ::= { jnxPppSummary 38 }
+
+jnxPppSummaryPppNetworkOsiNcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP OSI NCPs in the system with an operational
+        state of closed."
+    ::= { jnxPppSummary 39 }
+
+jnxPppSummaryPppNetworkIfLastChangeTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The value of the sysUpTime at the time of the last PPP network
+        interface creation or deletion in the system.  If the number of PPP
+        network interfaces has been unchanged since the last re-initialization
+        of the system, then this object contains a zero value. "
+    ::= { jnxPppSummary 40 }
+
+jnxPppSummaryPppIpv6NCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number IPv6 NCPs configured in the system."
+    ::= { jnxPppSummary 41 }
+
+jnxPppSummaryPppIpv6NcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IPv6 NCPs in the system with an operational
+        state of opened(1)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 42 }
+
+jnxPppSummaryPppIpv6NcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IPv6 NCPs in the system with an operational
+        state of not-opened(2)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 43 }
+
+jnxPppSummaryPppNetworkIpv6NCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number IPv6 NCPs configured in the system."
+    ::= { jnxPppSummary 44 }
+
+jnxPppSummaryPppNetworkIpv6NcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IPv6 NCPs in the system with an operational
+        state of opened(1)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 45 }
+
+jnxPppSummaryPppNetworkIpv6NcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IPv6 NCPs in the system with an operational
+        state of not-opened(2)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 46 }
+
+jnxPppSummaryPppStaticInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of static PPP interfaces configured in the system."
+    ::= { jnxPppSummary 47 }
+
+jnxPppSummaryPppMplsNCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number MPLS NCPs configured in the system."
+    ::= { jnxPppSummary 48 }
+
+jnxPppSummaryPppIpAdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IP NCPs in the system that are
+        administratively configured to open(1)."
+    ::= { jnxPppSummary 49 }
+
+jnxPppSummaryPppIpAdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IP NCPs in the system that are
+        administratively configured to close(2)."
+    ::= { jnxPppSummary 50 }
+
+jnxPppSummaryPppIpv6AdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IPV6 NCPs in the system that are
+        administratively configured to open(1)."
+    ::= { jnxPppSummary 51 }
+
+jnxPppSummaryPppIpv6AdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IPV6 NCPs in the system that are
+        administratively configured to close(2)."
+    ::= { jnxPppSummary 52 }
+
+jnxPppSummaryPppOsiAdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system that are
+        administratively configured to open(1)."
+    ::= { jnxPppSummary 53 }
+
+jnxPppSummaryPppOsiAdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system that are
+        administratively configured to close(2)."
+    ::= { jnxPppSummary 54 }
+
+jnxPppSummaryPppMplsAdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system that are
+        administratively configured to open(1)."
+    ::= { jnxPppSummary 55 }
+
+jnxPppSummaryPppMplsAdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system that are
+        administratively configured to close(2)."
+    ::= { jnxPppSummary 56 }
+
+jnxPppSummaryPppIpNcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IP NCPs in the system with an operational state
+        of notPresent(3)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 57}
+
+jnxPppSummaryPppIpNcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IP NCPs in the system with an operational
+        state of noResources(4)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 58 }
+
+jnxPppSummaryPppIpv6NcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IPV6 NCPs in the system with an operational state
+        of notPresent(3)."
+    ::= { jnxPppSummary 59 }
+
+jnxPppSummaryPppIpv6NcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP IPV6 NCPs in the system with an operational
+        state of noResources(4)."
+    ::= { jnxPppSummary 60 }
+
+jnxPppSummaryPppOsiNcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP OSI NCPs in the system with an operational state
+        of notPresent(3)."
+    ::= { jnxPppSummary 61 }
+
+jnxPppSummaryPppOsiNcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP OSI NCPs in the system with an operational
+        state of noResources(4)."
+    ::= { jnxPppSummary 62 }
+
+jnxPppSummaryPppMplsNcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP MPLS NCPs in the system with an operational state
+        of opened(1)."
+    ::= { jnxPppSummary 63 }
+
+jnxPppSummaryPppMplsNcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP MPLS NCPs in the system with an operational
+        state of not-opened(2)."
+    ::= { jnxPppSummary 64 }
+
+jnxPppSummaryPppMplsNcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP MPLS NCPs in the system with an operational state
+        of notPresent(3)."
+    ::= { jnxPppSummary 65 }
+
+jnxPppSummaryPppMplsNcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPP MPLS NCPs in the system with an operational
+        state of noResources(4)."
+    ::= { jnxPppSummary 66 }
+
+jnxPppSummaryPppLinkStaticInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of static PPP Link interfaces configured in the system."
+    ::= { jnxPppSummary 67 }
+
+jnxPppSummaryPppNetworkStaticInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of static PPP network interfaces configured in the system."
+    ::= { jnxPppSummary 68 }
+
+jnxPppSummaryPppNetworkMplsNCPs OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+        interfaces."
+    ::= { jnxPppSummary 69 }
+
+jnxPppSummaryPppNetworkIpAdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IP NCPs in the system configured on PPP network
+         interfaces that are administratively configured to open(1)."
+    ::= { jnxPppSummary 70 }
+
+jnxPppSummaryPppNetworkIpAdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IP NCPs in the system configured on PPP network
+         interfaces that are administratively configured to close(2)."
+    ::= { jnxPppSummary 71 }
+
+jnxPppSummaryPppNetworkIpv6AdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IPV6 NCPs in the system configured on PPP network
+         interfaces that are administratively configured to open(1)."
+    ::= { jnxPppSummary 72 }
+
+jnxPppSummaryPppNetworkIpv6AdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IPV6 NCPs in the system configured on PPP network
+         interfaces that are administratively configured to close(2)."
+    ::= { jnxPppSummary 73 }
+
+jnxPppSummaryPppNetworkOsiAdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system configured on PPP network
+         interfaces that are administratively configured to open(1)."
+    ::= { jnxPppSummary 74 }
+
+jnxPppSummaryPppNetworkOsiAdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system configured on PPP network
+         interfaces that are administratively configured to close(2)."
+    ::= { jnxPppSummary 75 }
+
+jnxPppSummaryPppNetworkMplsAdminOpen OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+         interfaces that are administratively configured to open(1)."
+    ::= { jnxPppSummary 76 }
+
+jnxPppSummaryPppNetworkMplsAdminClose OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+         interfaces that are administratively configured to close(2)."
+    ::= { jnxPppSummary 77 }
+
+jnxPppSummaryPppNetworkIpNcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IP NCPs in the system configured on PPP network
+        interfaces with an operational state of notPresent(3)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 78 }
+
+jnxPppSummaryPppNetworkIpNcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IP NCPs in the system configured on PPP network
+        interfaces with an operational state of noResources(4)."
+    REFERENCE
+        "PPP-IP-NCP-MIB.pppIpOperStatus"
+    ::= { jnxPppSummary 79 }
+
+jnxPppSummaryPppNetworkIpv6NcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IPV6 NCPs in the system configured on PPP network
+        interfaces with an operational state of notPresent(3)."
+    ::= { jnxPppSummary 80 }
+
+jnxPppSummaryPppNetworkIpv6NcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of IPV6 NCPs in the system configured on PPP network
+        interfaces with an operational state of noResources(4)."
+    ::= { jnxPppSummary 81 }
+
+jnxPppSummaryPppNetworkOsiNcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system configured on PPP network
+        interfaces with an operational state of notPresent(3)."
+    ::= { jnxPppSummary 82 }
+
+jnxPppSummaryPppNetworkOsiNcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of OSI NCPs in the system configured on PPP network
+        interfaces with an operational state of noResources(4)."
+    ::= { jnxPppSummary 83 }
+
+jnxPppSummaryPppNetworkMplsNcpOpened OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+        interfaces with an operational state of opened(1)."
+    ::= { jnxPppSummary 84 }
+
+jnxPppSummaryPppNetworkMplsNcpClosed OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+        interfaces with an operational state of not-opened(2)."
+    ::= { jnxPppSummary 85 }
+
+jnxPppSummaryPppNetworkMplsNcpNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+        interfaces with an operational state of notPresent(3)."
+    ::= { jnxPppSummary 86 }
+
+jnxPppSummaryPppNetworkMplsNcpNoResources OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of MPLS NCPs in the system configured on PPP network
+        interfaces with an operational state of noResources(4)."
+    ::= { jnxPppSummary 87 }
+
+-- ////////////////////////////////////////////////////////////////////////////
+--
+-- PPP IPv6 NCP
+--
+-- This section defines objects used to manage the PPP Network
+-- Control Protocol for IPv6 protocol operation (IPV6CP).
+--
+-- ////////////////////////////////////////////////////////////////////////////
+--
+-- The PPP IPv6 Table
+--
+jnxPppIpv6Table OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppIpv6Entry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table containing the IPv6 parameters for the local PPP entity."
+    ::= { jnxPppIpv6 1 }
+
+jnxPppIpv6Entry OBJECT-TYPE
+    SYNTAX      JnxPppIpv6Entry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "IPV6CP status information for a particular PPP link."
+    INDEX     { ifIndex }
+    ::= { jnxPppIpv6Table 1 }
+
+JnxPppIpv6Entry ::= SEQUENCE {
+    jnxPppIpv6ServiceStatus                       INTEGER,
+    jnxPppIpv6OperStatus                          INTEGER,
+    jnxPppIpv6TerminateReason                     INTEGER,
+    jnxPppIpv6TerminateNegFailOption              INTEGER,
+    jnxPppIpv6LocalIpv6AddressIfIdentifier        Ipv6AddressIfIdentifier,
+    jnxPppIpv6RemoteIpv6AddressIfIdentifier       Ipv6AddressIfIdentifier,
+    jnxPppIpv6NetworkStatusIpv6cpRenegoTerminates Counter32}
+
+jnxPppIpv6ServiceStatus OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates whether IPv6 protocol service is operating over this PPP
+        link.  Service is established on this link through means outside this
+        MIB."
+    ::= { jnxPppIpv6Entry 1 }
+
+jnxPppIpv6OperStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    opened(1),
+                    notOpened(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The operational status of the IPv6 network protocol.  If the value of
+        this object is up then the finite state machine for the IPv6 network
+        protocol has reached the Opened state."
+    ::= { jnxPppIpv6Entry 2 }
+
+jnxPppIpv6TerminateReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    noService(2),
+                    admin(3),
+                    linkDown(4),
+                    peerTerminated(5),
+                    peerRenegotiated(6),
+                    maxRetriesExceeded(7),
+                    negotiationFailure(8) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reason the IPV6CP link was terminated:
+            none                    None.
+            other                   Not specified.
+            noService              No IPv6 service configured on this PPP link.
+            admin                   Administratively disabled.
+            linkDown                Underlying link is down.
+            peerTerminated          Peer initiated termination.
+            peerRenegotiated        Peer initiated renegotiation.
+            maxRetriesExceeded      Maximum number of config retries exceeded.
+            negotiationFailure      Failed to negotiate IPV6CP option.  See
+                                    jnxPppIpv6TerminateNegFailOption."
+    ::= { jnxPppIpv6Entry 3 }
+
+jnxPppIpv6TerminateNegFailOption OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    none(0),
+                    other(1),
+                    localIpv6AddressIfIdentifier(2),
+                    remoteIpv6AddressIfIdentifier(3) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Reports the PPP IPV6CP option for which negotiation failed, when
+        jnxPppIpv6TerminateReason has the value 'negotiationFailure'."
+    ::= { jnxPppIpv6Entry 4 }
+
+jnxPppIpv6LocalIpv6AddressIfIdentifier OBJECT-TYPE
+    SYNTAX      Ipv6AddressIfIdentifier
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "IPv6 Address Interface Identifier used by the local side."
+    ::= { jnxPppIpv6Entry 5 }
+
+jnxPppIpv6RemoteIpv6AddressIfIdentifier OBJECT-TYPE
+    SYNTAX      Ipv6AddressIfIdentifier
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "IPv6 Address Interface Identifier used by the remote side."
+    ::= { jnxPppIpv6Entry 6 }
+
+jnxPppIpv6NetworkStatusIpv6cpRenegoTerminates OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of times ipv6cp terminated due to peer exceeding max
+        renegotiation attempts."
+    ::= { jnxPppIpv6Entry 7 }
+
+--
+-- The PPP IPv6 Config Table
+--
+jnxPppIpv6ConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPppIpv6ConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Table containing the IPv6 parameters for the local PPP entity."
+    ::= { jnxPppIpv6 2 }
+
+jnxPppIpv6ConfigEntry OBJECT-TYPE
+    SYNTAX      JnxPppIpv6ConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "IPV6CP configuration information for a particular PPP link."
+    INDEX     { ifIndex }
+    ::= { jnxPppIpv6ConfigTable 1 }
+
+JnxPppIpv6ConfigEntry ::= SEQUENCE {
+    jnxPppIpv6ConfigAdminStatus            INTEGER,
+    jnxPppIpv6ConfigInitiateIpv6           INTEGER,
+    jnxPppIpv6ConfigMaxIpv6cpRenegotiation Integer32 }
+
+jnxPppIpv6ConfigAdminStatus OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    open(1),
+                    close(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The immediate desired status of the IPv6 network protocol.  Setting
+        this object to open will inject an administrative open event into the
+        IPv6 network protocol's finite state machine.  Setting this object to
+        close will inject an administrative close event into the IPv6 network
+        protocol's finite state machine."
+    ::= { jnxPppIpv6ConfigEntry 1 }
+
+jnxPppIpv6ConfigInitiateIpv6 OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Enables the initiation of negotiation of the IPv6CP."
+    DEFVAL { disable }
+    ::= { jnxPppIpv6ConfigEntry 2 }
+
+jnxPppIpv6ConfigMaxIpv6cpRenegotiation OBJECT-TYPE
+    SYNTAX      Integer32 (1..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Maximum number of allowed ipv6cp renegotiation attempts from peer."
+    DEFVAL { 30 }
+    ::= { jnxPppIpv6ConfigEntry 3 }
+
+
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- PPP Globals
+--
+--  The globals are non interface based objects
+--
+-- /////////////////////////////////////////////////////////////////////////////
+jnxPppPeerIpAddressOptional OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This option is used to ignore the conflicts between ppp client's  
+         requested IP address and radius/local pool returned address in server 
+         during IPNCP  negotiation. Enabling this will ensure the IPNCP  
+         negotiation to succeed even though the client does not include 
+         IP address option in the  IPNCP configure request."    
+    ::= { jnxPppGlobalConfig 1 }
+
+
+
+END

--- a/mibs/junos/mib-jnx-pppoe.txt
+++ b/mibs/junos/mib-jnx-pppoe.txt
@@ -1,0 +1,1377 @@
+
+--
+-- Juniper Enterprise Specifics MIB
+-- 
+-- Copyright (c) 2010-2011, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JNX-PPPOE-MIB  DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32, Unsigned32 ,Counter64
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue, MacAddress
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    InterfaceIndex, InterfaceIndexOrZero
+        FROM IF-MIB
+    jnxPppoeMibRoot
+        FROM JUNIPER-SMI;
+
+jnxPPPoEMIB  MODULE-IDENTITY
+    LAST-UPDATED "201007220942Z"  -- 22-Jul-10 03:12 PM EST
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+        "       Juniper Networks, Inc.
+        Postal: 10 Technology Park Drive
+                Westford, MA  01886-3146
+                USA
+        Tel:    +1 978 589 5800
+        Email:  support@Juniper.net"
+    DESCRIPTION
+        "The Point-to-Point Protocol over Ethernet (PPPoE) MIB for the Junos
+        product family.  This MIB contains managed objects for each of
+        two interface layers: PPPoE interfaces, and PPPoE subinterfaces.  For
+        each of these layers, management objects are provided to query for an
+        available interface index, and to create/delete interfaces of that type."
+
+    -- Revision History
+
+    REVISION    "201306130000Z"  -- 13-Jun-13 05:32 AM EST  - JUNOS 13.1
+    DESCRIPTION
+        "Deprecated InterfaceIndex type and added InterfaceIndexOrZero type 
+         for jnxPPPoENextIfIndex and jnxPPPoESubIfNextIfIndex.
+         Modified minimum range for jnxPPPoEIfServiceNameTable."
+
+    REVISION    "201007220942Z"  -- 22-Jul-10 03:12 PM EST  - JUNOS 11.0
+    DESCRIPTION
+        "Initial version."
+    ::= { jnxPppoeMibRoot 1 }
+
+
+
+
+JnxPPPoEServiceNameAction  ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "The set of Service-name action types.
+            drop        no PADO packet will be sent.
+            terminate   a PADO packet will be sent."
+    SYNTAX      INTEGER {
+                    drop(0),
+                    terminate(1) }
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Managed objects
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+jnxPPPoEObjects        OBJECT IDENTIFIER ::= { jnxPPPoEMIB 1 }
+jnxPPPoEIfLayer        OBJECT IDENTIFIER ::= { jnxPPPoEObjects 1 }
+jnxPPPoESubIfLayer     OBJECT IDENTIFIER ::= { jnxPPPoEObjects 2 }
+jnxPPPoESummary        OBJECT IDENTIFIER ::= { jnxPPPoEObjects 3 }
+jnxPPPoEServices       OBJECT IDENTIFIER ::= { jnxPPPoEObjects 4 }
+
+
+-- /////////////////////////////////////////////////////////////////////////////
+
+--
+-- This layer is managed with the following elements:
+--  o NextIfIndex (generator for PPPoEIfIndex selection)
+--  o Interface Table (creation/configuration/deletion of PPPoEinterfaces)
+--  o Statistics Table (PPPoEinterface statistics)
+--
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- IfIndex selection for creating new PPPoEinterfaces
+--
+jnxPPPoENextIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Coordinate ifIndex value allocation for entries in jnxPPPoEIfTable.
+
+        A GET of this object returns the next available ifIndex value to be used
+        to create an entry in the associated interface table; or zero, if no
+        valid ifIndex value is available.  This object also returns a value of
+        zero when it is the lexicographic successor of a varbind presented in an
+        SNMP GETNEXT or GETBULK request, for which circumstance it is assumed
+        that ifIndex allocation is unintended.
+
+        Successive GETs will typically return different values, thus avoiding
+        collisions among cooperating management clients seeking to create table
+        entries simultaneously."
+    ::= { jnxPPPoEIfLayer 1 }
+
+--
+-- The PPPoEInterface Table
+--
+jnxPPPoEIfTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoEIfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The parameters for the PPPoEservice on this interface."
+    REFERENCE
+        "RFC 2156 A method for transmitting PPP over Ethernet"
+    ::= { jnxPPPoEIfLayer 2 }
+
+jnxPPPoEIfEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoEIfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The Parameters for a particular PPPoEinterface.
+
+        Creating/deleting entries in this table causes corresponding entries for
+        be created/deleted in ifTable/ifXTable/jnxIfTable, and
+        jnxPPPoEIfStatsTable."
+    INDEX     { jnxPPPoEIfIfIndex }
+    ::= { jnxPPPoEIfTable 1 }
+
+JnxPPPoEIfEntry ::= SEQUENCE {
+    jnxPPPoEIfIfIndex           InterfaceIndex,
+    jnxPPPoEIfMaxNumSessions    INTEGER,
+    jnxPPPoEIfRowStatus         RowStatus,
+    jnxPPPoEIfLowerIfIndex      InterfaceIndexOrZero,
+    jnxPPPoEIfAcName            DisplayString,
+    jnxPPPoEIfDupProtect        INTEGER,
+    jnxPPPoEIfPADIFlag          INTEGER,
+    jnxPPPoEIfAutoconfig        INTEGER,
+    jnxPPPoEIfServiceNameTable  DisplayString,
+    jnxPPPoEIfPadrRemoteCircuitIdCapture INTEGER,
+    jnxPPPoEIfMtu               Integer32,
+    jnxPPPoEIfLockoutMin        Integer32,
+    jnxPPPoEIfLockoutMax        Integer32 ,
+    jnxPPPoEIfDynamicProfile   DisplayString}
+
+jnxPPPoEIfIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex value of the corresponding ifEntry."
+    ::= { jnxPPPoEIfEntry 1 }
+
+jnxPPPoEIfMaxNumSessions OBJECT-TYPE
+    SYNTAX      INTEGER (0..65335)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of sessions allowed on the PPPoEinterface, zero indicates
+        unlimited."
+    DEFVAL    { 0 }
+    ::= { jnxPPPoEIfEntry 2 }
+
+jnxPPPoEIfRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with READ-CREATE
+         maximum access, according to the
+        RowStatus textual convention, constrained to support the following
+        values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST be
+        explicitly configured:
+            jnxPPPoEIfRowStatus
+            jnxPPPoEIfLowerIfIndex
+
+        In addition, when creating an entry the following conditions must hold:
+            A value for jnxPPPoEIfIndex must have been determined previously,
+            by reading jnxPPPoENextIfIndex.
+
+            The interface identified by jnxPPPoEIfLowerIfIndex must exist, and
+            must be an interface type that permits layering of PPPoEabove it.
+
+        A corresponding entry in ifTable/ifXTable/jnxIfTable is created or
+        destroyed as a result of creating or destroying an entry in this table.
+
+         The following values can be read from this object:
+             active(1)"
+    ::= { jnxPPPoEIfEntry 3 }
+
+jnxPPPoEIfLowerIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of an interface over which this PPPoEinterface is to be
+        layered.  A value of zero indicates no layering.  An implementation may
+        choose to require that a nonzero value be configured at entry creation."
+    ::= { jnxPPPoEIfEntry 4 }
+
+jnxPPPoEIfAcName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The name to use for the AC-NAME tag that is sent in any PADO that is
+        sent on this interface."
+    ::= { jnxPPPoEIfEntry 5 }
+
+jnxPPPoEIfDupProtect OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Flag to allow duplicate MAC addresses."
+    DEFVAL    { disable }
+    ::= { jnxPPPoEIfEntry 6 }
+
+jnxPPPoEIfPADIFlag OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }  
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This flag controls whether we always respond to a PADI with a PADO
+        regardless of the ability to create the session and allows the session
+        establish phase to resolve it."
+    DEFVAL    { disable }
+    ::= { jnxPPPoEIfEntry 7 }
+
+jnxPPPoEIfAutoconfig OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This flags determines whether the upper PPPoEinterface is created
+        dynamically or statically.  When enable(1) the interface is created
+        dynamically."
+    DEFVAL    {disable  }
+    ::= { jnxPPPoEIfEntry 8 }
+
+jnxPPPoEIfServiceNameTable OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Associate a PPPoEService Name Table with this interface for PADI
+        processing."
+    ::= { jnxPPPoEIfEntry 9 }
+
+jnxPPPoEIfPadrRemoteCircuitIdCapture OBJECT-TYPE
+    SYNTAX          INTEGER  { enable(1), disable(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This flags determines whether the remote circuit id string will
+        be captured and subsequently used as the NAS-PORT-ID radius
+        attribute when it arrives as a tag in the PADR packet."
+    DEFVAL    { disable }
+    ::= { jnxPPPoEIfEntry 10 }
+
+jnxPPPoEIfMtu OBJECT-TYPE
+    SYNTAX      Integer32 (1|2|66..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The initial Maximum Transmit Unit (MTU) that the PPPoEmajor interface
+        entity will advertise to the remote entity.
+
+        If the value of this variable is 1 then the local PPPoEentity will
+        use an MTU value determined by its underlying media interface.
+
+        If the value of this variable is 2 then the local PPPoEentity will
+        use a value determined by the PPPoEMax-Mtu-Tag transmitted from the
+        client in the PADR packet.  If no Max-Mtu-Tag is received, the value
+        defaults to a maximum of 1494.
+
+		The operational MTU is limited by the MTU of the underlying media
+        interface minus the PPPoEframe overhead."
+    DEFVAL    { 1494 }
+    ::= { jnxPPPoEIfEntry 11 }
+
+jnxPPPoEIfLockoutMin OBJECT-TYPE
+    SYNTAX      Integer32 (0..86400)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The lower bound, in seconds, of the time range used to specify 
+        the duration of the lockout of the client from recognition for
+        the specified interface.  This only takes effect if
+        jnxPPPoEIfAutoconfig is set for this interface.
+
+        The ability to lockout the client in the event of an error in
+        creating a PPP interface is enabled by default.  The initial lockout
+        duration is this object's value and increases exponentially for
+        each failure that occurs for the client creating a PPP interface
+        for the PPPoEinterface within the greater of 15 minutes
+        and jnxPPPoEIfLockoutMax.
+
+        The lockout duration for the client will not exceed jnxPPPoEIfLockoutMax.
+        If the time between creation errors for the PPP interface for this
+        interface is greater than the greater of 15 minutes and
+        jnxPPPoEIfLockoutMax, then the lockout duration reverts to this
+        object's value.
+
+
+        To disable the ability to lockout the client from recognition in the
+        event of an error in creating a PPP interface for the specified interface,
+        the value of this object and jnxPPPoEIfLockoutMin must be set to 0.
+        It is not recommended that this lockout feature be disabled except for 
+        debugging purposes or when this interface supports more than one session."
+    DEFVAL    { 0 }
+    ::= { jnxPPPoEIfEntry 12 }
+
+jnxPPPoEIfLockoutMax OBJECT-TYPE
+    SYNTAX      Integer32 (0..86400)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The upper bound, in seconds, of the time range used to specify 
+        the duration of the lockout of the client from recognition for
+        the specified interface.  This only takes effect if
+        jnxPPPoEIfAutoconfig is set for this interface.
+
+        The ability to lockout the client from recognition in the event
+        of an error in creating a PPP interface is enabled by default.
+        The initial lockout duration is jnxPPPoEIfLockoutMin and
+        increases exponentially for each failure that occurs for the client
+        interface within the greater of 15 minutes and this object's value.
+
+        The lockout duration for the client will not exceed jnxPPPoEIfLockoutMax.
+        If the time between creation errors for the PPP interface for this
+        interface is greater than the greater of 15 minutes and
+        jnxPPPoEIfLockoutMax, then the lockout duration reverts to
+        jnxPPPoEIfLockoutMin.
+
+        To disable the ability to lockout the client from recognition in the
+        event of an error in creating a PPP interface for the specified interface,
+        the value of this object and jnxPPPoEIfLockoutMin must be set to 0.
+        It is not recommended that this lockout feature be disabled except for 
+        debugging purposes or when this interface supports more than one session."
+    DEFVAL    { 0 }
+	::= { jnxPPPoEIfEntry 13 }
+
+jnxPPPoEIfDynamicProfile OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Attach dynamic-profile to this interface"
+    DEFVAL    { " " }
+    ::= { jnxPPPoEIfEntry 14 }
+
+--
+-- The PPPoEInterface Statistics Table
+--
+jnxPPPoEIfStatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoEIfStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The statistics for the PPP over Ethernet Interface for the PPPoE
+        service on this interface."
+    ::= { jnxPPPoEIfLayer 3 }
+
+jnxPPPoEIfStatsEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoEIfStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The statistics for a particular PPPoEInterface."
+    INDEX     { jnxPPPoEIfIfIndex }
+    ::= { jnxPPPoEIfStatsTable 1 }
+
+JnxPPPoEIfStatsEntry ::= SEQUENCE {
+    jnxPPPoEIfStatsRxPADI                   Counter32,
+    jnxPPPoEIfStatsTxPADO                   Counter32,
+    jnxPPPoEIfStatsRxPADR                   Counter32,
+    jnxPPPoEIfStatsTxPADS                   Counter32,
+    jnxPPPoEIfStatsRxPADT                   Counter32,
+    jnxPPPoEIfStatsTxPADT                   Counter32,
+    jnxPPPoEIfStatsRxInvVersion             Counter32,
+    jnxPPPoEIfStatsRxInvCode                Counter32,
+    jnxPPPoEIfStatsRxInvTags                Counter32,
+    jnxPPPoEIfStatsRxInvSession             Counter32,
+    jnxPPPoEIfStatsRxInvTypes               Counter32,
+    jnxPPPoEIfStatsRxInvPackets             Counter32,
+    jnxPPPoEIfStatsRxInsufficientResources  Counter32,
+    jnxPPPoEIfStatsTxPADM                   Counter32,
+    jnxPPPoEIfStatsTxPADN                   Counter32,
+    jnxPPPoEIfStatsRxInvTagLength           Counter32,
+    jnxPPPoEIfStatsRxInvLength              Counter32,
+    jnxPPPoEIfStatsRxInvPadISession         Counter32,
+    jnxPPPoEIfStatsRxInvPadRSession         Counter32 }
+
+jnxPPPoEIfStatsRxPADI OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADI packets received."
+    ::= { jnxPPPoEIfStatsEntry 1 }
+
+jnxPPPoEIfStatsTxPADO OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADO packets transmitted."
+    ::= { jnxPPPoEIfStatsEntry 2 }
+
+jnxPPPoEIfStatsRxPADR OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADR packets received."
+    ::= { jnxPPPoEIfStatsEntry 3 }
+
+jnxPPPoEIfStatsTxPADS OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADS packets transmitted."
+    ::= { jnxPPPoEIfStatsEntry 4 }
+
+jnxPPPoEIfStatsRxPADT OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADT packets received."
+    ::= { jnxPPPoEIfStatsEntry 5 }
+
+jnxPPPoEIfStatsTxPADT OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADT packets transmitted."
+    ::= { jnxPPPoEIfStatsEntry 6 }
+
+jnxPPPoEIfStatsRxInvVersion OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received with invalid version."
+    ::= { jnxPPPoEIfStatsEntry 7 }
+
+jnxPPPoEIfStatsRxInvCode OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received with invalid code."
+    ::= { jnxPPPoEIfStatsEntry 8 }
+
+jnxPPPoEIfStatsRxInvTags OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received with invalid tags."
+    ::= { jnxPPPoEIfStatsEntry 9 }
+
+jnxPPPoEIfStatsRxInvSession OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+        "Number of packets received with invalid session identifiers.
+
+        This object became obsolete when separate counters were added for PADI
+        and PADR packets."
+    ::= { jnxPPPoEIfStatsEntry 10 }
+
+jnxPPPoEIfStatsRxInvTypes OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received with invalid types."
+    ::= { jnxPPPoEIfStatsEntry 11 }
+
+jnxPPPoEIfStatsRxInvPackets OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of invalid packets received."
+    ::= { jnxPPPoEIfStatsEntry 12 }
+
+jnxPPPoEIfStatsRxInsufficientResources OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of session requests that could not be honored due to invalid
+        resources."
+    ::= { jnxPPPoEIfStatsEntry 13 }
+
+jnxPPPoEIfStatsTxPADM OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADM packets transmitted."
+    ::= { jnxPPPoEIfStatsEntry 14 }
+
+jnxPPPoEIfStatsTxPADN OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADN packets transmitted."
+    ::= { jnxPPPoEIfStatsEntry 15 }
+
+jnxPPPoEIfStatsRxInvTagLength OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received with invalid tag length."
+    ::= { jnxPPPoEIfStatsEntry 16 }
+
+jnxPPPoEIfStatsRxInvLength OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of packets received with invalid length."
+    ::= { jnxPPPoEIfStatsEntry 17 }
+
+jnxPPPoEIfStatsRxInvPadISession OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADI packets received with invalid session identifiers."
+    ::= { jnxPPPoEIfStatsEntry 18 }
+
+jnxPPPoEIfStatsRxInvPadRSession OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Number of PADR packets received with invalid session identifiers."
+    ::= { jnxPPPoEIfStatsEntry 19 }
+
+--
+-- The PPPoEInterface Client Lockout Table
+--
+jnxPPPoEIfLockoutTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoEIfLockoutEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+      "The lockout configuration and state of a PPPoEclient on this interface."
+    ::= { jnxPPPoEIfLayer 4 }
+
+jnxPPPoEIfLockoutEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoEIfLockoutEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry contains the configuration and state of a particular
+         PPPoEinterface client lockout."
+    INDEX     { jnxPPPoEIfIfIndex, jnxPPPoEIfLockoutClientAddress }
+    ::= { jnxPPPoEIfLockoutTable 1 }
+
+JnxPPPoEIfLockoutEntry ::= SEQUENCE {
+	jnxPPPoEIfLockoutClientAddress     MacAddress,
+	jnxPPPoEIfLockoutTime              Integer32,
+	jnxPPPoEIfLockoutElapsedTime       Integer32,
+	jnxPPPoEIfLockoutNextTime          Integer32 }
+
+jnxPPPoEIfLockoutClientAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The source MAC address if the client."
+    ::= { jnxPPPoEIfLockoutEntry 1 }
+
+jnxPPPoEIfLockoutTime OBJECT-TYPE
+    SYNTAX      Integer32 (0..86400)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time duration, in seconds, currently used to lockout the
+        specified encapsulation type from recognition for the specified
+        interface.  The reported value is within the range specified by
+        jnxPPPoEIfLockoutMin and jnxPPPoEIfLockoutMax.  A value of 0 
+        indicates that no lockout is occurring for the encapsulation type
+        for the specified interface."
+    ::= { jnxPPPoEIfLockoutEntry 2 }
+
+jnxPPPoEIfLockoutElapsedTime OBJECT-TYPE
+    SYNTAX      Integer32 (0..86400)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The elapsed time, in seconds, that the specified encapsulation type
+        has been locked-out from recognition for the specified interface. 
+        Its value will not exceed that of jnxPPPoEIfLockoutTime.  A value of 
+        0 indicates that no lockout is occurring for the encapsulation type
+        for the specified interface."
+    ::= { jnxPPPoEIfLockoutEntry 3 }
+
+jnxPPPoEIfLockoutNextTime OBJECT-TYPE
+    SYNTAX      Integer32 (0..86400)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The time duration, in seconds, that will be used to lockout the 
+        specified encapsulation type from recognition for the specified
+        interface for the next event that results in a lockout condition.
+        The reported value is within the range specified by
+        jnxPPPoEIfLockoutMin and jnxPPPoEIfLockoutMax.  When
+        jnxPPPoEIfEnable is set to enable, a value of 0 indicates that
+        lockout is prevented from occurring for the encapsulation type
+        for the specified interface (i.e., jnxPPPoEIfLockoutMin and
+        jnxPPPoEIfLockoutMax are both set to 0)."
+    ::= { jnxPPPoEIfLockoutEntry 4 }
+
+
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- PPPoESubinterface Layer
+--
+-- This layer is managed with the following elements:
+--  o NextIfIndex (generator for PPPoEsubinterface IfIndex selection)
+--  o SubIf Table (creation/configuration/deletion of PPPoEsubinterfaces)
+--
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- IfIndex selection for creating new PPPoESubinterfaces
+--
+jnxPPPoESubIfNextIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Coordinate ifIndex value allocation for entries in jnxPPPoESubIfTable.
+
+        A GET of this object returns the next available ifIndex value to be used
+        to create an entry in the associated interface table; or zero, if no
+        valid ifIndex value is available.  This object also returns a value of
+        zero when it is the lexicographic successor of a varbind presented in an
+        SNMP GETNEXT or GETBULK request, for which circumstance it is assumed
+        that ifIndex allocation is unintended.
+
+        Successive GETs will typically return different values, thus avoiding
+        collisions among cooperating management clients seeking to create table
+        entries simultaneously."
+    ::= { jnxPPPoESubIfLayer 1 }
+
+
+--
+-- The PPPoESubinterface Table
+--
+jnxPPPoESubIfTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoESubIfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for PPPoESubinterfaces present in the
+        system."
+    ::= { jnxPPPoESubIfLayer 2 }
+
+jnxPPPoESubIfEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoESubIfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Each entry describes the characteristics of a PPPoESubinterface.
+        With READ-CREATE maximum access ,creating/deleting entries in this 
+        table causes corresponding entries for
+        be created /deleted in ifTable/ifXTable/jnxIfTable."
+    INDEX     { jnxPPPoESubIfIndex }
+    ::= { jnxPPPoESubIfTable 1 }
+
+JnxPPPoESubIfEntry ::= SEQUENCE {
+    jnxPPPoESubIfIndex          InterfaceIndex,
+    jnxPPPoESubIfRowStatus      RowStatus,
+    jnxPPPoESubIfLowerIfIndex   InterfaceIndexOrZero,
+    jnxPPPoESubIfId             Integer32,
+    jnxPPPoESubIfSessionId      Integer32,
+    jnxPPPoESubIfMotm           DisplayString,
+    jnxPPPoESubIfUrl            DisplayString }
+
+jnxPPPoESubIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of the PPPoESubinterface.  When creating entries in this
+        table, suitable values for this object are determined by reading
+        jnxPPPoESubNextIfIndex."
+    ::= { jnxPPPoESubIfEntry 1 }
+
+jnxPPPoESubIfRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with READ-CREATE
+         maximum access ,according to the
+        RowStatus textual convention, constrained to support the following
+        values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST be
+        explicitly configured:
+            jnxPPPoESubIfRowStatus
+            jnxPPPoESubIfLowerIfIndex
+
+        In addition, when creating an entry the following conditions must hold:
+            A value for jnxPPPoESubIfIndex must have been determined
+            previously, by reading jnxPPPoESubIfNextIfIndex.
+
+            The interface identified by jnxPPPoESubIfLowerIfIndex must exist,
+            and must be a PPPoEinterface.
+
+            A positive value configured for jnxPPPoESubIfId must not already be
+            assigned to another subinterface layered onto the same underlying
+            PPPoEinterface.
+
+        A corresponding entry in ifTable/ifXTable/jnxIfTable is created or
+        destroyed as a result of creating or destroying an entry in this table.
+
+        The following values can be read from this object:
+             active(1) "
+    ::= { jnxPPPoESubIfEntry 2 }
+
+jnxPPPoESubIfLowerIfIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The ifIndex of a PPPoEinterface over which this PPPoESubinterface is
+        to be layered.  A value of zero indicates no layering.  An
+        implementation may choose to require that a nonzero value be configured
+        at entry creation."
+    ::= { jnxPPPoESubIfEntry 3 }
+
+jnxPPPoESubIfId OBJECT-TYPE
+    SYNTAX      Integer32 (-1..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "An integer identifier for the PPPoEsubinterface, used in conjunction
+        with the command-line interface.  It is provided here for
+        cross-reference purposes only.
+
+        The value must be unique among subinterfaces configured on the same
+        underlying PPPoEinterface.
+
+        If this object is not configured, or is configured with a value of -1, a
+        nonzero value will be allocated internally and can be retrieved from
+        this object after table entry creation has succeeded.
+
+        A value of zero for this object is reserved for future use."
+    DEFVAL    { -1 }
+    ::= { jnxPPPoESubIfEntry 4 }
+
+jnxPPPoESubIfSessionId OBJECT-TYPE
+    SYNTAX      Integer32 (0..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The current sessionId associated with this sub-interface."
+    ::= { jnxPPPoESubIfEntry 5 }
+
+jnxPPPoESubIfMotm OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A message to send via a PADM on the sub-interface when the
+        sub-interface transitions to the ifOperStatusUp state.  The client may
+        choose to display this message to the user."
+    ::= { jnxPPPoESubIfEntry 6 }
+
+jnxPPPoESubIfUrl OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..127))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A URL to be sent via a PADM on the sub-interface when the sub-interface
+        transitions to the ifOperStatusUp state.  The client may use this URL as
+        the initial web-page for the user."
+    ::= { jnxPPPoESubIfEntry 7 }
+
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- PPPoEInterface per queue stats table.
+-- This is a new table added in addition to existing 
+-- JUNOSe PPPoEMIB.
+-- /////////////////////////////////////////////////////////////////////////////
+
+jnxPppoeSubIfQueueStatsTable OBJECT-TYPE
+   SYNTAX	                    SEQUENCE OF JnxPppoeSubIfPerQueueStatsEntry
+   MAX-ACCESS                       not-accessible
+   STATUS                                  current
+   DESCRIPTION
+    "Table containing the Queue parameters for the PPPoEsessions."
+::=  { jnxPPPoESubIfLayer 3 }   
+
+jnxPppoeSubIfPerQueueStatsEntry OBJECT-TYPE
+    SYNTAX      JnxPppoeSubIfPerQueueStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+               "The statistics for a particular trrafic class queue for 
+                PPPoEsub Interface(i.e. session). ). Forwarding class to
+                 queue number mapping is not always one-to-one. Forwarding
+                  classes and queues are the same only when default 
+                  forwarding-class-to-queue mapping is in effect "
+    INDEX     { jnxPPPoESubIfIndex,
+                jnxPppoeSubIfQueueIndex }
+    ::= { jnxPppoeSubIfQueueStatsTable 1 }
+
+JnxPppoeSubIfPerQueueStatsEntry ::= SEQUENCE {
+jnxPppoeSubIfQueueIndex                                 INTEGER(0..7),
+jnxPppoeSubIfQueueStatsPacketSent                       Counter64,
+jnxPppoeSubIfQueueStatsBytesSent                        Counter64,
+jnxPppoeSubIfQueueStatsPacketDropped                    Counter64,
+jnxPppoeSubIfQueueStatsBytesDropped                     Counter64,
+jnxPppoeSubIfQueueStatsActualBitRate                    Counter32,
+jnxPppoeSubIfQueueStatsActualDroppedBitRate             Counter32 }
+
+jnxPppoeSubIfQueueIndex                OBJECT-TYPE
+      SYNTAX               INTEGER(0..7)
+      MAX-ACCESS           not-accessible
+      STATUS               current
+      DESCRIPTION
+      "This attribute returns the queue index ranging from 0 to 7 of the
+      queue configure on the PPPoEsubinterface to support the traffic class for 
+      PPPoEsession configured on that subinterface. Forwarding class to queue
+      number mapping is not always one-to-one. Forwarding classes and queues are
+       the same only when default forwarding-class-to-queue mapping is in effect."
+::= { jnxPppoeSubIfPerQueueStatsEntry 1}
+
+jnxPppoeSubIfQueueStatsPacketSent  OBJECT-TYPE
+       SYNTAX            Counter64
+       MAX-ACCESS   read-only
+       STATUS             current
+       DESCRIPTION   
+                  "This attribute returns the counts of number of packet sent
+                   per PPPoEsession and per queue."
+       ::= { jnxPppoeSubIfPerQueueStatsEntry 2} 
+
+jnxPppoeSubIfQueueStatsBytesSent   OBJECT-TYPE
+       SYNTAX            Counter64
+       MAX-ACCESS   read-only
+       STATUS             current
+       DESCRIPTION   
+                  "This attribute returns the counts of number of bytes sent 
+                  per PPPoEsession and per queue." 
+       ::= { jnxPppoeSubIfPerQueueStatsEntry 3 }
+
+jnxPppoeSubIfQueueStatsPacketDropped   OBJECT-TYPE
+       SYNTAX            Counter64
+       MAX-ACCESS   read-only
+       STATUS             current
+       DESCRIPTION   
+                  "This attribute returns the number of packet dropped per 
+                  PPPoEsession and per queue."
+       ::= { jnxPppoeSubIfPerQueueStatsEntry 4}
+
+ jnxPppoeSubIfQueueStatsBytesDropped   OBJECT-TYPE
+       SYNTAX            Counter64
+       MAX-ACCESS   read-only
+       STATUS             current
+       DESCRIPTION   
+                  "This attribute returns the number of bytes dropped per 
+                  PPPoEsession and per queue."
+        ::= { jnxPppoeSubIfPerQueueStatsEntry 5 }
+
+jnxPppoeSubIfQueueStatsActualBitRate   OBJECT-TYPE
+       SYNTAX            Counter32
+       MAX-ACCESS   read-only
+       STATUS             current
+       DESCRIPTION   
+                  "This attribute returns the actual bit rate for per
+                   PPPoEsession and per queue."
+       ::= { jnxPppoeSubIfPerQueueStatsEntry  6 }
+             
+jnxPppoeSubIfQueueStatsActualDroppedBitRate    OBJECT-TYPE
+       SYNTAX            Counter32
+       MAX-ACCESS   read-only
+       STATUS             current
+       DESCRIPTION   
+                  "This attribute returns the actual dropped bit rate for per 
+                  PPPoEsession and per queue."
+      ::= { jnxPppoeSubIfPerQueueStatsEntry 7 }
+
+-- /////////////////////////////////////////////////////////////////////////////
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- PPPoEService-name tables
+--
+--  The service-name tables are non interface based objects
+-- This layer is managed with the following elements:
+--
+--  o Service-name table table (table if service-name tables)
+--  o Service-name table (service-name table entries) indexed by Service-name
+--    table name and service-name string value.
+--  o Service-name AciAri table (service-name AciAri table entries) indexed by 
+--    Service-name table name,service-name string value, Agent circuit
+-- Id( Aci string value)
+--    and Agent Remote Id (ari string value)
+--
+-- ///////////////////////////////////////////////////////////////
+
+-- /////////////////////////////////////////////////////////////////////////////
+--
+-- Service-name table table
+--
+-- /////////////////////////////////////////////////////////////////////////////
+jnxPPPoEServiceNameTableTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoEServiceNameTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for the PPPoEService-name tables."
+    ::= { jnxPPPoEServices 1 }
+
+jnxPPPoEServiceNameTableEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoEServiceNameTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The parameters for the PPPoEservice-name table."
+    INDEX     { jnxPPPoEServiceNameTableName }
+    ::= { jnxPPPoEServiceNameTableTable 1 }
+
+JnxPPPoEServiceNameTableEntry ::= SEQUENCE {
+    jnxPPPoEServiceNameTableName        DisplayString,
+    jnxPPPoEServiceNameTableRowStatus   RowStatus }
+
+jnxPPPoEServiceNameTableName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Service-name table name."
+    ::= { jnxPPPoEServiceNameTableEntry 1 }
+
+
+jnxPPPoEServiceNameTableRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with READ-CREATE
+         maximum access,according to the
+        RowStatus textual convention, constrained to support the following
+        values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST be
+        explicitly configured:
+            jnxPPPoEServiceNameTableRowStatus
+            jnxPPPoEServiceNameTableName
+           
+
+        The Empty Service and  Any  service will be automatically configured 
+       for each Service Name Table created. On creating or deleting an entry in 
+        this table will create/destroy an entry for <Empty >Service and <Any> 
+        service in jnxServiceNameTable.
+
+        A corresponding entry in jnxServiceNameTable gets created or destroyed
+        as a result of creating or destroying an entry in this table.
+         The following values can be read from this object:
+             active(1) "
+    ::= { jnxPPPoEServiceNameTableEntry 2 }
+
+-- ==========================================================================
+
+-- Service-name Table
+
+-- ========================================================================
+jnxPPPoEServiceNameTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoEServiceNameEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for the PPPoEService-names."
+    ::= { jnxPPPoEServices 2 }
+
+jnxPPPoEServiceNameEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoEServiceNameEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The parameters for the PPPoEservice-name table entry."
+    INDEX     { jnxPPPoEServiceNameTableName,
+                jnxPPPoEServiceName }
+    ::= { jnxPPPoEServiceNameTable 1 }
+
+JnxPPPoEServiceNameEntry ::= SEQUENCE {
+    jnxPPPoEServiceName                DisplayString,
+    jnxPPPoEServiceNameAction          JnxPPPoEServiceNameAction,
+    jnxPPPoEServiceNameDynamicProfile  DisplayString,
+    jnxPPPoEServiceNameRoutingInstance DisplayString,
+    jnxPPPoEServiceNameMaxSessions     Unsigned32,
+    jnxPPPoEServiceNameRowStatus       RowStatus }
+
+jnxPPPoEServiceName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..64))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Service-name tag value."
+    ::= { jnxPPPoEServiceNameEntry 1 }
+
+jnxPPPoEServiceNameAction OBJECT-TYPE
+    SYNTAX      JnxPPPoEServiceNameAction
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Identifies the behavior when the the Service-name tag is received in a
+        PADI frame."
+    ::= { jnxPPPoEServiceNameEntry 2 }
+
+jnxPPPoEServiceNameDynamicProfile OBJECT-TYPE
+    SYNTAX      DisplayString 
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Dynamic Profile associated with a Service-name."
+    ::= { jnxPPPoEServiceNameEntry 3 }
+
+jnxPPPoEServiceNameRoutingInstance OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Routing Instance associated with a Service-name."
+    ::= { jnxPPPoEServiceNameEntry 4 }
+
+jnxPPPoEServiceNameMaxSessions OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Max Sessions value used to cap the number of active PPPoEssessions 
+        that may be established with the specified Service entry."
+    ::= { jnxPPPoEServiceNameEntry 5 }
+
+
+jnxPPPoEServiceNameRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with READ-CREATE 
+        maximum access  ,according to the
+        RowStatus textual convention, constrained to support the following
+        values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST be
+        explicitly configured:
+            jnxPPPoEServiceNameRowStatus
+
+        The Service name is configured via the INDEX specified.
+
+        A corresponding entry in jnxPPPoEServiceNameAciAriTable is destroyed
+        as a result of destroying an entry in this table.
+
+        The following values can be read from this object:
+             active(1)"
+    ::= { jnxPPPoEServiceNameEntry 6 }
+
+-- ===========================================================================
+
+
+--Service-name ACI ARI Table
+
+-- ==============================================
+jnxPPPoEServiceNameAciAriTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF JnxPPPoEServiceNameAciAriEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "This table contains entries for the PPPoEServicename AciAri entries."
+    ::= { jnxPPPoEServices 3 }
+
+jnxPPPoEServiceNameAciAriEntry OBJECT-TYPE
+    SYNTAX      JnxPPPoEServiceNameAciAriEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The parameters for the PPPoEservice-name AciAri table entry."
+    INDEX     { jnxPPPoEServiceNameTableName,
+                jnxPPPoEServiceName, 
+                jnxPPPoEServiceNameAgentCircuitId,
+                jnxPPPoEServiceNameAgentRemoteId
+                }
+    ::= { jnxPPPoEServiceNameAciAriTable 1 }
+
+JnxPPPoEServiceNameAciAriEntry ::= SEQUENCE {
+    jnxPPPoEServiceNameAgentCircuitId                DisplayString,
+    jnxPPPoEServiceNameAgentRemoteId                 DisplayString,
+    jnxPPPoEServiceNameAciAriAction                  JnxPPPoEServiceNameAction,
+    jnxPPPoEServiceNameAciAriDynamicProfile          DisplayString,
+    jnxPPPoEServiceNameAciAriRoutingInstance         DisplayString,
+    jnxPPPoEServiceNameAciAriStaticInterface         DisplayString,
+    jnxPPPoEServiceNameAciAriRowStatus               RowStatus }
+
+jnxPPPoEServiceNameAgentCircuitId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "ACI tag values that the PPPoEclient would send in the PADI/PADR 
+        control packet."
+    ::= { jnxPPPoEServiceNameAciAriEntry 1 }
+
+jnxPPPoEServiceNameAgentRemoteId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "ACI tag values that the PPPoEclient would send in the PADI/PADR 
+        control packet."
+    ::= { jnxPPPoEServiceNameAciAriEntry 2 }
+
+
+jnxPPPoEServiceNameAciAriAction OBJECT-TYPE
+    SYNTAX      JnxPPPoEServiceNameAction
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Identifies the behavior when the the Service-name with ACI/ARI pairs 
+        is received in a PADI frame."
+    ::= { jnxPPPoEServiceNameAciAriEntry 3 }
+
+jnxPPPoEServiceNameAciAriDynamicProfile OBJECT-TYPE
+    SYNTAX      DisplayString 
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Dynamic Profile associated with a Service-name and ACI/ARI pairs"
+    ::= { jnxPPPoEServiceNameAciAriEntry 4 }
+
+jnxPPPoEServiceNameAciAriRoutingInstance OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..31))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Routing-Instance associated with a Service-name and ACI/ARI pairs"
+    ::= { jnxPPPoEServiceNameAciAriEntry 5 }
+
+jnxPPPoEServiceNameAciAriStaticInterface OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Static Interface associated with each ACI/ARI Entry."
+    ::= { jnxPPPoEServiceNameAciAriEntry 6 }
+
+
+jnxPPPoEServiceNameAciAriRowStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Controls creation/deletion of entries in this table with READ-CREATE
+         maximum access, according to the
+        RowStatus textual convention, constrained to support the following
+        values only:
+            createAndGo
+            destroy
+
+        To create an entry in this table, the following entry objects MUST be
+        explicitly configured:
+            jnxPPPoEServiceNameAciAriRowStatus
+
+        The ACIARI Entry is configured via the INDEX specified.
+
+        The following values can be read from this object:
+             active(1)"
+    ::= { jnxPPPoEServiceNameAciAriEntry 7 }
+
+-- 
+-- ////////////////////////////////////////////////////////////////////////////
+--
+-- PPP Interface Summary Counts
+--
+-- /////////////////////////////////////////////////////////////////////////////
+jnxPPPoEMajorInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces configured and created in
+        the system."
+    ::= { jnxPPPoESummary 1 }
+
+jnxPPPoESummaryMajorIfAdminUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces in the system that are
+        administratively configured to up(1)."
+    REFERENCE
+        "ifAdminStatus from IF-MIB"
+    ::= { jnxPPPoESummary 2 }
+
+jnxPPPoESummaryMajorIfAdminDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces in the system that are
+        administrateively configued to down(2)."
+    REFERENCE
+        "ifAdminStatus from IF-MIB"
+    ::= { jnxPPPoESummary 3 }
+
+jnxPPPoESummaryMajorIfOperUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces in the system with an
+        operational state of up(1)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 4 }
+
+jnxPPPoESummaryMajorIfOperDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces in the system with an
+        operational state of down(2)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 5 }
+
+jnxPPPoESummaryMajorIfLowerLayerDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces in the system with an
+        operational state of lowerLayerDown(7)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 6 }
+
+jnxPPPoESummaryMajorIfNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEmajor interfaces in the system with an
+        operational state of notPresent(6)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 7 }
+
+jnxPPPoESummarySubInterfaceCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces configured in the system."
+    ::= { jnxPPPoESummary 8 }
+
+jnxPPPoESummarySubIfAdminUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces in the system that are
+        administratively configured to up(1)."
+    REFERENCE
+        "ifAdminStatus from IF-MIB"
+    ::= { jnxPPPoESummary 9 }
+
+jnxPPPoESummarySubIfAdminDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces in the system that are
+        administrateively configued to down(2)."
+    REFERENCE
+        "ifAdminStatus from IF-MIB"
+    ::= { jnxPPPoESummary 10 }
+
+jnxPPPoESummarySubIfOperUp OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces in the system with an
+        operational state of up(1)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 11 }
+
+jnxPPPoESummarySubIfOperDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces in the system with an
+        operational state of down(2)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 12 }
+
+jnxPPPoESummarySubIfLowerLayerDown OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces in the system with an
+        operational state of lowerLayerDown(7)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 13 }
+
+jnxPPPoESummarySubIfNotPresent OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The total number of PPPoEsubinterfaces in the system with an
+        operational state of notPresent(6)."
+    REFERENCE
+        "ifOperStatus from IF-MIB"
+    ::= { jnxPPPoESummary 14 }
+
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Notifications
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- No notifications are defined in this MIB.  Placeholders follow.
+-- jnxPPPoETrapControl      OBJECT IDENTIFIER ::= { jnxPPPoEMIB 2 }
+-- jnxPPPoETraps            OBJECT IDENTIFIER ::= { jnxPPPoEMIB 3 }
+-- jnxPPPoETrapPrefix       OBJECT IDENTIFIER ::= { jnxPPPoETraps 0 }
+
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Conformance information
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+jnxPPPoEConformance OBJECT IDENTIFIER ::= { jnxPPPoEMIB 4 }
+jnxPPPoECompliances OBJECT IDENTIFIER ::= { jnxPPPoEConformance 1 }
+jnxPPPoEGroups      OBJECT IDENTIFIER ::= { jnxPPPoEConformance 2 }
+
+
+END
+
+

--- a/mibs/junos/mib-jnx-pwtdm.txt
+++ b/mibs/junos/mib-jnx-pwtdm.txt
@@ -31,13 +31,6 @@
      jnxVpnPwVpnType, jnxVpnPwVpnName, jnxVpnPwIndex
         FROM JUNIPER-VPN-MIB
 
-     -- jnxPwCfgIndexOrzero
-        -- FROM PW-TC-STD-MIB
-
-      -- jnxPwCfgIndexOrzero
-      -- FROM JUNIPER-PW-TC-MIB
-
-
     jnxPwTdmMibRoot
         FROM JUNIPER-SMI;
 

--- a/mibs/junos/mib-jnx-rpm-twamp.txt
+++ b/mibs/junos/mib-jnx-rpm-twamp.txt
@@ -1,0 +1,896 @@
+--
+-- Juniper Enterprise Specific MIB: TWAMP MIB
+-- 
+-- Copyright (c) 2007, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-TWAMP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Unsigned32, Integer32
+        FROM SNMPv2-SMI              -- RFC2578
+    NOTIFICATION-TYPE, OBJECT-IDENTITY,IpAddress
+	FROM SNMPv2-SMI
+    DateAndTime, TEXTUAL-CONVENTION, DisplayString
+        FROM SNMPv2-TC
+    CounterBasedGauge64
+        FROM HCNUM-TC
+    pingCtlOwnerIndex, pingCtlTestName, pingProbeHistoryIndex
+        FROM DISMAN-PING-MIB
+    jnxTwampMibRoot, jnxTwampNotificationPrefix
+        FROM JUNIPER-SMI
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB;
+
+jnxTwampMib MODULE-IDENTITY
+    LAST-UPDATED "201403010000Z" 
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+		     Juniper Networks, Inc.
+		     1194 N. Mathilda Avenue
+		     Sunnyvale, CA 94089
+		     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This mib provides data associated with the TWAMP feature" 
+    -- revision history
+    REVISION "201403010000Z" 
+    DESCRIPTION
+            "Initial definition."
+    ::= { jnxTwampMibRoot 1 }
+
+
+JnxTwampClientCollectionType ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Each TWAMP entry can maintain several collections of probes and
+         provide separate calculations over each collection.  The types of
+         collections include:
+
+             currentTest       -- the test currently being executed
+             lastCompletedTest -- the most recently completed test
+             movingAverage     -- the 'n' most recent probes (n is configurable)
+             allTests          -- all the probes (since the entry was last
+                                  reset).
+         
+         Objects with this type identify a specific collection."
+    SYNTAX INTEGER {  
+               currentTest       (1),
+               lastCompletedTest (2),
+               movingAverage     (3),
+               allTests          (4)
+           }
+
+JnxTwampClientMeasurementType ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "For each individual probe, several different measurements can be
+         made.  These include the following (all measurements are provided
+         in units of microseconds):
+
+             roundTripTime -- this is the delay between the the transmission of
+                 a probe and the arrival of its response.
+
+             rttJitter -- this is the difference between the current round trip
+                 time measurement and the previous one.
+
+             rttInterarrivalJitter -- An estimate of the statistical variance
+                 of a packet's interarrival time.  Defined in rfc1889 as:
+
+                   J=J+(|D(i-1,i)|-J)/16
+
+                 where J is the interarrival jitter and D(i-1, i) is the current
+                 round trip jitter measurement.
+
+             egress -- this is the delay beween the transmission of a probe and
+                 its arrival at its destination.
+
+             egressJitter -- this is the difference between the current egress
+                 delay the previous measurement.
+
+             egressInterarrivalJitter -- similar to rttInterarrivalJitter, but
+                 applied to egress jitter measurements.
+
+             ingress -- this is the delay between the transmission of a probe
+                 response and its arrival at its destination.
+
+             ingressJitter -- this is the difference between the current ingress
+                 delay and the previous measurement.
+
+             ingressInterarrivalJitter -- similar to rttInterarrivalJitter, but
+                 applied to ingress jitter measurements.
+       Note, due to clock synchronization artifacts, many one-way
+         jitter measurements & calculations may include signifacant variations,
+         in some cases orders of magnitude greater than the round trip times.
+         Because of this, one-way jitter measurements will only be performed
+         on samples which are less than 10 seconds apart."
+    SYNTAX     INTEGER {
+                   roundTripTime             (1),
+                   rttJitter                 (2),
+                   rttInterarrivalJitter     (3),
+                   egress                    (4),
+                   egressJitter              (5),
+                   egressInterarrivalJitter  (6),
+                   ingress                   (7),
+                   ingressJitter             (8),
+                   ingressInterarrivalJitter (9)
+               }
+
+JnxTwampClientMeasurementSet ::= TEXTUAL-CONVENTION
+    STATUS current
+    DESCRIPTION
+        "Over each collection of probes, TWAMP calculates statistics for several
+         sets of measurements.  These sets include the following:
+
+             roundTripTime    -- the set of round trip delays
+             posRttJitter     -- the set of positive round trip jitter
+                                 measurements
+             negRttJitter     -- the set of negative round trip jitter
+                                 measurements
+             egress           -- the set of outgoing (source to destination)
+                                 one-way delays
+             posEgressJitter  -- the set of positive egress jitter measurements
+             negEgressJitter  -- the set of negative egress jitter measurements
+             ingress          -- the set of incoming (destination to source)
+                                 one-way delays
+             posIngressJitter -- the set of positive ingress jitter measurements
+             negIngressJitter -- the set of negative ingress jitter measurements
+
+        Objects with this type identify a specific set of measurements."
+    SYNTAX INTEGER {
+               roundTripTime    (1),
+               posRttJitter     (2),
+               negRttJitter     (3),
+               egress           (4),
+               posEgressJitter  (5),
+               negEgressJitter  (6),
+               ingress          (7),
+               posIngressJitter (8),
+               negIngressJitter (9)
+           }
+
+
+jnxTwampClientNode	OBJECT-IDENTITY
+    STATUS			current
+    DESCRIPTION	
+			  "The node contains all the TWAMP client related tables."
+::= {jnxTwampMib 1}
+
+jnxTwampRpmIdentity	OBJECT-TYPE
+    SYNTAX		INTEGER {
+				rpm(1),
+				twamp(2)
+				}
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION		
+	      "This object is added to be binded to the traps. This object simply identifies if 
+		its an RPM type of test or a TWAMP type of test."
+::= {jnxTwampMib 2}
+
+--
+-- Sample Results Table
+--
+    jnxTwampClientResultsSampleTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxTwampClientResultsSampleEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table provides measurements from the latest individual TWAMP
+             probe samples.  Within each sample, the specific measurement type
+             is identified by jnxTwampClientResSampleType.  Note, if the latest
+             probe was unsuccessful, no measurement types will be available.
+
+             See the definition of JnxTwampClientMeasurementType for details on
+             the types of measurements available."
+        ::= { jnxTwampClientNode 1 }
+
+    jnxTwampClientResultsSampleEntry OBJECT-TYPE
+        SYNTAX      JnxTwampClientResultsSampleEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Each entry provides a specific measurement type for a single
+             probe."
+        INDEX { pingCtlOwnerIndex, pingCtlTestName, jnxTwampResSampleType }
+        ::= { jnxTwampClientResultsSampleTable 1 }
+
+    JnxTwampClientResultsSampleEntry ::=
+        SEQUENCE {
+            jnxTwampResSampleType          JnxTwampClientMeasurementType,
+            jnxTwampResSampleValue         Integer32,
+            jnxTwampResSampleDate          DateAndTime
+        }
+
+    jnxTwampResSampleType OBJECT-TYPE
+        SYNTAX     JnxTwampClientMeasurementType
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "This object identifies the specific measurement type returned
+            by jnxTwampResSampleValue."
+       ::= { jnxTwampClientResultsSampleEntry 1 }
+
+    jnxTwampResSampleValue OBJECT-TYPE
+       SYNTAX     Integer32
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+           "This object returns the measurement identified by the corresponding
+            jnxTwampResSampleType."
+       ::= { jnxTwampClientResultsSampleEntry 2 }
+
+    jnxTwampResSampleDate OBJECT-TYPE
+        SYNTAX     DateAndTime
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the date and time of when this measurement
+             was obtained."
+        ::= { jnxTwampClientResultsSampleEntry 3 }
+
+
+--
+-- Summary Results Table
+--
+    jnxTwampClientResultsSummaryTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxTwampClientResultsSummaryEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table provides a summary of the results for a specific
+             TWAMP entry (identified by pingCtlOwnerIndex/pingCtlTestName).
+             The scope of the summary is identified by jnxTwampClientResSumCollection."
+        ::= { jnxTwampClientNode 2 }
+
+    jnxTwampClientResultsSummaryEntry OBJECT-TYPE
+        SYNTAX      JnxTwampClientResultsSummaryEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Each entry in the table provides a summary of the TWAMP results
+             over a single collection of probes(test session).  For each TWAMP entry, there
+             are several collections maintained: the current test, the
+             most recently completed test, a configurable number of the most
+             recent probes (aka 'moving average'), and a global collection
+             representing all the probes.  Each entry in this table summarizes
+             the results for one of these collections."
+        INDEX { pingCtlOwnerIndex, pingCtlTestName, jnxTwampResSumCollection }
+        ::= { jnxTwampClientResultsSummaryTable 1 }
+
+    JnxTwampClientResultsSummaryEntry ::=
+        SEQUENCE {
+            jnxTwampResSumCollection               JnxTwampClientCollectionType,
+            jnxTwampResSumSent                     Unsigned32,
+            jnxTwampResSumReceived                 Unsigned32,
+            jnxTwampResSumPercentLost              Unsigned32,
+            jnxTwampResSumDate                     DateAndTime
+        }
+
+    jnxTwampResSumCollection OBJECT-TYPE
+        SYNTAX      JnxTwampClientCollectionType
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This object identifes the collection of probes over which the
+             summary data represented by the other objects in this table
+             applies.  Note, if a collection type is not supported or not
+             configured, it will not be instantiated in this table."
+        ::= { jnxTwampClientResultsSummaryEntry 1 }
+
+    jnxTwampResSumSent OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the number of probes sent within the
+             collection identified by jnxTwampResSumCollection."
+        ::= { jnxTwampClientResultsSummaryEntry 2 }
+
+    jnxTwampResSumReceived OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the number of probes received within the
+             collection identified by jnxTwampResSumCollection."
+        ::= { jnxTwampClientResultsSummaryEntry 3 }
+
+    jnxTwampResSumPercentLost OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the percentage of probes lost within the
+             collection identified by jnxTwampResSumCollection."
+        ::= { jnxTwampClientResultsSummaryEntry 4 }
+
+    jnxTwampResSumDate OBJECT-TYPE
+        SYNTAX     DateAndTime
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the date and time of when the most recent
+             probe within the collection identified by jnxTwampResSumCollection
+             was completed."
+        ::= { jnxTwampClientResultsSummaryEntry 5 }
+---
+--Calculated Results Table
+--
+    jnxTwampClientResultsCalculatedTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxTwampClientResultsCalculatedEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table provides a set of calculated values for each
+             TWAMP entry, for each collection of probes maintained within that
+             entry, and for each supported measurement set within that
+             collection of probes.
+
+             This table will skip over any measurement set for which
+             there are 0 samples."
+        ::= { jnxTwampClientNode 3 }
+
+    jnxTwampClientResultsCalculatedEntry OBJECT-TYPE
+        SYNTAX      JnxTwampClientResultsCalculatedEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            ""
+        INDEX { pingCtlOwnerIndex, pingCtlTestName, jnxTwampResSumCollection,
+                jnxTwampResCalcSet }
+        ::= { jnxTwampClientResultsCalculatedTable 1 }
+
+    JnxTwampClientResultsCalculatedEntry ::=
+        SEQUENCE {
+            jnxTwampResCalcSet       JnxTwampClientMeasurementSet,
+            jnxTwampResCalcSamples   Unsigned32,
+            jnxTwampResCalcMin       Unsigned32,
+            jnxTwampResCalcMax       Unsigned32,
+            jnxTwampResCalcAverage   Unsigned32,
+            jnxTwampResCalcPkToPk    Unsigned32,
+            jnxTwampResCalcStdDev    Unsigned32,
+            jnxTwampResCalcSum       CounterBasedGauge64
+        }
+
+    jnxTwampResCalcSet OBJECT-TYPE
+        SYNTAX      JnxTwampClientMeasurementSet
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This object identifies the measurement set upon which the
+             calculations returned by the other objects in this table are
+             based."
+        ::= { jnxTwampClientResultsCalculatedEntry 1 }
+
+    jnxTwampResCalcSamples OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The number of samples used in this calculations."
+        ::= { jnxTwampClientResultsCalculatedEntry 2 }
+
+    jnxTwampResCalcMin OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The minimum of all the samples in the collection and measurement
+             set associated with this row.  Values are provided in units
+             of microseconds."
+        ::= { jnxTwampClientResultsCalculatedEntry 3 }
+
+    jnxTwampResCalcMax OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The maximum of all the samples in the collection and measurement
+             set associated with this row.  Values are provided in units
+             of microseconds."
+        ::= { jnxTwampClientResultsCalculatedEntry 4 }
+    jnxTwampResCalcAverage OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The average of all the samples in the collection and measurement
+             set associated with this row.  Values are provided in units
+             of microseconds."
+        ::= { jnxTwampClientResultsCalculatedEntry 5 }
+
+    jnxTwampResCalcPkToPk OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The difference between the minimum and maximum of all the samples
+             in the collection and measurement set associated with this row.
+             Values are provided in units of microseconds."
+        ::= { jnxTwampClientResultsCalculatedEntry 6 }
+
+    jnxTwampResCalcStdDev OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The standard deviation calculated over all the samples
+             in the collection and measurement set associated with this row.
+             Values are provided in units of microseconds."
+        ::= { jnxTwampClientResultsCalculatedEntry 7 }
+
+    jnxTwampResCalcSum OBJECT-TYPE
+        SYNTAX     CounterBasedGauge64
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The sum of all the samples in the collection and measurement set
+             associated with this row.  Values are provided in units of
+             microseconds."
+        ::= { jnxTwampClientResultsCalculatedEntry 8 }
+
+
+--
+-- History Sample Table
+--
+    jnxTwampClientHistorySampleTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxTwampClientHistorySampleEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table provides measurements for individual TWAMP probe samples(test sessions).
+             In addition to the last completed sample, a configurable number of
+             the most recent samples are available as well.  Within each sample,
+             the specific measurement type is identified by
+             jnxTwampHistSampleType.  Note, if probe was unsuccessful, no
+             measurement types will be available for that history entry.
+
+             See the definition of JnxTwampClientMeasurementType for details on
+             of measurements available."
+        ::= { jnxTwampClientNode 4 }
+
+    jnxTwampClientHistorySampleEntry OBJECT-TYPE
+        SYNTAX      JnxTwampClientHistorySampleEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            ""
+        INDEX { pingCtlOwnerIndex, pingCtlTestName, pingProbeHistoryIndex,
+                jnxTwampHistSampleType }
+        ::= { jnxTwampClientHistorySampleTable 1 }
+
+    JnxTwampClientHistorySampleEntry ::=
+        SEQUENCE {
+            jnxTwampHistSampleType          JnxTwampClientMeasurementType,
+            jnxTwampHistSampleValue         Integer32
+        }
+
+    jnxTwampHistSampleType OBJECT-TYPE
+        SYNTAX     JnxTwampClientMeasurementType
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "This object identifies the specific measurement type returned
+            by jnxTwampHistSampleValue."
+       ::= { jnxTwampClientHistorySampleEntry 1 }
+
+    jnxTwampHistSampleValue OBJECT-TYPE
+       SYNTAX     Integer32
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+           "This object returns the measurement identified by the corresponding
+            jnxTwampHistSampleType."
+       ::= { jnxTwampClientHistorySampleEntry 2 }
+
+--
+-- History Summary Table
+--
+    jnxTwampClientHistorySummaryTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxTwampClientHistorySummaryEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table provides historical summary data for each collection
+             of probes(test session) within each TWAMP Control Entry, similar to the
+             jnxTwampClientResultsSummaryTable.
+
+             In addition to the current summary, this table provides the same
+             number of historical entries as the jnxTwampClientHistorySampleTable."
+        ::= { jnxTwampClientNode 5 }
+
+    jnxTwampClientHistorySummaryEntry OBJECT-TYPE
+        SYNTAX      JnxTwampClientHistorySummaryEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            ""
+        INDEX { pingCtlOwnerIndex, pingCtlTestName, pingProbeHistoryIndex,
+                jnxTwampHistSumCollection }
+        ::= { jnxTwampClientHistorySummaryTable 1 }
+
+    JnxTwampClientHistorySummaryEntry ::=
+        SEQUENCE {
+            jnxTwampHistSumCollection  JnxTwampClientCollectionType,
+            jnxTwampHistSumSent        Unsigned32,
+            jnxTwampHistSumReceived    Unsigned32,
+            jnxTwampHistSumPercentLost Unsigned32
+        }
+
+    jnxTwampHistSumCollection OBJECT-TYPE
+        SYNTAX      JnxTwampClientCollectionType
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "Identifies the collection of probes whose results are summarized by
+             this row.
+
+             At this time, historical summaries are available only for the
+             current test (currentTest(1))."
+        ::= { jnxTwampClientHistorySummaryEntry 1 }
+
+    jnxTwampHistSumSent OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the number of probes sent within the
+             collection identified by jnxTwampHistSumCollection."
+        ::= { jnxTwampClientHistorySummaryEntry 2 }
+
+    jnxTwampHistSumReceived OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the number of probes received within the
+             collection identified by jnxTwampHistSumCollection."
+        ::= { jnxTwampClientHistorySummaryEntry 3 }
+
+    jnxTwampHistSumPercentLost OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "This object provides the percentage of probes lost within the
+             collection identified by jnxTwampHistSumCollection."
+        ::= { jnxTwampClientHistorySummaryEntry 4 }
+
+
+
+--
+-- History Calculated Table
+--
+    jnxTwampClientHistoryCalculatedTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxTwampClientHistoryCalculatedEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "This table provides a set of calculated values for each
+             TWAMP control entry, for each test session maintained within that
+             entry, and for each supported calculated type within that
+             collection of probes, similar to the jnxTwampClientResultsCalculatedTable.
+
+             In addition to the current summary, this table provides the same
+             number of historical entries as the jnxTwampClientHistorySampleTable."
+        ::= { jnxTwampClientNode 6 }
+
+    jnxTwampClientHistoryCalculatedEntry OBJECT-TYPE
+        SYNTAX      JnxTwampClientHistoryCalculatedEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            ""
+        INDEX { pingCtlOwnerIndex, pingCtlTestName, pingProbeHistoryIndex,
+                jnxTwampHistSumCollection, jnxTwampHistCalcSet }
+        ::= { jnxTwampClientHistoryCalculatedTable 1 }
+    JnxTwampClientHistoryCalculatedEntry ::=
+        SEQUENCE {
+            jnxTwampHistCalcSet       JnxTwampClientMeasurementSet,
+            jnxTwampHistCalcSamples   Unsigned32,
+            jnxTwampHistCalcMin       Unsigned32,
+            jnxTwampHistCalcMax       Unsigned32,
+            jnxTwampHistCalcAverage   Unsigned32,
+            jnxTwampHistCalcPkToPk    Unsigned32,
+            jnxTwampHistCalcStdDev    Unsigned32,
+            jnxTwampHistCalcSum       CounterBasedGauge64
+        }
+
+    jnxTwampHistCalcSet OBJECT-TYPE
+       SYNTAX     JnxTwampClientMeasurementSet
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+            "This object identifies the measurement set upon which the
+             calculations returned by the other objects in this table are
+             based."
+       ::= { jnxTwampClientHistoryCalculatedEntry 1 }
+
+    jnxTwampHistCalcSamples OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The number of samples used in this calculations."
+        ::= { jnxTwampClientHistoryCalculatedEntry 2 }
+
+    jnxTwampHistCalcMin OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The minimum of all the samples in the collection and measurement
+             set associated with this row.  Values are provided in units
+             of microseconds."
+        ::= { jnxTwampClientHistoryCalculatedEntry 3 }
+    jnxTwampHistCalcMax OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The maximum of all the samples in the collection and measurement
+             set associated with this row.  Values are provided in units
+             of microseconds."
+        ::= { jnxTwampClientHistoryCalculatedEntry 4 }
+
+    jnxTwampHistCalcAverage OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The average of all the samples in the collection and measurement
+             set associated with this row.  Values are provided in units
+             of microseconds."
+        ::= { jnxTwampClientHistoryCalculatedEntry 5 }
+
+    jnxTwampHistCalcPkToPk OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The difference between the minimum and maximum of all the samples
+             in the collection and measurement set associated with this row.
+             Values are provided in units of microseconds."
+        ::= { jnxTwampClientHistoryCalculatedEntry 6 }
+
+    jnxTwampHistCalcStdDev OBJECT-TYPE
+        SYNTAX     Unsigned32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The standard deviation calculated over all the samples
+             in the collection and measurement set associated with this row.
+             Values are provided in units of microseconds."
+        ::= { jnxTwampClientHistoryCalculatedEntry 7 }
+
+    jnxTwampHistCalcSum OBJECT-TYPE
+        SYNTAX     CounterBasedGauge64
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+            "The sum of all the samples in the collection and measurement set
+             associated with this row.  Values are provided in units of
+             microseconds."
+        ::= { jnxTwampClientHistoryCalculatedEntry 8 }
+
+-- Control Sessions Table --
+    jnxTwampClientControlConnectionTable OBJECT-TYPE
+        SYNTAX       SEQUENCE OF JnxTwampClientCCEntry
+        MAX-ACCESS   not-accessible
+        STATUS       current
+        DESCRIPTION
+                "Table of Client Sessions."
+        ::= { jnxTwampClientNode 7 }
+
+    jnxTwampClientCCEntry OBJECT-TYPE
+        SYNTAX       JnxTwampClientCCEntry
+        MAX-ACCESS   not-accessible
+        STATUS       current
+        DESCRIPTION
+                "TWAMP Client Session characteristics."
+        INDEX { jnxTwampClientControlConnectionID }
+        ::= { jnxTwampClientControlConnectionTable 1 }
+
+
+    JnxTwampClientCCEntry ::= 
+        SEQUENCE {
+            jnxTwampClientControlConnectionID  SnmpAdminString,
+            jnxTwampClientCCName      DisplayString,
+            jnxTwampClientCCStatus    INTEGER(0..65535),
+            jnxTwampClientServerAddress    IpAddress,
+            jnxTwampClientServerPort  INTEGER(0..65535),
+            jnxTwampClientTSConfiguredCount INTEGER(0..65535),
+            jnxTwampClientTSActiveCount        INTEGER(0..65535),
+            jnxTwampClientAuthMode     INTEGER(0..65535)
+        } 
+
+    jnxTwampClientControlConnectionID OBJECT-TYPE
+        SYNTAX              SnmpAdminString (SIZE(0..32))
+        MAX-ACCESS          not-accessible
+        STATUS              current
+        DESCRIPTION
+            "TWAMP Client control session ID."
+            ::= { jnxTwampClientCCEntry 1 }
+
+    jnxTwampClientCCName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+             "Text string containing the session's unique name."
+            ::= { jnxTwampClientCCEntry 2 }
+
+    jnxTwampClientCCStatus OBJECT-TYPE
+        SYNTAX         INTEGER {
+                        active(1),
+                        stopped(2)
+                    }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+                "If the control session is active, this would return 1.
+                 If the control session does not have any currently
+                 running test sessions and is not active, this would return 2."
+            ::= { jnxTwampClientCCEntry 3 }
+
+    jnxTwampClientServerAddress OBJECT-TYPE
+        SYNTAX             IpAddress
+        MAX-ACCESS         read-only
+        STATUS             current
+        DESCRIPTION
+                "Server IP address for TWAMP TCP control session."
+            ::= { jnxTwampClientCCEntry 4 }
+    jnxTwampClientServerPort     OBJECT-TYPE
+        SYNTAX             INTEGER (0..65535)
+        MAX-ACCESS         read-only
+        STATUS             current
+        DESCRIPTION
+                "Destination port for TWAMP TCP control connection."
+            ::= { jnxTwampClientCCEntry 5 }
+
+    jnxTwampClientTSConfiguredCount OBJECT-TYPE
+        SYNTAX             INTEGER (0..65535)
+        MAX-ACCESS         read-only
+        STATUS             current
+        DESCRIPTION
+               "Number test sessions configured."
+            ::= { jnxTwampClientCCEntry 6 }
+
+    jnxTwampClientTSActiveCount     OBJECT-TYPE
+        SYNTAX             INTEGER(0..65535)
+        MAX-ACCESS         read-only
+        STATUS             current
+        DESCRIPTION
+                "Number of test sessions currently running."
+            ::= { jnxTwampClientCCEntry 7 }
+
+    jnxTwampClientAuthMode    OBJECT-TYPE
+        SYNTAX             INTEGER {
+                            none(1),
+                            authenticated(2),
+                            encrypted(3),
+                            controlOnlyEncrypted(4)
+                         }
+        MAX-ACCESS           read-only
+        STATUS               current
+        DESCRIPTION
+                " Authenticated mode for the control session."
+            ::= {jnxTwampClientCCEntry 8 }
+
+--- Table containing entries for all test sessions 
+ jnxTwampClientTestSessionsTable        OBJECT-TYPE
+    SYNTAX              SEQUENCE OF JnxTwampClientTSEntry
+    MAX-ACCESS          not-accessible
+    STATUS              current
+    DESCRIPTION
+              "Table of Test Sessions."
+     ::= {jnxTwampClientNode 8}
+
+ jnxTwampClientTSEntry          OBJECT-TYPE
+    SYNTAX              JnxTwampClientTSEntry
+    MAX-ACCESS          not-accessible
+    STATUS              current
+    DESCRIPTION
+              "TWAMP Test Session characteristics."
+    INDEX {pingCtlOwnerIndex, jnxTwampClientTestSessionID }
+    ::= { jnxTwampClientTestSessionsTable 1 }
+
+ JnxTwampClientTSEntry ::= SEQUENCE {
+        jnxTwampClientTestSessionID     SnmpAdminString,
+        jnxTwampClientTSName            DisplayString,
+        jnxTwampClientTSStatus          INTEGER,
+        jnxTwampClientTSSenderAddress   IpAddress,
+        jnxTwampClientTSSenderPort      INTEGER,
+        jnxTwampClientTSReflectorAddress IpAddress,
+        jnxTwampClientTSReflectorPort   INTEGER
+  }
+
+ jnxTwampClientTestSessionID    OBJECT-TYPE
+    SYNTAX              SnmpAdminString (SIZE(0..32))
+    MAX-ACCESS          not-accessible
+    STATUS              current
+    DESCRIPTION
+              "Test Session ID."
+        ::= { jnxTwampClientTSEntry 1 }
+
+
+ jnxTwampClientTSName           OBJECT-TYPE
+    SYNTAX              DisplayString
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+              "TWAMP Test Session Name."
+        ::= {jnxTwampClientTSEntry 2 }
+
+ jnxTwampClientTSStatus         OBJECT-TYPE
+    SYNTAX              INTEGER {
+                                active (1),
+                                stopped (2)
+                        }
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+              "TWAMP Test Session status."
+        ::= {jnxTwampClientTSEntry 3 }
+ jnxTwampClientTSSenderAddress  OBJECT-TYPE
+    SYNTAX              IpAddress
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+              "Twamp Test Sender Address."
+        ::= {jnxTwampClientTSEntry 4 }
+
+ jnxTwampClientTSSenderPort     OBJECT-TYPE
+    SYNTAX              INTEGER (0..65535)
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+              "TWAMP Test Session Sender Port."
+        ::= {jnxTwampClientTSEntry 5 }
+
+ jnxTwampClientTSReflectorAddress OBJECT-TYPE
+    SYNTAX              IpAddress
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+              "TWAMP Test Session Reflector Address."
+        ::= {jnxTwampClientTSEntry 6}
+
+ jnxTwampClientTSReflectorPort  OBJECT-TYPE
+    SYNTAX              INTEGER (0..65535)
+    MAX-ACCESS          read-only
+    STATUS              current
+    DESCRIPTION
+              "TWAMP Test Session Reflector Port. "
+        ::= {jnxTwampClientTSEntry 7 }
+
+
+twampNotifications      OBJECT IDENTIFIER ::= {jnxTwampNotificationPrefix 1 }
+
+ jnxTwampClientControlConnectionClosed  NOTIFICATION-TYPE
+    OBJECTS {
+                jnxTwampClientCCName
+        }
+    STATUS              current
+    DESCRIPTION
+              "This trap is generated when all the test iterations configured under the control
+                connection finish running and control connection is closed."
+
+        ::= {twampNotifications 1 }
+ jnxTwampClientTestIterationFinished    NOTIFICATION-TYPE
+    OBJECTS {
+                jnxTwampClientCCName
+        }
+    STATUS              current
+    DESCRIPTION
+              "This trap is generated when one test iteration is finished for all the
+                test sessions configured under the control connection."
+        ::= {twampNotifications 2 }
+
+
+END

--- a/mibs/junos/mib-jnx-rps.txt
+++ b/mibs/junos/mib-jnx-rps.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: RPS 
 --
--- Copyright (c) 2007-2008, Juniper Networks, Inc.
+-- Copyright (c) 2007-2009, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.

--- a/mibs/junos/mib-jnx-services.txt
+++ b/mibs/junos/mib-jnx-services.txt
@@ -1,0 +1,988 @@
+--
+-- Juniper Enterprise Specifics MIB
+-- 
+-- Copyright (c) 2003-2004, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+--
+
+JUNIPER-Services-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter64, Gauge32
+        FROM SNMPv2-SMI
+    ifIndex
+        FROM IF-MIB
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    jnxMibs
+        FROM JUNIPER-SMI;
+
+jnxServicesInfoMib  	MODULE-IDENTITY
+    LAST-UPDATED 	"200307182154Z" -- Fri Jul 18 21:54:00 2003 UTC
+    ORGANIZATION 	"Juniper Networks, Inc."
+    CONTACT-INFO
+            		"Juniper Technical Assistance Center
+			Juniper Networks, Inc.
+			1194 N. Mathilda Avenue
+			Sunnyvale, CA 94089
+			E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This is Juniper Networks' implementation of enterprise
+	     specific MIB for monitoring services properties"
+
+    -- revision history -- 
+    
+	REVISION "200401300000Z"    -- 30 January, 2004
+	DESCRIPTION
+		"Initial version."
+
+    ::= { jnxMibs 27 }
+
+
+--
+-- Flow table aggregate statistics information
+--
+-- These statistics concern the basic flow table functionality 
+-- available on both AS PICs and GGSN-I PICs
+--
+
+
+jnxSvcFlowTableAggStatsTable	OBJECT-TYPE
+    SYNTAX       		SEQUENCE OF JnxSvcFlowTableAggStatsEntry
+    MAX-ACCESS   		not-accessible
+    STATUS       		current
+    DESCRIPTION
+	"Aggregated statistics information about all flow tables on 
+	 the service PIC interface."
+    ::= { jnxServicesInfoMib 1 }
+
+jnxSvcFlowTableAggStatsEntry	OBJECT-TYPE
+    SYNTAX			JnxSvcFlowTableAggStatsEntry
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+	"An entry containing aggregated statistics for all 
+	 flow tables for a particular service pic interface."
+    INDEX   		{ ifIndex }
+    ::= { jnxSvcFlowTableAggStatsTable 1 }
+
+JnxSvcFlowTableAggStatsEntry ::= SEQUENCE {
+
+    --- flow creation, cleanup, counts
+    
+    jnxSvcAggFlow			Gauge32,
+    jnxSvcAggFlowMaximum		Gauge32,
+    jnxSvcAggFlowCreated		Counter64,
+    jnxSvcAggFlowFreed			Counter64,
+    jnxSvcAggFlowIdleFreed		Counter64,
+
+    --- TCP flows (all types)
+
+    jnxSvcAggFlowTcp			Gauge32,
+    jnxSvcAggFlowTcpMaximum		Gauge32,
+    jnxSvcAggFlowTcpCreated		Counter64,
+    jnxSvcAggFlowTcpFreed		Counter64,
+    jnxSvcAggFlowTcpIdleFreed		Counter64,
+
+    --- UDP flows (all types)
+
+    jnxSvcAggFlowUdp			Gauge32,
+    jnxSvcAggFlowUdpMaximum		Gauge32,
+    jnxSvcAggFlowUdpCreated		Counter64,
+    jnxSvcAggFlowUdpFreed		Counter64,
+    jnxSvcAggFlowUdpIdleFreed		Counter64,
+
+    -- general counters for packets 
+
+    jnxSvcAggFlowPkt			Counter64, -- total
+    jnxSvcAggFlowPktErr		Counter64,
+    jnxSvcAggFlowByte			Counter64, -- total 
+    jnxSvcAggFlowByteErr		Counter64,
+
+    -- ICMP packets are a special case
+    
+    jnxSvcAggFlowIcmpPkt		Counter64, -- total
+    jnxSvcAggFlowIcmpPktErr		Counter64,
+    jnxSvcAggFlowIcmpPktErrBadFlow	Counter64,
+    jnxSvcAggFlowIcmpByte		Counter64, -- total
+    jnxSvcAggFlowIcmpByteErr	Counter64,
+    
+    -- TCP packets overall statistics
+    
+    jnxSvcAggFlowTcpPkt			Counter64, -- total 
+    jnxSvcAggFlowTcpPktErr		Counter64,
+    jnxSvcAggFlowTcpPktErrBadFlow	Counter64,
+    jnxSvcAggFlowTcpByte		Counter64, -- total
+    jnxSvcAggFlowTcpByteErr	Counter64,
+    
+    -- UDP packets overall statistics
+
+    jnxSvcAggFlowUdpPkt			Counter64, -- total 
+    jnxSvcAggFlowUdpPktErr		Counter64,
+    jnxSvcAggFlowUdpPktErrBadFlow	Counter64, 
+    jnxSvcAggFlowUdpByte		Counter64, -- total
+    jnxSvcAggFlowUdpByteErr	Counter64
+}
+
+jnxSvcAggFlow		OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of flows of any kind in the flow table."
+    ::= { jnxSvcFlowTableAggStatsEntry 1 }
+    
+jnxSvcAggFlowMaximum	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Maximum number of flows of any kind in the flow table
+    	 (high water mark)."
+    ::= { jnxSvcFlowTableAggStatsEntry 2 }
+    
+jnxSvcAggFlowCreated	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of flows of any kind that have been
+    	 created in the flow table."
+    ::= { jnxSvcFlowTableAggStatsEntry 3 }
+    
+jnxSvcAggFlowFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of flows of any kind that have been
+    	 freed from the flow table for any reason."
+    ::= { jnxSvcFlowTableAggStatsEntry 4 }
+    
+jnxSvcAggFlowIdleFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of flows of any kind that have been
+    	 freed from the flow table by idle flow detection."
+    ::= { jnxSvcFlowTableAggStatsEntry 5 }
+    
+jnxSvcAggFlowTcp	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP flows in the flow table."
+    ::= { jnxSvcFlowTableAggStatsEntry 6 }
+    
+jnxSvcAggFlowTcpMaximum	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Maximum number of TCP flows in the flow table
+    	 (high water mark)."
+    ::= { jnxSvcFlowTableAggStatsEntry 7 }
+    
+jnxSvcAggFlowTcpCreated	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP flows that have been
+    	 created in the flow table."
+    ::= { jnxSvcFlowTableAggStatsEntry 8 }
+    
+jnxSvcAggFlowTcpFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP flows that have been
+    	 freed from the flow table for any reason."
+    ::= { jnxSvcFlowTableAggStatsEntry 9 }
+    
+jnxSvcAggFlowTcpIdleFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP flows that have been
+    	 freed from the flow table by idle flow detection."
+    ::= { jnxSvcFlowTableAggStatsEntry 10 }
+    
+jnxSvcAggFlowUdp	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of UDP flows in the flow table."
+    ::= { jnxSvcFlowTableAggStatsEntry 11 }
+    
+jnxSvcAggFlowUdpMaximum	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Maximum number of TCP flows in the flow table
+    	 (high water mark)."
+    ::= { jnxSvcFlowTableAggStatsEntry 12 }
+    
+jnxSvcAggFlowUdpCreated	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP flows that have been
+    	 created in the flow table."
+    ::= { jnxSvcFlowTableAggStatsEntry 13 }
+    
+jnxSvcAggFlowUdpFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of UDP flows that have been
+    	 freed from the flow table for any reason."
+    ::= { jnxSvcFlowTableAggStatsEntry 14 }
+    
+jnxSvcAggFlowUdpIdleFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP flows that have been
+    	 freed from the flow table by idle flow detection."
+    ::= { jnxSvcFlowTableAggStatsEntry 15 }
+    
+jnxSvcAggFlowPkt	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of packets processed by all flows."
+    ::= { jnxSvcFlowTableAggStatsEntry 16 }
+    
+jnxSvcAggFlowPktErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of packets 
+    	 found to be in invalid  in processing by all flows."
+    ::= { jnxSvcFlowTableAggStatsEntry 17 }
+    
+jnxSvcAggFlowByte	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for packets processed by all flows."
+    ::= { jnxSvcFlowTableAggStatsEntry 18 }
+    
+jnxSvcAggFlowByteErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for packets
+    	found to be in invalid in processing by all flows."
+    ::= { jnxSvcFlowTableAggStatsEntry 19 }
+    
+jnxSvcAggFlowIcmpPkt	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of ICMP packets processed."
+    ::= { jnxSvcFlowTableAggStatsEntry 20 }
+    
+jnxSvcAggFlowIcmpPktErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of ICMP packets 
+    	found to be in invalid for any reason."
+    ::= { jnxSvcFlowTableAggStatsEntry 21 }
+    
+jnxSvcAggFlowIcmpPktErrBadFlow	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of ICMP packets 
+    	 found to be in invalid because the flow was invalid."
+    ::= { jnxSvcFlowTableAggStatsEntry 22 }
+    
+jnxSvcAggFlowIcmpByte	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for all ICMP packets processed."
+    ::= { jnxSvcFlowTableAggStatsEntry 23 }
+    
+jnxSvcAggFlowIcmpByteErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for all 
+    	ICMP packets found to be in invalid."
+    ::= { jnxSvcFlowTableAggStatsEntry 24 }
+    
+jnxSvcAggFlowTcpPkt	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP packets processed."
+    ::= { jnxSvcFlowTableAggStatsEntry 25 }
+    
+jnxSvcAggFlowTcpPktErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP packets found to be in invalid 
+    	 for any reason."
+    ::= { jnxSvcFlowTableAggStatsEntry 26 }
+    
+jnxSvcAggFlowTcpPktErrBadFlow	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of TCP packets found to be in invalid 
+    	 because the flow was invalid."
+    ::= { jnxSvcFlowTableAggStatsEntry 27 }
+    
+jnxSvcAggFlowTcpByte	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for all TCP packets processed."
+    ::= { jnxSvcFlowTableAggStatsEntry 28 }
+    
+jnxSvcAggFlowTcpByteErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for all TCP packets found to be in invalid"
+    ::= { jnxSvcFlowTableAggStatsEntry 29 }
+    
+jnxSvcAggFlowUdpPkt	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of UDP packets processed."
+    ::= { jnxSvcFlowTableAggStatsEntry 30 }
+    
+jnxSvcAggFlowUdpPktErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of UDP packets found to be in invalid 
+    	 for any reason."
+    ::= { jnxSvcFlowTableAggStatsEntry 31 }
+    
+jnxSvcAggFlowUdpPktErrBadFlow	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of UDP packets 
+    	 found to be in invalid because the flow
+    	 was invalid."
+    ::= { jnxSvcFlowTableAggStatsEntry 32 }
+    
+jnxSvcAggFlowUdpByte	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for all UDP packets processed."
+    ::= { jnxSvcFlowTableAggStatsEntry 33 }
+    
+jnxSvcAggFlowUdpByteErr	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+    	"Total number of bytes for all TCP packets
+    	found to be in invalid."
+    ::= { jnxSvcFlowTableAggStatsEntry 34 }
+
+
+--
+-- Service Identification Service Statistics
+--
+-- Service Indentification is supported only by the GGSN-I 
+-- PIC.
+--
+
+
+jnxSvcServIdTable		OBJECT-TYPE
+    SYNTAX       		SEQUENCE OF JnxSvcServIdTableEntry
+    MAX-ACCESS   		not-accessible
+    STATUS       		current
+    DESCRIPTION
+	"Information about the service-identification service for
+	 the service PIC interface."
+    ::= { jnxServicesInfoMib 2 }
+
+jnxSvcServIdTableEntry	OBJECT-TYPE
+    SYNTAX			JnxSvcServIdTableEntry
+    MAX-ACCESS			not-accessible
+    STATUS			current
+    DESCRIPTION
+	"An entry containing aggregate Service Identification service
+	 information applicable to particular service pic interfaces."
+    INDEX   		{ ifIndex }
+    ::= { jnxSvcServIdTable 1 }
+
+JnxSvcServIdTableEntry ::= SEQUENCE {
+    -- packet statistics for the service
+    jnxSvcServIdPkt				Counter64,
+    jnxSvcServIdByte				Counter64,
+    jnxSvcServIdErrPkt			Counter64,
+    jnxSvcServIdErrByte			Counter64,
+   
+    -- header examination functionality statistics
+    jnxSvcServIdHeadExPkt			Counter64,
+    jnxSvcServIdHeadExByte			Counter64,
+    jnxSvcServIdHeadExFlow			Counter64,
+    jnxSvcServIdHeadExFlowMtch			Counter64,
+    jnxSvcServIdHeadExProtoReq			Counter64,
+    jnxSvcServIdHeadExHttpProtoReq		Counter64,
+    jnxSvcServIdHeadExWapProtoReq		Counter64,
+
+    -- protocol identification and URI extraction 
+    jnxSvcServIdProtFlow			Gauge32,
+    jnxSvcServIdProtInsPkt			Counter64,
+    jnxSvcServIdProtInsByte			Counter64,
+    jnxSvcServIdProtInsFlowInsp			Counter64,
+    jnxSvcServIdProtInsFlowProtIdent		Counter64,
+    
+    -- URI matching
+    jnxSvcServIdProtInsHttpUri			Counter64,
+    jnxSvcServIdProtInsHttpUriMtch		Counter64,
+    jnxSvcServIdProtInsWapUri			Counter64,
+    jnxSvcServIdProtInsWapUriMtch		Counter64,
+
+    -- Detailed packet drop-or-in-error information
+    jnxSvcServIdPktTcpMalform			Counter64,
+    jnxSvcServIdWAPInvalidTxn			Counter64,
+    jnxSvcServIdErrWAPTxn			Counter64,
+    jnxSvcServIdErrHTTPTxn			Counter64,
+
+    -- Configuration-related Error counters    
+    jnxSvcServIdHeadExFailCfgState		Counter64,
+    jnxSvcServIdProtInsFailCfgState		Counter64,
+    
+    -- Transaction counters
+    jnxSvcTransactionWapCreated			Counter64,
+    jnxSvcTransactionWapMaximum			Gauge32,
+    jnxSvcTransactionWapFreed			Counter64,
+    jnxSvcTransactionWapIdleFreed		Counter64,
+    jnxSvcTransactionHttpCreated		Counter64,
+    jnxSvcTransactionHttpMaximum		Gauge32,
+    jnxSvcTransactionHttpFreed			Counter64,
+    jnxSvcTransactionHttpIdleFreed		Counter64,
+
+    -- Transaction error counters
+    jnxSvcServidProtInsUriErrProcess		Counter64,
+    jnxSvcServidProtInsUriErrTooLong		Counter64,
+    jnxSvcServidProtInsErrParseTx		Counter64,
+    jnxSvcServidProtInsUriErrNoRes		Counter64
+}
+
+jnxSvcServIdPkt	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Total count for all packets processed by service."
+    ::= { jnxSvcServIdTableEntry 1 }
+
+jnxSvcServIdByte	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Total bytes for all packets processed by service."
+    ::= { jnxSvcServIdTableEntry 2 }
+
+jnxSvcServIdErrPkt	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Total number of all packets 
+	     found to be in invalid by this service 
+	     during or as a result of processing."
+    ::= { jnxSvcServIdTableEntry 3 }
+
+jnxSvcServIdErrByte	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Total butes for all packets 
+	     found to be in invalid by this service 
+	     during or as a result of processing."
+    ::= { jnxSvcServIdTableEntry 4 }
+
+jnxSvcServIdHeadExPkt	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Packets processed by the service header 
+	     examination function.  This is the first 
+	     packet for a flow for any service set 
+	     specifying a header inspection rule set."
+    ::= { jnxSvcServIdTableEntry 5 }
+
+jnxSvcServIdHeadExByte	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Bytes for all packets processed by the service header 
+	     examination function.  This is the first 
+	     packet for a flow for any service set 
+	     specifying a header inspection rule set."
+    ::= { jnxSvcServIdTableEntry 6 }
+
+jnxSvcServIdHeadExFlow	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Packets processed by the service header 
+	     examination function.  This is the first 
+	     packet for a flow for any service set 
+	     specifying a header inspection rule set and
+	     only includes processing of packets that result
+	     in the creation of a flow."
+    ::= { jnxSvcServIdTableEntry 7 }
+
+jnxSvcServIdHeadExFlowMtch	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Flows that matched any rule configured for the  
+	     header examination function for the service set
+	     associated with the flow."
+    ::= { jnxSvcServIdTableEntry 8 }
+
+jnxSvcServIdHeadExProtoReq	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Flows identified as requiring protocol 
+	     inspection and URI extraction as a result of 
+	     the header examination function."
+    ::= { jnxSvcServIdTableEntry 13 }
+
+jnxSvcServIdHeadExHttpProtoReq	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Flows identified by header examination function as 
+	     potentially requiring HTTP protocol inspection and 
+	     URI extraction."
+    ::= { jnxSvcServIdTableEntry 14 }
+
+jnxSvcServIdHeadExWapProtoReq	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Flows identified by header examination function as 
+	     potentially requiring WAP protocol inspection and 
+	     URI extraction."
+    ::= { jnxSvcServIdTableEntry 15 }
+
+
+jnxSvcServIdProtFlow	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Flows currently undergoing protocol inspection and
+	     URI extraction. Does not include flows that have been
+	     marked as no longer requiring inspection or flows
+	     that are in an error state."
+    ::= { jnxSvcServIdTableEntry 16 }
+
+jnxSvcServIdProtInsPkt	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Total number of packets processed by protocol 
+	     inspection function while attempting to parse a 
+	     transaction and extract URIs."
+    ::= { jnxSvcServIdTableEntry 17 }
+
+jnxSvcServIdProtInsByte	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Total bytes for all packets processed by protocol 
+	     inspection function while attempting to parse a 
+	     transaction and extract URIs."
+    ::= { jnxSvcServIdTableEntry 18 }
+
+
+jnxSvcServIdProtInsFlowInsp	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+      	    "Total number of flows that have been inspected or 
+      	     are at present being inspected by the protocol 
+      	     inspection and identification function."
+    ::= { jnxSvcServIdTableEntry 19 }
+
+jnxSvcServIdProtInsFlowProtIdent	OBJECT-TYPE
+    SYNTAX 		Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+      	    "Flows for which the protocol inspection and 
+      	     identification function has determined the 
+      	     protocol in use and begun transaction processing."
+    ::= { jnxSvcServIdTableEntry 20 }
+
+jnxSvcServIdProtInsHttpUri	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Number of HTTP transactions that have successfully
+	     extracted a URI."
+    ::= { jnxSvcServIdTableEntry 24 }
+
+jnxSvcServIdProtInsHttpUriMtch	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Number of HTTP transaction URIs that were matched
+	     by a URI rule configured for the active service set."
+    ::= { jnxSvcServIdTableEntry 25 }
+
+jnxSvcServIdProtInsWapUri	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Number of WAP transactions that have successfully
+	     extracted a URI."
+    ::= { jnxSvcServIdTableEntry 26 }
+
+jnxSvcServIdProtInsWapUriMtch	OBJECT-TYPE
+    SYNTAX      	Counter64
+    MAX-ACCESS  	read-only
+    STATUS      	current
+    DESCRIPTION
+	    "Number of WAP transaction URIs that were matched
+	     by a URI rule configured for the active service set."
+    ::= { jnxSvcServIdTableEntry 27 }
+
+jnxSvcServIdPktTcpMalform	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of TCP packets found to be in invalid due 
+	     to being malformed, for an incorrect sequence 
+	     number, or other reason."
+    ::= { jnxSvcServIdTableEntry 28 }
+
+jnxSvcServIdWAPInvalidTxn	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Numbee of packets found to be in invalid 
+	     due to invalid WAP transaction identifier."
+    ::= { jnxSvcServIdTableEntry 29 }
+
+jnxSvcServIdErrWAPTxn	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of packets found to be in invalid 
+	    because the WAP transaction 
+	    or flow was in an error state."
+    ::= { jnxSvcServIdTableEntry 30 }
+
+jnxSvcServIdErrHTTPTxn	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of packets found to be in invalid 
+	     because the HTTP transaction or flow was 
+	     in an error state."
+    ::= { jnxSvcServIdTableEntry 31 }
+
+jnxSvcServIdHeadExFailCfgState	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of header inspections that failed due to 
+	     internal configuration state."
+    ::= { jnxSvcServIdTableEntry 32 }
+
+jnxSvcServIdProtInsFailCfgState	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of URI inspections that failed due to 
+	    internal configuration state. "
+    ::= { jnxSvcServIdTableEntry 33 }
+
+jnxSvcTransactionWapCreated	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of WAP transaction sessions created."
+    ::= { jnxSvcServIdTableEntry 34 }
+
+jnxSvcTransactionWapMaximum	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Peak number of simultaneous of WAP transaction 
+	    sessions since start."
+    ::= { jnxSvcServIdTableEntry 35 }
+	
+jnxSvcTransactionWapFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of WAP transaction sessions freed."
+    ::= { jnxSvcServIdTableEntry 36 }
+	
+jnxSvcTransactionWapIdleFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of WAP transaction sessions freed by idle clean-up."
+    ::= { jnxSvcServIdTableEntry 37 }
+	
+jnxSvcTransactionHttpCreated	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of HTTP transaction sessions created."
+    ::= { jnxSvcServIdTableEntry 38 }
+
+jnxSvcTransactionHttpMaximum	OBJECT-TYPE
+    SYNTAX		Gauge32
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Peak number of simultaneous of HTTP 
+	     transaction sessions since start."
+    ::= { jnxSvcServIdTableEntry 39 }
+	
+jnxSvcTransactionHttpFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of WAP transaction sessions freed."
+    ::= { jnxSvcServIdTableEntry 40 }
+	
+jnxSvcTransactionHttpIdleFreed	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of WAP transaction sessions freed by idle clean-up."
+    ::= { jnxSvcServIdTableEntry 41 }
+
+jnxSvcServidProtInsUriErrProcess	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of URIs that failed to process due to 
+	     internal processing error."
+    ::= { jnxSvcServIdTableEntry 42 }
+
+jnxSvcServidProtInsUriErrTooLong	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of URIs that were not processed because 
+	     they exceeded the maximum supported URI length."
+    ::= { jnxSvcServIdTableEntry 43 }
+	
+jnxSvcServidProtInsErrParseTx	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of flows which experienced a transaction 
+	     parse error or any kind that prevented URI extraction.
+	     This does not include length limitations or 
+	     processing errors."
+    ::= { jnxSvcServIdTableEntry 44 }
+
+jnxSvcServidProtInsUriErrNoRes	OBJECT-TYPE
+    SYNTAX		Counter64
+    MAX-ACCESS		read-only
+    STATUS		current
+    DESCRIPTION
+	    "Number of URIs that were not processed due to lack 
+	     of system resources."
+    ::= { jnxSvcServIdTableEntry 45 }
+
+--
+-- Conformance & compliance (lint hush.. )
+--
+
+jnxSvcMIBConformance
+         OBJECT IDENTIFIER ::= { jnxServicesInfoMib 20 }
+jnxSvcMIBCompliances
+         OBJECT IDENTIFIER ::= { jnxSvcMIBConformance 1 }
+jnxSvcMIBGroups
+         OBJECT IDENTIFIER ::= { jnxSvcMIBConformance 2 }
+
+jnxSvcMIBCompliance		MODULE-COMPLIANCE
+   STATUS			current
+   DESCRIPTION 
+         "Compliance statement for the Juniper enterprise-specific
+          service PIC interface service information MIB."
+   MODULE
+   MANDATORY-GROUPS { 
+	jnxSvcFlowTableAggStatsGroup,
+	jnxSvcServIdiceGroup
+   }
+   ::= { jnxSvcMIBCompliances 1 }
+
+
+jnxSvcFlowTableAggStatsGroup 	OBJECT-GROUP
+   OBJECTS { 
+	jnxSvcAggFlow,
+	jnxSvcAggFlowMaximum,
+	jnxSvcAggFlowCreated,
+	jnxSvcAggFlowFreed,
+	jnxSvcAggFlowIdleFreed,
+	jnxSvcAggFlowTcp,
+	jnxSvcAggFlowTcpMaximum,
+	jnxSvcAggFlowTcpCreated,
+	jnxSvcAggFlowTcpFreed,
+	jnxSvcAggFlowTcpIdleFreed,
+	jnxSvcAggFlowUdp,
+	jnxSvcAggFlowUdpMaximum,
+	jnxSvcAggFlowUdpCreated,
+	jnxSvcAggFlowUdpFreed,
+	jnxSvcAggFlowUdpIdleFreed,
+	jnxSvcAggFlowPkt,
+	jnxSvcAggFlowPktErr,
+	jnxSvcAggFlowByte,
+	jnxSvcAggFlowByteErr,
+	jnxSvcAggFlowIcmpPkt,
+	jnxSvcAggFlowIcmpPktErr,
+	jnxSvcAggFlowIcmpPktErrBadFlow,
+	jnxSvcAggFlowIcmpByte,
+	jnxSvcAggFlowIcmpByteErr,
+	jnxSvcAggFlowTcpPkt,
+	jnxSvcAggFlowTcpPktErr,
+	jnxSvcAggFlowTcpPktErrBadFlow,
+	jnxSvcAggFlowTcpByte,
+	jnxSvcAggFlowTcpByteErr,
+	jnxSvcAggFlowUdpPkt,
+	jnxSvcAggFlowUdpPktErr,
+	jnxSvcAggFlowUdpPktErrBadFlow,
+	jnxSvcAggFlowUdpByte,
+	jnxSvcAggFlowUdpByteErr
+   }
+   STATUS current
+   DESCRIPTION
+         "Basic aggregate statistics for flow table activity."
+   ::= { jnxSvcMIBGroups 1 }
+
+
+jnxSvcServIdiceGroup 	OBJECT-GROUP
+   OBJECTS { 
+	jnxSvcServIdPkt,
+	jnxSvcServIdByte,
+	jnxSvcServIdErrPkt,
+	jnxSvcServIdErrByte,
+	jnxSvcServIdHeadExPkt,
+	jnxSvcServIdHeadExByte,
+	jnxSvcServIdHeadExFlow,
+	jnxSvcServIdHeadExFlowMtch,
+	jnxSvcServIdHeadExProtoReq,
+	jnxSvcServIdHeadExHttpProtoReq,
+	jnxSvcServIdHeadExWapProtoReq,
+	jnxSvcServIdProtFlow,
+	jnxSvcServIdProtInsPkt,
+	jnxSvcServIdProtInsByte,
+	jnxSvcServIdProtInsFlowInsp,
+	jnxSvcServIdProtInsFlowProtIdent,
+	jnxSvcServIdProtInsHttpUri,
+	jnxSvcServIdProtInsHttpUriMtch,
+	jnxSvcServIdProtInsWapUri,
+	jnxSvcServIdProtInsWapUriMtch,
+	jnxSvcServIdPktTcpMalform,
+	jnxSvcServIdWAPInvalidTxn,
+	jnxSvcServIdErrWAPTxn,
+	jnxSvcServIdErrHTTPTxn,
+	jnxSvcServIdHeadExFailCfgState,
+	jnxSvcServIdProtInsFailCfgState,
+	jnxSvcTransactionWapCreated,
+	jnxSvcTransactionWapMaximum,
+	jnxSvcTransactionWapFreed,
+	jnxSvcTransactionWapIdleFreed,
+	jnxSvcTransactionHttpCreated,
+	jnxSvcTransactionHttpMaximum,
+	jnxSvcTransactionHttpFreed,
+	jnxSvcTransactionHttpIdleFreed,
+	jnxSvcServidProtInsUriErrProcess,
+	jnxSvcServidProtInsUriErrTooLong,
+	jnxSvcServidProtInsErrParseTx,
+	jnxSvcServidProtInsUriErrNoRes
+   }
+   STATUS current
+   DESCRIPTION
+         "Basic aggregate statistics for the Service Identification 
+          service."
+   ::= { jnxSvcMIBGroups 2 }
+
+
+
+END
+
+

--- a/mibs/junos/mib-jnx-smi.txt
+++ b/mibs/junos/mib-jnx-smi.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Structure of Management Information
 -- 
--- Copyright (c) 2002-2008, Juniper Networks, Inc.
+-- Copyright (c) 2002-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -15,7 +15,7 @@ IMPORTS
         FROM SNMPv2-SMI;
 
 juniperMIB MODULE-IDENTITY
-    LAST-UPDATED "200910290000Z"
+    LAST-UPDATED "201007090000Z"
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
             "        Juniper Technical Assistance Center
@@ -25,9 +25,15 @@ juniperMIB MODULE-IDENTITY
 		     E-mail: support@juniper.net"
     DESCRIPTION
             "The Structure of Management Information for Juniper Networks."
+    REVISION     "201007090000Z"    -- Jul 09, 2010
+    DESCRIPTION  
+             "Added jnxLicenseMibRoot branch."
     REVISION     "200910290000Z"    -- Oct 29, 2009
     DESCRIPTION  
              "Added jnxCosNotifications branch."
+    REVISION     "201006180000Z"    -- Jun 18, 2010
+    DESCRIPTION  
+             "Added jnxLicenseMibRoot branch."
     REVISION    "200304170100Z" -- 17-Apr-03
     DESCRIPTION
             "Added jnxExperiment branch."
@@ -43,6 +49,38 @@ juniperMIB MODULE-IDENTITY
     REVISION    "200710090000Z" -- 9-Oct-07
     DESCRIPTION
             "Added jnxAdvancedInsightMgr branch."
+    REVISION    "200912310000Z" -- 31-Dec-09
+    DESCRIPTION
+            "Added jnxBxMibRoot branch."
+    REVISION    "201007140000Z" -- 14-Jul-10
+    DESCRIPTION
+            "Added jnxSubscriberMibRoot branch."
+    REVISION    "201101260000Z" -- 26-Jan-11
+    DESCRIPTION
+            "Added jnxDcfMibRoot branch."
+    REVISION    "201202100000Z" -- 10-Feb-12
+    DESCRIPTION
+            "Added jnxMediaFlow branch."
+    REVISION    "201208010000Z" -- 01-Aug-12
+    DESCRIPTION
+            "Added jnxSDKApplicationsRoot branch."
+    REVISION    "201211010000Z" -- 01-Nov12
+    DESCRIPTION
+            "Added jnxJVAEMibRoot branch."
+    REVISION    "201212070000Z" -- 7-Dec-12
+    DESCRIPTION
+            "Added jnxStrm branch."
+    REVISION    "201301250000Z" -- 25-Jan-13
+    DESCRIPTION
+            "Added jnxIfOtnMibRoot branch.
+             Added jnxOpticsMibRoot branch.
+             Added jnxAlarmExtMibRoot branch.
+             Added jnxoptIfMibRoot branch.
+             Added jnxIfOtnNotifications branch.
+             Added jnxOpticsNotifications branch."
+    REVISION    "201311260000Z" -- 26-Nov-13
+    DESCRIPTION
+            " Added jnxSnmpSetMibRoot branch"
     ::= { enterprises 2636 }
 
 --
@@ -61,13 +99,25 @@ jnxProducts OBJECT-IDENTITY
     -- The following OIDs are used as the basis for identifying other
     -- Juniper products.
     --
-    jnxReservedProducts1            OBJECT IDENTIFIER ::= { jnxProducts 2 }
-    jnxReservedProducts2            OBJECT IDENTIFIER ::= { jnxProducts 3 }
+    -- jnxMediaFlow refers to the root MIB object for Juniper's 
+    -- Media Flow Controller, a non-JUNOS based product. 
+    jnxMediaFlow                    OBJECT IDENTIFIER ::= { jnxProducts 2 }
+
+    --
+    -- Top-level object identifier registry used by the JunosSpace Products.
+
+    jnxJunosSpace                   OBJECT IDENTIFIER ::= { jnxProducts 3 }
+
     jnxReservedProducts3            OBJECT IDENTIFIER ::= { jnxProducts 4 }
     jnxReservedProducts4            OBJECT IDENTIFIER ::= { jnxProducts 5 }
     jnxReservedProducts5            OBJECT IDENTIFIER ::= { jnxProducts 6 }
+    jnxSDKApplicationsRoot          OBJECT IDENTIFIER ::= { jnxProducts 7 }
+    jnxJAB                          OBJECT IDENTIFIER ::= { jnxProducts 8 }
 
 
+   -- jnxStrm refers to the root MIB object for STRM products.
+   -- STRM is a non-JUNOS based product.
+    jnxStrm                         OBJECT IDENTIFIER ::= { jnxProducts 9 }
 
 jnxServices OBJECT-IDENTITY
     STATUS  current
@@ -87,7 +137,7 @@ jnxMibs OBJECT-IDENTITY
     jnxJsMibRoot               OBJECT IDENTIFIER ::= { jnxMibs 39 }
     jnxExMibRoot               OBJECT IDENTIFIER ::= { jnxMibs 40 }
     jnxWxMibRoot               OBJECT IDENTIFIER ::= { jnxMibs 41 }
-    jnxReservedMibs4           OBJECT IDENTIFIER ::= { jnxMibs 42 }
+    jnxDcfMibRoot              OBJECT IDENTIFIER ::= { jnxMibs 42 }
     jnxReservedMibs5           OBJECT IDENTIFIER ::= { jnxMibs 43 }
 
     -- PFE data
@@ -129,9 +179,61 @@ jnxMibs OBJECT-IDENTITY
     -- juniper OTN MIB
     jnxOtnMibRoot              OBJECT IDENTIFIER ::= { jnxMibs 56 }
 
+    -- juniper power supply management MIB
+    jnxPsuMIBRoot              OBJECT IDENTIFIER ::= { jnxMibs 58 }
 
+    -- juniper NAT MIB
+    jnxSvcsMibRoot             OBJECT IDENTIFIER ::= { jnxMibs 59 }
 
+    -- juniper DOM MIB
+    jnxDomMibRoot              OBJECT IDENTIFIER ::= { jnxMibs 60 }
 
+    -- juniper JDHCPD MIB Release 10.4
+    jnxJdhcpMibRoot            OBJECT IDENTIFIER ::= { jnxMibs 61 }
+
+    -- juniper JDHCPDv6 MIB Release 10.4
+    jnxJdhcpv6MibRoot          OBJECT IDENTIFIER ::= { jnxMibs 62 }
+
+    -- juniper License management MIB
+    jnxLicenseMibRoot          OBJECT IDENTIFIER ::= { jnxMibs 63 }
+
+    -- juniper Subscriber MIB
+    jnxSubscriberMibRoot       OBJECT IDENTIFIER ::= { jnxMibs 64 }
+
+    -- juniper MAG MIB 
+    jnxMagMibRoot              OBJECT IDENTIFIER ::= { jnxMibs 65 }
+
+    -- Root of juniper MobileGateway MIBs
+    jnxMobileGatewayMibRoot    OBJECT IDENTIFIER ::= { jnxMibs 66 }
+
+    -- juniper PPPOE MIB 
+    jnxPppoeMibRoot            OBJECT IDENTIFIER ::= { jnxMibs 67 }
+
+    -- juniper PPP MIB 
+    jnxPppMibRoot            OBJECT IDENTIFIER ::= { jnxMibs 68 }
+
+    -- junosV App Engine MIB
+    jnxJVAEMibRoot           OBJECT IDENTIFIER ::= { jnxMibs 69 }
+
+    -- juniper if otn mib
+    jnxIfOtnMibRoot            OBJECT IDENTIFIER ::= { jnxMibs 70 }
+
+    -- juniper if optics mib
+    jnxOpticsMibRoot           OBJECT IDENTIFIER ::= { jnxMibs 71 }
+
+    jnxAlarmExtMibRoot         OBJECT IDENTIFIER ::= { jnxMibs 72 }
+
+    -- jnx-optif -  rfc3591 mapped as jnx mib
+    jnxoptIfMibRoot            OBJECT IDENTIFIER ::= { jnxMibs 73 }
+
+    -- juniper FRU config mib
+    jnxFruMibRoot            OBJECT IDENTIFIER ::= { jnxMibs 74 }
+
+    -- juniper timing(PTP/SyncE) events notification mib
+    jnxTimingNotfnsMIBRoot   OBJECT IDENTIFIER ::= { jnxMibs 75 }
+
+    jnxSnmpSetMibRoot        OBJECT IDENTIFIER ::= { jnxMibs 76 }
+    
 jnxTraps OBJECT-IDENTITY 
     STATUS  current
     DESCRIPTION
@@ -156,8 +258,20 @@ jnxTraps OBJECT-IDENTITY
     -- jnxSAIDPNotifications is for Stand alone IDP devices
     jnxSAIDPNotifications      OBJECT IDENTIFIER ::= { jnxTraps 16 }
     jnxCosNotifications        OBJECT IDENTIFIER ::= { jnxTraps 17 }
+    jnxDomNotifications        OBJECT IDENTIFIER ::= { jnxTraps 18 }
+    jnxFabricChassisTraps      OBJECT IDENTIFIER ::= { jnxTraps 19 }
+    jnxFabricChassisOKTraps    OBJECT IDENTIFIER ::= { jnxTraps 20 }
 
+    -- juniper if otn traps
+    jnxIfOtnNotifications      OBJECT IDENTIFIER ::= { jnxTraps 21 }
 
+    -- juniper if optics traps
+    jnxOpticsNotifications     OBJECT IDENTIFIER ::= { jnxTraps 22 }
+
+    -- juniper FRU config traps
+    jnxFruTraps                OBJECT IDENTIFIER ::= { jnxTraps 23 }
+    jnxSnmpSetTraps              OBJECT IDENTIFIER ::= { jnxTraps 24 }
+    
 --  This is the top-level object identifier registry used by Juniper
 --  products for SNMP modules containing experimental MIB definitions.
 --  In this context, experimental MIBs are defined as:
@@ -193,5 +307,11 @@ jnxAAA OBJECT IDENTIFIER ::= { juniperMIB 8 }
 -- Advanced Insight Manager. 
 --
 jnxAdvancedInsightMgr OBJECT IDENTIFIER ::= { juniperMIB 9 }
+
+--
+-- This is the top-level object identifier registry used by the
+-- BX series Products.
+--
+jnxBxMibRoot OBJECT IDENTIFIER ::= { juniperMIB 10 }
 
 END

--- a/mibs/junos/mib-jnx-sp-nat.txt
+++ b/mibs/junos/mib-jnx-sp-nat.txt
@@ -1,0 +1,390 @@
+-- *******************************************************************
+-- Juniper Services Network Address Translation (NAT) MIB.
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-- *******************************************************************
+
+	JUNIPER-NAT-MIB DEFINITIONS ::= BEGIN
+
+	IMPORTS
+
+        Gauge32, Integer32, Unsigned32,
+        NOTIFICATION-TYPE,
+    	MODULE-IDENTITY, OBJECT-TYPE	FROM SNMPv2-SMI
+	InterfaceIndex                  FROM IF-MIB
+	DateAndTime,
+    	DisplayString		        FROM SNMPv2-TC 
+    	InetAddressType,
+        InetAddress,
+        InetAddressIPv4 	        FROM INET-ADDRESS-MIB
+    jnxSvcsMibRoot                  FROM JUNIPER-SMI;
+
+	jnxNatMIB MODULE-IDENTITY
+        LAST-UPDATED  "201007122022Z" -- July 12, 2010" 
+    	ORGANIZATION  "Juniper Networks, Inc."
+    	CONTACT-INFO
+					"Juniper Technical Assistance Center
+					 Juniper Networks, Inc.
+					 1194 N. Mathilda Avenue
+					 Sunnyvale, CA 94089
+
+					 E-mail: support@juniper.net
+					 HTTP://www.juniper.net"
+    	DESCRIPTION
+            "This module defines the object that are used to monitor
+             network address translation attributes."
+
+        REVISION        "201007122022Z" -- July 12, 2010
+    	DESCRIPTION 	"Creation Date"
+
+    ::= { jnxSvcsMibRoot 1 }
+
+
+    jnxNatNotifications OBJECT IDENTIFIER ::= { jnxNatMIB 0 }
+    jnxNatObjects       OBJECT IDENTIFIER ::= { jnxNatMIB 1 }
+    jnxNatTrapVars      OBJECT IDENTIFIER ::= { jnxNatMIB 2 }
+
+-- ***************************************************************
+--  Source NAT Table
+-- ***************************************************************
+
+    jnxSrcNatStatsTable OBJECT-TYPE
+        SYNTAX        SEQUENCE OF JnxSrcNatStatsEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "This table exposes the source NAT translation
+         attributes of the translated addresses.
+
+         When performing source IP address translation, the services pic
+         translates the original source IP address and/or port
+         number to different one.  The resource, address source pools
+         provide the service pic with a supply of addresses from
+         which to draw when performing source network address translation.
+
+         This table contains information on source IP address
+         translation only."
+        ::= { jnxNatObjects 1 }
+
+    jnxSrcNatStatsEntry OBJECT-TYPE
+        SYNTAX        JnxSrcNatStatsEntry
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "Source NAT address entries.  It is indexed by the address
+         pool table and the address allocated. "
+        INDEX   { jnxNatSrcPoolName } 
+        ::= { jnxSrcNatStatsTable 1 }
+
+    JnxSrcNatStatsEntry ::= SEQUENCE
+    {
+        jnxNatSrcPoolName         DisplayString,
+        jnxNatSrcXlatedAddrType   INTEGER,
+        jnxNatSrcPoolType         INTEGER,
+        jnxNatSrcNumPortAvail     Unsigned32,
+        jnxNatSrcNumPortInuse     Unsigned32,
+        jnxNatSrcNumAddressAvail  Unsigned32,
+        jnxNatSrcNumAddressInUse  Unsigned32,
+        jnxNatSrcNumSessions      Unsigned32
+    }
+
+
+    jnxNatSrcPoolName OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(0..64))
+        MAX-ACCESS    not-accessible 
+        STATUS        current
+        DESCRIPTION
+            "The name of dynamic source IP address pool.
+
+             This is the address pool where the translated
+             address is allocated from. "
+        ::= { jnxSrcNatStatsEntry 1 }
+
+    jnxNatSrcXlatedAddrType OBJECT-TYPE
+        SYNTAX        INTEGER {
+                        ipv4       (1),
+                        ipv6       (2)
+                      }
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The type of dynamic source IP address allocated from
+            the address pool used in the NAT translation.
+            For NAT MIB, supporting ipv4(1) and ipv6(2) only."
+        ::= { jnxSrcNatStatsEntry 2 }
+
+    jnxNatSrcPoolType OBJECT-TYPE
+        SYNTAX        INTEGER {
+                         static               (1),
+                         dynamic-napt         (2),
+                         dynamic-nat          (3),
+                         basic-nat44          (11),
+                         dynamic-nat44        (12),
+                         napt-44              (13),
+                         dnat-44              (14),
+                         stateful-nat64       (15),
+                         stateless-nat64      (16),
+                         basic-nat-pt         (17),
+                         napt-pt              (18),
+                         basic-nat66          (19),
+                         stateless-nat66      (20),
+                         napt-66              (21),
+                         twice-napt-44        (22),
+                         twice-basic-nat-44   (23),
+                         twice-dynamic-nat-44 (24),
+                         det-napt44           (25),
+                         sd-napt44            (26) 
+                      }
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Source NAT can do address translation with or without port
+             translation.  The source port pool type indicates
+             whether the address translation is done with port or without
+             the port, or if it is a static translation."
+        ::= { jnxSrcNatStatsEntry 3 }
+
+    jnxNatSrcNumPortAvail OBJECT-TYPE
+        SYNTAX        Unsigned32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The number of ports available with this pool."
+        ::= { jnxSrcNatStatsEntry 4 }
+
+    jnxNatSrcNumPortInuse OBJECT-TYPE
+        SYNTAX        Unsigned32 
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The number of ports in use for this NAT address entry.
+         This attribute is only applicable to translation with
+         port translation."
+        ::= { jnxSrcNatStatsEntry 5 }
+
+    jnxNatSrcNumAddressAvail OBJECT-TYPE
+        SYNTAX        Unsigned32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The total number of addresses available in this pool."
+        ::= { jnxSrcNatStatsEntry 6 }
+
+    jnxNatSrcNumAddressInUse OBJECT-TYPE
+        SYNTAX        Unsigned32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The number of addresses in use from this pool.
+            This attribute is only applicable to pools used with
+            source dynamic translations."
+        ::= { jnxSrcNatStatsEntry 7 }
+
+    jnxNatSrcNumSessions OBJECT-TYPE
+        SYNTAX        Unsigned32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "The number of sessions are in use based on this NAT address
+         entry."
+
+        ::= { jnxSrcNatStatsEntry 8 }
+
+-- ***************************************************************
+--  NAT Rule Hit Table
+-- ***************************************************************
+
+    jnxNatRuleTable OBJECT-TYPE
+        SYNTAX        SEQUENCE OF JnxNatRuleEntry 
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+			"This table monitors NAT rule hits  "
+        ::= { jnxNatObjects 2 }  
+
+    jnxNatRuleEntry OBJECT-TYPE
+        SYNTAX        JnxNatRuleEntry 
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "NAT rule hit entries.  It is indexed by the rule index"
+        INDEX   { jnxNatRuleName }
+        ::= { jnxNatRuleTable 1 }
+
+    JnxNatRuleEntry ::= SEQUENCE
+    {
+        jnxNatRuleName                     DisplayString,
+        jnxNatRuleType                     INTEGER,
+        jnxNatRuleTransHits                Unsigned32
+    }
+
+    jnxNatRuleName OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(0..128)) 
+        MAX-ACCESS    not-accessible 
+        STATUS        current
+        DESCRIPTION
+        	"NAT rule name"
+    ::= { jnxNatRuleEntry 1 }
+
+    jnxNatRuleType OBJECT-TYPE
+        SYNTAX        INTEGER {
+                static-source         (1),
+                static-destination    (2),
+                dynamic-source        (3),
+                napt                  (4),
+                basic-nat44          (11),
+                dynamic-nat44        (12),
+                napt-44              (13),
+                dnat-44              (14),
+                stateful-nat64       (15),
+                stateless-nat64      (16),
+                basic-nat-pt         (17),
+                napt-pt              (18),
+                basic-nat66          (19),
+                stateless-nat66      (20),
+                napt-66              (21),
+                twice-napt-44        (22),
+                twice-basic-nat-44   (23),
+                twice-dynamic-nat-44 (24),
+                det-napt44           (25),
+                sd-napt44            (26) 
+        }
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+        	"NAT types: Static Source, Static Destination,
+             Dynamic Source and NAPT"
+    ::= { jnxNatRuleEntry 2 }
+
+    jnxNatRuleTransHits OBJECT-TYPE
+        SYNTAX        Unsigned32
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+        	"The number of hits on this NAT rule"
+    ::= { jnxNatRuleEntry 3 }
+
+-- ***************************************************************
+--  NAT Pool Hit Table
+-- ***************************************************************
+
+    jnxNatPoolTable OBJECT-TYPE
+        SYNTAX        SEQUENCE OF JnxNatPoolEntry 
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+			"This table monitors NAT pool hits  "
+        ::= { jnxNatObjects 3 }  
+
+    jnxNatPoolEntry OBJECT-TYPE
+        SYNTAX        JnxNatPoolEntry 
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "NAT pool hit entries.  It is indexed by the pool index"
+        INDEX   { jnxNatPoolName }
+        ::= { jnxNatPoolTable 1 }
+
+    JnxNatPoolEntry ::= SEQUENCE
+    {
+        jnxNatPoolName                     DisplayString,
+        jnxNatPoolType                     INTEGER,
+        jnxNatPoolTransHits                Unsigned32
+    }
+
+    jnxNatPoolName OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(0..64)) 
+        MAX-ACCESS    not-accessible 
+        STATUS        current
+        DESCRIPTION
+        	"NAT Pool name"
+    ::= { jnxNatPoolEntry 1 }
+
+    jnxNatPoolType OBJECT-TYPE
+        SYNTAX        INTEGER {
+                static-source         (1),
+                static-destination    (2),
+                dynamic-source        (3),
+                napt                  (4),
+                basic-nat44          (11),
+                dynamic-nat44        (12),
+                napt-44              (13),
+                dnat-44              (14),
+                stateful-nat64       (15),
+                stateless-nat64      (16),
+                basic-nat-pt         (17),
+                napt-pt              (18),
+                basic-nat66          (19),
+                stateless-nat66      (20),
+                napt-66              (21),
+                twice-napt-44        (22),
+                twice-basic-nat-44   (23),
+                twice-dynamic-nat-44 (24),
+                det-napt44           (25),
+                sd-napt44            (26) 
+        }
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+        	"NAT types: Static Source, Static Destination,
+             Dynamic Source and NAPT"
+    ::= { jnxNatPoolEntry 2 }
+
+    jnxNatPoolTransHits OBJECT-TYPE
+        SYNTAX        Unsigned32 
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+        	"The number of hits on this NAT Pool"
+    ::= { jnxNatPoolEntry 3 }
+
+-- ***************************************************************
+--  NAT Trap definition
+-- ***************************************************************
+
+-- ***************************************************************
+-- Trap variables
+-- ***************************************************************
+
+    jnxNatAddrPoolUtil OBJECT-TYPE
+        SYNTAX      Integer32 (0..100)
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "The dynamic address pool utilization in terms of number of ports utilized."
+        ::= { jnxNatTrapVars 1 }
+
+    jnxNatTrapSrcPoolName OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(1..64))
+        MAX-ACCESS    accessible-for-notify
+        STATUS        current
+        DESCRIPTION
+            "Source NAT Pool name who issues trap"
+        ::= { jnxNatTrapVars 2 }
+
+-- ***************************************************************
+-- NAT Address Pool Utilization Threshold Status 
+-- ***************************************************************
+
+    jnxNatAddrPoolThresholdStatus NOTIFICATION-TYPE
+        OBJECTS                 { jnxNatTrapSrcPoolName,
+                                  jnxNatAddrPoolUtil }
+        STATUS          current
+        DESCRIPTION
+             "The Source NAT address pool utilization threshold status
+              trap signifies that the address pool utilization
+	      is either exceeds threshold value, or clear of
+              that value.
+					
+			  jnxNatTrapPoolName is the name of the resource pool
+			  jnxNatAddrPoolUtil is the number of ports utilized 
+              of the address pool." 
+        ::= { jnxNatNotifications 1 }
+	
+-- ***************************************************************
+--  END of File 
+-- ***************************************************************
+END

--- a/mibs/junos/mib-jnx-sp.txt
+++ b/mibs/junos/mib-jnx-sp.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Service PIC MIB
 -- 
--- Copyright (c) 2003, 2005-2006, Juniper Networks, Inc.
+-- Copyright (c) 2003-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -17,7 +17,9 @@ IMPORTS
         FROM SNMPv2-TC
     ifIndex, InterfaceIndex
         FROM IF-MIB
-    jnxMibs, jnxSpNotifications
+    CounterBasedGauge64
+        FROM HCNUM-TC
+    jnxMibs
         FROM JUNIPER-SMI;
 
 jnxSpMIB  MODULE-IDENTITY
@@ -39,7 +41,9 @@ jnxSpMIB  MODULE-IDENTITY
             "Initial revision."
     ::= { jnxMibs 32 }
 
-
+    jnxSpNotifications    OBJECT IDENTIFIER ::= { jnxSpMIB 0 }
+    jnxFlowLimitTrapVars  OBJECT IDENTIFIER ::= { jnxSpMIB 2 }
+    
 --
 -- Per Service Set information
 --
@@ -224,7 +228,8 @@ jnxSpMIB  MODULE-IDENTITY
             jnxSpSvcSetSvcTypeSvcSets           Gauge32,
             jnxSpSvcSetSvcTypeMemoryUsage       Gauge32,
             jnxSpSvcSetSvcTypePctMemoryUsage    Gauge32,
-            jnxSpSvcSetSvcTypeCpuUtil           Gauge32
+            jnxSpSvcSetSvcTypeCpuUtil           Gauge32,
+            jnxSpSvcSetSvcTypeMemoryUsage64     CounterBasedGauge64
         }
 
     jnxSpSvcSetSvcTypeIndex OBJECT-TYPE
@@ -294,6 +299,16 @@ jnxSpMIB  MODULE-IDENTITY
             percentage of the total."
         ::= { jnxSpSvcSetSvcTypeEntry 7 }
 
+    jnxSpSvcSetSvcTypeMemoryUsage64 OBJECT-TYPE
+        SYNTAX      CounterBasedGauge64
+        UNITS       "bytes"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The amount of memory used by this Service Type, expressed in
+            bytes, represented by 64 bit integer."
+        ::= { jnxSpSvcSetSvcTypeEntry 8 }
+
 --
 -- Per Interface information
 --
@@ -326,7 +341,9 @@ jnxSpMIB  MODULE-IDENTITY
             jnxSpSvcSetIfPolMemoryUsage    Gauge32,
             jnxSpSvcSetIfPctPolMemoryUsage Gauge32,
             jnxSpSvcSetIfMemoryZone        INTEGER,
-            jnxSpSvcSetIfCpuUtil           Gauge32
+            jnxSpSvcSetIfCpuUtil           Gauge32,
+            jnxSpSvcSetIfMemoryUsage64     CounterBasedGauge64,
+            jnxSpSvcSetIfPolMemoryUsage64  CounterBasedGauge64
         }
 
     jnxSpSvcSetIfTableName OBJECT-TYPE
@@ -418,6 +435,26 @@ jnxSpMIB  MODULE-IDENTITY
             percentage of the total."
         ::= { jnxSpSvcSetIfEntry 8 }
 
+    jnxSpSvcSetIfMemoryUsage64 OBJECT-TYPE
+        SYNTAX      CounterBasedGauge64
+        UNITS       "bytes"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The amount of memory used by this Service PIC, expressed in
+            bytes, represented by 64 bit integer."
+        ::= { jnxSpSvcSetIfEntry 9 }
+
+    jnxSpSvcSetIfPolMemoryUsage64 OBJECT-TYPE
+        SYNTAX      CounterBasedGauge64
+        UNITS       "bytes"
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The amount of policy memory used by this Service PIC, expressed in
+            bytes, represented by 64 bit integer."
+        ::= { jnxSpSvcSetIfEntry 10 }
+
 --
 -- Service PIC Notification definitions
 --
@@ -465,5 +502,31 @@ jnxSpMIB  MODULE-IDENTITY
             "This indicates a Service Pic has crossed below its internal 
             threshold for CPU utilization (85%)."
         ::= { jnxSpNotificationPrefix 4 }
+      
+    jnxSpSvcSetFlowLimitUtil OBJECT-TYPE
+        SYNTAX      Integer32 (0..100)
+        MAX-ACCESS  accessible-for-notify
+       STATUS      current
+        DESCRIPTION
+            "The Total no of flows present in this Service Set, expressed as a
+            percentage of the total maximum flows."
+        ::= { jnxFlowLimitTrapVars 1 }
+
+   jnxSpSvcSetNameUtil OBJECT-TYPE
+        SYNTAX        DisplayString (SIZE(1..96))
+        MAX-ACCESS    accessible-for-notify
+        STATUS        current
+        DESCRIPTION
+            "The Service Set name."
+        ::= { jnxFlowLimitTrapVars 2 }
+
+   jnxSpSvcSetFlowLimitUtilized NOTIFICATION-TYPE
+        OBJECTS {jnxSpSvcSetFlowLimitUtil,
+                 jnxSpSvcSetNameUtil}
+        STATUS  current
+        DESCRIPTION
+            "This indicates a Service Set has reached its upper limit of flows
+            threshold of a maximun flows allowed for a service set."
+        ::= { jnxSpNotifications 1 }
 
 END

--- a/mibs/junos/mib-jnx-subscriber.txt
+++ b/mibs/junos/mib-jnx-subscriber.txt
@@ -1,0 +1,725 @@
+-- *****************************************************************************
+-- JUNIPER-SUBSCRIBER-MIB
+--
+-- Juniper Networks Enterprise MIB
+--   Subscriber MIB
+--
+-- Copyright (c) 2010-2013, Juniper Networks, Inc.
+-- All rights reserved.
+-- *****************************************************************************
+
+JUNIPER-SUBSCRIBER-MIB  DEFINITIONS ::= BEGIN
+
+IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, Integer32, IpAddress, Unsigned32 
+                                        FROM SNMPv2-SMI
+       TEXTUAL-CONVENTION, DisplayString, MacAddress
+                                        FROM SNMPv2-TC
+       InterfaceIndex
+                                        FROM IF-MIB
+       CounterBasedGauge64               -- RFC 2856
+                                        FROM HCNUM-TC
+       jnxSubscriberMibRoot
+                                        FROM JUNIPER-SMI;
+
+
+jnxSubscriberMIB  MODULE-IDENTITY
+       LAST-UPDATED "201312130000Z"  -- 20-Dec-13
+       ORGANIZATION "Juniper Networks, Inc."
+       CONTACT-INFO
+             " Juniper Technical Assistance Center
+             Juniper Networks, Inc.
+             1194 N. Mathilda Avenue
+             Sunnyvale, CA 94089
+             E-mail: support@juniper.net"
+       DESCRIPTION
+             "The Subscriber MIB for the Juniper Networks enterprise."
+       -- Revision History
+       REVISION    "201005110000Z"  -- 11-May-10
+       DESCRIPTION
+             "Initial version of jnxSubscriberMIB module."
+       REVISION    "201205020000Z"  -- 02-May-12
+       DESCRIPTION
+             "Updated related to subscriber accounting session id."
+       REVISION    "201312130000Z"  -- 20-Dec-13
+       DESCRIPTION
+             "Added jnxSubscriberAccountingTable MIB."
+       ::= { jnxSubscriberMibRoot  1 }
+
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Textual conventions
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+JnxSubscriberState  ::= TEXTUAL-CONVENTION
+       STATUS      current
+       DESCRIPTION
+             "The set of possible AAA subscriber states, expressed as a bit map:
+                init                 INIT state only
+                configured           CONFIGURED state only
+                active               ACTIVE state only
+                terminated           TERMINATED state only
+                terminating          TERMINATING state only
+                unknown              Unknown state "
+       SYNTAX      INTEGER {
+             init(0),
+             configured(1),
+             active(2),
+             terminating(3),
+             terminated(4),
+             unknown(5) }
+
+JnxSubscriberClientType  ::= TEXTUAL-CONVENTION
+       STATUS      current
+       DESCRIPTION
+             "The set of possible AAA subscriber client types:
+                none                None of the following
+                dhcp                DHCP clients only
+                l2tp                L2TP clients only
+                ppp                 PPP clients only
+                pppoe               PPPoE clients only
+                vlan                VLAN clients only
+                generic             Generic clients only
+                mobileIp            Mobile Ip clients only
+                vplsPw              VPLS pseudowires only
+                static              Static clients only
+                mlppp               MLPPP clients only "
+       SYNTAX      BITS {
+             none(0),
+             dhcp(1),
+             vlan(2),
+             generic(3),
+             mobileIp(4),
+             vplsPw(5),
+             ppp(6),
+             ppppoe(7),
+             l2tp(8),
+             static(9),
+             mlppp(10) }
+
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Managed object groups
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+jnxSubscriberObjects                OBJECT IDENTIFIER ::= {jnxSubscriberMIB 1}
+jnxSubscriberGeneral                OBJECT IDENTIFIER ::= {jnxSubscriberObjects 1}
+jnxSubscriberLogicalSystemObjects   OBJECT IDENTIFIER ::= {jnxSubscriberObjects 2}
+jnxSubscriberRoutingInstanceObjects OBJECT IDENTIFIER ::= {jnxSubscriberObjects 3}
+
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Managed objects for Subscriber functions
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+jnxSubscriberTotalCount OBJECT-TYPE
+       SYNTAX      CounterBasedGauge64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "Total number of subscribers."
+       ::= { jnxSubscriberGeneral 1 }
+
+jnxSubscriberActiveCount OBJECT-TYPE
+       SYNTAX      CounterBasedGauge64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "Number of active subscribers."
+       ::= { jnxSubscriberGeneral 2 }
+
+jnxSubscriberTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF JnxSubscriberEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The entries in this table represent subscribers."
+       ::= { jnxSubscriberGeneral 3 }
+
+jnxSubscriberInterfaceHardwareIndexTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF JnxSubscriberInterfaceHardwareIndexEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The entries in this table represent subscribers Interface Hardware Index."
+       ::= { jnxSubscriberGeneral 4 }
+
+jnxSubscriberPortCountTable  OBJECT-TYPE
+       SYNTAX      SEQUENCE OF JnxSubscriberPortCountEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             " The entries in this table represent each port.
+               Each entry contains the port name and the number
+               of active subscribers present on that port."
+       ::= { jnxSubscriberGeneral 5 }
+
+jnxSubscriberAccountingTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF JnxSubscriberAccountingEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The entries in this table represent subscribers with accounting."
+       ::= { jnxSubscriberGeneral 6 }
+
+
+jnxSubscriberInterfaceHardwareIndexEntry OBJECT-TYPE
+       SYNTAX      JnxSubscriberInterfaceHardwareIndexEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "A specification of subscribers."
+       INDEX     { jnxSubscriberInterfaceHardwareIndexHandleHiWord, jnxSubscriberInterfaceHardwareIndexHandleLoWord }
+       ::= { jnxSubscriberInterfaceHardwareIndexTable 1 }
+
+JnxSubscriberInterfaceHardwareIndexEntry ::= SEQUENCE {
+       jnxSubscriberInterfaceHardwareIndexHandleHiWord         Unsigned32,
+       jnxSubscriberInterfaceHardwareIndexHandleLoWord         Unsigned32,
+       jnxSubscriberInterfaceHardwareIndex     Unsigned32 }
+
+jnxSubscriberInterfaceHardwareIndexHandleHiWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+             
+             This object is equal to the most significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberInterfaceHardwareIndexEntry 1 }
+
+jnxSubscriberInterfaceHardwareIndexHandleLoWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+
+             This object is equal to the least significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberInterfaceHardwareIndexEntry 2}
+
+jnxSubscriberInterfaceHardwareIndex OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+            "The subscriber interface hardware index."
+       ::= { jnxSubscriberInterfaceHardwareIndexEntry 3}
+
+jnxSubscriberEntry OBJECT-TYPE
+       SYNTAX      JnxSubscriberEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "A specification of subscribers."
+       INDEX     { jnxSubscriberHandleHiWord, jnxSubscriberHandleLoWord }
+       ::= { jnxSubscriberTable 1 }
+
+
+JnxSubscriberEntry ::= SEQUENCE {
+       jnxSubscriberHandleHiWord         Unsigned32,
+       jnxSubscriberHandleLoWord         Unsigned32,
+       jnxSubscriberUserName             DisplayString,
+       jnxSubscriberClientType           JnxSubscriberClientType,
+       jnxSubscriberIpAddress            IpAddress,
+       jnxSubscriberIpAddressMask        IpAddress,
+       jnxSubscriberLogicalSystem        OCTET STRING,
+       jnxSubscriberRoutingInstance      OCTET STRING,
+       jnxSubscriberInterface            DisplayString,
+       jnxSubscriberInterfaceType        INTEGER,
+       jnxSubscriberMacAddress           MacAddress,
+       jnxSubscriberState                JnxSubscriberState,
+       jnxSubscriberLoginTime            DisplayString,
+       jnxSubscriberAcctSessionId        DisplayString }
+
+jnxSubscriberHandleHiWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+             
+             This object is equal to the most significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberEntry 1 }
+
+jnxSubscriberHandleLoWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+
+             This object is equal to the least significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberEntry 2}
+
+jnxSubscriberUserName OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The userName associated with this subscriber."
+       ::= { jnxSubscriberEntry 3 }
+
+jnxSubscriberClientType OBJECT-TYPE
+       SYNTAX      JnxSubscriberClientType
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The client type for this subscriber."
+       ::= { jnxSubscriberEntry 4 }
+
+jnxSubscriberIpAddress OBJECT-TYPE
+       SYNTAX      IpAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The client IP Address assigned to this subscriber."
+       ::= { jnxSubscriberEntry 5 }
+
+jnxSubscriberIpAddressMask OBJECT-TYPE
+       SYNTAX      IpAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The client IP Address Mask assigned to this subscriber."
+       ::= { jnxSubscriberEntry 6 }
+
+jnxSubscriberLogicalSystem OBJECT-TYPE
+       SYNTAX      OCTET STRING (SIZE(0..63))
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The logical system associated with this subscriber."
+       ::= { jnxSubscriberEntry 7 }
+
+jnxSubscriberRoutingInstance OBJECT-TYPE
+       SYNTAX      OCTET STRING (SIZE(0..128))
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The routing instance associated with this subscriber."
+    ::= { jnxSubscriberEntry 8 }
+
+jnxSubscriberInterface OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The textual name of the interface associated with this subscriber."
+    ::= { jnxSubscriberEntry 9 }
+
+jnxSubscriberInterfaceType OBJECT-TYPE
+       SYNTAX      INTEGER {
+             none(0),
+             static(1),
+             dynamic(2) }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The type of the interface associated with this subscriber."
+       ::= { jnxSubscriberEntry 10 }
+
+jnxSubscriberMacAddress OBJECT-TYPE
+       SYNTAX      MacAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The MAC address of the interface associated with this subscriber."
+       ::= { jnxSubscriberEntry 11 }
+
+jnxSubscriberState OBJECT-TYPE
+       SYNTAX      JnxSubscriberState
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The state of this subscriber."
+       ::= { jnxSubscriberEntry 12 }
+
+jnxSubscriberLoginTime OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The time this subscriber logged in to the server."
+       ::= { jnxSubscriberEntry 13 }
+
+jnxSubscriberAcctSessionId OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The accounting session id associated with this subscriber."
+       ::= { jnxSubscriberEntry 14 }
+
+
+jnxSubscriberPortCountEntry OBJECT-TYPE
+       SYNTAX      JnxSubscriberPortCountEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "A specification of Port containing the port name 
+              and the number of active subscribers on that port"
+       INDEX       { jnxSubscriberPort }
+       ::= { jnxSubscriberPortCountTable 1 }
+
+JnxSubscriberPortCountEntry ::= SEQUENCE {
+       jnxSubscriberPort                  DisplayString,
+       jnxSubscriberPortTunneledCounter  CounterBasedGauge64, 
+       jnxSubscriberPortTerminatedCounter  CounterBasedGauge64 }
+
+jnxSubscriberPort  OBJECT-TYPE
+       SYNTAX       DisplayString (SIZE(1..32))
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+             "Name of the port in string"
+       ::= { jnxSubscriberPortCountEntry 1  }
+
+
+jnxSubscriberPortTunneledCounter OBJECT-TYPE
+       SYNTAX       CounterBasedGauge64
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+             "Number of active Tunneled subscribers present on the port"
+       ::= { jnxSubscriberPortCountEntry 2  }
+
+jnxSubscriberPortTerminatedCounter OBJECT-TYPE
+       SYNTAX       CounterBasedGauge64
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+             "Number of active Tunneled subscribers present on the port"
+       ::= { jnxSubscriberPortCountEntry 3  }
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Subscriber information by logical system
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+jnxSubscriberLogicalSystemTotalCount OBJECT-TYPE
+       SYNTAX      CounterBasedGauge64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The number of total subscribers on the logical system."
+       ::= { jnxSubscriberLogicalSystemObjects 1 }
+
+jnxSubscriberLogicalSystemActiveCount OBJECT-TYPE
+       SYNTAX      CounterBasedGauge64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The number of active subscribers on the logical system."
+       ::= { jnxSubscriberLogicalSystemObjects 2 }
+
+jnxSubscriberLogicalSystemTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF JnxSubscriberLogicalSystemEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The entries in this table sort subscribers within the logical system.
+             
+             The logical system name must be provided in the SNMP query. The
+             logical system will be identified by either the context field in V3
+             requests, or it will be encoded in the community string in V1 or
+             V2c requests.
+
+             User can query for logical-system/routing-instance specific data by
+             prefixing the community string with
+             <logical-system>/<routing-instance>@, where '@' acts as a separator
+             between community name and routing-instance name.
+
+             If no logical system is specified, this table shows data for the
+             default logical system. The name of the routing instance is ignored
+             for this table."
+       ::= { jnxSubscriberLogicalSystemObjects 3 }
+
+jnxSubscriberLogicalSystemEntry OBJECT-TYPE
+       SYNTAX      JnxSubscriberLogicalSystemEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "A specification of subscribers within the logical system."
+       INDEX     { jnxSubscriberLogicalSystemHandleHiWord, jnxSubscriberLogicalSystemHandleLoWord }
+       ::= { jnxSubscriberLogicalSystemTable 1 }
+
+JnxSubscriberLogicalSystemEntry ::= SEQUENCE {
+       jnxSubscriberLogicalSystemHandleHiWord   Unsigned32,
+       jnxSubscriberLogicalSystemHandleLoWord   Unsigned32,
+       jnxSubscriberLogicalSystemState          JnxSubscriberState }
+
+jnxSubscriberLogicalSystemHandleHiWord  OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+
+             This object is equal to the most significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberLogicalSystemEntry 1 }
+
+jnxSubscriberLogicalSystemHandleLoWord  OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+
+             This object is equal to the least significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberLogicalSystemEntry 2 }
+
+jnxSubscriberLogicalSystemState OBJECT-TYPE
+       SYNTAX      JnxSubscriberState
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The state of this subscriber."
+       ::= { jnxSubscriberLogicalSystemEntry 3 }
+
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-- Subscriber information by routing instance
+-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+jnxSubscriberRoutingInstanceTotalCount OBJECT-TYPE
+       SYNTAX      CounterBasedGauge64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The number of total subscribers on the routing instance."
+       ::= { jnxSubscriberRoutingInstanceObjects 1 }
+
+jnxSubscriberRoutingInstanceActiveCount OBJECT-TYPE
+       SYNTAX      CounterBasedGauge64
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The number of active subscribers on the routing instance."
+       ::= { jnxSubscriberRoutingInstanceObjects 2 }
+
+jnxSubscriberRoutingInstanceTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF JnxSubscriberRoutingInstanceEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The entries in this table sort subscribers within routing instance.
+             
+             The routing instance name must be provided in the SNMP query. The
+             routing instance will be identified by either the context field in V3
+             requests, or it will be encoded in the community string in V1 or
+             V2c requests.
+
+             User can query for logical-system/routing-instance specific data by
+             prefixing the community string with
+             <logical-system>/<routing-instance>@, where '@' acts as a separator
+             between community name and routing-instance name.
+
+             If no routing instance is specified, this table shows data for the
+             default routing instance. The name of the logical system is ignored
+             for this table."
+       ::= { jnxSubscriberRoutingInstanceObjects 3 }
+
+jnxSubscriberRoutingInstanceEntry OBJECT-TYPE
+       SYNTAX      JnxSubscriberRoutingInstanceEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "A specification of subscribers within routing instance."
+       INDEX     { jnxSubscriberRoutingInstanceHandleHiWord, jnxSubscriberRoutingInstanceHandleLoWord }
+       ::= { jnxSubscriberRoutingInstanceTable 1 }
+
+JnxSubscriberRoutingInstanceEntry ::= SEQUENCE {
+       jnxSubscriberRoutingInstanceHandleHiWord Unsigned32,
+       jnxSubscriberRoutingInstanceHandleLoWord Unsigned32,
+       jnxSubscriberRoutingInstanceState        JnxSubscriberState }
+
+jnxSubscriberRoutingInstanceHandleHiWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+             
+             This object is equal to the most significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberRoutingInstanceEntry 1 }
+
+jnxSubscriberRoutingInstanceHandleLoWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+
+             This object is equal to the least significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberRoutingInstanceEntry 2 }
+
+jnxSubscriberRoutingInstanceState OBJECT-TYPE
+       SYNTAX      JnxSubscriberState
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The state of this subscriber."
+       ::= { jnxSubscriberRoutingInstanceEntry 3 }
+
+jnxSubscriberAccountingEntry OBJECT-TYPE
+       SYNTAX      JnxSubscriberAccountingEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "A specification of subscribers with Accounting."
+       INDEX     { jnxSubscriberAccountingHandleHiWord, jnxSubscriberAccountingHandleLoWord }
+       ::= { jnxSubscriberAccountingTable 1 }
+
+
+JnxSubscriberAccountingEntry ::= SEQUENCE {
+       jnxSubscriberAccountingHandleHiWord         Unsigned32,
+       jnxSubscriberAccountingHandleLoWord         Unsigned32,
+       jnxSubscriberAccountingUserName             DisplayString,
+       jnxSubscriberAccountingClientType           JnxSubscriberClientType,
+       jnxSubscriberAccountingIpAddress            IpAddress,
+       jnxSubscriberAccountingIpAddressMask        IpAddress,
+       jnxSubscriberAccountingLogicalSystem        OCTET STRING,
+       jnxSubscriberAccountingRoutingInstance      OCTET STRING,
+       jnxSubscriberAccountingInterface            DisplayString,
+       jnxSubscriberAccountingInterfaceType        INTEGER,
+       jnxSubscriberAccountingMacAddress           MacAddress,
+       jnxSubscriberAccountingState                JnxSubscriberState,
+       jnxSubscriberAccountingLoginTime            DisplayString,
+       jnxSubscriberAccountingAcctSessionId        DisplayString }
+
+jnxSubscriberAccountingHandleHiWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+             
+             This object is equal to the most significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberAccountingEntry 1 }
+
+jnxSubscriberAccountingHandleLoWord OBJECT-TYPE
+       SYNTAX      Unsigned32(0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+             "The subscriber handle associated with this subscriber. A
+             subscriber handle is a monotonically increasing number.
+
+             This object is equal to the least significant 32 bit of the 64 bit
+             subscriber id."
+       ::= { jnxSubscriberAccountingEntry 2}
+
+jnxSubscriberAccountingUserName OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The userName associated with this subscriber."
+       ::= { jnxSubscriberAccountingEntry 3 }
+
+jnxSubscriberAccountingClientType OBJECT-TYPE
+       SYNTAX      JnxSubscriberClientType
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The client type for this subscriber."
+       ::= { jnxSubscriberAccountingEntry 4 }
+
+jnxSubscriberAccountingIpAddress OBJECT-TYPE
+       SYNTAX      IpAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The client IP Address assigned to this subscriber."
+       ::= { jnxSubscriberAccountingEntry 5 }
+
+jnxSubscriberAccountingIpAddressMask OBJECT-TYPE
+       SYNTAX      IpAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The client IP Address Mask assigned to this subscriber."
+       ::= { jnxSubscriberAccountingEntry 6 }
+
+jnxSubscriberAccountingLogicalSystem OBJECT-TYPE
+       SYNTAX      OCTET STRING (SIZE(0..63))
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The logical system associated with this subscriber."
+       ::= { jnxSubscriberAccountingEntry 7 }
+
+jnxSubscriberAccountingRoutingInstance OBJECT-TYPE
+       SYNTAX      OCTET STRING (SIZE(0..128))
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The routing instance associated with this subscriber."
+    ::= { jnxSubscriberAccountingEntry 8 }
+
+jnxSubscriberAccountingInterface OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The textual name of the interface associated with this subscriber."
+    ::= { jnxSubscriberAccountingEntry 9 }
+
+jnxSubscriberAccountingInterfaceType OBJECT-TYPE
+       SYNTAX      INTEGER {
+             none(0),
+             static(1),
+             dynamic(2) }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The type of the interface associated with this subscriber."
+       ::= { jnxSubscriberAccountingEntry 10 }
+
+jnxSubscriberAccountingMacAddress OBJECT-TYPE
+       SYNTAX      MacAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The MAC address of the interface associated with this subscriber."
+       ::= { jnxSubscriberAccountingEntry 11 }
+
+jnxSubscriberAccountingState OBJECT-TYPE
+       SYNTAX      JnxSubscriberState
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The state of this subscriber."
+       ::= { jnxSubscriberAccountingEntry 12 }
+
+jnxSubscriberAccountingLoginTime OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The time this subscriber logged in to the server."
+       ::= { jnxSubscriberAccountingEntry 13 }
+
+jnxSubscriberAccountingAcctSessionId OBJECT-TYPE
+       SYNTAX      DisplayString
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+             "The accounting session id associated with this subscriber."
+       ::= { jnxSubscriberAccountingEntry 14 }
+
+END

--- a/mibs/junos/mib-jnx-syslog.txt
+++ b/mibs/junos/mib-jnx-syslog.txt
@@ -113,7 +113,7 @@ JnxSyslogFacility  ::= TEXTUAL-CONVENTION
       INDEX     { jnxSyslogId }
       ::= { jnxSyslogTable 1 }
 
-    JnxSyslogEntry::=
+    JnxSyslogEntry ::=
         SEQUENCE {
           jnxSyslogId             Unsigned32,
           jnxSyslogEventName      DisplayString,

--- a/mibs/junos/mib-jnx-timing-notifications.txt
+++ b/mibs/junos/mib-jnx-timing-notifications.txt
@@ -1,0 +1,900 @@
+-------------------------------------------------------------------------------
+-- Juniper Enterprise Specific MIB: Timing feature defect/event notification MIB
+-- 
+-- Copyright (c) 2001-2003, Juniper Networks, Inc.
+-- All rights reserved.
+--
+-- The contents of this document are subject to change without notice.
+-------------------------------------------------------------------------------
+
+JUNIPER-TIMING-NOTFNS-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    Integer32, Unsigned32, Gauge32,
+    TimeTicks, Counter32, Counter64,
+    IpAddress
+        FROM SNMPv2-SMI -- [RFC2578]
+    TEXTUAL-CONVENTION, DisplayString
+        FROM SNMPv2-TC  -- [RFC2579]
+    InterfaceIndex, ifOperStatus
+        FROM IF-MIB     -- [RFC2863a]
+    InetAddress
+        FROM INET-ADDRESS-MIB
+    OBJECT-GROUP, NOTIFICATION-GROUP, MODULE-COMPLIANCE
+        FROM SNMPv2-CONF
+    jnxTimingNotfnsMIBRoot
+        FROM JUNIPER-SMI;
+
+
+jnxTimingNotfnsMIB MODULE-IDENTITY
+    LAST-UPDATED "201304220930Z"  -- Mon Apr 22 09:30 2013 UTC
+    ORGANIZATION "Juniper Networks, Inc."
+    CONTACT-INFO
+            "        Juniper Technical Assistance Center
+                     Juniper Networks, Inc.
+                     1194 N. Mathilda Avenue
+                     Sunnyvale, CA 94089
+                     E-mail: support@juniper.net"
+
+    DESCRIPTION
+            "This is Juniper Networks' implementation of enterprise
+             specific MIB for alarms from the router chassis box."
+    --  Revision history
+    REVISION     "201303151541Z" -- Fri Mar 15 15:41 2013 UTC
+    DESCRIPTION  "Initial Version"
+
+    ::= { jnxTimingNotfnsMIBRoot 1 }
+
+
+jnxTimingFaults          OBJECT IDENTIFIER ::= { jnxTimingNotfnsMIB 1 }
+jnxTimingEvents           OBJECT IDENTIFIER ::= { jnxTimingNotfnsMIB 2 }
+jnxTimingNotfObjects      OBJECT IDENTIFIER ::= { jnxTimingNotfnsMIB 3 }
+jnxTimingConformance      OBJECT IDENTIFIER ::= { jnxTimingNotfnsMIB 4 }
+
+
+-------------------------------------------------------------------------------
+-- Textual Conventions
+-------------------------------------------------------------------------------
+JnxPtpClockIdTC ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1x:"
+    STATUS       current
+    DESCRIPTION
+            "Clock Identifier."
+    SYNTAX       OCTET STRING (SIZE (8))
+
+JnxPtpPhaseOffsetTC ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d-9"
+    STATUS       current
+    DESCRIPTION
+            "Phase Offset."
+    SYNTAX       Integer32 (0..1000)
+
+
+-------------------------------------------------------------------------------
+-- Objects 
+-------------------------------------------------------------------------------
+jnxClksyncState OBJECT-TYPE
+    SYNTAX      INTEGER { clear(0), set(1) }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "Fault status."
+    ::= { jnxTimingNotfObjects 1 }
+
+jnxClksyncIfIndex  OBJECT-TYPE
+        SYNTAX      InterfaceIndex
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Snmp ifIndex of member interface."
+        ::= { jnxTimingNotfObjects 2 }
+
+jnxClksyncIntfName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Interface name."
+        ::= { jnxTimingNotfObjects 3 }
+
+jnxAcbFpgaRevMajor OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "Major version information."
+    ::= { jnxTimingNotfObjects 4 }
+
+jnxAcbFpgaRevMinor OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "Minor version information."
+    ::= { jnxTimingNotfObjects 5 }
+
+jnxBootCpldFpgaRevMajor OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "Major version information."
+    ::= { jnxTimingNotfObjects 6 }
+
+jnxBootCpldFpgaRevMinor OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "Minor version information."
+    ::= { jnxTimingNotfObjects 7 }
+
+jnxClksyncQualityCode OBJECT-TYPE
+    SYNTAX      INTEGER {
+        --eec1
+        prc(0),
+        ssu-a(1),
+        ssu-b(2),
+        sec(3),
+        dnu(4),
+        --eec2
+        stu(10),
+        prs(11),
+        tnc(13),
+        st2(14),
+        st3e(15),
+        st3(16),
+        smc(17),
+        st4(18),
+        dus(19)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "SSM/ESMC quality levels."
+    ::= { jnxTimingNotfObjects 8 }
+
+jnxClksyncDpllState OBJECT-TYPE
+    SYNTAX      INTEGER {
+        unknown(-1),
+        lock-acq(0),
+        locked(1),
+        holder(2),
+        freerun(3)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "BITS/SyncE DPLL states."
+    ::= { jnxTimingNotfObjects 9 }
+
+jnxPtpServoState OBJECT-TYPE
+    SYNTAX      INTEGER {
+        init(0),
+        free-run(1),
+        holdover(2),
+        acquiring(3),
+        freq-locked(4),
+        phase-aligned(5)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP servo states."
+    ::= { jnxTimingNotfObjects 10 }
+
+jnxPtpClass OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP clock status."
+    ::= { jnxTimingNotfObjects 11 }
+
+jnxPtpAccuracy OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP clock accuracy."
+    ::= { jnxTimingNotfObjects 12 }
+
+jnxPtpGmId OBJECT-TYPE
+    SYNTAX      JnxPtpClockIdTC
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP Grand Master clock-id."
+    ::= { jnxTimingNotfObjects 13 }
+
+jnxPtpGmIpAddr OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP Grand Master stream ip-address."
+    ::= { jnxTimingNotfObjects 14 }
+
+jnxClkStreamHandle OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP clock accuracy."
+    ::= { jnxTimingNotfObjects 15 }
+
+jnxRemoteIpAddr OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "PTP clock stream's remote ip-address."
+    ::= { jnxTimingNotfObjects 16 }
+
+jnxClksyncHybridState OBJECT-TYPE
+    SYNTAX      INTEGER {
+        init(0),
+        freq-acq(1),
+        freqLck-phaseAcq1(2),
+        freqLck-phaseAcq2(3),
+        freqLck-phaseAcq3(4),
+        freq-phase-lck(5)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "hybrid states."
+    ::= { jnxTimingNotfObjects 17 }
+
+jnxPtpPhaseOffset OBJECT-TYPE
+    SYNTAX      JnxPtpPhaseOffsetTC
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+            "Phase Offset."
+    ::= { jnxTimingNotfObjects 18 }
+
+jnxClksyncQualityCodeStr OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "SSM/ESMC quality levels in string format."
+        ::= { jnxTimingNotfObjects 19 }
+
+jnxClksyncDpllStateStr OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Dpll state in string format."
+        ::= { jnxTimingNotfObjects 20 }
+
+jnxPtpServoStateStr OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "PTP servo states in string format."
+        ::= { jnxTimingNotfObjects 21 }
+
+jnxClksyncHybridStateStr OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "hybrid states in string format."
+        ::= { jnxTimingNotfObjects 22 }
+
+jnxClksyncColorStr OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "Color of the LED unit."
+        ::= { jnxTimingNotfObjects 23 }
+
+
+-------------------------------------------------------------------------------
+-- Faults
+-------------------------------------------------------------------------------
+    jnxTimingFaultLOSSet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that Loss Of Signal has been detected.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 1 }
+
+    jnxTimingFaultLOSClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that Loss Of Signal has been cleared.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 2 }
+
+    jnxTimingFaultEFDSet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Exceeded frequency deviation.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 3 }
+
+    jnxTimingFaultEFDClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Exceeded frequency deviation cleared.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 4 }
+
+    jnxTimingFaultLOESMCSet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Loss of ESMC.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 5 }
+
+    jnxTimingFaultLOESMCClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Loss of ESMC.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 6 }
+
+    jnxTimingFaultQLFailSet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies ESMC/SSM Quality Level failed.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 7 }
+
+    jnxTimingFaultQLFailClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies ESMC/SSM Quality Level failed.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 8 }
+
+    jnxTimingFaultLTISet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Loss of timing information.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 9 }
+
+    jnxTimingFaultLTIClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Loss of timing information.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 10 }
+
+    jnxTimingFaultAcbcFpgaVerNotCompatible NOTIFICATION-TYPE
+        OBJECTS {
+                jnxAcbFpgaRevMajor,
+                jnxAcbFpgaRevMinor
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies ACBC FPGA version is not compatible.
+
+             jnxBootCpldFpgaRevMajor indicates the current ACBC FPGA Major revision
+             jnxBootCpldFpgaRevMinor indicates the current ACBC FPGA Minor revision."
+    ::= { jnxTimingFaults 11 }
+
+    jnxTimingFaultBootCpldVerNotCompatible NOTIFICATION-TYPE
+        OBJECTS {
+                jnxBootCpldFpgaRevMajor,
+                jnxBootCpldFpgaRevMinor
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Boot-cpld version is not compatible.
+
+             jnxClksyncVersion indicates the current Boot-cpld version."
+    ::= { jnxTimingFaults 12 }
+
+    jnxTimingFaultPriSrcFailed NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Primary source failed
+             (Whenever PFM/CFM/SCM error occurs).
+
+             jnxClksyncIfIndex is the Primary source interface index
+             jnxClksyncIntfName is the Primary source interface name."
+    ::= { jnxTimingFaults 13 }
+
+    jnxTimingFaultSecSrcFailed NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Secondary source failed
+             (Whenever PFM/CFM/SCM error occurs).
+
+             jnxClksyncIfIndex is the Secondary source interface index
+             jnxClksyncIntfName is the Secondary source interface name."
+    ::= { jnxTimingFaults 14 }
+
+    jnxTimingFaultPtpUniNegRateRejectSet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClkStreamHandle,
+                jnxRemoteIpAddr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies: 
+             When acting as MASTER - Failing/rejecting clients for signaling messages
+             When acting as SLAVE - Failing or receiving rejection for signaling messages
+
+             jnxClkStreamHandle is the clock stream handle
+             jnxRemoteIpAddr is the clock stream's remote ip-address."
+    ::= { jnxTimingFaults  15 }
+
+    jnxTimingFaultPtpUniNegRateRejectClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClkStreamHandle,
+                jnxRemoteIpAddr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies: 
+             When acting as MASTER - Failing/rejecting clients for signaling messages
+             When acting as SLAVE - Failing or receiving rejection for signaling messages
+
+             jnxClkStreamHandle is the clock stream handle
+             jnxRemoteIpAddr is the clock stream's remote ip-address."
+    ::= { jnxTimingFaults  16 }
+
+
+-------------------------------------------------------------------------------
+-- Events
+-------------------------------------------------------------------------------
+    jnxTimingEventPriSrcRecovered NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Primary source recovered.
+
+             jnxClksyncIfIndex is the Primary source interface index
+             jnxClksyncIntfName is the Primary source interface name."
+    ::= { jnxTimingEvents 1 }
+
+    jnxTimingEventSecSrcRecovered NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Secondary source recovered.
+
+             jnxClksyncIfIndex is the Secondary source interface index
+             jnxClksyncIntfName is the Secondary source interface name."
+    ::= { jnxTimingEvents 2 }
+
+    jnxTimingEventPriRefChanged NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,  -- new ref ifIndex
+                jnxClksyncIntfName  -- new ref interface name
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Primary reference changed
+             (Ifd name change or change from synce to BITS/external interface etc).
+
+             jnxClksyncIfIndex is the Primary reference interface index
+             jnxClksyncIntfName is the Primary reference interface name."
+    ::= { jnxTimingEvents 3 }
+
+    jnxTimingEventSecRefChanged NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,  -- new ref ifIndex
+                jnxClksyncIntfName  -- new ref interface name
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies Secondary reference changed
+             (Ifd name change or change from synce to BITS/external interface etc).
+
+             jnxClksyncIfIndex is the Secondary reference interface index
+             jnxClksyncIntfName is the Secondary reference interface name."
+    ::= { jnxTimingEvents 4 }
+
+    jnxTimingEventQLChangedRx NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName,
+                jnxClksyncQualityCode, -- new quality code
+                jnxClksyncQualityCodeStr -- new quality code string
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies RX SSM/ESMC quality level changed.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name
+             jnxClksyncQualityCode is the SSM/ESMC quality level 
+             jnxClksyncQualityCodeStr is the SSM/ESMC quality level in string format."
+    ::= { jnxTimingEvents 5 }
+
+    jnxTimingEventQLChangedTx NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName,
+                jnxClksyncQualityCode, -- new quality code
+                jnxClksyncQualityCodeStr -- new quality code string
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies TX SSM/ESMC quality level changed.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name
+             jnxClksyncQualityCode is the SSM/ESMC quality level 
+             jnxClksyncQualityCodeStr is the SSM/ESMC quality level in string format."
+    ::= { jnxTimingEvents 6 }
+
+    jnxTimingEventSynceHldovrToLck NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies SyncE Holdover to Locked EEC state.
+
+             jnxClksyncIfIndex is the SyncE interface index
+             jnxClksyncIntfName is the SyncE interface name."
+    ::= { jnxTimingEvents 7 }
+
+    jnxTimingEventSynceLckToHldovr NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies SyncE Locked to Holdover EEC state.
+
+             jnxClksyncIfIndex is the SyncE interface index
+             jnxClksyncIntfName is the SyncE interface name."
+    ::= { jnxTimingEvents 8 }
+
+    jnxTimingEventDpllStatus NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncDpllState,
+                jnxClksyncDpllStateStr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that DPLL state change
+             (unknown, lock_acq, locked, holder, freerun).
+
+             jnxClksyncDpllState indicates the Dpll status
+             jnxClksyncDpllStateStr indicates the Dpll status in string format."
+    ::= { jnxTimingEvents 9 }
+
+    jnxTimingEventSynceDpllStatus NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName,
+                jnxClksyncDpllState,
+                jnxClksyncDpllStateStr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that Synce DPLL state change
+             (unknown, lock_acq, locked, holder, freerun).
+
+             jnxClksyncIfIndex is the interface index from which Frequency is derived
+             jnxClksyncIntfName is the interface name from which Frequency is derived
+             jnxClksyncDpllState indicates the Dpll status
+             jnxClksyncDpllStateStr indicates the Dpll status in string format."
+    ::= { jnxTimingEvents 10 }
+
+    jnxTimingEventBitsDpllStatus NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName,
+                jnxClksyncDpllState,
+                jnxClksyncDpllStateStr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that Synce DPLL state change
+             (unknown, lock_acq, locked, holder, freerun).
+
+             jnxClksyncIfIndex is the interface index from which Frequency is derived
+             jnxClksyncIntfName is the interface name from which Frequency is derived
+             jnxClksyncDpllState indicates the Dpll status
+             jnxClksyncDpllStateStr indicates the Dpll status in string format."
+    ::= { jnxTimingEvents 11 }
+
+    jnxTimingEventPtpServoStatus NOTIFICATION-TYPE
+        OBJECTS {
+                jnxPtpServoState,
+                jnxPtpServoStateStr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that PTP servo state
+             (Init, Acquiring, PhaseAligned, FreeRun, Holdover). 
+
+             jnxPtpServoState indicates the ptp servo status
+             jnxPtpServoStateStr indicates the ptp servo status in string format."
+    ::= { jnxTimingEvents 12 }
+
+    jnxTimingEventPtpGMClockClassChange NOTIFICATION-TYPE
+        OBJECTS {
+                jnxPtpGmId,
+                jnxPtpClass
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies PTP clock class changes.
+
+             jnxPtpGmId indicates the ptp Grand Master clock-id
+             jnxPtpClass indicates the ptp Grand Master clock status."
+    ::= { jnxTimingEvents 13 }
+
+    jnxTimingEventPtpGMClockAccuracyChange NOTIFICATION-TYPE
+        OBJECTS {
+                jnxPtpGmId,
+                jnxPtpAccuracy
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies PTP clock accuracy changes.
+
+             jnxPtpGmId indicates the ptp Grand Master clock-id
+             jnxPtpAccuracy indicates the ptp Grand Master clock accuracy."
+    ::= { jnxTimingEvents 14 }
+
+    jnxTimingEventPtpGMChange NOTIFICATION-TYPE
+        OBJECTS {
+                jnxPtpGmId
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies PTP Grand Master changes.
+
+             jnxPtpGmId indicates the ptp Grand Master clock-id."
+    ::= { jnxTimingEvents 15 }
+
+    jnxTimingEventHybridStatus NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncHybridState,
+                jnxClksyncHybridStateStr
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that Hybrid state
+             (Init, FreqAcq, FreqLckPhaseAcq, FreqPhaseLck). 
+
+             jnxClksyncHybridState indicates the hybrid status
+             jnxClksyncHybridStateStr indicates the hybrid status in string format."
+    ::= { jnxTimingEvents 16 }
+
+    jnxTimingEventSquelchSet NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that interface status changed to squelched.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 17 }
+
+    jnxTimingEventSquelchClear NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies that interface status changed to active.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name."
+    ::= { jnxTimingFaults 18 }
+
+    jnxTimingEventLedColorChange NOTIFICATION-TYPE
+        OBJECTS {
+                jnxClksyncIfIndex,
+                jnxClksyncIntfName,
+                jnxClksyncColorStr -- new LED color
+        }
+        STATUS  current
+        DESCRIPTION
+            "A trap which signifies TX SSM/ESMC quality level changed.
+
+             jnxClksyncIfIndex is the interface index
+             jnxClksyncIntfName is the interface name
+             jnxClksyncColorStr is the color of the LED unit."
+    ::= { jnxTimingEvents 19 }
+
+
+-------------------------------------------------------------------------------
+-- Conformance
+-------------------------------------------------------------------------------
+jnxTimingCompliances      OBJECT IDENTIFIER ::= { jnxTimingConformance 1 }
+jnxTimingGroups           OBJECT IDENTIFIER ::= { jnxTimingConformance 2 }
+
+jnxTimingCompliance MODULE-COMPLIANCE
+STATUS  current
+DESCRIPTION
+"The compliance statement for systems supporting
+ the Timing Notification MIB."
+MODULE -- this module
+-- MANDATORY-GROUPS {
+-- any mandatory groups should be mentioned here
+-- }
+GROUP       jnxTimingObjectsGroup
+DESCRIPTION
+"This group is optional."
+GROUP       jnxTimingNotfnFaultsGroup
+DESCRIPTION
+"This group is optional."
+GROUP       jnxTimingNotfnEventsGroup
+DESCRIPTION
+"This group is optional."
+::= { jnxTimingCompliances 1 }
+
+jnxTimingObjectsGroup OBJECT-GROUP
+OBJECTS {
+        jnxClksyncState,
+        jnxClksyncIfIndex,
+        jnxClksyncIntfName,
+        jnxAcbFpgaRevMajor,
+        jnxAcbFpgaRevMinor,
+        jnxBootCpldFpgaRevMajor,
+        jnxBootCpldFpgaRevMinor,
+        jnxClksyncQualityCode,
+        jnxClksyncDpllState,
+        jnxPtpServoState,
+        jnxPtpClass,
+        jnxPtpAccuracy,
+        jnxPtpGmId,
+        jnxPtpGmIpAddr,
+        jnxClkStreamHandle,
+        jnxRemoteIpAddr,
+        jnxClksyncHybridState,
+        jnxPtpPhaseOffset,
+        jnxClksyncQualityCodeStr,
+        jnxClksyncDpllStateStr,
+        jnxPtpServoStateStr,
+        jnxClksyncHybridStateStr,
+        jnxClksyncColorStr
+}
+STATUS current
+DESCRIPTION
+"Timing objects group."
+::= { jnxTimingGroups 1 }
+
+jnxTimingNotfnFaultsGroup NOTIFICATION-GROUP
+NOTIFICATIONS {
+        jnxTimingFaultLOSSet,
+        jnxTimingFaultLOSClear,
+        jnxTimingFaultEFDSet,
+        jnxTimingFaultEFDClear,
+        jnxTimingFaultLOESMCSet,
+        jnxTimingFaultLOESMCClear,
+        jnxTimingFaultQLFailSet,
+        jnxTimingFaultQLFailClear,
+        jnxTimingFaultLTISet,
+        jnxTimingFaultLTIClear,
+        jnxTimingFaultAcbcFpgaVerNotCompatible,
+        jnxTimingFaultBootCpldVerNotCompatible,
+        jnxTimingFaultPriSrcFailed,
+        jnxTimingFaultSecSrcFailed,
+        jnxTimingFaultPtpUniNegRateRejectSet,
+        jnxTimingFaultPtpUniNegRateRejectClear
+}
+STATUS current
+DESCRIPTION
+"Timing defects notification group."
+::= { jnxTimingGroups 2 }
+
+jnxTimingNotfnEventsGroup NOTIFICATION-GROUP
+NOTIFICATIONS {
+        jnxTimingEventPriSrcRecovered,
+        jnxTimingEventSecSrcRecovered,
+        jnxTimingEventPriRefChanged,
+        jnxTimingEventSecRefChanged,
+        jnxTimingEventQLChangedRx,
+        jnxTimingEventQLChangedTx,
+        jnxTimingEventSynceHldovrToLck,
+        jnxTimingEventSynceLckToHldovr,
+        jnxTimingEventDpllStatus,
+        jnxTimingEventSynceDpllStatus,
+        jnxTimingEventBitsDpllStatus,
+        jnxTimingEventPtpServoStatus,
+        jnxTimingEventPtpGMClockClassChange,
+        jnxTimingEventPtpGMClockAccuracyChange,
+        jnxTimingEventPtpGMChange,
+        jnxTimingEventHybridStatus,
+        jnxTimingEventSquelchSet,
+        jnxTimingEventSquelchClear,
+        jnxTimingEventLedColorChange
+}
+
+STATUS current
+DESCRIPTION
+"Timing events notification group."
+::= { jnxTimingGroups 3 }
+
+END
+

--- a/mibs/junos/mib-jnx-user-aaa.txt
+++ b/mibs/junos/mib-jnx-user-aaa.txt
@@ -1,7 +1,7 @@
 -- *******************************************************************
 -- Juniper User AAA objects MIB.
 --
--- Copyright (c) 2001-2007, Juniper Networks, Inc.
+-- Copyright (c) 2001-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -10,20 +10,23 @@
     JUNIPER-USER-AAA-MIB DEFINITIONS ::= BEGIN
 
     IMPORTS
-        Counter64, IpAddress, Integer32,
+        Counter64, IpAddress, Integer32, Counter32, Unsigned32,
         NOTIFICATION-TYPE, MODULE-IDENTITY, 
         OBJECT-TYPE
             FROM SNMPv2-SMI
-
-        TEXTUAL-CONVENTION, DisplayString
-            FROM SNMPv2-TC 
-
+        TEXTUAL-CONVENTION, DisplayString, RowStatus, TruthValue
+            FROM SNMPv2-TC
+        Ipv6AddressPrefix, Ipv6AddressIfIdentifier, Ipv6Address
+            FROM IPV6-TC
+        EnabledStatus
+            FROM JUNIPER-MIMSTP-MIB
         jnxUserAAAMibRoot
-            FROM JUNIPER-SMI;
-
+            FROM JUNIPER-SMI
+        InetAddressType, InetAddress, InetAddressPrefixLength
+            FROM INET-ADDRESS-MIB;
 
     jnxUserAAAMib  	MODULE-IDENTITY
-        LAST-UPDATED  "200708210000Z"
+        LAST-UPDATED "201303180000Z"
         ORGANIZATION  "Juniper Networks, Inc."
         CONTACT-INFO
             "Juniper Technical Assistance Center
@@ -36,6 +39,58 @@
         DESCRIPTION
             "This module defines the objects pertaining to User authentication,
              authorization and accounting"
+        REVISION      "201303180000Z"
+        DESCRIPTION   "jnxAccessAuthServerEnabled, corrected description" 
+        REVISION      "201212290000Z"
+        DESCRIPTION   "jnxUserAAADomainDynamicPorfile object has been
+                       deprecated and replaced by jnxUserAAADomainDynamicProfile"
+        REVISION      "201012080000Z"
+        DESCRIPTION   "Updates related to adding address pool display"
+        REVISION      "201011230000Z"
+        DESCRIPTION   "Updates related to adding address pool traps"
+        REVISION    "201002091110Z"
+        DESCRIPTION   "Added jnxUserAAAAssignment, jnxUserAAAGeneral,
+                       jnxUserAAADomainDelimiters,
+                       jnxUserAAADomainParseDirection, jnxUserAAADomain,
+                       jnxUserAAADomainTable, jnxUserAAADomainEntry,
+                       jnxUserAAADomainName, jnxUserAAADomainStripDomain,
+                       jnxUserAAADomainLogicalSystem,
+                       jnxUserAAADomainRoutingInstance,
+                       jnxUserAAADomainAddrPoolName,
+                       jnxUserAAADomainDynamicPorfile,
+                       jnxUserAAADomainTargetLogicalSystem,
+                       jnxUserAAADomainTargetRoutingInstance,
+                       jnxUserAAADomainTunnelProfile,
+                       jnxUserAAADomainTunnelTable, jnxUserAAADomainTunnelEntry,
+                       jnxUserAAADomainTunnelName, jnxUserAAADomainTunnelDefId,
+                       jnxUserAAADomainTunnelPreference,
+                       jnxUserAAADomainTunnelRemoteGwName,
+                       jnxUserAAADomainTunnelRemoteGwAddress,
+                       jnxUserAAADomainTunnelSourceGwName,
+                       jnxUserAAADomainTunnelSourceGwAddress,
+                       jnxUserAAADomainTunnelSecret,
+                       jnxUserAAADomainTunnelLogicalSystems,
+                       jnxUserAAADomainTunnelRoutingInstance,
+                       jnxUserAAADomainTunnelMedium, jnxUserAAADomainTunnelType,
+                       jnxUserAAADomainTunnelId,
+                       jnxUserAAADomainTunnelMaxSessions,
+                       jnxUserAAADomainPadnTable, jnxUserAAADomainPadnEntry,
+                       jnxUserAAADomainPadnIpAddress,
+                       jnxUserAAADomainPadnIpMask, jnxUserAAADomainPadnDistance,
+                       jnxUserAAAAccessProfile, jnxUserAAAAccessProfileGeneral,
+                       jnxUserAAAAccessProfileTable,
+                       jnxUserAAAAccessProfileEntry,
+                       jnxUserAAAAccessProfileName,
+                       jnxUserAAAAccessProfileAuthenticationOrder,
+                       jnxUserAAAAccessProfileAccountingOrder,
+                       jnxUserAAAAccessProfileAuthorizationOrder,
+                       jnxUserAAAAccessProfileProvisioningOrder,
+                       jnxUserAAAAccessProfileAccStopOnFailure,
+                       jnxUserAAAAccessProfileAccStopOnDeny,
+                       jnxUserAAAAccessProfileImmediateUpdate,
+                       jnxUserAAAAccessProfileCoaImmediateUpdate,
+                       jnxUserAAAAccessProfileInterval,
+                       jnxUserAAAAccessProfileStatType."
         REVISION      "200708210000Z"
         DESCRIPTION   "Updates related to SecurID authentication"
         REVISION      "200705140000Z"
@@ -51,9 +106,12 @@
     --  Next Branch node. 
     -- ***************************************************************
 
-	jnxUserAAAGlobalStats OBJECT IDENTIFIER ::= { jnxUserAAAObjects 1 }
+	jnxUserAAAGlobalStats        OBJECT IDENTIFIER ::= { jnxUserAAAObjects 1 }
 	jnxUserAAAAccessAuthStats    OBJECT IDENTIFIER ::= { jnxUserAAAObjects 2 }
-	jnxUserAAATrapVars    OBJECT IDENTIFIER ::= { jnxUserAAAObjects 3 }
+	jnxUserAAATrapVars           OBJECT IDENTIFIER ::= { jnxUserAAAObjects 3 }
+	jnxUserAAAAccessPool         OBJECT IDENTIFIER ::= { jnxUserAAAObjects 4 }
+	jnxUserAAAAssignment         OBJECT IDENTIFIER ::= { jnxUserAAAObjects 5 }
+	jnxUserAAAAccessProfile      OBJECT IDENTIFIER ::= { jnxUserAAAObjects 6 }
 
 
     -- ***************************************************************
@@ -68,16 +126,77 @@
             radius - authentication via a radius server.
             local  - local authenticaiton.
             ldap   - authentication via a LDAP server.
-            securid- authentication via RSA's SecurID authentication server"
+            securid- authentication via RSA's SecurID authentication server
+            jsrc   - authentication via jsrc"
 
         SYNTAX  INTEGER {
+                            none      (0),
                             radius    (1),
                             local     (2),
                             ldap      (3),
-                            securid   (4)
+                            securid   (4),
+                            jsrc      (5)
                         }
+    
+    JnxAccountingType  ::= TEXTUAL-CONVENTION
+        STATUS      current
+        DESCRIPTION
+            "There several choices for accounting, these are 
+            the types:
+            radius - accounting via a radius server.
+            local  - local accounting.
+            ldap   - accounting via a LDAP server.
+            securid- accounting via RSA's SecurID accounting server
+            jsrc   - accounting via jsrc"
+            
+        SYNTAX  INTEGER {
+                            none      (0),
+                            radius    (1),
+                            local     (2),
+                            ldap      (3),
+                            securid   (4),
+                            jsrc      (5)
+                         }
 
-
+    JnxAuthorizationType  ::= TEXTUAL-CONVENTION
+        STATUS      current
+        DESCRIPTION
+            "There several choices for authorization, these are 
+            the types:
+            radius - authorization via a radius server.
+            local  - local authorization.
+            ldap   - authorization via a LDAP server.
+            securid- authorization via RSA's SecurID authorization server
+            jsrc   - authorization via jsrc"
+            
+        SYNTAX  INTEGER {
+                            none      (0),
+                            radius    (1),
+                            local     (2),
+                            ldap      (3),
+                            securid   (4),
+                            jsrc      (5)
+                         }
+    JnxProvisioningType  ::= TEXTUAL-CONVENTION
+        STATUS      current
+        DESCRIPTION
+            "There several choices for provisioning, these are 
+            the types:
+            radius - provisioning via a radius server.
+            local  - local provisioning.
+            ldap   - provisioning via a LDAP server.
+            securid- provisioning via RSA's SecurID provisioning server
+            jsrc   - provisioning via jsrc"
+            
+        SYNTAX  INTEGER {
+                            none      (0),
+                            radius    (1),
+                            local     (2),
+                            ldap      (3),
+                            securid   (4),
+                            jsrc      (5)
+                         }
+    
     -- ***************************************************************
     -- Statistic counters for related to access authentication.
     -- ***************************************************************
@@ -175,6 +294,14 @@
             "The server name which identifies the authentication server."
         ::= { jnxUserAAATrapVars 1 }
 
+    jnxUserAAAAddressPoolName   OBJECT-TYPE
+        SYNTAX      DisplayString 
+        MAX-ACCESS  accessible-for-notify
+        STATUS      current
+        DESCRIPTION
+            "The address pool name which identifies the local address pool."
+        ::= { jnxUserAAATrapVars 2 }
+
 
     -- ***************************************************************
     -- definition of access authentication related traps.
@@ -213,15 +340,781 @@
 
 
     -- 
-    -- Authentication server starting to respond .
+    -- Authentication server state change to UP .
     -- 
     jnxAccessAuthServerEnabled NOTIFICATION-TYPE
         OBJECTS         { jnxUserAAAServerName }  
         STATUS          current
         DESCRIPTION
-            "An access authentication trap signifies that 
-             the External authentication server started responding
-             again."
+            "An access authentication trap signifies that the 
+             AAA client has changed the status of the External authentication server to UP."
         ::= { jnxUserAAANotifications 4 }
+
+    -- 
+    -- Address Pool or Linked Pool chain has reached its warning
+    -- threshold.
+    -- 
+	jnxAccessAuthAddressPoolHighThreshold NOTIFICATION-TYPE
+        OBJECTS         { jnxUserAAAAddressPoolName }  
+        STATUS          current
+        DESCRIPTION
+            "An access authentication trap signifies that 
+             the address pool has reached its high threshold."
+        ::= { jnxUserAAANotifications 5 }
+
+    -- 
+    -- Address Pool or Linked Pool chain has reached its abate
+    -- threshold.
+    -- 
+    jnxAccessAuthAddressPoolAbateThreshold NOTIFICATION-TYPE
+        OBJECTS         { jnxUserAAAAddressPoolName }  
+        STATUS          current
+        DESCRIPTION
+            "An access authentication trap signifies that 
+             the address pool has reached its abate threshold"
+        ::= { jnxUserAAANotifications 6 }
+
+    -- 
+    -- Address Pool or Linked Pool chain is completely used up.
+    -- 
+	jnxAccessAuthAddressPoolOutOfAddresses NOTIFICATION-TYPE
+        OBJECTS         { jnxUserAAAAddressPoolName }  
+        STATUS          current
+        DESCRIPTION
+            "An access authentication trap signifies that 
+             an Out Of Addresses event occured on the pool."
+        ::= { jnxUserAAANotifications 7 }
+
+    -- 
+    -- Address Pool or Linked Pool chain is completely used up.
+    -- 
+	jnxAccessAuthAddressPoolOutOfMemory NOTIFICATION-TYPE
+        OBJECTS         { jnxUserAAAAddressPoolName }  
+        STATUS          current
+        DESCRIPTION
+            "An access authentication trap signifies that 
+             an Out Of Memory event occured on the pool."
+        ::= { jnxUserAAANotifications 8 }
+
+    -- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    -- Managed objects for Access profile
+    -- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    jnxUserAAAAccessPoolGeneral OBJECT IDENTIFIER ::= { jnxUserAAAAccessPool 1 }
+
+    jnxUserAAAAccessPoolTable OBJECT-TYPE
+        SYNTAX       SEQUENCE OF JnxUserAAAAccessPool
+        MAX-ACCESS   not-accessible
+        STATUS       current
+        DESCRIPTION
+            "The entries in this table specify the address pools."
+         ::= { jnxUserAAAAccessPoolGeneral 1 }
+
+    jnxUserAAAAccessPoolEntry OBJECT-TYPE
+        SYNTAX      JnxUserAAAAccessPool
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A read-only description of the local address pools."
+        INDEX     { jnxUserAAAAccessPoolIdent }
+        ::= { jnxUserAAAAccessPoolTable 1 }
+
+    JnxUserAAAAccessPool ::= SEQUENCE {
+        jnxUserAAAAccessPoolIdent                Unsigned32,
+        jnxUserAAAAccessPoolRoutingInstance      DisplayString,
+        jnxUserAAAAccessPoolName                 DisplayString,
+        jnxUserAAAAccessPoolLinkName             DisplayString,
+        jnxUserAAAAccessPoolFamilyType           InetAddressType,
+        jnxUserAAAAccessPoolInetNetwork          InetAddress,
+        jnxUserAAAAccessPoolInetPrefixLength     InetAddressPrefixLength,
+        jnxUserAAAAccessPoolOutOfMemory          Counter64,
+        jnxUserAAAAccessPoolOutOfAddresses       Counter64,
+        jnxUserAAAAccessPoolAddressTotal         Counter64,
+        jnxUserAAAAccessPoolAddressesInUse       Counter64,
+        jnxUserAAAAccessPoolAddressUsage         INTEGER,
+        jnxUserAAAAccessPoolAddressUsageHigh     INTEGER,
+        jnxUserAAAAccessPoolAddressUsageAbate    INTEGER
+    }
+
+    jnxUserAAAAccessPoolIdent OBJECT-TYPE
+        SYNTAX      Unsigned32 (1..4294967295)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The address identifier key."
+        ::= { jnxUserAAAAccessPoolEntry 1 }
+
+    jnxUserAAAAccessPoolRoutingInstance OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(1..63))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The routing instance of the address pool."
+        ::= { jnxUserAAAAccessPoolEntry 2 }
+
+    jnxUserAAAAccessPoolName OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(1..63))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The address pool name."
+        ::= { jnxUserAAAAccessPoolEntry 3 }
+
+    jnxUserAAAAccessPoolLinkName OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(1..63))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The address pool link name."
+        ::= { jnxUserAAAAccessPoolEntry 4 }
+
+    jnxUserAAAAccessPoolFamilyType OBJECT-TYPE
+        SYNTAX       InetAddressType
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The family type of this pool."
+         ::= { jnxUserAAAAccessPoolEntry 5 }
+
+    jnxUserAAAAccessPoolInetNetwork OBJECT-TYPE
+        SYNTAX       InetAddress (SIZE(2..48))
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The Match criteria for this pool. Network or Prefix"
+         ::= { jnxUserAAAAccessPoolEntry 6 }
+
+    jnxUserAAAAccessPoolInetPrefixLength OBJECT-TYPE
+        SYNTAX       InetAddressPrefixLength
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The Prefix Length for an IPv6 pool"
+         ::= { jnxUserAAAAccessPoolEntry 7 }
+
+    jnxUserAAAAccessPoolOutOfMemory OBJECT-TYPE
+        SYNTAX       Counter64
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The Number of times this pool has flagged an Out of Memory condition."
+         ::= { jnxUserAAAAccessPoolEntry 8 }
+
+    jnxUserAAAAccessPoolOutOfAddresses OBJECT-TYPE
+        SYNTAX       Counter64
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The Number of times this pool has flagged an Out of Address condition."
+         ::= { jnxUserAAAAccessPoolEntry 9 }
+
+    jnxUserAAAAccessPoolAddressTotal OBJECT-TYPE
+        SYNTAX       Counter64
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The total number of Addresses or prefixes in this pool."
+         ::= { jnxUserAAAAccessPoolEntry 10 }
+
+    jnxUserAAAAccessPoolAddressesInUse OBJECT-TYPE
+        SYNTAX       Counter64
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The total number of Addresses or prefixes given out from this pool."
+         ::= { jnxUserAAAAccessPoolEntry 11 }
+
+    jnxUserAAAAccessPoolAddressUsage OBJECT-TYPE
+        SYNTAX       INTEGER
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The percentage of addresses used in this pool or linked pool.
+            If this pool is the head of a linked chain of pools, this number
+            reflects the Usage for the whole chain. Conversely, if this pool
+            it part of a linked chain of pools but not the head of the chain,
+            the value will not be used."
+         ::= { jnxUserAAAAccessPoolEntry 12 }
+
+    jnxUserAAAAccessPoolAddressUsageHigh OBJECT-TYPE
+        SYNTAX       INTEGER
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The configured high percentage threshold of addresses used in this
+            pool or linked pool. An SNMP trap is generated when this threshold
+            is exceeded. This trap will only be generated for unlinked pools or
+            pools that are the head of a linked chain of pools Conversely, if 
+            this pool it part of a linked chain of pools but not the head of the
+            chain, then no traps will be generated."
+         ::= { jnxUserAAAAccessPoolEntry 13 }
+
+    jnxUserAAAAccessPoolAddressUsageAbate OBJECT-TYPE
+        SYNTAX       INTEGER
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The configured abate percentage threshold of addresses used in this
+            pool or linked pool. An SNMP trap clear is generated when address use
+            falls below this threshold percentage. This trap will only be generated
+            for unlinked pools or pools that are the head of a linked chain of
+            pools Conversely, if this pool it part of a linked chain of pools but
+            not the head of the chain, then no traps will be generated."
+         ::= { jnxUserAAAAccessPoolEntry 14 }
+
+    -- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    -- Managed objects for Assignment functions
+    -- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    jnxUserAAAGeneral   OBJECT IDENTIFIER ::= { jnxUserAAAAssignment 1 }
+
+    jnxUserAAADomainDelimiters OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(0..8))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The list of delimiters used to separate the user's name from the
+             user's domain in the username field.  The default is '@'."
+        ::= { jnxUserAAAGeneral 1 }
+
+    jnxUserAAADomainParseDirection OBJECT-TYPE
+        SYNTAX      INTEGER {
+                        rightToLeft(1),
+                        leftToRight(2) }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The direction in which the user's name is parsed: either search
+            for domain delimiter from left to right or right to left; first
+            delimiter marks boundry. The default is right to left."
+        DEFVAL    { rightToLeft }
+        ::= { jnxUserAAAGeneral 2 }
+
+    jnxUserAAADomain     OBJECT IDENTIFIER ::= { jnxUserAAAAssignment 2 }
+
+    jnxUserAAADomainTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxUserAAADomainEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The entries in this table specify the assignment of a remote access
+            user to a logical system, based on the user's domain."
+        ::= { jnxUserAAADomain 1 }
+
+    jnxUserAAADomainEntry OBJECT-TYPE
+        SYNTAX      JnxUserAAADomainEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A specification of the logical system to which users on a specified
+            domain should be assigned."
+        INDEX     { IMPLIED jnxUserAAADomainName }
+        ::= { jnxUserAAADomainTable 1 }
+
+    JnxUserAAADomainEntry ::= SEQUENCE {
+        jnxUserAAADomainName                  DisplayString,
+        jnxUserAAADomainStripDomain           TruthValue,
+        jnxUserAAADomainLogicalSystem         DisplayString,
+        jnxUserAAADomainRoutingInstance       DisplayString,
+        jnxUserAAADomainAddrPoolName          DisplayString,
+        jnxUserAAADomainDynamicPorfile        DisplayString,
+        jnxUserAAADomainTargetLogicalSystem   DisplayString,
+        jnxUserAAADomainTargetRoutingInstance DisplayString,
+        jnxUserAAADomainTunnelProfile         DisplayString,
+        jnxUserAAADomainDynamicProfile        DisplayString }
+
+    jnxUserAAADomainName OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(1..63))
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The domain name uniquely identifying this entry."
+        ::= { jnxUserAAADomainEntry 1 }
+
+    jnxUserAAADomainStripDomain OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "Enables/disables the domain name stripping feature, which causes
+             the system to strip the domain name before sending the
+             access-request to RADIUS for authentication."
+        DEFVAL    { false }
+        ::= { jnxUserAAADomainEntry 2 }
+
+    jnxUserAAADomainLogicalSystem OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The name of the logical system, which will be used by the AAA
+             subsystem for this session. If not specified, will be mapped to
+             default."
+        DEFVAL    { "" }
+        ::= { jnxUserAAADomainEntry 3 }
+
+    jnxUserAAADomainRoutingInstance OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The name of the routing instance, which will be used by the AAA
+             subsystem for this session. If not specified, will be mapped to
+             default."
+        DEFVAL    { "" }
+        ::= { jnxUserAAADomainEntry 4 }
+
+    jnxUserAAADomainAddrPoolName OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(0..63))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The configured the address-pool-name for the domain name."
+        DEFVAL    { "" }
+        ::= { jnxUserAAADomainEntry 5 }
+
+    jnxUserAAADomainDynamicPorfile OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      deprecated
+        DESCRIPTION
+            "The configured dynamic-profile which will be used for this session
+             upon succeeding validation."
+        DEFVAL    { "" }
+        ::= { jnxUserAAADomainEntry 6 }
+
+    jnxUserAAADomainTargetLogicalSystem OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The configured target logical-system that this session will need to
+             be mapped to. If not specified, will be mapped to default."
+        ::= { jnxUserAAADomainEntry 7 }
+
+    jnxUserAAADomainTargetRoutingInstance OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The configured routing-instance that this session will need to be
+             mapped to."
+        ::= { jnxUserAAADomainEntry 8 }
+
+    jnxUserAAADomainTunnelProfile OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The associated tunnel profile."
+        ::= { jnxUserAAADomainEntry 9 }
+
+    jnxUserAAADomainDynamicProfile OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The configured dynamic-profile to be used for this session."
+        DEFVAL    { "" }
+        ::= { jnxUserAAADomainEntry 10 }
+
+    jnxUserAAADomainTunnelTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxUserAAADomainTunnelEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The entries in this table specify the tunnels associated with a
+            domain."
+        ::= { jnxUserAAADomain 2 }
+
+    jnxUserAAADomainTunnelEntry OBJECT-TYPE
+        SYNTAX      JnxUserAAADomainTunnelEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A specification of the tunnels associated with a domain."
+        INDEX     { jnxUserAAADomainTunnelName,
+                    jnxUserAAADomainTunnelDefId }
+        ::= { jnxUserAAADomainTunnelTable 1 }
+
+    JnxUserAAADomainTunnelEntry ::= SEQUENCE {
+        jnxUserAAADomainTunnelName                 OCTET STRING,
+        jnxUserAAADomainTunnelDefId                Integer32,
+        jnxUserAAADomainTunnelPreference           Integer32,
+        jnxUserAAADomainTunnelRemoteGwName         DisplayString,
+        jnxUserAAADomainTunnelRemoteGwAddress      IpAddress,
+        jnxUserAAADomainTunnelSourceGwName         DisplayString,
+        jnxUserAAADomainTunnelSourceGwAddress      IpAddress,
+        jnxUserAAADomainTunnelSecret               DisplayString,
+        jnxUserAAADomainTunnelLogicalSystems       DisplayString,
+        jnxUserAAADomainTunnelRoutingInstance      DisplayString,
+        jnxUserAAADomainTunnelMedium               INTEGER,
+        jnxUserAAADomainTunnelType                 INTEGER,
+        jnxUserAAADomainTunnelId                   DisplayString,
+        jnxUserAAADomainTunnelMaxSessions          Unsigned32}
+
+    jnxUserAAADomainTunnelName OBJECT-TYPE
+        SYNTAX      OCTET STRING (SIZE(1..63))
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The domain name associated with this entry."
+        ::= { jnxUserAAADomainTunnelEntry 1 }
+
+    jnxUserAAADomainTunnelDefId OBJECT-TYPE
+        SYNTAX      Integer32 (1..31)
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The tunnel definition id value associated with this entry."
+        ::= { jnxUserAAADomainTunnelEntry 2 }
+
+    jnxUserAAADomainTunnelPreference OBJECT-TYPE
+        SYNTAX      Integer32 (1..31)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+        "The tunnel's preference value associated with this entry. "
+        ::= { jnxUserAAADomainTunnelEntry 3 }
+
+    jnxUserAAADomainTunnelRemoteGwName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This name specifies the hostname expected from the peer (the LNS)
+             when a tunnel is setup."
+        ::= { jnxUserAAADomainTunnelEntry 4 }
+
+    jnxUserAAADomainTunnelRemoteGwAddress OBJECT-TYPE
+        SYNTAX      IpAddress
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "IP address of LNS tunnel endpoint"
+        ::= { jnxUserAAADomainTunnelEntry 5 }
+
+    jnxUserAAADomainTunnelSourceGwName OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "This name specifies the hostname expected from the peer (the LNS)
+             when a tunnel is setup."
+        ::= { jnxUserAAADomainTunnelEntry 6 }
+
+    jnxUserAAADomainTunnelSourceGwAddress OBJECT-TYPE
+        SYNTAX      IpAddress
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The source address of the tunnel (overrides the default address for
+             this LS/RI.) "
+        ::= { jnxUserAAADomainTunnelEntry 7 }
+
+    jnxUserAAADomainTunnelSecret OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(0..32))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The tunnel password associated with this entry."
+        ::= { jnxUserAAADomainTunnelEntry 8 }
+
+    jnxUserAAADomainTunnelLogicalSystems OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The logical systems associated with this entty."
+        ::= { jnxUserAAADomainTunnelEntry 9 }
+
+    jnxUserAAADomainTunnelRoutingInstance OBJECT-TYPE
+        SYNTAX      DisplayString
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The routing instance associated with this entty."
+        ::= { jnxUserAAADomainTunnelEntry 10 }
+
+    jnxUserAAADomainTunnelMedium OBJECT-TYPE
+        SYNTAX      INTEGER {
+                        tunnelMediumIPv4(1),
+                        tunnelMediumUnknown(2) }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The tunnel medium associated with this entry.  The medium dictates
+             the format of the tunnel address."
+        ::= { jnxUserAAADomainTunnelEntry 11 }
+
+    jnxUserAAADomainTunnelType OBJECT-TYPE
+        SYNTAX      INTEGER {
+                        tunnelL2tp(1),
+                        tunnelUnknown(2),
+                        tunnelL2f(3) }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The tunnel type associated with this entry."
+        ::= { jnxUserAAADomainTunnelEntry 12 }
+
+    jnxUserAAADomainTunnelId OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(0..32))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The tunnel identifier associated with this entry."
+        ::= { jnxUserAAADomainTunnelEntry 13 }
+
+    jnxUserAAADomainTunnelMaxSessions OBJECT-TYPE
+        SYNTAX      Unsigned32
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+             "The maximum number of tunnel sessions allowed in this tunnel
+             entry."
+        ::= { jnxUserAAADomainTunnelEntry 14 }
+
+
+    jnxUserAAADomainPadnTable OBJECT-TYPE
+        SYNTAX      SEQUENCE OF JnxUserAAADomainPadnEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The entries in this table specify the PPPoE active discovery
+             network (PADN) parameters associated with a domain."
+        ::= { jnxUserAAADomain 3 }
+
+    jnxUserAAADomainPadnEntry OBJECT-TYPE
+        SYNTAX      JnxUserAAADomainPadnEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A specification of the PPPoE active discovery network parameters
+            associated with a domain."
+        INDEX     { jnxUserAAADomainName,
+                    jnxUserAAADomainPadnIpAddress,
+                    jnxUserAAADomainPadnIpMask }
+        ::= { jnxUserAAADomainPadnTable 1 }
+
+    JnxUserAAADomainPadnEntry ::= SEQUENCE {
+        jnxUserAAADomainPadnIpAddress     IpAddress,
+        jnxUserAAADomainPadnIpMask        IpAddress,
+        jnxUserAAADomainPadnDistance      Integer32 }
+
+    jnxUserAAADomainPadnIpAddress OBJECT-TYPE
+        SYNTAX      IpAddress
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The IP address of this entry."
+        ::= { jnxUserAAADomainPadnEntry 1 }
+
+    jnxUserAAADomainPadnIpMask OBJECT-TYPE
+        SYNTAX      IpAddress
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The IP mask of this entry."
+        ::= { jnxUserAAADomainPadnEntry 2 }
+
+    jnxUserAAADomainPadnDistance OBJECT-TYPE
+        SYNTAX      Integer32 (0..255)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+            "The administrative distance metric of this entry."
+        ::= { jnxUserAAADomainPadnEntry 3 }
+
+
+    -- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    -- Managed objects for Access profile
+    -- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    jnxUserAAAAccessProfileGeneral OBJECT IDENTIFIER ::= { jnxUserAAAAccessProfile 1 }
+
+    jnxUserAAAAccessProfileTable OBJECT-TYPE
+        SYNTAX       SEQUENCE OF JnxUserAAAAccessProfileEntry
+        MAX-ACCESS   not-accessible
+        STATUS       current
+        DESCRIPTION
+            "The entries in this table specify the assignment of authentication
+             methods for a particular subscriber type."
+         ::= { jnxUserAAAAccessProfileGeneral 1 }
+
+    jnxUserAAAAccessProfileEntry OBJECT-TYPE
+        SYNTAX      JnxUserAAAAccessProfileEntry
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "A specification of the authentication methods for a particular
+            subscriber type."
+        INDEX     { IMPLIED jnxUserAAAAccessProfileName }
+        ::= { jnxUserAAAAccessProfileTable 1 }
+
+    JnxUserAAAAccessProfileEntry ::= SEQUENCE {
+        jnxUserAAAAccessProfileName                 DisplayString,
+        jnxUserAAAAccessProfileAuthenticationOrder  OCTET STRING,
+        jnxUserAAAAccessProfileAccountingOrder      OCTET STRING,
+        jnxUserAAAAccessProfileAuthorizationOrder   OCTET STRING,
+        jnxUserAAAAccessProfileProvisioningOrder    OCTET STRING,
+        jnxUserAAAAccessProfileAccStopOnFailure     TruthValue,
+        jnxUserAAAAccessProfileAccStopOnDeny        TruthValue,
+        jnxUserAAAAccessProfileImmediateUpdate      TruthValue,
+        jnxUserAAAAccessProfileCoaImmediateUpdate   TruthValue,
+        jnxUserAAAAccessProfileInterval             Integer32,
+        jnxUserAAAAccessProfileStatType             INTEGER
+    }
+
+    jnxUserAAAAccessProfileName OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE(1..63))
+        MAX-ACCESS  not-accessible
+        STATUS      current
+        DESCRIPTION
+            "The access profile name."
+        ::= { jnxUserAAAAccessProfileEntry 1 }
+
+    jnxUserAAAAccessProfileAuthenticationOrder OBJECT-TYPE
+        SYNTAX       OCTET STRING (SIZE(0..5))
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The set of authentication mechanisms configured on this system.  Each
+            octet in this object contains one of the values defined in the
+            JnxAuthenticateType TEXTUAL-CONVENTION.
+
+            The system will sequence through each octet of this object starting at
+            octet 1 and attempt to use the corresponding authentication protocol
+            defined by JnxAuthenticateType.
+
+            If an authentication protocol is configured and attempts to reach the
+            authentication server fail, the system will move to the next octet in
+            this object and retry the authentication in the form dictated by the
+            corresponding authentication protocoltype. The process of sequencing
+            thru each octet will stop if the authentication server is successfully
+            contacted, or there are no more configured octets in this object."
+         ::= { jnxUserAAAAccessProfileEntry 2 }
+
+    jnxUserAAAAccessProfileAccountingOrder OBJECT-TYPE
+        SYNTAX       OCTET STRING (SIZE(0..5))
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The set of accounting mechanisms configured on this system.  Each
+            octet in this object contains one of the values defined in the
+            JnxAccountingType TEXTUAL-CONVENTION.
+
+            The system will sequence through each octet of this object starting at
+            octet 1 and attempt to use the corresponding accounting protocol
+            defined by JnxAccountingType.
+
+            If an accounting protocol is configured and attempts to reach the
+            accounting server fail, the system will move to the next octet in
+            this object and retry the accounting in the form dictated by the
+            corresponding accounting protocoltype. The process of sequencing
+            thru each octet will stop if the accounting server is successfully
+            contacted, or there are no more configured octets in this object."
+         ::= { jnxUserAAAAccessProfileEntry 3 }
+
+    jnxUserAAAAccessProfileAuthorizationOrder OBJECT-TYPE
+        SYNTAX       OCTET STRING (SIZE(0..5))
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The set of accounting mechanisms configured on this system.  Each
+            octet in this object contains one of the values defined in the
+            JnxAuthorizationType TEXTUAL-CONVENTION.
+
+            The system will sequence through each octet of this object starting at
+            octet 1 and attempt to use the corresponding accounting protocol
+            defined by JnxAuthorizationType.
+
+            If an accounting protocol is configured and attempts to reach the
+            accounting server fail, the system will move to the next octet in
+            this object and retry the accounting in the form dictated by the
+            corresponding accounting protocoltype. The process of sequencing
+            thru each octet will stop if the accounting server is successfully
+            contacted, or there are no more configured octets in this object."
+         ::= { jnxUserAAAAccessProfileEntry 4 }
+
+     jnxUserAAAAccessProfileProvisioningOrder OBJECT-TYPE
+        SYNTAX       OCTET STRING (SIZE(0..5))
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The set of provisioning mechanisms configured on this system.  Each
+            octet in this object contains one of the values defined in the
+            JnxProvisioningType TEXTUAL-CONVENTION.
+
+            The system will sequence through each octet of this object starting at
+            octet 1 and attempt to use the corresponding accounting protocol
+            defined by JnxProvisioningType.
+
+            If an accounting protocol is configured and attempts to reach the
+            accounting server fail, the system will move to the next octet in
+            this object and retry the accounting in the form dictated by the
+            corresponding accounting protocoltype. The process of sequencing
+            thru each octet will stop if the accounting server is successfully
+            contacted, or there are no more configured octets in this object."
+         ::= { jnxUserAAAAccessProfileEntry 5 }
+
+
+    jnxUserAAAAccessProfileAccStopOnFailure OBJECT-TYPE
+        SYNTAX       TruthValue
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "Enables/disables the Acct-Stop message if a user fails
+             authentication, but AAA-server grants access."
+         ::= { jnxUserAAAAccessProfileEntry 6 }
+
+    jnxUserAAAAccessProfileAccStopOnDeny OBJECT-TYPE
+        SYNTAX       TruthValue
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "Enables/disables the Acct-Stop message if AAA-server denies
+             access."
+         ::= { jnxUserAAAAccessProfileEntry 7 }
+
+    jnxUserAAAAccessProfileImmediateUpdate OBJECT-TYPE
+        SYNTAX       TruthValue
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "Enables/disables the Acct-Update message on receipt of a
+             Acct-response for the Acct-Start message."
+         ::= { jnxUserAAAAccessProfileEntry 8 }
+
+    jnxUserAAAAccessProfileCoaImmediateUpdate OBJECT-TYPE
+        SYNTAX       TruthValue
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "Enables/disables the Acct-Update message on completion of
+             processing a change of authorization."
+         ::= { jnxUserAAAAccessProfileEntry 9 }
+
+    jnxUserAAAAccessProfileInterval OBJECT-TYPE
+        SYNTAX       Integer32
+        UNITS        "minutes"
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The interval in minutes between accounting updates(Interim-stats
+             off, if not specified)."
+         ::= { jnxUserAAAAccessProfileEntry 10 }
+
+    jnxUserAAAAccessProfileStatType OBJECT-TYPE
+        SYNTAX       INTEGER {
+                        time(0),
+                        volume-time(1) }
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The type of statistics are collected. These are the configured
+             types:
+                time         - the option to report only uptime
+                volume-time  - the option to report both volume and uptime"
+         ::= { jnxUserAAAAccessProfileEntry 11 }
 
 END

--- a/mibs/junos/mib-jnx-virtualchassis.txt
+++ b/mibs/junos/mib-jnx-virtualchassis.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Virtual Chassis
 --
--- Copyright (c) 2007-2008, Juniper Networks, Inc.
+-- Copyright (c) 2007-2013, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -10,17 +10,17 @@
 JUNIPER-VIRTUALCHASSIS-MIB  DEFINITIONS ::= BEGIN
 
 IMPORTS
-    MODULE-IDENTITY, OBJECT-TYPE    FROM SNMPv2-SMI 
-    OBJECT-IDENTITY                 FROM SNMPv2-SMI
-    NOTIFICATION-TYPE               FROM SNMPv2-SMI
-    MacAddress,DisplayString        FROM SNMPv2-TC
-    JnxChassisId                    FROM JUNIPER-MIB
-    jnxVccpNotifications            FROM JUNIPER-SMI
-    jnxExVirtualChassis             FROM JUNIPER-EX-SMI;
+    MODULE-IDENTITY, OBJECT-TYPE, Counter64     FROM SNMPv2-SMI 
+    OBJECT-IDENTITY                             FROM SNMPv2-SMI
+    NOTIFICATION-TYPE                           FROM SNMPv2-SMI
+    MacAddress,DisplayString                    FROM SNMPv2-TC
+    JnxChassisId                                FROM JUNIPER-MIB
+    jnxVccpNotifications                        FROM JUNIPER-SMI
+    jnxExVirtualChassis                         FROM JUNIPER-EX-SMI;
     
     jnxVirtualChassisMemberMIB MODULE-IDENTITY
                                       
-    LAST-UPDATED "200806170000Z" -- 17 June, 2008
+    LAST-UPDATED "201403180000Z" -- 18 March, 2014
     ORGANIZATION "Juniper Networks, Inc."
     CONTACT-INFO
          "Juniper Technical Assistance Center
@@ -31,15 +31,33 @@ IMPORTS
 
     DESCRIPTION
             "The MIB modules for Virtual Chassis Member.Virtual Chassis Member feature allows a set of
-             EX-Series switches to be connected together to form a Virtual Chassis. A virtual chassis
+             Juniper switches to be connected together to form a Virtual Chassis. A virtual chassis
              will give all the features of a real chassis, potentially at a much lower cost points.
              A virtual chassis will be managed as a single box and will appear as a single network
-             element to other switches and routers in the network. Some EX-Series switches will have
+             element to other switches and routers in the network. Some Juniper switches will have
              the special high speed stacking ports which are used to connect to each other to form a 
-             stack. The EX-Series switches can also be connected by the 10GE (or 1GE) network ports to
-             form a stack. These can be used by EX-Series switches that don't have dedicated stacking ports.
-             Up to a maximum of 10 boxes can be stacked together."
+             stack. The Juniper switches can also be connected by the network ports to form a stack.
+             These can be used by Juniper switches that don't have dedicated stacking ports."
 
+    REVISION
+        "201007130000Z" -- 13 July, 2010
+
+    DESCRIPTION
+        "Added jnxVccpMemberUp and jnxVccpMemberDown Traps."
+
+    REVISION
+        "201010140000Z" -- 14 October, 2010
+
+    DESCRIPTION
+        "Modified the range for jnxVirtualChassisMemberPriority from 0 to 255."
+
+    REVISION
+        "201403180000Z" -- 18 March, 2014
+
+    DESCRIPTION
+        "Generalize the MIB description for other Juniper platforms and update 
+         the jnxVirtualChassisMemberId from 9 to 31."
+ 
        ::= { jnxExVirtualChassis 1 }
 
 --
@@ -71,11 +89,13 @@ IMPORTS
         jnxVirtualChassisMemberMacAddBase                 MacAddress,
         jnxVirtualChassisMemberSWVersion                  DisplayString ,
         jnxVirtualChassisMemberPriority                   INTEGER,
-        jnxVirtualChassisMemberUptime                     INTEGER
+        jnxVirtualChassisMemberUptime                     INTEGER,
+        jnxVirtualChassisMemberModel                      DisplayString,
+        jnxVirtualChassisMemberLocation                   DisplayString
     }
 
     jnxVirtualChassisMemberId OBJECT-TYPE
-    SYNTAX      INTEGER (0..9)
+    SYNTAX      INTEGER (0..31)
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION
@@ -122,12 +142,12 @@ IMPORTS
     ::= {  jnxVirtualChassisMemberEntry 5 }
 
     jnxVirtualChassisMemberPriority OBJECT-TYPE
-    SYNTAX      INTEGER (1..255)
+    SYNTAX      INTEGER (0..255)
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION
         "This specifies the priority of the virtual-chassis member which can
-        vary from 1 to 255."
+        vary from 0 to 255."
     ::= {  jnxVirtualChassisMemberEntry 6 }
 
     jnxVirtualChassisMemberUptime OBJECT-TYPE
@@ -137,6 +157,22 @@ IMPORTS
     DESCRIPTION
         "Specifies the virtual-chassis member uptime. "
     ::= {  jnxVirtualChassisMemberEntry 7 }
+
+    jnxVirtualChassisMemberModel OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Specifies the virtual-chassis member model. "
+    ::= {  jnxVirtualChassisMemberEntry 8 }
+
+    jnxVirtualChassisMemberLocation OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Specifies the virtual-chassis member location. "
+    ::= {  jnxVirtualChassisMemberEntry 9 }
 
 
    -- jnxVirtualChassisPortTable holds the vccp port's admin/operation status
@@ -164,7 +200,21 @@ IMPORTS
         jnxVirtualChassisFpcId                          INTEGER,
         jnxVirtualChassisPortName                       DisplayString,
         jnxVirtualChassisPortAdminStatus                INTEGER,
-        jnxVirtualChassisPortOperStatus                 INTEGER
+        jnxVirtualChassisPortOperStatus                 INTEGER,
+        jnxVirtualChassisPortInPkts                     Counter64,
+        jnxVirtualChassisPortOutPkts                    Counter64,
+        jnxVirtualChassisPortInOctets                   Counter64,
+        jnxVirtualChassisPortOutOctets                  Counter64,
+        jnxVirtualChassisPortInMcasts                   Counter64,
+        jnxVirtualChassisPortOutMcasts                  Counter64,
+        jnxVirtualChassisPortInPkts1secRate             Counter64,
+        jnxVirtualChassisPortOutPkts1secRate            Counter64,
+        jnxVirtualChassisPortInOctets1secRate           Counter64,
+        jnxVirtualChassisPortOutOctets1secRate          Counter64,
+        jnxVirtualChassisPortCarrierTrans               Counter64,
+        jnxVirtualChassisPortInCRCAlignErrors           Counter64,
+        jnxVirtualChassisPortUndersizePkts              Counter64,
+        jnxVirtualChassisPortCollisions                 Counter64
     }
     
    jnxVirtualChassisFpcId OBJECT-TYPE
@@ -216,6 +266,146 @@ IMPORTS
             this port."
       ::= { jnxVirtualChassisPortEntry 4 }
   
+   jnxVirtualChassisPortInPkts OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of packets received on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortInPkts"
+      ::= { jnxVirtualChassisPortEntry 5 }
+  
+   jnxVirtualChassisPortOutPkts OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of packets sent from the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortOutPkts"
+      ::= { jnxVirtualChassisPortEntry 6 }
+  
+   jnxVirtualChassisPortInOctets OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of octets received on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortInOctets"
+      ::= { jnxVirtualChassisPortEntry 7 }
+  
+   jnxVirtualChassisPortOutOctets OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of octets sent on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortOutOctets"
+      ::= { jnxVirtualChassisPortEntry 8 }
+  
+   jnxVirtualChassisPortInMcasts OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of multicast packets received on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortInMcasts"
+      ::= { jnxVirtualChassisPortEntry 9 }
+  
+   jnxVirtualChassisPortOutMcasts OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of multicast packets sent from the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortOutMcasts"
+      ::= { jnxVirtualChassisPortEntry 10 }
+  
+   jnxVirtualChassisPortInPkts1secRate OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of packets received per second on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortInPkts1secRate"
+      ::= { jnxVirtualChassisPortEntry 11 }
+  
+   jnxVirtualChassisPortOutPkts1secRate OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of packets sent per second from the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortOutPkts1secRate"
+      ::= { jnxVirtualChassisPortEntry 12 }
+  
+   jnxVirtualChassisPortInOctets1secRate OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of octets received per secondon the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortInOctets1secRate"
+      ::= { jnxVirtualChassisPortEntry 13 }
+  
+   jnxVirtualChassisPortOutOctets1secRate OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of octets sent per second on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortOutOctets1secRate"
+      ::= { jnxVirtualChassisPortEntry 14 }
+  
+   jnxVirtualChassisPortCarrierTrans OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of Carrier errors on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortCarrierTrans"
+      ::= { jnxVirtualChassisPortEntry 15 }
+  
+   jnxVirtualChassisPortInCRCAlignErrors OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of Input CRC Alignment errors on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortInCRCAlignErrors"
+      ::= { jnxVirtualChassisPortEntry 16 }
+  
+   jnxVirtualChassisPortUndersizePkts OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of Undersize Packets on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortUndersizePkts"
+      ::= { jnxVirtualChassisPortEntry 17 }
+  
+   jnxVirtualChassisPortCollisions OBJECT-TYPE
+      SYNTAX        Counter64 
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+           "Indicates the total number of Collisions on the 
+           virtual-chassis port. This object is a 64-bit version of 
+           jnxVirtualChassisPortCollisions"
+      ::= { jnxVirtualChassisPortEntry 18 }
+  
   jnxVccpNotificationsPrefix OBJECT-IDENTITY
       STATUS current
       DESCRIPTION 
@@ -231,10 +421,12 @@ IMPORTS
 
 jnxVccpPortUp NOTIFICATION-TYPE
     OBJECTS { jnxVirtualChassisPortAdminStatus, 
-              jnxVirtualChassisPortOperStatus }
+              jnxVirtualChassisPortOperStatus,
+              jnxVirtualChassisMemberModel,
+              jnxVirtualChassisMemberLocation }
     STATUS  current
     DESCRIPTION
-            "A MemberUp trap signifies that the SNMP entity, acting in an
+            "A PortUp trap signifies that the SNMP entity, acting in an
             agent role, has detected that the jnxVirtualChassisPortOperStatus 
             object for one of its communication links left the  down state
             and transitioned into some other state (but not into the
@@ -244,15 +436,45 @@ jnxVccpPortUp NOTIFICATION-TYPE
 
 jnxVccpPortDown NOTIFICATION-TYPE
     OBJECTS { jnxVirtualChassisPortAdminStatus, 
-              jnxVirtualChassisPortOperStatus }
+              jnxVirtualChassisPortOperStatus,
+              jnxVirtualChassisMemberModel,
+              jnxVirtualChassisMemberLocation }
     STATUS  current
     DESCRIPTION
-            "A MemberDown trap signifies that the SNMP entity, acting in an
+            "A PortDown trap signifies that the SNMP entity, acting in an
             agent role, has detected that the jnxVirtualChassisPortOperStatus
-            object for one of its communication links left the  down state
-            and transitioned into some other state (but not into the
+            object for one of its communication links is about to enter the
+            down state from some other state (but not into the
             notPresent state).  This other state is indicated by the
             included value of jnxVirtualChassisPortOperStatus."
     ::= { jnxVccpNotificationsPrefix 2 }
+
+jnxVccpMemberUp NOTIFICATION-TYPE
+    OBJECTS { jnxVirtualChassisMemberSerialnumber,
+              jnxVirtualChassisMemberRole,
+              jnxVirtualChassisMemberModel,
+              jnxVirtualChassisMemberLocation }
+    STATUS  current
+    DESCRIPTION
+            "A MemberUp trap signifies that the SNMP entity, acting in an
+            agent role, has detected that the Member present at the location
+            jnxVirtualChassisMemberLocation on one of the Virtual
+            Chassis left the down state and transitioned into some other
+            state (but not into the notPresent state)."
+    ::= { jnxVccpNotificationsPrefix 3 }
+
+jnxVccpMemberDown NOTIFICATION-TYPE
+    OBJECTS { jnxVirtualChassisMemberSerialnumber,
+              jnxVirtualChassisMemberRole,
+              jnxVirtualChassisMemberModel,
+              jnxVirtualChassisMemberLocation }
+    STATUS  current
+    DESCRIPTION
+            "A MemberDown trap signifies that the SNMP entity, acting in an
+            agent role, has detected that the Member present at the location
+            jnxVirtualChassisMemberLocation on one of the Virtual
+            Chassis is about to enter the down state (but not into the notPresent
+            state)."
+    ::= { jnxVccpNotificationsPrefix 4 }
 
 END

--- a/mibs/junos/mib-jnx-vlan.txt
+++ b/mibs/junos/mib-jnx-vlan.txt
@@ -1,7 +1,7 @@
 --
 -- Juniper Enterprise Specific MIB: Vlan
 --
--- Copyright (c) 2007-2008, Juniper Networks, Inc.
+-- Copyright (c) 2007-2011, Juniper Networks, Inc.
 -- All rights reserved.
 --
 -- The contents of this document are subject to change without notice.
@@ -49,6 +49,11 @@ jnxVlanMIBObjects  MODULE-IDENTITY
     DESCRIPTION
         "Added new Object jnxExVlanTag to represent Vlan Tag information
          for each Vlan."
+    REVISION
+        "201009070000Z" -- Tue Sep 7 00:00:00 2010 UTC
+    DESCRIPTION
+        "Added new Objects jnxExVlanPortTagness and jnxExVlanPortAccessMode as
+        part of jnxExVlanPortGroupTable."
 
     ::= { jnxExVlan 1 }
 
@@ -561,7 +566,9 @@ JnxExVlanPortGroupEntry ::=
     SEQUENCE {
         jnxExVlanPortGroupIndex      Integer32,
         jnxExVlanPort                Integer32,
-        jnxExVlanPortStatus          INTEGER
+        jnxExVlanPortStatus          INTEGER,
+        jnxExVlanPortTagness         INTEGER,
+        jnxExVlanPortAccessMode      INTEGER
     }
 
 jnxExVlanPortGroupIndex OBJECT-TYPE
@@ -616,6 +623,28 @@ jnxExVlanPortStatus OBJECT-TYPE
                          associated with any VLAN."
     DEFVAL { allowed }
     ::= { jnxExVlanPortGroupEntry 3 }
+
+jnxExVlanPortTagness  OBJECT-TYPE
+    SYNTAX      INTEGER {
+        tagged   (1),
+        untagged (2)
+    }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The VlanPortTaqness gives whether the Port is tagged or untagged."
+    ::= { jnxExVlanPortGroupEntry 4 }
+
+jnxExVlanPortAccessMode  OBJECT-TYPE
+    SYNTAX      INTEGER {
+        access   (1),
+        trunk   (2)
+    }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The VlanPortAccessMode gives whether the Port is Access or Trunk."
+    ::= { jnxExVlanPortGroupEntry 5 }
 
 END
 

--- a/mibs/junos/mib-jnx-vpls-bgp.txt
+++ b/mibs/junos/mib-jnx-vpls-bgp.txt
@@ -1,0 +1,293 @@
+VPLS-BGP-DRAFT-01-MIB DEFINITIONS ::= BEGIN 
+
+      IMPORTS 
+      MODULE-IDENTITY, OBJECT-TYPE,  
+       Unsigned32, transmission  
+         FROM SNMPv2-SMI                    -- RFC2578
+
+      OBJECT-GROUP
+         FROM SNMPv2-CONF                   -- RFC2580 
+
+      RowStatus, StorageType,  TEXTUAL-CONVENTION
+         FROM SNMPv2-TC                     -- RFC2579 
+
+      SnmpAdminString  
+         FROM SNMP-FRAMEWORK-MIB            -- RFC3411
+
+      jnxExperiment
+	FROM JUNIPER-SMI
+
+      jnxVplsConfigIndex, jnxVplsPwBindIndex 
+               FROM VPLS-GENERIC-DRAFT-01-MIB;
+
+   jnxVplsBgpDraft01MIB MODULE-IDENTITY  
+      LAST-UPDATED "200612061200Z"  -- 06 Dec 2006 12:00:00 GMT
+      ORGANIZATION "Layer 2 Virtual Private Networks (L2VPN) 
+                                 Working  Group"  
+      CONTACT-INFO  
+          "  
+           V. J. Shah  
+           Email: vshah@juniper.net  
+
+           The L2VPN Working Group (email distribution l2vpn@ietf.org,  
+           http://www.ietf.org/html.charters/l2vpn-charter.html)  
+           "  
+      DESCRIPTION  
+          "Copyright (C) The IETF Trust (2010). The initial  
+           version of this MIB module was published in RFC XXXX.  
+   -- RFC Editor: Please replace XXXX with RFC number & remove 
+   --                    this note.  
+
+           For full legal notices see the RFC itself or see: 
+           http://www.ietf.org/copyrights/ianamib.html 
+
+           This MIB module contains managed object definitions for   
+           BGP signalled Virtual Private LAN Services as in 
+           [RFC4761]
+
+           This MIB module enables the use of any underlying PseudoWire 
+           network. "  
+
+      -- Revision history.  
+      REVISION  
+          "200612061200Z"  -- 06 Dec 2006 12:00:00 GMT
+      DESCRIPTION "Initial version published as part of RFC YYYY." 
+   -- RFC Editor: please replace YYYY with IANA assigned value, and  
+   -- delete this note.  
+         ::= { jnxExperiment 10 } 
+   -- RFC Editor: please replace XXXX with IANA assigne value, and  
+   -- delete this note.  
+
+   -- VPLS BGP specific Textual Conventions.
+
+   -- JnxVplsBgpRouteDistinguisher ::= TEXTUAL-CONVENTION
+   -- STATUS        current
+   -- DESCRIPTION
+   --      "Syntax for a route distinguisher. For a complete
+   --        definition of a route distinguisher, see [RFC4364].
+   --        For more details on use of a route distinguisher
+   --        for a VPLS service, see [RFC4761]"
+   --   REFERENCE
+   --       "[RFC4364]"
+   --   SYNTAX  OCTET STRING(SIZE (0..256))
+
+   -- JnxVplsBgpRouteTarget ::= TEXTUAL-CONVENTION
+   --   STATUS        current
+   --   DESCRIPTION
+   --       "Syntax for a route target. For a complete
+   --        definition of a route target, see [RFC4364]."
+   --   REFERENCE
+   --       "[RFC4364]"
+   --   SYNTAX  OCTET STRING(SIZE (0..256))    
+
+   -- Top-level components of this MIB.  
+
+   -- Tables, Scalars  
+   jnxVplsBgpObjects       OBJECT IDENTIFIER  
+                                 ::= { jnxVplsBgpDraft01MIB 1 }  
+   -- Conformance  
+   jnxVplsBgpConformance   OBJECT IDENTIFIER   
+                                 ::= { jnxVplsBgpDraft01MIB 2 }  
+
+      -- Vpls Bgp Config Table
+
+      jnxVplsBgpConfigTable OBJECT-TYPE 
+          SYNTAX          SEQUENCE OF JnxVplsBgpConfigEntry 
+          MAX-ACCESS      not-accessible 
+          STATUS          current 
+          DESCRIPTION     
+               "This table specifies information for configuring
+                and monitoring BGP specific parameters for 
+                Virtual Private Lan Services(VPLS)." 
+          ::= { jnxVplsBgpObjects 1 } 
+
+      jnxVplsBgpConfigEntry OBJECT-TYPE 
+          SYNTAX          JnxVplsBgpConfigEntry 
+          MAX-ACCESS      not-accessible 
+          STATUS          current 
+          DESCRIPTION     
+           "A row in this table represents BGP specific information 
+            for Virtual Private Lan Service(VPLS) in a packet network. 
+            It is indexed by jnxVplsConfigIndex, which uniquely 
+            identifies a single instance of a VPLS service.   
+
+            A row is automatically created when a VPLS service is 
+            configured using BGP signalling.
+
+            None of the read-create objects values can be 
+            changed when jnxVplsRowStatus is in the active(1) 
+            state. Changes are allowed when the jnxVplsRowStatus 
+            is in notInService(2) or notReady(3) states only.   
+            If the operator need to change one of the values 
+            for an active row the jnxVplsConfigRowStatus should be 
+            first changed to notInService(2), the objects may 
+            be changed now, and later to active(1) in order to 
+            re-initiate the signaling process with the new 
+            values in effect.  
+            "  
+          INDEX           { jnxVplsConfigIndex } 
+          ::= { jnxVplsBgpConfigTable 1 } 
+
+     JnxVplsBgpConfigEntry ::= 
+        SEQUENCE { 
+         jnxVplsBgpConfigVERangeSize         Unsigned32
+        } 
+
+     jnxVplsBgpConfigVERangeSize   OBJECT-TYPE
+        SYNTAX        Unsigned32 (0..65535)
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Specifies the size of the range of VE ids in this 
+             VPLS service. This number controls the size of the 
+             label block advertised for this VE by the PE.  
+             A value of 0 indicates that the range is not 
+             configured and the PE derives the range value 
+             from received advertisements from other PEs."
+        DEFVAL           { 0 }
+        ::= { jnxVplsBgpConfigEntry 1 }
+
+     -- Vpls Edge Device (VE) Identifier Table
+
+     jnxVplsBgpVETable OBJECT-TYPE
+         SYNTAX        SEQUENCE OF JnxVplsBgpVEEntry
+         MAX-ACCESS    not-accessible
+         STATUS        current
+         DESCRIPTION
+            "This table associates VPLS Edge devices to a VPLS service"
+         ::= { jnxVplsBgpObjects 2 }
+
+     jnxVplsBgpVEEntry OBJECT-TYPE
+         SYNTAX        JnxVplsBgpVEEntry
+         MAX-ACCESS    not-accessible
+         STATUS        current
+         DESCRIPTION
+            "An entry in this table is created for each VE Id 
+             configured on a PE for a particular VPLS service 
+             instance."
+         INDEX  { jnxVplsConfigIndex, jnxVplsBgpVEId }
+         ::= { jnxVplsBgpVETable 1 }
+
+     JnxVplsBgpVEEntry ::= 
+        SEQUENCE {
+          jnxVplsBgpVEId          Unsigned32,
+          jnxVplsBgpVEName        SnmpAdminString,
+          jnxVplsBgpVEPreference  Unsigned32,
+          jnxVplsBgpVERowStatus   RowStatus,
+          jnxVplsBgpVEStorageType StorageType
+        }
+
+     jnxVplsBgpVEId OBJECT-TYPE
+        SYNTAX        Unsigned32 (1..65535)
+        MAX-ACCESS    not-accessible
+        STATUS        current
+        DESCRIPTION
+            "A secondary index identifying a VE within an
+             instance of a VPLS service."
+        ::= { jnxVplsBgpVEEntry 1 }
+
+     jnxVplsBgpVEName OBJECT-TYPE
+        SYNTAX        SnmpAdminString
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Descriptive name for the site or u-PE assciated with 
+             this VE Id."
+        DEFVAL { "" }
+        ::= { jnxVplsBgpVEEntry 2 }
+
+     jnxVplsBgpVEPreference OBJECT-TYPE
+        SYNTAX        Unsigned32 (0..65535)
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "Specifies the preference of the VE Id on this PE 
+             if the site is multi-homed and VE Id is re-used."
+        DEFVAL           { 0 }
+        ::= { jnxVplsBgpVEEntry 3 }
+
+     jnxVplsBgpVERowStatus OBJECT-TYPE
+        SYNTAX        RowStatus
+        MAX-ACCESS    read-only
+        STATUS        current
+        DESCRIPTION
+            "This variable is used to create, modify, and/or
+             delete a row in this table.  When a row in this
+             table is in active(1) state, no objects in that row
+             can be modified except jnxVplsBgpSiteRowStatus."
+        ::= { jnxVplsBgpVEEntry 5 }
+
+     jnxVplsBgpVEStorageType OBJECT-TYPE   
+          SYNTAX        StorageType  
+
+
+          MAX-ACCESS    read-only  
+          STATUS        current  
+          DESCRIPTION  
+               "This variable indicates the storage type for this row."  
+          DEFVAL { volatile }
+          ::= { jnxVplsBgpVEEntry 6 }  
+
+      -- VPLS BGP PW Binding Table 
+
+      jnxVplsBgpPwBindTable OBJECT-TYPE 
+          SYNTAX          SEQUENCE OF JnxVplsBgpPwBindEntry 
+          MAX-ACCESS      not-accessible 
+          STATUS          current 
+          DESCRIPTION    
+               "This table provides BGP specific information for 
+                an association between a VPLS service and the 
+                corresponding Pseudo Wires. A service can have more 
+                than one Pseudo Wire association. Pseudo Wires are 
+                defined in the pwTable." 
+          ::= { jnxVplsBgpObjects 3 } 
+
+      jnxVplsBgpPwBindEntry OBJECT-TYPE 
+          SYNTAX          JnxVplsBgpPwBindEntry 
+          MAX-ACCESS      not-accessible 
+          STATUS          current 
+          DESCRIPTION     
+               "Each row represents an association between a 
+                VPLS instance and one or more Pseudo Wires 
+                defined in the pwTable. Each index is unique 
+                in describing an entry in this table. However
+                both indexes are required to define the one 
+                to many association of service to pseudowire.
+
+                An entry in this table in instantiated only when
+                BGP signalling is used to configure VPLS service.
+
+                Each entry in this table provides BGP specific
+                information for the VPlS represented by 
+                jnxVplsConfigIndex." 
+          INDEX  { jnxVplsConfigIndex, jnxVplsPwBindIndex } 
+          ::= { jnxVplsBgpPwBindTable 1 } 
+
+      JnxVplsBgpPwBindEntry ::= 
+          SEQUENCE { 
+              jnxVplsBgpPwBindLocalVEId        Unsigned32,
+              jnxVplsBgpPwBindRemoteVEId       Unsigned32 
+          } 
+
+
+
+      jnxVplsBgpPwBindLocalVEId   OBJECT-TYPE 
+           SYNTAX          Unsigned32 (1..65535)
+           MAX-ACCESS      read-only 
+           STATUS          current 
+           DESCRIPTION     
+                "Identifies the local VE that this Pseudo Wire
+                 is associated with."
+          ::= { jnxVplsBgpPwBindEntry 1 } 
+
+      jnxVplsBgpPwBindRemoteVEId   OBJECT-TYPE 
+           SYNTAX          Unsigned32 (1..65535)
+           MAX-ACCESS      read-only 
+           STATUS          current 
+           DESCRIPTION     
+                "Identifies the remote VE that this Pseudo Wire
+                 is associated with."
+          ::= { jnxVplsBgpPwBindEntry 2 } 
+
+     END       
+

--- a/mibs/junos/mib-jnx-vpls-generic.txt
+++ b/mibs/junos/mib-jnx-vpls-generic.txt
@@ -1,0 +1,799 @@
+VPLS-GENERIC-DRAFT-01-MIB DEFINITIONS ::= BEGIN
+
+      IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+      Unsigned32, Counter32, transmission
+         FROM SNMPv2-SMI                    -- RFC2578
+
+      OBJECT-GROUP, NOTIFICATION-GROUP
+         FROM SNMPv2-CONF                   -- RFC2580
+
+      TruthValue, RowStatus, StorageType, TEXTUAL-CONVENTION
+         FROM SNMPv2-TC                     -- RFC2579
+
+      SnmpAdminString
+         FROM SNMP-FRAMEWORK-MIB            -- RFC3411
+
+      jnxExperiment
+	FROM JUNIPER-SMI
+
+    --  PwIndexType
+    --    FROM PW-TC-STD-MIB
+
+      VPNIdOrZero
+        FROM VPN-TC-STD-MIB;                -- RFC4265
+        
+   jnxVplsGenericDraft01MIB MODULE-IDENTITY
+      LAST-UPDATED "201103261200Z"  -- 26 March 2011 12:00:00 GMT
+      ORGANIZATION "Layer 2 Virtual Private Networks (L2VPN)
+                                 Working  Group"
+      CONTACT-INFO
+          "
+           Thomas D. Nadeau
+           Email:  tnadeau@cisco.com
+
+           The L2VPN Working Group (email distribution l2vpn@ietf.org,
+           http://www.ietf.org/html.charters/l2vpn-charter.html)
+           "
+
+      DESCRIPTION
+          "Copyright (C) The IETF Trust (2010). The initial
+           version of this MIB module was published in RFC XXXX.
+   -- RFC Editor: Please replace XXXX with RFC number & remove
+   --                    this note.
+
+           For full legal notices see the RFC itself or see:
+           http://www.ietf.org/copyrights/ianamib.html
+
+           This MIB module contains generic managed object definitions
+           for Virtual Private LAN Services as in [RFC4762] and
+           [RFC4761]
+
+           This MIB module enables the use of any underlying PseudoWire
+           network."
+
+      -- Revision history.
+      REVISION
+          "201103261200Z"  -- 26 March 2011 12:00:00 GMT
+      DESCRIPTION
+          "Removed inline definition of VPNIdOrZero in favor
+           of importing the definition from VPN-TC-STD-MIB.
+          "
+      REVISION
+          "200608301200Z"  -- 30 August 2006 12:00:00 GMT
+      DESCRIPTION
+          "Changes from previous version:
+           1) Moved LDP Specific information to VPLS-LDP-DRAFT-01-MIB
+           2) Created the vplsStatusTable to store status information.
+           3)
+
+
+
+          "
+      REVISION
+          "200606041200Z"  -- 4 June 2006 12:00:00 GMT
+      DESCRIPTION "Initial version published as part of RFC YYYY."
+   -- RFC Editor: please replace YYYY with IANA assigned value, and
+   -- delete this note.
+
+         ::= { jnxExperiment 8 }
+
+   -- RFC Editor: please replace XXXX with IANA assigne value, and
+   -- delete this note.
+
+   -- Top-level components of this MIB.
+
+    PwIndexType ::= TEXTUAL-CONVENTION
+    STATUS	      current
+    DESCRIPTION
+	"Pseudowire Index. A unique value, greater than zero,
+	 for each locally-defined PW for indexing
+	 several MIB tables associated with the particular PW.
+	 It is recommended that values are assigned contiguously
+	 starting from 1. The value for each PW MUST remain
+	 constant at least from one re-initialization
+	 to the next re-initialization.
+	"
+    SYNTAX  Unsigned32	(1..4294967295)
+
+    -- Vpls BGP Autodiscovery specific Textual Convention
+
+    JnxVplsBgpRouteDistinguisher ::= TEXTUAL-CONVENTION
+      STATUS        current
+      DESCRIPTION
+          "Syntax for a route distinguisher. For a complete
+           definition of a route distinguisher, see [RFC4364].
+           For more details on use of a route distinguisher
+           for a VPLS service, see [RFC4761]"
+      REFERENCE
+          "[RFC4364]"
+      SYNTAX  OCTET STRING(SIZE (0..256))
+
+    JnxVplsBgpRouteTarget ::= TEXTUAL-CONVENTION
+      STATUS        current
+      DESCRIPTION
+          "Syntax for a route target. For a complete
+           definition of a route target, see [RFC4364]."
+      REFERENCE
+          "[RFC4364]"
+      SYNTAX  OCTET STRING(SIZE (0..256))    
+
+    JnxVplsBgpRouteTargetType ::= TEXTUAL-CONVENTION
+      STATUS        current
+      DESCRIPTION
+       "Used to define the type of a route target usage.
+        Route targets can be specified to be imported,
+        exported, or both.  For a complete definition of a
+        route target, see [RFC4364]."
+      REFERENCE
+        "[RFC4364]"
+      SYNTAX INTEGER { import(1), export(2), both(3) }
+
+   -- Notifications
+   jnxVplsNotifications OBJECT IDENTIFIER
+                                 ::= { jnxVplsGenericDraft01MIB 0 }
+   -- Tables, Scalars
+   jnxVplsObjects       OBJECT IDENTIFIER
+                                 ::= { jnxVplsGenericDraft01MIB 1 }
+   -- Conformance
+   jnxVplsConformance   OBJECT IDENTIFIER
+                                 ::= { jnxVplsGenericDraft01MIB 2 }
+
+   -- PW Virtual Connection Table
+
+   jnxVplsConfigIndexNext OBJECT-TYPE
+      SYNTAX            Unsigned32
+      MAX-ACCESS        read-only
+      STATUS            current
+      DESCRIPTION
+          "This object contains an appropriate value to be used
+           for jnxVplsConfigIndex when creating entries in the
+           jnxVplsConfigTable. The value 0 indicates that no
+           unassigned entries are available.  To obtain the
+           value of jnxVplsConfigIndex for a new entry in the
+           jnxVplsConfigTable, the manager issues a management
+           protocol retrieval operation to obtain the current
+           value of jnxVplsConfigIndex.  After each retrieval
+           operation, the agent should modify the value to
+           reflect the next unassigned index.  After a manager
+           retrieves a value the agent will determine through
+           its local policy when this index value will be made
+           available for reuse."
+      ::= { jnxVplsObjects 1 }
+
+      jnxVplsConfigTable OBJECT-TYPE
+          SYNTAX          SEQUENCE OF JnxVplsConfigEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+               "This table specifies information for configuring
+                and monitoring Virtual Private Lan Services(VPLS).
+                "
+          ::= { jnxVplsObjects 2 }
+
+      jnxVplsConfigEntry OBJECT-TYPE
+          SYNTAX          JnxVplsConfigEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+           "A row in this table represents a Virtual Private Lan
+            Service(VPLS) in a packet network. It is indexed by
+            jnxVplsConfigIndex, which uniquely identifies a single VPLS.
+
+            A row is created by the operator or by the agent if a
+            VPLS service is created by non-SNMP application or
+            due to autodiscovery process.
+
+            None of the read-create objects values can be
+            changed when jnxVplsConfigRowStatus is in the active(1)
+            state. Changes are allowed when the jnxVplsConfigRowStatus
+            is in notInService(2) or notReady(3) states only.
+            If the operator need to change one of the values
+            for an active row the jnxVplsConfigRowStatus should be
+            first changed to notInService(2), the objects may
+            be changed now, and later to active(1) in order to
+            re-initiate the signaling process with the new
+            values in effect.
+            "
+          INDEX           { jnxVplsConfigIndex }
+          ::= { jnxVplsConfigTable 1 }
+
+     JnxVplsConfigEntry ::=
+        SEQUENCE {
+         jnxVplsConfigIndex                                Unsigned32,
+         jnxVplsConfigName                                 SnmpAdminString,
+         jnxVplsConfigDescr                                SnmpAdminString,
+         jnxVplsConfigAdminStatus                          INTEGER,
+         jnxVplsConfigMacLearning                          TruthValue,
+         jnxVplsConfigDiscardUnknownDest                   TruthValue,
+         jnxVplsConfigMacAging                             TruthValue,
+         jnxVplsConfigFwdFullHighWatermark                 Unsigned32,
+         jnxVplsConfigFwdFullLowWatermark                  Unsigned32,
+
+         jnxVplsConfigRowStatus                            RowStatus,
+         jnxVplsConfigMtu                                  Unsigned32,
+         jnxVplsConfigVpnId                                VPNIdOrZero,
+         jnxVplsConfigServiceType                          INTEGER,
+         jnxVplsConfigStorageType                          StorageType
+          }
+
+      jnxVplsConfigIndex  OBJECT-TYPE
+          SYNTAX          Unsigned32 (1.. 2147483647)
+--          MAX-ACCESS      not-accessible
+          MAX-ACCESS      read-only 
+          STATUS          current
+          DESCRIPTION
+               "Unique index for the conceptual row identifying
+                a VPLS service."
+          ::= { jnxVplsConfigEntry 1 }
+
+      jnxVplsConfigName  OBJECT-TYPE
+          SYNTAX          SnmpAdminString
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "A textual name of the VPLS.
+                If there is no local name, or this object is
+                otherwise not applicable, then this object MUST
+                contain a zero-length octet string."
+          DEFVAL           { "" }
+          ::= { jnxVplsConfigEntry 2 }
+
+      jnxVplsConfigDescr  OBJECT-TYPE
+          SYNTAX          SnmpAdminString
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "A textual string containing information about the
+               VPLS service. If there is no information for this VPLS
+               service, then this object MUST contain a zero-length
+               octet string."
+          DEFVAL           { "" }
+          ::= { jnxVplsConfigEntry 3 }
+
+      jnxVplsConfigAdminStatus OBJECT-TYPE
+          SYNTAX          INTEGER {
+                              up(1),
+                              down(2),
+                              testing(3)   -- in some test mode
+
+                          }
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "The desired administrative state of the VPLS
+                service. If the administrative status of the
+                Vpls service is changed to enable then this
+                service is able to utilize the pseudo wire to
+                perform the tasks of a VPLS service.
+                The testing(3) state indicates that no operational
+                packets can be passed. "
+          DEFVAL           { down }
+          ::= { jnxVplsConfigEntry 4 }
+
+      jnxVplsConfigMacLearning OBJECT-TYPE
+          SYNTAX          TruthValue
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "This object specifies if MAC Learning is enabled
+                in this service. If this object is true then Mac
+                Learning is enabled. If false, then Mac Learning is
+                disabled."
+          DEFVAL          { true }
+          ::= { jnxVplsConfigEntry 6 }
+
+      jnxVplsConfigDiscardUnknownDest OBJECT-TYPE
+          SYNTAX          TruthValue
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "If the value of this object is 'true', then frames
+                received with an unknown destination MAC are discarded
+                in this VPLS. If 'false', then the packets are
+                processed."
+          DEFVAL          { false }
+          ::= { jnxVplsConfigEntry 7 }
+
+      jnxVplsConfigMacAging OBJECT-TYPE
+          SYNTAX          TruthValue
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "If the value of this object is 'true'
+                then the MAC ageing process is enabled in
+                this VPLS. If 'false', then the MAC ageing process
+                is disabled"
+          DEFVAL          { true }
+          ::= { jnxVplsConfigEntry 8 }
+
+      jnxVplsConfigFwdFullHighWatermark OBJECT-TYPE
+          SYNTAX          Unsigned32 (0..100)
+          UNITS           "percentage"
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "This object specifies the utilization of the
+                forwarding database for this VPLS instance at
+                which the jnxVplsFwdFullAlarmRaised notification
+                will be sent."
+          DEFVAL          { 95 }
+          ::= { jnxVplsConfigEntry 10 }
+
+      jnxVplsConfigFwdFullLowWatermark OBJECT-TYPE
+          SYNTAX          Unsigned32 (0..100)
+          UNITS           "percentage"
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "This object specifies the utilization of the
+                forwarding database for this VPLS instance
+                at which the jnxVplsFwdFullAlarmCleared
+                notification will be sent."
+          DEFVAL          { 90 }
+          ::= { jnxVplsConfigEntry 11 }
+
+      jnxVplsConfigRowStatus OBJECT-TYPE
+          SYNTAX          RowStatus
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "For creating, modifying, and deleting this row.
+                None of the read-create objects in the
+                conceptual rows may be changed when this
+                object is in the active(1) state."
+          ::= { jnxVplsConfigEntry 12 }
+
+      jnxVplsConfigMtu OBJECT-TYPE
+          SYNTAX          Unsigned32 (64..1518)
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "The value of this object specifies the MTU of this
+                vpls instance."
+          DEFVAL          { 1518 }
+          ::= { jnxVplsConfigEntry 13 }
+
+      jnxVplsConfigVpnId OBJECT-TYPE
+          SYNTAX          VPNIdOrZero
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "This objects indicates the IEEE 802-1990
+                VPN ID of the associated VPLS service."
+          ::= { jnxVplsConfigEntry 14 }
+
+      jnxVplsConfigServiceType OBJECT-TYPE
+          SYNTAX          INTEGER {
+                           vlan     (1),
+                           ethernet (2)
+                          }
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "The value of this object specifies the type of 
+                service emulated by this vpls instance."
+          DEFVAL          { vlan }
+          ::= { jnxVplsConfigEntry 15 }
+
+  jnxVplsConfigStorageType OBJECT-TYPE   
+          SYNTAX        StorageType  
+          MAX-ACCESS    read-only  
+          STATUS        current  
+          DESCRIPTION  
+               "This variable indicates the storage type for this row."  
+          DEFVAL { volatile }
+          ::= { jnxVplsConfigEntry 16 }  
+
+-- VPLS Status table
+
+      jnxVplsStatusTable OBJECT-TYPE
+          SYNTAX          SEQUENCE OF JnxVplsStatusEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+                "This table provides information for monitoring
+                Virtual Private Lan Services(VPLS).
+                "
+          ::= { jnxVplsObjects 3 }
+
+      jnxVplsStatusEntry OBJECT-TYPE
+          SYNTAX          JnxVplsStatusEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+           "A row in this table represents a Virtual Private Lan
+            Service(VPLS) in a packet network. It is indexed by
+            jnxVplsConfigIndex, which uniquely identifies a single VPLS.
+
+            A row in this table is automatically created by the agent
+            when a VPLS service is configured.
+            "
+          INDEX           { jnxVplsConfigIndex }
+          ::= { jnxVplsStatusTable 1 }
+
+     JnxVplsStatusEntry ::=
+        SEQUENCE {
+         jnxVplsStatusOperStatus                        INTEGER,
+         jnxVplsStatusPeerCount                         Counter32
+          }
+
+      jnxVplsStatusOperStatus OBJECT-TYPE
+          SYNTAX          INTEGER {
+                              other(0),
+                              up(1),
+                              down(2)
+                          }
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "The current operational state of this VPLS Service."
+          ::= { jnxVplsStatusEntry 1 }
+
+      jnxVplsStatusPeerCount OBJECT-TYPE
+          SYNTAX          Counter32
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "This objects specifies the number of peers
+                present in this vpls instance."
+          ::= { jnxVplsStatusEntry 2 }
+
+      -- VPLS PW Binding Table
+
+      jnxVplsPwBindTable OBJECT-TYPE
+          SYNTAX          SEQUENCE OF JnxVplsPwBindEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+               "This table provides an association between a
+                VPLS service and the corresponding Pseudo
+                Wires. A service can have more than one Pseudo
+                Wire association. Pseudo Wires are defined in
+                the pwTable"
+          ::= { jnxVplsObjects 4 }
+
+      jnxVplsPwBindEntry OBJECT-TYPE
+          SYNTAX          JnxVplsPwBindEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+               "Each row represents an association between a
+                VPLS instance and one or more Pseudo Wires
+                defined in the pwTable. Each index is unique
+                in describing an entry in this table. However
+                both indexes are required to define the one
+                to many association of service to
+                pseudowire."
+          INDEX  { jnxVplsConfigIndex, jnxVplsPwBindIndex }
+          ::= { jnxVplsPwBindTable 1 }
+
+      JnxVplsPwBindEntry ::=
+          SEQUENCE {
+              jnxVplsPwBindConfigType              INTEGER,
+              jnxVplsPwBindType                  INTEGER,
+              jnxVplsPwBindRowStatus             RowStatus,
+              jnxVplsPwBindStorageType             StorageType,
+	      jnxVplsPwBindIndex		      PwIndexType
+          }
+
+      jnxVplsPwBindConfigType   OBJECT-TYPE
+           SYNTAX          INTEGER {
+                                   manual        (1),
+                                   autodiscovery (2)
+                           }
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+                "The value of this object indicates
+                 whether the Pseudo Wire binding was created
+                 manually or via autodiscovery.
+
+                 The value of this object must be
+                 specifed when the row is created and cannot
+                 be changed while the row status is active(1)"
+          ::= { jnxVplsPwBindEntry 1 }
+
+      jnxVplsPwBindType   OBJECT-TYPE
+           SYNTAX          INTEGER {
+                                   mesh  (1),
+                                   spoke (2)
+                           }
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+                "The value of this object indicates
+                 whether the Pseudo Wire binding is of
+                 type mesh or spoke.
+
+                 The value of this object must be
+                 specifed when the row is created and cannot
+                 be changed while the row status is active(1)"
+          ::= { jnxVplsPwBindEntry 2 }
+
+      jnxVplsPwBindRowStatus  OBJECT-TYPE
+           SYNTAX          RowStatus
+           MAX-ACCESS      read-only
+           STATUS          current
+           DESCRIPTION
+                "For creating, modifying, and deleting this row.
+                 None of the read-create objects in the
+                 conceptual rows may be changed when this
+                 object is in the active(1) state"
+          ::= { jnxVplsPwBindEntry 3 }
+
+      jnxVplsPwBindStorageType OBJECT-TYPE   
+           SYNTAX        StorageType  
+           MAX-ACCESS    read-only 
+           STATUS        current  
+           DESCRIPTION  
+               "This variable indicates the storage type for this row."  
+           DEFVAL { volatile }
+           ::= { jnxVplsPwBindEntry 4 }  
+
+-- Joe Added xxx
+      jnxVplsPwBindIndex	 OBJECT-TYPE   
+           SYNTAX        PwIndexType  
+--           MAX-ACCESS    not-accessible 
+           MAX-ACCESS    read-only 
+           STATUS        current  
+           DESCRIPTION  
+               "Secondary Index for the conceptual row identifying
+		a pseudowire within the PwEntry which MUST 
+		match an entry from the PW-STD-MIB's PwTable
+		which represents an already-provisioned
+	        pseudowire that is then associated with this
+		VPLS instance.
+		"  
+           ::= { jnxVplsPwBindEntry 5 }  
+
+-- jnxVplsBgpADConfigTable 
+
+      jnxVplsBgpADConfigTable OBJECT-TYPE 
+            SYNTAX          SEQUENCE OF JnxVplsBgpADConfigEntry 
+            MAX-ACCESS      not-accessible 
+            STATUS          current 
+            DESCRIPTION 
+            "This table specifies information for configuring 
+             BGP Auto-discovery parameters for a given Vpls service. 
+            " 
+            ::= { jnxVplsObjects 5 } 
+
+      jnxVplsBgpADConfigEntry OBJECT-TYPE 
+            SYNTAX          JnxVplsBgpADConfigEntry 
+            MAX-ACCESS      not-accessible 
+            STATUS          current 
+            DESCRIPTION 
+            "A row in this table represents BGP based autodiscovery 
+             is in use for this instance of Vpls. 
+             A row in this table is indexed by jnxVplsConfigIndex, which 
+             uniquely identifies a single VPLS.  
+             None of the read-create objects can be changed when  
+             jnxVplsBGPADConfigRowStatus is in active(1) state. Changes 
+             are allowed when the jnxVplsBGPADConfigRowStatus is in  
+             notInService(2) or notReady(3) states only.  
+             If the operator need to change one of the values 
+             for an active row the jnxVplsConfigRowStatus should be 
+             first changed to notInService(2), the objects may 
+             be changed now, and later to active(1) in order to 
+             re-initiate the signaling process with the new 
+             values in effect. 
+            " 
+            INDEX      { jnxVplsConfigIndex } 
+            ::= { jnxVplsBgpADConfigTable 1 } 
+
+      JnxVplsBgpADConfigEntry ::= 
+         SEQUENCE { 
+          jnxVplsBgpADConfigRouteDistinguisher   JnxVplsBgpRouteDistinguisher, 
+          jnxVplsBgpADConfigPrefix               Unsigned32, 
+          jnxVplsBgpADConfigVplsId               JnxVplsBgpRouteDistinguisher, 
+          jnxVplsBgpADConfigRowStatus            RowStatus 
+         } 
+
+      jnxVplsBgpADConfigRouteDistinguisher OBJECT-TYPE 
+            SYNTAX          JnxVplsBgpRouteDistinguisher 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION 
+            " The route distinguisher for this VPLS. See [RFC4364]  
+            for a complete definition of a route distinguisher. 
+            for more details on use of a route distinguisher 
+            for a VPLS service, see [RFC4761] 
+            " 
+            ::= { jnxVplsBgpADConfigEntry 1 } 
+
+            jnxVplsBgpADConfigPrefix      OBJECT-TYPE 
+            SYNTAX          Unsigned32 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION 
+            " In case of auto-discovery the default prefix advertised 
+            is the ip address of the loopback. In case the user wants 
+            to override the loopback address, jnxVplsBgpADConfigPrefix  
+            should be set. When this value if non-zero it is used 
+            as the advertised IP address in the NLRI. 
+            " 
+            DEFVAL { 0 } 
+            ::= { jnxVplsBgpADConfigEntry 2 } 
+
+      jnxVplsBgpADConfigVplsId          OBJECT-TYPE 
+            SYNTAX          JnxVplsBgpRouteDistinguisher 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION 
+            " VplsId is a unique identifier for all VSIs belonging to 
+            the same VPLS. It is advertised as an extended community 
+            "
+            ::= { jnxVplsBgpADConfigEntry 3 } 
+
+      jnxVplsBgpADConfigRowStatus OBJECT-TYPE 
+            SYNTAX          RowStatus 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION     
+	    " For creating, modifying, and deleting this row. 
+            None of the read-create objects in the 
+            conceptual rows may be changed when this 
+            object is in the active(1) state. 
+            " 
+            ::= { jnxVplsBgpADConfigEntry 4 } 
+
+
+    -- jnxVplsBgpRteTargetTable 
+
+      jnxVplsBgpRteTargetTable   OBJECT-TYPE 
+            SYNTAX          SEQUENCE OF JnxVplsBgpRteTargetEntry 
+            MAX-ACCESS      not-accessible 
+            STATUS          current 
+            DESCRIPTION 
+            " This table specifies the list of Route Targets 
+              imported or exported by BGP during auto-discovery of VPLS. 
+            "    
+            ::= { jnxVplsObjects 6 } 
+
+      jnxVplsBgpRteTargetEntry   OBJECT-TYPE 
+            SYNTAX          JnxVplsBgpRteTargetEntry 
+            MAX-ACCESS      not-accessible 
+            STATUS          current 
+            DESCRIPTION 
+              "An entry in this table specifies the value of the 
+               Route Target being used by BGP. Depending on the value
+               of jnxVplsBgpRteTargetType an RT might be exported or 
+               imported or both. Every VPLS which 
+              uses auto-discovery for finding peer nodes can import and
+              export multiple Route Targets. This representation allows 
+              support for hierarchical VPLS. 
+            " 
+            INDEX     { jnxVplsConfigIndex, jnxVplsBgpRteTargetIndex } 
+            ::= { jnxVplsBgpRteTargetTable 1 } 
+
+      JnxVplsBgpRteTargetEntry ::=  
+         SEQUENCE { 
+          jnxVplsBgpRteTargetIndex          Unsigned32, 
+          jnxVplsBgpRteTargetRTType         JnxVplsBgpRouteTargetType, 
+          jnxVplsBgpRteTargetRT             JnxVplsBgpRouteTarget, 
+          jnxVplsBgpRteTargetRTRowStatus    RowStatus 
+         } 
+
+      jnxVplsBgpRteTargetIndex   OBJECT-TYPE 
+            SYNTAX          Unsigned32 
+            MAX-ACCESS      not-accessible 
+            STATUS          current 
+            DESCRIPTION 
+            "This index along with jnxVplsConfigIndex,identifies one entry 
+             in the jnxVplsBgpRteTargetTable. By keeping jnxVplsConfigIndex 
+             constant and using new value of jnxVplsBgpRteTargetIndex user 
+              can configure multiple Route Targets for the same Vpls. 
+            " 
+            ::= { jnxVplsBgpRteTargetEntry 1 } 
+
+      jnxVplsBgpRteTargetRTType  OBJECT-TYPE 
+            SYNTAX          JnxVplsBgpRouteTargetType 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION 
+            " Used to define the type of a route target usage. 
+              Route targets can be specified to be imported, 
+              exported, or both.  For a complete definition of a 
+              route target, see [RFC4364]. 
+            " 
+            ::= { jnxVplsBgpRteTargetEntry 2 } 
+
+      jnxVplsBgpRteTargetRT     OBJECT-TYPE 
+            SYNTAX          JnxVplsBgpRouteTarget 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION 
+            " The route target associated with the VPLS service. 
+              For more details on use of route targets 
+              for a VPLS service, see [RFC4761] 
+            " 
+            ::= { jnxVplsBgpRteTargetEntry 3 } 
+
+      jnxVplsBgpRteTargetRTRowStatus     OBJECT-TYPE 
+            SYNTAX          RowStatus 
+            MAX-ACCESS      read-only 
+            STATUS          current 
+            DESCRIPTION 
+            "This variable is used to create, modify, and/or 
+             delete a row in this table.  When a row in this 
+             table is in active(1) state, no objects in that row 
+             can be modified 
+            " 
+            ::= { jnxVplsBgpRteTargetEntry 4 } 
+
+      jnxVplsStatusNotifEnable  OBJECT-TYPE 
+            SYNTAX      TruthValue 
+            MAX-ACCESS  read-write 
+            STATUS      current 
+            DESCRIPTION 
+            "If this object is set to true(1), then it enables 
+             the emission of jnxVplsStatusChanged 
+             notification; otherwise this notification is not 
+             emitted." 
+            REFERENCE 
+            "See also [RFC3413] for explanation that
+            notifications are under the ultimate control of the
+            MIB module in this document."
+            DEFVAL { false }
+            ::= { jnxVplsObjects 7 }
+
+       jnxVplsNotificationMaxRate OBJECT-TYPE
+          SYNTAX       Unsigned32
+          MAX-ACCESS   read-write
+          STATUS       current
+          DESCRIPTION
+           "This object indicates the maximum number of
+            notifications issued per second. If events occur
+            more rapidly, the implementation may simply fail to
+            emit these notifications during that period, or may
+            queue them until an appropriate time. A value of 0
+            means no throttling is applied and events may be
+            notified at the rate at which they occur."
+          DEFVAL       { 0 }
+          ::= { jnxVplsObjects 8 }
+
+      -- VPLS Service Notifications
+
+      jnxVplsStatusChanged NOTIFICATION-TYPE
+          OBJECTS {
+              jnxVplsConfigVpnId,
+              jnxVplsConfigAdminStatus,
+              jnxVplsStatusOperStatus
+          }
+          STATUS          current
+          DESCRIPTION
+               "The jnxVplsStatusChanged notification is generated
+                when there is a change in the administrative or
+                operating status of a VPLS service."
+          ::= { jnxVplsNotifications 1 }
+
+      jnxVplsFwdFullAlarmRaised NOTIFICATION-TYPE
+          OBJECTS {
+              jnxVplsConfigVpnId,
+              jnxVplsConfigFwdFullHighWatermark,
+              jnxVplsConfigFwdFullLowWatermark
+          }
+          STATUS          current
+          DESCRIPTION
+               "The jnxVplsFwdFullAlarmRaised notification is
+                generated when the utilization of the Forwarding
+                database is above the value specified by
+                jnxVplsConfigFwdFullHighWatermark."
+          ::= { jnxVplsNotifications 2 }
+
+      jnxVplsFwdFullAlarmCleared NOTIFICATION-TYPE
+          OBJECTS {
+              jnxVplsConfigVpnId,
+              jnxVplsConfigFwdFullHighWatermark,
+              jnxVplsConfigFwdFullLowWatermark
+          }
+          STATUS          current
+          DESCRIPTION
+               "The jnxVplsFwdFullAlarmCleared notification is
+                generated when the utilization of the Forwarding
+                database is below the value specified by
+                jnxVplsConfigFwdFullLowWatermark."
+          ::= { jnxVplsNotifications 3 }
+
+       END

--- a/mibs/junos/mib-jnx-vpls-ldp.txt
+++ b/mibs/junos/mib-jnx-vpls-ldp.txt
@@ -1,0 +1,198 @@
+VPLS-LDP-DRAFT-01-MIB DEFINITIONS ::= BEGIN
+
+      IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+      Unsigned32, Counter32, transmission
+         FROM SNMPv2-SMI                    -- RFC2578
+
+      OBJECT-GROUP, NOTIFICATION-GROUP
+         FROM SNMPv2-CONF                   -- RFC2580
+
+      TruthValue, RowStatus, StorageType, TEXTUAL-CONVENTION
+         FROM SNMPv2-TC                     -- RFC2579
+
+      jnxExperiment
+	FROM JUNIPER-SMI
+
+      jnxVplsConfigIndex, jnxVplsPwBindIndex
+               FROM VPLS-GENERIC-DRAFT-01-MIB;
+
+   jnxVplsLdpDraft01MIB MODULE-IDENTITY
+      LAST-UPDATED "200608301200Z"  -- 20 August 2006 12:00:00 GMT
+      ORGANIZATION "Layer 2 Virtual Private Networks (L2VPN)
+                                 Working  Group"
+      CONTACT-INFO
+          "
+           Thomas D. Nadeau
+           Email:  tnadeau@cisco.com
+
+           The L2VPN Working Group (email distribution l2vpn@ietf.org,
+           http://www.ietf.org/html.charters/l2vpn-charter.html)
+           "
+        
+
+      DESCRIPTION
+          "Copyright (C) The IETF Trust (2010). The initial
+           version of this MIB module was published in RFC XXXX.
+
+   -- RFC Editor: Please replace XXXX with RFC number & remove
+   --                    this note.
+
+           For full legal notices see the RFC itself or see:
+           http://www.ietf.org/copyrights/ianamib.html
+
+           This MIB module contains managed object definitions for
+           LDP signalled Virtual Private LAN Services as in
+           [RFC4762]
+
+           This MIB module enables the use of any underlying PseudoWire
+           network. "
+
+      -- Revision history.
+
+      REVISION
+          "200608301200Z"  -- 30 Aug 2006 12:00:00 GMT
+      DESCRIPTION "Initial version published as part of RFC YYYY."
+   -- RFC Editor: please replace YYYY with IANA assigned value, and
+   -- delete this note.
+
+         ::= { jnxExperiment 9}
+
+   -- Top-level components of this MIB.
+
+
+   -- Notifications
+   jnxVplsLdpNotifications OBJECT IDENTIFIER
+                                 ::= { jnxVplsLdpDraft01MIB 0 }
+
+   -- Tables, Scalars
+   jnxVplsLdpObjects       OBJECT IDENTIFIER
+                                 ::= { jnxVplsLdpDraft01MIB 1 }
+   -- Conformance
+   jnxVplsLdpConformance   OBJECT IDENTIFIER
+                                 ::= { jnxVplsLdpDraft01MIB 2 }
+
+   jnxVplsLdpConfigTable OBJECT-TYPE
+          SYNTAX          SEQUENCE OF JnxVplsLdpConfigEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+               "This table specifies information for configuring
+                and monitoring LDP specific parameters for
+                Virtual Private Lan Services(VPLS)."
+          ::= { jnxVplsLdpObjects 1 }
+
+   jnxVplsLdpConfigEntry OBJECT-TYPE
+          SYNTAX          JnxVplsLdpConfigEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+           "A row in this table represents LDP specific information
+            for Virtual Private Lan Service(VPLS) in a packet network.
+            It is indexed by jnxVplsConfigIndex, which uniquely
+            identifies a single VPLS.
+
+            A row is automatically created when a VPLS service is
+            configured using LDP signalling.
+
+            None of the read-create objects values can be
+            changed when jnxVplsRowStatus is in the active(1)
+            state. Changes are allowed when the jnxVplsRowStatus
+            is in notInService(2) or notReady(3) states only.
+            If the operator need to change one of the values
+            for an active row the jnxVplsConfigRowStatus should be
+            first changed to notInService(2), the objects may
+            be changed now, and later to active(1) in order to
+            re-initiate the signaling process with the new
+            values in effect.
+            "
+          INDEX           { jnxVplsConfigIndex }
+          ::= { jnxVplsLdpConfigTable 1 }
+
+     JnxVplsLdpConfigEntry ::=
+        SEQUENCE {
+         jnxVplsLdpConfigMacAddrWithdraw                   TruthValue
+          }
+
+      jnxVplsLdpConfigMacAddrWithdraw OBJECT-TYPE
+          SYNTAX          TruthValue
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "This object specifies if MAC address withdrawal
+                is enabled in this service. If this object is true then
+                Mac address withdrawl Learning is enabled. If false,
+                then Mac Learning is disabled."
+          DEFVAL          { true }
+          ::= { jnxVplsLdpConfigEntry 1 }
+
+      -- VPLS LDP PW Binding Table
+
+      jnxVplsLdpPwBindTable OBJECT-TYPE
+          SYNTAX          SEQUENCE OF JnxVplsLdpPwBindEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+               "This table provides LDP specific information for
+                an association between a VPLS service and the
+                corresponding Pseudo Wires. A service can have more
+                than one Pseudo Wire association. Pseudo Wires are
+                defined in the pwTable."
+          ::= { jnxVplsLdpObjects 2 }
+
+      jnxVplsLdpPwBindEntry OBJECT-TYPE
+          SYNTAX          JnxVplsLdpPwBindEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+               "Each row represents an association between a
+                VPLS instance and one or more Pseudo Wires
+                defined in the pwTable. Each index is unique
+                in describing an entry in this table. However
+                both indexes are required to define the one
+                to many association of service to pseudowire.
+
+                An entry in this table in instantiated only when
+                LDP signalling is used to configure VPLS service.
+
+                Each entry in this table provides LDP specific
+                information for the VPlS represented by 
+
+
+                jnxVplsConfigIndex."
+          INDEX  { jnxVplsConfigIndex, jnxVplsPwBindIndex }
+          ::= { jnxVplsLdpPwBindTable 1 }
+
+      JnxVplsLdpPwBindEntry ::=
+          SEQUENCE {
+              jnxVplsLdpPwBindMacAddressLimit       Unsigned32
+          }
+
+      jnxVplsLdpPwBindMacAddressLimit OBJECT-TYPE
+          SYNTAX          Unsigned32 (0.. 4294967295)
+          MAX-ACCESS      read-only
+          STATUS          current
+          DESCRIPTION
+               "The value of this object specifies the maximum number
+                of learned and static entries allowed in the
+                Forwarding database for this PW Binding. The value 0
+                means there is no limit for this PW Binding."
+          DEFVAL          { 0 }
+          ::= { jnxVplsLdpPwBindEntry 1 }
+
+      -- VPLS Ldp Service Notifications
+
+      jnxVplsLdpPwBindMacTableFull NOTIFICATION-TYPE
+          OBJECTS {
+              jnxVplsConfigIndex, 
+              jnxVplsPwBindIndex
+          }
+          STATUS          current
+          DESCRIPTION
+               "The jnxVplsLdpPwBindMacTableFull notification is generated
+                when the number of learned MAC-Addresses increases to 
+                the value specified in jnxVplsLdpPwBindMacAddressLimit."
+          ::= { jnxVplsLdpNotifications 1 }
+
+     END
+

--- a/mibs/junos/mib-jnx-vpn.txt
+++ b/mibs/junos/mib-jnx-vpn.txt
@@ -21,7 +21,7 @@ IMPORTS
                                       FROM JUNIPER-SMI;
 
 jnxVpnMIB MODULE-IDENTITY
-    LAST-UPDATED "200505311800Z"
+    LAST-UPDATED "201010150000Z"
     ORGANIZATION "IETF Provider Provisioned VPNs WG"
     CONTACT-INFO
         "        Kireeti Kompella
@@ -35,6 +35,13 @@ jnxVpnMIB MODULE-IDENTITY
          L2 circuits."
 
     -- revision history
+    REVISION "201010150000Z"
+    DESCRIPTION
+	"Corrected DISPLAY-HINT for TEXTUAL-CONVENTIONs associated with a
+	 JnxVpnIdentifier."
+    REVISION "201008270000Z"
+    DESCRIPTION
+        "Corrected related TEXTUAL-CONVENTIONs associated with a JnxVpnIdentifier."
     REVISION "200204212128Z"
     DESCRIPTION
         "A VPN MIB module that allows one to configure and monitor
@@ -51,18 +58,18 @@ JnxVpnName ::= TEXTUAL-CONVENTION
     STATUS     current
     DESCRIPTION
         "Name of the VPN." 
-    SYNTAX  OCTET STRING (SIZE (1..128))
+    SYNTAX     OCTET STRING (SIZE (1..128))
 
 JnxVpnType ::= TEXTUAL-CONVENTION
     STATUS     current
     DESCRIPTION
         "Type of the VPN.  The following types have been defined:
-         bgpIpVpn:   RFC 2547 VPNs (see draft-ietf-ppvpn-rfc2547bis);
+         bgpIpVpn:   RFC 4364 VPNs;
          bgpL2Vpn:   BGP-based Layer 2 VPNs (see
                      draft-kompella-ppvpn-l2vpn);
          bgpVpls:    BGP-based VPLS (see draft-kompella-ppvnp-vpls);
          l2Circuit:  LDP-based point-to-point Layer 2 circuits (see
-                     draft-martini-l2circuit-trans-mpls);
+                     RFC 4906);
          ldpVpls:    LDP-based VPLS (see
                      draft-lasserre-vkompella-ppvpn-vpls);
          opticalVpn: BGP-based Optical (port based) VPNs (see
@@ -81,14 +88,51 @@ JnxVpnType ::= TEXTUAL-CONVENTION
         opticalVpn(7),
         vpOxc(8),
         ccc(9),
-	bgpAtmVpn(10)
+        bgpAtmVpn(10)
     }
 
 JnxVpnIdentifierType ::= TEXTUAL-CONVENTION
     STATUS      current
     DESCRIPTION
         "Type of the VPN Identifier.  This includes Route
-         Distinguishers, Route Targets, and VC IDs."
+         Distinguishers, Route Targets, and VC IDs.
+
+         none(0)                 This value MUST be used if the value of the
+                                 corresponding JnxVpnIdentifier object is a
+                                 zero-length string.
+
+         other(1)                A VPN identifier that does not match one of
+                                 the types defined in this MIB.
+
+         routeDistinguisher(2)   A VPN identifier as defined by the
+                                 JnxVpnRouteDistinguisher textual convention.
+
+         routeDistinguisher0(3)   A VPN identifier as defined by the
+                                 JnxVpnRouteDistinguisher0 textual convention.
+
+         routeDistinguisher1(4)  A VPN identifier as defined by the
+                                 JnxVpnRouteDistinguisher1 textual convention.
+
+         routeDistinguisher2(5)  A VPN identifier as defined by the
+                                 JnxVpnRouteDistinguisher2 textual convention.
+
+         routeTarget(6)          A VPN identifier as defined by the
+                                 JnxVpnRouteTarget textual convention.
+
+         routeTarget0(7)         A VPN identifier as defined by the
+                                 JnxVpnRouteTarget0 textual convention.
+
+         routeTarget1(8)         A VPN identifier as defined by the
+                                 JnxVpnRouteTarget1 textual convention.
+
+         routeTarget2(9)         A VPN identifier as defined by the
+                                 JnxVpnRouteTarget2 textual convention.
+
+         vcId(10)                A VPN identifier as defined by the
+                                 JnxVpnVCIdentifier textual convention.
+
+         localSwitch(11)         A VPN identifier as defined by the
+                                 JnxVpnLocalSwitchIdentifier textual convention."
     SYNTAX  INTEGER {
         none(0),
         other(1),
@@ -117,75 +161,79 @@ JnxVpnIdentifier ::= TEXTUAL-CONVENTION
          length and the last sub-identifier of the jnxVpnIdentifierType  
          object MUST be 1 less than the last sub-identifier of the
          jnxVpnIdentifier object."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+    SYNTAX      OCTET STRING(SIZE (0..256))
 
 JnxVpnRouteDistinguisher ::= TEXTUAL-CONVENTION
-    DISPLAY-HINT "2x:2x:2x:2x:2x:2x:2x:2x"
+    DISPLAY-HINT "1x:1x:1x:1x:1x:1x:1x:1x"
     STATUS      current 
     DESCRIPTION
-        "Represents a Generic Route Distinguisher.  Reference:
-         BGP/MPLS VPNs, draft-ietf-ppvpn-rfc2547bis."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Generic Route Distinguisher."
+    REFERENCE
+        "BGP/MPLS VPNs, RFC 4364."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnRouteDistinguisher0 ::= TEXTUAL-CONVENTION
-    DISPLAY-HINT "2d-2d:2d"
+    DISPLAY-HINT "2x-2d:4d"
     STATUS      current 
     DESCRIPTION
-        "Represents a Type 0 Route Distinguisher.  Reference:
-         BGP/MPLS VPNs, draft-ietf-ppvpn-rfc2547bis."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Type 0 Route Distinguisher."
+    REFERENCE
+        "BGP/MPLS VPNs, RFC 4364."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnRouteDistinguisher1 ::= TEXTUAL-CONVENTION
-    DISPLAY-HINT "2d-1d.1d.1d.1d:2d"
+    DISPLAY-HINT "2x-1d.1d.1d.1d:2d"
     STATUS      current 
     DESCRIPTION
-        "Represents a Type 1 Route Distinguisher.  Reference:
-         BGP/MPLS VPNs, draft-ietf-ppvpn-rfc2547bis."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Type 1 Route Distinguisher."
+    REFERENCE
+        "BGP/MPLS VPNs, RFC 4364."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnRouteDistinguisher2 ::= TEXTUAL-CONVENTION
-    DISPLAY-HINT "2d-4d:4d"
+    DISPLAY-HINT "2x-4d:2d"
     STATUS      current 
     DESCRIPTION
-        "Represents a Type 2 Route Distinguisher.  Reference:
-         BGP/MPLS VPNs, draft-ietf-ppvpn-rfc2547bis."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Type 2 Route Distinguisher."
+    REFERENCE
+        "BGP/MPLS VPNs, RFC 4364."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnRouteTarget ::= TEXTUAL-CONVENTION
-    DISPLAY-HINT "2x:2x:2x:2x:2x:2x:2x:2x"
+    DISPLAY-HINT "1x:1x:1x:1x:1x:1x:1x:1x"
     STATUS      current 
     DESCRIPTION
-        "Represents a Generic Route Target.  Reference:
-         BGP Extended Communities Attribute,
-         draft-ietf-idr-bgp-ext-communities."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Generic Route Target."
+    REFERENCE
+        "BGP Extended Communities Attribute, RFC 4360."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnRouteTarget0 ::= TEXTUAL-CONVENTION
     DISPLAY-HINT "2x-4d:2d"
     STATUS      current 
     DESCRIPTION
-        "Represents a Type 00 Route Target.  Reference:
-         BGP Extended Communities Attribute,
-         draft-ietf-idr-bgp-ext-communities."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Type 00 Route Target."
+    REFERENCE
+        "BGP Extended Communities Attribute, RFC 4360."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnRouteTarget1 ::= TEXTUAL-CONVENTION
     DISPLAY-HINT "2x-1d.1d.1d.1d:2d"
     STATUS      current 
     DESCRIPTION
-        "Represents a Type 01 Route Target.  Reference:
-         BGP Extended Communities Attribute,
-         draft-ietf-idr-bgp-ext-communities."
-    SYNTAX  OCTET STRING(SIZE (0..256))	
+        "Represents a Type 01 Route Target."
+    REFERENCE
+        "BGP Extended Communities Attribute, RFC 4360."
+     SYNTAX      OCTET STRING(SIZE (8))        
 
 JnxVpnRouteTarget2 ::= TEXTUAL-CONVENTION
     DISPLAY-HINT "2x-2d:4d"
     STATUS      current 
     DESCRIPTION
-        "Represents a Type 02 Route Target.  Reference:
-         BGP Extended Communities Attribute,
-         draft-ietf-idr-bgp-ext-communities."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+        "Represents a Type 02 Route Target."
+    REFERENCE
+        "BGP Extended Communities Attribute, RFC 4360."
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnVCIdentifier ::= TEXTUAL-CONVENTION
     DISPLAY-HINT "1d.1d.1d.1d:4d"
@@ -194,21 +242,21 @@ JnxVpnVCIdentifier ::= TEXTUAL-CONVENTION
         "Represents a PE ID, VC ID pair.  The PE ID is the Router ID
          of the remote PE.  The VC ID follows the description given
          in draft-martini-l2circuit-trans."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+    SYNTAX      OCTET STRING(SIZE (8))
 
 JnxVpnMultiplexor ::= TEXTUAL-CONVENTION
     STATUS      current  
     DESCRIPTION 
         "Syntax for a VPN multiplexor/demultiplexor within a
          Pseudo-Wire Tunnel."
-    SYNTAX  Unsigned32
+    SYNTAX      Unsigned32
 
 JnxVpnLocalSwitchIdentifier ::= TEXTUAL-CONVENTION
     STATUS      current 
     DESCRIPTION
         "The string representing the name of two interfaces that are being 
          locally switched separated by a colon."
-   SYNTAX  OCTET STRING(SIZE (0..256))
+    SYNTAX      OCTET STRING(SIZE (1..256))
 
 
 -- vpnInfo

--- a/mibs/junos/mib-l3vpnmib.txt
+++ b/mibs/junos/mib-l3vpnmib.txt
@@ -20,7 +20,7 @@ IMPORTS
       FROM IF-MIB
 
    VPNId
-     FROM PPVPN-TC-MIB
+     FROM VPN-TC-STD-MIB                 -- RFC4265
 
    SnmpAdminString
       FROM SNMP-FRAMEWORK-MIB
@@ -33,7 +33,7 @@ IMPORTS
       FROM BGP4-MIB;
 
 mplsVpnMIB MODULE-IDENTITY
-   LAST-UPDATED "200102281200Z"  -- 28 February 2002 12:00:00 GMT
+   LAST-UPDATED "201103261200Z"  -- 26 March 2011 12:00:00 GMT
    ORGANIZATION "Provider Provisioned Virtual Private
                  Networks Working Group."
    CONTACT-INFO
@@ -68,6 +68,12 @@ mplsVpnMIB MODULE-IDENTITY
          RFC3031, January 2001."
 
   -- Revision history.
+   REVISION "201103261200Z"  -- 26 March 2011 12:00:00 GMT
+   DESCRIPTION
+        "Changed to import VPNId from VPN-TC-STD-MIB instead of
+         PPVPN-TC-MIB.
+        "
+
    REVISION "200102281200Z"  -- 28 February 2002 12:00:00 GMT
    DESCRIPTION
         "mplsVpnVrfRouteIfIndex changed to InterfaceIndexOrZero.

--- a/mibs/junos/mib-pimmib.txt
+++ b/mibs/junos/mib-pimmib.txt
@@ -40,6 +40,8 @@ pimMIB MODULE-IDENTITY
 
 pimMIBObjects OBJECT IDENTIFIER ::= { pimMIB 1 }
 
+pimTraps      OBJECT IDENTIFIER ::= { pimMIBObjects 0 }
+
 pim           OBJECT IDENTIFIER ::= { pimMIBObjects 1 }
 
 pimJoinPruneInterval OBJECT-TYPE
@@ -760,6 +762,20 @@ pimComponentStatus OBJECT-TYPE
             protocol instance."
     ::= { pimComponentEntry 5 }
 
+-- PIM Traps
+
+pimNeighborLoss NOTIFICATION-TYPE
+    OBJECTS {
+       pimNeighborIfIndex
+    }
+    STATUS             current
+    DESCRIPTION
+            "A pimNeighborLoss trap signifies the loss of an adjacency
+            with a neighbor.  This trap should be generated when the
+            neighbor timer expires, and the router has no other
+            neighbors on the same interface with a lower IP address than
+            itself."
+    ::= { pimTraps 1 }
 
 -- conformance information
 

--- a/mibs/junos/mib-rfc1471.txt
+++ b/mibs/junos/mib-rfc1471.txt
@@ -1,0 +1,363 @@
+PPP-LCP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, transmission, Integer32, Counter32
+        FROM SNMPv2-SMI
+    OBJECT-GROUP
+        FROM SNMPv2-CONF
+    ifIndex
+        FROM IF-MIB;
+
+pppLcp MODULE-IDENTITY
+    LAST-UPDATED "200309172059Z"  -- 17-Sep-03 04:59 PM EDT
+    ORGANIZATION "IETF Network Working Group"
+    CONTACT-INFO  
+                "Author: Frank Kastenholz
+                Jnxper Networks, Inc.
+                Postal: 10 Technology Park Drive
+                Westford, MA  01886-3146
+                USA
+                 Tel:    +1 978 589 5800
+                 Email:  mib@Jnxper.net "
+    DESCRIPTION
+        "The Definitions of Managed Objects for the Link Control Protocol
+         of the Point-to-Point Protocol.  Based on RFC 1471."
+    -- Revision History
+    REVISION    "200309172059Z"  -- 17-Sep-03 04:59 PM EDT
+    DESCRIPTION
+        "Created SMIv2 version."
+    REVISION    "199306011200Z"  -- 01-Jun-93 08:00 AM EDT
+    DESCRIPTION
+        "Initial SMIv1 version of this MIB module found in RFC 1471."
+    ::= { ppp 1 }
+
+ppp OBJECT IDENTIFIER
+    ::= { transmission 23 }
+
+pppLink OBJECT IDENTIFIER
+    ::= { pppLcp 1 }
+
+pppLinkStatusTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF PppLinkStatusEntry
+    MAX-ACCESS   not-accessible
+    STATUS             current
+    DESCRIPTION 
+        "A table containing PPP-link specific variables for this PPP
+         implementation."
+    ::= { pppLink 1 }
+
+pppLinkStatusEntry OBJECT-TYPE
+    SYNTAX            PppLinkStatusEntry
+    MAX-ACCESS   not-accessible
+    STATUS              current
+    DESCRIPTION 
+        "Management information about a particular PPP Link."
+    INDEX       { ifIndex }
+    ::= { pppLinkStatusTable 1 }
+
+PppLinkStatusEntry ::= SEQUENCE {
+    pppLinkStatusPhysicalIndex                      Integer32,
+    pppLinkStatusBadAddresses                       Counter32,
+    pppLinkStatusBadControls                        Counter32,
+    pppLinkStatusPacketTooLongs                     Counter32,
+    pppLinkStatusBadFCSs                            Counter32,
+    pppLinkStatusLocalMRU                           Integer32,
+    pppLinkStatusRemoteMRU                          Integer32,
+    pppLinkStatusLocalToPeerACCMap                  OCTET STRING,
+    pppLinkStatusPeerToLocalACCMap                  OCTET STRING,
+    pppLinkStatusLocalToRemoteProtocolCompression   INTEGER,
+    pppLinkStatusRemoteToLocalProtocolCompression   INTEGER,
+    pppLinkStatusLocalToRemoteACCompression         INTEGER,
+    pppLinkStatusRemoteToLocalACCompression         INTEGER,
+    pppLinkStatusTransmitFcsSize                    Integer32,
+    pppLinkStatusReceiveFcsSize                     Integer32
+}
+
+pppLinkStatusPhysicalIndex OBJECT-TYPE	
+    SYNTAX      Integer32 (0..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The value of ifIndex that identifies the lower-level interface over
+         which this PPP Link is operating. This interface would usually be 
+         n HDLC or RS-232 type of interface. If there is no lower-layer 
+         interface element, or there is no ifEntry for the element, or the
+          element can not be identified, then the value of this object is 0.
+          For example, suppose that PPP is operating over a serial port. 
+          This would use two entries in the ifTable. The PPP could be 
+          running over `interface' number 123 and the serial port could be
+          running over `interface' number 987.  Therefore, ifSpecific.123
+          would contain the OBJECT IDENTIFIER ppp 
+          pppLinkStatusPhysicalIndex.123 would contain 987, and ifSpecific.987
+           would contain the OBJECT IDENTIFIER for the serial-port's media-specific MIB."
+    ::= { pppLinkStatusEntry 1 }
+
+pppLinkStatusBadAddresses OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of packets received with an incorrect Address Field. 
+        This counter is a component of the ifInErrors variable that is 
+        associated with the interface that represents this PPP Link."
+    REFERENCE   
+        "Section 3.1, Address Field, of RFC1331."
+    ::= { pppLinkStatusEntry 2 }
+
+pppLinkStatusBadControls OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of packets received on this link with an incorrect
+         Control Field. This counter is a component of the ifInErrors variable 
+         that is associated with the interface that represents this PPP Link."
+    REFERENCE   
+        "Section 3.1, Control Field, of RFC1331."
+    ::= { pppLinkStatusEntry 3 }
+
+pppLinkStatusPacketTooLongs OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of received packets that have been discarded because their
+         length exceeded the MRU. This counter is a component of the 
+         ifInErrors variable that is associated with the interface that 
+         represents this PPP Link. NOTE, packets which are longer than the 
+         MRU but which are successfully received and processed are NOT 
+         included in this count."
+    ::= { pppLinkStatusEntry 4 }
+
+pppLinkStatusBadFCSs OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of received packets that have been discarded due to having
+         an incorrect FCS. This counter is a component of the ifInErrors
+          variable that is associated with the interface that represents this PPP Link."
+    ::= { pppLinkStatusEntry 5 }
+
+pppLinkStatusLocalMRU OBJECT-TYPE
+    SYNTAX      Integer32 (1..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The current value of the MRU for the local PPP Entity. This value
+         is the MRU that the remote entity is using when sending packets 
+         to the local PPP entity. The value of this object is meaningful only 
+         when the link has reached the open state (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 6 }
+
+pppLinkStatusRemoteMRU OBJECT-TYPE
+    SYNTAX      Integer32 (1..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The current value of the MRU for the remote PPP Entity. This value is
+         the MRU that the local entity is using when sending packets to the 
+         remote PPP entity. The value of this object is meaningful only when 
+         the link has reached          the open state (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 7 }
+
+pppLinkStatusLocalToPeerACCMap OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(4))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The current value of the ACC Map used for sending packets from the 
+        local PPP entity to the remote PPP entity. The value of this object 
+        is meaningful only when the link has reached the open state 
+        (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 8 }
+
+pppLinkStatusPeerToLocalACCMap OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(4))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The ACC Map used by the remote PPP entity when transmitting 
+        packets to the local PPP entity. The value of this object is 
+        meaningful only when the link has reached the open state
+         (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 9 }
+
+pppLinkStatusLocalToRemoteProtocolCompression OBJECT-TYPE
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Indicates whether the local PPP entity will use Protocol 
+        Compression when transmitting packets to the remote PPP entity. 
+        The value of this object is meaningful only when the link 
+        has reached the open state (ifOperStatus is         up)."
+    ::= { pppLinkStatusEntry 10 }
+
+pppLinkStatusRemoteToLocalProtocolCompression OBJECT-TYPE
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Indicates whether the remote PPP entity will use Protocol Compression
+         when transmitting packets to the local PPP entity. The value of this
+          object is meaningful only when the link has reached the open state
+           (ifOperStatus is      up)."
+    ::= { pppLinkStatusEntry 11 }
+
+pppLinkStatusLocalToRemoteACCompression OBJECT-TYPE
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Indicates whether the local PPP entity will use Address and Control
+         Compression when transmitting packets to the remote PPP entity. 
+         The value of this object is meaningful only when the link has
+          reached the open state       (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 12 }
+
+pppLinkStatusRemoteToLocalACCompression OBJECT-TYPE
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Indicates whether the remote PPP entity will use Address and
+         Control Compression when transmitting packets to the local PPP entity. 
+         The value of this object is meaningful only when the link has reached 
+         the open state    (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 13 }
+
+pppLinkStatusTransmitFcsSize OBJECT-TYPE
+    SYNTAX      Integer32 (0..128)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The size of the Frame Check Sequence (FCS) in bits that the local node
+         will generate when sending packets to the remote node. The value of 
+         this object is meaningful only when the link has reached the open 
+         state (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 14 }
+
+pppLinkStatusReceiveFcsSize OBJECT-TYPE
+    SYNTAX      Integer32 (0..128)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The size of the Frame Check Sequence (FCS) in bits that the
+         remote node will generate when sending packets to the local node.
+          The value of this object is meaningful only when the link has
+           reached the open state (ifOperStatus is up)."
+    ::= { pppLinkStatusEntry 15 }
+
+pppLinkConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF PppLinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "A table containing the LCP configuration parameters for this PPP Link.
+         These variables represent the initial configuration of the PPP Link.
+          The actual values of the parameters may be changed when the link
+           is brought up via the LCP options negotiation mechanism."
+    ::= { pppLink 2 }
+
+pppLinkConfigEntry OBJECT-TYPE
+    SYNTAX      PppLinkConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "Configuration information about a particular PPP Link."
+    INDEX       { ifIndex }
+    ::= { pppLinkConfigTable 1 }
+
+PppLinkConfigEntry ::= SEQUENCE {
+    pppLinkConfigInitialMRU         Integer32,
+    pppLinkConfigReceiveACCMap      OCTET STRING,
+    pppLinkConfigTransmitACCMap     OCTET STRING,
+    pppLinkConfigMagicNumber        INTEGER,
+    pppLinkConfigFcsSize            Integer32
+}
+
+pppLinkConfigInitialMRU OBJECT-TYPE
+    SYNTAX      Integer32 (0..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The initial Maximum Receive Unit (MRU) that the local PPP entity
+         will advertise to the remote entity. If the value of this variable 
+         is 0 then the local PPP entity will not advertise any MRU to the
+          remote entity and the default         MRU will be assumed. 
+          Changing this object will have effect when the link is next restarted."
+    REFERENCE   
+        "Section 7.2, Maximum Receive Unit of RFC1331."
+    DEFVAL      { 1500 }
+    ::= { pppLinkConfigEntry 1 }
+
+pppLinkConfigReceiveACCMap OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(4))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The Asynchronous-Control-Character-Map (ACC) that the local PPP entity
+         requires for use on its receive side. In effect, this is the ACC Map 
+         that is required in order to ensure that the local modem will
+         successfully receive all          characters. The actual ACC map
+         used on the receive side of the link will be a combination of the
+         local node's pppLinkConfigReceiveACCMap and the remote node's 
+         pppLinkConfigTransmitACCMap. Changing this object will have effect
+          when the link is next restarted."
+    REFERENCE   
+        "Section 7.3, page 4, Async-Control-Character-
+         Map of RFC1331."
+    DEFVAL      { 'ffffffff'H }
+    ::= { pppLinkConfigEntry 2 }
+
+pppLinkConfigTransmitACCMap OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(4))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The Asynchronous-Control-Character-Map (ACC) that the local PPP
+         entity requires for use on its transmit side. In effect, this is
+         the ACC Map that is required in order to ensure that all characters
+         can be successfully transmitted through the local modem.  The actual
+         ACC map used on the transmit side of the link will be a
+         combination of the local node's PppLinkConfigTransmitACCMap
+         and the remote node's pppLinkConfigReceiveACCMap. Changing 
+         this object will have effect when the link is next restarted."
+    REFERENCE   
+        "Section 7.3, page 4, Async-Control-Character-
+         Map of RFC1331."
+    DEFVAL      { 'ffffffff'H }
+    ::= { pppLinkConfigEntry 3 }
+
+pppLinkConfigMagicNumber OBJECT-TYPE
+    SYNTAX      INTEGER { false(1), true(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "If true(2) then the local node will attempt to perform Magic Number 
+        negotiation with the remote node. If false(1) then this negotiation
+         is not performed. In any event, the local node will comply with any 
+         magic number negotiations attempted by the remote node, per the PPP 
+         specification. Changing this object will have effect when the link
+          is next restarted."
+    REFERENCE   
+        "Section 7.6, Magic Number, of RFC1331."
+    DEFVAL      { false }
+    ::= { pppLinkConfigEntry 4 }
+
+pppLinkConfigFcsSize OBJECT-TYPE
+    SYNTAX      Integer32 (0..128)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The size of the FCS, in bits, the local node will attempt
+         to negotiate for use with the remote node. Regardless of the 
+         value of this object, the local node will comply with any FCS
+          size negotiations initiated by the remote node, per the PPP
+           specification. Changing this object will have effect
+            when the link is next restarted."
+    DEFVAL      { 16 }
+    ::= { pppLinkConfigEntry 5 }
+
+END

--- a/mibs/junos/mib-rfc2737.txt
+++ b/mibs/junos/mib-rfc2737.txt
@@ -1,0 +1,1255 @@
+ENTITY-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, mib-2, NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+    TDomain, TAddress, TEXTUAL-CONVENTION,
+    AutonomousType, RowPointer, TimeStamp, TruthValue
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB;
+
+entityMIB MODULE-IDENTITY
+    LAST-UPDATED "9912070000Z" -- December 7, 1999
+    ORGANIZATION "IETF ENTMIB Working Group"
+    CONTACT-INFO
+            "        WG E-mail: entmib@cisco.com
+                  Subscribe: majordomo@cisco.com
+                         msg body: subscribe entmib
+
+                     Keith McCloghrie
+                     ENTMIB Working Group Chair
+                     Cisco Systems Inc.
+                     170 West Tasman Drive
+                     San Jose, CA 95134
+                     +1 408-526-5260
+                     kzm@cisco.com
+
+                     Andy Bierman
+                     ENTMIB Working Group Editor
+                     Cisco Systems Inc.
+                     170 West Tasman Drive
+                     San Jose, CA 95134
+                     +1 408-527-3711
+                     abierman@cisco.com"
+    DESCRIPTION
+            "The MIB module for representing multiple logical
+            entities supported by a single SNMP agent."
+    REVISION        "9912070000Z"
+    DESCRIPTION
+            "Initial Version of Entity MIB (Version 2).
+             This revision obsoletes RFC 2037.
+             This version published as RFC 2737."
+    REVISION        "9610310000Z"
+    DESCRIPTION
+
+            "Initial version (version 1), published as
+             RFC 2037."
+    ::= { mib-2 47 }
+
+entityMIBObjects OBJECT IDENTIFIER ::= { entityMIB 1 }
+
+-- MIB contains four groups
+entityPhysical OBJECT IDENTIFIER ::= { entityMIBObjects 1 }
+entityLogical  OBJECT IDENTIFIER ::= { entityMIBObjects 2 }
+entityMapping  OBJECT IDENTIFIER ::= { entityMIBObjects 3 }
+entityGeneral  OBJECT IDENTIFIER ::= { entityMIBObjects 4 }
+
+-- Textual Conventions
+PhysicalIndex ::= TEXTUAL-CONVENTION
+    STATUS            current
+    DESCRIPTION
+            "An arbitrary value which uniquely identifies the physical
+            entity.  The value should be a small positive integer; index
+            values for different physical entities are not necessarily
+            contiguous."
+    SYNTAX INTEGER (1..2147483647)
+
+PhysicalClass ::= TEXTUAL-CONVENTION
+    STATUS            current
+    DESCRIPTION
+            "An enumerated value which provides an indication of the
+            general hardware type of a particular physical entity.
+            There are no restrictions as to the number of
+            entPhysicalEntries of each entPhysicalClass, which must be
+            instantiated by an agent.
+
+            The enumeration 'other' is applicable if the physical entity
+            class is known, but does not match any of the supported
+            values.
+
+            The enumeration 'unknown' is applicable if the physical
+            entity class is unknown to the agent.
+
+            The enumeration 'chassis' is applicable if the physical
+            entity class is an overall container for networking
+            equipment.  Any class of physical entity except a stack may
+            be contained within a chassis, and a chassis may only be
+            contained within a stack.
+
+            The enumeration 'backplane' is applicable if the physical
+            entity class is some sort of device for aggregating and
+            forwarding networking traffic, such as a shared backplane in
+            a modular ethernet switch.  Note that an agent may model a
+
+            backplane as a single physical entity, which is actually
+            implemented as multiple discrete physical components (within
+            a chassis or stack).
+
+            The enumeration 'container' is applicable if the physical
+            entity class is capable of containing one or more removable
+            physical entities, possibly of different types. For example,
+            each (empty or full) slot in a chassis will be modeled as a
+            container. Note that all removable physical entities should
+            be modeled within a container entity, such as field-
+            replaceable modules, fans, or power supplies.  Note that all
+            known containers should be modeled by the agent, including
+            empty containers.
+
+            The enumeration 'powerSupply' is applicable if the physical
+            entity class is a power-supplying component.
+
+            The enumeration 'fan' is applicable if the physical entity
+            class is a fan or other heat-reduction component.
+
+            The enumeration 'sensor' is applicable if the physical
+            entity class is some sort of sensor, such as a temperature
+            sensor within a router chassis.
+
+            The enumeration 'module' is applicable if the physical
+            entity class is some sort of self-contained sub-system.  If
+            it is removable, then it should be modeled within a
+            container entity, otherwise it should be modeled directly
+            within another physical entity (e.g., a chassis or another
+            module).
+
+            The enumeration 'port' is applicable if the physical entity
+            class is some sort of networking port, capable of receiving
+            and/or transmitting networking traffic.
+
+            The enumeration 'stack' is applicable if the physical entity
+            class is some sort of super-container (possibly virtual),
+            intended to group together multiple chassis entities.  A
+            stack may be realized by a 'virtual' cable, a real
+            interconnect cable, attached to multiple chassis, or may in
+            fact be comprised of multiple interconnect cables. A stack
+            should not be modeled within any other physical entities,
+            but a stack may be contained within another stack.  Only
+            chassis entities should be contained within a stack."
+    SYNTAX      INTEGER  {
+       other(1),
+       unknown(2),
+       chassis(3),
+
+       backplane(4),
+       container(5),     -- e.g., chassis slot or daughter-card holder
+       powerSupply(6),
+       fan(7),
+       sensor(8),
+       module(9),        -- e.g., plug-in card or daughter-card
+       port(10),
+       stack(11)         -- e.g., stack of multiple chassis entities
+    }
+
+SnmpEngineIdOrNone ::= TEXTUAL-CONVENTION
+    STATUS            current
+    DESCRIPTION
+            "A specially formatted SnmpEngineID string for use with the
+            Entity MIB.
+
+            If an instance of an object of SYNTAX SnmpEngineIdOrNone has
+            a non-zero length, then the object encoding and semantics
+            are defined by the SnmpEngineID textual convention (see RFC
+            2571 [RFC2571]).
+
+            If an instance of an object of SYNTAX SnmpEngineIdOrNone
+            contains a zero-length string, then no appropriate
+            SnmpEngineID is associated with the logical entity (i.e.,
+            SNMPv3 not supported)."
+    SYNTAX OCTET STRING (SIZE(0..32)) -- empty string or SnmpEngineID
+
+--           The Physical Entity Table
+entPhysicalTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntPhysicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains one row per physical entity.  There is
+            always at least one row for an 'overall' physical entity."
+    ::= { entityPhysical 1 }
+
+entPhysicalEntry       OBJECT-TYPE
+    SYNTAX      EntPhysicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular physical entity.
+
+            Each entry provides objects (entPhysicalDescr,
+            entPhysicalVendorType, and entPhysicalClass) to help an NMS
+            identify and characterize the entry, and objects
+            (entPhysicalContainedIn and entPhysicalParentRelPos) to help
+
+            an NMS relate the particular entry to other entries in this
+            table."
+    INDEX   { entPhysicalIndex }
+    ::= { entPhysicalTable 1 }
+
+EntPhysicalEntry ::= SEQUENCE {
+      entPhysicalIndex          PhysicalIndex,
+      entPhysicalDescr          SnmpAdminString,
+      entPhysicalVendorType     AutonomousType,
+      entPhysicalContainedIn    INTEGER,
+      entPhysicalClass          PhysicalClass,
+      entPhysicalParentRelPos   INTEGER,
+      entPhysicalName           SnmpAdminString,
+      entPhysicalHardwareRev    SnmpAdminString,
+      entPhysicalFirmwareRev    SnmpAdminString,
+      entPhysicalSoftwareRev    SnmpAdminString,
+      entPhysicalSerialNum      SnmpAdminString,
+      entPhysicalMfgName        SnmpAdminString,
+      entPhysicalModelName      SnmpAdminString,
+      entPhysicalAlias          SnmpAdminString,
+      entPhysicalAssetID        SnmpAdminString,
+      entPhysicalIsFRU          TruthValue
+}
+
+entPhysicalIndex    OBJECT-TYPE
+    SYNTAX      PhysicalIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "The index for this entry."
+    ::= { entPhysicalEntry 1 }
+
+entPhysicalDescr OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual description of physical entity.  This object
+            should contain a string which identifies the manufacturer's
+            name for the physical entity, and should be set to a
+            distinct value for each version or model of the physical
+            entity. "
+    ::= { entPhysicalEntry 2 }
+
+entPhysicalVendorType OBJECT-TYPE
+    SYNTAX      AutonomousType
+    MAX-ACCESS  read-only
+    STATUS      current
+
+    DESCRIPTION
+            "An indication of the vendor-specific hardware type of the
+            physical entity.  Note that this is different from the
+            definition of MIB-II's sysObjectID.
+
+            An agent should set this object to a enterprise-specific
+            registration identifier value indicating the specific
+            equipment type in detail.  The associated instance of
+            entPhysicalClass is used to indicate the general type of
+            hardware device.
+
+            If no vendor-specific registration identifier exists for
+            this physical entity, or the value is unknown by this agent,
+            then the value { 0 0 } is returned."
+    ::= { entPhysicalEntry 3 }
+
+entPhysicalContainedIn OBJECT-TYPE
+    SYNTAX      INTEGER (0..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of entPhysicalIndex for the physical entity which
+            'contains' this physical entity.  A value of zero indicates
+            this physical entity is not contained in any other physical
+            entity.  Note that the set of 'containment' relationships
+            define a strict hierarchy; that is, recursion is not
+            allowed.
+
+            In the event a physical entity is contained by more than one
+            physical entity (e.g., double-wide modules), this object
+            should identify the containing entity with the lowest value
+            of entPhysicalIndex."
+    ::= { entPhysicalEntry 4 }
+
+entPhysicalClass OBJECT-TYPE
+    SYNTAX      PhysicalClass
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the general hardware type of the physical
+            entity.
+
+            An agent should set this object to the standard enumeration
+            value which most accurately indicates the general class of
+            the physical entity, or the primary class if there is more
+            than one.
+
+            If no appropriate standard registration identifier exists
+
+            for this physical entity, then the value 'other(1)' is
+            returned. If the value is unknown by this agent, then the
+            value 'unknown(2)' is returned."
+    ::= { entPhysicalEntry 5 }
+
+entPhysicalParentRelPos OBJECT-TYPE
+    SYNTAX      INTEGER (-1..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the relative position of this 'child'
+            component among all its 'sibling' components. Sibling
+            components are defined as entPhysicalEntries which share the
+            same instance values of each of the entPhysicalContainedIn
+            and entPhysicalClass objects.
+
+            An NMS can use this object to identify the relative ordering
+            for all sibling components of a particular parent
+            (identified by the entPhysicalContainedIn instance in each
+            sibling entry).
+
+            This value should match any external labeling of the
+            physical component if possible. For example, for a container
+            (e.g., card slot) labeled as 'slot #3',
+            entPhysicalParentRelPos should have the value '3'.  Note
+            that the entPhysicalEntry for the module plugged in slot 3
+            should have an entPhysicalParentRelPos value of '1'.
+
+            If the physical position of this component does not match
+            any external numbering or clearly visible ordering, then
+            user documentation or other external reference material
+            should be used to determine the parent-relative position. If
+            this is not possible, then the the agent should assign a
+            consistent (but possibly arbitrary) ordering to a given set
+            of 'sibling' components, perhaps based on internal
+            representation of the components.
+
+            If the agent cannot determine the parent-relative position
+            for some reason, or if the associated value of
+            entPhysicalContainedIn is '0', then the value '-1' is
+            returned. Otherwise a non-negative integer is returned,
+            indicating the parent-relative position of this physical
+            entity.
+
+            Parent-relative ordering normally starts from '1' and
+            continues to 'N', where 'N' represents the highest
+            positioned child entity.  However, if the physical entities
+            (e.g., slots) are labeled from a starting position of zero,
+
+            then the first sibling should be associated with a
+            entPhysicalParentRelPos value of '0'.  Note that this
+            ordering may be sparse or dense, depending on agent
+            implementation.
+
+            The actual values returned are not globally meaningful, as
+            each 'parent' component may use different numbering
+            algorithms. The ordering is only meaningful among siblings
+            of the same parent component.
+
+            The agent should retain parent-relative position values
+            across reboots, either through algorithmic assignment or use
+            of non-volatile storage."
+    ::= { entPhysicalEntry 6 }
+
+entPhysicalName OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The textual name of the physical entity.  The value of this
+            object should be the name of the component as assigned by
+            the local device and should be suitable for use in commands
+            entered at the device's `console'.  This might be a text
+            name, such as `console' or a simple component number (e.g.,
+            port or module number), such as `1', depending on the
+            physical component naming syntax of the device.
+
+            If there is no local name, or this object is otherwise not
+            applicable, then this object contains a zero-length string.
+
+            Note that the value of entPhysicalName for two physical
+            entities will be the same in the event that the console
+            interface does not distinguish between them, e.g., slot-1
+            and the card in slot-1."
+    ::= { entPhysicalEntry 7 }
+
+entPhysicalHardwareRev    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific hardware revision string for the
+            physical entity.  The preferred value is the hardware
+            revision identifier actually printed on the component itself
+            (if present).
+
+            Note that if revision information is stored internally in a
+
+            non-printable (e.g., binary) format, then the agent must
+            convert such information to a printable format, in an
+            implementation-specific manner.
+
+            If no specific hardware revision string is associated with
+            the physical component, or this information is unknown to
+            the agent, then this object will contain a zero-length
+            string."
+    ::= { entPhysicalEntry 8 }
+
+entPhysicalFirmwareRev    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific firmware revision string for the
+            physical entity.
+
+            Note that if revision information is stored internally in a
+            non-printable (e.g., binary) format, then the agent must
+            convert such information to a printable format, in an
+            implementation-specific manner.
+
+            If no specific firmware programs are associated with the
+            physical component, or this information is unknown to the
+            agent, then this object will contain a zero-length string."
+    ::= { entPhysicalEntry 9 }
+
+entPhysicalSoftwareRev    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific software revision string for the
+            physical entity.
+
+            Note that if revision information is stored internally in a
+            non-printable (e.g., binary) format, then the agent must
+            convert such information to a printable format, in an
+            implementation-specific manner.
+
+            If no specific software programs are associated with the
+            physical component, or this information is unknown to the
+            agent, then this object will contain a zero-length string."
+    ::= { entPhysicalEntry 10 }
+
+entPhysicalSerialNum   OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific serial number string for the physical
+            entity.  The preferred value is the serial number string
+            actually printed on the component itself (if present).
+
+            On the first instantiation of an physical entity, the value
+            of entPhysicalSerialNum associated with that entity is set
+            to the correct vendor-assigned serial number, if this
+            information is available to the agent.  If a serial number
+            is unknown or non-existent, the entPhysicalSerialNum will be
+            set to a zero-length string instead.
+
+            Note that implementations which can correctly identify the
+            serial numbers of all installed physical entities do not
+            need to provide write access to the entPhysicalSerialNum
+            object. Agents which cannot provide non-volatile storage for
+            the entPhysicalSerialNum strings are not required to
+            implement write access for this object.
+
+            Not every physical component will have a serial number, or
+            even need one.  Physical entities for which the associated
+            value of the entPhysicalIsFRU object is equal to 'false(2)'
+            (e.g., the repeater ports within a repeater module), do not
+            need their own unique serial number. An agent does not have
+            to provide write access for such entities, and may return a
+            zero-length string.
+
+            If write access is implemented for an instance of
+            entPhysicalSerialNum, and a value is written into the
+            instance, the agent must retain the supplied value in the
+            entPhysicalSerialNum instance associated with the same
+            physical entity for as long as that entity remains
+            instantiated. This includes instantiations across all re-
+            initializations/reboots of the network management system,
+            including those which result in a change of the physical
+            entity's entPhysicalIndex value."
+    ::= { entPhysicalEntry 11 }
+
+entPhysicalMfgName   OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The name of the manufacturer of this physical component.
+            The preferred value is the manufacturer name string actually
+            printed on the component itself (if present).
+
+            Note that comparisons between instances of the
+            entPhysicalModelName, entPhysicalFirmwareRev,
+            entPhysicalSoftwareRev, and the entPhysicalSerialNum
+            objects, are only meaningful amongst entPhysicalEntries with
+            the same value of entPhysicalMfgName.
+
+            If the manufacturer name string associated with the physical
+            component is unknown to the agent, then this object will
+            contain a zero-length string."
+    ::= { entPhysicalEntry 12 }
+
+entPhysicalModelName   OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific model name identifier string associated
+            with this physical component.  The preferred value is the
+            customer-visible part number, which may be printed on the
+            component itself.
+
+            If the model name string associated with the physical
+            component is unknown to the agent, then this object will
+            contain a zero-length string."
+    ::= { entPhysicalEntry 13 }
+
+entPhysicalAlias    OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object is an 'alias' name for the physical entity as
+            specified by a network manager, and provides a non-volatile
+            'handle' for the physical entity.
+
+            On the first instantiation of an physical entity, the value
+            of entPhysicalAlias associated with that entity is set to
+            the zero-length string.  However, agent may set the value to
+            a locally unique default value, instead of a zero-length
+            string.
+
+            If write access is implemented for an instance of
+            entPhysicalAlias, and a value is written into the instance,
+            the agent must retain the supplied value in the
+            entPhysicalAlias instance associated with the same physical
+            entity for as long as that entity remains instantiated.
+            This includes instantiations across all re-
+            initializations/reboots of the network management system,
+
+            including those which result in a change of the physical
+            entity's entPhysicalIndex value."
+    ::= { entPhysicalEntry 14 }
+
+entPhysicalAssetID OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object is a user-assigned asset tracking identifier
+            for the physical entity as specified by a network manager,
+            and provides non-volatile storage of this information.
+
+            On the first instantiation of an physical entity, the value
+            of entPhysicalAssetID associated with that entity is set to
+            the zero-length string.
+
+            Not every physical component will have a asset tracking
+            identifier, or even need one.  Physical entities for which
+            the associated value of the entPhysicalIsFRU object is equal
+            to 'false(2)' (e.g., the repeater ports within a repeater
+            module), do not need their own unique asset tracking
+            identifier. An agent does not have to provide write access
+            for such entities, and may instead return a zero-length
+            string.
+
+            If write access is implemented for an instance of
+            entPhysicalAssetID, and a value is written into the
+            instance, the agent must retain the supplied value in the
+            entPhysicalAssetID instance associated with the same
+            physical entity for as long as that entity remains
+            instantiated.  This includes instantiations across all re-
+            initializations/reboots of the network management system,
+            including those which result in a change of the physical
+            entity's entPhysicalIndex value.
+
+            If no asset tracking information is associated with the
+            physical component, then this object will contain a zero-
+            length string."
+    ::= { entPhysicalEntry 15 }
+
+entPhysicalIsFRU OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "This object indicates whether or not this physical entity
+            is considered a 'field replaceable unit' by the vendor.  If
+
+            this object contains the value 'true(1)' then this
+            entPhysicalEntry identifies a field replaceable unit.  For
+            all entPhysicalEntries which represent components that are
+            permanently contained within a field replaceable unit, the
+            value 'false(2)' should be returned for this object."
+
+    ::= { entPhysicalEntry 16 }
+
+--           The Logical Entity Table
+entLogicalTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntLogicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains one row per logical entity.  For agents
+            which implement more than one naming scope, at least one
+            entry must exist. Agents which instantiate all MIB objects
+            within a single naming scope are not required to implement
+            this table."
+    ::= { entityLogical 1 }
+
+entLogicalEntry       OBJECT-TYPE
+    SYNTAX      EntLogicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular logical entity.  Entities
+            may be managed by this agent or other SNMP agents (possibly)
+            in the same chassis."
+    INDEX       { entLogicalIndex }
+    ::= { entLogicalTable 1 }
+
+EntLogicalEntry ::= SEQUENCE {
+      entLogicalIndex            INTEGER,
+      entLogicalDescr            SnmpAdminString,
+      entLogicalType             AutonomousType,
+      entLogicalCommunity        OCTET STRING,
+      entLogicalTAddress         TAddress,
+      entLogicalTDomain          TDomain,
+      entLogicalContextEngineID  SnmpEngineIdOrNone,
+      entLogicalContextName      SnmpAdminString
+}
+
+entLogicalIndex OBJECT-TYPE
+    SYNTAX      INTEGER (1..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+
+            "The value of this object uniquely identifies the logical
+            entity. The value should be a small positive integer; index
+            values for different logical entities are are not
+            necessarily contiguous."
+    ::= { entLogicalEntry 1 }
+
+entLogicalDescr OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual description of the logical entity.  This object
+            should contain a string which identifies the manufacturer's
+            name for the logical entity, and should be set to a distinct
+            value for each version of the logical entity. "
+    ::= { entLogicalEntry 2 }
+
+entLogicalType OBJECT-TYPE
+    SYNTAX      AutonomousType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the type of logical entity.  This will
+            typically be the OBJECT IDENTIFIER name of the node in the
+            SMI's naming hierarchy which represents the major MIB
+            module, or the majority of the MIB modules, supported by the
+            logical entity.  For example:
+               a logical entity of a regular host/router -> mib-2
+               a logical entity of a 802.1d bridge -> dot1dBridge
+               a logical entity of a 802.3 repeater -> snmpDot3RptrMgmt
+            If an appropriate node in the SMI's naming hierarchy cannot
+            be identified, the value 'mib-2' should be used."
+    ::= { entLogicalEntry 3 }
+
+entLogicalCommunity OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "An SNMPv1 or SNMPv2C community-string which can be used to
+            access detailed management information for this logical
+            entity.  The agent should allow read access with this
+            community string (to an appropriate subset of all managed
+            objects) and may also return a community string based on the
+            privileges of the request used to read this object.  Note
+            that an agent may return a community string with read-only
+            privileges, even if this object is accessed with a read-
+            write community string. However, the agent must take care
+
+            not to return a community string which allows more
+            privileges than the community string used to access this
+            object.
+
+            A compliant SNMP agent may wish to conserve naming scopes by
+            representing multiple logical entities in a single 'default'
+            naming scope.  This is possible when the logical entities
+            represented by the same value of entLogicalCommunity have no
+            object instances in common.  For example, 'bridge1' and
+            'repeater1' may be part of the main naming scope, but at
+            least one additional community string is needed to represent
+            'bridge2' and 'repeater2'.
+
+            Logical entities 'bridge1' and 'repeater1' would be
+            represented by sysOREntries associated with the 'default'
+            naming scope.
+
+            For agents not accessible via SNMPv1 or SNMPv2C, the value
+            of this object is the empty string.  This object may also
+            contain an empty string if a community string has not yet
+            been assigned by the agent, or no community string with
+            suitable access rights can be returned for a particular SNMP
+            request.
+
+            Note that this object is deprecated. Agents which implement
+            SNMPv3 access should use the entLogicalContextEngineID and
+            entLogicalContextName objects to identify the context
+            associated with each logical entity.  SNMPv3 agents may
+            return a zero-length string for this object, or may continue
+            to return a community string (e.g., tri-lingual agent
+            support)."
+    ::= { entLogicalEntry 4 }
+
+entLogicalTAddress OBJECT-TYPE
+    SYNTAX      TAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The transport service address by which the logical entity
+            receives network management traffic, formatted according to
+            the corresponding value of entLogicalTDomain.
+
+            For snmpUDPDomain, a TAddress is 6 octets long, the initial
+            4 octets containing the IP-address in network-byte order and
+            the last 2 containing the UDP port in network-byte order.
+            Consult 'Transport Mappings for Version 2 of the Simple
+            Network Management Protocol' (RFC 1906 [RFC1906]) for
+            further information on snmpUDPDomain."
+
+    ::= { entLogicalEntry 5 }
+
+entLogicalTDomain OBJECT-TYPE
+    SYNTAX      TDomain
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Indicates the kind of transport service by which the
+            logical entity receives network management traffic.
+            Possible values for this object are presently found in the
+            Transport Mappings for SNMPv2 document (RFC 1906
+            [RFC1906])."
+    ::= { entLogicalEntry 6 }
+
+entLogicalContextEngineID    OBJECT-TYPE
+    SYNTAX      SnmpEngineIdOrNone
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The authoritative contextEngineID that can be used to send
+            an SNMP message concerning information held by this logical
+            entity, to the address specified by the associated
+            'entLogicalTAddress/entLogicalTDomain' pair.
+
+            This object, together with the associated
+            entLogicalContextName object, defines the context associated
+            with a particular logical entity, and allows access to SNMP
+            engines identified by a contextEngineId and contextName
+            pair.
+
+            If no value has been configured by the agent, a zero-length
+            string is returned, or the agent may choose not to
+            instantiate this object at all."
+    ::= { entLogicalEntry 7 }
+
+entLogicalContextName    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The contextName that can be used to send an SNMP message
+            concerning information held by this logical entity, to the
+            address specified by the associated
+            'entLogicalTAddress/entLogicalTDomain' pair.
+
+            This object, together with the associated
+            entLogicalContextEngineID object, defines the context
+            associated with a particular logical entity, and allows
+
+            access to SNMP engines identified by a contextEngineId and
+            contextName pair.
+
+            If no value has been configured by the agent, a zero-length
+            string is returned, or the agent may choose not to
+            instantiate this object at all."
+    ::= { entLogicalEntry 8 }
+
+entLPMappingTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntLPMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains zero or more rows of logical entity to
+            physical equipment associations. For each logical entity
+            known by this agent, there are zero or more mappings to the
+            physical resources which are used to realize that logical
+            entity.
+
+            An agent should limit the number and nature of entries in
+            this table such that only meaningful and non-redundant
+            information is returned. For example, in a system which
+            contains a single power supply, mappings between logical
+            entities and the power supply are not useful and should not
+            be included.
+
+            Also, only the most appropriate physical component which is
+            closest to the root of a particular containment tree should
+            be identified in an entLPMapping entry.
+
+            For example, suppose a bridge is realized on a particular
+            module, and all ports on that module are ports on this
+            bridge. A mapping between the bridge and the module would be
+            useful, but additional mappings between the bridge and each
+            of the ports on that module would be redundant (since the
+            entPhysicalContainedIn hierarchy can provide the same
+            information). If, on the other hand, more than one bridge
+            was utilizing ports on this module, then mappings between
+            each bridge and the ports it used would be appropriate.
+
+            Also, in the case of a single backplane repeater, a mapping
+            for the backplane to the single repeater entity is not
+            necessary."
+    ::= { entityMapping 1 }
+
+entLPMappingEntry       OBJECT-TYPE
+    SYNTAX      EntLPMappingEntry
+    MAX-ACCESS  not-accessible
+
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular logical entity to physical
+            equipment association. Note that the nature of the
+            association is not specifically identified in this entry.
+            It is expected that sufficient information exists in the
+            MIBs used to manage a particular logical entity to infer how
+            physical component information is utilized."
+    INDEX       { entLogicalIndex, entLPPhysicalIndex }
+    ::= { entLPMappingTable 1 }
+
+EntLPMappingEntry ::= SEQUENCE {
+      entLPPhysicalIndex         PhysicalIndex
+}
+
+entLPPhysicalIndex OBJECT-TYPE
+    SYNTAX      PhysicalIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of this object identifies the index value of a
+            particular entPhysicalEntry associated with the indicated
+            entLogicalEntity."
+    ::= { entLPMappingEntry 1 }
+
+-- logical entity/component to alias table
+entAliasMappingTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntAliasMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains zero or more rows, representing
+            mappings of logical entity and physical component to
+            external MIB identifiers.  Each physical port in the system
+            may be associated with a mapping to an external identifier,
+            which itself is associated with a particular logical
+            entity's naming scope.  A 'wildcard' mechanism is provided
+            to indicate that an identifier is associated with more than
+            one logical entity."
+    ::= { entityMapping 2 }
+
+entAliasMappingEntry       OBJECT-TYPE
+    SYNTAX      EntAliasMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular physical equipment, logical
+            entity to external identifier binding. Each logical
+
+            entity/physical component pair may be associated with one
+            alias mapping.  The logical entity index may also be used as
+            a 'wildcard' (refer to the entAliasLogicalIndexOrZero object
+            DESCRIPTION clause for details.)
+
+            Note that only entPhysicalIndex values which represent
+            physical ports (i.e. associated entPhysicalClass value is
+            'port(10)') are permitted to exist in this table."
+    INDEX { entPhysicalIndex, entAliasLogicalIndexOrZero }
+    ::= { entAliasMappingTable 1 }
+
+EntAliasMappingEntry ::= SEQUENCE {
+      entAliasLogicalIndexOrZero        INTEGER,
+      entAliasMappingIdentifier          RowPointer
+}
+
+entAliasLogicalIndexOrZero OBJECT-TYPE
+    SYNTAX      INTEGER (0..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "The value of this object identifies the logical entity
+            which defines the naming scope for the associated instance
+            of the 'entAliasMappingIdentifier' object.
+
+            If this object has a non-zero value, then it identifies the
+            logical entity named by the same value of entLogicalIndex.
+
+            If this object has a value of zero, then the mapping between
+            the physical component and the alias identifier for this
+            entAliasMapping entry is associated with all unspecified
+            logical entities. That is, a value of zero (the default
+            mapping) identifies any logical entity which does not have
+            an explicit entry in this table for a particular
+            entPhysicalIndex/entAliasMappingIdentifier pair.
+
+            For example, to indicate that a particular interface (e.g.,
+            physical component 33) is identified by the same value of
+            ifIndex for all logical entities, the following instance
+            might exist:
+
+                    entAliasMappingIdentifier.33.0 = ifIndex.5
+
+            In the event an entPhysicalEntry is associated differently
+            for some logical entities, additional entAliasMapping
+            entries may exist, e.g.:
+
+                    entAliasMappingIdentifier.33.0 = ifIndex.6
+
+                    entAliasMappingIdentifier.33.4 =  ifIndex.1
+                    entAliasMappingIdentifier.33.5 =  ifIndex.1
+                    entAliasMappingIdentifier.33.10 = ifIndex.12
+
+            Note that entries with non-zero entAliasLogicalIndexOrZero
+            index values have precedence over any zero-indexed entry. In
+            this example, all logical entities except 4, 5, and 10,
+            associate physical entity 33 with ifIndex.6."
+    ::= { entAliasMappingEntry 1 }
+
+entAliasMappingIdentifier OBJECT-TYPE
+    SYNTAX      RowPointer
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of this object identifies a particular conceptual
+            row associated with the indicated entPhysicalIndex and
+            entLogicalIndex pair.
+
+            Since only physical ports are modeled in this table, only
+            entries which represent interfaces or ports are allowed.  If
+            an ifEntry exists on behalf of a particular physical port,
+            then this object should identify the associated 'ifEntry'.
+            For repeater ports, the appropriate row in the
+            'rptrPortGroupTable' should be identified instead.
+
+            For example, suppose a physical port was represented by
+            entPhysicalEntry.3, entLogicalEntry.15 existed for a
+            repeater, and entLogicalEntry.22 existed for a bridge.  Then
+            there might be two related instances of
+            entAliasMappingIdentifier:
+               entAliasMappingIdentifier.3.15 == rptrPortGroupIndex.5.2
+               entAliasMappingIdentifier.3.22 == ifIndex.17
+            It is possible that other mappings (besides interfaces and
+            repeater ports) may be defined in the future, as required.
+
+            Bridge ports are identified by examining the Bridge MIB and
+            appropriate ifEntries associated with each 'dot1dBasePort',
+            and are thus not represented in this table."
+    ::= { entAliasMappingEntry 2 }
+
+-- physical mapping table
+entPhysicalContainsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntPhysicalContainsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table which exposes the container/'containee'
+
+            relationships between physical entities. This table provides
+            all the information found by constructing the virtual
+            containment tree for a given entPhysicalTable, but in a more
+            direct format.
+
+            In the event a physical entity is contained by more than one
+            other physical entity (e.g., double-wide modules), this
+            table should include these additional mappings, which cannot
+            be represented in the entPhysicalTable virtual containment
+            tree."
+    ::= { entityMapping 3 }
+
+entPhysicalContainsEntry OBJECT-TYPE
+    SYNTAX      EntPhysicalContainsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A single container/'containee' relationship."
+    INDEX       { entPhysicalIndex, entPhysicalChildIndex }
+    ::= { entPhysicalContainsTable 1 }
+
+EntPhysicalContainsEntry ::= SEQUENCE {
+      entPhysicalChildIndex     PhysicalIndex
+}
+
+entPhysicalChildIndex OBJECT-TYPE
+    SYNTAX      PhysicalIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of entPhysicalIndex for the contained physical
+            entity."
+    ::= { entPhysicalContainsEntry 1 }
+
+-- last change time stamp for the whole MIB
+entLastChangeTime OBJECT-TYPE
+    SYNTAX      TimeStamp
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime at the time a conceptual row is
+            created, modified, or deleted in any of these tables:
+                    - entPhysicalTable
+                    - entLogicalTable
+                    - entLPMappingTable
+                    - entAliasMappingTable
+                    - entPhysicalContainsTable
+            "
+
+    ::= { entityGeneral 1 }
+
+-- Entity MIB Trap Definitions
+entityMIBTraps      OBJECT IDENTIFIER ::= { entityMIB 2 }
+entityMIBTrapPrefix OBJECT IDENTIFIER ::= { entityMIBTraps 0 }
+
+entConfigChange NOTIFICATION-TYPE
+    STATUS             current
+    DESCRIPTION
+            "An entConfigChange notification is generated when the value
+            of entLastChangeTime changes. It can be utilized by an NMS
+            to trigger logical/physical entity table maintenance polls.
+
+            An agent should not generate more than one entConfigChange
+            'notification-event' in a given time interval (five seconds
+            is the suggested default).  A 'notification-event' is the
+            transmission of a single trap or inform PDU to a list of
+            notification destinations.
+
+            If additional configuration changes occur within the
+            throttling period, then notification-events for these
+            changes should be suppressed by the agent until the current
+            throttling period expires.  At the end of a throttling
+            period, one notification-event should be generated if any
+            configuration changes occurred since the start of the
+            throttling period. In such a case, another throttling period
+            is started right away.
+
+            An NMS should periodically check the value of
+            entLastChangeTime to detect any missed entConfigChange
+            notification-events, e.g., due to throttling or transmission
+            loss."
+   ::= { entityMIBTrapPrefix 1 }
+
+-- conformance information
+entityConformance OBJECT IDENTIFIER ::= { entityMIB 3 }
+
+entityCompliances OBJECT IDENTIFIER ::= { entityConformance 1 }
+entityGroups      OBJECT IDENTIFIER ::= { entityConformance 2 }
+
+-- compliance statements
+entityCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "The compliance statement for SNMP entities which implement
+            version 1 of the Entity MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS {
+
+                           entityPhysicalGroup,
+                           entityLogicalGroup,
+                           entityMappingGroup,
+                           entityGeneralGroup,
+                           entityNotificationsGroup
+        }
+    ::= { entityCompliances 1 }
+
+entity2Compliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for SNMP entities which implement
+            version 2 of the Entity MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS {
+                           entityPhysicalGroup,
+                           entityPhysical2Group,
+                           entityGeneralGroup,
+                           entityNotificationsGroup
+        }
+        GROUP entityLogical2Group
+        DESCRIPTION
+            "Implementation of this group is not mandatory for agents
+            which model all MIB object instances within a single naming
+            scope."
+
+        GROUP entityMappingGroup
+        DESCRIPTION
+            "Implementation of the entPhysicalContainsTable is mandatory
+            for all agents.  Implementation of the entLPMappingTable and
+            entAliasMappingTables are not mandatory for agents which
+            model all MIB object instances within a single naming scope.
+
+            Note that the entAliasMappingTable may be useful for all
+            agents, however implementation of the entityLogicalGroup or
+            entityLogical2Group is required to support this table."
+
+        OBJECT entPhysicalSerialNum
+        MIN-ACCESS   not-accessible
+        DESCRIPTION
+            "Read and write access is not required for agents which
+            cannot identify serial number information for physical
+            entities, and/or cannot provide non-volatile storage for
+            NMS-assigned serial numbers.
+
+            Write access is not required for agents which can identify
+            serial number information for physical entities, but cannot
+            provide non-volatile storage for NMS-assigned serial
+
+            numbers.
+
+            Write access is not required for physical entities for
+            physical entities for which the associated value of the
+            entPhysicalIsFRU object is equal to 'false(2)'."
+
+        OBJECT entPhysicalAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is required only if the associated
+            entPhysicalClass value is equal to 'chassis(3)'."
+
+        OBJECT entPhysicalAssetID
+        MIN-ACCESS   not-accessible
+        DESCRIPTION
+            "Read and write access is not required for agents which
+            cannot provide non-volatile storage for NMS-assigned asset
+            identifiers.
+
+            Write access is not required for physical entities for which
+            the associated value of entPhysicalIsFRU is equal to
+            'false(2)'."
+    ::= { entityCompliances 2 }
+
+-- MIB groupings
+entityPhysicalGroup    OBJECT-GROUP
+    OBJECTS {
+              entPhysicalDescr,
+              entPhysicalVendorType,
+              entPhysicalContainedIn,
+              entPhysicalClass,
+              entPhysicalParentRelPos,
+              entPhysicalName
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects which are used to represent
+            physical system components, for which a single agent
+            provides management information."
+    ::= { entityGroups 1 }
+
+entityLogicalGroup    OBJECT-GROUP
+    OBJECTS {
+              entLogicalDescr,
+              entLogicalType,
+              entLogicalCommunity,
+              entLogicalTAddress,
+              entLogicalTDomain
+
+            }
+    STATUS  deprecated
+    DESCRIPTION
+            "The collection of objects which are used to represent the
+            list of logical entities for which a single agent provides
+            management information."
+    ::= { entityGroups 2 }
+
+entityMappingGroup    OBJECT-GROUP
+    OBJECTS {
+              entLPPhysicalIndex,
+              entAliasMappingIdentifier,
+              entPhysicalChildIndex
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects which are used to represent the
+            associations between multiple logical entities, physical
+            components, interfaces, and port identifiers for which a
+            single agent provides management information."
+    ::= { entityGroups 3 }
+
+entityGeneralGroup    OBJECT-GROUP
+    OBJECTS {
+              entLastChangeTime
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects which are used to represent
+            general entity information for which a single agent provides
+            management information."
+    ::= { entityGroups 4 }
+
+entityNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS { entConfigChange }
+    STATUS        current
+    DESCRIPTION
+            "The collection of notifications used to indicate Entity MIB
+            data consistency and general status information."
+    ::= { entityGroups 5 }
+
+entityPhysical2Group    OBJECT-GROUP
+    OBJECTS {
+              entPhysicalHardwareRev,
+              entPhysicalFirmwareRev,
+              entPhysicalSoftwareRev,
+              entPhysicalSerialNum,
+              entPhysicalMfgName,
+
+              entPhysicalModelName,
+              entPhysicalAlias,
+              entPhysicalAssetID,
+              entPhysicalIsFRU
+            }
+
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects which are used to represent
+            physical system components, for which a single agent
+            provides management information.  This group augments the
+            objects contained in the entityPhysicalGroup."
+    ::= { entityGroups 6 }
+
+entityLogical2Group    OBJECT-GROUP
+    OBJECTS {
+              entLogicalDescr,
+              entLogicalType,
+              entLogicalTAddress,
+              entLogicalTDomain,
+              entLogicalContextEngineID,
+              entLogicalContextName
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects which are used to represent the
+            list of logical entities for which a single SNMP entity
+            provides management information."
+    ::= { entityGroups 7 }
+
+END
+

--- a/mibs/junos/mib-rfc3413target.txt
+++ b/mibs/junos/mib-rfc3413target.txt
@@ -28,7 +28,7 @@
            FROM SNMPv2-CONF;
 
    snmpTargetMIB MODULE-IDENTITY
-       LAST-UPDATED "200210140000Z"
+       LAST-UPDATED "201211270000Z"
        ORGANIZATION "IETF SNMPv3 Working Group"
        CONTACT-INFO
            "WG-email:   snmpv3@lists.tislabs.com
@@ -77,6 +77,9 @@
             version of this MIB module is part of RFC 3413;
             see the RFC itself for full legal notices.
            "
+       REVISION    "201211270000Z"             -- 27 November 2012
+       DESCRIPTION "Juniper Change - Fixed hex value of LF characters.
+                   These were not fixed in rev. 200210140000Z"
        REVISION    "200210140000Z"             -- 14 October 2002
        DESCRIPTION "Fixed DISPLAY-HINTS for UTF-8 strings, fixed hex
                     value of LF characters, clarified meaning of zero
@@ -139,7 +142,8 @@
 
                 -  An ASCII carriage return (CR) character (0x0D).
 
-                -  An ASCII line feed (LF) character (0x0B).
+                -  An ASCII line feed (LF) character (0x0A).
+
 
             Delimiter characters are used to separate tag values
             in a tag list.  An object of this type may only
@@ -199,7 +203,7 @@
 
                 -  An ASCII carriage return (CR) character (0x0D).
 
-                -  An ASCII line feed (LF) character (0x0B).
+                -  An ASCII line feed (LF) character (0x0A).
 
             Delimiter characters are used to separate tag values
             in a tag list.  Only a single delimiter character may

--- a/mibs/junos/mib-rfc3635.txt
+++ b/mibs/junos/mib-rfc3635.txt
@@ -1,0 +1,1854 @@
+   EtherLike-MIB DEFINITIONS ::= BEGIN
+
+       IMPORTS
+           MODULE-IDENTITY, OBJECT-TYPE, OBJECT-IDENTITY,
+           Integer32, Counter32, Counter64, mib-2, transmission
+               FROM SNMPv2-SMI
+           MODULE-COMPLIANCE, OBJECT-GROUP
+               FROM SNMPv2-CONF
+           TruthValue
+               FROM SNMPv2-TC
+           ifIndex, InterfaceIndex
+               FROM IF-MIB;
+
+       etherMIB MODULE-IDENTITY
+           LAST-UPDATED "200309190000Z"  -- September 19, 2003
+           ORGANIZATION "IETF Ethernet Interfaces and Hub MIB
+                        Working Group"
+           CONTACT-INFO
+               "WG E-mail: hubmib@ietf.org
+             To subscribe: hubmib-request@ietf.org
+
+                    Chair: Dan Romascanu
+                   Postal: Avaya Inc.
+                           Atidum Technology Park, Bldg. 3
+                           Tel Aviv 61131
+                           Israel
+                      Tel: +972 3 645 8414
+                   E-mail: dromasca@avaya.com
+
+                  Editor: John Flick
+                  Postal: Hewlett-Packard Company
+                          8000 Foothills Blvd. M/S 5557
+                          Roseville, CA 95747-5557
+                          USA
+                     Tel: +1 916 785 4018
+                     Fax: +1 916 785 1199
+                  E-mail: johnf@rose.hp.com"
+
+           DESCRIPTION "The MIB module to describe generic objects for
+                       ethernet-like network interfaces.
+
+                       The following reference is used throughout this
+                       MIB module:
+
+                       [IEEE 802.3 Std] refers to:
+                          IEEE Std 802.3, 2002 Edition: 'IEEE Standard
+                          for Information technology -
+                          Telecommunications and information exchange
+                          between systems - Local and metropolitan
+                          area networks - Specific requirements -
+                          Part 3: Carrier sense multiple access with
+                          collision detection (CSMA/CD) access method
+                          and physical layer specifications', as
+                          amended by IEEE Std 802.3ae-2002:
+                          'Amendment: Media Access Control (MAC)
+                          Parameters, Physical Layer, and Management
+                          Parameters for 10 Gb/s Operation', August,
+                          2002.
+
+                       Of particular interest is Clause 30, '10 Mb/s,
+                       100 Mb/s, 1000 Mb/s, and 10 Gb/s Management'.
+
+                       Copyright (C) The Internet Society (2003).  This
+                       version of this MIB module is part of RFC 3635;
+                       see the RFC itself for full legal notices."
+
+           REVISION    "200309190000Z"  -- September 19, 2003
+           DESCRIPTION "Updated to include support for 10 Gb/sec
+                        interfaces.  This resulted in the following
+                        revisions:
+
+                        - Updated dot3StatsAlignmentErrors and
+                          dot3StatsSymbolErrors DESCRIPTIONs to
+                          reflect behaviour at 10 Gb/s
+                        - Added dot3StatsRateControlAbility and
+                          dot3RateControlStatus for management
+                          of the Rate Control function in 10 Gb/s
+                          WAN applications
+                        - Added 64-bit versions of all counters
+                          that are used on high-speed ethernet
+                          interfaces
+                        - Added object groups to contain the new
+                          objects
+                        - Deprecated etherStatsBaseGroup and
+                          split into etherStatsBaseGroup2 and
+                          etherStatsHalfDuplexGroup, so that
+                          interfaces which can only operate at
+                          full-duplex do not need to implement
+                          half-duplex-only statistics
+                        - Deprecated dot3Compliance and replaced
+                          it with dot3Compliance2, which includes
+                          the compliance information for the new
+                          object groups
+
+
+
+
+
+                        In addition, the dot3Tests and dot3Errors
+                        object identities have been deprecated,
+                        since there is no longer a standard method
+                        for using them.
+
+                        This version published as RFC 3635."
+
+           REVISION    "199908240400Z"  -- August 24, 1999
+           DESCRIPTION "Updated to include support for 1000 Mb/sec
+                        interfaces and full-duplex interfaces.
+                        This version published as RFC 2665."
+
+           REVISION    "199806032150Z"  -- June 3, 1998
+           DESCRIPTION "Updated to include support for 100 Mb/sec
+                        interfaces.
+                        This version published as RFC 2358."
+
+           REVISION    "199402030400Z"  -- February 3, 1994
+           DESCRIPTION "Initial version, published as RFC 1650."
+           ::= { mib-2 35 }
+
+       etherMIBObjects OBJECT IDENTIFIER ::= { etherMIB 1 }
+
+       dot3    OBJECT IDENTIFIER ::= { transmission 7 }
+
+       -- the Ethernet-like Statistics group
+
+       dot3StatsTable OBJECT-TYPE
+           SYNTAX     SEQUENCE OF Dot3StatsEntry
+           MAX-ACCESS not-accessible
+           STATUS     current
+           DESCRIPTION "Statistics for a collection of ethernet-like
+                       interfaces attached to a particular system.
+                       There will be one row in this table for each
+                       ethernet-like interface in the system."
+
+
+           ::= { dot3 2 }
+
+       dot3StatsEntry OBJECT-TYPE
+           SYNTAX     Dot3StatsEntry
+           MAX-ACCESS not-accessible
+           STATUS     current
+           DESCRIPTION "Statistics for a particular interface to an
+                       ethernet-like medium."
+           INDEX       { dot3StatsIndex }
+           ::= { dot3StatsTable 1 }
+
+       Dot3StatsEntry ::=
+           SEQUENCE {
+               dot3StatsIndex                      InterfaceIndex,
+               dot3StatsAlignmentErrors            Counter32,
+               dot3StatsFCSErrors                  Counter32,
+               dot3StatsSingleCollisionFrames      Counter32,
+               dot3StatsMultipleCollisionFrames    Counter32,
+               dot3StatsSQETestErrors              Counter32,
+               dot3StatsDeferredTransmissions      Counter32,
+               dot3StatsLateCollisions             Counter32,
+               dot3StatsExcessiveCollisions        Counter32,
+               dot3StatsInternalMacTransmitErrors  Counter32,
+               dot3StatsCarrierSenseErrors         Counter32,
+               dot3StatsFrameTooLongs              Counter32,
+               dot3StatsInternalMacReceiveErrors   Counter32,
+               dot3StatsEtherChipSet               OBJECT IDENTIFIER,
+               dot3StatsSymbolErrors               Counter32,
+               dot3StatsDuplexStatus               INTEGER,
+               dot3StatsRateControlAbility         TruthValue,
+               dot3StatsRateControlStatus          INTEGER
+           }
+
+       dot3StatsIndex OBJECT-TYPE
+           SYNTAX      InterfaceIndex
+           MAX-ACCESS  read-only  -- read-only since originally an
+                                  -- SMIv1 index
+           STATUS      current
+           DESCRIPTION "An index value that uniquely identifies an
+                       interface to an ethernet-like medium.  The
+                       interface identified by a particular value of
+                       this index is the same interface as identified
+                       by the same value of ifIndex."
+           REFERENCE   "RFC 2863, ifIndex"
+           ::= { dot3StatsEntry 1 }
+
+       dot3StatsAlignmentErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames received on a particular
+                       interface that are not an integral number of
+                       octets in length and do not pass the FCS check.
+
+                       The count represented by an instance of this
+                       object is incremented when the alignmentError
+                       status is returned by the MAC service to the
+                       LLC (or other MAC user). Received frames for
+                       which multiple error conditions pertain are,
+                       according to the conventions of IEEE 802.3
+                       Layer Management, counted exclusively according
+                       to the error status presented to the LLC.
+
+                       This counter does not increment for group
+                       encoding schemes greater than 4 bits per group.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCStatsAlignmentErrors object for 10 Gb/s
+                       or faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.7,
+                       aAlignmentErrors"
+           ::= { dot3StatsEntry 2 }
+
+       dot3StatsFCSErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames received on a particular
+                       interface that are an integral number of octets
+                       in length but do not pass the FCS check.  This
+                       count does not include frames received with
+                       frame-too-long or frame-too-short error.
+
+                       The count represented by an instance of this
+                       object is incremented when the frameCheckError
+                       status is returned by the MAC service to the
+                       LLC (or other MAC user). Received frames for
+                       which multiple error conditions pertain are,
+                       according to the conventions of IEEE 802.3
+                       Layer Management, counted exclusively according
+                       to the error status presented to the LLC.
+
+                       Note:  Coding errors detected by the physical
+                       layer for speeds above 10 Mb/s will cause the
+                       frame to fail the FCS check.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCStatsFCSErrors object for 10 Gb/s or
+                       faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.6,
+                       aFrameCheckSequenceErrors."
+           ::= { dot3StatsEntry 3 }
+
+       dot3StatsSingleCollisionFrames OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames that are involved in a single
+                       collision, and are subsequently transmitted
+                       successfully.
+
+                       A frame that is counted by an instance of this
+                       object is also counted by the corresponding
+                       instance of either the ifOutUcastPkts,
+                       ifOutMulticastPkts, or ifOutBroadcastPkts,
+                       and is not counted by the corresponding
+                       instance of the dot3StatsMultipleCollisionFrames
+                       object.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.3,
+                       aSingleCollisionFrames."
+           ::= { dot3StatsEntry 4 }
+
+       dot3StatsMultipleCollisionFrames OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames that are involved in more
+
+                       than one collision and are subsequently
+                       transmitted successfully.
+
+                       A frame that is counted by an instance of this
+                       object is also counted by the corresponding
+                       instance of either the ifOutUcastPkts,
+                       ifOutMulticastPkts, or ifOutBroadcastPkts,
+                       and is not counted by the corresponding
+                       instance of the dot3StatsSingleCollisionFrames
+                       object.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.4,
+                       aMultipleCollisionFrames."
+           ::= { dot3StatsEntry 5 }
+
+       dot3StatsSQETestErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of times that the SQE TEST ERROR
+                       is received on a particular interface. The
+                       SQE TEST ERROR is set in accordance with the
+                       rules for verification of the SQE detection
+                       mechanism in the PLS Carrier Sense Function as
+                       described in IEEE Std. 802.3, 2000 Edition,
+                       section 7.2.4.6.
+
+                       This counter does not increment on interfaces
+                       operating at speeds greater than 10 Mb/s, or on
+                       interfaces operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 7.2.4.6, also 30.3.2.1.4,
+                       aSQETestErrors."
+           ::= { dot3StatsEntry 6 }
+
+       dot3StatsDeferredTransmissions OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames for which the first
+                       transmission attempt on a particular interface
+                       is delayed because the medium is busy.
+
+                       The count represented by an instance of this
+                       object does not include frames involved in
+                       collisions.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.9,
+                       aFramesWithDeferredXmissions."
+           ::= { dot3StatsEntry 7 }
+
+       dot3StatsLateCollisions OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "The number of times that a collision is
+                       detected on a particular interface later than
+                       one slotTime into the transmission of a packet.
+
+                       A (late) collision included in a count
+                       represented by an instance of this object is
+                       also considered as a (generic) collision for
+                       purposes of other collision-related
+                       statistics.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.10,
+                       aLateCollisions."
+           ::= { dot3StatsEntry 8 }
+
+       dot3StatsExcessiveCollisions OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames for which transmission on a
+                       particular interface fails due to excessive
+                       collisions.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.11,
+                       aFramesAbortedDueToXSColls."
+           ::= { dot3StatsEntry 9 }
+
+       dot3StatsInternalMacTransmitErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames for which transmission on a
+                       particular interface fails due to an internal
+                       MAC sublayer transmit error. A frame is only
+                       counted by an instance of this object if it is
+                       not counted by the corresponding instance of
+                       either the dot3StatsLateCollisions object, the
+                       dot3StatsExcessiveCollisions object, or the
+                       dot3StatsCarrierSenseErrors object.
+
+                       The precise meaning of the count represented by
+                       an instance of this object is implementation-
+                       specific.  In particular, an instance of this
+                       object may represent a count of transmission
+                       errors on a particular interface that are not
+                       otherwise counted.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCStatsInternalMacTransmitErrors object for
+                       10 Gb/s or faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.12,
+                       aFramesLostDueToIntMACXmitError."
+           ::= { dot3StatsEntry 10 }
+
+       dot3StatsCarrierSenseErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "The number of times that the carrier sense
+                       condition was lost or never asserted when
+                       attempting to transmit a frame on a particular
+                       interface.
+
+                       The count represented by an instance of this
+                       object is incremented at most once per
+                       transmission attempt, even if the carrier sense
+                       condition fluctuates during a transmission
+                       attempt.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.13,
+                       aCarrierSenseErrors."
+           ::= { dot3StatsEntry 11 }
+
+       -- { dot3StatsEntry 12 } is not assigned
+
+       dot3StatsFrameTooLongs OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames received on a particular
+                       interface that exceed the maximum permitted
+                       frame size.
+
+                       The count represented by an instance of this
+                       object is incremented when the frameTooLong
+                       status is returned by the MAC service to the
+                       LLC (or other MAC user). Received frames for
+                       which multiple error conditions pertain are,
+                       according to the conventions of IEEE 802.3
+                       Layer Management, counted exclusively according
+                       to the error status presented to the LLC.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 80 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCStatsFrameTooLongs object for 10 Gb/s
+                       or faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.25,
+                       aFrameTooLongErrors."
+           ::= { dot3StatsEntry 13 }
+
+       -- { dot3StatsEntry 14 } is not assigned
+
+       -- { dot3StatsEntry 15 } is not assigned
+
+       dot3StatsInternalMacReceiveErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames for which reception on a
+                       particular interface fails due to an internal
+                       MAC sublayer receive error. A frame is only
+                       counted by an instance of this object if it is
+                       not counted by the corresponding instance of
+                       either the dot3StatsFrameTooLongs object, the
+                       dot3StatsAlignmentErrors object, or the
+                       dot3StatsFCSErrors object.
+
+                       The precise meaning of the count represented by
+                       an instance of this object is implementation-
+                       specific.  In particular, an instance of this
+                       object may represent a count of receive errors
+                       on a particular interface that are not
+                       otherwise counted.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCStatsInternalMacReceiveErrors object for
+                       10 Gb/s or faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.15,
+                       aFramesLostDueToIntMACRcvError."
+           ::= { dot3StatsEntry 16 }
+
+       dot3StatsEtherChipSet OBJECT-TYPE
+           SYNTAX      OBJECT IDENTIFIER
+           MAX-ACCESS  read-only
+           STATUS      deprecated
+           DESCRIPTION "******** THIS OBJECT IS DEPRECATED ********
+
+                       This object contains an OBJECT IDENTIFIER
+                       which identifies the chipset used to
+                       realize the interface. Ethernet-like
+                       interfaces are typically built out of
+                       several different chips. The MIB implementor
+                       is presented with a decision of which chip
+                       to identify via this object. The implementor
+                       should identify the chip which is usually
+                       called the Medium Access Control chip.
+                       If no such chip is easily identifiable,
+                       the implementor should identify the chip
+                       which actually gathers the transmit
+                       and receive statistics and error
+                       indications. This would allow a
+                       manager station to correlate the
+                       statistics and the chip generating
+                       them, giving it the ability to take
+                       into account any known anomalies
+                       in the chip.
+
+                       This object has been deprecated.  Implementation
+                       feedback indicates that it is of limited use for
+                       debugging network problems in the field, and
+                       the administrative overhead involved in
+                       maintaining a registry of chipset OIDs is not
+                       justified."
+           ::= { dot3StatsEntry 17 }
+
+       dot3StatsSymbolErrors OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "For an interface operating at 100 Mb/s, the
+                       number of times there was an invalid data symbol
+                       when a valid carrier was present.
+
+                       For an interface operating in half-duplex mode
+                       at 1000 Mb/s, the number of times the receiving
+                       media is non-idle (a carrier event) for a period
+                       of time equal to or greater than slotTime, and
+                       during which there was at least one occurrence
+                       of an event that causes the PHY to indicate
+                       'Data reception error' or 'carrier extend error'
+                       on the GMII.
+
+                       For an interface operating in full-duplex mode
+                       at 1000 Mb/s, the number of times the receiving
+                       media is non-idle (a carrier event) for a period
+                       of time equal to or greater than minFrameSize,
+                       and during which there was at least one
+                       occurrence of an event that causes the PHY to
+                       indicate 'Data reception error' on the GMII.
+
+                       For an interface operating at 10 Gb/s, the
+                       number of times the receiving media is non-idle
+                       (a carrier event) for a period of time equal to
+                       or greater than minFrameSize, and during which
+                       there was at least one occurrence of an event
+                       that causes the PHY to indicate 'Receive Error'
+                       on the XGMII.
+
+                       The count represented by an instance of this
+                       object is incremented at most once per carrier
+                       event, even if multiple symbol errors occur
+                       during the carrier event.  This count does
+                       not increment if a collision is present.
+
+                       This counter does not increment when the
+                       interface is operating at 10 Mb/s.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCStatsSymbolErrors object for 10 Gb/s
+                       or faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.2.1.5,
+                       aSymbolErrorDuringCarrier."
+           ::= { dot3StatsEntry 18 }
+
+       dot3StatsDuplexStatus OBJECT-TYPE
+           SYNTAX      INTEGER {
+                           unknown(1),
+                           halfDuplex(2),
+                           fullDuplex(3)
+                       }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "The current mode of operation of the MAC
+                       entity.  'unknown' indicates that the current
+                       duplex mode could not be determined.
+
+                       Management control of the duplex mode is
+                       accomplished through the MAU MIB.  When
+                       an interface does not support autonegotiation,
+                       or when autonegotiation is not enabled, the
+                       duplex mode is controlled using
+                       ifMauDefaultType.  When autonegotiation is
+                       supported and enabled, duplex mode is controlled
+                       using ifMauAutoNegAdvertisedBits.  In either
+                       case, the currently operating duplex mode is
+                       reflected both in this object and in ifMauType.
+
+                       Note that this object provides redundant
+                       information with ifMauType.  Normally, redundant
+                       objects are discouraged.  However, in this
+                       instance, it allows a management application to
+                       determine the duplex status of an interface
+                       without having to know every possible value of
+                       ifMauType.  This was felt to be sufficiently
+                       valuable to justify the redundancy."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.32,
+                       aDuplexStatus."
+           ::= { dot3StatsEntry 19 }
+
+       dot3StatsRateControlAbility OBJECT-TYPE
+           SYNTAX      TruthValue
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "'true' for interfaces operating at speeds above
+                       1000 Mb/s that support Rate Control through
+                       lowering the average data rate of the MAC
+                       sublayer, with frame granularity, and 'false'
+                       otherwise."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.33,
+                       aRateControlAbility."
+           ::= { dot3StatsEntry 20 }
+
+       dot3StatsRateControlStatus OBJECT-TYPE
+           SYNTAX      INTEGER {
+                           rateControlOff(1),
+                           rateControlOn(2),
+                           unknown(3)
+                       }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "The current Rate Control mode of operation of
+                       the MAC sublayer of this interface."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.34,
+                       aRateControlStatus."
+           ::= { dot3StatsEntry 21 }
+
+       -- the Ethernet-like Collision Statistics group
+
+       -- Implementation of this group is optional; it is appropriate
+       -- for all systems which have the necessary metering
+
+       dot3CollTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Dot3CollEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "A collection of collision histograms for a
+                       particular set of interfaces."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.30,
+                       aCollisionFrames."
+
+
+           ::= { dot3 5 }
+
+       dot3CollEntry OBJECT-TYPE
+           SYNTAX      Dot3CollEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "A cell in the histogram of per-frame
+                       collisions for a particular interface.  An
+                       instance of this object represents the
+                       frequency of individual MAC frames for which
+                       the transmission (successful or otherwise) on a
+                       particular interface is accompanied by a
+                       particular number of media collisions."
+           INDEX       { ifIndex, dot3CollCount }
+           ::= { dot3CollTable 1 }
+
+       Dot3CollEntry ::=
+           SEQUENCE {
+               dot3CollCount        Integer32,
+               dot3CollFrequencies  Counter32
+           }
+
+       -- { dot3CollEntry 1 } is no longer in use
+
+       dot3CollCount OBJECT-TYPE
+           SYNTAX      Integer32 (1..16)
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "The number of per-frame media collisions for
+                       which a particular collision histogram cell
+                       represents the frequency on a particular
+                       interface."
+           ::= { dot3CollEntry 2 }
+
+       dot3CollFrequencies OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of individual MAC frames for which the
+                       transmission (successful or otherwise) on a
+                       particular interface occurs after the
+                       frame has experienced exactly the number
+                       of collisions in the associated
+                       dot3CollCount object.
+
+                       For example, a frame which is transmitted
+                       on interface 77 after experiencing
+                       exactly 4 collisions would be indicated
+                       by incrementing only dot3CollFrequencies.77.4.
+                       No other instance of dot3CollFrequencies would
+                       be incremented in this example.
+
+                       This counter does not increment when the
+                       interface is operating in full-duplex mode.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           ::= { dot3CollEntry 3 }
+
+       dot3ControlTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Dot3ControlEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "A table of descriptive and status information
+                       about the MAC Control sublayer on the
+                       ethernet-like interfaces attached to a
+                       particular system.  There will be one row in
+                       this table for each ethernet-like interface in
+                       the system which implements the MAC Control
+                       sublayer.  If some, but not all, of the
+                       ethernet-like interfaces in the system implement
+                       the MAC Control sublayer, there will be fewer
+                       rows in this table than in the dot3StatsTable."
+
+
+           ::= { dot3 9 }
+
+       dot3ControlEntry OBJECT-TYPE
+           SYNTAX      Dot3ControlEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "An entry in the table, containing information
+                       about the MAC Control sublayer on a single
+                       ethernet-like interface."
+           INDEX       { dot3StatsIndex }
+           ::= { dot3ControlTable 1 }
+
+       Dot3ControlEntry ::=
+           SEQUENCE {
+               dot3ControlFunctionsSupported       BITS,
+               dot3ControlInUnknownOpcodes         Counter32,
+               dot3HCControlInUnknownOpcodes       Counter64
+           }
+
+       dot3ControlFunctionsSupported OBJECT-TYPE
+           SYNTAX      BITS {
+                           pause(0)   -- 802.3 flow control
+                       }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A list of the possible MAC Control functions
+                       implemented for this interface."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.3.2,
+                       aMACControlFunctionsSupported."
+           ::= { dot3ControlEntry 1 }
+
+       dot3ControlInUnknownOpcodes OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of MAC Control frames received on this
+                       interface that contain an opcode that is not
+                       supported by this device.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCControlInUnknownOpcodes object for 10 Gb/s
+                       or faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.3.5,
+                       aUnsupportedOpcodesReceived"
+           ::= { dot3ControlEntry 2 }
+
+       dot3HCControlInUnknownOpcodes OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of MAC Control frames received on this
+                       interface that contain an opcode that is not
+                       supported by this device.
+
+                       This counter is a 64 bit version of
+                       dot3ControlInUnknownOpcodes.  It should be used
+                       on interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.3.5,
+                       aUnsupportedOpcodesReceived"
+           ::= { dot3ControlEntry 3 }
+
+       dot3PauseTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Dot3PauseEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "A table of descriptive and status information
+                       about the MAC Control PAUSE function on the
+                       ethernet-like interfaces attached to a
+                       particular system. There will be one row in
+                       this table for each ethernet-like interface in
+                       the system which supports the MAC Control PAUSE
+                       function (i.e., the 'pause' bit in the
+                       corresponding instance of
+                       dot3ControlFunctionsSupported is set).  If some,
+                       but not all, of the ethernet-like interfaces in
+                       the system implement the MAC Control PAUSE
+                       function (for example, if some interfaces only
+                       support half-duplex), there will be fewer rows
+                       in this table than in the dot3StatsTable."
+
+
+           ::= { dot3 10 }
+
+       dot3PauseEntry OBJECT-TYPE
+           SYNTAX      Dot3PauseEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "An entry in the table, containing information
+                       about the MAC Control PAUSE function on a single
+                       ethernet-like interface."
+           INDEX       { dot3StatsIndex }
+           ::= { dot3PauseTable 1 }
+
+       Dot3PauseEntry ::=
+
+           SEQUENCE {
+               dot3PauseAdminMode                  INTEGER,
+               dot3PauseOperMode                   INTEGER,
+               dot3InPauseFrames                   Counter32,
+               dot3OutPauseFrames                  Counter32,
+               dot3HCInPauseFrames                 Counter64,
+               dot3HCOutPauseFrames                Counter64
+           }
+
+       dot3PauseAdminMode OBJECT-TYPE
+           SYNTAX      INTEGER {
+                           disabled(1),
+                           enabledXmit(2),
+                           enabledRcv(3),
+                           enabledXmitAndRcv(4)
+                       }
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION "This object is used to configure the default
+                       administrative PAUSE mode for this interface.
+
+                       This object represents the
+                       administratively-configured PAUSE mode for this
+                       interface.  If auto-negotiation is not enabled
+                       or is not implemented for the active MAU
+                       attached to this interface, the value of this
+                       object determines the operational PAUSE mode
+                       of the interface whenever it is operating in
+                       full-duplex mode.  In this case, a set to this
+                       object will force the interface into the
+                       specified mode.
+
+                       If auto-negotiation is implemented and enabled
+                       for the MAU attached to this interface, the
+                       PAUSE mode for this interface is determined by
+                       auto-negotiation, and the value of this object
+                       denotes the mode to which the interface will
+                       automatically revert if/when auto-negotiation is
+                       later disabled.  Note that when auto-negotiation
+                       is running, administrative control of the PAUSE
+                       mode may be accomplished using the
+                       ifMauAutoNegCapAdvertisedBits object in the
+                       MAU-MIB.
+
+                       Note that the value of this object is ignored
+                       when the interface is not operating in
+                       full-duplex mode.
+
+                       An attempt to set this object to
+                       'enabledXmit(2)' or 'enabledRcv(3)' will fail
+                       on interfaces that do not support operation
+                       at greater than 100 Mb/s."
+           ::= { dot3PauseEntry 1 }
+
+       dot3PauseOperMode OBJECT-TYPE
+           SYNTAX      INTEGER {
+                           disabled(1),
+                           enabledXmit(2),
+                           enabledRcv(3),
+                           enabledXmitAndRcv(4)
+                       }
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "This object reflects the PAUSE mode currently
+                       in use on this interface, as determined by
+                       either (1) the result of the auto-negotiation
+                       function or (2) if auto-negotiation is not
+                       enabled or is not implemented for the active MAU
+                       attached to this interface, by the value of
+                       dot3PauseAdminMode.  Interfaces operating at
+                       100 Mb/s or less will never return
+                       'enabledXmit(2)' or 'enabledRcv(3)'.  Interfaces
+                       operating in half-duplex mode will always return
+                       'disabled(1)'.  Interfaces on which
+                       auto-negotiation is enabled but not yet
+                       completed should return the value
+                       'disabled(1)'."
+           ::= { dot3PauseEntry 2 }
+
+       dot3InPauseFrames OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of MAC Control frames received on this
+                       interface with an opcode indicating the PAUSE
+                       operation.
+
+                       This counter does not increment when the
+                       interface is operating in half-duplex mode.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCInPauseFrames object for 10 Gb/s or
+                       faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.4.3,
+                       aPAUSEMACCtrlFramesReceived."
+           ::= { dot3PauseEntry 3 }
+
+       dot3OutPauseFrames OBJECT-TYPE
+           SYNTAX      Counter32
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of MAC Control frames transmitted on
+                       this interface with an opcode indicating the
+                       PAUSE operation.
+
+                       This counter does not increment when the
+                       interface is operating in half-duplex mode.
+
+                       For interfaces operating at 10 Gb/s, this
+                       counter can roll over in less than 5 minutes if
+                       it is incrementing at its maximum rate.  Since
+                       that amount of time could be less than a
+                       management station's poll cycle time, in order
+                       to avoid a loss of information, a management
+                       station is advised to poll the
+                       dot3HCOutPauseFrames object for 10 Gb/s or
+                       faster interfaces.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.4.2,
+                       aPAUSEMACCtrlFramesTransmitted."
+           ::= { dot3PauseEntry 4 }
+
+       dot3HCInPauseFrames OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of MAC Control frames received on this
+                       interface with an opcode indicating the PAUSE
+                       operation.
+
+                       This counter does not increment when the
+                       interface is operating in half-duplex mode.
+
+                       This counter is a 64 bit version of
+                       dot3InPauseFrames.  It should be used on
+                       interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.4.3,
+                       aPAUSEMACCtrlFramesReceived."
+           ::= { dot3PauseEntry 5 }
+       dot3HCOutPauseFrames OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of MAC Control frames transmitted on
+                       this interface with an opcode indicating the
+                       PAUSE operation.
+
+                       This counter does not increment when the
+                       interface is operating in half-duplex mode.
+
+                       This counter is a 64 bit version of
+                       dot3OutPauseFrames.  It should be used on
+                       interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.4.2,
+                       aPAUSEMACCtrlFramesTransmitted."
+           ::= { dot3PauseEntry 6 }
+
+       dot3HCStatsTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF Dot3HCStatsEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "A table containing 64-bit versions of error
+                       counters from the dot3StatsTable.  The 32-bit
+                       versions of these counters may roll over quite
+                       quickly on higher speed ethernet interfaces.
+                       The counters that have 64-bit versions in this
+                       table are the counters that apply to full-duplex
+                       interfaces, since 10 Gb/s and faster
+                       ethernet-like interfaces do not support
+                       half-duplex, and very few 1000 Mb/s
+                       ethernet-like interfaces support half-duplex.
+
+                       Entries in this table are recommended for
+                       interfaces capable of operating at 1000 Mb/s or
+                       faster, and are required for interfaces capable
+                       of operating at 10 Gb/s or faster.  Lower speed
+                       ethernet-like interfaces do not need entries in
+                       this table, in which case there may be fewer
+                       entries in this table than in the
+                       dot3StatsTable. However, implementations
+                       containing interfaces with a mix of speeds may
+                       choose to implement entries in this table for
+                       all ethernet-like interfaces."
+           ::= { dot3 11 }
+
+       dot3HCStatsEntry OBJECT-TYPE
+           SYNTAX      Dot3HCStatsEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION "An entry containing 64-bit statistics for a
+                       single ethernet-like interface."
+           INDEX       { dot3StatsIndex }
+           ::= { dot3HCStatsTable 1 }
+
+       Dot3HCStatsEntry ::=
+           SEQUENCE {
+               dot3HCStatsAlignmentErrors           Counter64,
+               dot3HCStatsFCSErrors                 Counter64,
+               dot3HCStatsInternalMacTransmitErrors Counter64,
+               dot3HCStatsFrameTooLongs             Counter64,
+               dot3HCStatsInternalMacReceiveErrors  Counter64,
+               dot3HCStatsSymbolErrors              Counter64
+           }
+
+       dot3HCStatsAlignmentErrors OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames received on a particular
+                       interface that are not an integral number of
+                       octets in length and do not pass the FCS check.
+
+                       The count represented by an instance of this
+                       object is incremented when the alignmentError
+                       status is returned by the MAC service to the
+                       LLC (or other MAC user). Received frames for
+                       which multiple error conditions pertain are,
+                       according to the conventions of IEEE 802.3
+                       Layer Management, counted exclusively according
+                       to the error status presented to the LLC.
+
+                       This counter does not increment for group
+                       encoding schemes greater than 4 bits per group.
+
+                       This counter is a 64 bit version of
+                       dot3StatsAlignmentErrors.  It should be used
+                       on interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.7,
+                       aAlignmentErrors"
+           ::= { dot3HCStatsEntry 1 }
+
+       dot3HCStatsFCSErrors OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames received on a particular
+                       interface that are an integral number of octets
+                       in length but do not pass the FCS check.  This
+                       count does not include frames received with
+                       frame-too-long or frame-too-short error.
+
+                       The count represented by an instance of this
+                       object is incremented when the frameCheckError
+                       status is returned by the MAC service to the
+                       LLC (or other MAC user). Received frames for
+                       which multiple error conditions pertain are,
+                       according to the conventions of IEEE 802.3
+                       Layer Management, counted exclusively according
+                       to the error status presented to the LLC.
+
+                       Note:  Coding errors detected by the physical
+                       layer for speeds above 10 Mb/s will cause the
+                       frame to fail the FCS check.
+
+                       This counter is a 64 bit version of
+                       dot3StatsFCSErrors.  It should be used on
+                       interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.6,
+                       aFrameCheckSequenceErrors."
+           ::= { dot3HCStatsEntry 2 }
+
+       dot3HCStatsInternalMacTransmitErrors OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames for which transmission on a
+                       particular interface fails due to an internal
+                       MAC sublayer transmit error. A frame is only
+                       counted by an instance of this object if it is
+                       not counted by the corresponding instance of
+                       either the dot3StatsLateCollisions object, the
+                       dot3StatsExcessiveCollisions object, or the
+                       dot3StatsCarrierSenseErrors object.
+
+                       The precise meaning of the count represented by
+                       an instance of this object is implementation-
+                       specific.  In particular, an instance of this
+                       object may represent a count of transmission
+                       errors on a particular interface that are not
+                       otherwise counted.
+
+                       This counter is a 64 bit version of
+                       dot3StatsInternalMacTransmitErrors.  It should
+                       be used on interfaces operating at 10 Gb/s or
+                       faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.12,
+                       aFramesLostDueToIntMACXmitError."
+           ::= { dot3HCStatsEntry 3 }
+
+       dot3HCStatsFrameTooLongs OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames received on a particular
+                       interface that exceed the maximum permitted
+                       frame size.
+
+                       The count represented by an instance of this
+                       object is incremented when the frameTooLong
+                       status is returned by the MAC service to the
+                       LLC (or other MAC user). Received frames for
+                       which multiple error conditions pertain are,
+                       according to the conventions of IEEE 802.3
+                       Layer Management, counted exclusively according
+                       to the error status presented to the LLC.
+
+                       This counter is a 64 bit version of
+                       dot3StatsFrameTooLongs.  It should be used on
+                       interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.25,
+                       aFrameTooLongErrors."
+           ::= { dot3HCStatsEntry 4 }
+
+       dot3HCStatsInternalMacReceiveErrors OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "A count of frames for which reception on a
+                       particular interface fails due to an internal
+                       MAC sublayer receive error. A frame is only
+                       counted by an instance of this object if it is
+                       not counted by the corresponding instance of
+                       either the dot3StatsFrameTooLongs object, the
+                       dot3StatsAlignmentErrors object, or the
+                       dot3StatsFCSErrors object.
+
+                       The precise meaning of the count represented by
+                       an instance of this object is implementation-
+                       specific.  In particular, an instance of this
+                       object may represent a count of receive errors
+                       on a particular interface that are not
+                       otherwise counted.
+
+                       This counter is a 64 bit version of
+                       dot3StatsInternalMacReceiveErrors.  It should be
+                       used on interfaces operating at 10 Gb/s or
+                       faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.1.1.15,
+                       aFramesLostDueToIntMACRcvError."
+           ::= { dot3HCStatsEntry 5 }
+
+       dot3HCStatsSymbolErrors OBJECT-TYPE
+           SYNTAX      Counter64
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION "For an interface operating at 100 Mb/s, the
+                       number of times there was an invalid data symbol
+                       when a valid carrier was present.
+                       For an interface operating in half-duplex mode
+                       at 1000 Mb/s, the number of times the receiving
+                       media is non-idle (a carrier event) for a period
+                       of time equal to or greater than slotTime, and
+                       during which there was at least one occurrence
+                       of an event that causes the PHY to indicate
+                       'Data reception error' or 'carrier extend error'
+                       on the GMII.
+
+                       For an interface operating in full-duplex mode
+                       at 1000 Mb/s, the number of times the receiving
+                       media is non-idle (a carrier event) for a period
+                       of time equal to or greater than minFrameSize,
+                       and during which there was at least one
+                       occurrence of an event that causes the PHY to
+                       indicate 'Data reception error' on the GMII.
+
+                       For an interface operating at 10 Gb/s, the
+                       number of times the receiving media is non-idle
+                       (a carrier event) for a period of time equal to
+                       or greater than minFrameSize, and during which
+                       there was at least one occurrence of an event
+                       that causes the PHY to indicate 'Receive Error'
+                       on the XGMII.
+
+                       The count represented by an instance of this
+                       object is incremented at most once per carrier
+                       event, even if multiple symbol errors occur
+                       during the carrier event.  This count does
+                       not increment if a collision is present.
+
+                       This counter is a 64 bit version of
+                       dot3StatsSymbolErrors.  It should be used on
+                       interfaces operating at 10 Gb/s or faster.
+
+                       Discontinuities in the value of this counter can
+                       occur at re-initialization of the management
+                       system, and at other times as indicated by the
+                       value of ifCounterDiscontinuityTime."
+           REFERENCE   "[IEEE 802.3 Std.], 30.3.2.1.5,
+                       aSymbolErrorDuringCarrier."
+           ::= { dot3HCStatsEntry 6 }
+
+
+       --  802.3 Tests
+
+       dot3Tests   OBJECT IDENTIFIER ::= { dot3 6 }
+
+       dot3Errors  OBJECT IDENTIFIER ::= { dot3 7 }
+
+       --  TDR Test
+
+       dot3TestTdr OBJECT-IDENTITY
+           STATUS      deprecated
+           DESCRIPTION "******** THIS IDENTITY IS DEPRECATED *******
+
+                       The Time-Domain Reflectometry (TDR) test is
+                       specific to ethernet-like interfaces of type
+                       10Base5 and 10Base2.  The TDR value may be
+                       useful in determining the approximate distance
+                       to a cable fault.  It is advisable to repeat
+                       this test to check for a consistent resulting
+                       TDR value, to verify that there is a fault.
+
+                       A TDR test returns as its result the time
+                       interval, measured in 10 MHz ticks or 100 nsec
+                       units, between the start of TDR test
+                       transmission and the subsequent detection of a
+                       collision or deassertion of carrier.  On
+                       successful completion of a TDR test, the result
+                       is stored as the value of an appropriate
+                       instance of an appropriate vendor specific MIB
+                       object, and the OBJECT IDENTIFIER of that
+                       instance is stored in the appropriate instance
+                       of the appropriate test result code object
+                       (thereby indicating where the result has been
+                       stored).
+
+                       This object identity has been deprecated, since
+                       the ifTestTable in the IF-MIB was deprecated,
+                       and there is no longer a standard mechanism for
+                       initiating an interface test.  This left no
+                       standard way of using this object identity."
+           ::= { dot3Tests 1 }
+
+       -- Loopback Test
+
+       dot3TestLoopBack OBJECT-IDENTITY
+           STATUS      deprecated
+           DESCRIPTION "******** THIS IDENTITY IS DEPRECATED *******
+
+                       This test configures the MAC chip and executes
+                       an internal loopback test of memory, data paths,
+                       and the MAC chip logic.  This loopback test can
+                       only be executed if the interface is offline.
+                       Once the test has completed, the MAC chip should
+                       be reinitialized for network operation, but it
+                       should remain offline.
+
+                       If an error occurs during a test, the
+                       appropriate test result object will be set
+                       to indicate a failure.  The two OBJECT
+                       IDENTIFIER values dot3ErrorInitError and
+                       dot3ErrorLoopbackError may be used to provided
+                       more information as values for an appropriate
+                       test result code object.
+
+                       This object identity has been deprecated, since
+                       the ifTestTable in the IF-MIB was deprecated,
+                       and there is no longer a standard mechanism for
+                       initiating an interface test.  This left no
+                       standard way of using this object identity."
+           ::= { dot3Tests 2 }
+
+       dot3ErrorInitError OBJECT-IDENTITY
+           STATUS      deprecated
+           DESCRIPTION "******** THIS IDENTITY IS DEPRECATED *******
+
+                       Couldn't initialize MAC chip for test.
+
+                       This object identity has been deprecated, since
+                       the ifTestTable in the IF-MIB was deprecated,
+                       and there is no longer a standard mechanism for
+                       initiating an interface test.  This left no
+                       standard way of using this object identity."
+           ::= { dot3Errors 1 }
+
+       dot3ErrorLoopbackError OBJECT-IDENTITY
+           STATUS      deprecated
+           DESCRIPTION "******** THIS IDENTITY IS DEPRECATED *******
+
+                       Expected data not received (or not received
+                       correctly) in loopback test.
+
+                       This object identity has been deprecated, since
+                       the ifTestTable in the IF-MIB was deprecated,
+                       and there is no longer a standard mechanism for
+                       initiating an interface test.  This left no
+                       standard way of using this object identity."
+           ::= { dot3Errors 2 }
+
+       -- { dot3 8 }, the dot3ChipSets tree, is defined in [RFC2666]
+
+       -- conformance information
+
+       etherConformance OBJECT IDENTIFIER ::= { etherMIB 2 }
+
+       etherGroups      OBJECT IDENTIFIER ::= { etherConformance 1 }
+       etherCompliances OBJECT IDENTIFIER ::= { etherConformance 2 }
+
+       -- compliance statements
+
+       etherCompliance MODULE-COMPLIANCE
+           STATUS      deprecated
+           DESCRIPTION "******** THIS COMPLIANCE IS DEPRECATED ********
+
+                       The compliance statement for managed network
+                       entities which have ethernet-like network
+                       interfaces.
+
+                       This compliance is deprecated and replaced by
+                       dot3Compliance."
+
+           MODULE  -- this module
+               MANDATORY-GROUPS { etherStatsGroup }
+
+               GROUP       etherCollisionTableGroup
+               DESCRIPTION "This group is optional. It is appropriate
+                           for all systems which have the necessary
+                           metering. Implementation in such systems is
+                           highly recommended."
+           ::= { etherCompliances 1 }
+
+       ether100MbsCompliance MODULE-COMPLIANCE
+           STATUS      deprecated
+           DESCRIPTION "******** THIS COMPLIANCE IS DEPRECATED ********
+
+                       The compliance statement for managed network
+                       entities which have 100 Mb/sec ethernet-like
+                       network interfaces.
+
+                       This compliance is deprecated and replaced by
+                       dot3Compliance."
+
+           MODULE  -- this module
+               MANDATORY-GROUPS { etherStats100MbsGroup }
+
+               GROUP       etherCollisionTableGroup
+               DESCRIPTION "This group is optional. It is appropriate
+                           for all systems which have the necessary
+                           metering. Implementation in such systems is
+                           highly recommended."
+           ::= { etherCompliances 2 }
+
+       dot3Compliance MODULE-COMPLIANCE
+           STATUS      deprecated
+           DESCRIPTION "******** THIS COMPLIANCE IS DEPRECATED ********
+
+                       The compliance statement for managed network
+                       entities which have ethernet-like network
+                       interfaces.
+
+                       This compliance is deprecated and replaced by
+                       dot3Compliance2."
+
+           MODULE  -- this module
+               MANDATORY-GROUPS { etherStatsBaseGroup }
+
+               GROUP       etherDuplexGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating in full-duplex mode.
+                           It is highly recommended for all
+                           ethernet-like network interfaces."
+
+               GROUP       etherStatsLowSpeedGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating at 10 Mb/s or slower in
+                           half-duplex mode."
+
+               GROUP       etherStatsHighSpeedGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating at 100 Mb/s or faster."
+
+               GROUP       etherControlGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces that
+                           support the MAC Control sublayer."
+
+               GROUP       etherControlPauseGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces that
+                           support the MAC Control PAUSE function."
+
+               GROUP       etherCollisionTableGroup
+               DESCRIPTION "This group is optional. It is appropriate
+                           for all ethernet-like network interfaces
+                           which are capable of operating in
+                           half-duplex mode and have the necessary
+                           metering. Implementation in systems with
+                           such interfaces is highly recommended."
+           ::= { etherCompliances 3 }
+
+           dot3Compliance2 MODULE-COMPLIANCE
+               STATUS      current
+               DESCRIPTION "The compliance statement for managed network
+                           entities which have ethernet-like network
+                           interfaces.
+
+                           Note that compliance with this MIB module
+                           requires compliance with the ifCompliance3
+                           MODULE-COMPLIANCE statement of the IF-MIB
+                           (RFC2863).  In addition, compliance with this
+                           MIB module requires compliance  with the
+                           mauModIfCompl3 MODULE-COMPLIANCE statement of
+                           the MAU-MIB (RFC3636)."
+
+           MODULE  -- this module
+               MANDATORY-GROUPS { etherStatsBaseGroup2 }
+
+               GROUP       etherDuplexGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating in full-duplex mode.
+                           It is highly recommended for all
+                           ethernet-like network interfaces."
+
+               GROUP       etherRateControlGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating at speeds faster than
+                           1000 Mb/s. It is highly recommended for all
+                           ethernet-like network interfaces."
+
+               GROUP       etherStatsLowSpeedGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating at 10 Mb/s or slower in
+                           half-duplex mode."
+
+               GROUP       etherStatsHighSpeedGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating at 100 Mb/s or faster."
+
+               GROUP       etherStatsHalfDuplexGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating in half-duplex mode."
+
+               GROUP       etherHCStatsGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces which are
+                           capable of operating at 10 Gb/s or faster.
+                           It is recommended for all ethernet-like
+                           network interfaces which are capable of
+                           operating at 1000 Mb/s or faster."
+
+               GROUP       etherControlGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces that
+                           support the MAC Control sublayer."
+
+               GROUP       etherHCControlGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces that
+                           support the MAC Control sublayer and are
+                           capable of operating at 10 Gb/s or faster."
+
+               GROUP       etherControlPauseGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces that
+                           support the MAC Control PAUSE function."
+
+               GROUP       etherHCControlPauseGroup
+               DESCRIPTION "This group is mandatory for all
+                           ethernet-like network interfaces that
+                           support the MAC Control PAUSE function and
+                           are capable of operating at 10 Gb/s or
+                           faster."
+
+               GROUP       etherCollisionTableGroup
+               DESCRIPTION "This group is optional. It is appropriate
+                           for all ethernet-like network interfaces
+                           which are capable of operating in
+                           half-duplex mode and have the necessary
+                           metering. Implementation in systems with
+                           such interfaces is highly recommended."
+           ::= { etherCompliances 4 }
+
+       -- units of conformance
+
+       etherStatsGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsIndex,
+                         dot3StatsAlignmentErrors,
+                         dot3StatsFCSErrors,
+                         dot3StatsSingleCollisionFrames,
+                         dot3StatsMultipleCollisionFrames,
+                         dot3StatsSQETestErrors,
+                         dot3StatsDeferredTransmissions,
+                         dot3StatsLateCollisions,
+                         dot3StatsExcessiveCollisions,
+                         dot3StatsInternalMacTransmitErrors,
+                         dot3StatsCarrierSenseErrors,
+                         dot3StatsFrameTooLongs,
+                         dot3StatsInternalMacReceiveErrors,
+                         dot3StatsEtherChipSet
+                       }
+           STATUS      deprecated
+           DESCRIPTION "********* THIS GROUP IS DEPRECATED **********
+
+                       A collection of objects providing information
+                       applicable to all ethernet-like network
+                       interfaces.
+
+                       This object group has been deprecated and
+                       replaced by etherStatsBaseGroup and
+                       etherStatsLowSpeedGroup."
+           ::= { etherGroups 1 }
+
+       etherCollisionTableGroup OBJECT-GROUP
+           OBJECTS     { dot3CollFrequencies
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing a histogram
+                       of packets successfully transmitted after
+                       experiencing exactly N collisions."
+           ::= { etherGroups 2 }
+
+       etherStats100MbsGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsIndex,
+                         dot3StatsAlignmentErrors,
+                         dot3StatsFCSErrors,
+                         dot3StatsSingleCollisionFrames,
+                         dot3StatsMultipleCollisionFrames,
+                         dot3StatsDeferredTransmissions,
+                         dot3StatsLateCollisions,
+                         dot3StatsExcessiveCollisions,
+                         dot3StatsInternalMacTransmitErrors,
+                         dot3StatsCarrierSenseErrors,
+                         dot3StatsFrameTooLongs,
+                         dot3StatsInternalMacReceiveErrors,
+                         dot3StatsEtherChipSet,
+                         dot3StatsSymbolErrors
+                       }
+           STATUS      deprecated
+           DESCRIPTION "********* THIS GROUP IS DEPRECATED **********
+
+                       A collection of objects providing information
+                       applicable to 100 Mb/sec ethernet-like network
+                       interfaces.
+
+                       This object group has been deprecated and
+                       replaced by etherStatsBaseGroup and
+                       etherStatsHighSpeedGroup."
+           ::= { etherGroups 3 }
+
+       etherStatsBaseGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsIndex,
+                         dot3StatsAlignmentErrors,
+                         dot3StatsFCSErrors,
+                         dot3StatsSingleCollisionFrames,
+                         dot3StatsMultipleCollisionFrames,
+                         dot3StatsDeferredTransmissions,
+                         dot3StatsLateCollisions,
+                         dot3StatsExcessiveCollisions,
+                         dot3StatsInternalMacTransmitErrors,
+                         dot3StatsCarrierSenseErrors,
+                         dot3StatsFrameTooLongs,
+                         dot3StatsInternalMacReceiveErrors
+                       }
+           STATUS      deprecated
+           DESCRIPTION "********* THIS GROUP IS DEPRECATED **********
+
+                       A collection of objects providing information
+                       applicable to all ethernet-like network
+                       interfaces.
+
+                       This object group has been deprecated and
+                       replaced by etherStatsBaseGroup2 and
+                       etherStatsHalfDuplexGroup, to separate
+                       objects which must be implemented by all
+                       ethernet-like network interfaces from
+                       objects that need only be implemented on
+                       ethernet-like network interfaces that are
+                       capable of half-duplex operation."
+           ::= { etherGroups 4 }
+
+       etherStatsLowSpeedGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsSQETestErrors }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       applicable to ethernet-like network interfaces
+                       capable of operating at 10 Mb/s or slower in
+                       half-duplex mode."
+           ::= { etherGroups 5 }
+
+       etherStatsHighSpeedGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsSymbolErrors }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       applicable to ethernet-like network interfaces
+                       capable of operating at 100 Mb/s or faster."
+           ::= { etherGroups 6 }
+
+       etherDuplexGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsDuplexStatus }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       about the duplex mode of an ethernet-like
+                       network interface."
+           ::= { etherGroups 7 }
+
+       etherControlGroup OBJECT-GROUP
+           OBJECTS     { dot3ControlFunctionsSupported,
+                         dot3ControlInUnknownOpcodes
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       about the MAC Control sublayer on ethernet-like
+                       network interfaces."
+           ::= { etherGroups 8 }
+
+       etherControlPauseGroup OBJECT-GROUP
+           OBJECTS     { dot3PauseAdminMode,
+                         dot3PauseOperMode,
+                         dot3InPauseFrames,
+                         dot3OutPauseFrames
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       about and control of the MAC Control PAUSE
+                       function on ethernet-like network interfaces."
+           ::= { etherGroups 9 }
+
+       etherStatsBaseGroup2 OBJECT-GROUP
+           OBJECTS     { dot3StatsIndex,
+                         dot3StatsAlignmentErrors,
+                         dot3StatsFCSErrors,
+                         dot3StatsInternalMacTransmitErrors,
+                         dot3StatsFrameTooLongs,
+                         dot3StatsInternalMacReceiveErrors
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       applicable to all ethernet-like network
+                       interfaces."
+           ::= { etherGroups 10 }
+
+       etherStatsHalfDuplexGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsSingleCollisionFrames,
+                         dot3StatsMultipleCollisionFrames,
+                         dot3StatsDeferredTransmissions,
+                         dot3StatsLateCollisions,
+                         dot3StatsExcessiveCollisions,
+                         dot3StatsCarrierSenseErrors
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       applicable only to half-duplex ethernet-like
+                       network interfaces."
+           ::= { etherGroups 11 }
+
+       etherHCStatsGroup OBJECT-GROUP
+           OBJECTS     { dot3HCStatsAlignmentErrors,
+                         dot3HCStatsFCSErrors,
+                         dot3HCStatsInternalMacTransmitErrors,
+                         dot3HCStatsFrameTooLongs,
+                         dot3HCStatsInternalMacReceiveErrors,
+                         dot3HCStatsSymbolErrors
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing high-capacity
+                       statistics applicable to higher-speed
+                       ethernet-like network interfaces."
+           ::= { etherGroups 12 }
+
+       etherHCControlGroup OBJECT-GROUP
+           OBJECTS     { dot3HCControlInUnknownOpcodes }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing high-capacity
+                       statistics for the MAC Control sublayer on
+                       higher-speed ethernet-like network interfaces."
+           ::= { etherGroups 13 }
+
+       etherHCControlPauseGroup OBJECT-GROUP
+           OBJECTS     { dot3HCInPauseFrames,
+                         dot3HCOutPauseFrames
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing high-capacity
+                       statistics for the MAC Control PAUSE function on
+                       higher-speed ethernet-like network interfaces."
+           ::= { etherGroups 14 }
+
+       etherRateControlGroup OBJECT-GROUP
+           OBJECTS     { dot3StatsRateControlAbility,
+                         dot3StatsRateControlStatus
+                       }
+           STATUS      current
+           DESCRIPTION "A collection of objects providing information
+                       about the Rate Control function on ethernet-like
+                       interfaces."
+           ::= { etherGroups 15 }
+
+   END

--- a/mibs/junos/mib-rfc3637.txt
+++ b/mibs/junos/mib-rfc3637.txt
@@ -1,0 +1,628 @@
+ETHER-WIS DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    Gauge32, transmission
+        FROM SNMPv2-SMI
+    ifIndex
+        FROM IF-MIB
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    sonetMediumStuff2, sonetSectionStuff2,
+    sonetLineStuff2, sonetFarEndLineStuff2,
+    sonetPathStuff2, sonetFarEndPathStuff2,
+    sonetMediumType, sonetMediumLineCoding,
+    sonetMediumLineType, sonetMediumCircuitIdentifier,
+    sonetMediumLoopbackConfig, sonetSESthresholdSet,
+    sonetPathCurrentWidth
+        FROM SONET-MIB;
+
+etherWisMIB MODULE-IDENTITY
+    LAST-UPDATED "200309190000Z"  -- September 19, 2003
+        ORGANIZATION "IETF Ethernet Interfaces and Hub MIB
+                     Working Group"
+        CONTACT-INFO
+           "WG charter:
+              http://www.ietf.org/html.charters/hubmib-charter.html
+
+            Mailing Lists:
+              General Discussion: hubmib@ietf.org <mailto:hubmib@ietf.org>
+              To Subscribe: hubmib-request@ietf.org <mailto:hubmib-request@ietf.org>
+              In Body: subscribe your_email_address
+
+             Chair: Dan Romascanu
+            Postal: Avaya Inc.
+                    Atidim Technology Park, Bldg. 3
+                    Tel Aviv 61131
+                    Israel
+               Tel: +972 3 645 8414
+            E-mail: dromasca@avaya.com <mailto:dromasca@avaya.com>
+
+            Editor: C. M. Heard
+            Postal: 600 Rainbow Dr. #141
+                    Mountain View, CA 94041-2542
+                    USA
+               Tel: +1 650-964-8391
+            E-mail: heard@pobox.com <mailto:heard@pobox.com>"
+
+    DESCRIPTION
+      "The objects in this MIB module are used in conjunction
+      with objects in the SONET-MIB and the MAU-MIB to manage
+      the Ethernet WAN Interface Sublayer (WIS).
+
+      The following reference is used throughout this MIB module:
+
+      [IEEE 802.3 Std] refers to:
+         IEEE Std 802.3, 2000 Edition: 'IEEE Standard for
+         Information technology - Telecommunications and
+         information exchange between systems - Local and
+         metropolitan area networks - Specific requirements -
+         Part 3: Carrier sense multiple access with collision
+         detection (CSMA/CD) access method and physical layer
+         specifications', as amended by IEEE Std 802.3ae-2002,
+         'IEEE Standard for Carrier Sense Multiple Access with
+         Collision Detection (CSMA/CD) Access Method and
+         Physical Layer Specifications - Media Access Control
+         (MAC) Parameters, Physical Layer and Management
+         Parameters for 10 Gb/s Operation', 30 August 2002.
+
+      Of particular interest are Clause 50, 'WAN Interface
+      Sublayer (WIS), type 10GBASE-W', Clause 30, '10Mb/s,
+      100Mb/s, 1000Mb/s, and 10Gb/s MAC Control, and Link
+      Aggregation Management', and Clause 45, 'Management
+      Data Input/Output (MDIO) Interface'.
+
+      Copyright (C) The Internet Society (2003).  This version
+      of this MIB module is part of RFC 3637 </rfcs/rfc3637.html>;  see the RFC
+      itself for full legal notices."
+
+    REVISION    "200309190000Z"  -- September 19, 2003
+    DESCRIPTION "Initial version, published as RFC 3637 </rfcs/rfc3637.html>."
+
+    ::= { transmission 134 }
+
+-- The main sections of the module
+
+etherWisObjects     OBJECT IDENTIFIER ::= { etherWisMIB 1 }
+
+etherWisObjectsPath OBJECT IDENTIFIER ::= { etherWisMIB 2 }
+
+etherWisConformance OBJECT IDENTIFIER ::= { etherWisMIB 3 }
+
+-- groups in the Ethernet WIS MIB module
+
+etherWisDevice      OBJECT IDENTIFIER ::= { etherWisObjects 1 }
+
+etherWisSection     OBJECT IDENTIFIER ::= { etherWisObjects 2 }
+
+etherWisPath        OBJECT IDENTIFIER ::= { etherWisObjectsPath 1 }
+
+etherWisFarEndPath  OBJECT IDENTIFIER ::= { etherWisObjectsPath 2 }
+
+-- The Device group
+
+-- These objects provide WIS extensions to
+-- the SONET-MIB Medium Group.
+
+etherWisDeviceTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF EtherWisDeviceEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "The table for Ethernet WIS devices"
+     ::= { etherWisDevice 1 }
+
+etherWisDeviceEntry OBJECT-TYPE
+    SYNTAX  EtherWisDeviceEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "An entry in the Ethernet WIS device table.  For each
+       instance of this object there MUST be a corresponding
+       instance of sonetMediumEntry."
+    INDEX  { ifIndex }
+     ::= { etherWisDeviceTable 1 }
+
+EtherWisDeviceEntry ::=
+    SEQUENCE {
+        etherWisDeviceTxTestPatternMode     INTEGER,
+        etherWisDeviceRxTestPatternMode     INTEGER,
+        etherWisDeviceRxTestPatternErrors   Gauge32
+        }
+
+etherWisDeviceTxTestPatternMode OBJECT-TYPE
+    SYNTAX  INTEGER {
+                none(1),
+                squareWave(2),
+                prbs31(3),
+                mixedFrequency(4)
+            }
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+       "This variable controls the transmit test pattern mode.
+       The value none(1) puts the the WIS transmit path into
+       the normal operating mode.  The value squareWave(2) puts
+       the WIS transmit path into the square wave test pattern
+       mode described in [IEEE 802.3 Std.] subclause 50.3.8.1.
+       The value prbs31(3) puts the WIS transmit path into the
+       PRBS31 test pattern mode described in [IEEE 802.3 Std.]
+       subclause 50.3.8.2.  The value mixedFrequency(4) puts the
+       WIS transmit path into the mixed frequency test pattern
+       mode described in [IEEE 802.3 Std.] subclause 50.3.8.3.
+       Any attempt to set this object to a value other than
+       none(1) when the corresponding instance of ifAdminStatus
+       has the value up(1) MUST be rejected with the error
+       inconsistentValue, and any attempt to set the corresponding
+       instance of ifAdminStatus to the value up(1) when an
+       instance of this object has a value other than none(1)
+       MUST be rejected with the error inconsistentValue."
+    REFERENCE
+       "[IEEE 802.3 Std.], 50.3.8, WIS test pattern generator and
+       checker, 45.2.2.6, 10G WIS control 2 register (2.7), and
+       45.2.2.7.2, PRBS31 pattern testing ability (2.8.1)."
+     ::= { etherWisDeviceEntry 1 }
+
+etherWisDeviceRxTestPatternMode OBJECT-TYPE
+    SYNTAX  INTEGER {
+                none(1),
+                prbs31(3),
+                mixedFrequency(4)
+            }
+    MAX-ACCESS  read-write
+    STATUS  current
+
+    DESCRIPTION
+       "This variable controls the receive test pattern mode.
+       The value none(1) puts the the WIS receive path into the
+       normal operating mode.  The value prbs31(3) puts the WIS
+       receive path into the PRBS31 test pattern mode described
+       in [IEEE 802.3 Std.] subclause 50.3.8.2.  The value
+       mixedFrequency(4) puts the WIS receive path into the mixed
+       frequency test pattern mode described in [IEEE 802.3 Std.]
+       subclause 50.3.8.3.  Any attempt to set this object to a
+       value other than none(1) when the corresponding instance
+       of ifAdminStatus has the value up(1) MUST be rejected with
+       the error inconsistentValue, and any attempt to set the
+       corresponding instance of ifAdminStatus to the value up(1)
+       when an instance of this object has a value other than
+       none(1) MUST be rejected with the error inconsistentValue."
+    REFERENCE
+       "[IEEE 802.3 Std.], 50.3.8, WIS test pattern generator and
+       checker, 45.2.2.6, 10G WIS control 2 register (2.7), and
+       45.2.2.7.2, PRBS31 pattern testing ability (2.8.1)."
+     ::= { etherWisDeviceEntry 2 }
+
+etherWisDeviceRxTestPatternErrors OBJECT-TYPE
+    SYNTAX  Gauge32 ( 0..65535 )
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+       "This object counts the number of errors detected when the
+       WIS receive path is operating in the PRBS31 test pattern
+       mode.  It is reset to zero when the WIS receive path
+       initially enters that mode, and it increments each time
+       the PRBS pattern checker detects an error as described in
+       [IEEE 802.3 Std.] subclause 50.3.8.2 unless its value is
+       65535, in which case it remains unchanged.  This object is
+       writeable so that it may be reset upon explicit request
+       of a command generator application while the WIS receive
+       path continues to operate in PRBS31 test pattern mode."
+    REFERENCE
+       "[IEEE 802.3 Std.], 50.3.8, WIS test pattern generator and
+       checker, 45.2.2.7.2, PRBS31 pattern testing ability
+       (2.8.1), and 45.2.2.8, 10G WIS test pattern error counter
+       register (2.9)."
+     ::= { etherWisDeviceEntry 3 }
+
+-- The Section group
+
+-- These objects provide WIS extensions to
+-- the SONET-MIB Section Group.
+
+etherWisSectionCurrentTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF EtherWisSectionCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "The table for the current state of Ethernet WIS sections."
+     ::= { etherWisSection 1 }
+
+etherWisSectionCurrentEntry OBJECT-TYPE
+    SYNTAX  EtherWisSectionCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "An entry in the etherWisSectionCurrentTable.  For each
+       instance of this object there MUST be a corresponding
+       instance of sonetSectionCurrentEntry."
+    INDEX  { ifIndex }
+     ::= { etherWisSectionCurrentTable 1 }
+
+EtherWisSectionCurrentEntry ::=
+    SEQUENCE {
+        etherWisSectionCurrentJ0Transmitted OCTET STRING,
+        etherWisSectionCurrentJ0Received    OCTET STRING
+        }
+
+etherWisSectionCurrentJ0Transmitted OBJECT-TYPE
+    SYNTAX  OCTET STRING (SIZE (16))
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+       "This is the 16-octet section trace message that
+       is transmitted in the J0 byte.  The value SHOULD
+       be '89'h followed by fifteen octets of '00'h
+       (or some cyclic shift thereof) when the section
+       trace function is not used, and the implementation
+       SHOULD use that value (or a cyclic shift thereof)
+       as a default if no other value has been set."
+    REFERENCE
+       "[IEEE 802.3 Std.], 30.8.1.1.8, aJ0ValueTX."
+     ::= { etherWisSectionCurrentEntry 1 }
+
+etherWisSectionCurrentJ0Received OBJECT-TYPE
+    SYNTAX  OCTET STRING (SIZE (16))
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "This is the 16-octet section trace message that
+       was most recently received in the J0 byte."
+    REFERENCE
+       "[IEEE 802.3 Std.], 30.8.1.1.9, aJ0ValueRX."
+     ::= { etherWisSectionCurrentEntry 2 }
+
+-- The Path group
+
+-- These objects provide WIS extensions to
+-- the SONET-MIB Path Group.
+
+etherWisPathCurrentTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF EtherWisPathCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "The table for the current state of Ethernet WIS paths."
+     ::= { etherWisPath 1 }
+
+etherWisPathCurrentEntry OBJECT-TYPE
+    SYNTAX  EtherWisPathCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "An entry in the etherWisPathCurrentTable.  For each
+       instance of this object there MUST be a corresponding
+       instance of sonetPathCurrentEntry."
+    INDEX  { ifIndex }
+     ::= { etherWisPathCurrentTable 1 }
+
+EtherWisPathCurrentEntry ::=
+    SEQUENCE {
+        etherWisPathCurrentStatus           BITS,
+        etherWisPathCurrentJ1Transmitted    OCTET STRING,
+        etherWisPathCurrentJ1Received       OCTET STRING
+        }
+
+etherWisPathCurrentStatus OBJECT-TYPE
+    SYNTAX  BITS {
+                etherWisPathLOP(0),
+                etherWisPathAIS(1),
+                etherWisPathPLM(2),
+                etherWisPathLCD(3)
+            }
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "This variable indicates the current status of the
+       path payload with a bit map that can indicate multiple
+       defects at once.  The bit positions are assigned as
+       follows:
+
+       etherWisPathLOP(0)
+          This bit is set to indicate that an
+          LOP-P (Loss of Pointer - Path) defect
+          is being experienced.  Note:  when this
+          bit is set, sonetPathSTSLOP MUST be set
+          in the corresponding instance of
+          sonetPathCurrentStatus.
+
+       etherWisPathAIS(1)
+          This bit is set to indicate that an
+          AIS-P (Alarm Indication Signal - Path)
+          defect is being experienced.  Note:  when
+          this bit is set, sonetPathSTSAIS MUST be
+          set in the corresponding instance of
+          sonetPathCurrentStatus.
+
+       etherWisPathPLM(1)
+          This bit is set to indicate that a
+          PLM-P (Payload Label Mismatch - Path)
+          defect is being experienced.  Note:  when
+          this bit is set, sonetPathSignalLabelMismatch
+          MUST be set in the corresponding instance of
+          sonetPathCurrentStatus.
+
+       etherWisPathLCD(3)
+          This bit is set to indicate that an
+          LCD-P (Loss of Codegroup Delination - Path)
+          defect is being experienced.  Since this
+          defect is detected by the PCS and not by
+          the path layer itself, there is no
+          corresponding bit in sonetPathCurrentStatus."
+    REFERENCE
+       "[IEEE 802.3 Std.], 30.8.1.1.18, aPathStatus."
+     ::= { etherWisPathCurrentEntry 1 }
+
+etherWisPathCurrentJ1Transmitted OBJECT-TYPE
+    SYNTAX  OCTET STRING (SIZE (16))
+    MAX-ACCESS  read-write
+    STATUS  current
+    DESCRIPTION
+       "This is the 16-octet path trace message that
+       is transmitted in the J1 byte.  The value SHOULD
+       be '89'h followed by fifteen octets of '00'h
+       (or some cyclic shift thereof) when the path
+       trace function is not used, and the implementation
+       SHOULD use that value (or a cyclic shift thereof)
+       as a default if no other value has been set."
+    REFERENCE
+       "[IEEE 802.3 Std.], 30.8.1.1.23, aJ1ValueTX."
+     ::= { etherWisPathCurrentEntry 2 }
+
+etherWisPathCurrentJ1Received OBJECT-TYPE
+    SYNTAX  OCTET STRING (SIZE (16))
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "This is the 16-octet path trace message that
+       was most recently received in the J1 byte."
+    REFERENCE
+       "[IEEE 802.3 Std.], 30.8.1.1.24, aJ1ValueRX."
+     ::= { etherWisPathCurrentEntry 3 }
+
+-- The Far End Path group
+
+-- These objects provide WIS extensions to
+-- the SONET-MIB Far End Path Group.
+
+etherWisFarEndPathCurrentTable OBJECT-TYPE
+    SYNTAX  SEQUENCE OF EtherWisFarEndPathCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "The table for the current far-end state of Ethernet WIS
+       paths."
+     ::= { etherWisFarEndPath 1 }
+
+etherWisFarEndPathCurrentEntry OBJECT-TYPE
+    SYNTAX  EtherWisFarEndPathCurrentEntry
+    MAX-ACCESS  not-accessible
+    STATUS  current
+    DESCRIPTION
+       "An entry in the etherWisFarEndPathCurrentTable.  For each
+       instance of this object there MUST be a corresponding
+       instance of sonetFarEndPathCurrentEntry."
+    INDEX  { ifIndex }
+     ::= { etherWisFarEndPathCurrentTable 1 }
+
+EtherWisFarEndPathCurrentEntry ::=
+    SEQUENCE {
+        etherWisFarEndPathCurrentStatus     BITS
+        }
+
+etherWisFarEndPathCurrentStatus OBJECT-TYPE
+    SYNTAX  BITS {
+                etherWisFarEndPayloadDefect(0),
+                etherWisFarEndServerDefect(1)
+            }
+    MAX-ACCESS  read-only
+    STATUS  current
+    DESCRIPTION
+       "This variable indicates the current status at the
+       far end of the path using a bit map that can indicate
+       multiple defects at once.  The bit positions are
+       assigned as follows:
+
+       etherWisFarEndPayloadDefect(0)
+          A far end payload defect (i.e., far end
+          PLM-P or LCD-P) is currently being signaled
+          in G1 bits 5-7.
+
+       etherWisFarEndServerDefect(1)
+          A far end server defect (i.e., far end
+          LOP-P or AIS-P) is currently being signaled
+          in G1 bits 5-7.  Note:  when this bit is set,
+          sonetPathSTSRDI MUST be set in the corresponding
+          instance of sonetPathCurrentStatus."
+    REFERENCE
+       "[IEEE 802.3 Std.], 30.8.1.1.25, aFarEndPathStatus."
+     ::= { etherWisFarEndPathCurrentEntry 1 }
+
+--
+--     Conformance Statements
+--
+
+etherWisGroups      OBJECT IDENTIFIER ::= { etherWisConformance 1 }
+
+etherWisCompliances OBJECT IDENTIFIER ::= { etherWisConformance 2 }
+
+--     Object Groups
+
+etherWisDeviceGroupBasic OBJECT-GROUP
+    OBJECTS {
+        etherWisDeviceTxTestPatternMode,
+        etherWisDeviceRxTestPatternMode
+        }
+    STATUS  current
+    DESCRIPTION
+       "A collection of objects that support test
+       features required of all WIS devices."
+     ::= { etherWisGroups 1 }
+
+etherWisDeviceGroupExtra OBJECT-GROUP
+    OBJECTS {
+        etherWisDeviceRxTestPatternErrors
+        }
+    STATUS  current
+    DESCRIPTION
+       "A collection of objects that support
+       optional WIS device test features."
+     ::= { etherWisGroups 2 }
+
+etherWisSectionGroup OBJECT-GROUP
+    OBJECTS {
+        etherWisSectionCurrentJ0Transmitted,
+        etherWisSectionCurrentJ0Received
+        }
+    STATUS  current
+    DESCRIPTION
+       "A collection of objects that provide
+       required information about a WIS section."
+     ::= { etherWisGroups 3 }
+
+etherWisPathGroup OBJECT-GROUP
+    OBJECTS {
+        etherWisPathCurrentStatus,
+        etherWisPathCurrentJ1Transmitted,
+        etherWisPathCurrentJ1Received
+        }
+    STATUS  current
+    DESCRIPTION
+       "A collection of objects that provide
+       required information about a WIS path."
+     ::= { etherWisGroups 4 }
+
+etherWisFarEndPathGroup OBJECT-GROUP
+    OBJECTS {
+        etherWisFarEndPathCurrentStatus
+        }
+    STATUS  current
+    DESCRIPTION
+       "A collection of objects that provide required
+       information about the far end of a WIS path."
+     ::= { etherWisGroups 5 }
+
+--     Compliance Statements
+
+etherWisCompliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+       "The compliance statement for interfaces that include
+       the Ethernet WIS.  Compliance with the following
+       external compliance statements is prerequisite:
+
+       MIB Module             Compliance Statement
+       ----------             --------------------
+       IF-MIB                 ifCompliance3
+       IF-INVERTED-STACK-MIB  ifInvCompliance
+       EtherLike-MIB          dot3Compliance2
+       MAU-MIB                mauModIfCompl3"
+
+    MODULE  -- this module
+        MANDATORY-GROUPS {
+            etherWisDeviceGroupBasic,
+            etherWisSectionGroup,
+            etherWisPathGroup,
+            etherWisFarEndPathGroup
+            }
+
+        OBJECT       etherWisDeviceTxTestPatternMode
+        SYNTAX       INTEGER {
+            none(1),
+            squareWave(2),
+            mixedFrequency(4)
+            }
+        DESCRIPTION
+            "Support for values other than none(1),
+            squareWave(2), and mixedFrequency(4)
+            is not required."
+
+        OBJECT       etherWisDeviceRxTestPatternMode
+        SYNTAX       INTEGER {
+            none(1),
+            mixedFrequency(4)
+            }
+        DESCRIPTION
+            "Support for values other than none(1)
+            and mixedFrequency(4) is not required."
+
+        GROUP        etherWisDeviceGroupExtra
+        DESCRIPTION
+            "Implementation of this group, along with support for
+            the value prbs31(3) for etherWisDeviceTxTestPatternMode
+            and etherWisDeviceRxTestPatternMode, is necessary if the
+            optional PRBS31 test pattern mode is to be supported."
+
+        OBJECT       etherWisDeviceRxTestPatternErrors
+        WRITE-SYNTAX Gauge32 ( 0 )
+        DESCRIPTION
+            "An implementation is not required to
+            allow values other than zero to be
+            written to this object."
+
+    MODULE SONET-MIB
+        MANDATORY-GROUPS {
+            sonetMediumStuff2,
+            sonetSectionStuff2,
+            sonetLineStuff2,
+            sonetFarEndLineStuff2,
+            sonetPathStuff2,
+            sonetFarEndPathStuff2
+            }
+
+        OBJECT       sonetMediumType
+        SYNTAX       INTEGER {
+            sonet(1)
+            }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support
+            for any value other than sonet(1)."
+
+        OBJECT       sonetMediumLineCoding
+        SYNTAX       INTEGER {
+            sonetMediumNRZ(4)
+            }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support
+            for any value other than sonetMediumNRZ(4)."
+
+        OBJECT       sonetMediumLineType
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT       sonetMediumCircuitIdentifier
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT       sonetMediumLoopbackConfig
+        SYNTAX       BITS {
+            sonetNoLoop(0),
+            sonetFacilityLoop(1)
+            }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for values
+            other than sonetNoLoop(0) and sonetFacilityLoop(1)."
+
+        OBJECT       sonetSESthresholdSet
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, and only one
+            of the enumerated values need be supported."
+
+        OBJECT       sonetPathCurrentWidth
+        SYNTAX       INTEGER {
+            sts192cSTM64(6)
+            }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support
+            for any value other than sts192cSTM64(6)."
+
+     ::= { etherWisCompliances 1 }
+
+END

--- a/mibs/junos/mib-rfc3811.txt
+++ b/mibs/junos/mib-rfc3811.txt
@@ -266,12 +266,14 @@ MPLS-TC-STD-MIB DEFINITIONS ::= BEGIN
           SYNTAX  OCTET STRING (SIZE (6))
 
        MplsLsrIdentifier ::= TEXTUAL-CONVENTION
+          DISPLAY-HINT "1d.1d.1d.1d"
           STATUS      current
           DESCRIPTION
              "The Label Switching Router (LSR) identifier is the
               first 4 bytes of the Label Distribution Protocol
               (LDP) identifier."
           SYNTAX  OCTET STRING (SIZE (4))
+
        MplsLdpLabelType ::= TEXTUAL-CONVENTION
           STATUS      current
           DESCRIPTION

--- a/mibs/junos/mib-rfc4001.txt
+++ b/mibs/junos/mib-rfc4001.txt
@@ -1,0 +1,399 @@
+INET-ADDRESS-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, mib-2, Unsigned32 FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION                 FROM SNMPv2-TC;
+
+inetAddressMIB MODULE-IDENTITY
+    LAST-UPDATED "200502040000Z"
+    ORGANIZATION
+        "IETF Operations and Management Area"
+    CONTACT-INFO
+        "Juergen Schoenwaelder (Editor)
+         International University Bremen
+         P.O. Box 750 561
+         28725 Bremen, Germany
+
+         Phone: +49 421 200-3587
+         EMail: j.schoenwaelder@iu-bremen.de
+
+         Send comments to <ietfmibs@ops.ietf.org>."
+    DESCRIPTION
+        "This MIB module defines textual conventions for
+         representing Internet addresses.  An Internet
+         address can be an IPv4 address, an IPv6 address,
+         or a DNS domain name.  This module also defines
+         textual conventions for Internet port numbers,
+         autonomous system numbers, and the length of an
+         Internet address prefix.
+
+         Copyright (C) The Internet Society (2005).  This version
+         of this MIB module is part of RFC 4001, see the RFC
+         itself for full legal notices."
+    REVISION     "200502040000Z"
+    DESCRIPTION
+        "Third version, published as RFC 4001.  This revision
+         introduces the InetZoneIndex, InetScopeType, and
+         InetVersion textual conventions."
+    REVISION     "200205090000Z"
+    DESCRIPTION
+        "Second version, published as RFC 3291.  This
+         revision contains several clarifications and
+         introduces several new textual conventions:
+         InetAddressPrefixLength, InetPortNumber,
+         InetAutonomousSystemNumber, InetAddressIPv4z,
+         and InetAddressIPv6z."
+    REVISION     "200006080000Z"
+    DESCRIPTION
+        "Initial version, published as RFC 2851."
+    ::= { mib-2 76 }
+
+InetAddressType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "A value that represents a type of Internet address.
+
+         unknown(0)  An unknown address type.  This value MUST
+                     be used if the value of the corresponding
+                     InetAddress object is a zero-length string.
+                     It may also be used to indicate an IP address
+                     that is not in one of the formats defined
+                     below.
+
+         ipv4(1)     An IPv4 address as defined by the
+                     InetAddressIPv4 textual convention.
+
+         ipv6(2)     An IPv6 address as defined by the
+                     InetAddressIPv6 textual convention.
+
+         ipv4z(3)    A non-global IPv4 address including a zone
+                     index as defined by the InetAddressIPv4z
+                     textual convention.
+
+         ipv6z(4)    A non-global IPv6 address including a zone
+                     index as defined by the InetAddressIPv6z
+                     textual convention.
+
+         dns(16)     A DNS domain name as defined by the
+                     InetAddressDNS textual convention.
+
+         Each definition of a concrete InetAddressType value must be
+         accompanied by a definition of a textual convention for use
+         with that InetAddressType.
+
+         To support future extensions, the InetAddressType textual
+         convention SHOULD NOT be sub-typed in object type definitions.
+         It MAY be sub-typed in compliance statements in order to
+         require only a subset of these address types for a compliant
+         implementation.
+
+         Implementations must ensure that InetAddressType objects
+         and any dependent objects (e.g., InetAddress objects) are
+         consistent.  An inconsistentValue error must be generated
+         if an attempt to change an InetAddressType object would,
+         for example, lead to an undefined InetAddress value.  In
+         particular, InetAddressType/InetAddress pairs must be
+         changed together if the address type changes (e.g., from
+         ipv6(2) to ipv4(1))."
+    SYNTAX       INTEGER {
+                     unknown(0),
+                     ipv4(1),
+                     ipv6(2),
+                     ipv4z(3),
+                     ipv6z(4),
+                     dns(16)
+                 }
+
+InetAddress ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "Denotes a generic Internet address.
+
+         An InetAddress value is always interpreted within the context
+         of an InetAddressType value.  Every usage of the InetAddress
+         textual convention is required to specify the InetAddressType
+         object that provides the context.  It is suggested that the
+         InetAddressType object be logically registered before the
+         object(s) that use the InetAddress textual convention, if
+         they appear in the same logical row.
+
+         The value of an InetAddress object must always be
+         consistent with the value of the associated InetAddressType
+         object.  Attempts to set an InetAddress object to a value
+         inconsistent with the associated InetAddressType
+         must fail with an inconsistentValue error.
+
+         When this textual convention is used as the syntax of an
+         index object, there may be issues with the limit of 128
+         sub-identifiers specified in SMIv2, STD 58.  In this case,
+         the object definition MUST include a 'SIZE' clause to
+         limit the number of potential instance sub-identifiers;
+         otherwise the applicable constraints MUST be stated in
+         the appropriate conceptual row DESCRIPTION clauses, or
+         in the surrounding documentation if there is no single
+         DESCRIPTION clause that is appropriate."
+    SYNTAX       OCTET STRING (SIZE (0..255))
+
+InetAddressIPv4 ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1d.1d.1d.1d"
+    STATUS       current
+    DESCRIPTION
+        "Represents an IPv4 network address:
+
+           Octets   Contents         Encoding
+            1-4     IPv4 address     network-byte order
+
+         The corresponding InetAddressType value is ipv4(1).
+
+         This textual convention SHOULD NOT be used directly in object
+         definitions, as it restricts addresses to a specific format.
+         However, if it is used, it MAY be used either on its own or in
+         conjunction with InetAddressType, as a pair."
+    SYNTAX       OCTET STRING (SIZE (4))
+
+InetAddressIPv6 ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "2x:2x:2x:2x:2x:2x:2x:2x"
+    STATUS       current
+    DESCRIPTION
+        "Represents an IPv6 network address:
+
+           Octets   Contents         Encoding
+            1-16    IPv6 address     network-byte order
+
+         The corresponding InetAddressType value is ipv6(2).
+
+         This textual convention SHOULD NOT be used directly in object
+         definitions, as it restricts addresses to a specific format.
+         However, if it is used, it MAY be used either on its own or in
+         conjunction with InetAddressType, as a pair."
+    SYNTAX       OCTET STRING (SIZE (16))
+
+InetAddressIPv4z ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1d.1d.1d.1d%4d"
+    STATUS       current
+    DESCRIPTION
+        "Represents a non-global IPv4 network address, together
+         with its zone index:
+
+           Octets   Contents         Encoding
+            1-4     IPv4 address     network-byte order
+            5-8     zone index       network-byte order
+
+         The corresponding InetAddressType value is ipv4z(3).
+
+         The zone index (bytes 5-8) is used to disambiguate identical
+         address values on nodes that have interfaces attached to
+         different zones of the same scope.  The zone index may contain
+         the special value 0, which refers to the default zone for each
+         scope.
+
+         This textual convention SHOULD NOT be used directly in object
+         definitions, as it restricts addresses to a specific format.
+         However, if it is used, it MAY be used either on its own or in
+         conjunction with InetAddressType, as a pair."
+    SYNTAX       OCTET STRING (SIZE (8))
+
+InetAddressIPv6z ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "2x:2x:2x:2x:2x:2x:2x:2x%4d"
+    STATUS       current
+    DESCRIPTION
+        "Represents a non-global IPv6 network address, together
+         with its zone index:
+
+           Octets   Contents         Encoding
+            1-16    IPv6 address     network-byte order
+           17-20    zone index       network-byte order
+
+         The corresponding InetAddressType value is ipv6z(4).
+
+         The zone index (bytes 17-20) is used to disambiguate
+         identical address values on nodes that have interfaces
+         attached to different zones of the same scope.  The zone index
+         may contain the special value 0, which refers to the default
+         zone for each scope.
+
+         This textual convention SHOULD NOT be used directly in object
+         definitions, as it restricts addresses to a specific format.
+         However, if it is used, it MAY be used either on its own or in
+         conjunction with InetAddressType, as a pair."
+    SYNTAX       OCTET STRING (SIZE (20))
+
+InetAddressDNS ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255a"
+    STATUS       current
+    DESCRIPTION
+        "Represents a DNS domain name.  The name SHOULD be fully
+         qualified whenever possible.
+
+         The corresponding InetAddressType is dns(16).
+
+         The DESCRIPTION clause of InetAddress objects that may have
+         InetAddressDNS values MUST fully describe how (and when)
+         these names are to be resolved to IP addresses.
+
+         The resolution of an InetAddressDNS value may require to
+         query multiple DNS records (e.g., A for IPv4 and AAAA for
+         IPv6).  The order of the resolution process and which DNS
+         record takes precedence depends on the configuration of the
+         resolver.
+
+         This textual convention SHOULD NOT be used directly in object
+         definitions, as it restricts addresses to a specific format.
+         However, if it is used, it MAY be used either on its own or in
+         conjunction with InetAddressType, as a pair."
+    SYNTAX       OCTET STRING (SIZE (1..255))
+
+InetAddressPrefixLength ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "Denotes the length of a generic Internet network address
+         prefix.  A value of n corresponds to an IP address mask
+         that has n contiguous 1-bits from the most significant
+         bit (MSB), with all other bits set to 0.
+
+         An InetAddressPrefixLength value is always interpreted within
+         the context of an InetAddressType value.  Every usage of the
+         InetAddressPrefixLength textual convention is required to
+         specify the InetAddressType object that provides the
+         context.  It is suggested that the InetAddressType object be
+         logically registered before the object(s) that use the
+         InetAddressPrefixLength textual convention, if they appear
+         in the same logical row.
+
+         InetAddressPrefixLength values larger than
+         the maximum length of an IP address for a specific
+         InetAddressType are treated as the maximum significant
+         value applicable for the InetAddressType.  The maximum
+         significant value is 32 for the InetAddressType
+         'ipv4(1)' and 'ipv4z(3)' and 128 for the InetAddressType
+         'ipv6(2)' and 'ipv6z(4)'.  The maximum significant value
+         for the InetAddressType 'dns(16)' is 0.
+
+         The value zero is object-specific and must be defined as
+         part of the description of any object that uses this
+         syntax.  Examples of the usage of zero might include
+         situations where the Internet network address prefix
+         is unknown or does not apply.
+
+         The upper bound of the prefix length has been chosen to
+         be consistent with the maximum size of an InetAddress."
+    SYNTAX       Unsigned32 (0..2040)
+
+InetPortNumber ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "Represents a 16 bit port number of an Internet transport
+         layer protocol.  Port numbers are assigned by IANA.  A
+         current list of all assignments is available from
+         <http://www.iana.org/>.
+
+         The value zero is object-specific and must be defined as
+         part of the description of any object that uses this
+         syntax.  Examples of the usage of zero might include
+         situations where a port number is unknown, or when the
+         value zero is used as a wildcard in a filter."
+    REFERENCE   "STD 6 (RFC 768), STD 7 (RFC 793) and RFC 2960"
+    SYNTAX       Unsigned32 (0..65535)
+
+InetAutonomousSystemNumber ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "Represents an autonomous system number that identifies an
+         Autonomous System (AS).  An AS is a set of routers under a
+         single technical administration, using an interior gateway
+         protocol and common metrics to route packets within the AS,
+         and using an exterior gateway protocol to route packets to
+         other ASes'.  IANA maintains the AS number space and has
+         delegated large parts to the regional registries.
+
+         Autonomous system numbers are currently limited to 16 bits
+         (0..65535).  There is, however, work in progress to enlarge the
+         autonomous system number space to 32 bits.  Therefore, this
+         textual convention uses an Unsigned32 value without a
+         range restriction in order to support a larger autonomous
+         system number space."
+    REFERENCE   "RFC 1771, RFC 1930"
+    SYNTAX       Unsigned32
+
+InetScopeType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+        "Represents a scope type.  This textual convention can be used
+         in cases where a MIB has to represent different scope types
+         and there is no context information, such as an InetAddress
+         object, that implicitly defines the scope type.
+
+         Note that not all possible values have been assigned yet, but
+         they may be assigned in future revisions of this specification.
+         Applications should therefore be able to deal with values
+         not yet assigned."
+    REFERENCE   "RFC 3513"
+    SYNTAX       INTEGER {
+                     -- reserved(0),
+                     interfaceLocal(1),
+                     linkLocal(2),
+                     subnetLocal(3),
+                     adminLocal(4),
+                     siteLocal(5), -- site-local unicast addresses
+                                   -- have been deprecated by RFC 3879
+                     -- unassigned(6),
+                     -- unassigned(7),
+                     organizationLocal(8),
+                     -- unassigned(9),
+                     -- unassigned(10),
+                     -- unassigned(11),
+                     -- unassigned(12),
+                     -- unassigned(13),
+                     global(14)
+                     -- reserved(15)
+                 }
+
+InetZoneIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+        "A zone index identifies an instance of a zone of a
+         specific scope.
+
+         The zone index MUST disambiguate identical address
+         values.  For link-local addresses, the zone index will
+         typically be the interface index (ifIndex as defined in the
+         IF-MIB) of the interface on which the address is configured.
+
+         The zone index may contain the special value 0, which refers
+         to the default zone.  The default zone may be used in cases
+         where the valid zone index is not known (e.g., when a
+         management application has to write a link-local IPv6
+         address without knowing the interface index value).  The
+         default zone SHOULD NOT be used as an easy way out in
+         cases where the zone index for a non-global IPv6 address
+         is known."
+    REFERENCE   "RFC4007"
+    SYNTAX       Unsigned32
+
+InetVersion ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+        "A value representing a version of the IP protocol.
+
+         unknown(0)  An unknown or unspecified version of the IP
+                     protocol.
+
+         ipv4(1)     The IPv4 protocol as defined in RFC 791 (STD 5).
+
+         ipv6(2)     The IPv6 protocol as defined in RFC 2460.
+
+         Note that this textual convention SHOULD NOT be used to
+         distinguish different address types associated with IP
+         protocols.  The InetAddressType has been designed for this
+         purpose."
+    REFERENCE   "RFC 791, RFC 2460"
+    SYNTAX       INTEGER {
+                     unknown(0),
+                     ipv4(1),
+                     ipv6(2)
+                 }
+END

--- a/mibs/junos/mib-rfc4087.txt
+++ b/mibs/junos/mib-rfc4087.txt
@@ -1,0 +1,731 @@
+   TUNNEL-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, transmission,
+       Integer32, IpAddress    FROM SNMPv2-SMI          -- [RFC2578]
+
+       RowStatus, StorageType  FROM SNMPv2-TC           -- [RFC2579]
+
+       MODULE-COMPLIANCE,
+       OBJECT-GROUP            FROM SNMPv2-CONF         -- [RFC2580]
+
+       InetAddressType,
+       InetAddress             FROM INET-ADDRESS-MIB    -- [RFC4001]
+
+       IPv6FlowLabelOrAny      FROM IPV6-FLOW-LABEL-MIB -- [RFC3595]
+
+       ifIndex,
+       InterfaceIndexOrZero    FROM IF-MIB              -- [RFC2863]
+
+       IANAtunnelType          FROM IANAifType-MIB;     -- [IFTYPE]
+
+   tunnelMIB MODULE-IDENTITY
+       LAST-UPDATED "200505160000Z" -- May 16, 2005
+       ORGANIZATION "IETF IP Version 6 (IPv6) Working Group"
+       CONTACT-INFO
+               " Dave Thaler
+                 Microsoft Corporation
+                 One Microsoft Way
+                 Redmond, WA  98052-6399
+                 EMail: dthaler@microsoft.com"
+       DESCRIPTION
+               "The MIB module for management of IP Tunnels,
+               independent of the specific encapsulation scheme in
+               use.
+
+               Copyright (C) The Internet Society (2005).  This
+               version of this MIB module is part of RFC 4087;  see
+               the RFC itself for full legal notices."
+       REVISION     "200505160000Z" -- May 16, 2005
+       DESCRIPTION
+               "IPv4-specific objects were deprecated, including
+               tunnelIfLocalAddress, tunnelIfRemoteAddress, the
+               tunnelConfigTable, and the tunnelMIBBasicGroup.
+
+               Added IP version-agnostic objects that should be used
+               instead, including tunnelIfAddressType,
+               tunnelIfLocalInetAddress, tunnelIfRemoteInetAddress,
+               the tunnelInetConfigTable, and the
+               tunnelIMIBInetGroup.
+
+               The new tunnelIfLocalInetAddress and
+               tunnelIfRemoteInetAddress objects are read-write,
+               rather than read-only.
+
+               Updated DESCRIPTION clauses of existing version-
+               agnostic objects (e.g., tunnelIfTOS) that contained
+               IPv4-specific text to cover IPv6 as well.
+
+               Added tunnelIfFlowLabel for tunnels over IPv6.
+
+               The encapsulation method was previously an INTEGER
+               type, and is now an IANA-maintained textual
+               convention.
+
+               Published as RFC 4087."
+       REVISION     "199908241200Z" -- August 24, 1999
+       DESCRIPTION
+               "Initial version, published as RFC 2667."
+       ::= { transmission 131 }
+
+   tunnelMIBObjects OBJECT IDENTIFIER ::= { tunnelMIB 1 }
+
+   tunnel      OBJECT IDENTIFIER ::= { tunnelMIBObjects 1 }
+
+   -- the IP Tunnel MIB-Group
+   --
+   -- a collection of objects providing information about
+   -- IP Tunnels
+
+   tunnelIfTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF TunnelIfEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "The (conceptual) table containing information on
+               configured tunnels."
+       ::= { tunnel 1 }
+
+   tunnelIfEntry OBJECT-TYPE
+       SYNTAX     TunnelIfEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "An entry (conceptual row) containing the information
+               on a particular configured tunnel."
+       INDEX      { ifIndex }
+       ::= { tunnelIfTable 1 }
+
+   TunnelIfEntry ::= SEQUENCE {
+       tunnelIfLocalAddress            IpAddress,   -- deprecated
+       tunnelIfRemoteAddress           IpAddress,   -- deprecated
+       tunnelIfEncapsMethod            IANAtunnelType,
+       tunnelIfHopLimit                Integer32,
+       tunnelIfSecurity                INTEGER,
+       tunnelIfTOS                     Integer32,
+       tunnelIfFlowLabel               IPv6FlowLabelOrAny,
+       tunnelIfAddressType             InetAddressType,
+       tunnelIfLocalInetAddress        InetAddress,
+       tunnelIfRemoteInetAddress       InetAddress,
+       tunnelIfEncapsLimit             Integer32
+   }
+
+   tunnelIfLocalAddress OBJECT-TYPE
+       SYNTAX     IpAddress
+       MAX-ACCESS read-only
+       STATUS     deprecated
+       DESCRIPTION
+               "The address of the local endpoint of the tunnel
+               (i.e., the source address used in the outer IP
+               header), or 0.0.0.0 if unknown or if the tunnel is
+               over IPv6.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelIfLocalInetAddress."
+       ::= { tunnelIfEntry 1 }
+
+   tunnelIfRemoteAddress OBJECT-TYPE
+       SYNTAX     IpAddress
+       MAX-ACCESS read-only
+       STATUS     deprecated
+       DESCRIPTION
+               "The address of the remote endpoint of the tunnel
+               (i.e., the destination address used in the outer IP
+               header), or 0.0.0.0 if unknown, or an IPv6 address, or
+               the tunnel is not a point-to-point link (e.g., if it
+               is a 6to4 tunnel).
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelIfRemoteInetAddress."
+       ::= { tunnelIfEntry 2 }
+
+   tunnelIfEncapsMethod OBJECT-TYPE
+       SYNTAX     IANAtunnelType
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+               "The encapsulation method used by the tunnel."
+       ::= { tunnelIfEntry 3 }
+
+   tunnelIfHopLimit OBJECT-TYPE
+       SYNTAX     Integer32 (0 | 1..255)
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The IPv4 TTL or IPv6 Hop Limit to use in the outer IP
+               header.  A value of 0 indicates that the value is
+               copied from the payload's header."
+       ::= { tunnelIfEntry 4 }
+
+   tunnelIfSecurity OBJECT-TYPE
+       SYNTAX     INTEGER {
+                      none(1),   -- no security
+                      ipsec(2),  -- IPsec security
+                      other(3)
+                  }
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+               "The method used by the tunnel to secure the outer IP
+               header.  The value ipsec indicates that IPsec is used
+               between the tunnel endpoints for authentication or
+               encryption or both.  More specific security-related
+               information may be available in a MIB module for the
+               security protocol in use."
+       ::= { tunnelIfEntry 5 }
+
+   tunnelIfTOS OBJECT-TYPE
+       SYNTAX     Integer32 (-2..63)
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The method used to set the high 6 bits (the
+               differentiated services codepoint) of the IPv4 TOS or
+               IPv6 Traffic Class in the outer IP header.  A value of
+               -1 indicates that the bits are copied from the
+               payload's header.  A value of -2 indicates that a
+               traffic conditioner is invoked and more information
+               may be available in a traffic conditioner MIB module.
+               A value between 0 and 63 inclusive indicates that the
+               bit field is set to the indicated value.
+
+               Note: instead of the name tunnelIfTOS, a better name
+               would have been tunnelIfDSCPMethod, but the existing
+               name appeared in RFC 2667 and existing objects cannot
+               be renamed."
+       ::= { tunnelIfEntry 6 }
+
+   tunnelIfFlowLabel OBJECT-TYPE
+       SYNTAX     IPv6FlowLabelOrAny
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The method used to set the IPv6 Flow Label value.
+               This object need not be present in rows where
+               tunnelIfAddressType indicates the tunnel is not over
+               IPv6.  A value of -1 indicates that a traffic
+               conditioner is invoked and more information may be
+               available in a traffic conditioner MIB.  Any other
+               value indicates that the Flow Label field is set to
+               the indicated value."
+       ::= { tunnelIfEntry 7 }
+
+   tunnelIfAddressType OBJECT-TYPE
+       SYNTAX     InetAddressType
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The type of address in the corresponding
+               tunnelIfLocalInetAddress and tunnelIfRemoteInetAddress
+               objects."
+       ::= { tunnelIfEntry 8 }
+
+   tunnelIfLocalInetAddress OBJECT-TYPE
+       SYNTAX     InetAddress
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The address of the local endpoint of the tunnel
+               (i.e., the source address used in the outer IP
+               header).  If the address is unknown, the value is
+               0.0.0.0 for IPv4 or :: for IPv6.  The type of this
+               object is given by tunnelIfAddressType."
+       ::= { tunnelIfEntry 9 }
+
+   tunnelIfRemoteInetAddress OBJECT-TYPE
+       SYNTAX     InetAddress
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The address of the remote endpoint of the tunnel
+               (i.e., the destination address used in the outer IP
+               header).  If the address is unknown or the tunnel is
+               not a point-to-point link (e.g., if it is a 6to4
+               tunnel), the value is 0.0.0.0 for tunnels over IPv4 or
+               :: for tunnels over IPv6.  The type of this object is
+               given by tunnelIfAddressType."
+       ::= { tunnelIfEntry 10 }
+
+   tunnelIfEncapsLimit OBJECT-TYPE
+       SYNTAX     Integer32 (-1 | 0..255)
+       MAX-ACCESS read-write
+       STATUS     current
+       DESCRIPTION
+               "The maximum number of additional encapsulations
+               permitted for packets undergoing encapsulation at this
+               node.  A value of -1 indicates that no limit is
+               present (except as a result of the packet size)."
+       REFERENCE  "RFC 2473, section 4.1.1"
+       ::= { tunnelIfEntry 11 }
+
+   tunnelConfigTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF TunnelConfigEntry
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+               "The (conceptual) table containing information on
+               configured tunnels.  This table can be used to map a
+               set of tunnel endpoints to the associated ifIndex
+               value.  It can also be used for row creation.  Note
+               that every row in the tunnelIfTable with a fixed IPv4
+               destination address should have a corresponding row in
+               the tunnelConfigTable, regardless of whether it was
+               created via SNMP.
+
+               Since this table does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigTable."
+       ::= { tunnel 2 }
+
+   tunnelConfigEntry OBJECT-TYPE
+       SYNTAX     TunnelConfigEntry
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+               "An entry (conceptual row) containing the information
+               on a particular configured tunnel.
+
+               Since this entry does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigEntry."
+       INDEX      { tunnelConfigLocalAddress,
+                    tunnelConfigRemoteAddress,
+                    tunnelConfigEncapsMethod,
+                    tunnelConfigID }
+       ::= { tunnelConfigTable 1 }
+
+   TunnelConfigEntry ::= SEQUENCE {
+       tunnelConfigLocalAddress            IpAddress,
+       tunnelConfigRemoteAddress           IpAddress,
+       tunnelConfigEncapsMethod            IANAtunnelType,
+       tunnelConfigID                      Integer32,
+       tunnelConfigIfIndex                 InterfaceIndexOrZero,
+       tunnelConfigStatus                  RowStatus
+   }
+
+   tunnelConfigLocalAddress OBJECT-TYPE
+       SYNTAX     IpAddress
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+               "The address of the local endpoint of the tunnel, or
+               0.0.0.0 if the device is free to choose any of its
+               addresses at tunnel establishment time.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigLocalAddress."
+       ::= { tunnelConfigEntry 1 }
+
+   tunnelConfigRemoteAddress OBJECT-TYPE
+       SYNTAX     IpAddress
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+               "The address of the remote endpoint of the tunnel.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigRemoteAddress."
+       ::= { tunnelConfigEntry 2 }
+
+   tunnelConfigEncapsMethod OBJECT-TYPE
+       SYNTAX     IANAtunnelType
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+               "The encapsulation method used by the tunnel.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigEncapsMethod."
+       ::= { tunnelConfigEntry 3 }
+
+   tunnelConfigID OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+               "An identifier used to distinguish between multiple
+               tunnels of the same encapsulation method, with the
+               same endpoints.  If the encapsulation protocol only
+               allows one tunnel per set of endpoint addresses (such
+               as for GRE or IP-in-IP), the value of this object is
+               1.  For encapsulation methods (such as L2F) which
+               allow multiple parallel tunnels, the manager is
+               responsible for choosing any ID which does not
+               conflict with an existing row, such as choosing a
+               random number.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigID."
+       ::= { tunnelConfigEntry 4 }
+
+   tunnelConfigIfIndex OBJECT-TYPE
+       SYNTAX     InterfaceIndexOrZero
+       MAX-ACCESS read-only
+       STATUS     deprecated
+       DESCRIPTION
+               "If the value of tunnelConfigStatus for this row is
+               active, then this object contains the value of ifIndex
+               corresponding to the tunnel interface.  A value of 0
+               is not legal in the active state, and means that the
+               interface index has not yet been assigned.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigIfIndex."
+       ::= { tunnelConfigEntry 5 }
+
+   tunnelConfigStatus OBJECT-TYPE
+       SYNTAX     RowStatus
+       MAX-ACCESS read-create
+       STATUS     deprecated
+       DESCRIPTION
+               "The status of this row, by which new entries may be
+               created, or old entries deleted from this table.  The
+               agent need not support setting this object to
+               createAndWait or notInService since there are no other
+               writable objects in this table, and writable objects
+               in rows of corresponding tables such as the
+               tunnelIfTable may be modified while this row is
+               active.
+
+               To create a row in this table for an encapsulation
+               method which does not support multiple parallel
+               tunnels with the same endpoints, the management
+               station should simply use a tunnelConfigID of 1, and
+               set tunnelConfigStatus to createAndGo.  For
+               encapsulation methods such as L2F which allow multiple
+               parallel tunnels, the management station may select a
+               pseudo-random number to use as the tunnelConfigID and
+               set tunnelConfigStatus to createAndGo.  In the event
+               that this ID is already in use and an
+               inconsistentValue is returned in response to the set
+               operation, the management station should simply select
+               a new pseudo-random number and retry the operation.
+
+               Creating a row in this table will cause an interface
+               index to be assigned by the agent in an
+               implementation-dependent manner, and corresponding
+               rows will be instantiated in the ifTable and the
+               tunnelIfTable.  The status of this row will become
+               active as soon as the agent assigns the interface
+               index, regardless of whether the interface is
+               operationally up.
+
+               Deleting a row in this table will likewise delete the
+               corresponding row in the ifTable and in the
+               tunnelIfTable.
+
+               Since this object does not support IPv6, it is
+               deprecated in favor of tunnelInetConfigStatus."
+       ::= { tunnelConfigEntry 6 }
+
+   tunnelInetConfigTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF TunnelInetConfigEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "The (conceptual) table containing information on
+               configured tunnels.  This table can be used to map a
+               set of tunnel endpoints to the associated ifIndex
+               value.  It can also be used for row creation.  Note
+               that every row in the tunnelIfTable with a fixed
+               destination address should have a corresponding row in
+               the tunnelInetConfigTable, regardless of whether it
+               was created via SNMP."
+       ::= { tunnel 3 }
+
+   tunnelInetConfigEntry OBJECT-TYPE
+       SYNTAX     TunnelInetConfigEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "An entry (conceptual row) containing the information
+               on a particular configured tunnel.  Note that there is
+               a 128 subid maximum for object OIDs.  Implementers
+               need to be aware that if the total number of octets in
+               tunnelInetConfigLocalAddress and
+               tunnelInetConfigRemoteAddress exceeds 110 then OIDs of
+               column instances in this table will have more than 128
+               sub-identifiers and cannot be accessed using SNMPv1,
+               SNMPv2c, or SNMPv3.  In practice this is not expected
+               to be a problem since IPv4 and IPv6 addresses will not
+               cause the limit to be reached, but if other types are
+               supported by an agent, care must be taken to ensure
+               that the sum of the lengths do not cause the limit to
+               be exceeded."
+       INDEX      { tunnelInetConfigAddressType,
+                    tunnelInetConfigLocalAddress,
+                    tunnelInetConfigRemoteAddress,
+                    tunnelInetConfigEncapsMethod,
+                    tunnelInetConfigID }
+       ::= { tunnelInetConfigTable 1 }
+
+   TunnelInetConfigEntry ::= SEQUENCE {
+       tunnelInetConfigAddressType         InetAddressType,
+       tunnelInetConfigLocalAddress        InetAddress,
+       tunnelInetConfigRemoteAddress       InetAddress,
+       tunnelInetConfigEncapsMethod        IANAtunnelType,
+       tunnelInetConfigID                  Integer32,
+       tunnelInetConfigIfIndex             InterfaceIndexOrZero,
+       tunnelInetConfigStatus              RowStatus,
+       tunnelInetConfigStorageType         StorageType
+   }
+
+   tunnelInetConfigAddressType OBJECT-TYPE
+       SYNTAX     InetAddressType
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "The address type over which the tunnel encapsulates
+               packets."
+       ::= { tunnelInetConfigEntry 1 }
+
+   tunnelInetConfigLocalAddress OBJECT-TYPE
+       SYNTAX     InetAddress
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "The address of the local endpoint of the tunnel, or
+               0.0.0.0 (for IPv4) or :: (for IPv6) if the device is
+               free to choose any of its addresses at tunnel
+               establishment time."
+       ::= { tunnelInetConfigEntry 2 }
+
+   tunnelInetConfigRemoteAddress OBJECT-TYPE
+       SYNTAX     InetAddress
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "The address of the remote endpoint of the tunnel."
+       ::= { tunnelInetConfigEntry 3 }
+
+   tunnelInetConfigEncapsMethod OBJECT-TYPE
+       SYNTAX     IANAtunnelType
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "The encapsulation method used by the tunnel."
+       ::= { tunnelInetConfigEntry 4 }
+
+   tunnelInetConfigID OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+               "An identifier used to distinguish between multiple
+               tunnels of the same encapsulation method, with the
+               same endpoints.  If the encapsulation protocol only
+               allows one tunnel per set of endpoint addresses (such
+               as for GRE or IP-in-IP), the value of this object is
+               1.  For encapsulation methods (such as L2F) which
+               allow multiple parallel tunnels, the manager is
+               responsible for choosing any ID which does not
+               conflict with an existing row, such as choosing a
+               random number."
+       ::= { tunnelInetConfigEntry 5 }
+
+   tunnelInetConfigIfIndex OBJECT-TYPE
+       SYNTAX     InterfaceIndexOrZero
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+               "If the value of tunnelInetConfigStatus for this row
+               is active, then this object contains the value of
+               ifIndex corresponding to the tunnel interface.  A
+               value of 0 is not legal in the active state, and means
+               that the interface index has not yet been assigned."
+       ::= { tunnelInetConfigEntry 6 }
+
+   tunnelInetConfigStatus OBJECT-TYPE
+       SYNTAX     RowStatus
+       MAX-ACCESS read-create
+       STATUS     current
+       DESCRIPTION
+               "The status of this row, by which new entries may be
+               created, or old entries deleted from this table.  The
+               agent need not support setting this object to
+               createAndWait or notInService since there are no other
+               writable objects in this table, and writable objects
+               in rows of corresponding tables such as the
+               tunnelIfTable may be modified while this row is
+               active.
+
+               To create a row in this table for an encapsulation
+               method which does not support multiple parallel
+               tunnels with the same endpoints, the management
+               station should simply use a tunnelInetConfigID of 1,
+               and set tunnelInetConfigStatus to createAndGo.  For
+               encapsulation methods such as L2F which allow multiple
+               parallel tunnels, the management station may select a
+               pseudo-random number to use as the tunnelInetConfigID
+               and set tunnelInetConfigStatus to createAndGo.  In the
+               event that this ID is already in use and an
+               inconsistentValue is returned in response to the set
+               operation, the management station should simply select
+               a new pseudo-random number and retry the operation.
+
+               Creating a row in this table will cause an interface
+               index to be assigned by the agent in an
+               implementation-dependent manner, and corresponding
+               rows will be instantiated in the ifTable and the
+               tunnelIfTable.  The status of this row will become
+               active as soon as the agent assigns the interface
+               index, regardless of whether the interface is
+               operationally up.
+
+               Deleting a row in this table will likewise delete the
+               corresponding row in the ifTable and in the
+               tunnelIfTable."
+       ::= { tunnelInetConfigEntry 7 }
+
+   tunnelInetConfigStorageType OBJECT-TYPE
+       SYNTAX     StorageType
+       MAX-ACCESS read-create
+       STATUS     current
+       DESCRIPTION
+               "The storage type of this row.  If the row is
+               permanent(4), no objects in the row need be writable."
+       ::= { tunnelInetConfigEntry 8 }
+
+   -- conformance information
+
+   tunnelMIBConformance
+                     OBJECT IDENTIFIER ::= { tunnelMIB 2 }
+   tunnelMIBCompliances
+                     OBJECT IDENTIFIER ::= { tunnelMIBConformance 1 }
+   tunnelMIBGroups  OBJECT IDENTIFIER ::= { tunnelMIBConformance 2 }
+
+   -- compliance statements
+
+   tunnelMIBCompliance MODULE-COMPLIANCE
+       STATUS  deprecated
+       DESCRIPTION
+               "The (deprecated) IPv4-only compliance statement for
+               the IP Tunnel MIB.
+
+               This is deprecated in favor of
+               tunnelMIBInetFullCompliance and
+               tunnelMIBInetReadOnlyCompliance."
+       MODULE  -- this module
+       MANDATORY-GROUPS { tunnelMIBBasicGroup }
+
+           OBJECT      tunnelIfHopLimit
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelIfTOS
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelConfigStatus
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+      ::= { tunnelMIBCompliances 1 }
+
+   tunnelMIBInetFullCompliance MODULE-COMPLIANCE
+       STATUS  current
+       DESCRIPTION
+               "The full compliance statement for the IP Tunnel MIB."
+       MODULE  -- this module
+       MANDATORY-GROUPS { tunnelMIBInetGroup }
+
+           OBJECT      tunnelIfAddressType
+           SYNTAX      InetAddressType { ipv4(1), ipv6(2),
+                                         ipv4z(3), ipv6z(4) }
+           DESCRIPTION
+               "An implementation is only required to support IPv4
+               and/or IPv6 addresses.  An implementation only needs to
+               support the addresses it actually supports on the
+               device."
+      ::= { tunnelMIBCompliances 2 }
+
+   tunnelMIBInetReadOnlyCompliance MODULE-COMPLIANCE
+       STATUS  current
+       DESCRIPTION
+               "The read-only compliance statement for the IP Tunnel
+               MIB."
+       MODULE  -- this module
+       MANDATORY-GROUPS { tunnelMIBInetGroup }
+
+           OBJECT      tunnelIfHopLimit
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelIfTOS
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelIfFlowLabel
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+           OBJECT      tunnelIfAddressType
+           SYNTAX      InetAddressType { ipv4(1), ipv6(2),
+                                         ipv4z(3), ipv6z(4) }
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required.
+
+               An implementation is only required to support IPv4
+               and/or IPv6 addresses.  An implementation only needs to
+               support the addresses it actually supports on the
+               device."
+
+           OBJECT      tunnelIfLocalInetAddress
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelIfRemoteInetAddress
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelIfEncapsLimit
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+
+           OBJECT      tunnelInetConfigStatus
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required, and active is the only
+               status that needs to be supported."
+
+           OBJECT      tunnelInetConfigStorageType
+           MIN-ACCESS  read-only
+           DESCRIPTION
+               "Write access is not required."
+      ::= { tunnelMIBCompliances 3 }
+
+   -- units of conformance
+
+   tunnelMIBBasicGroup OBJECT-GROUP
+       OBJECTS { tunnelIfLocalAddress, tunnelIfRemoteAddress,
+          tunnelIfEncapsMethod, tunnelIfHopLimit, tunnelIfTOS,
+          tunnelIfSecurity, tunnelConfigIfIndex, tunnelConfigStatus }
+       STATUS  deprecated
+       DESCRIPTION
+               "A collection of objects to support basic management
+               of IPv4 Tunnels.  Since this group cannot support
+               IPv6, it is deprecated in favor of
+               tunnelMIBInetGroup."
+       ::= { tunnelMIBGroups 1 }
+
+   tunnelMIBInetGroup OBJECT-GROUP
+       OBJECTS { tunnelIfAddressType, tunnelIfLocalInetAddress,
+          tunnelIfRemoteInetAddress, tunnelIfEncapsMethod,
+          tunnelIfEncapsLimit,
+          tunnelIfHopLimit, tunnelIfTOS, tunnelIfFlowLabel,
+          tunnelIfSecurity, tunnelInetConfigIfIndex,
+          tunnelInetConfigStatus, tunnelInetConfigStorageType }
+       STATUS  current
+       DESCRIPTION
+               "A collection of objects to support basic management
+               of IPv4 and IPv6 Tunnels."
+       ::= { tunnelMIBGroups 2 }
+
+   END
+

--- a/mibs/junos/mib-rfc4133.txt
+++ b/mibs/junos/mib-rfc4133.txt
@@ -1,0 +1,1414 @@
+ENTITY-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, mib-2, NOTIFICATION-TYPE,
+    Integer32
+        FROM SNMPv2-SMI
+    TDomain, TAddress, TEXTUAL-CONVENTION,
+    AutonomousType, RowPointer, TimeStamp, TruthValue,
+    DateAndTime
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB;
+
+entityMIB MODULE-IDENTITY
+    LAST-UPDATED "200508100000Z"
+    ORGANIZATION "IETF ENTMIB Working Group"
+    CONTACT-INFO
+            "        WG E-mail: entmib@ietf.org
+                     Mailing list subscription info:
+                       http://www.ietf.org/mailman/listinfo/entmib
+
+                     Andy Bierman
+                     ietf@andybierman.com
+
+                     Keith McCloghrie
+                     Cisco Systems Inc.
+                     170 West Tasman Drive
+                     San Jose, CA 95134
+                     +1 408-526-5260
+                     kzm@cisco.com"
+
+    DESCRIPTION
+            "The MIB module for representing multiple logical
+            entities supported by a single SNMP agent.
+
+            Copyright (C) The Internet Society (2005).  This
+            version of this MIB module is part of RFC 4133; see
+            the RFC itself for full legal notices."
+
+    REVISION        "200508100000Z"
+    DESCRIPTION
+            "Initial Version of Entity MIB (Version 3).
+             This revision obsoletes RFC 2737.
+             Additions:
+               - cpu(12) enumeration added to PhysicalClass TC
+               - DISPLAY-HINT clause to PhysicalIndex TC
+               - PhysicalIndexOrZero TC
+               - entPhysicalMfgDate object
+               - entPhysicalUris object
+             Changes:
+               - entPhysicalContainedIn SYNTAX changed from
+                 INTEGER to PhysicalIndexOrZero
+
+             This version published as RFC 4133."
+
+    REVISION        "199912070000Z"
+    DESCRIPTION
+            "Initial Version of Entity MIB (Version 2).
+             This revision obsoletes RFC 2037.
+             This version published as RFC 2737."
+
+    REVISION        "199610310000Z"
+    DESCRIPTION
+            "Initial version (version 1), published as
+             RFC 2037."
+    ::= { mib-2 47 }
+
+entityMIBObjects OBJECT IDENTIFIER ::= { entityMIB 1 }
+
+-- MIB contains four groups
+entityPhysical OBJECT IDENTIFIER ::= { entityMIBObjects 1 }
+entityLogical  OBJECT IDENTIFIER ::= { entityMIBObjects 2 }
+entityMapping  OBJECT IDENTIFIER ::= { entityMIBObjects 3 }
+entityGeneral  OBJECT IDENTIFIER ::= { entityMIBObjects 4 }
+
+
+-- Textual Conventions
+PhysicalIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT      "d"
+    STATUS            current
+    DESCRIPTION
+            "An arbitrary value that uniquely identifies the physical
+            entity.  The value should be a small, positive integer.
+            Index values for different physical entities are not
+            necessarily contiguous."
+    SYNTAX Integer32 (1..2147483647)
+
+PhysicalIndexOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT      "d"
+    STATUS            current
+    DESCRIPTION
+            "This textual convention is an extension of the
+            PhysicalIndex convention, which defines a greater than zero
+            value used to identify a physical entity.  This extension
+            permits the additional value of zero.  The semantics of the
+            value zero are object-specific and must, therefore, be
+            defined as part of the description of any object that uses
+            this syntax.  Examples of the usage of this extension are
+            situations where none or all physical entities need to be
+            referenced."
+    SYNTAX Integer32 (0..2147483647)
+
+PhysicalClass ::= TEXTUAL-CONVENTION
+    STATUS            current
+    DESCRIPTION
+            "An enumerated value which provides an indication of the
+            general hardware type of a particular physical entity.
+            There are no restrictions as to the number of
+            entPhysicalEntries of each entPhysicalClass, which must be
+            instantiated by an agent.
+
+            The enumeration 'other' is applicable if the physical entity
+            class is known, but does not match any of the supported
+            values.
+
+            The enumeration 'unknown' is applicable if the physical
+            entity class is unknown to the agent.
+
+            The enumeration 'chassis' is applicable if the physical
+            entity class is an overall container for networking
+            equipment.  Any class of physical entity, except a stack,
+            may be contained within a chassis; and a chassis may only
+            be contained within a stack.
+            The enumeration 'backplane' is applicable if the physical
+            entity class is some sort of device for aggregating and
+            forwarding networking traffic, such as a shared backplane in
+            a modular ethernet switch.  Note that an agent may model a
+            backplane as a single physical entity, which is actually
+            implemented as multiple discrete physical components (within
+            a chassis or stack).
+
+            The enumeration 'container' is applicable if the physical
+            entity class is capable of containing one or more removable
+            physical entities, possibly of different types.  For
+            example, each (empty or full) slot in a chassis will be
+            modeled as a container.  Note that all removable physical
+            entities should be modeled within a container entity, such
+            as field-replaceable modules, fans, or power supplies.  Note
+            that all known containers should be modeled by the agent,
+            including empty containers.
+
+            The enumeration 'powerSupply' is applicable if the physical
+            entity class is a power-supplying component.
+
+            The enumeration 'fan' is applicable if the physical entity
+            class is a fan or other heat-reduction component.
+
+            The enumeration 'sensor' is applicable if the physical
+            entity class is some sort of sensor, such as a temperature
+            sensor within a router chassis.
+
+            The enumeration 'module' is applicable if the physical
+            entity class is some sort of self-contained sub-system.  If
+            the enumeration 'module' is removable, then it should be
+            modeled within a container entity, otherwise it should be
+            modeled directly within another physical entity (e.g., a
+            chassis or another module).
+
+            The enumeration 'port' is applicable if the physical entity
+            class is some sort of networking port, capable of receiving
+            and/or transmitting networking traffic.
+
+            The enumeration 'stack' is applicable if the physical entity
+            class is some sort of super-container (possibly virtual),
+            intended to group together multiple chassis entities.  A
+            stack may be realized by a 'virtual' cable, a real
+            interconnect cable, attached to multiple chassis, or may in
+            fact be comprised of multiple interconnect cables.  A stack
+            should not be modeled within any other physical entities,
+            but a stack may be contained within another stack.  Only
+            chassis entities should be contained within a stack.
+            The enumeration 'cpu' is applicable if the physical entity
+            class is some sort of central processing unit."
+    SYNTAX      INTEGER  {
+       other(1),
+       unknown(2),
+       chassis(3),
+       backplane(4),
+       container(5),     -- e.g., chassis slot or daughter-card holder
+       powerSupply(6),
+       fan(7),
+       sensor(8),
+       module(9),        -- e.g., plug-in card or daughter-card
+       port(10),
+       stack(11),        -- e.g., stack of multiple chassis entities
+       cpu(12)
+    }
+
+SnmpEngineIdOrNone ::= TEXTUAL-CONVENTION
+    STATUS            current
+    DESCRIPTION
+            "A specially formatted SnmpEngineID string for use with the
+            Entity MIB.
+
+            If an instance of an object of SYNTAX SnmpEngineIdOrNone has
+            a non-zero length, then the object encoding and semantics
+            are defined by the SnmpEngineID textual convention (see STD
+            62, RFC 3411 [RFC3411]).
+
+            If an instance of an object of SYNTAX SnmpEngineIdOrNone
+            contains a zero-length string, then no appropriate
+            SnmpEngineID is associated with the logical entity (i.e.,
+            SNMPv3 is not supported)."
+    SYNTAX OCTET STRING (SIZE(0..32)) -- empty string or SnmpEngineID
+
+
+--           The Physical Entity Table
+entPhysicalTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntPhysicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains one row per physical entity.  There is
+            always at least one row for an 'overall' physical entity."
+    ::= { entityPhysical 1 }
+
+entPhysicalEntry       OBJECT-TYPE
+    SYNTAX      EntPhysicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular physical entity.
+
+            Each entry provides objects (entPhysicalDescr,
+            entPhysicalVendorType, and entPhysicalClass) to help an NMS
+            identify and characterize the entry, and objects
+            (entPhysicalContainedIn and entPhysicalParentRelPos) to help
+            an NMS relate the particular entry to other entries in this
+            table."
+    INDEX   { entPhysicalIndex }
+    ::= { entPhysicalTable 1 }
+
+EntPhysicalEntry ::= SEQUENCE {
+      entPhysicalIndex          PhysicalIndex,
+      entPhysicalDescr          SnmpAdminString,
+      entPhysicalVendorType     AutonomousType,
+      entPhysicalContainedIn    PhysicalIndexOrZero,
+      entPhysicalClass          PhysicalClass,
+      entPhysicalParentRelPos   Integer32,
+      entPhysicalName           SnmpAdminString,
+      entPhysicalHardwareRev    SnmpAdminString,
+      entPhysicalFirmwareRev    SnmpAdminString,
+      entPhysicalSoftwareRev    SnmpAdminString,
+      entPhysicalSerialNum      SnmpAdminString,
+      entPhysicalMfgName        SnmpAdminString,
+      entPhysicalModelName      SnmpAdminString,
+      entPhysicalAlias          SnmpAdminString,
+      entPhysicalAssetID        SnmpAdminString,
+      entPhysicalIsFRU          TruthValue,
+      entPhysicalMfgDate        DateAndTime,
+      entPhysicalUris           OCTET STRING
+
+}
+
+entPhysicalIndex    OBJECT-TYPE
+    SYNTAX      PhysicalIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "The index for this entry."
+    ::= { entPhysicalEntry 1 }
+
+entPhysicalDescr OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual description of physical entity.  This object
+            should contain a string that identifies the manufacturer's
+            name for the physical entity, and should be set to a
+            distinct value for each version or model of the physical
+            entity."
+    ::= { entPhysicalEntry 2 }
+
+entPhysicalVendorType OBJECT-TYPE
+    SYNTAX      AutonomousType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the vendor-specific hardware type of the
+            physical entity.  Note that this is different from the
+            definition of MIB-II's sysObjectID.
+
+            An agent should set this object to an enterprise-specific
+            registration identifier value indicating the specific
+            equipment type in detail.  The associated instance of
+            entPhysicalClass is used to indicate the general type of
+            hardware device.
+
+            If no vendor-specific registration identifier exists for
+            this physical entity, or the value is unknown by this agent,
+            then the value { 0 0 } is returned."
+    ::= { entPhysicalEntry 3 }
+
+entPhysicalContainedIn OBJECT-TYPE
+    SYNTAX      PhysicalIndexOrZero
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of entPhysicalIndex for the physical entity which
+            'contains' this physical entity.  A value of zero indicates
+            this physical entity is not contained in any other physical
+            entity.  Note that the set of 'containment' relationships
+            define a strict hierarchy; that is, recursion is not
+            allowed.
+
+            In the event that a physical entity is contained by more
+            than one physical entity (e.g., double-wide modules), this
+            object should identify the containing entity with the lowest
+            value of entPhysicalIndex."
+    ::= { entPhysicalEntry 4 }
+
+entPhysicalClass OBJECT-TYPE
+    SYNTAX      PhysicalClass
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the general hardware type of the physical
+            entity.
+
+            An agent should set this object to the standard enumeration
+            value that most accurately indicates the general class of
+            the physical entity, or the primary class if there is more
+            than one entity.
+
+            If no appropriate standard registration identifier exists
+            for this physical entity, then the value 'other(1)' is
+            returned.  If the value is unknown by this agent, then the
+            value 'unknown(2)' is returned."
+    ::= { entPhysicalEntry 5 }
+
+entPhysicalParentRelPos OBJECT-TYPE
+    SYNTAX      Integer32 (-1..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the relative position of this 'child'
+            component among all its 'sibling' components.  Sibling
+            components are defined as entPhysicalEntries that share the
+            same instance values of each of the entPhysicalContainedIn
+            and entPhysicalClass objects.
+
+            An NMS can use this object to identify the relative ordering
+            for all sibling components of a particular parent
+            (identified by the entPhysicalContainedIn instance in each
+            sibling entry).
+
+            If possible, this value should match any external labeling
+            of the physical component.  For example, for a container
+            (e.g., card slot) labeled as 'slot #3',
+            entPhysicalParentRelPos should have the value '3'.  Note
+            that the entPhysicalEntry for the module plugged in slot 3
+            should have an entPhysicalParentRelPos value of '1'.
+
+            If the physical position of this component does not match
+            any external numbering or clearly visible ordering, then
+            user documentation or other external reference material
+            should be used to determine the parent-relative position.
+            If this is not possible, then the agent should assign a
+            consistent (but possibly arbitrary) ordering to a given set
+            of 'sibling' components, perhaps based on internal
+            representation of the components.
+            If the agent cannot determine the parent-relative position
+            for some reason, or if the associated value of
+            entPhysicalContainedIn is '0', then the value '-1' is
+            returned.  Otherwise, a non-negative integer is returned,
+            indicating the parent-relative position of this physical
+            entity.
+
+            Parent-relative ordering normally starts from '1' and
+            continues to 'N', where 'N' represents the highest
+            positioned child entity.  However, if the physical entities
+            (e.g., slots) are labeled from a starting position of zero,
+            then the first sibling should be associated with an
+            entPhysicalParentRelPos value of '0'.  Note that this
+            ordering may be sparse or dense, depending on agent
+            implementation.
+
+            The actual values returned are not globally meaningful, as
+            each 'parent' component may use different numbering
+            algorithms.  The ordering is only meaningful among siblings
+            of the same parent component.
+
+            The agent should retain parent-relative position values
+            across reboots, either through algorithmic assignment or use
+            of non-volatile storage."
+    ::= { entPhysicalEntry 6 }
+
+entPhysicalName OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The textual name of the physical entity.  The value of this
+            object should be the name of the component as assigned by
+            the local device and should be suitable for use in commands
+            entered at the device's `console'.  This might be a text
+            name (e.g., `console') or a simple component number (e.g.,
+            port or module number, such as `1'), depending on the
+            physical component naming syntax of the device.
+
+            If there is no local name, or if this object is otherwise
+            not applicable, then this object contains a zero-length
+            string.
+
+            Note that the value of entPhysicalName for two physical
+            entities will be the same in the event that the console
+            interface does not distinguish between them, e.g., slot-1
+            and the card in slot-1."
+    ::= { entPhysicalEntry 7 }
+
+
+
+entPhysicalHardwareRev    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific hardware revision string for the
+            physical entity.  The preferred value is the hardware
+            revision identifier actually printed on the component itself
+            (if present).
+
+            Note that if revision information is stored internally in a
+            non-printable (e.g., binary) format, then the agent must
+            convert such information to a printable format, in an
+            implementation-specific manner.
+
+            If no specific hardware revision string is associated with
+            the physical component, or if this information is unknown to
+            the agent, then this object will contain a zero-length
+            string."
+    ::= { entPhysicalEntry 8 }
+
+entPhysicalFirmwareRev    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific firmware revision string for the
+            physical entity.
+
+            Note that if revision information is stored internally in a
+            non-printable (e.g., binary) format, then the agent must
+            convert such information to a printable format, in an
+            implementation-specific manner.
+
+            If no specific firmware programs are associated with the
+            physical component, or if this information is unknown to the
+            agent, then this object will contain a zero-length string."
+    ::= { entPhysicalEntry 9 }
+
+entPhysicalSoftwareRev    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific software revision string for the
+            physical entity.
+
+            Note that if revision information is stored internally in a
+            non-printable (e.g., binary) format, then the agent must
+            convert such information to a printable format, in an
+            implementation-specific manner.
+
+            If no specific software programs are associated with the
+            physical component, or if this information is unknown to the
+            agent, then this object will contain a zero-length string."
+    ::= { entPhysicalEntry 10 }
+
+entPhysicalSerialNum   OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+     MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific serial number string for the physical
+            entity.  The preferred value is the serial number string
+            actually printed on the component itself (if present).
+
+            On the first instantiation of an physical entity, the value
+            of entPhysicalSerialNum associated with that entity is set
+            to the correct vendor-assigned serial number, if this
+            information is available to the agent.  If a serial number
+            is unknown or non-existent, the entPhysicalSerialNum will be
+            set to a zero-length string instead.
+
+            Note that implementations that can correctly identify the
+            serial numbers of all installed physical entities do not
+            need to provide write access to the entPhysicalSerialNum
+            object.  Agents which cannot provide non-volatile storage
+            for the entPhysicalSerialNum strings are not required to
+            implement write access for this object.
+
+            Not every physical component will have a serial number, or
+            even need one.  Physical entities for which the associated
+            value of the entPhysicalIsFRU object is equal to 'false(2)'
+            (e.g., the repeater ports within a repeater module), do not
+            need their own unique serial number.  An agent does not have
+            to provide write access for such entities, and may return a
+            zero-length string.
+
+            If write access is implemented for an instance of
+            entPhysicalSerialNum, and a value is written into the
+            instance, the agent must retain the supplied value in the
+            entPhysicalSerialNum instance (associated with the same
+            physical entity) for as long as that entity remains
+            instantiated.  This includes instantiations across all
+            re-initializations/reboots of the network management system,
+            including those resulting in a change of the physical
+            entity's entPhysicalIndex value."
+    ::= { entPhysicalEntry 11 }
+
+entPhysicalMfgName   OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The name of the manufacturer of this physical component.
+            The preferred value is the manufacturer name string actually
+            printed on the component itself (if present).
+
+            Note that comparisons between instances of the
+            entPhysicalModelName, entPhysicalFirmwareRev,
+            entPhysicalSoftwareRev, and the entPhysicalSerialNum
+            objects, are only meaningful amongst entPhysicalEntries with
+            the same value of entPhysicalMfgName.
+
+            If the manufacturer name string associated with the physical
+            component is unknown to the agent, then this object will
+            contain a zero-length string."
+    ::= { entPhysicalEntry 12 }
+
+entPhysicalModelName   OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor-specific model name identifier string associated
+            with this physical component.  The preferred value is the
+            customer-visible part number, which may be printed on the
+            component itself.
+
+            If the model name string associated with the physical
+            component is unknown to the agent, then this object will
+            contain a zero-length string."
+    ::= { entPhysicalEntry 13 }
+
+entPhysicalAlias    OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+     MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object is an 'alias' name for the physical entity, as
+            specified by a network manager, and provides a non-volatile
+            'handle' for the physical entity.
+
+            On the first instantiation of a physical entity, the value
+            of entPhysicalAlias associated with that entity is set to
+            the zero-length string.  However, the agent may set the
+            value to a locally unique default value, instead of a
+            zero-length string.
+
+            If write access is implemented for an instance of
+            entPhysicalAlias, and a value is written into the instance,
+            the agent must retain the supplied value in the
+            entPhysicalAlias instance (associated with the same physical
+            entity) for as long as that entity remains instantiated.
+            This includes instantiations across all
+            re-initializations/reboots of the network management system,
+            including those resulting in a change of the physical
+            entity's entPhysicalIndex value."
+    ::= { entPhysicalEntry 14 }
+
+entPhysicalAssetID OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..32))
+     MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object is a user-assigned asset tracking identifier
+            (as specified by a network manager) for the physical entity,
+            and provides non-volatile storage of this information.
+
+            On the first instantiation of a physical entity, the value
+            of entPhysicalAssetID associated with that entity is set to
+            the zero-length string.
+
+            Not every physical component will have an asset tracking
+            identifier, or even need one.  Physical entities for which
+            the associated value of the entPhysicalIsFRU object is equal
+            to 'false(2)' (e.g., the repeater ports within a repeater
+            module), do not need their own unique asset tracking
+            identifier.  An agent does not have to provide write access
+            for such entities, and may instead return a zero-length
+            string.
+
+            If write access is implemented for an instance of
+            entPhysicalAssetID, and a value is written into the
+            instance, the agent must retain the supplied value in the
+            entPhysicalAssetID instance (associated with the same
+            physical entity) for as long as that entity remains
+            instantiated.  This includes instantiations across all
+            re-initializations/reboots of the network management system,
+            including those resulting in a change of the physical
+            entity's entPhysicalIndex value.
+            If no asset tracking information is associated with the
+            physical component, then this object will contain a
+            zero-length string."
+    ::= { entPhysicalEntry 15 }
+
+entPhysicalIsFRU OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "This object indicates whether or not this physical entity
+            is considered a 'field replaceable unit' by the vendor.  If
+            this object contains the value 'true(1)' then this
+            entPhysicalEntry identifies a field replaceable unit.  For
+            all entPhysicalEntries that represent components
+            permanently contained within a field replaceable unit, the
+            value 'false(2)' should be returned for this object."
+    ::= { entPhysicalEntry 16 }
+
+entPhysicalMfgDate  OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "This object contains the date of manufacturing of the
+            managed entity.  If the manufacturing date is unknown or not
+            supported, the object is not instantiated.  The special
+            value '0000000000000000'H may also be returned in this
+            case."
+    ::= { entPhysicalEntry 17 }
+
+entPhysicalUris OBJECT-TYPE
+    SYNTAX      OCTET STRING
+     MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object contains additional identification information
+            about the physical entity.  The object contains URIs and,
+            therefore, the syntax of this object must conform to RFC
+            3986, section 2.
+
+            Multiple URIs may be present and are separated by white
+            space characters.  Leading and trailing white space
+            characters are ignored.
+
+            If no additional identification information is known
+            about the physical entity or supported, the object is not
+            instantiated.  A zero length octet string may also be
+            returned in this case."
+    REFERENCE
+            "RFC 3986, Uniform Resource Identifiers (URI): Generic
+            Syntax, section 2, August 1998."
+
+    ::= { entPhysicalEntry 18 }
+
+
+--           The Logical Entity Table
+entLogicalTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntLogicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains one row per logical entity.  For agents
+            that implement more than one naming scope, at least one
+            entry must exist.  Agents which instantiate all MIB objects
+            within a single naming scope are not required to implement
+            this table."
+    ::= { entityLogical 1 }
+
+entLogicalEntry       OBJECT-TYPE
+    SYNTAX      EntLogicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular logical entity.  Entities
+            may be managed by this agent or other SNMP agents (possibly)
+            in the same chassis."
+    INDEX       { entLogicalIndex }
+    ::= { entLogicalTable 1 }
+
+EntLogicalEntry ::= SEQUENCE {
+      entLogicalIndex            Integer32,
+      entLogicalDescr            SnmpAdminString,
+      entLogicalType             AutonomousType,
+      entLogicalCommunity        OCTET STRING,
+      entLogicalTAddress         TAddress,
+      entLogicalTDomain          TDomain,
+      entLogicalContextEngineID  SnmpEngineIdOrNone,
+      entLogicalContextName      SnmpAdminString
+}
+
+entLogicalIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "The value of this object uniquely identifies the logical
+            entity.  The value should be a small positive integer; index
+            values for different logical entities are not necessarily
+            contiguous."
+    ::= { entLogicalEntry 1 }
+
+entLogicalDescr OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual description of the logical entity.  This object
+            should contain a string that identifies the manufacturer's
+            name for the logical entity, and should be set to a distinct
+            value for each version of the logical entity."
+    ::= { entLogicalEntry 2 }
+
+entLogicalType OBJECT-TYPE
+    SYNTAX      AutonomousType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An indication of the type of logical entity.  This will
+            typically be the OBJECT IDENTIFIER name of the node in the
+            SMI's naming hierarchy which represents the major MIB
+            module, or the majority of the MIB modules, supported by the
+            logical entity.  For example:
+               a logical entity of a regular host/router -> mib-2
+               a logical entity of a 802.1d bridge -> dot1dBridge
+               a logical entity of a 802.3 repeater -> snmpDot3RptrMgmt
+            If an appropriate node in the SMI's naming hierarchy cannot
+            be identified, the value 'mib-2' should be used."
+    ::= { entLogicalEntry 3 }
+
+entLogicalCommunity OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "An SNMPv1 or SNMPv2C community-string, which can be used to
+            access detailed management information for this logical
+            entity.  The agent should allow read access with this
+            community string (to an appropriate subset of all managed
+            objects) and may also return a community string based on the
+            privileges of the request used to read this object.  Note
+            that an agent may return a community string with read-only
+            privileges, even if this object is accessed with a
+            read-write community string.  However, the agent must take
+            care not to return a community string that allows more
+            privileges than the community string used to access this
+            object.
+
+            A compliant SNMP agent may wish to conserve naming scopes by
+            representing multiple logical entities in a single 'default'
+            naming scope.  This is possible when the logical entities,
+            represented by the same value of entLogicalCommunity, have
+            no object instances in common.  For example, 'bridge1' and
+            'repeater1' may be part of the main naming scope, but at
+            least one additional community string is needed to represent
+            'bridge2' and 'repeater2'.
+
+            Logical entities 'bridge1' and 'repeater1' would be
+            represented by sysOREntries associated with the 'default'
+            naming scope.
+
+            For agents not accessible via SNMPv1 or SNMPv2C, the value
+            of this object is the empty string.  This object may also
+            contain an empty string if a community string has not yet
+            been assigned by the agent, or if no community string with
+            suitable access rights can be returned for a particular SNMP
+            request.
+
+            Note that this object is deprecated.  Agents which implement
+            SNMPv3 access should use the entLogicalContextEngineID and
+            entLogicalContextName objects to identify the context
+            associated with each logical entity.  SNMPv3 agents may
+            return a zero-length string for this object, or may continue
+            to return a community string (e.g., tri-lingual agent
+            support)."
+    ::= { entLogicalEntry 4 }
+
+entLogicalTAddress OBJECT-TYPE
+    SYNTAX      TAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The transport service address by which the logical entity
+            receives network management traffic, formatted according to
+            the corresponding value of entLogicalTDomain.
+
+            For snmpUDPDomain, a TAddress is 6 octets long: the initial
+            4 octets contain the IP-address in network-byte order and
+            the last 2 contain the UDP port in network-byte order.
+            Consult 'Transport Mappings for the Simple Network
+            Management Protocol' (STD 62, RFC 3417 [RFC3417]) for
+            further information on snmpUDPDomain."
+    ::= { entLogicalEntry 5 }
+
+entLogicalTDomain OBJECT-TYPE
+    SYNTAX      TDomain
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Indicates the kind of transport service by which the
+            logical entity receives network management traffic.
+            Possible values for this object are presently found in the
+            Transport Mappings for Simple Network Management Protocol'
+            (STD 62, RFC 3417 [RFC3417])."
+    ::= { entLogicalEntry 6 }
+
+entLogicalContextEngineID    OBJECT-TYPE
+    SYNTAX      SnmpEngineIdOrNone
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The authoritative contextEngineID that can be used to send
+            an SNMP message concerning information held by this logical
+            entity, to the address specified by the associated
+            'entLogicalTAddress/entLogicalTDomain' pair.
+
+            This object, together with the associated
+            entLogicalContextName object, defines the context associated
+            with a particular logical entity, and allows access to SNMP
+            engines identified by a contextEngineId and contextName
+            pair.
+
+            If no value has been configured by the agent, a zero-length
+            string is returned, or the agent may choose not to
+            instantiate this object at all."
+    ::= { entLogicalEntry 7 }
+
+entLogicalContextName    OBJECT-TYPE
+    SYNTAX      SnmpAdminString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The contextName that can be used to send an SNMP message
+            concerning information held by this logical entity, to the
+            address specified by the associated
+            'entLogicalTAddress/entLogicalTDomain' pair.
+
+            This object, together with the associated
+            entLogicalContextEngineID object, defines the context
+            associated with a particular logical entity, and allows
+            access to SNMP engines identified by a contextEngineId and
+            contextName pair.
+
+            If no value has been configured by the agent, a zero-length
+            string is returned, or the agent may choose not to
+            instantiate this object at all."
+    ::= { entLogicalEntry 8 }
+
+entLPMappingTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntLPMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains zero or more rows of logical entity to
+            physical equipment associations.  For each logical entity
+            known by this agent, there are zero or more mappings to the
+            physical resources, which are used to realize that logical
+            entity.
+
+            An agent should limit the number and nature of entries in
+            this table such that only meaningful and non-redundant
+            information is returned.  For example, in a system that
+            contains a single power supply, mappings between logical
+            entities and the power supply are not useful and should not
+            be included.
+
+            Also, only the most appropriate physical component, which is
+            closest to the root of a particular containment tree, should
+            be identified in an entLPMapping entry.
+
+            For example, suppose a bridge is realized on a particular
+            module, and all ports on that module are ports on this
+            bridge.  A mapping between the bridge and the module would
+            be useful, but additional mappings between the bridge and
+            each of the ports on that module would be redundant (because
+            the entPhysicalContainedIn hierarchy can provide the same
+            information).  On the other hand, if more than one bridge
+            were utilizing ports on this module, then mappings between
+            each bridge and the ports it used would be appropriate.
+
+            Also, in the case of a single backplane repeater, a mapping
+            for the backplane to the single repeater entity is not
+            necessary."
+    ::= { entityMapping 1 }
+
+entLPMappingEntry       OBJECT-TYPE
+    SYNTAX      EntLPMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular logical entity to physical
+            equipment association.  Note that the nature of the
+            association is not specifically identified in this entry.
+            It is expected that sufficient information exists in the
+            MIBs used to manage a particular logical entity to infer how
+            physical component information is utilized."
+    INDEX       { entLogicalIndex, entLPPhysicalIndex }
+    ::= { entLPMappingTable 1 }
+
+EntLPMappingEntry ::= SEQUENCE {
+      entLPPhysicalIndex         PhysicalIndex
+}
+
+entLPPhysicalIndex OBJECT-TYPE
+    SYNTAX      PhysicalIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of this object identifies the index value of a
+            particular entPhysicalEntry associated with the indicated
+            entLogicalEntity."
+    ::= { entLPMappingEntry 1 }
+
+
+-- logical entity/component to alias table
+entAliasMappingTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntAliasMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains zero or more rows, representing
+            mappings of logical entity and physical component to
+            external MIB identifiers.  Each physical port in the system
+            may be associated with a mapping to an external identifier,
+            which itself is associated with a particular logical
+            entity's naming scope.  A 'wildcard' mechanism is provided
+            to indicate that an identifier is associated with more than
+            one logical entity."
+    ::= { entityMapping 2 }
+
+entAliasMappingEntry       OBJECT-TYPE
+    SYNTAX      EntAliasMappingEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Information about a particular physical equipment, logical
+            entity to external identifier binding.  Each logical
+            entity/physical component pair may be associated with one
+            alias mapping.  The logical entity index may also be used as
+            a 'wildcard' (refer to the entAliasLogicalIndexOrZero object
+            DESCRIPTION clause for details.)
+
+            Note that only entPhysicalIndex values that represent
+            physical ports (i.e., associated entPhysicalClass value is
+            'port(10)') are permitted to exist in this table."
+    INDEX { entPhysicalIndex, entAliasLogicalIndexOrZero }
+    ::= { entAliasMappingTable 1 }
+
+EntAliasMappingEntry ::= SEQUENCE {
+      entAliasLogicalIndexOrZero        Integer32,
+      entAliasMappingIdentifier         RowPointer
+}
+
+entAliasLogicalIndexOrZero OBJECT-TYPE
+    SYNTAX      Integer32 (0..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "The value of this object identifies the logical entity
+            that defines the naming scope for the associated instance
+            of the 'entAliasMappingIdentifier' object.
+
+            If this object has a non-zero value, then it identifies the
+            logical entity named by the same value of entLogicalIndex.
+
+            If this object has a value of zero, then the mapping between
+            the physical component and the alias identifier for this
+            entAliasMapping entry is associated with all unspecified
+            logical entities.  That is, a value of zero (the default
+            mapping) identifies any logical entity that does not have
+            an explicit entry in this table for a particular
+            entPhysicalIndex/entAliasMappingIdentifier pair.
+
+            For example, to indicate that a particular interface (e.g.,
+            physical component 33) is identified by the same value of
+            ifIndex for all logical entities, the following instance
+            might exist:
+
+                    entAliasMappingIdentifier.33.0 = ifIndex.5
+
+            In the event an entPhysicalEntry is associated differently
+            for some logical entities, additional entAliasMapping
+            entries may exist, e.g.:
+
+                    entAliasMappingIdentifier.33.0 = ifIndex.6
+                    entAliasMappingIdentifier.33.4 =  ifIndex.1
+                    entAliasMappingIdentifier.33.5 =  ifIndex.1
+                    entAliasMappingIdentifier.33.10 = ifIndex.12
+
+            Note that entries with non-zero entAliasLogicalIndexOrZero
+            index values have precedence over zero-indexed entries.  In
+            this example, all logical entities except 4, 5, and 10,
+            associate physical entity 33 with ifIndex.6."
+    ::= { entAliasMappingEntry 1 }
+
+entAliasMappingIdentifier OBJECT-TYPE
+    SYNTAX      RowPointer
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of this object identifies a particular conceptual
+            row associated with the indicated entPhysicalIndex and
+            entLogicalIndex pair.
+
+            Because only physical ports are modeled in this table, only
+            entries that represent interfaces or ports are allowed.  If
+            an ifEntry exists on behalf of a particular physical port,
+            then this object should identify the associated 'ifEntry'.
+            For repeater ports, the appropriate row in the
+            'rptrPortGroupTable' should be identified instead.
+
+            For example, suppose a physical port was represented by
+            entPhysicalEntry.3, entLogicalEntry.15 existed for a
+            repeater, and entLogicalEntry.22 existed for a bridge.  Then
+            there might be two related instances of
+            entAliasMappingIdentifier:
+               entAliasMappingIdentifier.3.15 == rptrPortGroupIndex.5.2
+               entAliasMappingIdentifier.3.22 == ifIndex.17
+            It is possible that other mappings (besides interfaces and
+            repeater ports) may be defined in the future, as required.
+
+            Bridge ports are identified by examining the Bridge MIB and
+            appropriate ifEntries associated with each 'dot1dBasePort',
+            and are thus not represented in this table."
+    ::= { entAliasMappingEntry 2 }
+
+
+-- physical mapping table
+entPhysicalContainsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntPhysicalContainsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table that exposes the container/'containee'
+            relationships between physical entities.  This table
+            provides all the information found by constructing the
+            virtual containment tree for a given entPhysicalTable, but
+            in a more direct format.
+
+            In the event a physical entity is contained by more than one
+            other physical entity (e.g., double-wide modules), this
+            table should include these additional mappings, which cannot
+            be represented in the entPhysicalTable virtual containment
+            tree."
+    ::= { entityMapping 3 }
+
+entPhysicalContainsEntry OBJECT-TYPE
+    SYNTAX      EntPhysicalContainsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A single container/'containee' relationship."
+    INDEX       { entPhysicalIndex, entPhysicalChildIndex }
+    ::= { entPhysicalContainsTable 1 }
+
+EntPhysicalContainsEntry ::= SEQUENCE {
+      entPhysicalChildIndex     PhysicalIndex
+}
+
+entPhysicalChildIndex OBJECT-TYPE
+    SYNTAX      PhysicalIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of entPhysicalIndex for the contained physical
+            entity."
+    ::= { entPhysicalContainsEntry 1 }
+
+-- last change time stamp for the whole MIB
+entLastChangeTime OBJECT-TYPE
+    SYNTAX      TimeStamp
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime at the time a conceptual row is
+            created, modified, or deleted in any of these tables:
+                    - entPhysicalTable
+                    - entLogicalTable
+                    - entLPMappingTable
+                    - entAliasMappingTable
+                    - entPhysicalContainsTable
+            "
+    ::= { entityGeneral 1 }
+
+
+-- Entity MIB Trap Definitions
+entityMIBTraps      OBJECT IDENTIFIER ::= { entityMIB 2 }
+entityMIBTrapPrefix OBJECT IDENTIFIER ::= { entityMIBTraps 0 }
+
+entConfigChange NOTIFICATION-TYPE
+    STATUS             current
+    DESCRIPTION
+            "An entConfigChange notification is generated when the value
+            of entLastChangeTime changes.  It can be utilized by an NMS
+            to trigger logical/physical entity table maintenance polls.
+
+            An agent should not generate more than one entConfigChange
+            'notification-event' in a given time interval (five seconds
+            is the suggested default).  A 'notification-event' is the
+            transmission of a single trap or inform PDU to a list of
+            notification destinations.
+
+            If additional configuration changes occur within the
+            throttling period, then notification-events for these
+            changes should be suppressed by the agent until the current
+            throttling period expires.  At the end of a throttling
+            period, one notification-event should be generated if any
+            configuration changes occurred since the start of the
+            throttling period.  In such a case, another throttling
+            period is started right away.
+
+            An NMS should periodically check the value of
+            entLastChangeTime to detect any missed entConfigChange
+            notification-events, e.g., due to throttling or transmission
+            loss."
+   ::= { entityMIBTrapPrefix 1 }
+
+
+-- conformance information
+entityConformance OBJECT IDENTIFIER ::= { entityMIB 3 }
+
+entityCompliances OBJECT IDENTIFIER ::= { entityConformance 1 }
+entityGroups      OBJECT IDENTIFIER ::= { entityConformance 2 }
+
+
+-- compliance statements
+entityCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "The compliance statement for SNMP entities that implement
+            version 1 of the Entity MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS {
+                           entityPhysicalGroup,
+                           entityLogicalGroup,
+                           entityMappingGroup,
+                           entityGeneralGroup,
+                           entityNotificationsGroup
+        }
+    ::= { entityCompliances 1 }
+
+entity2Compliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "The compliance statement for SNMP entities that implement
+            version 2 of the Entity MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS {
+                           entityPhysicalGroup,
+                           entityPhysical2Group,
+                           entityGeneralGroup,
+                           entityNotificationsGroup
+        }
+        GROUP entityLogical2Group
+        DESCRIPTION
+            "Implementation of this group is not mandatory for agents
+            that model all MIB object instances within a single naming
+            scope."
+
+        GROUP entityMappingGroup
+        DESCRIPTION
+            "Implementation of the entPhysicalContainsTable is mandatory
+            for all agents.  Implementation of the entLPMappingTable and
+            entAliasMappingTables are not mandatory for agents that
+            model all MIB object instances within a single naming scope.
+
+            Note that the entAliasMappingTable may be useful for all
+            agents; however, implementation of the entityLogicalGroup or
+            entityLogical2Group is required to support this table."
+
+        OBJECT entPhysicalSerialNum
+        MIN-ACCESS   not-accessible
+        DESCRIPTION
+            "Read and write access is not required for agents that
+            cannot identify serial number information for physical
+            entities, and/or cannot provide non-volatile storage for
+            NMS-assigned serial numbers.
+
+            Write access is not required for agents that can identify
+            serial number information for physical entities, but cannot
+            provide non-volatile storage for NMS-assigned serial
+            numbers.
+
+            Write access is not required for physical entities for which
+            the associated value of the entPhysicalIsFRU object is equal
+            to 'false(2)'."
+
+        OBJECT entPhysicalAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is required only if the associated
+            entPhysicalClass value is equal to 'chassis(3)'."
+
+        OBJECT entPhysicalAssetID
+        MIN-ACCESS   not-accessible
+        DESCRIPTION
+            "Read and write access is not required for agents that
+            cannot provide non-volatile storage for NMS-assigned asset
+            identifiers.
+
+            Write access is not required for physical entities for which
+            the associated value of the entPhysicalIsFRU object is equal
+            to 'false(2)'."
+
+        OBJECT entPhysicalClass
+        SYNTAX INTEGER {
+            other(1),
+            unknown(2),
+            chassis(3),
+            backplane(4),
+            container(5),
+            powerSupply(6),
+            fan(7),
+            sensor(8),
+            module(9),
+            port(10),
+            stack(11)
+        }
+        DESCRIPTION
+            "Implementation of the 'cpu(12)' enumeration is not
+            required."
+
+    ::= { entityCompliances 2 }
+
+
+entity3Compliance MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for SNMP entities that implement
+            version 3 of the Entity MIB."
+    MODULE  -- this module
+        MANDATORY-GROUPS {
+                           entityPhysicalGroup,
+                           entityPhysical2Group,
+                           entityPhysical3Group,
+                           entityGeneralGroup,
+                           entityNotificationsGroup
+        }
+        GROUP entityLogical2Group
+        DESCRIPTION
+            "Implementation of this group is not mandatory for agents
+            that model all MIB object instances within a single naming
+            scope."
+
+        GROUP entityMappingGroup
+        DESCRIPTION
+            "Implementation of the entPhysicalContainsTable is mandatory
+            for all agents.  Implementation of the entLPMappingTable and
+            entAliasMappingTables are not mandatory for agents that
+            model all MIB object instances within a single naming scope.
+
+            Note that the entAliasMappingTable may be useful for all
+            agents; however, implementation of the entityLogicalGroup or
+            entityLogical2Group is required to support this table."
+
+        OBJECT entPhysicalSerialNum
+        MIN-ACCESS   not-accessible
+        DESCRIPTION
+            "Read and write access is not required for agents that
+            cannot identify serial number information for physical
+            entities, and/or cannot provide non-volatile storage for
+            NMS-assigned serial numbers.
+
+            Write access is not required for agents that can identify
+            serial number information for physical entities, but cannot
+            provide non-volatile storage for NMS-assigned serial
+            numbers.
+
+            Write access is not required for physical entities for
+            which the associated value of the entPhysicalIsFRU object
+            is equal to 'false(2)'."
+
+        OBJECT entPhysicalAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is required only if the associated
+            entPhysicalClass value is equal to 'chassis(3)'."
+
+        OBJECT entPhysicalAssetID
+        MIN-ACCESS   not-accessible
+        DESCRIPTION
+            "Read and write access is not required for agents that
+            cannot provide non-volatile storage for NMS-assigned asset
+            identifiers.
+
+            Write access is not required for physical entities for which
+            the associated value of entPhysicalIsFRU is equal to
+            'false(2)'."
+    ::= { entityCompliances 3 }
+
+
+-- MIB groupings
+entityPhysicalGroup    OBJECT-GROUP
+    OBJECTS {
+              entPhysicalDescr,
+              entPhysicalVendorType,
+              entPhysicalContainedIn,
+              entPhysicalClass,
+              entPhysicalParentRelPos,
+              entPhysicalName
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects used to represent physical
+            system components, for which a single agent provides
+            management information."
+    ::= { entityGroups 1 }
+
+entityLogicalGroup    OBJECT-GROUP
+    OBJECTS {
+              entLogicalDescr,
+              entLogicalType,
+              entLogicalCommunity,
+              entLogicalTAddress,
+              entLogicalTDomain
+            }
+    STATUS  deprecated
+    DESCRIPTION
+            "The collection of objects used to represent the list of
+            logical entities, for which a single agent provides
+            management information."
+
+    ::= { entityGroups 2 }
+
+entityMappingGroup    OBJECT-GROUP
+    OBJECTS {
+              entLPPhysicalIndex,
+              entAliasMappingIdentifier,
+              entPhysicalChildIndex
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects used to represent the
+            associations between multiple logical entities, physical
+            components, interfaces, and port identifiers, for which a
+            single agent provides management information."
+    ::= { entityGroups 3 }
+
+entityGeneralGroup    OBJECT-GROUP
+    OBJECTS {
+              entLastChangeTime
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects used to represent general entity
+            information, for which a single agent provides management
+            information."
+    ::= { entityGroups 4 }
+
+entityNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS { entConfigChange }
+    STATUS        current
+    DESCRIPTION
+            "The collection of notifications used to indicate Entity MIB
+            data consistency and general status information."
+    ::= { entityGroups 5 }
+
+entityPhysical2Group    OBJECT-GROUP
+    OBJECTS {
+              entPhysicalHardwareRev,
+              entPhysicalFirmwareRev,
+              entPhysicalSoftwareRev,
+              entPhysicalSerialNum,
+              entPhysicalMfgName,
+              entPhysicalModelName,
+              entPhysicalAlias,
+              entPhysicalAssetID,
+              entPhysicalIsFRU
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects used to represent physical
+            system components, for which a single agent provides
+            management information.  This group augments the objects
+            contained in the entityPhysicalGroup."
+    ::= { entityGroups 6 }
+
+entityLogical2Group    OBJECT-GROUP
+    OBJECTS {
+              entLogicalDescr,
+              entLogicalType,
+              entLogicalTAddress,
+              entLogicalTDomain,
+              entLogicalContextEngineID,
+              entLogicalContextName
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects used to represent the
+            list of logical entities, for which a single SNMP entity
+            provides management information."
+    ::= { entityGroups 7 }
+
+entityPhysical3Group    OBJECT-GROUP
+    OBJECTS {
+              entPhysicalMfgDate,
+              entPhysicalUris
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of objects used to represent physical
+            system components, for which a single agent provides
+            management information.  This group augments the objects
+            contained in the entityPhysicalGroup."
+    ::= { entityGroups 8 }
+
+
+END

--- a/mibs/junos/mib-rfc4265.txt
+++ b/mibs/junos/mib-rfc4265.txt
@@ -1,0 +1,72 @@
+VPN-TC-STD-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, mib-2
+           FROM SNMPv2-SMI
+
+       TEXTUAL-CONVENTION
+           FROM SNMPv2-TC;
+
+   vpnTcMIB MODULE-IDENTITY
+       LAST-UPDATED "200511150000Z"  -- 15 November 2005
+       ORGANIZATION
+           "Layer 3 Virtual Private Networks (L3VPN) Working Group."
+
+       CONTACT-INFO
+           "Benson Schliesser
+            bensons@savvis.net
+
+            Thomas D. Nadeau
+            tnadeau@cisco.com
+
+            This TC MIB is a product of the PPVPN
+            http://www.ietf.org/html.charters/ppvpn-charter.html
+            and subsequently the L3VPN
+            http://www.ietf.org/html.charters/l3vpn-charter.html
+            working groups.
+
+            Comments and discussion should be directed to
+            l3vpn@ietf.org"
+       DESCRIPTION
+           "This MIB contains TCs for VPNs.
+
+            Copyright (C) The Internet Society (2005).  This version
+            of this MIB module is part of RFC 4265;  see the RFC
+            itself for full legal notices."
+       -- Revision history.
+       REVISION "200511150000Z"  -- 15 November 2005
+       DESCRIPTION "Initial version, published as RFC 4265."
+       ::= { mib-2 129 }
+
+   -- definition of textual conventions
+
+   VPNId ::= TEXTUAL-CONVENTION
+       STATUS current
+       DESCRIPTION
+           "The purpose of a VPN-ID is to uniquely identify a VPN.
+            The Global VPN Identifier format is:
+            3 octet VPN Authority, Organizationally Unique Identifier
+            followed by 4 octet VPN index identifying VPN according
+            to OUI"
+       REFERENCE
+           "Fox, B. and Gleeson, B., 'Virtual Private Networks
+            Identifier', RFC 2685, September 1999."
+       SYNTAX    OCTET STRING (SIZE (7))
+
+   VPNIdOrZero ::= TEXTUAL-CONVENTION
+       STATUS            current
+       DESCRIPTION
+           "This textual convention is an extension of the
+            VPNId textual convention that defines a non-zero-length
+            OCTET STRING to identify a physical entity.  This extension
+            permits the additional value of a zero-length OCTET STRING.
+            The semantics of the value zero-length OCTET STRING are
+            object-specific and must therefore be defined
+            as part of the description of any object that uses this
+            syntax.  Examples of usage of this extension are
+            situations where none or all VPN IDs need to be
+            referenced."
+       SYNTAX    OCTET STRING (SIZE (0 | 7))
+
+   END
+

--- a/mibs/junos/mib-rfc4268.txt
+++ b/mibs/junos/mib-rfc4268.txt
@@ -1,0 +1,330 @@
+ENTITY-STATE-MIB DEFINITIONS ::= BEGIN
+
+     IMPORTS
+         MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, mib-2
+             FROM SNMPv2-SMI
+         DateAndTime
+             FROM SNMPv2-TC
+         MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+              FROM SNMPv2-CONF
+         entPhysicalIndex
+              FROM ENTITY-MIB
+         EntityAdminState, EntityOperState, EntityUsageState,
+         EntityAlarmStatus, EntityStandbyStatus
+              FROM ENTITY-STATE-TC-MIB;
+
+     entityStateMIB MODULE-IDENTITY
+         LAST-UPDATED "200511220000Z"
+         ORGANIZATION "IETF Entity MIB Working Group"
+         CONTACT-INFO
+                 " General Discussion: entmib@ietf.org
+                   To Subscribe:
+                   http://www.ietf.org/mailman/listinfo/entmib
+
+                   http://www.ietf.org/html.charters/entmib-charter.html
+
+                   Sharon Chisholm
+                   Nortel Networks
+                   PO Box 3511 Station C
+                   Ottawa, Ont.  K1Y 4H7
+                   Canada
+                   schishol@nortel.com
+
+                   David T. Perkins
+                   548 Qualbrook Ct
+                   San Jose, CA 95110
+                   USA
+                   Phone: 408 394-8702
+                   dperkins@snmpinfo.com
+                  "
+         DESCRIPTION
+             "This MIB defines a state extension to the Entity MIB.
+
+              Copyright (C) The Internet Society 2005.  This version
+              of this MIB module is part of RFC 4268; see the RFC
+              itself for full legal notices."
+         REVISION    "200511220000Z"
+         DESCRIPTION
+             "Initial version, published as RFC 4268."
+         ::= { mib-2 131 }
+
+
+     -- Entity State Objects
+
+     entStateObjects OBJECT IDENTIFIER ::= { entityStateMIB 1 }
+
+     entStateTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF EntStateEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "A table of information about state/status of entities.
+           This is a sparse augment of the entPhysicalTable.  Entries
+           appear in this table for values of
+           entPhysicalClass [RFC4133] that in this implementation
+           are able to report any of the state or status stored in
+           this table.
+           "
+      ::= { entStateObjects 1 }
+
+
+       entStateEntry OBJECT-TYPE
+          SYNTAX      EntStateEntry
+          MAX-ACCESS  not-accessible
+          STATUS      current
+          DESCRIPTION
+              "State information about this physical entity."
+          INDEX       { entPhysicalIndex }
+          ::= { entStateTable 1 }
+
+       EntStateEntry ::= SEQUENCE {
+           entStateLastChanged DateAndTime,
+           entStateAdmin       EntityAdminState,
+           entStateOper        EntityOperState,
+           entStateUsage       EntityUsageState,
+           entStateAlarm       EntityAlarmStatus,
+           entStateStandby     EntityStandbyStatus
+          }
+
+     entStateLastChanged OBJECT-TYPE
+      SYNTAX      DateAndTime
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+        "The value of this object is the date and
+         time when the value of any of entStateAdmin,
+         entStateOper, entStateUsage, entStateAlarm,
+         or entStateStandby changed for this entity.
+
+         If there has been no change since
+         the last re-initialization of the local system,
+         this object contains the date and time of
+         local system initialization.  If there has been
+         no change since the entity was added to the
+         local system, this object contains the date and
+         time of the insertion."
+      ::= { entStateEntry 1 }
+
+   entStateAdmin OBJECT-TYPE
+          SYNTAX      EntityAdminState
+           MAX-ACCESS  read-write
+          STATUS      current
+          DESCRIPTION
+               "The administrative state for this entity.
+                This object refers to an entities administrative
+                permission to service both other entities within
+                its containment hierarchy as well other users of
+                its services defined by means outside the scope
+                of this MIB.
+
+                Setting this object to 'notSupported' will result
+                in an 'inconsistentValue' error.  For entities that
+                do not support administrative state, all set
+                operations will result in an 'inconsistentValue'
+                error.
+
+                Some physical entities exhibit only a subset of the
+                remaining administrative state values.  Some entities
+                cannot be locked, and hence this object exhibits only
+                the 'unlocked' state.  Other entities cannot be shutdown
+                gracefully, and hence this object does not exhibit the
+                'shuttingDown' state.  A value of 'inconsistentValue'
+                will be returned if attempts are made to set this
+                object to values not supported by its administrative
+                model."
+          ::= { entStateEntry 2 }
+
+    entStateOper OBJECT-TYPE
+          SYNTAX      EntityOperState
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The operational state for this entity.
+
+               Note that unlike the state model used within the
+               Interfaces MIB [RFC2863], this object does not follow
+               the administrative state.  An administrative state of
+               down does not predict an operational state
+               of disabled.
+
+               A value of 'testing' means that entity currently being
+               tested and cannot therefore report whether it is
+               operational or not.
+
+               A value of 'disabled' means that an entity is totally
+               inoperable and unable to provide service both to entities
+               within its containment hierarchy, or to other receivers
+               of its service as defined in ways outside the scope of
+               this MIB.
+
+               A value of 'enabled' means that an entity is fully or
+               partially operable and able to provide service both to
+               entities within its containment hierarchy, or to other
+               receivers of its service as defined in ways outside the
+               scope of this MIB.
+
+               Note that some implementations may not be able to
+               accurately report entStateOper while the
+               entStateAdmin object has a value other than 'unlocked'.
+               In these cases, this object MUST have a value
+               of 'unknown'."
+          ::= { entStateEntry 3 }
+
+    entStateUsage OBJECT-TYPE
+          SYNTAX      EntityUsageState
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The usage state for this entity.
+
+               This object refers to an entity's ability to service more
+               physical entities in a containment hierarchy.  A value
+               of 'idle' means this entity is able to contain other
+               entities but that no other entity is currently
+               contained within this entity.
+
+               A value of 'active' means that at least one entity is
+               contained within this entity, but that it could handle
+               more.  A value of 'busy' means that the entity is unable
+               to handle any additional entities being contained in it.
+
+               Some entities will exhibit only a subset of the
+               usage state values.  Entities that are unable to ever
+               service any entities within a containment hierarchy will
+               always have a usage state of 'busy'.  Some entities will
+               only ever be able to support one entity within its
+               containment hierarchy and will therefore only exhibit
+               values of 'idle' and 'busy'."
+             ::= { entStateEntry 4 }
+
+    entStateAlarm OBJECT-TYPE
+          SYNTAX      EntityAlarmStatus
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The alarm status for this entity.  It does not include
+               the alarms raised on child components within its
+               containment hierarchy.
+
+               A value of 'unknown' means that this entity is
+               unable to report alarm state.  Note that this differs
+               from 'indeterminate', which means that alarm state
+               is supported and there are alarms against this entity,
+               but the severity of some of the alarms is not known.
+
+               If no bits are set, then this entity supports reporting
+               of alarms, but there are currently no active alarms
+               against this entity."
+          ::= { entStateEntry 5 }
+
+   entStateStandby OBJECT-TYPE
+          SYNTAX EntityStandbyStatus
+          MAX-ACCESS read-only
+          STATUS current
+          DESCRIPTION
+               "The standby status for this entity.
+
+               Some entities will exhibit only a subset of the
+               remaining standby state values.  If this entity
+               cannot operate in a standby role, the value of this
+               object will always be 'providingService'."
+     ::= { entStateEntry 6 }
+
+   -- Notifications
+    entStateNotifications OBJECT IDENTIFIER ::= { entityStateMIB 0 }
+
+   entStateOperEnabled NOTIFICATION-TYPE
+      OBJECTS { entStateAdmin,
+                entStateAlarm
+              }
+      STATUS             current
+      DESCRIPTION
+              "An entStateOperEnabled notification signifies that the
+               SNMP entity, acting in an agent role, has detected that
+               the entStateOper object for one of its entities has
+               transitioned into the 'enabled' state.
+
+               The entity this notification refers can be identified by
+               extracting the entPhysicalIndex from one of the
+               variable bindings.  The entStateAdmin and entStateAlarm
+               varbinds may be examined to find out additional
+               information on the administrative state at the time of
+               the operation state change as well as to find out whether
+               there were any known alarms against the entity at that
+               time that may explain why the physical entity has become
+               operationally disabled."
+     ::= { entStateNotifications 1 }
+
+   entStateOperDisabled NOTIFICATION-TYPE
+      OBJECTS { entStateAdmin,
+                entStateAlarm }
+      STATUS             current
+      DESCRIPTION
+              "An entStateOperDisabled notification signifies that the
+               SNMP entity, acting in an agent role, has detected that
+               the entStateOper object for one of its entities has
+               transitioned into the 'disabled' state.
+
+               The entity this notification refers can be identified by
+               extracting the entPhysicalIndex from one of the
+               variable bindings.  The entStateAdmin and entStateAlarm
+               varbinds may be examined to find out additional
+               information on the administrative state at the time of
+               the operation state change as well as to find out whether
+               there were any known alarms against the entity at that
+               time that may affect the physical entity's
+               ability to stay operationally enabled."
+     ::= { entStateNotifications 2 }
+
+   -- Conformance and Compliance
+
+   entStateConformance OBJECT IDENTIFIER ::= { entityStateMIB 2 }
+
+   entStateCompliances OBJECT IDENTIFIER
+                     ::= { entStateConformance 1 }
+
+   entStateCompliance MODULE-COMPLIANCE
+         STATUS  current
+         DESCRIPTION
+             "The compliance statement for systems supporting
+             the Entity State MIB."
+         MODULE -- this module
+             MANDATORY-GROUPS {
+              entStateGroup
+             }
+         GROUP       entStateNotificationsGroup
+            DESCRIPTION
+                "This group is optional."
+         OBJECT entStateAdmin
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+      ::= { entStateCompliances 1 }
+
+   entStateGroups OBJECT IDENTIFIER ::= { entStateConformance 2 }
+
+   entStateGroup OBJECT-GROUP
+      OBJECTS {
+              entStateLastChanged,
+              entStateAdmin,
+              entStateOper,
+              entStateUsage,
+              entStateAlarm,
+              entStateStandby
+              }
+       STATUS   current
+       DESCRIPTION
+            "Standard Entity State group."
+       ::= { entStateGroups 1}
+
+   entStateNotificationsGroup NOTIFICATION-GROUP
+      NOTIFICATIONS {
+              entStateOperEnabled,
+              entStateOperDisabled
+              }
+       STATUS   current
+       DESCRIPTION
+            "Standard Entity State Notification group."
+       ::= { entStateGroups 2}
+
+END

--- a/mibs/junos/mib-rfc4293.txt
+++ b/mibs/junos/mib-rfc4293.txt
@@ -1,0 +1,4952 @@
+IP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    Integer32, Counter32, IpAddress,
+    mib-2, Unsigned32, Counter64,
+    zeroDotZero                        FROM SNMPv2-SMI
+    PhysAddress, TruthValue,
+    TimeStamp, RowPointer,
+    TEXTUAL-CONVENTION, TestAndIncr,
+    RowStatus, StorageType             FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP    FROM SNMPv2-CONF
+    InetAddress, InetAddressType,
+    InetAddressPrefixLength,
+    InetVersion, InetZoneIndex         FROM INET-ADDRESS-MIB
+    InterfaceIndex                     FROM IF-MIB;
+
+ipMIB MODULE-IDENTITY
+    LAST-UPDATED "200602020000Z"
+    ORGANIZATION "IETF IPv6 MIB Revision Team"
+    CONTACT-INFO
+           "Editor:
+            Shawn A. Routhier
+            Interworking Labs
+            108 Whispering Pines Dr. Suite 235
+            Scotts Valley, CA 95066
+            USA
+            EMail: <sar@iwl.com>"
+    DESCRIPTION
+           "The MIB module for managing IP and ICMP implementations, but
+            excluding their management of IP routes.
+
+            Copyright (C) The Internet Society (2006).  This version of
+            this MIB module is part of RFC 4293; see the RFC itself for
+            full legal notices."
+
+    REVISION      "200602020000Z"
+    DESCRIPTION
+           "The IP version neutral revision with added IPv6 objects for
+            ND, default routers, and router advertisements.  As well as
+            being the successor to RFC 2011, this MIB is also the
+            successor to RFCs 2465 and 2466.  Published as RFC 4293."
+
+    REVISION      "199411010000Z"
+    DESCRIPTION
+           "A separate MIB module (IP-MIB) for IP and ICMP management
+            objects.  Published as RFC 2011."
+
+    REVISION      "199103310000Z"
+    DESCRIPTION
+           "The initial revision of this MIB module was part of MIB-II,
+            which was published as RFC 1213."
+    ::= { mib-2 48}
+
+--
+-- The textual conventions we define and use in this MIB.
+--
+
+IpAddressOriginTC ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+           "The origin of the address.
+
+            manual(2) indicates that the address was manually configured
+            to a specified address, e.g., by user configuration.
+
+            dhcp(4) indicates an address that was assigned to this
+            system by a DHCP server.
+
+            linklayer(5) indicates an address created by IPv6 stateless
+            auto-configuration.
+
+            random(6) indicates an address chosen by the system at
+            random, e.g., an IPv4 address within 169.254/16, or an RFC
+            3041 privacy address."
+    SYNTAX     INTEGER {
+        other(1),
+        manual(2),
+        dhcp(4),
+        linklayer(5),
+        random(6)
+    }
+
+IpAddressStatusTC ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+           "The status of an address.  Most of the states correspond to
+            states from the IPv6 Stateless Address Autoconfiguration
+            protocol.
+
+            The preferred(1) state indicates that this is a valid
+            address that can appear as the destination or source address
+            of a packet.
+
+            The deprecated(2) state indicates that this is a valid but
+            deprecated address that should no longer be used as a source
+            address in new communications, but packets addressed to such
+            an address are processed as expected.
+
+            The invalid(3) state indicates that this isn't a valid
+            address and it shouldn't appear as the destination or source
+            address of a packet.
+
+            The inaccessible(4) state indicates that the address is not
+            accessible because the interface to which this address is
+            assigned is not operational.
+
+            The unknown(5) state indicates that the status cannot be
+            determined for some reason.
+
+            The tentative(6) state indicates that the uniqueness of the
+            address on the link is being verified.  Addresses in this
+            state should not be used for general communication and
+            should only be used to determine the uniqueness of the
+            address.
+
+            The duplicate(7) state indicates the address has been
+            determined to be non-unique on the link and so must not be
+            used.
+
+            The optimistic(8) state indicates the address is available
+            for use, subject to restrictions, while its uniqueness on
+            a link is being verified.
+
+            In the absence of other information, an IPv4 address is
+            always preferred(1)."
+    REFERENCE "RFC 2462"
+    SYNTAX     INTEGER {
+        preferred(1),
+        deprecated(2),
+        invalid(3),
+        inaccessible(4),
+        unknown(5),
+        tentative(6),
+        duplicate(7),
+        optimistic(8)
+    }
+
+IpAddressPrefixOriginTC ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+           "The origin of this prefix.
+
+            manual(2) indicates a prefix that was manually configured.
+
+            wellknown(3) indicates a well-known prefix, e.g., 169.254/16
+            for IPv4 auto-configuration or fe80::/10 for IPv6 link-local
+            addresses.  Well known prefixes may be assigned by IANA,
+            the address registries, or by specification in a standards
+            track RFC.
+
+            dhcp(4) indicates a prefix that was assigned by a DHCP
+            server.
+
+            routeradv(5) indicates a prefix learned from a router
+            advertisement.
+
+            Note: while IpAddressOriginTC and IpAddressPrefixOriginTC
+            are similar, they are not identical.  The first defines how
+            an address was created, while the second defines how a
+            prefix was found."
+    SYNTAX     INTEGER {
+        other(1),
+        manual(2),
+        wellknown(3),
+        dhcp(4),
+        routeradv(5)
+    }
+
+Ipv6AddressIfIdentifierTC ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "2x:"
+     STATUS       current
+     DESCRIPTION
+       "This data type is used to model IPv6 address
+       interface identifiers.  This is a binary string
+       of up to 8 octets in network byte-order."
+     SYNTAX      OCTET STRING (SIZE (0..8))
+
+--
+-- the IP general group
+-- some objects that affect all of IPv4
+--
+
+ip       OBJECT IDENTIFIER ::= { mib-2 4 }
+
+ipForwarding OBJECT-TYPE
+    SYNTAX     INTEGER {
+                    forwarding(1),    -- acting as a router
+                    notForwarding(2)  -- NOT acting as a router
+               }
+     MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The indication of whether this entity is acting as an IPv4
+            router in respect to the forwarding of datagrams received
+            by, but not addressed to, this entity.  IPv4 routers forward
+            datagrams.  IPv4 hosts do not (except those source-routed
+            via the host).
+
+            When this object is written, the entity should save the
+            change to non-volatile storage and restore the object from
+            non-volatile storage upon re-initialization of the system.
+            Note: a stronger requirement is not used because this object
+            was previously defined."
+    ::= { ip 1 }
+
+ipDefaultTTL OBJECT-TYPE
+    SYNTAX     Integer32 (1..255)
+     MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The default value inserted into the Time-To-Live field of
+            the IPv4 header of datagrams originated at this entity,
+            whenever a TTL value is not supplied by the transport layer
+            protocol.
+
+            When this object is written, the entity should save the
+            change to non-volatile storage and restore the object from
+            non-volatile storage upon re-initialization of the system.
+            Note: a stronger requirement is not used because this object
+            was previously defined."
+    ::= { ip 2 }
+
+ipReasmTimeout OBJECT-TYPE
+    SYNTAX     Integer32
+    UNITS      "seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The maximum number of seconds that received fragments are
+            held while they are awaiting reassembly at this entity."
+    ::= { ip 13 }
+
+--
+-- the IPv6 general group
+-- Some objects that affect all of IPv6
+--
+
+ipv6IpForwarding OBJECT-TYPE
+    SYNTAX     INTEGER {
+                    forwarding(1),    -- acting as a router
+                    notForwarding(2)  -- NOT acting as a router
+               }
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The indication of whether this entity is acting as an IPv6
+            router on any interface in respect to the forwarding of
+            datagrams received by, but not addressed to, this entity.
+            IPv6 routers forward datagrams.  IPv6 hosts do not (except
+            those source-routed via the host).
+
+            When this object is written, the entity SHOULD save the
+            change to non-volatile storage and restore the object from
+            non-volatile storage upon re-initialization of the system."
+    ::= { ip 25 }
+
+ipv6IpDefaultHopLimit OBJECT-TYPE
+    SYNTAX     Integer32 (0..255)
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The default value inserted into the Hop Limit field of the
+            IPv6 header of datagrams originated at this entity whenever
+            a Hop Limit value is not supplied by the transport layer
+            protocol.
+
+            When this object is written, the entity SHOULD save the
+            change to non-volatile storage and restore the object from
+            non-volatile storage upon re-initialization of the system."
+    REFERENCE "RFC 2461 Section 6.3.2"
+    ::= { ip 26 }
+
+--
+-- IPv4 Interface Table
+--
+
+ipv4InterfaceTableLastChange OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            a row in the ipv4InterfaceTable was added or deleted, or
+            when an ipv4InterfaceReasmMaxSize or an
+            ipv4InterfaceEnableStatus object was modified.
+
+            If new objects are added to the ipv4InterfaceTable that
+            require the ipv4InterfaceTableLastChange to be updated when
+            they are modified, they must specify that requirement in
+            their description clause."
+    ::= { ip 27 }
+
+ipv4InterfaceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF Ipv4InterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table containing per-interface IPv4-specific
+            information."
+    ::= { ip 28 }
+
+ipv4InterfaceEntry OBJECT-TYPE
+    SYNTAX     Ipv4InterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "An entry containing IPv4-specific information for a specific
+            interface."
+    INDEX { ipv4InterfaceIfIndex }
+    ::= { ipv4InterfaceTable 1 }
+
+Ipv4InterfaceEntry ::= SEQUENCE {
+        ipv4InterfaceIfIndex         InterfaceIndex,
+        ipv4InterfaceReasmMaxSize    Integer32,
+        ipv4InterfaceEnableStatus    INTEGER,
+        ipv4InterfaceRetransmitTime  Unsigned32
+    }
+
+ipv4InterfaceIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface to
+            which this entry is applicable.  The interface identified by
+            a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipv4InterfaceEntry 1 }
+
+ipv4InterfaceReasmMaxSize OBJECT-TYPE
+    SYNTAX     Integer32 (0..65535)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The size of the largest IPv4 datagram that this entity can
+            re-assemble from incoming IPv4 fragmented datagrams received
+            on this interface."
+    ::= { ipv4InterfaceEntry 2 }
+
+ipv4InterfaceEnableStatus OBJECT-TYPE
+    SYNTAX     INTEGER {
+                 up(1),
+                 down(2)
+    }
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The indication of whether IPv4 is enabled (up) or disabled
+            (down) on this interface.  This object does not affect the
+            state of the interface itself, only its connection to an
+            IPv4 stack.  The IF-MIB should be used to control the state
+            of the interface."
+    ::= { ipv4InterfaceEntry 3 }
+
+ipv4InterfaceRetransmitTime OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "milliseconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The time between retransmissions of ARP requests to a
+            neighbor when resolving the address or when probing the
+            reachability of a neighbor."
+    REFERENCE "RFC 1122"
+    DEFVAL { 1000 }
+    ::= { ipv4InterfaceEntry 4 }
+
+--
+-- v6 interface table
+--
+
+ipv6InterfaceTableLastChange OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            a row in the ipv6InterfaceTable was added or deleted or when
+            an ipv6InterfaceReasmMaxSize, ipv6InterfaceIdentifier,
+            ipv6InterfaceEnableStatus, ipv6InterfaceReachableTime,
+            ipv6InterfaceRetransmitTime, or ipv6InterfaceForwarding
+            object was modified.
+
+            If new objects are added to the ipv6InterfaceTable that
+            require the ipv6InterfaceTableLastChange to be updated when
+            they are modified, they must specify that requirement in
+            their description clause."
+    ::= { ip 29 }
+
+ipv6InterfaceTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF Ipv6InterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table containing per-interface IPv6-specific
+            information."
+    ::= { ip 30 }
+
+ipv6InterfaceEntry OBJECT-TYPE
+    SYNTAX     Ipv6InterfaceEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "An entry containing IPv6-specific information for a given
+            interface."
+    INDEX { ipv6InterfaceIfIndex }
+    ::= { ipv6InterfaceTable 1 }
+
+Ipv6InterfaceEntry ::= SEQUENCE {
+        ipv6InterfaceIfIndex         InterfaceIndex,
+        ipv6InterfaceReasmMaxSize    Unsigned32,
+        ipv6InterfaceIdentifier      Ipv6AddressIfIdentifierTC,
+        ipv6InterfaceEnableStatus    INTEGER,
+        ipv6InterfaceReachableTime   Unsigned32,
+        ipv6InterfaceRetransmitTime  Unsigned32,
+        ipv6InterfaceForwarding      INTEGER
+    }
+
+ipv6InterfaceIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface to
+            which this entry is applicable.  The interface identified by
+            a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipv6InterfaceEntry 1 }
+
+ipv6InterfaceReasmMaxSize OBJECT-TYPE
+    SYNTAX     Unsigned32 (1500..65535)
+    UNITS      "octets"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The size of the largest IPv6 datagram that this entity can
+            re-assemble from incoming IPv6 fragmented datagrams received
+            on this interface."
+    ::= { ipv6InterfaceEntry 2 }
+
+ipv6InterfaceIdentifier OBJECT-TYPE
+    SYNTAX     Ipv6AddressIfIdentifierTC
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The Interface Identifier for this interface.  The Interface
+            Identifier is combined with an address prefix to form an
+            interface address.
+
+            By default, the Interface Identifier is auto-configured
+            according to the rules of the link type to which this
+            interface is attached.
+
+            A zero length identifier may be used where appropriate.  One
+            possible example is a loopback interface."
+    ::= { ipv6InterfaceEntry 3 }
+
+-- This object ID is reserved as it was used in earlier versions of
+-- the MIB module.  In theory, OIDs are not assigned until the
+-- specification is released as an RFC; however, as some companies
+-- may have shipped code based on earlier versions of the MIB, it
+-- seems best to reserve this OID.  This OID had been
+-- ipv6InterfacePhysicalAddress.
+-- ::= { ipv6InterfaceEntry 4}
+
+ipv6InterfaceEnableStatus OBJECT-TYPE
+    SYNTAX     INTEGER {
+                 up(1),
+                 down(2)
+    }
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The indication of whether IPv6 is enabled (up) or disabled
+            (down) on this interface.  This object does not affect the
+            state of the interface itself, only its connection to an
+            IPv6 stack.  The IF-MIB should be used to control the state
+            of the interface.
+
+            When this object is written, the entity SHOULD save the
+            change to non-volatile storage and restore the object from
+            non-volatile storage upon re-initialization of the system."
+    ::= { ipv6InterfaceEntry 5 }
+
+ipv6InterfaceReachableTime OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "milliseconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The time a neighbor is considered reachable after receiving
+            a reachability confirmation."
+    REFERENCE "RFC 2461, Section 6.3.2"
+    ::= { ipv6InterfaceEntry 6 }
+
+ipv6InterfaceRetransmitTime OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "milliseconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The time between retransmissions of Neighbor Solicitation
+            messages to a neighbor when resolving the address or when
+            probing the reachability of a neighbor."
+    REFERENCE "RFC 2461, Section 6.3.2"
+    ::= { ipv6InterfaceEntry 7 }
+
+ipv6InterfaceForwarding OBJECT-TYPE
+    SYNTAX     INTEGER {
+                    forwarding(1),    -- acting as a router
+                    notForwarding(2)  -- NOT acting as a router
+               }
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "The indication of whether this entity is acting as an IPv6
+            router on this interface with respect to the forwarding of
+            datagrams received by, but not addressed to, this entity.
+            IPv6 routers forward datagrams.  IPv6 hosts do not (except
+            those source-routed via the host).
+
+            This object is constrained by ipv6IpForwarding and is
+            ignored if ipv6IpForwarding is set to notForwarding.  Those
+            systems that do not provide per-interface control of the
+            forwarding function should set this object to forwarding for
+            all interfaces and allow the ipv6IpForwarding object to
+            control the forwarding capability.
+
+            When this object is written, the entity SHOULD save the
+            change to non-volatile storage and restore the object from
+            non-volatile storage upon re-initialization of the system."
+    ::= { ipv6InterfaceEntry 8 }
+
+--
+-- Per-Interface or System-Wide IP statistics.
+--
+-- The following two tables, ipSystemStatsTable and ipIfStatsTable,
+-- are intended to provide the same counters at different granularities.
+-- The ipSystemStatsTable provides system wide counters aggregating
+-- the traffic counters for all interfaces for a given address type.
+-- The ipIfStatsTable provides the same counters but for specific
+-- interfaces rather than as an aggregate.
+--
+-- Note well: If a system provides both system-wide and interface-
+-- specific values, the system-wide value may not be equal to the sum
+-- of the interface-specific values across all interfaces due to e.g.,
+-- dynamic interface creation/deletion.
+--
+-- Note well: Both of these tables contain some items that are
+-- represented by two objects, representing the value in either 32
+-- or 64 bits.  For those objects, the 32-bit value MUST be the low
+-- order 32 bits of the 64-bit value.  Also note that the 32-bit
+-- counters must be included when the 64-bit counters are included.
+
+ipTrafficStats OBJECT IDENTIFIER ::= { ip 31 }
+
+ipSystemStatsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpSystemStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table containing system wide, IP version specific
+            traffic statistics.  This table and the ipIfStatsTable
+            contain similar objects whose difference is in their
+            granularity.  Where this table contains system wide traffic
+            statistics, the ipIfStatsTable contains the same statistics
+            but counted on a per-interface basis."
+    ::= { ipTrafficStats 1 }
+
+ipSystemStatsEntry OBJECT-TYPE
+    SYNTAX     IpSystemStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "A statistics entry containing system-wide objects for a
+            particular IP version."
+    INDEX { ipSystemStatsIPVersion }
+    ::= { ipSystemStatsTable 1 }
+
+IpSystemStatsEntry ::= SEQUENCE {
+        ipSystemStatsIPVersion           InetVersion,
+        ipSystemStatsInReceives          Counter32,
+        ipSystemStatsHCInReceives        Counter64,
+        ipSystemStatsInOctets            Counter32,
+        ipSystemStatsHCInOctets          Counter64,
+        ipSystemStatsInHdrErrors         Counter32,
+        ipSystemStatsInNoRoutes          Counter32,
+        ipSystemStatsInAddrErrors        Counter32,
+        ipSystemStatsInUnknownProtos     Counter32,
+        ipSystemStatsInTruncatedPkts     Counter32,
+        ipSystemStatsInForwDatagrams     Counter32,
+        ipSystemStatsHCInForwDatagrams   Counter64,
+        ipSystemStatsReasmReqds          Counter32,
+        ipSystemStatsReasmOKs            Counter32,
+        ipSystemStatsReasmFails          Counter32,
+        ipSystemStatsInDiscards          Counter32,
+        ipSystemStatsInDelivers          Counter32,
+        ipSystemStatsHCInDelivers        Counter64,
+        ipSystemStatsOutRequests         Counter32,
+        ipSystemStatsHCOutRequests       Counter64,
+        ipSystemStatsOutNoRoutes         Counter32,
+        ipSystemStatsOutForwDatagrams    Counter32,
+        ipSystemStatsHCOutForwDatagrams  Counter64,
+        ipSystemStatsOutDiscards         Counter32,
+        ipSystemStatsOutFragReqds        Counter32,
+        ipSystemStatsOutFragOKs          Counter32,
+        ipSystemStatsOutFragFails        Counter32,
+        ipSystemStatsOutFragCreates      Counter32,
+        ipSystemStatsOutTransmits        Counter32,
+        ipSystemStatsHCOutTransmits      Counter64,
+        ipSystemStatsOutOctets           Counter32,
+        ipSystemStatsHCOutOctets         Counter64,
+        ipSystemStatsInMcastPkts         Counter32,
+        ipSystemStatsHCInMcastPkts       Counter64,
+        ipSystemStatsInMcastOctets       Counter32,
+        ipSystemStatsHCInMcastOctets     Counter64,
+        ipSystemStatsOutMcastPkts        Counter32,
+        ipSystemStatsHCOutMcastPkts      Counter64,
+        ipSystemStatsOutMcastOctets      Counter32,
+        ipSystemStatsHCOutMcastOctets    Counter64,
+        ipSystemStatsInBcastPkts         Counter32,
+        ipSystemStatsHCInBcastPkts       Counter64,
+        ipSystemStatsOutBcastPkts        Counter32,
+        ipSystemStatsHCOutBcastPkts      Counter64,
+        ipSystemStatsDiscontinuityTime   TimeStamp,
+        ipSystemStatsRefreshRate         Unsigned32
+    }
+
+ipSystemStatsIPVersion OBJECT-TYPE
+    SYNTAX     InetVersion
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP version of this row."
+    ::= { ipSystemStatsEntry 1 }
+
+-- This object ID is reserved to allow the IDs for this table's objects
+-- to align with the objects in the ipIfStatsTable.
+-- ::= { ipSystemStatsEntry 2 }
+
+ipSystemStatsInReceives OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of input IP datagrams received, including
+            those received in error.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 3 }
+
+ipSystemStatsHCInReceives OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of input IP datagrams received, including
+            those received in error.  This object counts the same
+            datagrams as ipSystemStatsInReceives, but allows for larger
+            values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 4 }
+
+ipSystemStatsInOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in input IP datagrams,
+            including those received in error.  Octets from datagrams
+            counted in ipSystemStatsInReceives MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 5 }
+
+ipSystemStatsHCInOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in input IP datagrams,
+            including those received in error.  This object counts the
+            same octets as ipSystemStatsInOctets, but allows for larger
+            values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 6 }
+
+ipSystemStatsInHdrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded due to errors in
+            their IP headers, including version number mismatch, other
+            format errors, hop count exceeded, errors discovered in
+            processing their IP options, etc.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 7 }
+
+ipSystemStatsInNoRoutes OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded because no route
+            could be found to transmit them to their destination.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 8 }
+
+ipSystemStatsInAddrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded because the IP
+            address in their IP header's destination field was not a
+            valid address to be received at this entity.  This count
+            includes invalid addresses (e.g., ::0).  For entities
+            that are not IP routers and therefore do not forward
+            datagrams, this counter includes datagrams discarded
+            because the destination address was not a local address.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 9 }
+
+ipSystemStatsInUnknownProtos OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of locally-addressed IP datagrams received
+            successfully but discarded because of an unknown or
+            unsupported protocol.
+
+            When tracking interface statistics, the counter of the
+            interface to which these datagrams were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the datagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 10 }
+
+ipSystemStatsInTruncatedPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded because the
+            datagram frame didn't carry enough data.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 11 }
+
+ipSystemStatsInForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input datagrams for which this entity was not
+            their final IP destination and for which this entity
+            attempted to find a route to forward them to that final
+            destination.  In entities that do not act as IP routers,
+            this counter will include only those datagrams that were
+            Source-Routed via this entity, and the Source-Route
+            processing was successful.
+
+            When tracking interface statistics, the counter of the
+            incoming interface is incremented for each datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 12 }
+
+ipSystemStatsHCInForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input datagrams for which this entity was not
+            their final IP destination and for which this entity
+            attempted to find a route to forward them to that final
+            destination.  This object counts the same packets as
+            ipSystemStatsInForwDatagrams, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 13 }
+
+ipSystemStatsReasmReqds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP fragments received that needed to be
+            reassembled at this interface.
+
+            When tracking interface statistics, the counter of the
+            interface to which these fragments were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the fragments.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 14 }
+
+ipSystemStatsReasmOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams successfully reassembled.
+
+            When tracking interface statistics, the counter of the
+            interface to which these datagrams were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the datagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 15 }
+
+ipSystemStatsReasmFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of failures detected by the IP re-assembly
+            algorithm (for whatever reason: timed out, errors, etc.).
+            Note that this is not necessarily a count of discarded IP
+            fragments since some algorithms (notably the algorithm in
+            RFC 815) can lose track of the number of fragments by
+            combining them as they are received.
+
+            When tracking interface statistics, the counter of the
+            interface to which these fragments were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the fragments.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 16 }
+
+ipSystemStatsInDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams for which no problems were
+            encountered to prevent their continued processing, but
+            were discarded (e.g., for lack of buffer space).  Note that
+            this counter does not include any datagrams discarded while
+            awaiting re-assembly.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 17 }
+
+ipSystemStatsInDelivers OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of datagrams successfully delivered to IP
+            user-protocols (including ICMP).
+
+            When tracking interface statistics, the counter of the
+            interface to which these datagrams were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the datagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 18 }
+
+ipSystemStatsHCInDelivers OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of datagrams successfully delivered to IP
+            user-protocols (including ICMP).  This object counts the
+            same packets as ipSystemStatsInDelivers, but allows for
+            larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 19 }
+
+ipSystemStatsOutRequests OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that local IP user-
+            protocols (including ICMP) supplied to IP in requests for
+            transmission.  Note that this counter does not include any
+            datagrams counted in ipSystemStatsOutForwDatagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 20 }
+
+ipSystemStatsHCOutRequests OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that local IP user-
+            protocols (including ICMP) supplied to IP in requests for
+            transmission.  This object counts the same packets as
+            ipSystemStatsOutRequests, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 21 }
+
+ipSystemStatsOutNoRoutes OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of locally generated IP datagrams discarded
+            because no route could be found to transmit them to their
+            destination.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 22 }
+
+ipSystemStatsOutForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of datagrams for which this entity was not their
+            final IP destination and for which it was successful in
+            finding a path to their final destination.  In entities
+            that do not act as IP routers, this counter will include
+            only those datagrams that were Source-Routed via this
+            entity, and the Source-Route processing was successful.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            forwarded datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 23 }
+
+ipSystemStatsHCOutForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of datagrams for which this entity was not their
+            final IP destination and for which it was successful in
+            finding a path to their final destination.  This object
+            counts the same packets as ipSystemStatsOutForwDatagrams,
+            but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 24 }
+
+ipSystemStatsOutDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of output IP datagrams for which no problem was
+            encountered to prevent their transmission to their
+            destination, but were discarded (e.g., for lack of
+            buffer space).  Note that this counter would include
+            datagrams counted in ipSystemStatsOutForwDatagrams if any
+            such datagrams met this (discretionary) discard criterion.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 25 }
+
+ipSystemStatsOutFragReqds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams that would require fragmentation
+            in order to be transmitted.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 26 }
+
+ipSystemStatsOutFragOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams that have been successfully
+            fragmented.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 27 }
+
+ipSystemStatsOutFragFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams that have been discarded because
+            they needed to be fragmented but could not be.  This
+            includes IPv4 packets that have the DF bit set and IPv6
+            packets that are being forwarded and exceed the outgoing
+            link MTU.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for an unsuccessfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 28 }
+
+ipSystemStatsOutFragCreates OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of output datagram fragments that have been
+            generated as a result of IP fragmentation.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 29 }
+
+ipSystemStatsOutTransmits OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that this entity supplied
+            to the lower layers for transmission.  This includes
+            datagrams generated locally and those forwarded by this
+            entity.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 30 }
+
+ipSystemStatsHCOutTransmits OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that this entity supplied
+            to the lower layers for transmission.  This object counts
+            the same datagrams as ipSystemStatsOutTransmits, but allows
+            for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 31 }
+
+ipSystemStatsOutOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets in IP datagrams delivered to the
+            lower layers for transmission.  Octets from datagrams
+            counted in ipSystemStatsOutTransmits MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 32 }
+
+ipSystemStatsHCOutOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets in IP datagrams delivered to the
+            lower layers for transmission.  This objects counts the same
+            octets as ipSystemStatsOutOctets, but allows for larger
+            values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 33 }
+
+ipSystemStatsInMcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams received.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 34 }
+
+ipSystemStatsHCInMcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams received.  This object
+            counts the same datagrams as ipSystemStatsInMcastPkts but
+            allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 35 }
+
+ipSystemStatsInMcastOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in IP multicast
+            datagrams.  Octets from datagrams counted in
+            ipSystemStatsInMcastPkts MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 36 }
+
+ipSystemStatsHCInMcastOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in IP multicast
+            datagrams.  This object counts the same octets as
+            ipSystemStatsInMcastOctets, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 37 }
+
+ipSystemStatsOutMcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams transmitted.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 38 }
+
+ipSystemStatsHCOutMcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams transmitted.  This
+            object counts the same datagrams as
+            ipSystemStatsOutMcastPkts, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 39 }
+
+ipSystemStatsOutMcastOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets transmitted in IP multicast
+            datagrams.  Octets from datagrams counted in
+            ipSystemStatsOutMcastPkts MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 40 }
+
+ipSystemStatsHCOutMcastOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets transmitted in IP multicast
+            datagrams.  This object counts the same octets as
+            ipSystemStatsOutMcastOctets, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 41 }
+
+ipSystemStatsInBcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams received.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 42 }
+
+ipSystemStatsHCInBcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams received.  This object
+            counts the same datagrams as ipSystemStatsInBcastPkts but
+            allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 43 }
+
+ipSystemStatsOutBcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams transmitted.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 44 }
+
+ipSystemStatsHCOutBcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams transmitted.  This
+            object counts the same datagrams as
+            ipSystemStatsOutBcastPkts, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipSystemStatsDiscontinuityTime."
+    ::= { ipSystemStatsEntry 45 }
+
+ipSystemStatsDiscontinuityTime OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            any one or more of this entry's counters suffered a
+            discontinuity.
+
+            If no such discontinuities have occurred since the last re-
+            initialization of the local management subsystem, then this
+            object contains a zero value."
+    ::= { ipSystemStatsEntry 46 }
+
+ipSystemStatsRefreshRate OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "milli-seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The minimum reasonable polling interval for this entry.
+            This object provides an indication of the minimum amount of
+            time required to update the counters in this entry."
+    ::= { ipSystemStatsEntry 47 }
+
+ipIfStatsTableLastChange OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            a row in the ipIfStatsTable was added or deleted.
+
+            If new objects are added to the ipIfStatsTable that require
+            the ipIfStatsTableLastChange to be updated when they are
+            modified, they must specify that requirement in their
+            description clause."
+    ::= { ipTrafficStats 2 }
+
+ipIfStatsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpIfStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table containing per-interface traffic statistics.  This
+            table and the ipSystemStatsTable contain similar objects
+            whose difference is in their granularity.  Where this table
+            contains per-interface statistics, the ipSystemStatsTable
+            contains the same statistics, but counted on a system wide
+            basis."
+    ::= { ipTrafficStats 3 }
+
+ipIfStatsEntry OBJECT-TYPE
+    SYNTAX     IpIfStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "An interface statistics entry containing objects for a
+            particular interface and version of IP."
+    INDEX { ipIfStatsIPVersion, ipIfStatsIfIndex }
+    ::= { ipIfStatsTable 1 }
+
+IpIfStatsEntry ::= SEQUENCE {
+        ipIfStatsIPVersion           InetVersion,
+        ipIfStatsIfIndex             InterfaceIndex,
+        ipIfStatsInReceives          Counter32,
+        ipIfStatsHCInReceives        Counter64,
+        ipIfStatsInOctets            Counter32,
+        ipIfStatsHCInOctets          Counter64,
+        ipIfStatsInHdrErrors         Counter32,
+        ipIfStatsInNoRoutes          Counter32,
+        ipIfStatsInAddrErrors        Counter32,
+        ipIfStatsInUnknownProtos     Counter32,
+        ipIfStatsInTruncatedPkts     Counter32,
+        ipIfStatsInForwDatagrams     Counter32,
+        ipIfStatsHCInForwDatagrams   Counter64,
+        ipIfStatsReasmReqds          Counter32,
+        ipIfStatsReasmOKs            Counter32,
+        ipIfStatsReasmFails          Counter32,
+        ipIfStatsInDiscards          Counter32,
+        ipIfStatsInDelivers          Counter32,
+        ipIfStatsHCInDelivers        Counter64,
+        ipIfStatsOutRequests         Counter32,
+        ipIfStatsHCOutRequests       Counter64,
+        ipIfStatsOutForwDatagrams    Counter32,
+        ipIfStatsHCOutForwDatagrams  Counter64,
+        ipIfStatsOutDiscards         Counter32,
+        ipIfStatsOutFragReqds        Counter32,
+        ipIfStatsOutFragOKs          Counter32,
+        ipIfStatsOutFragFails        Counter32,
+        ipIfStatsOutFragCreates      Counter32,
+        ipIfStatsOutTransmits        Counter32,
+        ipIfStatsHCOutTransmits      Counter64,
+        ipIfStatsOutOctets           Counter32,
+        ipIfStatsHCOutOctets         Counter64,
+        ipIfStatsInMcastPkts         Counter32,
+        ipIfStatsHCInMcastPkts       Counter64,
+        ipIfStatsInMcastOctets       Counter32,
+        ipIfStatsHCInMcastOctets     Counter64,
+        ipIfStatsOutMcastPkts        Counter32,
+        ipIfStatsHCOutMcastPkts      Counter64,
+        ipIfStatsOutMcastOctets      Counter32,
+        ipIfStatsHCOutMcastOctets    Counter64,
+        ipIfStatsInBcastPkts         Counter32,
+        ipIfStatsHCInBcastPkts       Counter64,
+        ipIfStatsOutBcastPkts        Counter32,
+        ipIfStatsHCOutBcastPkts      Counter64,
+        ipIfStatsDiscontinuityTime   TimeStamp,
+        ipIfStatsRefreshRate         Unsigned32
+    }
+
+ipIfStatsIPVersion OBJECT-TYPE
+    SYNTAX     InetVersion
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP version of this row."
+    ::= { ipIfStatsEntry 1 }
+
+ipIfStatsIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface to
+            which this entry is applicable.  The interface identified by
+            a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipIfStatsEntry 2 }
+
+ipIfStatsInReceives OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of input IP datagrams received, including
+            those received in error.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 3 }
+
+ipIfStatsHCInReceives OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of input IP datagrams received, including
+            those received in error.  This object counts the same
+            datagrams as ipIfStatsInReceives, but allows for larger
+            values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 4 }
+
+ipIfStatsInOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in input IP datagrams,
+            including those received in error.  Octets from datagrams
+            counted in ipIfStatsInReceives MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 5 }
+
+ipIfStatsHCInOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in input IP datagrams,
+            including those received in error.  This object counts the
+            same octets as ipIfStatsInOctets, but allows for larger
+            values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 6 }
+
+ipIfStatsInHdrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded due to errors in
+            their IP headers, including version number mismatch, other
+            format errors, hop count exceeded, errors discovered in
+            processing their IP options, etc.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 7 }
+
+ipIfStatsInNoRoutes OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded because no route
+            could be found to transmit them to their destination.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 8 }
+
+ipIfStatsInAddrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded because the IP
+            address in their IP header's destination field was not a
+            valid address to be received at this entity.  This count
+            includes invalid addresses (e.g., ::0).  For entities that
+            are not IP routers and therefore do not forward datagrams,
+            this counter includes datagrams discarded because the
+            destination address was not a local address.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 9 }
+
+ipIfStatsInUnknownProtos OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of locally-addressed IP datagrams received
+            successfully but discarded because of an unknown or
+            unsupported protocol.
+
+            When tracking interface statistics, the counter of the
+            interface to which these datagrams were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the datagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 10 }
+
+ipIfStatsInTruncatedPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams discarded because the
+            datagram frame didn't carry enough data.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 11 }
+
+ipIfStatsInForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input datagrams for which this entity was not
+            their final IP destination and for which this entity
+            attempted to find a route to forward them to that final
+            destination.  In entities that do not act as IP routers,
+            this counter will include only those datagrams that were
+            Source-Routed via this entity, and the Source-Route
+            processing was successful.
+
+            When tracking interface statistics, the counter of the
+            incoming interface is incremented for each datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 12 }
+
+ipIfStatsHCInForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input datagrams for which this entity was not
+            their final IP destination and for which this entity
+            attempted to find a route to forward them to that final
+            destination.  This object counts the same packets as
+            ipIfStatsInForwDatagrams, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 13 }
+
+ipIfStatsReasmReqds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP fragments received that needed to be
+            reassembled at this interface.
+
+            When tracking interface statistics, the counter of the
+            interface to which these fragments were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the fragments.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 14 }
+
+ipIfStatsReasmOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams successfully reassembled.
+
+            When tracking interface statistics, the counter of the
+            interface to which these datagrams were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the datagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 15 }
+
+ipIfStatsReasmFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of failures detected by the IP re-assembly
+            algorithm (for whatever reason: timed out, errors, etc.).
+            Note that this is not necessarily a count of discarded IP
+            fragments since some algorithms (notably the algorithm in
+            RFC 815) can lose track of the number of fragments by
+            combining them as they are received.
+
+            When tracking interface statistics, the counter of the
+            interface to which these fragments were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the fragments.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 16 }
+
+ipIfStatsInDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input IP datagrams for which no problems were
+            encountered to prevent their continued processing, but
+            were discarded (e.g., for lack of buffer space).  Note that
+            this counter does not include any datagrams discarded while
+            awaiting re-assembly.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 17 }
+
+ipIfStatsInDelivers OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of datagrams successfully delivered to IP
+            user-protocols (including ICMP).
+
+            When tracking interface statistics, the counter of the
+            interface to which these datagrams were addressed is
+            incremented.  This interface might not be the same as the
+            input interface for some of the datagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 18 }
+
+ipIfStatsHCInDelivers OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of datagrams successfully delivered to IP
+            user-protocols (including ICMP).  This object counts the
+            same packets as ipIfStatsInDelivers, but allows for larger
+            values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 19 }
+
+ipIfStatsOutRequests OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that local IP user-
+            protocols (including ICMP) supplied to IP in requests for
+            transmission.  Note that this counter does not include any
+            datagrams counted in ipIfStatsOutForwDatagrams.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 20 }
+
+ipIfStatsHCOutRequests OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that local IP user-
+            protocols (including ICMP) supplied to IP in requests for
+            transmission.  This object counts the same packets as
+            ipIfStatsOutRequests, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 21 }
+
+-- This object ID is reserved to allow the IDs for this table's objects
+-- to align with the objects in the ipSystemStatsTable.
+-- ::= {ipIfStatsEntry 22}
+
+ipIfStatsOutForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of datagrams for which this entity was not their
+            final IP destination and for which it was successful in
+            finding a path to their final destination.  In entities
+            that do not act as IP routers, this counter will include
+            only those datagrams that were Source-Routed via this
+            entity, and the Source-Route processing was successful.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            forwarded datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 23 }
+
+ipIfStatsHCOutForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of datagrams for which this entity was not their
+            final IP destination and for which it was successful in
+            finding a path to their final destination.  This object
+            counts the same packets as ipIfStatsOutForwDatagrams, but
+            allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 24 }
+
+ipIfStatsOutDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of output IP datagrams for which no problem was
+            encountered to prevent their transmission to their
+            destination, but were discarded (e.g., for lack of
+            buffer space).  Note that this counter would include
+            datagrams counted in ipIfStatsOutForwDatagrams if any such
+            datagrams met this (discretionary) discard criterion.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 25 }
+
+ipIfStatsOutFragReqds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams that would require fragmentation
+            in order to be transmitted.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 26 }
+
+ipIfStatsOutFragOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams that have been successfully
+            fragmented.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 27 }
+
+ipIfStatsOutFragFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP datagrams that have been discarded because
+            they needed to be fragmented but could not be.  This
+            includes IPv4 packets that have the DF bit set and IPv6
+            packets that are being forwarded and exceed the outgoing
+            link MTU.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for an unsuccessfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 28 }
+
+ipIfStatsOutFragCreates OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of output datagram fragments that have been
+            generated as a result of IP fragmentation.
+
+            When tracking interface statistics, the counter of the
+            outgoing interface is incremented for a successfully
+            fragmented datagram.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 29 }
+
+ipIfStatsOutTransmits OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that this entity supplied
+            to the lower layers for transmission.  This includes
+            datagrams generated locally and those forwarded by this
+            entity.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 30 }
+
+ipIfStatsHCOutTransmits OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of IP datagrams that this entity supplied
+            to the lower layers for transmission.  This object counts
+            the same datagrams as ipIfStatsOutTransmits, but allows for
+            larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 31 }
+
+ipIfStatsOutOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets in IP datagrams delivered to the
+            lower layers for transmission.  Octets from datagrams
+            counted in ipIfStatsOutTransmits MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 32 }
+
+ipIfStatsHCOutOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets in IP datagrams delivered to the
+            lower layers for transmission.  This objects counts the same
+            octets as ipIfStatsOutOctets, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 33 }
+
+ipIfStatsInMcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams received.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 34 }
+
+ipIfStatsHCInMcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams received.  This object
+            counts the same datagrams as ipIfStatsInMcastPkts, but
+            allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 35 }
+
+ipIfStatsInMcastOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in IP multicast
+            datagrams.  Octets from datagrams counted in
+            ipIfStatsInMcastPkts MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 36 }
+
+ipIfStatsHCInMcastOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets received in IP multicast
+            datagrams.  This object counts the same octets as
+            ipIfStatsInMcastOctets, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 37 }
+
+ipIfStatsOutMcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams transmitted.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 38 }
+
+ipIfStatsHCOutMcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP multicast datagrams transmitted.  This
+            object counts the same datagrams as ipIfStatsOutMcastPkts,
+            but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 39 }
+
+ipIfStatsOutMcastOctets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets transmitted in IP multicast
+            datagrams.  Octets from datagrams counted in
+            ipIfStatsOutMcastPkts MUST be counted here.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 40 }
+
+ipIfStatsHCOutMcastOctets OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of octets transmitted in IP multicast
+            datagrams.  This object counts the same octets as
+            ipIfStatsOutMcastOctets, but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 41 }
+
+ipIfStatsInBcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams received.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 42 }
+
+ipIfStatsHCInBcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams received.  This object
+            counts the same datagrams as ipIfStatsInBcastPkts, but
+            allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 43 }
+
+ipIfStatsOutBcastPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams transmitted.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 44 }
+
+ipIfStatsHCOutBcastPkts OBJECT-TYPE
+    SYNTAX     Counter64
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of IP broadcast datagrams transmitted.  This
+            object counts the same datagrams as ipIfStatsOutBcastPkts,
+            but allows for larger values.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ipIfStatsDiscontinuityTime."
+    ::= { ipIfStatsEntry 45 }
+
+ipIfStatsDiscontinuityTime OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime on the most recent occasion at which
+            any one or more of this entry's counters suffered a
+            discontinuity.
+
+            If no such discontinuities have occurred since the last re-
+            initialization of the local management subsystem, then this
+            object contains a zero value."
+    ::= { ipIfStatsEntry 46 }
+
+ipIfStatsRefreshRate OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS "milli-seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The minimum reasonable polling interval for this entry.
+            This object provides an indication of the minimum amount of
+            time required to update the counters in this entry."
+    ::= { ipIfStatsEntry 47 }
+
+--
+-- Internet Address Prefix table
+--
+
+ipAddressPrefixTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpAddressPrefixEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "This table allows the user to determine the source of an IP
+            address or set of IP addresses, and allows other tables to
+            share the information via pointer rather than by copying.
+
+            For example, when the node configures both a unicast and
+            anycast address for a prefix, the ipAddressPrefix objects
+            for those addresses will point to a single row in this
+            table.
+
+            This table primarily provides support for IPv6 prefixes, and
+            several of the objects are less meaningful for IPv4.  The
+            table continues to allow IPv4 addresses to allow future
+            flexibility.  In order to promote a common configuration,
+            this document includes suggestions for default values for
+            IPv4 prefixes.  Each of these values may be overridden if an
+            object is meaningful to the node.
+
+            All prefixes used by this entity should be included in this
+            table independent of how the entity learned the prefix.
+            (This table isn't limited to prefixes learned from router
+            advertisements.)"
+    ::= { ip 32 }
+
+ipAddressPrefixEntry OBJECT-TYPE
+    SYNTAX     IpAddressPrefixEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "An entry in the ipAddressPrefixTable."
+    INDEX    { ipAddressPrefixIfIndex, ipAddressPrefixType,
+               ipAddressPrefixPrefix, ipAddressPrefixLength }
+    ::= { ipAddressPrefixTable 1 }
+
+IpAddressPrefixEntry ::= SEQUENCE {
+        ipAddressPrefixIfIndex               InterfaceIndex,
+        ipAddressPrefixType                  InetAddressType,
+        ipAddressPrefixPrefix                InetAddress,
+        ipAddressPrefixLength                InetAddressPrefixLength,
+        ipAddressPrefixOrigin                IpAddressPrefixOriginTC,
+        ipAddressPrefixOnLinkFlag            TruthValue,
+        ipAddressPrefixAutonomousFlag        TruthValue,
+        ipAddressPrefixAdvPreferredLifetime  Unsigned32,
+        ipAddressPrefixAdvValidLifetime      Unsigned32
+    }
+
+ipAddressPrefixIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface on
+            which this prefix is configured.  The interface identified
+            by a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipAddressPrefixEntry 1 }
+
+ipAddressPrefixType OBJECT-TYPE
+    SYNTAX     InetAddressType
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The address type of ipAddressPrefix."
+    ::= { ipAddressPrefixEntry 2 }
+
+ipAddressPrefixPrefix OBJECT-TYPE
+    SYNTAX     InetAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The address prefix.  The address type of this object is
+            specified in ipAddressPrefixType.  The length of this object
+            is the standard length for objects of that type (4 or 16
+            bytes).  Any bits after ipAddressPrefixLength must be zero.
+
+            Implementors need to be aware that, if the size of
+            ipAddressPrefixPrefix exceeds 114 octets, then OIDS of
+            instances of columns in this row will have more than 128
+            sub-identifiers and cannot be accessed using SNMPv1,
+            SNMPv2c, or SNMPv3."
+    ::= { ipAddressPrefixEntry 3 }
+
+ipAddressPrefixLength OBJECT-TYPE
+    SYNTAX     InetAddressPrefixLength
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The prefix length associated with this prefix.
+
+            The value 0 has no special meaning for this object.  It
+            simply refers to address '::/0'."
+    ::= { ipAddressPrefixEntry 4 }
+
+ipAddressPrefixOrigin OBJECT-TYPE
+    SYNTAX     IpAddressPrefixOriginTC
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The origin of this prefix."
+    ::= { ipAddressPrefixEntry 5 }
+
+ipAddressPrefixOnLinkFlag OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "This object has the value 'true(1)', if this prefix can be
+            used for on-link determination; otherwise, the value is
+            'false(2)'.
+
+            The default for IPv4 prefixes is 'true(1)'."
+    REFERENCE "For IPv6 RFC 2461, especially sections 2 and 4.6.2 and
+               RFC 2462"
+    ::= { ipAddressPrefixEntry 6 }
+
+ipAddressPrefixAutonomousFlag OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "Autonomous address configuration flag.  When true(1),
+            indicates that this prefix can be used for autonomous
+            address configuration (i.e., can be used to form a local
+            interface address).  If false(2), it is not used to auto-
+            configure a local interface address.
+
+            The default for IPv4 prefixes is 'false(2)'."
+    REFERENCE "For IPv6 RFC 2461, especially sections 2 and 4.6.2 and
+               RFC 2462"
+    ::= { ipAddressPrefixEntry 7 }
+
+ipAddressPrefixAdvPreferredLifetime OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The remaining length of time, in seconds, that this prefix
+            will continue to be preferred, i.e., time until deprecation.
+
+            A value of 4,294,967,295 represents infinity.
+
+            The address generated from a deprecated prefix should no
+            longer be used as a source address in new communications,
+            but packets received on such an interface are processed as
+            expected.
+
+            The default for IPv4 prefixes is 4,294,967,295 (infinity)."
+    REFERENCE "For IPv6 RFC 2461, especially sections 2 and 4.6.2 and
+               RFC 2462"
+    ::= { ipAddressPrefixEntry 8 }
+
+ipAddressPrefixAdvValidLifetime OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS       "seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The remaining length of time, in seconds, that this prefix
+            will continue to be valid, i.e., time until invalidation.  A
+            value of 4,294,967,295 represents infinity.
+
+            The address generated from an invalidated prefix should not
+            appear as the destination or source address of a packet.
+
+            The default for IPv4 prefixes is 4,294,967,295 (infinity)."
+    REFERENCE "For IPv6 RFC 2461, especially sections 2 and 4.6.2 and
+               RFC 2462"
+    ::= { ipAddressPrefixEntry 9 }
+
+--
+-- Internet Address Table
+--
+
+ipAddressSpinLock OBJECT-TYPE
+    SYNTAX     TestAndIncr
+     MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "An advisory lock used to allow cooperating SNMP managers to
+            coordinate their use of the set operation in creating or
+            modifying rows within this table.
+
+            In order to use this lock to coordinate the use of set
+            operations, managers should first retrieve
+            ipAddressTableSpinLock.  They should then determine the
+            appropriate row to create or modify.  Finally, they should
+            issue the appropriate set command, including the retrieved
+            value of ipAddressSpinLock.  If another manager has altered
+            the table in the meantime, then the value of
+            ipAddressSpinLock will have changed, and the creation will
+            fail as it will be specifying an incorrect value for
+            ipAddressSpinLock.  It is suggested, but not required, that
+            the ipAddressSpinLock be the first var bind for each set of
+            objects representing a 'row' in a PDU."
+    ::= { ip 33 }
+
+ipAddressTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpAddressEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "This table contains addressing information relevant to the
+            entity's interfaces.
+
+            This table does not contain multicast address information.
+            Tables for such information should be contained in multicast
+            specific MIBs, such as RFC 3019.
+
+            While this table is writable, the user will note that
+            several objects, such as ipAddressOrigin, are not.  The
+            intention in allowing a user to write to this table is to
+            allow them to add or remove any entry that isn't
+            permanent.  The user should be allowed to modify objects
+            and entries when that would not cause inconsistencies
+            within the table.  Allowing write access to objects, such
+            as ipAddressOrigin, could allow a user to insert an entry
+            and then label it incorrectly.
+
+            Note well: When including IPv6 link-local addresses in this
+            table, the entry must use an InetAddressType of 'ipv6z' in
+            order to differentiate between the possible interfaces."
+    ::= { ip 34 }
+
+ipAddressEntry OBJECT-TYPE
+    SYNTAX     IpAddressEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "An address mapping for a particular interface."
+    INDEX { ipAddressAddrType, ipAddressAddr }
+    ::= { ipAddressTable 1 }
+
+IpAddressEntry ::= SEQUENCE {
+        ipAddressAddrType     InetAddressType,
+        ipAddressAddr         InetAddress,
+        ipAddressIfIndex      InterfaceIndex,
+        ipAddressType         INTEGER,
+        ipAddressPrefix       RowPointer,
+        ipAddressOrigin       IpAddressOriginTC,
+        ipAddressStatus       IpAddressStatusTC,
+        ipAddressCreated      TimeStamp,
+        ipAddressLastChanged  TimeStamp,
+        ipAddressRowStatus    RowStatus,
+        ipAddressStorageType  StorageType
+    }
+
+ipAddressAddrType OBJECT-TYPE
+    SYNTAX     InetAddressType
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The address type of ipAddressAddr."
+    ::= { ipAddressEntry 1 }
+
+ipAddressAddr OBJECT-TYPE
+    SYNTAX     InetAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP address to which this entry's addressing information
+            pertains.  The address type of this object is specified in
+            ipAddressAddrType.
+
+            Implementors need to be aware that if the size of
+            ipAddressAddr exceeds 116 octets, then OIDS of instances of
+            columns in this row will have more than 128 sub-identifiers
+            and cannot be accessed using SNMPv1, SNMPv2c, or SNMPv3."
+    ::= { ipAddressEntry 2 }
+
+ipAddressIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface to
+            which this entry is applicable.  The interface identified by
+            a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipAddressEntry 3 }
+
+ipAddressType OBJECT-TYPE
+    SYNTAX     INTEGER {
+                 unicast(1),
+                 anycast(2),
+                 broadcast(3)
+    }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The type of address.  broadcast(3) is not a valid value for
+            IPv6 addresses (RFC 3513)."
+    DEFVAL { unicast }
+    ::= { ipAddressEntry 4 }
+
+ipAddressPrefix OBJECT-TYPE
+    SYNTAX     RowPointer
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "A pointer to the row in the prefix table to which this
+            address belongs.  May be { 0 0 } if there is no such row."
+    DEFVAL { zeroDotZero }
+    ::= { ipAddressEntry 5 }
+
+ipAddressOrigin OBJECT-TYPE
+    SYNTAX     IpAddressOriginTC
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The origin of the address."
+    ::= { ipAddressEntry 6 }
+
+ipAddressStatus OBJECT-TYPE
+    SYNTAX     IpAddressStatusTC
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The status of the address, describing if the address can be
+            used for communication.
+
+            In the absence of other information, an IPv4 address is
+            always preferred(1)."
+    DEFVAL { preferred }
+    ::= { ipAddressEntry 7 }
+
+ipAddressCreated OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime at the time this entry was created.
+            If this entry was created prior to the last re-
+            initialization of the local network management subsystem,
+            then this object contains a zero value."
+    ::= { ipAddressEntry 8 }
+
+ipAddressLastChanged OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime at the time this entry was last
+            updated.  If this entry was updated prior to the last re-
+            initialization of the local network management subsystem,
+            then this object contains a zero value."
+    ::= { ipAddressEntry 9 }
+
+ipAddressRowStatus OBJECT-TYPE
+    --SYNTAX     RowStatus
+    SYNTAX     RowStatus { active(1) }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The status of this conceptual row.
+
+            The RowStatus TC requires that this DESCRIPTION clause
+            states under which circumstances other objects in this row
+            can be modified.  The value of this object has no effect on
+            whether other objects in this conceptual row can be
+            modified.
+
+            A conceptual row can not be made active until the
+            ipAddressIfIndex has been set to a valid index."
+    ::= { ipAddressEntry 10 }
+
+ipAddressStorageType OBJECT-TYPE
+    SYNTAX     StorageType
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The storage type for this conceptual row.  If this object
+            has a value of 'permanent', then no other objects are
+            required to be able to be modified."
+    DEFVAL { volatile }
+    ::= { ipAddressEntry 11 }
+
+--
+-- the Internet Address Translation table
+--
+
+ipNetToPhysicalTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpNetToPhysicalEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP Address Translation table used for mapping from IP
+            addresses to physical addresses.
+
+            The Address Translation tables contain the IP address to
+            'physical' address equivalences.  Some interfaces do not use
+            translation tables for determining address equivalences
+            (e.g., DDN-X.25 has an algorithmic method); if all
+            interfaces are of this type, then the Address Translation
+            table is empty, i.e., has zero entries.
+
+            While many protocols may be used to populate this table, ARP
+            and Neighbor Discovery are the most likely
+            options."
+    REFERENCE "RFC 826 and RFC 2461"
+    ::= { ip 35 }
+
+ipNetToPhysicalEntry OBJECT-TYPE
+    SYNTAX     IpNetToPhysicalEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "Each entry contains one IP address to `physical' address
+            equivalence."
+    INDEX       { ipNetToPhysicalIfIndex,
+                  ipNetToPhysicalNetAddressType,
+                  ipNetToPhysicalNetAddress }
+    ::= { ipNetToPhysicalTable 1 }
+
+IpNetToPhysicalEntry ::= SEQUENCE {
+        ipNetToPhysicalIfIndex         InterfaceIndex,
+        ipNetToPhysicalNetAddressType  InetAddressType,
+        ipNetToPhysicalNetAddress      InetAddress,
+        ipNetToPhysicalPhysAddress     PhysAddress,
+        ipNetToPhysicalLastUpdated     TimeStamp,
+        ipNetToPhysicalType            INTEGER,
+        ipNetToPhysicalState           INTEGER,
+        ipNetToPhysicalRowStatus       RowStatus
+    }
+
+ipNetToPhysicalIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface to
+            which this entry is applicable.  The interface identified by
+            a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipNetToPhysicalEntry 1 }
+
+ipNetToPhysicalNetAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The type of ipNetToPhysicalNetAddress."
+    ::= { ipNetToPhysicalEntry 2 }
+
+ipNetToPhysicalNetAddress OBJECT-TYPE
+    SYNTAX     InetAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP Address corresponding to the media-dependent
+            `physical' address.  The address type of this object is
+            specified in ipNetToPhysicalAddressType.
+
+            Implementors need to be aware that if the size of
+            ipNetToPhysicalNetAddress exceeds 115 octets, then OIDS of
+            instances of columns in this row will have more than 128
+            sub-identifiers and cannot be accessed using SNMPv1,
+            SNMPv2c, or SNMPv3."
+    ::= { ipNetToPhysicalEntry 3 }
+
+ipNetToPhysicalPhysAddress OBJECT-TYPE
+    SYNTAX     PhysAddress (SIZE(0..65535))
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The media-dependent `physical' address.
+
+            As the entries in this table are typically not persistent
+            when this object is written the entity SHOULD NOT save the
+            change to non-volatile storage."
+    ::= { ipNetToPhysicalEntry 4 }
+
+ipNetToPhysicalLastUpdated OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The value of sysUpTime at the time this entry was last
+            updated.  If this entry was updated prior to the last re-
+            initialization of the local network management subsystem,
+            then this object contains a zero value."
+    ::= { ipNetToPhysicalEntry 5 }
+
+ipNetToPhysicalType OBJECT-TYPE
+    SYNTAX     INTEGER {
+                other(1),        -- none of the following
+                invalid(2),      -- an invalidated mapping
+                dynamic(3),
+                static(4),
+                local(5)         -- local interface
+            }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The type of mapping.
+
+            Setting this object to the value invalid(2) has the effect
+            of invalidating the corresponding entry in the
+            ipNetToPhysicalTable.  That is, it effectively dis-
+            associates the interface identified with said entry from the
+            mapping identified with said entry.  It is an
+            implementation-specific matter as to whether the agent
+            removes an invalidated entry from the table.  Accordingly,
+            management stations must be prepared to receive tabular
+            information from agents that corresponds to entries not
+            currently in use.  Proper interpretation of such entries
+            requires examination of the relevant ipNetToPhysicalType
+            object.
+
+            The 'dynamic(3)' type indicates that the IP address to
+            physical addresses mapping has been dynamically resolved
+            using e.g., IPv4 ARP or the IPv6 Neighbor Discovery
+            protocol.
+
+            The 'static(4)' type indicates that the mapping has been
+            statically configured.  Both of these refer to entries that
+            provide mappings for other entities addresses.
+
+            The 'local(5)' type indicates that the mapping is provided
+            for an entity's own interface address.
+
+            As the entries in this table are typically not persistent
+            when this object is written the entity SHOULD NOT save the
+            change to non-volatile storage."
+    DEFVAL { static }
+    ::= { ipNetToPhysicalEntry 6 }
+
+ipNetToPhysicalState OBJECT-TYPE
+    SYNTAX     INTEGER {
+                     reachable(1), -- confirmed reachability
+
+                     stale(2),     -- unconfirmed reachability
+
+                     delay(3),     -- waiting for reachability
+                                   -- confirmation before entering
+                                   -- the probe state
+
+                     probe(4),     -- actively probing
+
+                     invalid(5),   -- an invalidated mapping
+
+                     unknown(6),   -- state can not be determined
+                                   -- for some reason.
+
+                     incomplete(7) -- address resolution is being
+                                   -- performed.
+                    }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The Neighbor Unreachability Detection state for the
+            interface when the address mapping in this entry is used.
+            If Neighbor Unreachability Detection is not in use (e.g. for
+            IPv4), this object is always unknown(6)."
+    REFERENCE "RFC 2461"
+    ::= { ipNetToPhysicalEntry 7 }
+
+ipNetToPhysicalRowStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The status of this conceptual row.
+
+            The RowStatus TC requires that this DESCRIPTION clause
+            states under which circumstances other objects in this row
+            can be modified.  The value of this object has no effect on
+            whether other objects in this conceptual row can be
+            modified.
+
+            A conceptual row can not be made active until the
+            ipNetToPhysicalPhysAddress object has been set.
+
+            Note that if the ipNetToPhysicalType is set to 'invalid',
+            the managed node may delete the entry independent of the
+            state of this object."
+    ::= { ipNetToPhysicalEntry 8 }
+
+--
+-- The IPv6 Scope Zone Index Table.
+--
+
+ipv6ScopeZoneIndexTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF Ipv6ScopeZoneIndexEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table used to describe IPv6 unicast and multicast scope
+            zones.
+
+            For those objects that have names rather than numbers, the
+            names were chosen to coincide with the names used in the
+            IPv6 address architecture document. "
+    REFERENCE "Section 2.7 of RFC 4291"
+    ::= { ip 36 }
+
+ipv6ScopeZoneIndexEntry OBJECT-TYPE
+    SYNTAX     Ipv6ScopeZoneIndexEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "Each entry contains the list of scope identifiers on a given
+            interface."
+    INDEX { ipv6ScopeZoneIndexIfIndex }
+    ::= { ipv6ScopeZoneIndexTable 1 }
+
+Ipv6ScopeZoneIndexEntry ::= SEQUENCE {
+        ipv6ScopeZoneIndexIfIndex            InterfaceIndex,
+        ipv6ScopeZoneIndexLinkLocal          InetZoneIndex,
+        ipv6ScopeZoneIndex3                  InetZoneIndex,
+        ipv6ScopeZoneIndexAdminLocal         InetZoneIndex,
+        ipv6ScopeZoneIndexSiteLocal          InetZoneIndex,
+        ipv6ScopeZoneIndex6                  InetZoneIndex,
+        ipv6ScopeZoneIndex7                  InetZoneIndex,
+        ipv6ScopeZoneIndexOrganizationLocal  InetZoneIndex,
+        ipv6ScopeZoneIndex9                  InetZoneIndex,
+        ipv6ScopeZoneIndexA                  InetZoneIndex,
+        ipv6ScopeZoneIndexB                  InetZoneIndex,
+        ipv6ScopeZoneIndexC                  InetZoneIndex,
+        ipv6ScopeZoneIndexD                  InetZoneIndex
+    }
+
+ipv6ScopeZoneIndexIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface to
+            which these scopes belong.  The interface identified by a
+            particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipv6ScopeZoneIndexEntry 1 }
+
+ipv6ScopeZoneIndexLinkLocal OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for the link-local scope on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 2 }
+
+ipv6ScopeZoneIndex3 OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope 3 on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 3 }
+
+ipv6ScopeZoneIndexAdminLocal OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for the admin-local scope on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 4 }
+
+ipv6ScopeZoneIndexSiteLocal OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for the site-local scope on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 5 }
+
+ipv6ScopeZoneIndex6 OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope 6 on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 6 }
+
+ipv6ScopeZoneIndex7 OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope 7 on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 7 }
+
+ipv6ScopeZoneIndexOrganizationLocal OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for the organization-local scope on this
+            interface."
+    ::= { ipv6ScopeZoneIndexEntry 8 }
+
+ipv6ScopeZoneIndex9 OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope 9 on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 9 }
+
+ipv6ScopeZoneIndexA OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope A on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 10 }
+
+ipv6ScopeZoneIndexB OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope B on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 11 }
+
+ipv6ScopeZoneIndexC OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope C on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 12 }
+
+ipv6ScopeZoneIndexD OBJECT-TYPE
+    SYNTAX     InetZoneIndex
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The zone index for scope D on this interface."
+    ::= { ipv6ScopeZoneIndexEntry 13 }
+
+--
+-- The Default Router Table
+-- This table simply lists the default routers; for more information
+-- about routing tables, see the routing MIBs
+--
+
+ipDefaultRouterTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpDefaultRouterEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table used to describe the default routers known to this
+            entity."
+    ::= { ip 37 }
+
+ipDefaultRouterEntry OBJECT-TYPE
+    SYNTAX     IpDefaultRouterEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "Each entry contains information about a default router known
+            to this entity."
+    INDEX {ipDefaultRouterAddressType, ipDefaultRouterAddress,
+           ipDefaultRouterIfIndex}
+    ::= { ipDefaultRouterTable 1 }
+
+IpDefaultRouterEntry ::= SEQUENCE {
+        ipDefaultRouterAddressType  InetAddressType,
+        ipDefaultRouterAddress      InetAddress,
+        ipDefaultRouterIfIndex      InterfaceIndex,
+        ipDefaultRouterLifetime     Unsigned32,
+        ipDefaultRouterPreference   INTEGER
+    }
+
+ipDefaultRouterAddressType OBJECT-TYPE
+    SYNTAX     InetAddressType
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The address type for this row."
+    ::= { ipDefaultRouterEntry 1 }
+
+ipDefaultRouterAddress OBJECT-TYPE
+    SYNTAX     InetAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP address of the default router represented by this
+            row.  The address type of this object is specified in
+            ipDefaultRouterAddressType.
+
+            Implementers need to be aware that if the size of
+            ipDefaultRouterAddress exceeds 115 octets, then OIDS of
+            instances of columns in this row will have more than 128
+            sub-identifiers and cannot be accessed using SNMPv1,
+            SNMPv2c, or SNMPv3."
+    ::= { ipDefaultRouterEntry 2 }
+
+ipDefaultRouterIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface by
+            which the router can be reached.  The interface identified
+            by a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipDefaultRouterEntry 3 }
+
+ipDefaultRouterLifetime OBJECT-TYPE
+    SYNTAX     Unsigned32 (0..65535)
+    UNITS      "seconds"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The remaining length of time, in seconds, that this router
+            will continue to be useful as a default router.  A value of
+            zero indicates that it is no longer useful as a default
+            router.  It is left to the implementer of the MIB as to
+            whether a router with a lifetime of zero is removed from the
+            list.
+
+            For IPv6, this value should be extracted from the router
+            advertisement messages."
+    REFERENCE "For IPv6 RFC 2462 sections 4.2 and 6.3.4"
+    ::= { ipDefaultRouterEntry 4 }
+
+ipDefaultRouterPreference OBJECT-TYPE
+    SYNTAX     INTEGER {
+                     reserved (-2),
+                     low (-1),
+                     medium (0),
+                     high (1)
+                    }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "An indication of preference given to this router as a
+            default router as described in he Default Router
+            Preferences document.  Treating the value as a
+            2 bit signed integer allows for simple arithmetic
+            comparisons.
+
+            For IPv4 routers or IPv6 routers that are not using the
+            updated router advertisement format, this object is set to
+            medium (0)."
+    REFERENCE "RFC 4291, section 2.1"
+    ::= { ipDefaultRouterEntry 5 }
+
+--
+-- Configuration information for constructing router advertisements
+--
+
+ipv6RouterAdvertSpinLock OBJECT-TYPE
+    SYNTAX     TestAndIncr
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+           "An advisory lock used to allow cooperating SNMP managers to
+            coordinate their use of the set operation in creating or
+            modifying rows within this table.
+
+            In order to use this lock to coordinate the use of set
+            operations, managers should first retrieve
+            ipv6RouterAdvertSpinLock.  They should then determine the
+            appropriate row to create or modify.  Finally, they should
+            issue the appropriate set command including the retrieved
+            value of ipv6RouterAdvertSpinLock.  If another manager has
+            altered the table in the meantime, then the value of
+            ipv6RouterAdvertSpinLock will have changed and the creation
+            will fail as it will be specifying an incorrect value for
+            ipv6RouterAdvertSpinLock.  It is suggested, but not
+            required, that the ipv6RouterAdvertSpinLock be the first var
+            bind for each set of objects representing a 'row' in a PDU."
+    ::= { ip 38 }
+
+ipv6RouterAdvertTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF Ipv6RouterAdvertEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table containing information used to construct router
+            advertisements."
+    ::= { ip 39 }
+
+ipv6RouterAdvertEntry OBJECT-TYPE
+    SYNTAX     Ipv6RouterAdvertEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "An entry containing information used to construct router
+            advertisements.
+
+            Information in this table is persistent, and when this
+            object is written, the entity SHOULD save the change to
+            non-volatile storage."
+    INDEX { ipv6RouterAdvertIfIndex }
+    ::= { ipv6RouterAdvertTable 1 }
+
+Ipv6RouterAdvertEntry ::= SEQUENCE {
+        ipv6RouterAdvertIfIndex          InterfaceIndex,
+        ipv6RouterAdvertSendAdverts      TruthValue,
+        ipv6RouterAdvertMaxInterval      Unsigned32,
+        ipv6RouterAdvertMinInterval      Unsigned32,
+        ipv6RouterAdvertManagedFlag      TruthValue,
+        ipv6RouterAdvertOtherConfigFlag  TruthValue,
+        ipv6RouterAdvertLinkMTU          Unsigned32,
+        ipv6RouterAdvertReachableTime    Unsigned32,
+        ipv6RouterAdvertRetransmitTime   Unsigned32,
+        ipv6RouterAdvertCurHopLimit      Unsigned32,
+        ipv6RouterAdvertDefaultLifetime  Unsigned32,
+        ipv6RouterAdvertRowStatus        RowStatus
+    }
+
+ipv6RouterAdvertIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndex
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The index value that uniquely identifies the interface on
+            which router advertisements constructed with this
+            information will be transmitted.  The interface identified
+            by a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipv6RouterAdvertEntry 1 }
+
+ipv6RouterAdvertSendAdverts OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "A flag indicating whether the router sends periodic
+            router advertisements and responds to router solicitations
+            on this interface."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { false }
+    ::= { ipv6RouterAdvertEntry 2 }
+
+ipv6RouterAdvertMaxInterval OBJECT-TYPE
+    SYNTAX     Unsigned32 (4..1800)
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The maximum time allowed between sending unsolicited router
+            advertisements from this interface."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { 600 }
+    ::= { ipv6RouterAdvertEntry 3 }
+
+ipv6RouterAdvertMinInterval OBJECT-TYPE
+    SYNTAX     Unsigned32 (3..1350)
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The minimum time allowed between sending unsolicited router
+            advertisements from this interface.
+
+            The default is 0.33 * ipv6RouterAdvertMaxInterval, however,
+            in the case of a low value for ipv6RouterAdvertMaxInterval,
+            the minimum value for this object is restricted to 3."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    ::= { ipv6RouterAdvertEntry 4 }
+
+ipv6RouterAdvertManagedFlag OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The true/false value to be placed into the 'managed address
+            configuration' flag field in router advertisements sent from
+            this interface."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { false }
+    ::= { ipv6RouterAdvertEntry 5 }
+
+ipv6RouterAdvertOtherConfigFlag OBJECT-TYPE
+    SYNTAX     TruthValue
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The true/false value to be placed into the 'other stateful
+            configuration' flag field in router advertisements sent from
+            this interface."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { false }
+    ::= { ipv6RouterAdvertEntry 6 }
+
+ipv6RouterAdvertLinkMTU OBJECT-TYPE
+    SYNTAX     Unsigned32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The value to be placed in MTU options sent by the router on
+            this interface.
+
+            A value of zero indicates that no MTU options are sent."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { 0 }
+    ::= { ipv6RouterAdvertEntry 7 }
+
+ipv6RouterAdvertReachableTime OBJECT-TYPE
+    SYNTAX     Unsigned32 (0..3600000)
+    UNITS      "milliseconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The value to be placed in the reachable time field in router
+            advertisement messages sent from this interface.
+
+            A value of zero in the router advertisement indicates that
+            the advertisement isn't specifying a value for reachable
+            time."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { 0 }
+    ::= { ipv6RouterAdvertEntry 8 }
+
+ipv6RouterAdvertRetransmitTime OBJECT-TYPE
+    SYNTAX     Unsigned32
+    UNITS      "milliseconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The value to be placed in the retransmit timer field in
+            router advertisements sent from this interface.
+
+            A value of zero in the router advertisement indicates that
+            the advertisement isn't specifying a value for retrans
+            time."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    DEFVAL { 0 }
+    ::= { ipv6RouterAdvertEntry 9 }
+
+ipv6RouterAdvertCurHopLimit OBJECT-TYPE
+    SYNTAX     Unsigned32 (0..255)
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The default value to be placed in the current hop limit
+            field in router advertisements sent from this interface.
+            The value should be set to the current diameter of the
+            Internet.
+
+            A value of zero in the router advertisement indicates that
+            the advertisement isn't specifying a value for curHopLimit.
+
+            The default should be set to the value specified in the IANA
+            web pages (www.iana.org) at the time of implementation."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    ::= { ipv6RouterAdvertEntry 10 }
+
+ipv6RouterAdvertDefaultLifetime OBJECT-TYPE
+    SYNTAX     Unsigned32 (0|4..9000)
+    UNITS      "seconds"
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The value to be placed in the router lifetime field of
+            router advertisements sent from this interface.  This value
+            MUST be either 0 or between ipv6RouterAdvertMaxInterval and
+            9000 seconds.
+
+            A value of zero indicates that the router is not to be used
+            as a default router.
+
+            The default is 3 * ipv6RouterAdvertMaxInterval."
+    REFERENCE "RFC 2461 Section 6.2.1"
+    ::= { ipv6RouterAdvertEntry 11 }
+
+ipv6RouterAdvertRowStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The status of this conceptual row.
+
+            As all objects in this conceptual row have default values, a
+            row can be created and made active by setting this object
+            appropriately.
+
+            The RowStatus TC requires that this DESCRIPTION clause
+            states under which circumstances other objects in this row
+            can be modified.  The value of this object has no effect on
+            whether other objects in this conceptual row can be
+            modified."
+    ::= { ipv6RouterAdvertEntry 12 }
+
+--
+-- ICMP section
+--
+
+icmp     OBJECT IDENTIFIER ::= { mib-2 5 }
+
+--
+-- ICMP non-message-specific counters
+--
+
+-- These object IDs are reserved, as they were used in earlier
+-- versions of the MIB module.  In theory, OIDs are not assigned
+-- until the specification is released as an RFC; however, as some
+-- companies may have shipped code based on earlier versions of
+-- the MIB, it seems best to reserve these OIDs.
+-- ::= { icmp 27 }
+-- ::= { icmp 28 }
+
+icmpStatsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IcmpStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table of generic system-wide ICMP counters."
+    ::= { icmp 29 }
+
+icmpStatsEntry OBJECT-TYPE
+    SYNTAX     IcmpStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "A conceptual row in the icmpStatsTable."
+    INDEX    { icmpStatsIPVersion }
+    ::= { icmpStatsTable 1 }
+
+IcmpStatsEntry ::= SEQUENCE {
+        icmpStatsIPVersion  InetVersion,
+        icmpStatsInMsgs     Counter32,
+        icmpStatsInErrors   Counter32,
+        icmpStatsOutMsgs    Counter32,
+        icmpStatsOutErrors  Counter32
+    }
+
+icmpStatsIPVersion OBJECT-TYPE
+    SYNTAX     InetVersion
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP version of the statistics."
+    ::= { icmpStatsEntry 1 }
+
+icmpStatsInMsgs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of ICMP messages that the entity received.
+            Note that this counter includes all those counted by
+            icmpStatsInErrors."
+    ::= { icmpStatsEntry 2 }
+
+icmpStatsInErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of ICMP messages that the entity received but
+            determined as having ICMP-specific errors (bad ICMP
+            checksums, bad length, etc.)."
+    ::= { icmpStatsEntry 3 }
+
+icmpStatsOutMsgs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of ICMP messages that the entity attempted
+            to send.  Note that this counter includes all those counted
+            by icmpStatsOutErrors."
+    ::= { icmpStatsEntry 4 }
+
+icmpStatsOutErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of ICMP messages that this entity did not send
+            due to problems discovered within ICMP, such as a lack of
+            buffers.  This value should not include errors discovered
+            outside the ICMP layer, such as the inability of IP to route
+            the resultant datagram.  In some implementations, there may
+            be no types of error that contribute to this counter's
+            value."
+    ::= { icmpStatsEntry 5 }
+
+--
+-- per-version, per-message type ICMP counters
+--
+
+icmpMsgStatsTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IcmpMsgStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The table of system-wide per-version, per-message type ICMP
+            counters."
+    ::= { icmp 30 }
+
+icmpMsgStatsEntry OBJECT-TYPE
+    SYNTAX     IcmpMsgStatsEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "A conceptual row in the icmpMsgStatsTable.
+
+            The system should track each ICMP type value, even if that
+            ICMP type is not supported by the system.  However, a
+            given row need not be instantiated unless a message of that
+            type has been processed, i.e., the row for
+            icmpMsgStatsType=X MAY be instantiated before but MUST be
+            instantiated after the first message with Type=X is
+            received or transmitted.  After receiving or transmitting
+            any succeeding messages with Type=X, the relevant counter
+            must be incremented."
+    INDEX { icmpMsgStatsIPVersion, icmpMsgStatsType }
+    ::= { icmpMsgStatsTable 1 }
+
+IcmpMsgStatsEntry ::= SEQUENCE {
+        icmpMsgStatsIPVersion  InetVersion,
+        icmpMsgStatsType       Integer32,
+        icmpMsgStatsInPkts     Counter32,
+        icmpMsgStatsOutPkts    Counter32
+    }
+
+icmpMsgStatsIPVersion OBJECT-TYPE
+    SYNTAX     InetVersion
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The IP version of the statistics."
+    ::= { icmpMsgStatsEntry 1 }
+
+icmpMsgStatsType OBJECT-TYPE
+    SYNTAX     Integer32 (0..255)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The ICMP type field of the message type being counted by
+            this row.
+
+            Note that ICMP message types are scoped by the address type
+            in use."
+    REFERENCE "http://www.iana.org/assignments/icmp-parameters and
+               http://www.iana.org/assignments/icmpv6-parameters"
+    ::= { icmpMsgStatsEntry 2 }
+
+icmpMsgStatsInPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of input packets for this AF and type."
+    ::= { icmpMsgStatsEntry 3 }
+
+icmpMsgStatsOutPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of output packets for this AF and type."
+    ::= { icmpMsgStatsEntry 4 }
+--
+-- conformance information
+--
+
+ipMIBConformance OBJECT IDENTIFIER ::= { ipMIB 2 }
+
+ipMIBCompliances OBJECT IDENTIFIER ::= { ipMIBConformance 1 }
+ipMIBGroups      OBJECT IDENTIFIER ::= { ipMIBConformance 2 }
+
+-- compliance statements
+ipMIBCompliance2 MODULE-COMPLIANCE
+    STATUS     current
+    DESCRIPTION
+            "The compliance statement for systems that implement IP -
+             either IPv4 or IPv6.
+
+            There are a number of INDEX objects that cannot be
+            represented in the form of OBJECT clauses in SMIv2, but
+            for which we have the following compliance requirements,
+            expressed in OBJECT clause form in this description
+            clause:
+            -- OBJECT        ipSystemStatsIPVersion
+            -- SYNTAX        InetVersion {ipv4(1), ipv6(2)}
+            -- DESCRIPTION
+            --     This MIB requires support for only IPv4 and IPv6
+            --     versions.
+            --
+            -- OBJECT        ipIfStatsIPVersion
+            -- SYNTAX        InetVersion {ipv4(1), ipv6(2)}
+            -- DESCRIPTION
+            --     This MIB requires support for only IPv4 and IPv6
+            --     versions.
+            --
+            -- OBJECT        icmpStatsIPVersion
+            -- SYNTAX        InetVersion {ipv4(1), ipv6(2)}
+            -- DESCRIPTION
+            --     This MIB requires support for only IPv4 and IPv6
+            --     versions.
+            --
+            -- OBJECT        icmpMsgStatsIPVersion
+            -- SYNTAX        InetVersion {ipv4(1), ipv6(2)}
+            -- DESCRIPTION
+            --     This MIB requires support for only IPv4 and IPv6
+            --     versions.
+            --
+            -- OBJECT        ipAddressPrefixType
+            -- SYNTAX        InetAddressType {ipv4(1), ipv6(2)}
+            -- DESCRIPTION
+            --     This MIB requires support for only global IPv4 and
+            --     IPv6 address types.
+            --
+            -- OBJECT        ipAddressPrefixPrefix
+            -- SYNTAX        InetAddress (Size(4 | 16))
+            -- DESCRIPTION
+            --     This MIB requires support for only global IPv4 and
+            --     IPv6 addresses and so the size can be either 4 or
+            --     16 bytes.
+            --
+            -- OBJECT        ipAddressAddrType
+            -- SYNTAX        InetAddressType {ipv4(1), ipv6(2),
+            --                                ipv4z(3), ipv6z(4)}
+            -- DESCRIPTION
+            --     This MIB requires support for only global and
+            --     non-global IPv4 and IPv6 address types.
+            --
+            -- OBJECT        ipAddressAddr
+            -- SYNTAX        InetAddress (Size(4 | 8 | 16 | 20))
+            -- DESCRIPTION
+            --     This MIB requires support for only global and
+            --     non-global IPv4 and IPv6 addresses and so the size
+            --     can be 4, 8, 16, or 20 bytes.
+            --
+            -- OBJECT        ipNetToPhysicalNetAddressType
+            -- SYNTAX        InetAddressType {ipv4(1), ipv6(2),
+            --                                ipv4z(3), ipv6z(4)}
+            -- DESCRIPTION
+            --     This MIB requires support for only global and
+            --     non-global IPv4 and IPv6 address types.
+            --
+            -- OBJECT        ipNetToPhysicalNetAddress
+            -- SYNTAX        InetAddress (Size(4 | 8 | 16 | 20))
+            -- DESCRIPTION
+            --     This MIB requires support for only global and
+            --     non-global IPv4 and IPv6 addresses and so the size
+            --     can be 4, 8, 16, or 20 bytes.
+            --
+            -- OBJECT        ipDefaultRouterAddressType
+            -- SYNTAX        InetAddressType {ipv4(1), ipv6(2),
+            --                                ipv4z(3), ipv6z(4)}
+            -- DESCRIPTION
+            --     This MIB requires support for only global and
+            --     non-global IPv4 and IPv6 address types.
+            --
+            -- OBJECT        ipDefaultRouterAddress
+            -- SYNTAX        InetAddress (Size(4 | 8 | 16 | 20))
+            -- DESCRIPTION
+            --     This MIB requires support for only global and
+            --     non-global IPv4 and IPv6 addresses and so the size
+            --     can be 4, 8, 16, or 20 bytes."
+
+    MODULE -- this module
+
+    MANDATORY-GROUPS { ipSystemStatsGroup,   ipAddressGroup,
+                       ipNetToPhysicalGroup, ipDefaultRouterGroup,
+                       icmpStatsGroup }
+
+    GROUP ipSystemStatsHCOctetGroup
+    DESCRIPTION
+           "This group is mandatory for systems that have an aggregate
+            bandwidth of greater than 20MB.  Including this group does
+            not allow an entity to neglect the 32 bit versions of these
+            objects."
+
+    GROUP ipSystemStatsHCPacketGroup
+    DESCRIPTION
+           "This group is mandatory for systems that have an aggregate
+            bandwidth of greater than 650MB.  Including this group
+            does not allow an entity to neglect the 32 bit versions of
+            these objects."
+
+    GROUP ipIfStatsGroup
+    DESCRIPTION
+           "This group is optional for all systems."
+
+    GROUP ipIfStatsHCOctetGroup
+    DESCRIPTION
+           "This group is mandatory for systems that include the
+            ipIfStatsGroup and include links with bandwidths of greater
+            than 20MB.  Including this group does not allow an entity to
+            neglect the 32 bit versions of these objects."
+
+    GROUP ipIfStatsHCPacketGroup
+    DESCRIPTION
+           "This group is mandatory for systems that include the
+            ipIfStatsGroup and include links with bandwidths of greater
+            than 650MB.  Including this group does not allow an entity
+            to neglect the 32 bit versions of these objects."
+
+    GROUP ipv4GeneralGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv4."
+
+    GROUP ipv4IfGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv4."
+
+    GROUP ipv4SystemStatsGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv4."
+
+    GROUP ipv4SystemStatsHCPacketGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv4 and
+            that have an aggregate bandwidth of greater than 650MB.
+            Including this group does not allow an entity to neglect the
+            32 bit versions of these objects."
+
+    GROUP ipv4IfStatsGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv4 and
+            including the ipIfStatsGroup."
+
+    GROUP ipv4IfStatsHCPacketGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv4 and
+            including the ipIfStatsHCPacketGroup.  Including this group
+            does not allow an entity to neglect the 32 bit versions of
+            these objects."
+
+    GROUP ipv6GeneralGroup2
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv6."
+
+    GROUP ipv6IfGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv6."
+
+    GROUP ipAddressPrefixGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv6."
+
+    GROUP ipv6ScopeGroup
+    DESCRIPTION
+           "This group is mandatory for all systems supporting IPv6."
+
+    GROUP ipv6RouterAdvertGroup
+    DESCRIPTION
+           "This group is mandatory for all IPv6 routers."
+
+    GROUP ipLastChangeGroup
+    DESCRIPTION
+           "This group is optional for all agents."
+
+    OBJECT     ipv6IpForwarding
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6IpDefaultHopLimit
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv4InterfaceEnableStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6InterfaceEnableStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6InterfaceForwarding
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipAddressSpinLock
+    MIN-ACCESS not-accessible
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object.  However, if an agent provides write access to any
+            of the other objects in the ipAddressGroup, it SHOULD
+            provide write access to this object as well."
+
+    OBJECT     ipAddressIfIndex
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    OBJECT     ipAddressType
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    OBJECT     ipAddressStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    OBJECT     ipAddressRowStatus
+    SYNTAX     RowStatus { active(1) }
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    OBJECT     ipAddressStorageType
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object.
+
+            If an agent allows this object to be written or created, it
+            is not required to allow this object to be set to readOnly,
+            permanent, or nonVolatile."
+
+    OBJECT     ipNetToPhysicalPhysAddress
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    OBJECT     ipNetToPhysicalType
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    OBJECT     ipv6RouterAdvertSpinLock
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object.  However, if an agent provides write access to
+            any of the other objects in the ipv6RouterAdvertGroup, it
+            SHOULD provide write access to this object as well."
+
+    OBJECT     ipv6RouterAdvertSendAdverts
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertMaxInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertMinInterval
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertManagedFlag
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertOtherConfigFlag
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertLinkMTU
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertReachableTime
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertRetransmitTime
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertCurHopLimit
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertDefaultLifetime
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write access to this
+            object."
+
+    OBJECT     ipv6RouterAdvertRowStatus
+    MIN-ACCESS read-only
+    DESCRIPTION
+           "An agent is not required to provide write or create access
+            to this object."
+
+    ::= { ipMIBCompliances 2 }
+
+-- units of conformance
+
+ipv4GeneralGroup OBJECT-GROUP
+    OBJECTS   { ipForwarding, ipDefaultTTL, ipReasmTimeout }
+    STATUS     current
+    DESCRIPTION
+           "The group of IPv4-specific objects for basic management of
+            IPv4 entities."
+    ::= { ipMIBGroups 3 }
+
+ipv4IfGroup OBJECT-GROUP
+    OBJECTS   { ipv4InterfaceReasmMaxSize, ipv4InterfaceEnableStatus,
+                ipv4InterfaceRetransmitTime }
+    STATUS     current
+    DESCRIPTION
+           "The group of IPv4-specific objects for basic management of
+            IPv4 interfaces."
+    ::= { ipMIBGroups 4 }
+
+ipv6GeneralGroup2 OBJECT-GROUP
+    OBJECTS { ipv6IpForwarding, ipv6IpDefaultHopLimit }
+    STATUS     current
+    DESCRIPTION
+           "The IPv6 group of objects providing for basic management of
+            IPv6 entities."
+    ::= { ipMIBGroups 5 }
+
+ipv6IfGroup OBJECT-GROUP
+    OBJECTS   { ipv6InterfaceReasmMaxSize,   ipv6InterfaceIdentifier,
+                ipv6InterfaceEnableStatus,   ipv6InterfaceReachableTime,
+                ipv6InterfaceRetransmitTime, ipv6InterfaceForwarding }
+    STATUS     current
+    DESCRIPTION
+           "The group of IPv6-specific objects for basic management of
+            IPv6 interfaces."
+    ::= { ipMIBGroups 6 }
+
+ipLastChangeGroup OBJECT-GROUP
+    OBJECTS   { ipv4InterfaceTableLastChange,
+                ipv6InterfaceTableLastChange,
+                ipIfStatsTableLastChange }
+    STATUS     current
+    DESCRIPTION
+           "The last change objects associated with this MIB.  These
+            objects are optional for all agents.  They SHOULD be
+            implemented on agents where it is possible to determine the
+            proper values.  Where it is not possible to determine the
+            proper values, for example when the tables are split amongst
+            several sub-agents using AgentX, the agent MUST NOT
+            implement these objects to return an incorrect or static
+            value."
+    ::= { ipMIBGroups 7 }
+
+ipSystemStatsGroup OBJECT-GROUP
+    OBJECTS   { ipSystemStatsInReceives,
+                ipSystemStatsInOctets,
+                ipSystemStatsInHdrErrors,
+                ipSystemStatsInNoRoutes,
+                ipSystemStatsInAddrErrors,
+                ipSystemStatsInUnknownProtos,
+                ipSystemStatsInTruncatedPkts,
+                ipSystemStatsInForwDatagrams,
+                ipSystemStatsReasmReqds,
+                ipSystemStatsReasmOKs,
+                ipSystemStatsReasmFails,
+                ipSystemStatsInDiscards,
+                ipSystemStatsInDelivers,
+                ipSystemStatsOutRequests,
+                ipSystemStatsOutNoRoutes,
+                ipSystemStatsOutForwDatagrams,
+                ipSystemStatsOutDiscards,
+                ipSystemStatsOutFragReqds,
+                ipSystemStatsOutFragOKs,
+                ipSystemStatsOutFragFails,
+                ipSystemStatsOutFragCreates,
+                ipSystemStatsOutTransmits,
+                ipSystemStatsOutOctets,
+                ipSystemStatsInMcastPkts,
+                ipSystemStatsInMcastOctets,
+                ipSystemStatsOutMcastPkts,
+                ipSystemStatsOutMcastOctets,
+                ipSystemStatsDiscontinuityTime,
+                ipSystemStatsRefreshRate }
+    STATUS     current
+    DESCRIPTION
+           "IP system wide statistics."
+    ::= { ipMIBGroups 8 }
+
+ipv4SystemStatsGroup OBJECT-GROUP
+    OBJECTS   { ipSystemStatsInBcastPkts, ipSystemStatsOutBcastPkts }
+    STATUS     current
+    DESCRIPTION
+           "IPv4 only system wide statistics."
+    ::= { ipMIBGroups 9 }
+
+ipSystemStatsHCOctetGroup OBJECT-GROUP
+    OBJECTS   { ipSystemStatsHCInOctets,
+                ipSystemStatsHCOutOctets,
+                ipSystemStatsHCInMcastOctets,
+                ipSystemStatsHCOutMcastOctets
+}
+    STATUS     current
+    DESCRIPTION
+           "IP system wide statistics for systems that may overflow the
+            standard octet counters within 1 hour."
+    ::= { ipMIBGroups 10 }
+
+ipSystemStatsHCPacketGroup OBJECT-GROUP
+    OBJECTS   { ipSystemStatsHCInReceives,
+                ipSystemStatsHCInForwDatagrams,
+                ipSystemStatsHCInDelivers,
+                ipSystemStatsHCOutRequests,
+                ipSystemStatsHCOutForwDatagrams,
+                ipSystemStatsHCOutTransmits,
+                ipSystemStatsHCInMcastPkts,
+                ipSystemStatsHCOutMcastPkts
+}
+    STATUS     current
+    DESCRIPTION
+           "IP system wide statistics for systems that may overflow the
+            standard packet counters within 1 hour."
+    ::= { ipMIBGroups 11 }
+
+ipv4SystemStatsHCPacketGroup OBJECT-GROUP
+    OBJECTS   { ipSystemStatsHCInBcastPkts,
+                ipSystemStatsHCOutBcastPkts }
+    STATUS     current
+    DESCRIPTION
+           "IPv4 only system wide statistics for systems that may
+            overflow the standard packet counters within 1 hour."
+    ::= { ipMIBGroups 12 }
+
+ipIfStatsGroup OBJECT-GROUP
+    OBJECTS   { ipIfStatsInReceives,        ipIfStatsInOctets,
+                ipIfStatsInHdrErrors,       ipIfStatsInNoRoutes,
+                ipIfStatsInAddrErrors,      ipIfStatsInUnknownProtos,
+                ipIfStatsInTruncatedPkts,   ipIfStatsInForwDatagrams,
+                ipIfStatsReasmReqds,        ipIfStatsReasmOKs,
+                ipIfStatsReasmFails,        ipIfStatsInDiscards,
+                ipIfStatsInDelivers,        ipIfStatsOutRequests,
+                ipIfStatsOutForwDatagrams,  ipIfStatsOutDiscards,
+                ipIfStatsOutFragReqds,      ipIfStatsOutFragOKs,
+                ipIfStatsOutFragFails,      ipIfStatsOutFragCreates,
+                ipIfStatsOutTransmits,      ipIfStatsOutOctets,
+                ipIfStatsInMcastPkts,       ipIfStatsInMcastOctets,
+                ipIfStatsOutMcastPkts,      ipIfStatsOutMcastOctets,
+                ipIfStatsDiscontinuityTime, ipIfStatsRefreshRate }
+    STATUS     current
+    DESCRIPTION
+           "IP per-interface statistics."
+    ::= { ipMIBGroups 13 }
+
+ipv4IfStatsGroup OBJECT-GROUP
+    OBJECTS   { ipIfStatsInBcastPkts, ipIfStatsOutBcastPkts }
+    STATUS     current
+    DESCRIPTION
+           "IPv4 only per-interface statistics."
+    ::= { ipMIBGroups 14 }
+
+ipIfStatsHCOctetGroup OBJECT-GROUP
+    OBJECTS   { ipIfStatsHCInOctets,      ipIfStatsHCOutOctets,
+                ipIfStatsHCInMcastOctets, ipIfStatsHCOutMcastOctets }
+    STATUS     current
+    DESCRIPTION
+           "IP per-interfaces statistics for systems that include
+            interfaces that may overflow the standard octet
+            counters within 1 hour."
+    ::= { ipMIBGroups 15 }
+
+ipIfStatsHCPacketGroup OBJECT-GROUP
+    OBJECTS   { ipIfStatsHCInReceives,       ipIfStatsHCInForwDatagrams,
+                ipIfStatsHCInDelivers,       ipIfStatsHCOutRequests,
+                ipIfStatsHCOutForwDatagrams, ipIfStatsHCOutTransmits,
+                ipIfStatsHCInMcastPkts,      ipIfStatsHCOutMcastPkts }
+    STATUS     current
+    DESCRIPTION
+           "IP per-interfaces statistics for systems that include
+            interfaces that may overflow the standard packet counters
+            within 1 hour."
+    ::= { ipMIBGroups 16 }
+
+ipv4IfStatsHCPacketGroup OBJECT-GROUP
+    OBJECTS   { ipIfStatsHCInBcastPkts, ipIfStatsHCOutBcastPkts }
+    STATUS     current
+    DESCRIPTION
+           "IPv4 only per-interface statistics for systems that include
+            interfaces that may overflow the standard packet counters
+            within 1 hour."
+    ::= { ipMIBGroups 17 }
+
+ipAddressPrefixGroup OBJECT-GROUP
+    OBJECTS   { ipAddressPrefixOrigin,
+                ipAddressPrefixOnLinkFlag,
+                ipAddressPrefixAutonomousFlag,
+                ipAddressPrefixAdvPreferredLifetime,
+                ipAddressPrefixAdvValidLifetime }
+    STATUS     current
+    DESCRIPTION
+           "The group of objects for providing information about address
+            prefixes used by this node."
+    ::= { ipMIBGroups 18 }
+
+ipAddressGroup OBJECT-GROUP
+    OBJECTS   { ipAddressSpinLock,  ipAddressIfIndex,
+                ipAddressType,      ipAddressPrefix,
+                ipAddressOrigin,    ipAddressStatus,
+                ipAddressCreated,   ipAddressLastChanged,
+                ipAddressRowStatus, ipAddressStorageType }
+    STATUS     current
+    DESCRIPTION
+           "The group of objects for providing information about the
+            addresses relevant to this entity's interfaces."
+    ::= { ipMIBGroups 19 }
+
+ipNetToPhysicalGroup OBJECT-GROUP
+    OBJECTS   { ipNetToPhysicalPhysAddress, ipNetToPhysicalLastUpdated,
+                ipNetToPhysicalType,        ipNetToPhysicalState,
+                ipNetToPhysicalRowStatus }
+    STATUS     current
+    DESCRIPTION
+           "The group of objects for providing information about the
+            mappings of network address to physical address known to
+            this node."
+    ::= { ipMIBGroups 20 }
+
+ipv6ScopeGroup OBJECT-GROUP
+    OBJECTS   { ipv6ScopeZoneIndexLinkLocal,
+                ipv6ScopeZoneIndex3,
+                ipv6ScopeZoneIndexAdminLocal,
+                ipv6ScopeZoneIndexSiteLocal,
+                ipv6ScopeZoneIndex6,
+                ipv6ScopeZoneIndex7,
+                ipv6ScopeZoneIndexOrganizationLocal,
+                ipv6ScopeZoneIndex9,
+                ipv6ScopeZoneIndexA,
+                ipv6ScopeZoneIndexB,
+                ipv6ScopeZoneIndexC,
+                ipv6ScopeZoneIndexD }
+    STATUS     current
+    DESCRIPTION
+           "The group of objects for managing IPv6 scope zones."
+    ::= { ipMIBGroups 21 }
+
+ipDefaultRouterGroup OBJECT-GROUP
+    OBJECTS   { ipDefaultRouterLifetime, ipDefaultRouterPreference }
+    STATUS     current
+    DESCRIPTION
+           "The group of objects for providing information about default
+            routers known to this node."
+    ::= { ipMIBGroups 22 }
+
+ipv6RouterAdvertGroup OBJECT-GROUP
+    OBJECTS   { ipv6RouterAdvertSpinLock,
+                ipv6RouterAdvertSendAdverts,
+                ipv6RouterAdvertMaxInterval,
+                ipv6RouterAdvertMinInterval,
+                ipv6RouterAdvertManagedFlag,
+                ipv6RouterAdvertOtherConfigFlag,
+                ipv6RouterAdvertLinkMTU,
+                ipv6RouterAdvertReachableTime,
+                ipv6RouterAdvertRetransmitTime,
+                ipv6RouterAdvertCurHopLimit,
+                ipv6RouterAdvertDefaultLifetime,
+                ipv6RouterAdvertRowStatus
+}
+    STATUS     current
+    DESCRIPTION
+           "The group of objects for controlling information advertised
+            by IPv6 routers."
+    ::= { ipMIBGroups 23 }
+
+icmpStatsGroup OBJECT-GROUP
+    OBJECTS   {icmpStatsInMsgs,    icmpStatsInErrors,
+               icmpStatsOutMsgs,   icmpStatsOutErrors,
+               icmpMsgStatsInPkts, icmpMsgStatsOutPkts }
+    STATUS     current
+    DESCRIPTION
+           "The group of objects providing ICMP statistics."
+    ::= { ipMIBGroups 24 }
+
+--
+-- Deprecated objects
+--
+
+ipInReceives OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The total number of input datagrams received from
+            interfaces, including those received in error.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsInRecieves."
+    ::= { ip 3 }
+
+ipInHdrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of input datagrams discarded due to errors in
+            their IPv4 headers, including bad checksums, version number
+            mismatch, other format errors, time-to-live exceeded, errors
+            discovered in processing their IPv4 options, etc.
+
+            This object has been deprecated as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsInHdrErrors."
+    ::= { ip 4 }
+
+ipInAddrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of input datagrams discarded because the IPv4
+            address in their IPv4 header's destination field was not a
+            valid address to be received at this entity.  This count
+            includes invalid addresses (e.g., 0.0.0.0) and addresses of
+            unsupported Classes (e.g., Class E).  For entities which are
+            not IPv4 routers, and therefore do not forward datagrams,
+            this counter includes datagrams discarded because the
+            destination address was not a local address.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsInAddrErrors."
+    ::= { ip 5 }
+
+ipForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of input datagrams for which this entity was not
+            their final IPv4 destination, as a result of which an
+            attempt was made to find a route to forward them to that
+            final destination.  In entities which do not act as IPv4
+            routers, this counter will include only those packets which
+            were Source-Routed via this entity, and the Source-Route
+            option processing was successful.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsInForwDatagrams."
+    ::= { ip 6 }
+
+ipInUnknownProtos OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of locally-addressed datagrams received
+            successfully but discarded because of an unknown or
+            unsupported protocol.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsInUnknownProtos."
+    ::= { ip 7 }
+
+ipInDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of input IPv4 datagrams for which no problems
+            were encountered to prevent their continued processing, but
+            which were discarded (e.g., for lack of buffer space).  Note
+            that this counter does not include any datagrams discarded
+            while awaiting re-assembly.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsInDiscards."
+    ::= { ip 8 }
+
+ipInDelivers OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The total number of input datagrams successfully delivered
+            to IPv4 user-protocols (including ICMP).
+
+            This object has been deprecated as a new IP version neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsIndelivers."
+    ::= { ip 9 }
+
+ipOutRequests OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The total number of IPv4 datagrams which local IPv4 user
+            protocols (including ICMP) supplied to IPv4 in requests for
+            transmission.  Note that this counter does not include any
+            datagrams counted in ipForwDatagrams.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsOutRequests."
+    ::= { ip 10 }
+
+ipOutDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of output IPv4 datagrams for which no problem was
+            encountered to prevent their transmission to their
+            destination, but which were discarded (e.g., for lack of
+            buffer space).  Note that this counter would include
+            datagrams counted in ipForwDatagrams if any such packets met
+            this (discretionary) discard criterion.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsOutDiscards."
+    ::= { ip 11 }
+
+ipOutNoRoutes OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of IPv4 datagrams discarded because no route
+            could be found to transmit them to their destination.  Note
+            that this counter includes any packets counted in
+            ipForwDatagrams which meet this `no-route' criterion.  Note
+            that this includes any datagrams which a host cannot route
+            because all of its default routers are down.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsOutNoRoutes."
+    ::= { ip 12 }
+
+ipReasmReqds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of IPv4 fragments received which needed to be
+            reassembled at this entity.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsReasmReqds."
+    ::= { ip 14 }
+
+ipReasmOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of IPv4 datagrams successfully re-assembled.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsReasmOKs."
+    ::= { ip 15 }
+
+ipReasmFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of failures detected by the IPv4 re-assembly
+            algorithm (for whatever reason: timed out, errors, etc).
+            Note that this is not necessarily a count of discarded IPv4
+            fragments since some algorithms (notably the algorithm in
+            RFC 815) can lose track of the number of fragments by
+            combining them as they are received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsReasmFails."
+    ::= { ip 16 }
+
+ipFragOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of IPv4 datagrams that have been successfully
+            fragmented at this entity.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsOutFragOKs."
+    ::= { ip 17 }
+
+ipFragFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of IPv4 datagrams that have been discarded
+            because they needed to be fragmented at this entity but
+            could not be, e.g., because their Don't Fragment flag was
+            set.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsOutFragFails."
+    ::= { ip 18 }
+
+ipFragCreates OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of IPv4 datagram fragments that have been
+            generated as a result of fragmentation at this entity.
+
+            This object has been deprecated as a new IP version neutral
+            table has been added.  It is loosely replaced by
+            ipSystemStatsOutFragCreates."
+    ::= { ip 19 }
+
+ipRoutingDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of routing entries which were chosen to be
+            discarded even though they are valid.  One possible reason
+            for discarding such an entry could be to free-up buffer
+            space for other routing entries.
+
+            This object was defined in pre-IPv6 versions of the IP MIB.
+            It was implicitly IPv4 only, but the original specifications
+            did not indicate this protocol restriction.  In order to
+            clarify the specifications, this object has been deprecated
+            and a similar, but more thoroughly clarified, object has
+            been added to the IP-FORWARD-MIB."
+    ::= { ip 23 }
+
+-- the deprecated IPv4 address table
+
+ipAddrTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpAddrEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+           "The table of addressing information relevant to this
+            entity's IPv4 addresses.
+
+            This table has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by the
+            ipAddressTable although several objects that weren't deemed
+            useful weren't carried forward while another
+            (ipAdEntReasmMaxSize) was moved to the ipv4InterfaceTable."
+    ::= { ip 20 }
+
+ipAddrEntry OBJECT-TYPE
+    SYNTAX     IpAddrEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+           "The addressing information for one of this entity's IPv4
+            addresses."
+    INDEX      { ipAdEntAddr }
+    ::= { ipAddrTable 1 }
+
+IpAddrEntry ::= SEQUENCE {
+        ipAdEntAddr          IpAddress,
+        ipAdEntIfIndex       INTEGER,
+        ipAdEntNetMask       IpAddress,
+        ipAdEntBcastAddr     INTEGER,
+        ipAdEntReasmMaxSize  INTEGER
+    }
+
+ipAdEntAddr OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The IPv4 address to which this entry's addressing
+            information pertains."
+    ::= { ipAddrEntry 1 }
+
+ipAdEntIfIndex OBJECT-TYPE
+    SYNTAX     INTEGER (1..2147483647)
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The index value which uniquely identifies the interface to
+            which this entry is applicable.  The interface identified by
+            a particular value of this index is the same interface as
+            identified by the same value of the IF-MIB's ifIndex."
+    ::= { ipAddrEntry 2 }
+
+ipAdEntNetMask OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The subnet mask associated with the IPv4 address of this
+            entry.  The value of the mask is an IPv4 address with all
+            the network bits set to 1 and all the hosts bits set to 0."
+    ::= { ipAddrEntry 3 }
+
+ipAdEntBcastAddr OBJECT-TYPE
+    SYNTAX     INTEGER (0..1)
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The value of the least-significant bit in the IPv4 broadcast
+            address used for sending datagrams on the (logical)
+            interface associated with the IPv4 address of this entry.
+            For example, when the Internet standard all-ones broadcast
+            address is used, the value will be 1.  This value applies to
+            both the subnet and network broadcast addresses used by the
+            entity on this (logical) interface."
+    ::= { ipAddrEntry 4 }
+
+ipAdEntReasmMaxSize OBJECT-TYPE
+    SYNTAX     INTEGER (0..65535)
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The size of the largest IPv4 datagram which this entity can
+            re-assemble from incoming IPv4 fragmented datagrams received
+            on this interface."
+    ::= { ipAddrEntry 5 }
+
+-- the deprecated IPv4 Address Translation table
+
+-- The Address Translation tables contain the IpAddress to
+-- "physical" address equivalences.  Some interfaces do not
+-- use translation tables for determining address
+-- equivalences (e.g., DDN-X.25 has an algorithmic method);
+-- if all interfaces are of this type, then the Address
+-- Translation table is empty, i.e., has zero entries.
+
+ipNetToMediaTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpNetToMediaEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+           "The IPv4 Address Translation table used for mapping from
+            IPv4 addresses to physical addresses.
+
+            This table has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by the
+            ipNetToPhysicalTable."
+    ::= { ip 22 }
+
+ipNetToMediaEntry OBJECT-TYPE
+    SYNTAX     IpNetToMediaEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+           "Each entry contains one IpAddress to `physical' address
+            equivalence."
+    INDEX       { ipNetToMediaIfIndex,
+                  ipNetToMediaNetAddress }
+    ::= { ipNetToMediaTable 1 }
+
+IpNetToMediaEntry ::= SEQUENCE {
+        ipNetToMediaIfIndex      INTEGER,
+        ipNetToMediaPhysAddress  PhysAddress,
+        ipNetToMediaNetAddress   IpAddress,
+        ipNetToMediaType         INTEGER
+    }
+
+ipNetToMediaIfIndex OBJECT-TYPE
+    SYNTAX     INTEGER (1..2147483647)
+     MAX-ACCESS read-create
+    STATUS     deprecated
+    DESCRIPTION
+           "The interface on which this entry's equivalence is
+            effective.  The interface identified by a particular value
+            of this index is the same interface as identified by the
+            same value of the IF-MIB's ifIndex.
+
+            This object predates the rule limiting index objects to a
+            max access value of 'not-accessible' and so continues to use
+            a value of 'read-create'."
+    ::= { ipNetToMediaEntry 1 }
+
+ipNetToMediaPhysAddress OBJECT-TYPE
+    SYNTAX     PhysAddress (SIZE(0..65535))
+     MAX-ACCESS read-create
+    STATUS     deprecated
+    DESCRIPTION
+           "The media-dependent `physical' address.  This object should
+            return 0 when this entry is in the 'incomplete' state.
+
+            As the entries in this table are typically not persistent
+            when this object is written the entity should not save the
+            change to non-volatile storage.  Note: a stronger
+            requirement is not used because this object was previously
+            defined."
+    ::= { ipNetToMediaEntry 2 }
+
+ipNetToMediaNetAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+     MAX-ACCESS read-create
+    STATUS     deprecated
+    DESCRIPTION
+           "The IpAddress corresponding to the media-dependent
+            `physical' address.
+
+            This object predates the rule limiting index objects to a
+            max access value of 'not-accessible' and so continues to use
+            a value of 'read-create'."
+    ::= { ipNetToMediaEntry 3 }
+
+ipNetToMediaType OBJECT-TYPE
+    SYNTAX     INTEGER {
+                other(1),        -- none of the following
+                invalid(2),      -- an invalidated mapping
+                dynamic(3),
+                static(4)
+            }
+     MAX-ACCESS read-create
+    STATUS     deprecated
+    DESCRIPTION
+           "The type of mapping.
+
+            Setting this object to the value invalid(2) has the effect
+            of invalidating the corresponding entry in the
+            ipNetToMediaTable.  That is, it effectively dis-associates
+            the interface identified with said entry from the mapping
+            identified with said entry.  It is an implementation-
+            specific matter as to whether the agent removes an
+            invalidated entry from the table.  Accordingly, management
+            stations must be prepared to receive tabular information
+            from agents that corresponds to entries not currently in
+            use.  Proper interpretation of such entries requires
+            examination of the relevant ipNetToMediaType object.
+
+            As the entries in this table are typically not persistent
+            when this object is written the entity should not save the
+            change to non-volatile storage.  Note: a stronger
+            requirement is not used because this object was previously
+            defined."
+    ::= { ipNetToMediaEntry 4 }
+
+-- the deprecated ICMP group
+
+icmpInMsgs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The total number of ICMP messages which the entity received.
+            Note that this counter includes all those counted by
+            icmpInErrors.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            icmpStatsInMsgs."
+    ::= { icmp 1 }
+
+icmpInErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP messages which the entity received but
+            determined as having ICMP-specific errors (bad ICMP
+            checksums, bad length, etc.).
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            icmpStatsInErrors."
+    ::= { icmp 2 }
+
+icmpInDestUnreachs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Destination Unreachable messages
+            received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 3 }
+
+icmpInTimeExcds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Time Exceeded messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 4 }
+
+icmpInParmProbs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Parameter Problem messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 5 }
+
+icmpInSrcQuenchs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Source Quench messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 6 }
+
+icmpInRedirects OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Redirect messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 7 }
+
+icmpInEchos OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Echo (request) messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 8 }
+
+icmpInEchoReps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Echo Reply messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 9 }
+
+icmpInTimestamps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Timestamp (request) messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 10 }
+
+icmpInTimestampReps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Timestamp Reply messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 11 }
+
+icmpInAddrMasks OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Address Mask Request messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 12 }
+
+icmpInAddrMaskReps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Address Mask Reply messages received.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 13 }
+
+icmpOutMsgs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The total number of ICMP messages which this entity
+            attempted to send.  Note that this counter includes all
+            those counted by icmpOutErrors.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            icmpStatsOutMsgs."
+    ::= { icmp 14 }
+
+icmpOutErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP messages which this entity did not send
+            due to problems discovered within ICMP, such as a lack of
+            buffers.  This value should not include errors discovered
+            outside the ICMP layer, such as the inability of IP to route
+            the resultant datagram.  In some implementations, there may
+            be no types of error which contribute to this counter's
+            value.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by
+            icmpStatsOutErrors."
+    ::= { icmp 15 }
+
+icmpOutDestUnreachs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Destination Unreachable messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 16 }
+
+icmpOutTimeExcds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Time Exceeded messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 17 }
+
+icmpOutParmProbs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Parameter Problem messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 18 }
+
+icmpOutSrcQuenchs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Source Quench messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 19 }
+
+icmpOutRedirects OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Redirect messages sent.  For a host, this
+            object will always be zero, since hosts do not send
+            redirects.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 20 }
+
+icmpOutEchos OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Echo (request) messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 21 }
+
+icmpOutEchoReps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Echo Reply messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 22 }
+
+icmpOutTimestamps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Timestamp (request) messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 23 }
+
+icmpOutTimestampReps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Timestamp Reply messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 24 }
+
+icmpOutAddrMasks OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Address Mask Request messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 25 }
+
+icmpOutAddrMaskReps OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+           "The number of ICMP Address Mask Reply messages sent.
+
+            This object has been deprecated, as a new IP version-neutral
+            table has been added.  It is loosely replaced by a column in
+            the icmpMsgStatsTable."
+    ::= { icmp 26 }
+
+-- deprecated conformance information
+-- deprecated compliance statements
+
+ipMIBCompliance MODULE-COMPLIANCE
+    STATUS     deprecated
+    DESCRIPTION
+           "The compliance statement for systems that implement only
+            IPv4.  For version-independence, this compliance statement
+            is deprecated in favor of ipMIBCompliance2."
+    MODULE  -- this module
+        MANDATORY-GROUPS { ipGroup,
+                           icmpGroup }
+    ::= { ipMIBCompliances 1 }
+
+-- deprecated units of conformance
+
+ipGroup OBJECT-GROUP
+    OBJECTS   { ipForwarding,           ipDefaultTTL,
+                ipInReceives,           ipInHdrErrors,
+                ipInAddrErrors,         ipForwDatagrams,
+                ipInUnknownProtos,      ipInDiscards,
+                ipInDelivers,           ipOutRequests,
+                ipOutDiscards,          ipOutNoRoutes,
+                ipReasmTimeout,         ipReasmReqds,
+                ipReasmOKs,             ipReasmFails,
+                ipFragOKs,              ipFragFails,
+                ipFragCreates,          ipAdEntAddr,
+                ipAdEntIfIndex,         ipAdEntNetMask,
+                ipAdEntBcastAddr,       ipAdEntReasmMaxSize,
+                ipNetToMediaIfIndex,    ipNetToMediaPhysAddress,
+                ipNetToMediaNetAddress, ipNetToMediaType,
+                ipRoutingDiscards
+}
+    STATUS     deprecated
+    DESCRIPTION
+           "The ip group of objects providing for basic management of IP
+            entities, exclusive of the management of IP routes.
+
+            As part of the version independence, this group has been
+            deprecated.  "
+    ::= { ipMIBGroups 1 }
+
+icmpGroup OBJECT-GROUP
+    OBJECTS   { icmpInMsgs,          icmpInErrors,
+                icmpInDestUnreachs,  icmpInTimeExcds,
+                icmpInParmProbs,     icmpInSrcQuenchs,
+                icmpInRedirects,     icmpInEchos,
+                icmpInEchoReps,      icmpInTimestamps,
+                icmpInTimestampReps, icmpInAddrMasks,
+                icmpInAddrMaskReps,  icmpOutMsgs,
+                icmpOutErrors,       icmpOutDestUnreachs,
+                icmpOutTimeExcds,    icmpOutParmProbs,
+                icmpOutSrcQuenchs,   icmpOutRedirects,
+                icmpOutEchos,        icmpOutEchoReps,
+                icmpOutTimestamps,   icmpOutTimestampReps,
+                icmpOutAddrMasks,    icmpOutAddrMaskReps }
+    STATUS     deprecated
+    DESCRIPTION
+           "The icmp group of objects providing ICMP statistics.
+
+            As part of the version independence, this group has been
+            deprecated.  "
+    ::= { ipMIBGroups 2 }
+
+END

--- a/mibs/junos/mib-rfc4382.txt
+++ b/mibs/junos/mib-rfc4382.txt
@@ -1,0 +1,1583 @@
+MPLS-L3VPN-STD-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+   MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+   Integer32, Counter32, Unsigned32, Gauge32
+      FROM SNMPv2-SMI                                     -- [RFC2578]
+   MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+      FROM SNMPv2-CONF                                    -- [RFC2580]
+   TEXTUAL-CONVENTION, TruthValue, RowStatus,
+   TimeStamp, StorageType
+      FROM SNMPv2-TC                                      -- [RFC2579]
+   InterfaceIndex, InterfaceIndexOrZero
+      FROM IF-MIB                                         -- [RFC2863]
+   VPNIdOrZero
+     FROM VPN-TC-STD-MIB                                  -- [RFC4265]
+   SnmpAdminString
+      FROM SNMP-FRAMEWORK-MIB                             -- [RFC3411]
+   IANAipRouteProtocol
+      FROM IANA-RTPROTO-MIB                               -- [RTPROTO]
+   InetAddress, InetAddressType,
+   InetAddressPrefixLength,
+   InetAutonomousSystemNumber
+      FROM INET-ADDRESS-MIB                               -- [RFC4001]
+   mplsStdMIB
+      FROM MPLS-TC-STD-MIB                                -- [RFC3811]
+   MplsIndexType
+      FROM MPLS-LSR-STD-MIB                               -- [RFC3813]
+   ;
+
+mplsL3VpnMIB MODULE-IDENTITY
+   LAST-UPDATED "200601230000Z"  -- 23 January 2006
+   ORGANIZATION "IETF Layer-3 Virtual Private
+                 Networks Working Group."
+   CONTACT-INFO
+          "        Thomas D. Nadeau
+                   tnadeau@cisco.com
+
+                   Harmen van der Linde
+                   havander@cisco.com
+
+                   Comments and discussion to l3vpn@ietf.org"
+   DESCRIPTION
+        "This MIB contains managed object definitions for the
+         Layer-3 Multiprotocol Label Switching Virtual
+         Private Networks.
+
+        Copyright (C) The Internet Society (2006).  This
+        version of this MIB module is part of RFC4382; see
+        the RFC itself for full legal notices."
+  -- Revision history.
+  REVISION
+      "200601230000Z"  -- 23 January 2006
+   DESCRIPTION
+      "Initial version.  Published as RFC 4382."
+   ::= { mplsStdMIB 11 }
+
+-- Textual Conventions.
+MplsL3VpnName ::= TEXTUAL-CONVENTION
+   STATUS        current
+   DESCRIPTION
+       "An identifier that is assigned to each MPLS/BGP VPN and
+        is used to uniquely identify it.  This is assigned by the
+        system operator or NMS and SHOULD be unique throughout
+        the MPLS domain.  If this is the case, then this identifier
+        can then be used at any LSR within a specific MPLS domain
+        to identify this MPLS/BGP VPN.  It may also be possible to
+        preserve the uniqueness of this identifier across MPLS
+        domain boundaries, in which case this identifier can then
+        be used to uniquely identify MPLS/BGP VPNs on a more global
+        basis.  This object MAY be set to the VPN ID as defined in
+        RFC 2685."
+   REFERENCE
+        "RFC 2685 Fox B., et al, 'Virtual Private
+         Networks Identifier', September 1999."
+   SYNTAX OCTET STRING (SIZE (0..31))
+
+MplsL3VpnRouteDistinguisher ::= TEXTUAL-CONVENTION
+   STATUS        current
+   DESCRIPTION
+       "Syntax for a route distinguisher and route target
+        as defined in [RFC4364]."
+   REFERENCE
+        "[RFC4364]"
+   SYNTAX  OCTET STRING(SIZE (0..256))
+
+MplsL3VpnRtType ::= TEXTUAL-CONVENTION
+   STATUS        current
+   DESCRIPTION
+       "Used to define the type of a route target usage.
+        Route targets can be specified to be imported,
+        exported, or both.  For a complete definition of a
+        route target, see [RFC4364]."
+   REFERENCE
+        "[RFC4364]"
+   SYNTAX INTEGER { import(1), export(2), both(3) }
+
+-- Top level components of this MIB.
+mplsL3VpnNotifications OBJECT IDENTIFIER ::= { mplsL3VpnMIB 0 }
+mplsL3VpnObjects       OBJECT IDENTIFIER ::= { mplsL3VpnMIB 1 }
+mplsL3VpnScalars       OBJECT IDENTIFIER ::= { mplsL3VpnObjects 1 }
+mplsL3VpnConf          OBJECT IDENTIFIER ::= { mplsL3VpnObjects 2 }
+mplsL3VpnPerf          OBJECT IDENTIFIER ::= { mplsL3VpnObjects 3 }
+mplsL3VpnRoute         OBJECT IDENTIFIER ::= { mplsL3VpnObjects 4 }
+mplsL3VpnConformance   OBJECT IDENTIFIER ::= { mplsL3VpnMIB 2 }
+
+--
+-- Scalar Objects
+--
+
+mplsL3VpnConfiguredVrfs OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "The number of VRFs that are configured on this node."
+   ::= { mplsL3VpnScalars 1 }
+
+mplsL3VpnActiveVrfs OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "The number of VRFs that are active on this node.
+        That is, those VRFs whose corresponding mplsL3VpnVrfOperStatus
+        object value is equal to operational (1)."
+   ::= { mplsL3VpnScalars 2 }
+
+mplsL3VpnConnectedInterfaces OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of interfaces connected to a VRF."
+   ::= { mplsL3VpnScalars 3 }
+
+mplsL3VpnNotificationEnable OBJECT-TYPE
+   SYNTAX        TruthValue
+   MAX-ACCESS    read-write
+   STATUS        current
+   DESCRIPTION
+        "If this object is true, then it enables the
+         generation of all notifications defined in
+         this MIB.  This object's value should be
+         preserved across agent reboots."
+   REFERENCE
+       "See also [RFC3413] for explanation that
+        notifications are under the ultimate control of the
+        MIB modules in this document."
+   DEFVAL { false }
+   ::= { mplsL3VpnScalars 4 }
+
+mplsL3VpnVrfConfMaxPossRts  OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+     "Denotes maximum number of routes that the device
+      will allow all VRFs jointly to hold.  If this value is
+      set to 0, this indicates that the device is
+      unable to determine the absolute maximum.  In this
+      case, the configured maximum MAY not actually
+      be allowed by the device."
+   ::= { mplsL3VpnScalars 5 }
+
+mplsL3VpnVrfConfRteMxThrshTime  OBJECT-TYPE
+   SYNTAX        Unsigned32
+   UNITS         "seconds"
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+     "Denotes the interval in seconds, at which the route max threshold
+      notification may be reissued after the maximum value has been
+      exceeded (or has been reached if mplsL3VpnVrfConfMaxRoutes and
+      mplsL3VpnVrfConfHighRteThresh are equal) and the initial
+      notification has been issued.  This value is intended to prevent
+      continuous generation of notifications by an agent in the event
+      that routes are continually added to a VRF after it has reached
+      its maximum value.  If this value is set to 0, the agent should
+      only issue a single notification at the time that the maximum
+      threshold has been reached, and should not issue any more
+      notifications until the value of routes has fallen below the
+      configured threshold value.  This is the recommended default
+      behavior."
+   DEFVAL { 0 }
+   ::= { mplsL3VpnScalars 6 }
+
+mplsL3VpnIllLblRcvThrsh OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-write
+   STATUS        current
+   DESCRIPTION
+       "The number of illegally received labels above which
+        the mplsNumVrfSecIllglLblThrshExcd notification
+        is issued.  The persistence of this value mimics
+        that of the device's configuration."
+   ::= { mplsL3VpnScalars 7 }
+
+-- VPN Interface Configuration Table
+
+mplsL3VpnIfConfTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MplsL3VpnIfConfEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "This table specifies per-interface MPLS capability
+        and associated information."
+   ::= { mplsL3VpnConf 1 }
+
+mplsL3VpnIfConfEntry OBJECT-TYPE
+   SYNTAX        MplsL3VpnIfConfEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "An entry in this table is created by an LSR for
+        every interface capable of supporting MPLS L3VPN.
+        Each entry in this table is meant to correspond to
+        an entry in the Interfaces Table."
+   INDEX       { mplsL3VpnVrfName, mplsL3VpnIfConfIndex }
+   ::= { mplsL3VpnIfConfTable 1 }
+
+MplsL3VpnIfConfEntry ::= SEQUENCE {
+  mplsL3VpnIfConfIndex             InterfaceIndex,
+  mplsL3VpnIfVpnClassification     INTEGER,
+  mplsL3VpnIfVpnRouteDistProtocol  BITS,
+  mplsL3VpnIfConfStorageType       StorageType,
+  mplsL3VpnIfConfRowStatus         RowStatus
+}
+
+mplsL3VpnIfConfIndex OBJECT-TYPE
+   SYNTAX        InterfaceIndex
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "This is a unique index for an entry in the
+        mplsL3VpnIfConfTable.  A non-zero index for an
+        entry indicates the ifIndex for the corresponding
+        interface entry in the MPLS-VPN-layer in the ifTable.
+        Note that this table does not necessarily correspond
+        one-to-one with all entries in the Interface MIB
+        having an ifType of MPLS-layer; rather, only those
+        that are enabled for MPLS L3VPN functionality."
+   REFERENCE
+       "RFC2863"
+   ::= { mplsL3VpnIfConfEntry 1 }
+
+mplsL3VpnIfVpnClassification OBJECT-TYPE
+   SYNTAX        INTEGER { carrierOfCarrier (1),
+                           enterprise (2),
+                           interProvider (3)
+   }
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "Denotes whether this link participates in a
+        carrier's carrier, enterprise, or inter-provider
+        scenario."
+   DEFVAL { enterprise }
+   ::= { mplsL3VpnIfConfEntry 2 }
+
+mplsL3VpnIfVpnRouteDistProtocol OBJECT-TYPE
+   SYNTAX        BITS { none (0),
+                        bgp (1),
+                        ospf (2),
+                        rip(3),
+                        isis(4),
+                        static(5),
+                        other (6)
+   }
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "Denotes the route distribution protocol across the
+        PE-CE link.  Note that more than one routing protocol
+        may be enabled at the same time; thus, this object is
+        specified as a bitmask.  For example, static(5) and
+        ospf(2) are a typical configuration."
+   ::= { mplsL3VpnIfConfEntry 3 }
+
+mplsL3VpnIfConfStorageType  OBJECT-TYPE
+   SYNTAX      StorageType
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+       "The storage type for this VPN If entry.
+        Conceptual rows having the value 'permanent'
+        need not allow write access to any columnar
+        objects in the row."
+   REFERENCE
+        "See RFC2579."
+   DEFVAL { volatile }
+   ::= { mplsL3VpnIfConfEntry 4 }
+
+mplsL3VpnIfConfRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS    read-create
+   STATUS      current
+   DESCRIPTION
+       "This variable is used to create, modify, and/or
+        delete a row in this table.  Rows in this
+        table signify that the specified interface is
+        associated with this VRF.  If the row creation
+        operation succeeds, the interface will have been
+        associated with the specified VRF, otherwise the
+        agent MUST not allow the association.  If the agent
+        only allows read-only operations on this table, it
+        MUST create entries in this table as they are created
+        on the device.  When a row in this table is in
+        active(1) state, no objects in that row can be
+        modified except mplsL3VpnIfConfStorageType and
+        mplsL3VpnIfConfRowStatus."
+   ::= { mplsL3VpnIfConfEntry 5 }
+
+-- VRF Configuration Table
+mplsL3VpnVrfTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MplsL3VpnVrfEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "This table specifies per-interface MPLS L3VPN
+        VRF Table capability and associated information.
+        Entries in this table define VRF routing instances
+        associated with MPLS/VPN interfaces.  Note that
+        multiple interfaces can belong to the same VRF
+        instance.  The collection of all VRF instances
+        comprises an actual VPN."
+   ::= { mplsL3VpnConf 2 }
+
+mplsL3VpnVrfEntry OBJECT-TYPE
+   SYNTAX        MplsL3VpnVrfEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "An entry in this table is created by an LSR for
+        every VRF capable of supporting MPLS L3VPN.  The
+        indexing provides an ordering of VRFs per-VPN
+        interface."
+   INDEX       { mplsL3VpnVrfName }
+   ::= { mplsL3VpnVrfTable 1 }
+MplsL3VpnVrfEntry ::= SEQUENCE {
+  mplsL3VpnVrfName                      MplsL3VpnName,
+  mplsL3VpnVrfVpnId                     VPNIdOrZero,
+  mplsL3VpnVrfDescription               SnmpAdminString,
+  mplsL3VpnVrfRD                        MplsL3VpnRouteDistinguisher,
+  mplsL3VpnVrfCreationTime              TimeStamp,
+  mplsL3VpnVrfOperStatus                INTEGER,
+  mplsL3VpnVrfActiveInterfaces          Gauge32,
+  mplsL3VpnVrfAssociatedInterfaces      Unsigned32,
+  mplsL3VpnVrfConfMidRteThresh          Unsigned32,
+  mplsL3VpnVrfConfHighRteThresh         Unsigned32,
+  mplsL3VpnVrfConfMaxRoutes             Unsigned32,
+  mplsL3VpnVrfConfLastChanged           TimeStamp,
+  mplsL3VpnVrfConfRowStatus             RowStatus,
+  mplsL3VpnVrfConfAdminStatus           INTEGER,
+  mplsL3VpnVrfConfStorageType           StorageType
+}
+
+mplsL3VpnVrfName OBJECT-TYPE
+   SYNTAX        MplsL3VpnName
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "The human-readable name of this VPN.  This MAY
+        be equivalent to the [RFC2685] VPN-ID, but may
+        also vary.  If it is set to the VPN ID, it MUST
+        be equivalent to the value of mplsL3VpnVrfVpnId.
+        It is strongly recommended that all sites supporting
+        VRFs that are part of the same VPN use the same
+        naming convention for VRFs as well as the same VPN
+        ID."
+   REFERENCE
+       "[RFC2685]"
+   ::= { mplsL3VpnVrfEntry 1 }
+
+mplsL3VpnVrfVpnId OBJECT-TYPE
+   SYNTAX        VPNIdOrZero
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "The VPN ID as specified in [RFC2685].  If a VPN ID
+        has not been specified for this VRF, then this
+        variable SHOULD be set to a zero-length OCTET
+        STRING."
+   ::= { mplsL3VpnVrfEntry 2 }
+
+mplsL3VpnVrfDescription OBJECT-TYPE
+   SYNTAX        SnmpAdminString
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "The human-readable description of this VRF."
+   DEFVAL { "" }
+   ::= { mplsL3VpnVrfEntry 3 }
+
+mplsL3VpnVrfRD OBJECT-TYPE
+   SYNTAX        MplsL3VpnRouteDistinguisher
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "The route distinguisher for this VRF."
+   DEFVAL { "" }
+   ::= { mplsL3VpnVrfEntry 4 }
+
+mplsL3VpnVrfCreationTime OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "The time at which this VRF entry was created."
+   ::= { mplsL3VpnVrfEntry 5 }
+
+mplsL3VpnVrfOperStatus OBJECT-TYPE
+   SYNTAX        INTEGER { up (1),
+                           down (2)
+                         }
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Denotes whether or not a VRF is operational.  A VRF is
+        up(1) when there is at least one interface associated
+        with the VRF whose ifOperStatus is up(1).  A VRF is
+        down(2) when:
+        a. There does not exist at least one interface whose
+           ifOperStatus is up(1).
+        b. There are no interfaces associated with the VRF."
+   ::= { mplsL3VpnVrfEntry 6 }
+
+mplsL3VpnVrfActiveInterfaces OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of interfaces connected to this VRF with
+        ifOperStatus = up(1).
+
+        This value should increase when an interface is associated
+        with the corresponding VRF and its corresponding ifOperStatus
+        is equal to up(1).  If an interface is associated whose
+        ifOperStatus is not up(1), then the value is not incremented
+        until such time as it transitions to this state.
+
+        This value should be decremented when an interface is
+        disassociated with a VRF or the corresponding ifOperStatus
+        transitions out of the up(1) state to any other state.
+       "
+   ::= { mplsL3VpnVrfEntry 7 }
+
+mplsL3VpnVrfAssociatedInterfaces OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Total number of interfaces connected to this VRF
+        (independent of ifOperStatus type)."
+   ::= { mplsL3VpnVrfEntry 8 }
+
+mplsL3VpnVrfConfMidRteThresh    OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+     "Denotes mid-level water marker for the number
+      of routes that this VRF may hold."
+  DEFVAL { 0 }
+  ::= { mplsL3VpnVrfEntry 9 }
+
+mplsL3VpnVrfConfHighRteThresh  OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+     "Denotes high-level water marker for the number of
+      routes that this VRF may hold."
+   DEFVAL { 0 }
+  ::= { mplsL3VpnVrfEntry 10 }
+
+mplsL3VpnVrfConfMaxRoutes  OBJECT-TYPE
+   SYNTAX        Unsigned32
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+     "Denotes maximum number of routes that this VRF is
+      configured to hold.  This value MUST be less than or
+      equal to mplsL3VpnVrfConfMaxPossRts unless it is set
+      to 0."
+   DEFVAL { 0 }
+  ::= { mplsL3VpnVrfEntry 11 }
+
+mplsL3VpnVrfConfLastChanged  OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+     "The value of sysUpTime at the time of the last
+      change of this table entry, which includes changes of
+      VRF parameters defined in this table or addition or
+      deletion of interfaces associated with this VRF."
+  ::= { mplsL3VpnVrfEntry 12 }
+
+mplsL3VpnVrfConfRowStatus OBJECT-TYPE
+   SYNTAX        RowStatus
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "This variable is used to create, modify, and/or
+        delete a row in this table.
+        When a row in this table is in active(1) state, no
+        objects in that row can be modified except
+        mplsL3VpnVrfConfAdminStatus, mplsL3VpnVrfConfRowStatus,
+        and mplsL3VpnVrfConfStorageType."
+  ::= { mplsL3VpnVrfEntry 13 }
+
+mplsL3VpnVrfConfAdminStatus OBJECT-TYPE
+   SYNTAX     INTEGER {
+                      up(1),     -- ready to pass packets
+                      down(2),   -- can't pass packets
+                      testing(3) -- in some test mode
+                }
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+        "Indicates the desired operational status of this
+         VRF."
+  ::= { mplsL3VpnVrfEntry 14 }
+
+mplsL3VpnVrfConfStorageType  OBJECT-TYPE
+   SYNTAX        StorageType
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+        "The storage type for this VPN VRF entry.
+         Conceptual rows having the value 'permanent'
+         need not allow write access to any columnar
+         objects in the row."
+   REFERENCE
+        "See RFC2579."
+   DEFVAL { volatile }
+   ::= { mplsL3VpnVrfEntry 15 }
+
+
+-- MplsL3VpnVrfRTTable
+mplsL3VpnVrfRTTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF MplsL3VpnVrfRTEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "This table specifies per-VRF route target association.
+         Each entry identifies a connectivity policy supported
+         as part of a VPN."
+    ::= { mplsL3VpnConf 3 }
+
+mplsL3VpnVrfRTEntry OBJECT-TYPE
+    SYNTAX       MplsL3VpnVrfRTEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+       "An entry in this table is created by an LSR for
+        each route target configured for a VRF supporting
+        a MPLS L3VPN instance.  The indexing provides an
+        ordering per-VRF instance.  See [RFC4364] for a
+        complete definition of a route target."
+    INDEX  { mplsL3VpnVrfName, mplsL3VpnVrfRTIndex,
+             mplsL3VpnVrfRTType }
+    ::= { mplsL3VpnVrfRTTable 1 }
+
+MplsL3VpnVrfRTEntry ::= SEQUENCE {
+     mplsL3VpnVrfRTIndex       Unsigned32,
+     mplsL3VpnVrfRTType        MplsL3VpnRtType,
+     mplsL3VpnVrfRT            MplsL3VpnRouteDistinguisher,
+     mplsL3VpnVrfRTDescr       SnmpAdminString,
+     mplsL3VpnVrfRTRowStatus   RowStatus,
+     mplsL3VpnVrfRTStorageType StorageType
+   }
+
+mplsL3VpnVrfRTIndex OBJECT-TYPE
+   SYNTAX        Unsigned32 (1..4294967295)
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "Auxiliary index for route targets configured for a
+        particular VRF."
+   ::= { mplsL3VpnVrfRTEntry 2 }
+
+mplsL3VpnVrfRTType OBJECT-TYPE
+   SYNTAX        MplsL3VpnRtType
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "The route target distribution type."
+   ::= { mplsL3VpnVrfRTEntry 3 }
+
+mplsL3VpnVrfRT OBJECT-TYPE
+   SYNTAX        MplsL3VpnRouteDistinguisher
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "The route target distribution policy."
+   DEFVAL { "" }
+   ::= { mplsL3VpnVrfRTEntry 4 }
+
+mplsL3VpnVrfRTDescr OBJECT-TYPE
+   SYNTAX        SnmpAdminString
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "Description of the route target."
+   DEFVAL { "" }
+   ::= { mplsL3VpnVrfRTEntry 5 }
+
+mplsL3VpnVrfRTRowStatus OBJECT-TYPE
+   SYNTAX        RowStatus
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+       "This variable is used to create, modify, and/or
+        delete a row in this table.  When a row in this
+        table is in active(1) state, no objects in that row
+        can be modified except mplsL3VpnVrfRTRowStatus."
+   ::= { mplsL3VpnVrfRTEntry 6 }
+
+mplsL3VpnVrfRTStorageType OBJECT-TYPE
+   SYNTAX        StorageType
+   MAX-ACCESS    read-create
+   STATUS        current
+   DESCRIPTION
+        "The storage type for this VPN route target (RT) entry.
+         Conceptual rows having the value 'permanent'
+         need not allow write access to any columnar
+         objects in the row."
+   REFERENCE
+        "See RFC2579."
+   DEFVAL { volatile }
+   ::= { mplsL3VpnVrfRTEntry 7 }
+
+-- VRF Security Table
+
+mplsL3VpnVrfSecTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MplsL3VpnVrfSecEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "This table specifies per MPLS L3VPN VRF Table
+        security-related counters."
+   ::= { mplsL3VpnConf 6 }
+
+mplsL3VpnVrfSecEntry OBJECT-TYPE
+   SYNTAX        MplsL3VpnVrfSecEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "An entry in this table is created by an LSR for
+        every VRF capable of supporting MPLS L3VPN.  Each
+        entry in this table is used to indicate security-related
+        information for each VRF entry."
+   AUGMENTS      { mplsL3VpnVrfEntry }
+      ::= { mplsL3VpnVrfSecTable 1 }
+
+MplsL3VpnVrfSecEntry ::= SEQUENCE {
+       mplsL3VpnVrfSecIllegalLblVltns     Counter32,
+       mplsL3VpnVrfSecDiscontinuityTime   TimeStamp
+}
+
+mplsL3VpnVrfSecIllegalLblVltns OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Indicates the number of illegally received
+        labels on this VPN/VRF.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        mplsL3VpnVrfSecDiscontinuityTime."
+   ::= { mplsL3VpnVrfSecEntry 1 }
+
+mplsL3VpnVrfSecDiscontinuityTime  OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "The value of sysUpTime on the most recent occasion at
+        which any one or more of this entry's counters suffered
+        a discontinuity.  If no such discontinuities have
+        occurred since the last re-initialization of the local
+        management subsystem, then this object contains a zero
+        value."
+   ::= { mplsL3VpnVrfSecEntry 2 }
+
+
+-- VRF Performance Table
+
+mplsL3VpnVrfPerfTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MplsL3VpnVrfPerfEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "This table specifies per MPLS L3VPN VRF Table performance
+        information."
+   ::= { mplsL3VpnPerf 1 }
+
+mplsL3VpnVrfPerfEntry OBJECT-TYPE
+   SYNTAX        MplsL3VpnVrfPerfEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "An entry in this table is created by an LSR for
+        every VRF capable of supporting MPLS L3VPN."
+   AUGMENTS      { mplsL3VpnVrfEntry }
+      ::= { mplsL3VpnVrfPerfTable 1 }
+
+MplsL3VpnVrfPerfEntry ::= SEQUENCE {
+   mplsL3VpnVrfPerfRoutesAdded       Counter32,
+   mplsL3VpnVrfPerfRoutesDeleted     Counter32,
+   mplsL3VpnVrfPerfCurrNumRoutes     Gauge32,
+   mplsL3VpnVrfPerfRoutesDropped     Counter32,
+   mplsL3VpnVrfPerfDiscTime          TimeStamp
+}
+
+mplsL3VpnVrfPerfRoutesAdded OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Indicates the number of routes added to this VPN/VRF
+        since the last discontinuity.  Discontinuities in
+        the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        mplsL3VpnVrfPerfDiscTime."
+   ::= { mplsL3VpnVrfPerfEntry 1 }
+
+mplsL3VpnVrfPerfRoutesDeleted OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Indicates the number of routes removed from this VPN/VRF.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        mplsL3VpnVrfPerfDiscTime."
+   ::= { mplsL3VpnVrfPerfEntry 2 }
+
+mplsL3VpnVrfPerfCurrNumRoutes     OBJECT-TYPE
+   SYNTAX        Gauge32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "Indicates the number of routes currently used by this
+        VRF."
+   ::= { mplsL3VpnVrfPerfEntry 3 }
+
+
+mplsL3VpnVrfPerfRoutesDropped OBJECT-TYPE
+   SYNTAX        Counter32
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "This counter should be incremented when the number of routes
+        contained by the specified VRF exceeds or attempts to exceed
+        the maximum allowed value as indicated by
+        mplsL3VpnVrfMaxRouteThreshold.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        mplsL3VpnVrfPerfDiscTime."
+  ::= { mplsL3VpnVrfPerfEntry 4 }
+
+mplsL3VpnVrfPerfDiscTime  OBJECT-TYPE
+   SYNTAX        TimeStamp
+   MAX-ACCESS    read-only
+   STATUS        current
+   DESCRIPTION
+       "The value of sysUpTime on the most recent occasion at
+        which any one or more of this entry's counters suffered
+        a discontinuity.  If no such discontinuities have
+        occurred since the last re-initialization of the local
+        management subsystem, then this object contains a zero
+        value."
+  ::= { mplsL3VpnVrfPerfEntry 5 }
+
+-- VRF Routing Table
+
+mplsL3VpnVrfRteTable  OBJECT-TYPE
+   SYNTAX        SEQUENCE OF MplsL3VpnVrfRteEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "This table specifies per-interface MPLS L3VPN VRF Table
+        routing information.  Entries in this table define VRF routing
+        entries associated with the specified MPLS/VPN interfaces.  Note
+        that this table contains both BGP and Interior Gateway Protocol
+        IGP routes, as both may appear in the same VRF."
+    REFERENCE
+       "[RFC2096]"
+   ::= { mplsL3VpnRoute 1 }
+
+mplsL3VpnVrfRteEntry OBJECT-TYPE
+   SYNTAX        MplsL3VpnVrfRteEntry
+   MAX-ACCESS    not-accessible
+   STATUS        current
+   DESCRIPTION
+       "An entry in this table is created by an LSR for every route
+        present configured (either dynamically or statically) within
+        the context of a specific VRF capable of supporting MPLS/BGP
+        VPN.  The indexing provides an ordering of VRFs per-VPN
+        interface.
+
+        Implementers need to be aware that there are quite a few
+        index objects that together can exceed the size allowed
+        for an Object Identifier (OID).  So implementers must make
+        sure that OIDs of column instances in this table will have
+        no more than 128 sub-identifiers, otherwise they cannot be
+        accessed using SNMPv1, SNMPv2c, or SNMPv3."
+
+      INDEX  { mplsL3VpnVrfName,
+               mplsL3VpnVrfRteInetCidrDestType,
+               mplsL3VpnVrfRteInetCidrDest,
+               mplsL3VpnVrfRteInetCidrPfxLen,
+               mplsL3VpnVrfRteInetCidrPolicy,
+               mplsL3VpnVrfRteInetCidrNHopType,
+               mplsL3VpnVrfRteInetCidrNextHop
+      }
+      ::= { mplsL3VpnVrfRteTable 1 }
+
+MplsL3VpnVrfRteEntry ::= SEQUENCE {
+         mplsL3VpnVrfRteInetCidrDestType     InetAddressType,
+         mplsL3VpnVrfRteInetCidrDest         InetAddress,
+         mplsL3VpnVrfRteInetCidrPfxLen       InetAddressPrefixLength,
+         mplsL3VpnVrfRteInetCidrPolicy       OBJECT IDENTIFIER,
+         mplsL3VpnVrfRteInetCidrNHopType     InetAddressType,
+         mplsL3VpnVrfRteInetCidrNextHop      InetAddress,
+         mplsL3VpnVrfRteInetCidrIfIndex      InterfaceIndexOrZero,
+         mplsL3VpnVrfRteInetCidrType         INTEGER,
+         mplsL3VpnVrfRteInetCidrProto        IANAipRouteProtocol,
+         mplsL3VpnVrfRteInetCidrAge          Gauge32,
+         mplsL3VpnVrfRteInetCidrNextHopAS    InetAutonomousSystemNumber,
+         mplsL3VpnVrfRteInetCidrMetric1      Integer32,
+         mplsL3VpnVrfRteInetCidrMetric2      Integer32,
+         mplsL3VpnVrfRteInetCidrMetric3      Integer32,
+         mplsL3VpnVrfRteInetCidrMetric4      Integer32,
+         mplsL3VpnVrfRteInetCidrMetric5      Integer32,
+         mplsL3VpnVrfRteXCPointer            MplsIndexType,
+         mplsL3VpnVrfRteInetCidrStatus       RowStatus
+       }
+
+    mplsL3VpnVrfRteInetCidrDestType OBJECT-TYPE
+        SYNTAX     InetAddressType
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+               "The type of the mplsL3VpnVrfRteInetCidrDest address, as
+                defined in the InetAddress MIB.
+
+                Only those address types that may appear in an actual
+                routing table are allowed as values of this object."
+        REFERENCE "RFC4001"
+        ::= { mplsL3VpnVrfRteEntry 1 }
+
+    mplsL3VpnVrfRteInetCidrDest OBJECT-TYPE
+        SYNTAX     InetAddress
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+               "The destination IP address of this route.
+
+                The type of this address is determined by the value of
+                the mplsL3VpnVrfRteInetCidrDestType object.
+
+                The values for the index objects
+                mplsL3VpnVrfRteInetCidrDest and
+                mplsL3VpnVrfRteInetCidrPfxLen must be consistent.  When
+                the value of mplsL3VpnVrfRteInetCidrDest is x, then
+                the bitwise logical-AND of x with the value of the mask
+                formed from the corresponding index object
+                mplsL3VpnVrfRteInetCidrPfxLen MUST be
+                equal to x.  If not, then the index pair is not
+                consistent and an inconsistentName error must be
+                returned on SET or CREATE requests."
+        ::= { mplsL3VpnVrfRteEntry 2 }
+
+    mplsL3VpnVrfRteInetCidrPfxLen OBJECT-TYPE
+        SYNTAX     InetAddressPrefixLength (0..128)
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+               "Indicates the number of leading one bits that form the
+                mask to be logical-ANDed with the destination address
+                before being compared to the value in the
+                mplsL3VpnVrfRteInetCidrDest field.
+
+                The values for the index objects
+                mplsL3VpnVrfRteInetCidrDest and
+                mplsL3VpnVrfRteInetCidrPfxLen must be consistent.  When
+                the value of mplsL3VpnVrfRteInetCidrDest is x, then the
+                bitwise logical-AND of x with the value of the mask
+                formed from the corresponding index object
+                mplsL3VpnVrfRteInetCidrPfxLen MUST be
+                equal to x.  If not, then the index pair is not
+                consistent and an inconsistentName error must be
+                returned on SET or CREATE requests."
+        ::= { mplsL3VpnVrfRteEntry 3 }
+
+    mplsL3VpnVrfRteInetCidrPolicy OBJECT-TYPE
+        SYNTAX     OBJECT IDENTIFIER
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+               "This object is an opaque object without any defined
+                semantics.  Its purpose is to serve as an additional
+                index that may delineate between multiple entries to
+                the same destination.  The value { 0 0 } shall be used
+                as the default value for this object."
+        ::= { mplsL3VpnVrfRteEntry 4 }
+
+    mplsL3VpnVrfRteInetCidrNHopType OBJECT-TYPE
+        SYNTAX     InetAddressType
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+               "The type of the mplsL3VpnVrfRteInetCidrNextHop address,
+                as defined in the InetAddress MIB.
+
+                Value should be set to unknown(0) for non-remote
+                routes.
+
+                Only those address types that may appear in an actual
+                routing table are allowed as values of this object."
+        REFERENCE "RFC4001"
+        ::= { mplsL3VpnVrfRteEntry 5 }
+
+    mplsL3VpnVrfRteInetCidrNextHop OBJECT-TYPE
+        SYNTAX     InetAddress
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+               "On remote routes, the address of the next system en
+                route.  For non-remote routes, a zero-length string.
+                The type of this address is determined by the value of
+                the mplsL3VpnVrfRteInetCidrNHopType object."
+        ::= { mplsL3VpnVrfRteEntry 6 }
+
+    mplsL3VpnVrfRteInetCidrIfIndex OBJECT-TYPE
+        SYNTAX     InterfaceIndexOrZero
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "The ifIndex value that identifies the local interface
+                through which the next hop of this route should be
+                reached.  A value of 0 is valid and represents the
+                scenario where no interface is specified."
+        DEFVAL { 0 }
+        ::= { mplsL3VpnVrfRteEntry 7 }
+
+    mplsL3VpnVrfRteInetCidrType OBJECT-TYPE
+        SYNTAX     INTEGER {
+                    other    (1), -- not specified by this MIB
+                    reject   (2), -- route which discards traffic and
+                                  --   returns ICMP notification
+                    local    (3), -- local interface
+                    remote   (4), -- remote destination
+                    blackhole(5)  -- route which discards traffic
+                                  --   silently
+                 }
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "The type of route.  Note that local(3) refers to a
+                route for which the next hop is the final destination;
+                remote(4) refers to a route for which the next hop is
+                not the final destination.
+
+                Routes that do not result in traffic forwarding or
+                rejection should not be displayed even if the
+                implementation keeps them stored internally.
+
+                reject(2) refers to a route that, if matched, discards
+                the message as unreachable and returns a notification
+                (e.g., ICMP error) to the message sender.  This is used
+                in some protocols as a means of correctly aggregating
+                routes.
+
+                blackhole(5) refers to a route that, if matched,
+                discards the message silently."
+        DEFVAL { other }
+        ::= { mplsL3VpnVrfRteEntry 8 }
+
+    mplsL3VpnVrfRteInetCidrProto OBJECT-TYPE
+        SYNTAX     IANAipRouteProtocol
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+               "The routing mechanism via which this route was learned.
+                Inclusion of values for gateway routing protocols is
+                not intended to imply that hosts should support those
+                protocols."
+        ::= { mplsL3VpnVrfRteEntry 9 }
+
+    mplsL3VpnVrfRteInetCidrAge OBJECT-TYPE
+        SYNTAX     Gauge32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION
+               "The number of seconds since this route was last updated
+                or otherwise determined to be correct.  Note that no
+                semantics of 'too old' can be implied except through
+                knowledge of the routing protocol by which the route
+                was learned."
+        ::= { mplsL3VpnVrfRteEntry 10 }
+
+    mplsL3VpnVrfRteInetCidrNextHopAS OBJECT-TYPE
+        SYNTAX     InetAutonomousSystemNumber
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "The Autonomous System Number of the next hop.  The
+                semantics of this object are determined by the
+                routing protocol specified in the route's
+                mplsL3VpnVrfRteInetCidrProto value.  When this
+                object is unknown or not relevant, its value should
+                be set to zero."
+        DEFVAL { 0 }
+        ::= { mplsL3VpnVrfRteEntry 11 }
+
+    mplsL3VpnVrfRteInetCidrMetric1 OBJECT-TYPE
+        SYNTAX     Integer32 (-1 | 0..2147483647)
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "The primary routing metric for this route.  The
+                semantics of this metric are determined by the
+                routing protocol specified in the route's
+                mplsL3VpnVrfRteInetCidrProto value.  If this
+                metric is not used, its value should be set to
+                -1."
+        DEFVAL { -1 }
+        ::= { mplsL3VpnVrfRteEntry 12 }
+
+    mplsL3VpnVrfRteInetCidrMetric2 OBJECT-TYPE
+        SYNTAX     Integer32 (-1 | 0..2147483647)
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "An alternate routing metric for this route.  The
+                semantics of this metric are determined by the routing
+                protocol specified in the route's
+                mplsL3VpnVrfRteInetCidrProto
+                value.  If this metric is not used, its value should be
+                set to -1."
+        DEFVAL { -1 }
+        ::= { mplsL3VpnVrfRteEntry 13 }
+
+    mplsL3VpnVrfRteInetCidrMetric3 OBJECT-TYPE
+        SYNTAX     Integer32 (-1 | 0..2147483647)
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "An alternate routing metric for this route.  The
+                semantics of this metric are determined by the routing
+                protocol specified in the route's
+                mplsL3VpnVrfRteInetCidrProto
+                value.  If this metric is not used, its value should be
+                set to -1."
+        DEFVAL { -1 }
+        ::= { mplsL3VpnVrfRteEntry 14 }
+
+    mplsL3VpnVrfRteInetCidrMetric4 OBJECT-TYPE
+        SYNTAX     Integer32 (-1 | 0..2147483647)
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "An alternate routing metric for this route.  The
+                semantics of this metric are determined by the routing
+                protocol specified in the route's
+                mplsL3VpnVrfRteInetCidrProto value.  If this metric
+                is not used, its value should be set to -1."
+        DEFVAL { -1 }
+        ::= { mplsL3VpnVrfRteEntry 15 }
+
+    mplsL3VpnVrfRteInetCidrMetric5 OBJECT-TYPE
+        SYNTAX     Integer32 (-1 | 0..2147483647)
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "An alternate routing metric for this route.  The
+                semantics of this metric are determined by the routing
+                protocol specified in the route's
+                mplsL3VpnVrfRteInetCidrProto value.  If this metric is
+                not used, its value should be set to -1."
+        DEFVAL { -1 }
+        ::= { mplsL3VpnVrfRteEntry 16 }
+
+   mplsL3VpnVrfRteXCPointer  OBJECT-TYPE
+      SYNTAX       MplsIndexType
+      MAX-ACCESS   read-create
+      STATUS       current
+      DESCRIPTION
+        "Index into mplsXCTable that identifies which cross-
+        connect entry is associated with this VRF route entry
+        by containing the mplsXCIndex of that cross-connect entry.
+        The string containing the single-octet 0x00 indicates that
+        a label stack is not associated with this route entry.  This
+        can be the case because the label bindings have not yet
+        been established, or because some change in the agent has
+        removed them.
+
+        When the label stack associated with this VRF route is created,
+        it MUST establish the associated cross-connect
+        entry in the mplsXCTable and then set that index to the value
+        of this object.  Changes to the cross-connect object in the
+        mplsXCTable MUST automatically be reflected in the value of
+        this object.  If this object represents a static routing entry,
+        then the manager must ensure that this entry is maintained
+        consistently in the corresponding mplsXCTable as well."
+      REFERENCE
+       "RFC 3813 - Multiprotocol Label Switching (MPLS) Label Switching
+        Router (LSR) Management Information base (MIB), C. Srinivasan,
+        A. Vishwanathan, and T. Nadeau, June 2004"
+       ::= { mplsL3VpnVrfRteEntry 17 }
+
+    mplsL3VpnVrfRteInetCidrStatus OBJECT-TYPE
+        SYNTAX     RowStatus
+        MAX-ACCESS read-create
+        STATUS     current
+        DESCRIPTION
+               "The row status variable, used according to row
+                installation and removal conventions.
+                A row entry cannot be modified when the status is
+                marked as active(1)."
+        ::= { mplsL3VpnVrfRteEntry 18 }
+
+
+-- MPLS L3VPN Notifications
+mplsL3VpnVrfUp NOTIFICATION-TYPE
+   OBJECTS     { mplsL3VpnIfConfRowStatus,
+                 mplsL3VpnVrfOperStatus
+               }
+   STATUS      current
+   DESCRIPTION
+       "This notification is generated when:
+        a. No interface is associated with this VRF, and the first
+           (and only first) interface associated with it has its
+           ifOperStatus change to up(1).
+
+        b. One interface is associated with this VRF, and
+           the ifOperStatus of this interface changes to up(1).
+
+        c. Multiple interfaces are associated with this VRF, and the
+           ifOperStatus of all interfaces is down(2), and the first
+           of those interfaces has its ifOperStatus change to up(1)."
+   ::= { mplsL3VpnNotifications 1 }
+
+mplsL3VpnVrfDown NOTIFICATION-TYPE
+   OBJECTS     { mplsL3VpnIfConfRowStatus,
+                 mplsL3VpnVrfOperStatus
+               }
+   STATUS      current
+   DESCRIPTION
+       "This notification is generated when:
+        a. One interface is associated with this VRF, and
+           the ifOperStatus of this interface changes from up(1)
+           to down(2).
+
+        b. Multiple interfaces are associated with this VRF, and
+           the ifOperStatus of all except one of these interfaces is
+           equal to up(1), and the ifOperStatus of that interface
+           changes from up(1) to down(2).
+
+        c. The last interface with ifOperStatus equal to up(1)
+           is disassociated from a VRF."
+   ::= { mplsL3VpnNotifications 2 }
+
+mplsL3VpnVrfRouteMidThreshExceeded NOTIFICATION-TYPE
+   OBJECTS     { mplsL3VpnVrfPerfCurrNumRoutes,
+                 mplsL3VpnVrfConfMidRteThresh
+               }
+   STATUS      current
+   DESCRIPTION
+       "This notification is generated when the number of routes
+        contained by the specified VRF exceeds the value indicated by
+        mplsL3VpnVrfMidRouteThreshold.  A single notification MUST be
+        generated when this threshold is exceeded, and no other
+        notifications of this type should be issued until the value
+        of mplsL3VpnVrfPerfCurrNumRoutes has fallen below that of
+        mplsL3VpnVrfConfMidRteThresh."
+   ::= { mplsL3VpnNotifications 3 }
+
+mplsL3VpnVrfNumVrfRouteMaxThreshExceeded NOTIFICATION-TYPE
+   OBJECTS     { mplsL3VpnVrfPerfCurrNumRoutes,
+                 mplsL3VpnVrfConfHighRteThresh
+               }
+   STATUS      current
+   DESCRIPTION
+       "This notification is generated when the number of routes
+        contained by the specified VRF exceeds or attempts to exceed
+        the maximum allowed value as indicated by
+        mplsL3VpnVrfMaxRouteThreshold.  In cases where
+        mplsL3VpnVrfConfHighRteThresh is set to the same value
+        as mplsL3VpnVrfConfMaxRoutes, mplsL3VpnVrfConfHighRteThresh
+        need not be exceeded; rather, just reached for this notification
+        to be issued.
+
+        Note that mplsL3VpnVrfConfRteMxThrshTime denotes the interval
+        at which the this notification will be reissued after the
+        maximum value has been exceeded (or reached if
+        mplsL3VpnVrfConfMaxRoutes and mplsL3VpnVrfConfHighRteThresh are
+        equal) and the initial notification has been issued.  This value
+        is intended to prevent continuous generation of notifications by
+        an agent in the event that routes are continually added to a VRF
+        after it has reached its maximum value.  The default value is 0
+        minutes.  If this value is set to 0, the agent should only issue
+        a single notification at the time that the maximum threshold has
+        been reached, and should not issue any more notifications until
+        the value of routes has fallen below the configured threshold
+        value."
+   ::= { mplsL3VpnNotifications 4 }
+
+mplsL3VpnNumVrfSecIllglLblThrshExcd NOTIFICATION-TYPE
+   OBJECTS     { mplsL3VpnVrfSecIllegalLblVltns }
+   STATUS      current
+   DESCRIPTION
+       "This notification is generated when the number of illegal
+        label violations on a VRF as indicated by
+        mplsL3VpnVrfSecIllegalLblVltns has exceeded
+        mplsL3VpnIllLblRcvThrsh.  The threshold is not
+        included in the varbind here because the value of
+        mplsL3VpnVrfSecIllegalLblVltns should be one greater than
+        the threshold at the time this notification is issued."
+   ::= { mplsL3VpnNotifications 5 }
+
+
+mplsL3VpnNumVrfRouteMaxThreshCleared NOTIFICATION-TYPE
+   OBJECTS     { mplsL3VpnVrfPerfCurrNumRoutes,
+                 mplsL3VpnVrfConfHighRteThresh
+               }
+   STATUS      current
+   DESCRIPTION
+       "This notification is generated only after the number of routes
+        contained by the specified VRF exceeds or attempts to exceed
+        the maximum allowed value as indicated by
+        mplsVrfMaxRouteThreshold, and then falls below this value.  The
+        emission of this notification informs the operator that the
+        error condition has been cleared without the operator having to
+        query the device.
+
+        Note that mplsL3VpnVrfConfRteMxThrshTime denotes the interval at
+        which the mplsNumVrfRouteMaxThreshExceeded notification will
+        be reissued after the maximum value has been exceeded (or
+        reached if mplsL3VpnVrfConfMaxRoutes and
+        mplsL3VpnVrfConfHighRteThresh are equal) and the initial
+        notification has been issued.  Therefore,
+        the generation of this notification should also be emitted with
+        this same frequency (assuming that the error condition is
+        cleared).  Specifically, if the error condition is reached and
+        cleared several times during the period of time specified in
+        mplsL3VpnVrfConfRteMxThrshTime, only a single notification will
+        be issued to indicate the first instance of the error condition
+        as well as the first time the error condition is cleared.
+        This behavior is intended to prevent continuous generation of
+        notifications by an agent in the event that routes are
+        continually added and removed to/from a VRF after it has
+        reached its maximum value.  The default value is 0.  If this
+        value is set to 0, the agent should issue a notification
+        whenever the maximum threshold has been cleared."
+   ::= { mplsL3VpnNotifications 6 }
+
+-- Conformance Statement
+mplsL3VpnGroups
+      OBJECT IDENTIFIER ::= { mplsL3VpnConformance 1 }
+
+mplsL3VpnCompliances
+      OBJECT IDENTIFIER ::= { mplsL3VpnConformance 2 }
+
+-- Module Compliance
+
+mplsL3VpnModuleFullCompliance MODULE-COMPLIANCE
+      STATUS current
+      DESCRIPTION
+          "Compliance statement for agents that provide full support
+           for the MPLS-L3VPN-STD-MIB"
+      MODULE -- this module
+         MANDATORY-GROUPS    { mplsL3VpnScalarGroup,
+                               mplsL3VpnVrfGroup,
+                               mplsL3VpnIfGroup,
+                               mplsL3VpnPerfGroup,
+                               mplsL3VpnVrfRteGroup,
+                               mplsL3VpnVrfRTGroup,
+                               mplsL3VpnSecGroup,
+                               mplsL3VpnNotificationGroup
+                             }
+
+   GROUP       mplsL3VpnPerfRouteGroup
+   DESCRIPTION "This group is only mandatory for LSRs that
+                support tracking the number of routes attempted
+                to be added to VRFs."
+
+   OBJECT       mplsL3VpnIfConfRowStatus
+   SYNTAX       RowStatus { active(1), notInService(2) }
+   WRITE-SYNTAX RowStatus { active(1), notInService(2),
+                            createAndGo(4), destroy(6)
+                          }
+   DESCRIPTION "Support for createAndWait and notReady is
+                not required."
+
+
+   OBJECT       mplsL3VpnVrfConfRowStatus
+   SYNTAX       RowStatus { active(1), notInService(2) }
+   WRITE-SYNTAX RowStatus { active(1), notInService(2),
+                            createAndGo(4), destroy(6)
+                          }
+   DESCRIPTION "Support for createAndWait and notReady is
+                not required."
+   OBJECT       mplsL3VpnVrfRTRowStatus
+   SYNTAX       RowStatus { active(1), notInService(2) }
+   WRITE-SYNTAX RowStatus { active(1), notInService(2),
+                            createAndGo(4), destroy(6)
+                          }
+   DESCRIPTION "Support for createAndWait and notReady is
+                not required."
+   ::= { mplsL3VpnCompliances 1 }
+
+
+--
+-- ReadOnly Compliance
+--
+
+mplsL3VpnModuleReadOnlyCompliance MODULE-COMPLIANCE
+      STATUS current
+      DESCRIPTION "Compliance requirement for implementations that only
+                   provide read-only support for MPLS-L3VPN-STD-MIB.
+                   Such devices can then be monitored but cannot be
+                   configured using this MIB module."
+
+      MODULE -- this module
+         MANDATORY-GROUPS    { mplsL3VpnScalarGroup,
+                               mplsL3VpnVrfGroup,
+                               mplsL3VpnIfGroup,
+                               mplsL3VpnPerfGroup,
+                               mplsL3VpnVrfRteGroup,
+                               mplsL3VpnVrfRTGroup,
+                               mplsL3VpnSecGroup,
+                               mplsL3VpnNotificationGroup
+                             }
+
+   GROUP       mplsL3VpnPerfRouteGroup
+   DESCRIPTION "This group is only mandatory for LSRs that
+                support tracking the number of routes attempted to
+                be added to VRFs."
+
+   OBJECT       mplsL3VpnIfConfRowStatus
+   SYNTAX       RowStatus { active(1) }
+   MIN-ACCESS   read-only
+   DESCRIPTION  "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfConfRowStatus
+   SYNTAX       RowStatus { active(1) }
+   MIN-ACCESS   read-only
+   DESCRIPTION  "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRTRowStatus
+   SYNTAX       RowStatus { active(1) }
+   MIN-ACCESS   read-only
+   DESCRIPTION  "Write access is not required."
+
+   OBJECT       mplsL3VpnIfVpnClassification
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+   OBJECT       mplsL3VpnIfVpnRouteDistProtocol
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnIfConfStorageType
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfVpnId
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfDescription
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRD
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfConfMidRteThresh
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfConfHighRteThresh
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfConfMaxRoutes
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfConfStorageType
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRT
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRTDescr
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRTStorageType
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+   OBJECT       mplsL3VpnVrfRteInetCidrIfIndex
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrType
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrNextHopAS
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrMetric1
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrMetric2
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrMetric3
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrMetric4
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrMetric5
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteXCPointer
+   MIN-ACCESS   read-only
+   DESCRIPTION "Write access is not required."
+
+   OBJECT       mplsL3VpnVrfRteInetCidrStatus
+   SYNTAX       RowStatus { active(1) }
+   MIN-ACCESS   read-only
+   DESCRIPTION  "Write access is not required."
+   ::= { mplsL3VpnCompliances 2 }
+
+
+   -- Units of conformance.
+   mplsL3VpnScalarGroup OBJECT-GROUP
+      OBJECTS { mplsL3VpnConfiguredVrfs,
+                mplsL3VpnActiveVrfs,
+                mplsL3VpnConnectedInterfaces,
+                mplsL3VpnNotificationEnable,
+                mplsL3VpnVrfConfMaxPossRts,
+                mplsL3VpnVrfConfRteMxThrshTime,
+                mplsL3VpnIllLblRcvThrsh
+             }
+      STATUS  current
+      DESCRIPTION
+             "Collection of scalar objects required for MPLS VPN
+              management."
+      ::= { mplsL3VpnGroups 1 }
+
+   mplsL3VpnVrfGroup OBJECT-GROUP
+      OBJECTS { mplsL3VpnVrfVpnId,
+                mplsL3VpnVrfDescription,
+                mplsL3VpnVrfRD,
+                mplsL3VpnVrfCreationTime,
+                mplsL3VpnVrfOperStatus,
+                mplsL3VpnVrfActiveInterfaces,
+                mplsL3VpnVrfAssociatedInterfaces,
+                mplsL3VpnVrfConfMidRteThresh,
+                mplsL3VpnVrfConfHighRteThresh,
+                mplsL3VpnVrfConfMaxRoutes,
+                mplsL3VpnVrfConfLastChanged,
+                mplsL3VpnVrfConfRowStatus,
+                mplsL3VpnVrfConfAdminStatus,
+                mplsL3VpnVrfConfStorageType
+       }
+      STATUS  current
+      DESCRIPTION
+             "Collection of objects needed for MPLS VPN VRF
+              management."
+      ::= { mplsL3VpnGroups 2 }
+
+   mplsL3VpnIfGroup OBJECT-GROUP
+        OBJECTS { mplsL3VpnIfVpnClassification,
+                  mplsL3VpnIfVpnRouteDistProtocol,
+                  mplsL3VpnIfConfStorageType,
+                  mplsL3VpnIfConfRowStatus
+           }
+      STATUS  current
+      DESCRIPTION
+             "Collection of objects needed for MPLS VPN interface
+              management."
+      ::= { mplsL3VpnGroups 3 }
+
+   mplsL3VpnPerfGroup OBJECT-GROUP
+      OBJECTS { mplsL3VpnVrfPerfRoutesAdded,
+                mplsL3VpnVrfPerfRoutesDeleted,
+                mplsL3VpnVrfPerfCurrNumRoutes
+             }
+      STATUS  current
+      DESCRIPTION
+             "Collection of objects needed for MPLS VPN
+              performance information."
+      ::= { mplsL3VpnGroups 4 }
+
+   mplsL3VpnPerfRouteGroup OBJECT-GROUP
+      OBJECTS { mplsL3VpnVrfPerfRoutesDropped,
+                mplsL3VpnVrfPerfDiscTime
+             }
+      STATUS  current
+      DESCRIPTION
+             "Collection of objects needed to track MPLS VPN
+              routing table dropped routes."
+      ::= { mplsL3VpnGroups 5 }
+
+   mplsL3VpnSecGroup OBJECT-GROUP
+      OBJECTS { mplsL3VpnVrfSecIllegalLblVltns,
+                mplsL3VpnVrfSecDiscontinuityTime }
+      STATUS  current
+      DESCRIPTION
+             "Collection of objects needed for MPLS VPN
+              security-related information."
+      ::= { mplsL3VpnGroups 7 }
+
+   mplsL3VpnVrfRteGroup OBJECT-GROUP
+      OBJECTS {
+            mplsL3VpnVrfRteInetCidrIfIndex,
+            mplsL3VpnVrfRteInetCidrType,
+            mplsL3VpnVrfRteInetCidrProto,
+            mplsL3VpnVrfRteInetCidrAge,
+            mplsL3VpnVrfRteInetCidrNextHopAS,
+            mplsL3VpnVrfRteInetCidrMetric1,
+            mplsL3VpnVrfRteInetCidrMetric2,
+            mplsL3VpnVrfRteInetCidrMetric3,
+            mplsL3VpnVrfRteInetCidrMetric4,
+            mplsL3VpnVrfRteInetCidrMetric5,
+            mplsL3VpnVrfRteXCPointer,
+            mplsL3VpnVrfRteInetCidrStatus
+       }
+      STATUS  current
+      DESCRIPTION
+             "Objects required for VRF route table management."
+   ::= { mplsL3VpnGroups 8 }
+
+   mplsL3VpnVrfRTGroup OBJECT-GROUP
+      OBJECTS { mplsL3VpnVrfRTDescr,
+                mplsL3VpnVrfRT,
+                mplsL3VpnVrfRTRowStatus,
+                mplsL3VpnVrfRTStorageType
+              }
+      STATUS  current
+      DESCRIPTION
+             "Objects required for VRF route target management."
+   ::= { mplsL3VpnGroups 9 }
+
+   mplsL3VpnNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS { mplsL3VpnVrfUp,
+                       mplsL3VpnVrfDown,
+                       mplsL3VpnVrfRouteMidThreshExceeded,
+                       mplsL3VpnVrfNumVrfRouteMaxThreshExceeded,
+                       mplsL3VpnNumVrfSecIllglLblThrshExcd,
+                       mplsL3VpnNumVrfRouteMaxThreshCleared
+                     }
+      STATUS  current
+      DESCRIPTION
+             "Objects required for MPLS VPN notifications."
+   ::= { mplsL3VpnGroups 10 }
+END
+

--- a/mibs/junos/mib-rfc4444.txt
+++ b/mibs/junos/mib-rfc4444.txt
@@ -1,0 +1,4305 @@
+ISIS-MIB DEFINITIONS ::= BEGIN
+     IMPORTS
+        TEXTUAL-CONVENTION, RowStatus, TruthValue, TimeStamp
+                FROM SNMPv2-TC               -- RFC2579
+        MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+            Unsigned32, Counter32, mib-2
+                FROM SNMPv2-SMI              -- RFC2578
+        MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+                FROM SNMPv2-CONF             -- RFC2580
+        SnmpAdminString
+                FROM SNMP-FRAMEWORK-MIB      -- RFC2571
+        IndexInteger, IndexIntegerNextFree
+                FROM DIFFSERV-MIB            -- RFC3289
+        InterfaceIndex
+                FROM IF-MIB                  -- RFC2863
+        InetAddressType, InetAddress, InetAddressPrefixLength
+                FROM INET-ADDRESS-MIB;       -- RFC3291
+
+    isisMIB MODULE-IDENTITY
+        LAST-UPDATED "200604040000Z" -- April 4, 2006, midnight
+        ORGANIZATION "IETF IS-IS for IP Internets Working Group"
+        CONTACT-INFO
+            "IS-IS for IP Internets working Group
+             http://www.ietf.org/html.charters/isis-charter.html
+             isis-wg@ietf.org
+
+             Jeff Parker
+             Department of Computer Science
+             Middlebury College,
+             Middlebury, Vermont 05753
+             jeffp at middlbury dot edu"
+
+        DESCRIPTION
+             "This document describes a management information base for
+             the IS-IS Routing protocol, as described in ISO 10589,
+             when it is used to construct routing tables for IP
+             networks, as described in RFC 1195.
+
+             This document is based on a 1994 IETF document by Chris
+             Gunner.  This version has been modified to include
+             current syntax, to exclude portions of the protocol that
+             are not relevant to IP, and to add management support for
+             current practice.
+
+             Copyright (C) The Internet Society (2006).  This version
+             of this MIB module is part of RFC 4444; see the RFC
+             itself for full legal notices."
+
+        REVISION "200604040000Z" -- April 4, 2006, midnight
+
+        DESCRIPTION
+            "Initial version, published as RFC 4444."
+    ::= { mib-2 138 }
+
+-- Top-level structure of the MIB
+
+isisNotifications       OBJECT IDENTIFIER ::= { isisMIB 0 }
+isisObjects             OBJECT IDENTIFIER ::= { isisMIB 1 }
+isisConformance         OBJECT IDENTIFIER ::= { isisMIB 2 }
+
+-- OBJECT IDENTIFIER definitions
+
+-- System wide attributes.
+isisSystem OBJECT IDENTIFIER ::= { isisObjects 1 }
+
+-- Attributes associated with the domain or with the area.
+isisSysLevel OBJECT IDENTIFIER ::= { isisObjects 2 }
+
+-- Attributes associated with one Circuit
+isisCirc OBJECT IDENTIFIER ::= { isisObjects 3 }
+
+-- Attributes associated with area or domain relevant within a Circuit.
+isisCircLevelValues OBJECT IDENTIFIER ::= { isisObjects 4 }
+
+-- System and circuit counters.
+isisCounters OBJECT IDENTIFIER ::= { isisObjects 5 }
+
+-- Attributes associated with an adjacent Protocol Peer.
+isisISAdj OBJECT IDENTIFIER ::= { isisObjects 6 }
+
+-- Attributes associated with a configured address.
+isisReachAddr OBJECT IDENTIFIER ::= { isisObjects 7 }
+
+-- Attributes associated with IP routes learned by
+-- configuration or through another protocol.
+isisIPReachAddr OBJECT IDENTIFIER ::= { isisObjects 8 }
+
+-- The collection of Link State PDUs known to the Intermediate System
+isisLSPDataBase OBJECT IDENTIFIER ::= { isisObjects 9 }
+
+-- Objects included in Notifications.
+isisNotification OBJECT IDENTIFIER ::= { isisObjects 10 }
+
+-- Type definitions
+
+    IsisOSINSAddress ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "OSI Network Service Address, e.g., NSAP, SNPA, or Network
+             Entity Title"
+        SYNTAX OCTET STRING (SIZE(0..20))
+
+    IsisSystemID ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "The ID for an Intermediate System.  This should
+             be unique within a network, and is included
+             in all PDUs originated by an Intermediate System.
+             The protocol does not place any meanings upon
+             the bits, other than using ordering to break
+             ties in electing a Designated IS on a LAN."
+        REFERENCE "{ISIS.aoi systemId (119)}"
+        SYNTAX OCTET STRING (SIZE(6))
+
+    IsisLinkStatePDUID ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "The 8-byte Link State PDU (LSP) ID,
+             consisting of the 6-byte SystemID of the
+             originating IS; a one-byte PseudoNode ID,
+             which is 0 unless the LSP represents the
+             topology of a LAN; and a one-byte LSP
+             fragment number that is issued in sequence,
+             starting with 0.  Non-zero PseudoNode IDs
+             need to be unique to the IS but need not
+             match the IfIndex."
+        REFERENCE "{See section 9.8 of ISO 10589}"
+        SYNTAX OCTET STRING (SIZE(8))
+
+    IsisAdminState ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "Type used in enabling and disabling a row."
+        SYNTAX INTEGER
+            {
+                on(1),
+                off(2)
+            }
+
+    IsisLSPBuffSize ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "Integer sub-range for maximum LSP size."
+        SYNTAX Unsigned32 (512..16000)
+
+    IsisLevelState ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "States of the IS-IS protocol."
+        SYNTAX INTEGER
+            {
+                off (1),
+                on (2),
+                waiting (3),
+                overloaded(4)
+            }
+
+    IsisSupportedProtocol ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "Types of network protocol supported by Integrated IS-IS.
+             The values for ISO8473 and IP are those registered for
+             these protocols in ISO TR9577."
+        REFERENCE "{See section 5.3.1 of RFC 1195}"
+        SYNTAX INTEGER
+            {
+                iso8473(129),
+                ipV6(142),
+                ip(204)
+            }
+
+    IsisDefaultMetric ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "Integer sub-range for default metric for single hop.
+             ISO 10589 provides for 4 types of metric.  Only the
+             'default' metric is used in practice."
+        REFERENCE "{See section 7.2.2 of ISO 10589}"
+        SYNTAX Unsigned32 (0..63)
+
+    IsisWideMetric ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "Wide metric for IS Neighbors.  ISO 10589 provides a
+             6-bit metric.  Traffic Engineering extensions provide
+             24-bit metrics."
+        REFERENCE "{See section 3 of RFC 3784}"
+        SYNTAX Unsigned32 (0..16777215)
+
+    IsisFullMetric ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "Full metric for IP Routes.  Traffic Engineering extensions
+             provide 32-bit metrics."
+        REFERENCE "{See section 4 of RFC 3784}"
+        SYNTAX Unsigned32
+
+    IsisMetricType ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "Is this an Internal or External Metric?"
+        REFERENCE "{See section 7.2.2 of ISO 10589}"
+        SYNTAX INTEGER
+            {
+                internal(1),
+                external(2)
+            }
+
+    IsisMetricStyle ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "Do we use RFC 1195 style metrics or wide metrics?"
+        REFERENCE "{See section 5 of RFC 3787}"
+        SYNTAX INTEGER
+            {
+                narrow(1),
+                wide(2),
+                both(3)
+            }
+
+    IsisISLevel ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "Identifies a level."
+        REFERENCE "{See definitions 3.6.1 and 3.6.11 of ISO 10589}"
+        SYNTAX INTEGER
+            {
+                area(1),        -- L1
+                domain(2)       -- L2
+            }
+
+    IsisLevel ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "Identifies one or more levels."
+        REFERENCE "{See definitions 3.6.1 and 3.6.11 of ISO 10589}"
+        SYNTAX INTEGER
+            {
+                level1(1),
+                level2(2),
+                level1and2(3)
+            }
+
+    IsisPDUHeader ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "A block to contain the header from a PDU."
+        SYNTAX OCTET STRING (SIZE(0..64))
+
+    IsisCircuitID ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "ID for a circuit."
+        REFERENCE "{See section 7.2.7 of ISO 10589}"
+        SYNTAX OCTET STRING (SIZE(0|7))
+
+    IsisISPriority ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "Integer sub-range for IS-IS priority."
+        REFERENCE "{See section 9.5 of ISO 10589}"
+        SYNTAX Unsigned32 (0..127)
+
+    IsisUnsigned16TC ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "An Unsigned32 further restricted to 16 bits.  Note that
+             the ASN.1 BER encoding may still require 24 bits for
+             some values."
+        SYNTAX Unsigned32 (0..65535)
+
+    IsisUnsigned8TC ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "d"
+        STATUS current
+        DESCRIPTION
+            "An Unsigned32 further restricted to 8 bits.  Note that
+             the ASN.1 BER encoding may still require 16 bits for
+             some values."
+        SYNTAX Unsigned32 (0..255)
+
+-- Behavior Definitions
+
+-- ResettingTimer behavior definition
+--
+
+-- "This behavior applies to objects that specify the interval
+-- between events in the operation of the protocol state machine.
+-- If the value of such an object is set to a new value while
+-- the protocol state machine is in operation, the implementation
+-- shall take the necessary steps to ensure that for any time
+-- interval that was in progress when the value of the
+-- corresponding object was changed, the next expiration of that
+-- interval takes place the specified time after the original
+-- start of that interval, or immediately, whichever is later.
+-- The precision with which this time shall be implemented shall
+-- be the same as that associated with the basic operation of
+-- the timer object."
+
+-- ReplaceOnlyWhileDisabled behavior definition
+-- "This behavior applies to objects that may not be modified
+-- while the corresponding table row's variable of type
+-- IsisAdminState is in state on."
+
+-- ManualOrAutomatic behavior definition
+-- "This behavior applies to objects that are read-write
+-- if the object was created manually.  Objects that were
+-- created automatically that have this behavior are
+-- read-only.
+
+    isisSysObject  OBJECT IDENTIFIER ::= { isisSystem 1 }
+
+    isisSysVersion OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                unknown(0),
+                one(1)
+            }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The version number of the IS-IS protocol that
+             is implemented."
+        REFERENCE "{ISIS.aoi version (1)}"
+        DEFVAL { one }
+    ::= { isisSysObject 1 }
+
+    isisSysLevelType OBJECT-TYPE
+        SYNTAX IsisLevel
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "At which levels is the Intermediate System
+             running? This object may not be modified when
+             the isisSysAdminState variable is in state 'on'
+             for this Intermediate System.
+
+             Configured values MUST survive an agent reboot."
+        REFERENCE "{ISIS.aoi iSType (2)}"
+        DEFVAL { level1and2 }
+    ::= { isisSysObject 2 }
+
+    isisSysID OBJECT-TYPE
+        SYNTAX IsisSystemID
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The ID for this Intermediate System.
+             This value is appended to each of the
+             area addresses to form the Network Entity Titles.
+             The derivation of a value for this object is
+             implementation specific.  Some implementations may
+             automatically assign values and not permit an
+             SNMP write, while others may require the value
+             to be set manually.
+
+             Configured values MUST survive an agent reboot."
+        REFERENCE "{ISIS.aoi systemId (119)}"
+    ::= { isisSysObject 3 }
+
+    isisSysMaxPathSplits OBJECT-TYPE
+        SYNTAX Unsigned32 (1..32)
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Maximum number of paths with equal routing metric value
+             which it is permitted to split between.  This object
+             may not be modified when the isisSysAdminState variable
+             is in state 'on' for this Intermediate System.
+
+             Configured values MUST survive an agent reboot."
+        REFERENCE "{ISIS.aoi maximumPathSplits (3)}"
+        DEFVAL { 2 }
+    ::= { isisSysObject 4 }
+
+    isisSysMaxLSPGenInt OBJECT-TYPE
+        SYNTAX Unsigned32 (1..65235)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Maximum interval, in seconds, between generated LSPs
+             by this Intermediate System.  This object follows
+             the ResettingTimer behavior.  The value must be
+             greater than any value configured for
+             isisSysLevelMinLSPGenInt, and should be at least 300
+             seconds less than isisSysMaxAge.
+
+             Configured values MUST survive an agent reboot."
+        REFERENCE "{ISIS.aoi maximumLSPGenerationInterval (6)}"
+        DEFVAL { 900 }
+    ::= { isisSysObject 5 }
+
+    isisSysPollESHelloRate OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (1..65535)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The value, in seconds, to be used for the suggested ES
+             configuration timer in ISH PDUs when soliciting the ES
+             configuration.
+
+             Configured values MUST survive an agent reboot."
+        REFERENCE "{ISIS.aoi pollESHelloRate (13)}"
+        DEFVAL { 50 }
+    ::= { isisSysObject 6 }
+
+    isisSysWaitTime OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (1..65535)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Number of seconds to delay in state 'waiting' before
+             entering the state 'on'.  This object follows the
+             ResettingTimer behavior.
+
+             Configured values MUST survive an agent reboot."
+        REFERENCE "{ISIS.aoi waitingTime (15)}"
+        DEFVAL { 60 }
+    ::= { isisSysObject 7 }
+
+    isisSysAdminState OBJECT-TYPE
+        SYNTAX IsisAdminState
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The administrative state of this Intermediate
+             System.  Setting this object to the value 'on'
+             when its current value is 'off' enables
+             the Intermediate System.
+
+             Configured values MUST survive an agent reboot."
+        DEFVAL { off }
+    ::= { isisSysObject 8 }
+
+    isisSysL2toL1Leaking OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "If true, allow the router to leak L2 routes into L1.
+
+             Configured values MUST survive an agent reboot."
+        DEFVAL { false }
+    ::= { isisSysObject 9 }
+
+    isisSysMaxAge OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (350..65535)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Value to place in RemainingLifeTime field of
+             the LSPs we generate.
+             This should be at least 300 seconds greater than
+             isisSysMaxLSPGenInt.
+
+             Configured values MUST survive an agent reboot."
+        DEFVAL { 1200 }
+    ::= { isisSysObject 10 }
+
+    isisSysReceiveLSPBufferSize OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (1492..16000)
+        UNITS "bytes"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Size of the largest buffer we are designed or
+             configured to store.  This should be at least
+             as big as the maximum isisSysLevelOrigLSPBuffSize
+             supported by the system.
+             If resources allow, we will store and flood LSPs
+             larger than isisSysReceiveLSPBufferSize, as this
+             can help avoid problems in networks with different
+             values for isisSysLevelOrigLSPBuffSize.
+
+             Configured values MUST survive an agent reboot."
+        DEFVAL { 1492 }
+    ::= { isisSysObject 11 }
+
+    isisSysProtSupported OBJECT-TYPE
+        SYNTAX BITS {
+                    iso8473 (0),
+                    ipv4 (1),
+                    ipv6 (2)
+                  }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "This attribute contains the set of protocols
+             supported by this Intermediate System."
+    ::= { isisSysObject 12 }
+
+    isisSysNotificationEnable OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "If this object is set to true(1), then it enables
+             the emission of IS-IS Notifications.  If it is
+             set to false(2), these notifications are not sent.
+
+             Configured values MUST survive an agent reboot."
+        DEFVAL { true }
+    ::= { isisSysObject 13 }
+
+-- The Level 1 Manual Area Address Table
+
+    isisManAreaAddrTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisManAreaAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The set of manual area addresses configured on this
+             Intermediate System.
+
+             At least one row in which the value of
+             isisManAreaAddrExistState is active must be present.
+             The maximum number of rows in this table for
+             which the object isisManAreaAddrExistState has the
+             value active is 3.
+
+             An attempt to create more than 3 rows of
+             isisManAreaAddrEntry with state 'active' in one
+             instance of the IS-IS protocol should
+             return inconsistentValue."
+        REFERENCE "{ISIS.aoi manualAreaAddresses (10)}"
+    ::= { isisSystem 2 }
+
+    isisManAreaAddrEntry OBJECT-TYPE
+        SYNTAX IsisManAreaAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one area address manually configured
+             on this system.
+
+             Dynamically created rows MUST survive an agent reboot."
+        INDEX { isisManAreaAddr }
+    ::= { isisManAreaAddrTable 1 }
+
+    IsisManAreaAddrEntry ::=
+        SEQUENCE {
+            isisManAreaAddr
+                IsisOSINSAddress,
+            isisManAreaAddrExistState
+                RowStatus
+            }
+
+    isisManAreaAddr OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "A manually configured area address for this system.
+
+             Note: An index for the entry {1, {49.0001} active} in
+             this table would be the ordered pair
+             (1, (0x03 0x49 0x00 0x01)), as the length of an octet
+             string is part of the OID."
+    ::= { isisManAreaAddrEntry 1 }
+
+    isisManAreaAddrExistState OBJECT-TYPE
+        SYNTAX RowStatus
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The state of the isisManAreaAddrEntry.  If the
+             isisSysAdminState for this Intermediate System is 'on' and
+             an attempt is made to set this object to the value
+             'destroy' or 'notInService' when this is the only
+             isisManAreaAddrEntry in state 'active' for this
+             Intermediate System should return inconsistentValue.
+
+             A row entry cannot be modified when the value of this
+             object is 'active'."
+    ::= { isisManAreaAddrEntry 2 }
+
+-- The Level 1 Area Address Table
+
+-- The Level 1 Area Address Table contains the
+-- union of the sets of relevant area addresses configured
+-- or learned from Level 1 LSPs received by this Intermediate System.
+
+    isisAreaAddrTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisAreaAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The union of the sets of area addresses reported in all
+             Level 1 LSPs with fragment number zero generated by this
+             Intermediate System, or received from other Intermediate
+             Systems that are reachable via Level 1 routing."
+        REFERENCE "{ISIS.aoi areaAddresses (18)}"
+    ::= { isisSystem 3 }
+
+    isisAreaAddrEntry OBJECT-TYPE
+        SYNTAX IsisAreaAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one area address reported in a
+             Level 1 LSP generated or received by this Intermediate
+             System.
+
+             Dynamically learned rows do not survive an agent reboot."
+        INDEX { isisAreaAddr }
+    ::= { isisAreaAddrTable 1 }
+
+    IsisAreaAddrEntry ::=
+        SEQUENCE {
+            isisAreaAddr
+                IsisOSINSAddress
+            }
+
+    isisAreaAddr OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "An area address reported in a Level 1 LSP."
+    ::= { isisAreaAddrEntry 1 }
+
+-- The Summary Address Table
+
+-- The Summary Address Table contains the set of summary
+-- addresses manually configured for the Intermediate System.
+--
+-- This is used to control leaking L1 routes into L2.
+
+    isisSummAddrTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisSummAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The set of IP summary addresses to use in forming
+             summary TLVs originated by this Intermediate System.
+
+             An administrator may use a summary address to combine
+             and modify IP Reachability announcements.  If the
+             Intermediate system can reach any subset of the summary
+             address, the summary address MUST be announced instead,
+             at the configured metric."
+    ::= { isisSystem 4 }
+
+    isisSummAddrEntry OBJECT-TYPE
+        SYNTAX IsisSummAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one IP summary address.
+
+             Dynamically created rows MUST survive an agent reboot.
+
+             Implementers need to be aware that if the total number
+             of elements (octets or sub-identifiers) in
+             isisSummAddress and isisSummAddrPrefixLen is too great,
+             then OIDs of column instances in this table will have
+             more than 128 subidentifiers and cannot be accessed
+             using SNMPv1, SNMPv2c, or SNMPv3."
+        INDEX { isisSummAddressType,
+                isisSummAddress,
+                isisSummAddrPrefixLen }
+    ::= { isisSummAddrTable 1 }
+
+    IsisSummAddrEntry ::=
+        SEQUENCE {
+            isisSummAddressType
+                InetAddressType,
+            isisSummAddress
+                InetAddress,
+            isisSummAddrPrefixLen
+                InetAddressPrefixLength,
+            isisSummAddrExistState
+                RowStatus,
+            isisSummAddrMetric
+                IsisDefaultMetric,
+            isisSummAddrFullMetric
+                IsisFullMetric
+        }
+
+    isisSummAddressType OBJECT-TYPE
+        SYNTAX InetAddressType
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The Type of IP address for this summary address."
+    ::= { isisSummAddrEntry 1 }
+
+    isisSummAddress OBJECT-TYPE
+        SYNTAX InetAddress
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The IP Address value for this summary address.
+             The address must not contain any set host bits
+             (bits set after the address prefix determined by
+             isisSummAddrPrefixLen).
+
+             The type of this address is determined by the value of
+             the isisSummAddressType object."
+    ::= { isisSummAddrEntry 2 }
+
+    isisSummAddrPrefixLen OBJECT-TYPE
+        SYNTAX InetAddressPrefixLength
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The Length of the IP NetMask for this summary address.
+
+             The values for the index objects isisSummAddress and
+             isisSummAddrPrefixLen must be consistent.  When the value
+             of isisSummAddress (excluding the zone index, if one
+             is present) is x, then the bitwise logical-AND
+             of x with the value of the mask formed from the
+             corresponding index object isisSummAddrPrefixLen MUST be
+             equal to x.  If not, then the index pair is not
+             consistent, and an inconsistentName error must be
+             returned on SET or CREATE requests."
+    ::= { isisSummAddrEntry 3 }
+
+    isisSummAddrExistState OBJECT-TYPE
+        SYNTAX RowStatus
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The existence state of this summary address.  Support
+             for 'createAndWait' and 'notInService' is not required.
+
+             A row entry cannot be modified when the value of this
+             object is 'active'."
+    ::= { isisSummAddrEntry 4 }
+
+    isisSummAddrMetric OBJECT-TYPE
+        SYNTAX IsisDefaultMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The metric value to announce this summary
+             address within LSPs generated by this system."
+        DEFVAL { 20 }
+    ::= { isisSummAddrEntry 5 }
+
+    isisSummAddrFullMetric OBJECT-TYPE
+        SYNTAX IsisFullMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The wide metric value to announce this summary
+             address within LSPs generated by this system."
+        DEFVAL { 20 }
+    ::= { isisSummAddrEntry 6 }
+
+-- The Redistribution table defines addresses that should be
+-- leaked from L2 to L1 if isisSysL2toL1Leaking is enabled.
+
+    isisRedistributeAddrTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisRedistributeAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "This table provides criteria to decide if a route should
+             be leaked from L2 to L1 when Domain Wide Prefix leaking is
+             enabled.
+
+             Addresses that match the summary mask in the table MUST
+             be announced at L1 by routers when isisSysL2toL1Leaking
+             is enabled.  Routes that fall into the ranges specified
+             are announced as is, without being summarized.  Routes
+             that do not match a summary mask are not announced."
+    ::= { isisSystem 5 }
+
+    isisRedistributeAddrEntry OBJECT-TYPE
+        SYNTAX IsisRedistributeAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one configured IP summary
+             address to manage leaking L2 addresses into L1.
+
+             Dynamically created rows MUST survive an agent reboot.
+
+             Implementers need to be aware that if the total number
+             of elements (octets or sub-identifiers) in
+             isisRedistributeAddrAddress and
+             isisRedistributeAddrPrefixLen is too great, then OIDs
+             of column instances in this table will have more than
+             128 subidentifiers and cannot be accessed using SNMPv1,
+             SNMPv2c, or SNMPv3."
+        INDEX { isisRedistributeAddrType,
+                isisRedistributeAddrAddress,
+                isisRedistributeAddrPrefixLen }
+    ::= { isisRedistributeAddrTable 1 }
+
+    IsisRedistributeAddrEntry ::=
+        SEQUENCE {
+            isisRedistributeAddrType
+                InetAddressType,
+            isisRedistributeAddrAddress
+                InetAddress,
+            isisRedistributeAddrPrefixLen
+                InetAddressPrefixLength,
+            isisRedistributeAddrExistState
+                RowStatus
+        }
+
+    isisRedistributeAddrType OBJECT-TYPE
+        SYNTAX InetAddressType
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The Type of IP address for this summary address."
+    ::= { isisRedistributeAddrEntry 1 }
+
+    isisRedistributeAddrAddress OBJECT-TYPE
+        SYNTAX InetAddress
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The IP Address value for this summary address.
+             The type of this address is determined by the
+             value of the isisRedistributeAddrType object.
+             The address must not contain any set host bits -
+             bits set after the address prefix determined by
+             isisRedistributeAddrPrefixLen."
+
+    ::= { isisRedistributeAddrEntry 2 }
+
+    isisRedistributeAddrPrefixLen OBJECT-TYPE
+        SYNTAX InetAddressPrefixLength
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The Length of the IP NetMask for this summary address.
+
+             The values for the index objects
+             isisRedistributeAddrAddress and
+             isisRedistributeAddrPrefixLen must be consistent.
+             When the value of isisRedistributeAddrAddress
+             (excluding the zone index, if one is present) is x,
+             then the bitwise logical-AND of x with the value of
+             the mask formed from the corresponding index object
+             isisRedistributeAddrPrefixLen MUST be equal to x.
+             If not, then the index pair is not consistent, and an
+             inconsistentName error must be returned on SET or
+             CREATE requests."
+
+    ::= { isisRedistributeAddrEntry 3 }
+
+    isisRedistributeAddrExistState OBJECT-TYPE
+        SYNTAX RowStatus
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The existence state of this summary address.  Support
+             for createAndWait and notInService is not required.
+
+             A row entry cannot be modified when the value of this
+             object is 'active'."
+    ::= { isisRedistributeAddrEntry 4 }
+
+-- The Router Table keeps track of hostnames and router IDs
+-- associated with Intermediate Systems in the area and domain.
+
+    isisRouterTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisRouterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The set of hostnames and router ID."
+    ::= { isisSystem 6 }
+
+    isisRouterEntry OBJECT-TYPE
+        SYNTAX IsisRouterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry tracks information about one Intermediate
+             System at one level.
+
+             Dynamically learned rows do not survive an agent reboot."
+        INDEX { isisRouterSysID,
+                isisRouterLevel }
+    ::= { isisRouterTable 1 }
+
+    IsisRouterEntry ::=
+        SEQUENCE {
+            isisRouterSysID
+                IsisSystemID,
+            isisRouterLevel
+                IsisISLevel,
+            isisRouterHostName
+                SnmpAdminString,
+            isisRouterID
+                Unsigned32
+        }
+
+    isisRouterSysID OBJECT-TYPE
+        SYNTAX IsisSystemID
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The System ID of the Intermediate System."
+    ::= { isisRouterEntry 1 }
+
+    isisRouterLevel OBJECT-TYPE
+        SYNTAX IsisISLevel
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The level at which the information about this
+             Intermediate System was received."
+    ::= { isisRouterEntry 2 }
+
+    isisRouterHostName OBJECT-TYPE
+        SYNTAX SnmpAdminString
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The hostname listed in the LSP, or a zero-length
+             string if none."
+    ::= { isisRouterEntry 3 }
+
+    isisRouterID OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The Router ID found in the LSP, or zero if none."
+    ::= { isisRouterEntry 4 }
+
+-- The System Level Table
+-- This table captures level-specific information about the system
+
+    isisSysLevelTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisSysLevelEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Level specific information about the System."
+    ::= { isisSysLevel 1 }
+
+    isisSysLevelEntry OBJECT-TYPE
+        SYNTAX IsisSysLevelEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each row describes variables configured for Area or Domain.
+
+             Configured values MUST survive an agent reboot."
+        INDEX { isisSysLevelIndex }
+    ::= { isisSysLevelTable 1 }
+
+    IsisSysLevelEntry ::=
+        SEQUENCE {
+            isisSysLevelIndex
+                IsisISLevel,
+            isisSysLevelOrigLSPBuffSize
+                IsisLSPBuffSize,
+            isisSysLevelMinLSPGenInt
+                IsisUnsigned16TC,
+            isisSysLevelState
+                IsisLevelState,
+            isisSysLevelSetOverload
+                TruthValue,
+            isisSysLevelSetOverloadUntil
+                Unsigned32,
+            isisSysLevelMetricStyle
+                IsisMetricStyle,
+            isisSysLevelSPFConsiders
+                IsisMetricStyle,
+            isisSysLevelTEEnabled
+                TruthValue
+        }
+
+    isisSysLevelIndex OBJECT-TYPE
+        SYNTAX IsisISLevel
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The level that this entry describes."
+    ::= { isisSysLevelEntry 1 }
+
+    isisSysLevelOrigLSPBuffSize OBJECT-TYPE
+        SYNTAX IsisLSPBuffSize
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The maximum size of LSPs and SNPs originated by
+             this Intermediate System at this level.  This
+             object may not be modified when the isisSysAdminState
+             variable is in state 'on' for this Intermediate System."
+        REFERENCE "{ISIS.aoi originatingL1LSPBufferSize (9)}"
+        DEFVAL { 1492 }
+    ::= { isisSysLevelEntry 2 }
+
+    isisSysLevelMinLSPGenInt OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (1..65535)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Minimum interval, in seconds, between successive
+             generation of LSPs with the same LSPID at this level
+             by this Intermediate System."
+        REFERENCE "{ISIS.aoi minimumLSPGenerationInterval (11)}"
+        DEFVAL { 30 }
+    ::= { isisSysLevelEntry 3 }
+
+    isisSysLevelState OBJECT-TYPE
+        SYNTAX IsisLevelState
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The state of the database at this level.
+             The value 'off' indicates that IS-IS is not active at
+             this level.
+             The value 'on' indicates that IS-IS is active at this
+             level and is not overloaded.
+             The value 'waiting' indicates a database that is low on
+             an essential resource, such as memory.
+             The administrator may force the state to 'overloaded'
+             by setting the object isisSysLevelSetOverload.
+             If the state is 'waiting' or 'overloaded', we
+             originate LSPs with the overload bit set."
+        REFERENCE "{ISIS.aoi l1State (17)}"
+    ::= { isisSysLevelEntry 4 }
+
+    isisSysLevelSetOverload OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Administratively set the overload bit for the level.
+             The overload bit MUST continue to be set if the
+             implementation runs out of memory, independent of
+             this variable.  It may also be set manually independent
+             of this variable, using the isisSysLevelSetOverloadUntil
+             object."
+        DEFVAL { false }
+    ::= { isisSysLevelEntry 5 }
+
+    isisSysLevelSetOverloadUntil OBJECT-TYPE
+        SYNTAX Unsigned32
+        UNITS "Seconds until clearing manually set Overload Bit"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "If this object is non-zero, the overload bit is set at
+             this level when the isisSysAdminState variable goes to
+             state 'on' for this Intermediate System.  The overload bit
+             remains set for isisSysLevelSetOverloadUntil seconds.
+             When isisSysLevelSetOverloadUntil seconds have elapsed,
+             the overload flag remains set if the implementation has
+             run out of memory, or if it is set manually using the
+             isisSysLevelSetOverload object.
+
+             If isisSysLevelSetOverload is false, the system clears
+             the overload bit when isisSysLevelSetOverloadUntil seconds
+             have elapsed, if the system has not run out of memory."
+    ::= { isisSysLevelEntry 6 }
+
+    isisSysLevelMetricStyle OBJECT-TYPE
+        SYNTAX IsisMetricStyle
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Which style of metric do we generate in our LSPs
+             at this level?"
+        DEFVAL { narrow }
+    ::= { isisSysLevelEntry 7 }
+
+    isisSysLevelSPFConsiders OBJECT-TYPE
+        SYNTAX IsisMetricStyle
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Which style of metric do we consider in our
+             SPF computation at this level?"
+        DEFVAL { narrow }
+    ::= { isisSysLevelEntry 8 }
+
+    isisSysLevelTEEnabled OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Do we do Traffic Engineering at this level?"
+        DEFVAL { false }
+    ::= { isisSysLevelEntry 9 }
+
+-- Static to provide next CircIndex
+
+    isisNextCircIndex OBJECT-TYPE
+        SYNTAX IndexIntegerNextFree
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "This object is used to assist a management
+             application in creating new rows in the
+             isisCircTable.  If it is possible to create
+             a new instance of isisCircEntry, then this
+             object will contain a non-zero value that
+             is not in use as the index of any row in the
+             isisCircTable.  The network manager reads the
+             value of this object and then (if the
+             value read is non-zero) attempts to create
+             the corresponding instance of isisCircEntry.
+             If the set request fails with the code
+             'inconsistentValue', then the process must be
+             repeated;  if the set request succeeds, then
+             the agent will change the value of this object
+             according to an implementation-specific
+             algorithm."
+    ::= { isisCirc  1 }
+
+-- The Circuit Table
+-- Each broadcast or point-to-point interface on the system
+-- corresponds to one entry in the Circuit table.  However, there
+-- may be multiple X.25 DA circuit entries in the Circuit table
+-- for a given X.25 interface.
+
+    isisCircTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisCircEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The table of circuits used by this
+             Intermediate System."
+    ::= { isisCirc 2 }
+
+    isisCircEntry OBJECT-TYPE
+        SYNTAX IsisCircEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "An isisCircEntry exists for each circuit configured
+             for Integrated IS-IS on this system.
+
+             Dynamically created rows MUST survive an agent reboot."
+        INDEX { isisCircIndex }
+    ::= { isisCircTable 1 }
+
+    IsisCircEntry ::=
+        SEQUENCE {
+            isisCircIndex
+                IndexInteger,
+            isisCircIfIndex
+                InterfaceIndex,
+            isisCircAdminState
+                IsisAdminState,
+            isisCircExistState
+                RowStatus,
+            isisCircType
+                INTEGER,
+            isisCircExtDomain
+                TruthValue,
+            isisCircLevelType
+                IsisLevel,
+            isisCircPassiveCircuit
+                TruthValue,
+            isisCircMeshGroupEnabled
+                INTEGER,
+            isisCircMeshGroup
+                Unsigned32,
+            isisCircSmallHellos
+                TruthValue,
+            isisCircLastUpTime
+                TimeStamp,
+            isisCirc3WayEnabled
+                TruthValue,
+            isisCircExtendedCircID
+                Unsigned32
+        }
+
+    isisCircIndex OBJECT-TYPE
+        SYNTAX IndexInteger
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "An index used to uniquely identify this circuit.
+             When creating a row in this table, the
+             isisNextCircIndex object should be retrieved,
+             and its value should be specified as the value
+             of this index using a SET operation.  A retrieved
+             value of zero(0) indicates that no rows can be
+             created at this time."
+    ::= { isisCircEntry 1 }
+
+    isisCircIfIndex OBJECT-TYPE
+        SYNTAX InterfaceIndex
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The value of ifIndex for the interface to which this
+             circuit corresponds.  This object cannot be modified
+             after creation."
+    ::= { isisCircEntry 2 }
+
+    isisCircAdminState OBJECT-TYPE
+        SYNTAX IsisAdminState
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The administrative state of the circuit."
+        DEFVAL { off }
+    ::= { isisCircEntry 3 }
+
+    isisCircExistState OBJECT-TYPE
+        SYNTAX RowStatus
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The existence state of this circuit.  Setting the state
+             to 'notInService' halts the generation and processing of
+             IS-IS protocol PDUs on this circuit.  Setting the state
+             to destroy will also erase any configuration associated
+             with the circuit.  Support for 'createAndWait' and
+             'notInService' is not required.
+
+             A row entry cannot be modified when the value of this
+             object is 'active'."
+    ::= { isisCircEntry 4 }
+
+    isisCircType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                broadcast(1),
+                ptToPt(2),
+                staticIn(3),
+                staticOut(4),
+                dA(5)
+            }
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The type of the circuit.  This object follows the
+             ReplaceOnlyWhileDisabled behavior.  The type specified
+             must be compatible with the type of the interface defined
+             by the value of isisCircIfIndex."
+        REFERENCE "{ISIS.aoi type (33)}"
+    ::= { isisCircEntry 5 }
+
+    isisCircExtDomain OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "If true, suppress normal transmission of and
+             interpretation of Intra-domain IS-IS PDUs on this
+             circuit."
+        REFERENCE "{ISIS.aoi externalDomain (46)}"
+        DEFVAL { false }
+    ::= { isisCircEntry 6 }
+
+    isisCircLevelType OBJECT-TYPE
+        SYNTAX IsisLevel
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Indicates which type of packets will be sent and
+             accepted on this circuit.  The values set will be
+             saved, but the values used will be modified by
+             the settings of isisSysLevelType.  Thus, if the
+             isisSysTpe is level2 and the isisCircLevelType
+             for a circuit is level1, the circuit will not send
+             or receive IS-IS packets.  This object follows the
+             ReplaceOnlyWhileDisabled behavior."
+        DEFVAL { level1and2 }
+    ::= { isisCircEntry 7 }
+
+    isisCircPassiveCircuit OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Should we include this interface in LSPs, even if
+             it is not running the IS-IS Protocol?"
+        DEFVAL { false }
+    ::= { isisCircEntry 8 }
+
+    isisCircMeshGroupEnabled OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                inactive(1),
+                blocked(2),
+                set(3)
+            }
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Is this port a member of a mesh group, or is it
+             blocked?  Circuits in the same mesh group act as a
+             virtual multiaccess network.  LSPs seen on one circuit
+             in a mesh group will not be flooded to another circuit
+             in the same mesh group."
+        REFERENCE "{ RFC 2973 }"
+        DEFVAL { inactive }
+    ::= { isisCircEntry 9 }
+
+    isisCircMeshGroup OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Circuits in the same mesh group act as a virtual
+             multiaccess network.  LSPs seen on one circuit in
+             a mesh group will not be flooded to another circuit
+             in the same mesh group.  If isisCircMeshGroupEnabled
+             is inactive or blocked, this value is ignored."
+        REFERENCE "{ RFC 2973 }"
+    ::= { isisCircEntry 10 }
+
+    isisCircSmallHellos OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Can we send unpadded hellos on LAN circuits?  False
+             means the LAN Hellos must be padded.
+             Implementations should allow the administrator to read
+             this value.  An implementation need not be able to
+             support unpadded hellos to be conformant."
+         DEFVAL { false }
+    ::= { isisCircEntry 11 }
+
+    isisCircLastUpTime OBJECT-TYPE
+        SYNTAX TimeStamp
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "How long the circuit has been enabled, measured in
+             hundredths of seconds since the last re-initialization
+             of the network management subsystem; 0 if the
+             circuit has never been 'on'."
+    ::= { isisCircEntry 12 }
+
+    isisCirc3WayEnabled OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Is this circuit enabled to run 3Way handshake?"
+        DEFVAL { true }
+    ::= { isisCircEntry 13 }
+
+    isisCircExtendedCircID OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The value to be used as the extended circuit ID in
+             3Way handshake.  This value is only used if
+             isisCirc3WayEnabled is true, and it must be unique
+             across all circuits on this IS."
+    ::= { isisCircEntry 14 }
+
+-- The Circuit Level Table
+-- This table captures level-specific information about a circuit
+
+    isisCircLevelTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisCircLevelEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Level specific information about circuits used by IS-IS."
+    ::= { isisCircLevelValues 1 }
+
+    isisCircLevelEntry OBJECT-TYPE
+        SYNTAX IsisCircLevelEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "An isisCircLevelEntry exists for each level on
+             each circuit configured for Integrated IS-IS on
+             this system.
+
+             Configured values MUST survive an agent reboot."
+        INDEX { isisCircIndex,
+                isisCircLevelIndex }
+    ::= { isisCircLevelTable 1 }
+
+    IsisCircLevelEntry ::=
+        SEQUENCE {
+            isisCircLevelIndex
+                IsisISLevel,
+            isisCircLevelMetric
+                IsisDefaultMetric,
+            isisCircLevelWideMetric
+                IsisWideMetric,
+            isisCircLevelISPriority
+                IsisISPriority,
+            isisCircLevelIDOctet
+                Unsigned32,
+            isisCircLevelID
+                IsisCircuitID,
+            isisCircLevelDesIS
+                IsisCircuitID,
+            isisCircLevelHelloMultiplier
+                Unsigned32,
+            isisCircLevelHelloTimer
+                Unsigned32,
+            isisCircLevelDRHelloTimer
+                Unsigned32,
+            isisCircLevelLSPThrottle
+                IsisUnsigned16TC,
+            isisCircLevelMinLSPRetransInt
+                Unsigned32,
+            isisCircLevelCSNPInterval
+                Unsigned32,
+            isisCircLevelPartSNPInterval
+                Unsigned32
+        }
+
+    isisCircLevelIndex OBJECT-TYPE
+        SYNTAX IsisISLevel
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The level that this entry describes."
+    ::= { isisCircLevelEntry 1 }
+
+    isisCircLevelMetric OBJECT-TYPE
+        SYNTAX IsisDefaultMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The metric value of this circuit for this level."
+        REFERENCE "{ISIS.aoi l1DefaultMetric (35)}"
+        DEFVAL { 10 }
+    ::= { isisCircLevelEntry 2 }
+
+    isisCircLevelWideMetric OBJECT-TYPE
+        SYNTAX IsisWideMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The wide metric value of this circuit for this level."
+        DEFVAL { 10 }
+    ::= { isisCircLevelEntry 3 }
+
+    isisCircLevelISPriority OBJECT-TYPE
+        SYNTAX IsisISPriority
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The priority for becoming the LAN-Designated
+             Intermediate System at this level."
+        REFERENCE "{ISIS.aoi l2IntermediateSystemPriority (73)}"
+        DEFVAL { 64 }
+    ::= { isisCircLevelEntry 4 }
+
+    isisCircLevelIDOctet OBJECT-TYPE
+        SYNTAX Unsigned32(0..255)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "A one-byte identifier for the circuit selected by the
+             Intermediate System.
+
+             On point-to-point circuits, the value is used as the Local
+             Circuit ID in point-to-point IIH PDUs transmitted on this
+             circuit.  In this case, values of isisCircLevelIDOctet do
+             not need to be unique.
+
+             For broadcast circuits, the value is used to generate the
+             LAN ID that will be used if this Intermediate System is
+             elected as the Designated IS on this circuit.  The value
+             is required to differ on LANs where the Intermediate System
+             is the Designated Intermediate System."
+    ::= { isisCircLevelEntry 5 }
+
+    isisCircLevelID OBJECT-TYPE
+        SYNTAX IsisCircuitID
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "On a point-to-point circuit with a fully initialized
+             adjacency to a peer IS, the value of this object is
+             the circuit ID negotiated during adjacency initialization.
+             On a point to point circuit without such an adjacency,
+             the value is the concatenation of the local system ID
+             and the one-byte isisCircLevelIDOctet for this circuit,
+             i.e., the value that would be proposed for the circuit ID.
+             On other circuit types, the value returned is the zero-
+             length OCTET STRING."
+        REFERENCE "{ISIS.aoi ptPtCircuitID (51)}"
+    ::= { isisCircLevelEntry 6 }
+
+    isisCircLevelDesIS OBJECT-TYPE
+        SYNTAX IsisCircuitID
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The ID of the LAN-Designated Intermediate System
+             on this circuit at this level.  If, for any reason,
+             this system is not partaking in the relevant
+             Designated Intermediate System election process,
+             then the value returned is the zero-length OCTET STRING."
+        REFERENCE "{ISIS.aoi l2DesignatedIntermediateSystem (75)}"
+    ::= { isisCircLevelEntry 7 }
+
+    isisCircLevelHelloMultiplier OBJECT-TYPE
+        SYNTAX Unsigned32 (2..100)
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "This value is multiplied by the corresponding HelloTimer,
+             and the result in seconds (rounded up) is used as the
+             holding time in transmitted hellos, to be used by
+             receivers of hello packets from this IS."
+        REFERENCE "{ISIS.aoi iSISHelloTimer (45)}"
+        DEFVAL { 10 }
+    ::= { isisCircLevelEntry 8 }
+
+    isisCircLevelHelloTimer OBJECT-TYPE
+        SYNTAX Unsigned32 (10..600000)
+        UNITS "milliseconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Maximum period, in milliseconds, between IIH PDUs
+             on multiaccess networks at this level for LANs.
+             The value at L1 is used as the period between
+             Hellos on L1L2 point-to-point circuits.  Setting
+             this value at level 2 on an L1L2 point-to-point
+             circuit will result in an error of InconsistentValue.
+
+             This object follows the ResettingTimer behavior."
+        REFERENCE "{ISIS.aoi iSISHelloTimer (45)}"
+        DEFVAL { 3000 }
+    ::= { isisCircLevelEntry 9 }
+
+    isisCircLevelDRHelloTimer OBJECT-TYPE
+        SYNTAX Unsigned32 (10..120000)
+        UNITS "milliseconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Period, in milliseconds, between Hello PDUs on
+             multiaccess networks when this IS is the Designated
+             Intermediate System.  This object follows the
+             ResettingTimer behavior."
+        REFERENCE "{ISIS.aoi iSISHelloTimer (45)}"
+        DEFVAL { 1000 }
+    ::= { isisCircLevelEntry 10 }
+
+    isisCircLevelLSPThrottle OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (1..65535)
+        UNITS "milliseconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Minimal interval of time, in milliseconds, between
+             transmissions of LSPs on an interface at this level."
+        REFERENCE
+            "{ISIS.aoi minimumBroadcastLSPTransmissionInterval (5)}"
+        DEFVAL { 30 }
+    ::= { isisCircLevelEntry 11 }
+
+    isisCircLevelMinLSPRetransInt OBJECT-TYPE
+        SYNTAX Unsigned32 (1..300)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Minimum interval, in seconds, between re-transmission of
+             an LSP at this level.  This object follows the
+             ResettingTimer behavior.
+
+             Note that isisCircLevelLSPThrottle controls
+             how fast we send back-to-back LSPs.  This variable
+             controls how fast we re-send the same LSP."
+        REFERENCE "{ISIS.aoi minimumLSPTransmissionInterval (5)}"
+        DEFVAL { 5 }
+    ::= { isisCircLevelEntry 12 }
+    isisCircLevelCSNPInterval OBJECT-TYPE
+        SYNTAX Unsigned32 (1..600)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Interval of time, in seconds, between periodic
+             transmission of a complete set of CSNPs on
+             multiaccess networks if this router is the
+             designated router at this level.
+             This object follows the ResettingTimer behavior."
+        REFERENCE "{ISIS.aoi completeSNPInterval (8)}"
+        DEFVAL { 10 }
+    ::= { isisCircLevelEntry 13 }
+
+    isisCircLevelPartSNPInterval OBJECT-TYPE
+        SYNTAX Unsigned32 (1..120)
+        UNITS "seconds"
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Minimum interval, in seconds, between sending Partial
+             Sequence Number PDUs at this level.  This object
+             follows the ResettingTimer behavior."
+        REFERENCE "{ISIS.aoi partialSNPInterval (14)}"
+        DEFVAL { 2 }
+    ::= { isisCircLevelEntry 14 }
+
+-- isisSystemCounterTable keeps track of system-wide events.
+
+    isisSystemCounterTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisSystemCounterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "System-wide counters for this Intermediate System."
+    ::= { isisCounters 1 }
+
+    isisSystemCounterEntry OBJECT-TYPE
+        SYNTAX IsisSystemCounterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "System-wide IS-IS counters."
+        INDEX { isisSysStatLevel }
+    ::= { isisSystemCounterTable 1 }
+
+    IsisSystemCounterEntry ::=
+        SEQUENCE {
+            isisSysStatLevel
+                IsisISLevel,
+            isisSysStatCorrLSPs
+                Counter32,
+            isisSysStatAuthTypeFails
+                Counter32,
+            isisSysStatAuthFails
+                Counter32,
+            isisSysStatLSPDbaseOloads
+                Counter32,
+            isisSysStatManAddrDropFromAreas
+                Counter32,
+            isisSysStatAttmptToExMaxSeqNums
+                Counter32,
+            isisSysStatSeqNumSkips
+                Counter32,
+            isisSysStatOwnLSPPurges
+                Counter32,
+            isisSysStatIDFieldLenMismatches
+                Counter32,
+            isisSysStatPartChanges
+                Counter32,
+            isisSysStatSPFRuns
+                Counter32,
+            isisSysStatLSPErrors
+                Counter32
+        }
+
+    isisSysStatLevel OBJECT-TYPE
+        SYNTAX IsisISLevel
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The level that this entry describes."
+    ::= { isisSystemCounterEntry 1 }
+
+    isisSysStatCorrLSPs OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of corrupted in-memory frames"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of corrupted in-memory LSPs detected.
+
+             LSPs received from the wire with a bad checksum
+             are silently dropped and are not counted.
+
+             LSPs received from the wire with parse errors
+             are counted by isisSysStatLSPErrors."
+        REFERENCE "{ISIS.aoi corruptedLSPsDetected (19)}"
+    ::= { isisSystemCounterEntry 2 }
+
+    isisSysStatAuthTypeFails OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of frames with authentication type mismatches"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of authentication type mismatches recognized
+             by this Intermediate System."
+    ::= { isisSystemCounterEntry 3 }
+
+    isisSysStatAuthFails OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of frames with authentication key failures"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of authentication key failures recognized
+             by this Intermediate System."
+    ::= { isisSystemCounterEntry 4 }
+
+    isisSysStatLSPDbaseOloads OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times the LSP database has become
+             overloaded."
+        REFERENCE "{ISIS.aoi lSPL1DatabaseOverloads (20)}"
+    ::= { isisSystemCounterEntry 5 }
+
+    isisSysStatManAddrDropFromAreas OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times a manual address has been dropped from
+             the area."
+        REFERENCE "{ISIS.aoi manualAddressesDroppedFromArea (21)}"
+    ::= { isisSystemCounterEntry 6 }
+
+    isisSysStatAttmptToExMaxSeqNums OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times the IS has attempted to exceed the
+             maximum sequence number."
+        REFERENCE
+            "{ISIS.aoi attemptsToExceedmaximumSequenceNumber (22)}"
+    ::= { isisSystemCounterEntry 7 }
+
+    isisSysStatSeqNumSkips OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times a sequence number skip has occurred."
+        REFERENCE "{ISIS.aoi sequenceNumberSkips (23)}"
+    ::= { isisSystemCounterEntry 8 }
+
+    isisSysStatOwnLSPPurges OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times a zero-aged copy of the system's own LSP
+             is received from some other node."
+        REFERENCE "{ISIS.aoi ownLSPPurges (24)}"
+    ::= { isisSystemCounterEntry 9 }
+
+    isisSysStatIDFieldLenMismatches OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of frames with ID length mismatches"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times a PDU is received with a different value
+             for ID field length from that of the receiving system."
+        REFERENCE "{ISIS.aoi iDFieldLengthMismatches (25)}"
+    ::= { isisSystemCounterEntry 10 }
+
+    isisSysStatPartChanges OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Partition changes."
+    ::= { isisSystemCounterEntry 11 }
+
+    isisSysStatSPFRuns OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of times we ran SPF at this level."
+    ::= { isisSystemCounterEntry 12 }
+
+    isisSysStatLSPErrors OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of frames with errors that we have received"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Number of LSPs with errors we have received."
+    ::= { isisSystemCounterEntry 13 }
+
+-- isisCircuitCounterTable keeps track of events
+-- specific to a circuit and a level
+
+    isisCircuitCounterTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisCircuitCounterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Circuit specific counters for this
+             Intermediate System."
+    ::= { isisCounters 2 }
+
+    isisCircuitCounterEntry OBJECT-TYPE
+        SYNTAX IsisCircuitCounterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "An isisCircuitCounterEntry exists for each circuit
+             used by Integrated IS-IS on this system."
+        INDEX { isisCircIndex,
+                isisCircuitType }
+    ::= { isisCircuitCounterTable 1 }
+
+    IsisCircuitCounterEntry ::= SEQUENCE {
+          isisCircuitType
+              INTEGER,
+          isisCircAdjChanges
+              Counter32,
+          isisCircNumAdj
+              Unsigned32,
+          isisCircInitFails
+              Counter32,
+          isisCircRejAdjs
+              Counter32,
+          isisCircIDFieldLenMismatches
+              Counter32,
+          isisCircMaxAreaAddrMismatches
+              Counter32,
+          isisCircAuthTypeFails
+              Counter32,
+          isisCircAuthFails
+              Counter32,
+          isisCircLANDesISChanges
+              Counter32
+       }
+
+    isisCircuitType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                lanlevel1(1),
+                lanlevel2(2),
+                p2pcircuit(3)
+            }
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "What type of circuit saw these counts?
+
+             The point-to-point Hello PDU includes
+             both L1 and L2, and ISs form a single
+             adjacency on point-to-point links.
+             Thus, we combine counts on
+             point-to-point links into one group."
+    ::= { isisCircuitCounterEntry 1 }
+
+    isisCircAdjChanges OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times an adjacency state change has
+             occurred on this circuit."
+        REFERENCE "{ISIS.aoi changesInAdjacencyState (40)}"
+    ::= { isisCircuitCounterEntry 2 }
+
+    isisCircNumAdj OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of adjacencies on this circuit."
+        REFERENCE "{ISIS.aoi changesInAdjacencyState (40)}"
+    ::= { isisCircuitCounterEntry 3 }
+
+    isisCircInitFails OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times initialization of this circuit has
+             failed.  This counts events such as PPP NCP failures.
+             Failures to form an adjacency are counted by
+             isisCircRejAdjs."
+    ::= { isisCircuitCounterEntry 4 }
+
+    isisCircRejAdjs OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times an adjacency has been rejected on
+             this circuit."
+        REFERENCE "{ISIS.aoi rejectedAdjacencies (42)}"
+    ::= { isisCircuitCounterEntry 5 }
+
+    isisCircIDFieldLenMismatches OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of frames with ID field length mismatch"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times an IS-IS control PDU with an ID
+             field length different from that for this system has been
+             received."
+        REFERENCE "{ISIS.aoi iDFieldLengthMismatches (25)}"
+    ::= { isisCircuitCounterEntry 6 }
+
+    isisCircMaxAreaAddrMismatches OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times an IS-IS control PDU with a
+             max area address field different from that for this
+             system has been received."
+        REFERENCE "{ISIS.aoi iDFieldLengthMismatches (25)}"
+    ::= { isisCircuitCounterEntry 7 }
+
+    isisCircAuthTypeFails OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times an IS-IS control PDU with
+             an auth type field different from that for this
+             system has been received."
+    ::= { isisCircuitCounterEntry 8 }
+
+    isisCircAuthFails OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times an IS-IS control PDU with
+             the correct auth type has failed to pass authentication
+             validation."
+    ::= { isisCircuitCounterEntry 9 }
+
+    isisCircLANDesISChanges OBJECT-TYPE
+        SYNTAX Counter32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of times the Designated IS has changed
+             on this circuit at this level.  If the circuit is
+             point to point, this count is zero."
+    ::= { isisCircuitCounterEntry 10 }
+
+-- isisPacketCounterTable keeps track of the number of IS-IS
+-- control packets sent and received at each level
+
+    isisPacketCounterTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisPacketCounterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Information about IS-IS protocol traffic at one level,
+             on one circuit, in one direction."
+    ::= { isisCounters 3 }
+
+    isisPacketCounterEntry OBJECT-TYPE
+        SYNTAX IsisPacketCounterEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Information about IS-IS protocol traffic at one level,
+             on one circuit, in one direction."
+        INDEX { isisCircIndex,
+                isisPacketCountLevel,
+                isisPacketCountDirection }
+    ::= { isisPacketCounterTable 1 }
+
+    IsisPacketCounterEntry ::=
+        SEQUENCE {
+            isisPacketCountLevel
+                IsisISLevel,
+            isisPacketCountDirection
+                INTEGER,
+            isisPacketCountIIHello
+                Counter32,
+            isisPacketCountISHello
+                Counter32,
+            isisPacketCountESHello
+                Counter32,
+            isisPacketCountLSP
+                Counter32,
+            isisPacketCountCSNP
+                Counter32,
+            isisPacketCountPSNP
+                Counter32,
+            isisPacketCountUnknown
+                Counter32
+    }
+
+    isisPacketCountLevel OBJECT-TYPE
+        SYNTAX IsisISLevel
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The level at which these PDU counts have been collected."
+    ::= { isisPacketCounterEntry 1 }
+
+    isisPacketCountDirection OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                sending(1),
+                receiving(2)
+            }
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Were we sending or receiving these PDUs?"
+    ::= { isisPacketCounterEntry 2 }
+
+    isisPacketCountIIHello OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of IS-IS Hellos frames seen in this direction
+              at this level"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of IS-IS Hello PDUs seen in this
+             direction at this level.
+
+             Point-to-Point IIH PDUs are counted at
+             the lowest enabled level: at L1 on L1 or L1L2 circuits,
+             and at L2 otherwise."
+        REFERENCE "{ISIS.aoi iSISControlPDUsSent (43)}"
+    ::= { isisPacketCounterEntry 3 }
+
+    isisPacketCountISHello OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of ES-IS frames seen in this direction at
+             this level."
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of ES-IS Hello PDUs seen in this
+             direction.  ISH PDUs are counted at the
+             lowest enabled level: at L1 on L1 or L1L2
+             circuits, and at L2 otherwise."
+    ::= { isisPacketCounterEntry 4 }
+
+    isisPacketCountESHello OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of ES Hello frames seen in this direction at
+             this level"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of ES Hello PDUs seen in this
+             direction.  ESH PDUs are counted at the
+             lowest enabled level: at L1 on L1 or L1L2
+             circuits, and at L2 otherwise."
+    ::= { isisPacketCounterEntry 5 }
+
+    isisPacketCountLSP OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of IS-IS LSP frames seen in this direction at
+             this level"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of IS-IS LSPs seen in this
+             direction at this level."
+        REFERENCE "{ISIS.aoi iSISControlPDUsSent (43)}"
+    ::= { isisPacketCounterEntry 6 }
+
+    isisPacketCountCSNP OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of IS-IS CSNP frames seen in this direction at
+             this level"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of IS-IS CSNPs seen in this
+             direction at this level."
+        REFERENCE "{ISIS.aoi iSISControlPDUsSent (43)}"
+    ::= { isisPacketCounterEntry 7 }
+
+    isisPacketCountPSNP OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of IS-IS PSNP frames seen in this direction at
+             this level"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of IS-IS PSNPs seen in this
+             direction at this level."
+        REFERENCE "{ISIS.aoi iSISControlPDUsSent (43)}"
+    ::= { isisPacketCounterEntry 8 }
+
+    isisPacketCountUnknown OBJECT-TYPE
+        SYNTAX Counter32
+        UNITS "Number of unknown IS-IS frames seen at this level"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The number of unknown IS-IS PDUs seen
+             at this level."
+        REFERENCE "{ISIS.aoi iSISControlPDUsSent (43)}"
+    ::= { isisPacketCounterEntry 9 }
+
+-- The IS Adjacency Table
+--
+-- Each adjacency to an IS corresponds to one entry in this
+-- table.
+
+    isisISAdjTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisISAdjEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The table of adjacencies to Intermediate Systems."
+    ::= { isisISAdj 1 }
+
+    isisISAdjEntry OBJECT-TYPE
+        SYNTAX IsisISAdjEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry corresponds to one adjacency to an
+             Intermediate System on this system.
+
+             Dynamically learned rows do not survive an agent reboot."
+        INDEX { isisCircIndex,
+                isisISAdjIndex }
+    ::= { isisISAdjTable 1 }
+
+    IsisISAdjEntry ::=
+        SEQUENCE {
+            isisISAdjIndex
+                Unsigned32,
+            isisISAdjState
+                INTEGER,
+            isisISAdj3WayState
+                INTEGER,
+            isisISAdjNeighSNPAAddress
+                IsisOSINSAddress,
+            isisISAdjNeighSysType
+                INTEGER,
+            isisISAdjNeighSysID
+                IsisSystemID,
+            isisISAdjNbrExtendedCircID
+                Unsigned32,
+            isisISAdjUsage
+                IsisLevel,
+            isisISAdjHoldTimer
+                IsisUnsigned16TC,
+            isisISAdjNeighPriority
+                IsisISPriority,
+            isisISAdjLastUpTime
+                TimeStamp
+      }
+
+    isisISAdjIndex OBJECT-TYPE
+        SYNTAX Unsigned32(1..4294967295)
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "A unique value identifying the IS adjacency from all
+             other such adjacencies on this circuit.  This value is
+             automatically assigned by the system when the adjacency
+             is created."
+    ::= { isisISAdjEntry 1 }
+
+    isisISAdjState OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                 down (1),
+                 initializing (2),
+                 up (3),
+                 failed(4)
+            }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The state of the adjacency."
+        REFERENCE "{ISIS.aoi adjacencyState (78)}"
+    ::= { isisISAdjEntry 2 }
+
+    isisISAdj3WayState OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                 up (0),
+                 initializing (1),
+                 down (2),
+                 failed (3)
+            }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The 3Way state of the adjacency.  These are picked
+             to match the historical on-the-wire representation
+             of the 3Way state and are not intended to match
+             isisISAdjState."
+        REFERENCE "{ RFC 3373 }"
+    ::= { isisISAdjEntry 3 }
+
+    isisISAdjNeighSNPAAddress OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The SNPA address of the neighboring system."
+        REFERENCE "{ISIS.aoi neighbourSNPAAddress (79)}"
+    ::= { isisISAdjEntry 4 }
+
+    isisISAdjNeighSysType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                l1IntermediateSystem(1),
+                l2IntermediateSystem(2),
+                l1L2IntermediateSystem(3),
+                unknown(4)
+            }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The type of the neighboring system."
+        REFERENCE "{ISIS.aoi neighbourSystemType (80)}"
+    ::= { isisISAdjEntry 5 }
+
+    isisISAdjNeighSysID OBJECT-TYPE
+        SYNTAX IsisSystemID
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The system ID of the neighboring Intermediate
+             System."
+        REFERENCE "{ISIS.aoi neighbourSystemIds (83)}"
+    ::= { isisISAdjEntry 6 }
+
+    isisISAdjNbrExtendedCircID OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The 4-byte Extended Circuit ID learned from the
+             Neighbor during 3-way handshake, or 0."
+    ::= { isisISAdjEntry 7 }
+
+    isisISAdjUsage OBJECT-TYPE
+        SYNTAX IsisLevel
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "How is the adjacency used?  On a point-to-point link,
+             this might be level1and2, but on a LAN, the usage will
+             be level1 on the adjacency between peers at L1,
+             and level2 for the adjacency between peers at L2."
+        REFERENCE "{ISIS.aoi adjacencyUsage (82)}"
+    ::= { isisISAdjEntry 8 }
+
+    isisISAdjHoldTimer OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (1..65535)
+        UNITS "seconds"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The holding time, in seconds, for this adjacency.
+             This value is based on received IIH PDUs and
+             the elapsed time since receipt."
+        REFERENCE "{ISIS.aoi holdingTimer (85)}"
+    ::= { isisISAdjEntry 9 }
+
+    isisISAdjNeighPriority OBJECT-TYPE
+        SYNTAX IsisISPriority
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Priority of the neighboring Intermediate System for
+             becoming the Designated Intermediate System."
+        REFERENCE "{ISIS.aoi lANPriority (86)}"
+    ::= { isisISAdjEntry 10 }
+
+    isisISAdjLastUpTime OBJECT-TYPE
+        SYNTAX TimeStamp
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "When the adjacency most recently entered the state 'up',
+             measured in hundredths of a second since the last
+             re-initialization of the network management subsystem.
+             Holds 0 if the adjacency has never been in state 'up'."
+    ::= { isisISAdjEntry 11 }
+
+-- The IS Adjacency Area Address Table
+
+-- The IS Adjacency Area Address Table contains the set of
+-- Area Addresses of neighboring
+-- Intermediate Systems as reported in IIH PDUs.
+
+    isisISAdjAreaAddrTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisISAdjAreaAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "This table contains the set of Area Addresses of
+             neighboring Intermediate Systems as reported in received
+             IIH PDUs."
+        REFERENCE "{ISIS.aoi areaAddressesOfNeighbour (84)}"
+    ::= { isisISAdj 2 }
+
+    isisISAdjAreaAddrEntry OBJECT-TYPE
+        SYNTAX IsisISAdjAreaAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one Area Address reported by a
+             neighboring Intermediate System in its IIH PDUs.
+
+             Dynamically learned rows do not survive an agent reboot."
+        INDEX { isisCircIndex,
+                isisISAdjIndex,
+                isisISAdjAreaAddrIndex }
+    ::= { isisISAdjAreaAddrTable 1 }
+
+    IsisISAdjAreaAddrEntry ::=
+        SEQUENCE {
+            isisISAdjAreaAddrIndex
+                Unsigned32,
+            isisISAdjAreaAddress
+                IsisOSINSAddress
+            }
+
+    isisISAdjAreaAddrIndex OBJECT-TYPE
+        SYNTAX Unsigned32(1..4294967295)
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "An index for the areas associated with one neighbor.
+             This provides a simple way to walk the table."
+    ::= { isisISAdjAreaAddrEntry 1 }
+
+    isisISAdjAreaAddress OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "One Area Address as reported in IIH PDUs received from
+             the neighbor."
+    ::= { isisISAdjAreaAddrEntry 2 }
+
+-- The IS Adjacency IP Address Table
+
+-- The IS Adjacency IP Address Table contains the
+-- set of IP Addresses of neighboring Intermediate Systems
+-- as reported in received IIH PDUs.
+
+    isisISAdjIPAddrTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisISAdjIPAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "This table contains the set of IP Addresses of
+             neighboring Intermediate Systems as reported in received
+             IIH PDUs."
+    ::= { isisISAdj 3 }
+
+    isisISAdjIPAddrEntry OBJECT-TYPE
+        SYNTAX IsisISAdjIPAddrEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one IP Address reported by a
+             neighboring Intermediate System in its IIH PDUs.
+
+             Dynamically learned rows do not survive an agent reboot."
+        INDEX { isisCircIndex,
+                isisISAdjIndex,
+                isisISAdjIPAddrIndex
+                }
+    ::= { isisISAdjIPAddrTable 1 }
+
+    IsisISAdjIPAddrEntry ::=
+        SEQUENCE {
+            isisISAdjIPAddrIndex
+                Unsigned32,
+            isisISAdjIPAddrType
+                 InetAddressType,
+            isisISAdjIPAddrAddress
+                InetAddress
+        }
+
+    isisISAdjIPAddrIndex OBJECT-TYPE
+        SYNTAX Unsigned32(1..4294967295)
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "An index to this table that identifies the IP addresses
+             to which this entry belongs."
+    ::= { isisISAdjIPAddrEntry 1 }
+
+    isisISAdjIPAddrType OBJECT-TYPE
+        SYNTAX InetAddressType
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The type of one IP Address as reported in IIH PDUs
+             received from the neighbor."
+    ::= { isisISAdjIPAddrEntry 2 }
+
+    isisISAdjIPAddrAddress OBJECT-TYPE
+        SYNTAX InetAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "One IP Address as reported in IIH PDUs received from the
+             neighbor.
+
+             The type of this address is determined by the value of
+             the isisISAdjIPAddrType object."
+    ::= { isisISAdjIPAddrEntry 3 }
+
+-- The IS Adjacency Protocol Supported Table
+--
+-- The IS Adjacency Protocol Supported Table contains the set of
+-- protocols supported by neighboring
+-- Intermediate Systems as reported in received IIH PDUs.
+
+    isisISAdjProtSuppTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisISAdjProtSuppEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "This table contains the set of protocols supported by
+             neighboring Intermediate Systems as reported in received
+             IIH PDUs."
+    ::= { isisISAdj 4 }
+
+    isisISAdjProtSuppEntry OBJECT-TYPE
+        SYNTAX IsisISAdjProtSuppEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry contains one protocol supported by a
+             neighboring Intermediate System as reported in its IIH
+             PDUs.
+
+             Dynamically learned rows do not survive an agent reboot."
+        INDEX {  isisCircIndex,
+                 isisISAdjIndex,
+                 isisISAdjProtSuppProtocol }
+    ::= { isisISAdjProtSuppTable 1 }
+
+    IsisISAdjProtSuppEntry ::=
+        SEQUENCE {
+            isisISAdjProtSuppProtocol
+                IsisSupportedProtocol
+        }
+
+    isisISAdjProtSuppProtocol OBJECT-TYPE
+        SYNTAX IsisSupportedProtocol
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "One supported protocol as reported in IIH PDUs received
+             from the neighbor."
+    ::= { isisISAdjProtSuppEntry 1 }
+
+-- The Reachable Address Group
+--
+-- The Reachable Address Table
+-- Each entry records information about a reachable address
+-- (NSAP or address prefix) manually configured on the system
+-- or learned through another protocol.
+
+    isisRATable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisRAEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The table of Reachable Addresses to NSAPs or Address
+             Prefixes."
+    ::= { isisReachAddr 1 }
+
+    isisRAEntry OBJECT-TYPE
+        SYNTAX IsisRAEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry defines a configured Reachable Address
+             to an NSAP or Address Prefix.
+
+             Dynamically created rows MUST survive an agent reboot."
+        INDEX { isisCircIndex,
+                isisRAIndex }
+    ::= { isisRATable 1 }
+
+    IsisRAEntry ::=
+        SEQUENCE {
+            isisRAIndex
+                Unsigned32,
+            isisRAExistState
+                RowStatus,
+            isisRAAdminState
+                IsisAdminState,
+            isisRAAddrPrefix
+                IsisOSINSAddress,
+            isisRAMapType
+                INTEGER,
+            isisRAMetric
+                IsisDefaultMetric,
+            isisRAMetricType
+                IsisMetricType,
+            isisRASNPAAddress
+                IsisOSINSAddress,
+            isisRASNPAMask
+                IsisOSINSAddress,
+            isisRASNPAPrefix
+                IsisOSINSAddress,
+            isisRAType
+                INTEGER
+        }
+
+    isisRAIndex OBJECT-TYPE
+        SYNTAX Unsigned32(1..4294967295)
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The identifier for this isisRAEntry.  This value must be
+             unique amongst all Reachable Addresses on the same parent
+             Circuit."
+    ::= { isisRAEntry 1 }
+
+    isisRAExistState OBJECT-TYPE
+        SYNTAX RowStatus
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The existence state of this Reachable Address.  This
+             object follows the ManualOrAutomatic behaviors.  Support
+             for 'createAndWait' and 'notInService' is not required.
+
+             A row entry cannot be modified when the value of this
+             object is 'active'."
+    ::= { isisRAEntry 2 }
+
+    isisRAAdminState OBJECT-TYPE
+        SYNTAX IsisAdminState
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The administrative state of the Reachable Address.  This
+             object follows the ManualOrAutomatic behaviors."
+        DEFVAL { off }
+    ::= { isisRAEntry 3 }
+
+    isisRAAddrPrefix OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The destination of this Reachable Address.  This is an
+             Address Prefix.  This object follows the
+             ReplaceOnlyWhileDisabled and ManualOrAutomatic
+             behaviors."
+        REFERENCE "{ISIS.aoi addressPrefix (98)}"
+    ::= { isisRAEntry 4 }
+
+    isisRAMapType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                none (1),
+                explicit (2),
+                extractIDI (3),
+                extractDSP (4)
+            }
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The type of mapping to be employed to ascertain the SNPA
+             Address that should be used in forwarding PDUs for this
+             Reachable Address prefix.  This object follows the
+             ManualOrAutomatic behavior.  The following values of
+             mapping type are defined:
+
+                 none: The mapping is null because the neighbor SNPA is
+                       implicit by nature of the subnetwork (e.g., a
+                       point-to-point linkage).
+
+                 explicit: The subnetwork addresses in the object
+                       isisRASNPAAddress are to be used.
+
+                 extractIDI: The SNPA is embedded in the IDI of
+                       the destination NSAP Address.  The mapping
+                       algorithm extracts the SNPA to be used
+                       according to the format and encoding rules of
+                       ISO8473/Add2.  This SNPA extraction algorithm can
+                       be used in conjunction with Reachable Address
+                       prefixes from the X.121, F.69, E.163, and E.164
+                       addressing subdomains.
+
+                 extractDSP: All, or a suffix, of the SNPA is embedded
+                       in the DSP of the destination address.  This SNPA
+                       extraction algorithm extracts the embedded
+                       subnetwork addressing information by performing a
+                       logical AND of the isisRASNPAMask object value
+                       with the destination address.  The part of the
+                       SNPA extracted from the destination NSAP is
+                       appended to the isisRASNPAPrefix object value to
+                       form the next hop subnetwork addressing
+                       information."
+
+        REFERENCE "{ISO10589-ISIS.aoi mappingType (107)}"
+    ::= { isisRAEntry 5 }
+
+    isisRAMetric OBJECT-TYPE
+        SYNTAX IsisDefaultMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The metric value for reaching the specified
+             prefix over this circuit.  This object follows the
+             ManualOrAutomatic behavior."
+        REFERENCE "{ISIS.aoi DefaultMetric (99)}"
+        DEFVAL { 20 }
+    ::= { isisRAEntry 6 }
+
+    isisRAMetricType OBJECT-TYPE
+        SYNTAX IsisMetricType
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Indicates whether the metric is internal or
+             external.  This object follows the ManualOrAutomatic
+             behavior."
+        REFERENCE "{ISIS.aoi DefaultMetricType (103)}"
+        DEFVAL { internal }
+    ::= { isisRAEntry 7 }
+
+    isisRASNPAAddress OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The SNPA Address to which a PDU may be forwarded in
+             order to reach a destination that matches the address
+             prefix of the Reachable Address.  This object follows the
+             ManualOrAutomatic behavior."
+        REFERENCE "{ISIS.aoi sNPAAddresses (109)}"
+-- Note only one address may be specified per Reachable Address
+-- in the MIB
+        DEFVAL { ''H }
+    ::= { isisRAEntry 8 }
+
+    isisRASNPAMask OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "A bit mask with 1 bit indicating the positions in the
+             effective destination address from which embedded SNPA
+             information is to be extracted.  For the extraction, the
+             first octet of the isisRASNPAMask object value is aligned
+             with the first octet (AFI) of the NSAP Address.  If the
+             isisRASNPAMask object value and NSAP Address are of
+             different lengths, the shorter of the two is logically
+             padded with zeros before performing the extraction.  This
+             object follows the ManualOrAutomatic behavior."
+        REFERENCE "{ISIS.aoi sNPAMask (122)}"
+        DEFVAL { '00'H }
+    ::= { isisRAEntry 9 }
+
+    isisRASNPAPrefix OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "A fixed SNPA prefix for use when the isisRAMapType is
+             extractDSP.  The SNPA Address to use is formed by
+             concatenating the fixed SNPA prefix with a variable SNPA
+             part that is extracted from the effective destination
+             address.  For Reachable Address prefixes in which the
+             entire SNPA is embedded in the DSP, the SNPA Prefix shall
+             be null.  This object follows the ManualOrAutomatic
+             behavior."
+        REFERENCE "{ISIS.aoi sNPAPrefix (123)}"
+        DEFVAL { '00'H }
+    ::= { isisRAEntry 10 }
+
+    isisRAType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                manual (1),
+                automatic (2)
+            }
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The type of Reachable address.  Those of type
+             manual are created by the network manager.  Those
+             of type automatic are created through propagation
+             of routing information from another routing
+             protocol (e.g., IDRP). "
+        DEFVAL {manual}
+    ::= {isisRAEntry 11 }
+
+
+-- The IP Reachable Address Table
+
+-- Each entry records information about one IP reachable
+-- address manually configured on this system or learned from
+-- another protocol.
+
+    isisIPRATable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisIPRAEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The table of IP Reachable Addresses to networks,
+             subnetworks, or hosts either manually configured or
+             learned from another protocol."
+    ::= { isisIPReachAddr 1 }
+
+    isisIPRAEntry OBJECT-TYPE
+        SYNTAX IsisIPRAEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry defines an IP Reachable Address to a network,
+             subnetwork, or host.
+
+             Each IP Reachable Address may have multiple entries in the
+             table, one for each equal cost path to the reachable
+             address.
+
+             Dynamically created rows MUST survive an agent reboot.
+
+             Implementers need to be aware that if the total number
+             of elements (octets or sub-identifiers) in
+             isisIPRADestr, isisIPRADestPrefixLen, and
+             isisIPRANextHopIndex is too great, then OIDs of column
+             instances in this table will have more than 128
+             subidentifiers and cannot be accessed using SNMPv1,
+             SNMPv2c, or SNMPv3."
+        INDEX {  isisSysLevelIndex,
+                 isisIPRADestType,
+                 isisIPRADest,
+                 isisIPRADestPrefixLen,
+                 isisIPRANextHopIndex }
+    ::= { isisIPRATable 1 }
+
+    IsisIPRAEntry ::=
+        SEQUENCE {
+            isisIPRADestType
+                InetAddressType,
+            isisIPRADest
+                InetAddress,
+            isisIPRADestPrefixLen
+                InetAddressPrefixLength,
+            isisIPRANextHopIndex
+                Unsigned32,
+            isisIPRANextHopType
+                InetAddressType,
+            isisIPRANextHop
+                InetAddress,
+            isisIPRAType
+                INTEGER,
+            isisIPRAExistState
+                RowStatus,
+            isisIPRAAdminState
+                IsisAdminState,
+            isisIPRAMetric
+                IsisDefaultMetric,
+            isisIPRAMetricType
+                IsisMetricType,
+            isisIPRAFullMetric
+                IsisFullMetric,
+            isisIPRASNPAAddress
+                IsisOSINSAddress,
+            isisIPRASourceType
+                INTEGER
+        }
+
+    isisIPRADestType OBJECT-TYPE
+        SYNTAX InetAddressType
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The type of this IP Reachable Address."
+    ::= { isisIPRAEntry 1 }
+
+    isisIPRADest OBJECT-TYPE
+        SYNTAX InetAddress
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The destination of this IP Reachable Address.  This is
+             a network address, subnetwork address, or host
+             address.
+
+             The type of this address is determined by the value of
+             the isisIPRADestType object."
+
+    ::= { isisIPRAEntry 2 }
+
+    isisIPRADestPrefixLen OBJECT-TYPE
+        SYNTAX InetAddressPrefixLength
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The length of the IP Netmask for Reachability Address.
+
+             The values for the index objects isisIPRADest and
+             isisIPRADestPrefixLen must be consistent.  When the value
+             of isisIPRADest (excluding the zone index, if one
+             is present) is x, then the bitwise logical-AND
+             of x with the value of the mask formed from the
+             corresponding index object isisIPRADestPrefixLen MUST be
+             equal to x.  If not, then the index pair is not
+             consistent, and an inconsistentName error must be
+             returned on SET or CREATE requests."
+    ::= { isisIPRAEntry 3 }
+
+    isisIPRANextHopIndex OBJECT-TYPE
+        SYNTAX Unsigned32(1..4294967295)
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Index of next hop.  Used when there are multiple Equal
+             Cost Multipath alternatives for the same destination."
+    ::= { isisIPRAEntry 4 }
+
+    isisIPRANextHopType OBJECT-TYPE
+        SYNTAX InetAddressType
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The type of the IP next hop address."
+    ::= { isisIPRAEntry 5 }
+
+    isisIPRANextHop OBJECT-TYPE
+        SYNTAX InetAddress
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The IP next hop to this destination.
+
+             The type of this address is determined by the value of
+             the isisIPRANextHopType object."
+    ::= { isisIPRAEntry 6 }
+
+    isisIPRAType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                manual (1),
+                automatic (2)
+            }
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The type of this IP Reachable Address.  Those of type
+             manual are created by the network manager.  Those of type
+             automatic are created through propagation of routing
+             information from another routing protocol.  This object
+             follows the ManualOrAutomatic behavior."
+    ::= { isisIPRAEntry 7 }
+
+    isisIPRAExistState OBJECT-TYPE
+        SYNTAX RowStatus
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The state of this IP Reachable Address.  This object
+             follows the ExistenceState and ManualOrAutomatic
+             behaviors.  Support for 'createAndWait' and
+             'notInService' is not required.
+
+             A row entry cannot be modified when the value of this
+             object is 'active'."
+    ::= { isisIPRAEntry 8 }
+
+    isisIPRAAdminState OBJECT-TYPE
+        SYNTAX IsisAdminState
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The administrative state of the IP Reachable Address.  This
+             object follows the IsisAdminState and ManualOrAutomatic
+             behaviors."
+        DEFVAL { off }
+    ::= { isisIPRAEntry 9 }
+
+    isisIPRAMetric OBJECT-TYPE
+        SYNTAX IsisDefaultMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The metric value for reaching the specified
+             destination over this circuit.  This object follows the
+             ManualOrAutomatic behavior."
+        DEFVAL { 10 }
+    ::= { isisIPRAEntry 10 }
+
+    isisIPRAMetricType OBJECT-TYPE
+        SYNTAX IsisMetricType
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "Indicates whether the metric is internal or
+             external.  This object follows the ManualOrAutomatic
+             behavior."
+        DEFVAL { internal }
+    ::= { isisIPRAEntry 11 }
+
+    isisIPRAFullMetric OBJECT-TYPE
+        SYNTAX IsisFullMetric
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The wide metric value for reaching the specified
+             destination over this circuit.  This object follows the
+             ManualOrAutomatic behavior."
+        DEFVAL { 10 }
+    ::= { isisIPRAEntry 12 }
+
+    isisIPRASNPAAddress OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS read-create
+        STATUS current
+        DESCRIPTION
+            "The SNPA Address to which a PDU may be forwarded in
+             order to reach a destination that matches this IP
+             Reachable Address.  This object follows the
+             ManualOrAutomatic behavior."
+        DEFVAL { ''H }
+    ::= { isisIPRAEntry 13 }
+
+    isisIPRASourceType OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                static (1),
+                direct (2),
+                ospfv2 (3),
+                ospfv3 (4),
+                isis   (5),
+                rip    (6),
+                igrp   (7),
+                eigrp  (8),
+                bgp    (9),
+                other (10)
+            }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The origin of this route."
+    ::= { isisIPRAEntry 14 }
+
+-- The LSP Database Table
+--
+-- The first table provides Summary Information about LSPs
+-- The next table provides a complete record
+
+    isisLSPSummaryTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisLSPSummaryEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The table of LSP Headers."
+    ::= { isisLSPDataBase 1 }
+
+    isisLSPSummaryEntry OBJECT-TYPE
+        SYNTAX IsisLSPSummaryEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry provides a summary describing an
+             LSP currently stored in the system.
+
+             Dynamically learned rows will not survive an
+             agent reboot."
+        INDEX {  isisLSPLevel,
+                 isisLSPID }
+    ::= { isisLSPSummaryTable 1 }
+
+    IsisLSPSummaryEntry ::=
+        SEQUENCE {
+            isisLSPLevel
+                IsisISLevel,
+            isisLSPID
+                IsisLinkStatePDUID,
+            isisLSPSeq
+                Unsigned32,
+            isisLSPZeroLife
+                TruthValue,
+            isisLSPChecksum
+                IsisUnsigned16TC,
+            isisLSPLifetimeRemain
+                IsisUnsigned16TC,
+            isisLSPPDULength
+                IsisUnsigned16TC,
+            isisLSPAttributes
+                IsisUnsigned8TC
+        }
+
+    isisLSPLevel OBJECT-TYPE
+        SYNTAX IsisISLevel
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "At which level does this LSP appear?"
+    ::= { isisLSPSummaryEntry 1 }
+
+    isisLSPID OBJECT-TYPE
+        SYNTAX IsisLinkStatePDUID
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The 8-byte LSP ID for this Link State PDU."
+    ::= { isisLSPSummaryEntry 2 }
+
+    isisLSPSeq OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The sequence number for this LSP."
+    ::= { isisLSPSummaryEntry 3 }
+
+    isisLSPZeroLife OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Is this LSP being purged by this system?"
+    ::= { isisLSPSummaryEntry 4 }
+
+    isisLSPChecksum OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The 16-bit Fletcher Checksum for this LSP."
+    ::= { isisLSPSummaryEntry 5 }
+
+    isisLSPLifetimeRemain OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC
+        UNITS "seconds"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The remaining lifetime, in seconds, for this LSP."
+    ::= { isisLSPSummaryEntry 6 }
+
+    isisLSPPDULength OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The length of this LSP."
+    ::= { isisLSPSummaryEntry 7 }
+
+    isisLSPAttributes OBJECT-TYPE
+        SYNTAX IsisUnsigned8TC
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "Flags carried by the LSP."
+    ::= { isisLSPSummaryEntry 8 }
+
+-- LSP Table
+--
+-- The full LSP as a sequence of {Type, Len, Value} tuples
+-- Since the underlying LSP may have changed while downloading
+-- TLVs, we provide the Sequence number and Checksum for each
+-- LSP TLV, so the network manager may verify that they are
+-- still working on the same version of the LSP.
+
+    isisLSPTLVTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF IsisLSPTLVEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The table of LSPs in the database."
+    ::= { isisLSPDataBase 2 }
+
+    isisLSPTLVEntry OBJECT-TYPE
+        SYNTAX IsisLSPTLVEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "Each entry describes a TLV within
+             an LSP currently stored in the system.
+
+             Dynamically learned rows will not survive an
+             agent reboot."
+        INDEX {  isisLSPLevel,
+                 isisLSPID,
+                 isisLSPTLVIndex }
+    ::= { isisLSPTLVTable 1 }
+
+    IsisLSPTLVEntry ::=
+        SEQUENCE {
+            isisLSPTLVIndex
+                Unsigned32,
+            isisLSPTLVSeq
+                Unsigned32,
+            isisLSPTLVChecksum
+                IsisUnsigned16TC,
+            isisLSPTLVType
+                IsisUnsigned8TC,
+            isisLSPTLVLen
+                IsisUnsigned8TC,
+            isisLSPTLVValue
+                OCTET STRING
+        }
+
+    isisLSPTLVIndex OBJECT-TYPE
+        SYNTAX Unsigned32(1..4294967295)
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "The index of this TLV in the LSP.  The first TLV has
+             index 1, and the Nth TLV has an index of N."
+    ::= { isisLSPTLVEntry 1 }
+
+    isisLSPTLVSeq OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The sequence number for this LSP."
+    ::= { isisLSPTLVEntry 2 }
+
+    isisLSPTLVChecksum OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The 16-bit Fletcher Checksum for this LSP."
+    ::= { isisLSPTLVEntry 3 }
+
+    isisLSPTLVType OBJECT-TYPE
+        SYNTAX IsisUnsigned8TC
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The type of this TLV."
+    ::= { isisLSPTLVEntry 4 }
+
+    isisLSPTLVLen OBJECT-TYPE
+        SYNTAX IsisUnsigned8TC
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The length of this TLV."
+    ::= { isisLSPTLVEntry 5 }
+
+    isisLSPTLVValue OBJECT-TYPE
+        SYNTAX OCTET STRING (SIZE(0..255))
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The value of this TLV."
+    ::= { isisLSPTLVEntry 6 }
+
+
+-- The IS-IS Notification Table
+
+-- The IS-IS Notification Table records fields that are
+-- required for notifications
+
+    isisNotificationEntry OBJECT IDENTIFIER
+        ::= { isisNotification 1 }
+
+    isisNotificationSysLevelIndex OBJECT-TYPE
+        SYNTAX IsisLevel
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "The system level for this notification."
+    ::= { isisNotificationEntry 1 }
+
+    isisNotificationCircIfIndex OBJECT-TYPE
+        SYNTAX Unsigned32 (1..2147483647)
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "The identifier of this circuit relevant to
+             this notification."
+    ::= { isisNotificationEntry 2 }
+
+    isisPduLspId OBJECT-TYPE
+        SYNTAX IsisLinkStatePDUID
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "An Octet String that uniquely identifies
+             a Link State PDU."
+    ::= { isisNotificationEntry 3 }
+
+    isisPduFragment OBJECT-TYPE
+        SYNTAX IsisPDUHeader
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds up to 64 initial bytes of a PDU that
+             triggered the notification."
+    ::= { isisNotificationEntry 4 }
+
+    isisPduFieldLen OBJECT-TYPE
+        SYNTAX IsisUnsigned8TC
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds the System ID length reported in PDU we received."
+    ::= { isisNotificationEntry 5 }
+
+    isisPduMaxAreaAddress OBJECT-TYPE
+        SYNTAX IsisUnsigned8TC
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds the Max Area Addresses reported in a PDU
+             we received."
+    ::= { isisNotificationEntry 6 }
+
+    isisPduProtocolVersion OBJECT-TYPE
+        SYNTAX IsisUnsigned8TC
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds the Protocol version reported in PDU we received."
+    ::= { isisNotificationEntry 7 }
+
+    isisPduLspSize OBJECT-TYPE
+        SYNTAX Unsigned32 (0..2147483647)
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds the size of LSP we received that is too
+             big to forward."
+    ::= { isisNotificationEntry 8 }
+
+    isisPduOriginatingBufferSize OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (0..16000)
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds the size of isisSysLevelOrigLSPBuffSize advertised
+             by the peer in the originatingLSPBufferSize TLV.
+             If the peer does not advertise this TLV, this
+             value is set to 0."
+    ::= { isisNotificationEntry 9 }
+
+    isisPduBufferSize OBJECT-TYPE
+        SYNTAX IsisUnsigned16TC (0..16000)
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "Holds the size of LSP received from peer."
+    ::= { isisNotificationEntry 10 }
+
+    isisPduProtocolsSupported OBJECT-TYPE
+        SYNTAX OCTET STRING (SIZE(0..255))
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "The list of protocols supported by an
+             adjacent system.  This may be empty."
+    ::= { isisNotificationEntry 11 }
+
+    isisAdjState OBJECT-TYPE
+        SYNTAX INTEGER
+            {
+                 down (1),
+                 initializing (2),
+                 up (3),
+                 failed(4)
+            }
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "The current state of an adjacency."
+    ::= { isisNotificationEntry 12 }
+
+    isisErrorOffset OBJECT-TYPE
+        SYNTAX Unsigned32
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "An offset to a problem in a PDU.  If the problem
+             is a malformed TLV, this points to the beginning
+             of the TLV.  If the problem is in the header, this
+             points to the byte that is suspicious."
+    ::= { isisNotificationEntry 13 }
+
+    isisErrorTLVType OBJECT-TYPE
+        SYNTAX Unsigned32 (0..255)
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+             "The type for a malformed TLV."
+    ::= { isisNotificationEntry 14 }
+
+    isisNotificationAreaAddress OBJECT-TYPE
+        SYNTAX IsisOSINSAddress
+        MAX-ACCESS accessible-for-notify
+        STATUS current
+        DESCRIPTION
+            "An Area Address."
+    ::= { isisNotificationEntry 15 }
+
+-- Notification definitions
+--
+-- Note that notifications can be disabled by setting
+--     isisSysNotificationEnable false
+
+    isisDatabaseOverload NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisSysLevelState
+        }
+        STATUS current
+        DESCRIPTION
+            "This notification is generated when the system
+             enters or leaves the Overload state.  The number
+             of times this has been generated and cleared is kept
+             track of by isisSysStatLSPDbaseOloads."
+    ::= { isisNotifications 1 }
+
+    isisManualAddressDrops NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationAreaAddress
+        }
+        STATUS current
+        DESCRIPTION
+            "This notification is generated when one of the
+             manual areaAddresses assigned to this system is
+             ignored when computing routes.  The object
+             isisNotificationAreaAddress describes the area that
+             has been dropped.
+
+             The number of times this event has been generated
+             is counted by isisSysStatManAddrDropFromAreas.
+
+             The agent must throttle the generation of
+             consecutive isisManualAddressDrops notifications
+             so that there is at least a 5-second gap between
+             notifications of this type.  When notifications
+             are throttled, they are dropped, not queued for
+             sending at a future time."
+    ::= { isisNotifications 2 }
+
+    isisCorruptedLSPDetected NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisPduLspId
+        }
+        STATUS current
+        DESCRIPTION
+            "This notification is generated when we find that
+             an LSP that was stored in memory has become
+             corrupted.  The number of times this has been
+             generated is counted by isisSysCorrLSPs.
+
+             We forward an LSP ID.  We may have independent
+             knowledge of the ID, but in some implementations
+             there is a chance that the ID itself will be
+             corrupted."
+    ::= { isisNotifications 3 }
+
+    isisAttemptToExceedMaxSequence NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisPduLspId
+        }
+        STATUS current
+        DESCRIPTION
+            "When the sequence number on an LSP we generate
+             wraps the 32-bit sequence counter, we purge and
+             wait to re-announce this information.  This
+             notification describes that event.  Since these
+             should not be generated rapidly, we generate
+             an event each time this happens.
+
+             While the first 6 bytes of the LSPID are ours,
+             the other two contain useful information."
+    ::= { isisNotifications 4 }
+
+    isisIDLenMismatch  NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisPduFieldLen,
+            isisNotificationCircIfIndex,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a PDU
+             with a different value for the System ID Length.
+             This notification includes an index to identify
+             the circuit where we saw the PDU and the header of
+             the PDU, which may help a network manager identify
+             the source of the confusion.
+
+             The agent must throttle the generation of
+             consecutive isisIDLenMismatch notifications
+             so that there is at least a 5-second gap between
+             notifications of this type.  When notifications
+             are throttled, they are dropped, not queued for
+             sending at a future time."
+    ::= { isisNotifications 5 }
+
+    isisMaxAreaAddressesMismatch NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisPduMaxAreaAddress,
+            isisNotificationCircIfIndex,
+            isisPduFragment
+        }
+
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a PDU
+             with a different value for the Maximum Area
+             Addresses.  This notification includes the
+             header of the packet, which may help a
+             network manager identify the source of the
+             confusion.
+
+             The agent must throttle the generation of
+             consecutive isisMaxAreaAddressesMismatch
+             notifications so that there is at least a 5-second
+             gap between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 6 }
+
+    isisOwnLSPPurge NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduLspId
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a PDU
+             with our systemID and zero age.  This
+             notification includes the circuit Index
+             and router ID from the LSP, if available,
+             which may help a network manager
+             identify the source of the confusion."
+    ::= { isisNotifications 7 }
+
+    isisSequenceNumberSkip NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduLspId
+        }
+        STATUS current
+        DESCRIPTION
+            "When we receive an LSP with our System ID
+             and different contents, we may need to reissue
+             the LSP with a higher sequence number.
+
+             We send this notification if we need to increase
+             the sequence number by more than one.  If two
+             Intermediate Systems are configured with the same
+             System ID, this notification will fire."
+    ::= { isisNotifications 8 }
+
+    isisAuthenticationTypeFailure NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a PDU
+             with the wrong authentication type field.
+             This notification includes the header of the
+             packet, which may help a network manager
+             identify the source of the confusion.
+
+             The agent must throttle the generation of
+             consecutive isisAuthenticationTypeFailure
+             notifications so that there is at least a 5-second
+             gap between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 9 }
+
+    isisAuthenticationFailure NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a PDU
+             with an incorrect authentication information
+             field.  This notification includes the header
+             of the packet, which may help a network manager
+             identify the source of the confusion.
+             The agent must throttle the generation of
+             consecutive isisAuthenticationFailure
+             notifications so that there is at least a 5-second
+             gap between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 10 }
+
+    isisVersionSkew NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduProtocolVersion,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a Hello
+             PDU from an IS running a different version
+             of the protocol.  This notification includes
+             the header of the packet, which may help a
+             network manager identify the source of the
+             confusion.
+
+             The agent must throttle the generation of
+             consecutive isisVersionSkew notifications
+             so that there is at least a 5-second gap
+             between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 11 }
+
+    isisAreaMismatch NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationCircIfIndex,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a Hello
+             PDU from an IS that does not share any
+             area address.  This notification includes
+             the header of the packet, which may help a
+             network manager identify the source of the
+             confusion.
+
+             The agent must throttle the generation of
+             consecutive isisAreaMismatch notifications
+             so that there is at least a 5-second gap
+             between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 12 }
+
+    isisRejectedAdjacency NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we receive a Hello
+             PDU from an IS but do not establish an
+             adjacency for some reason.
+
+             The agent must throttle the generation of
+             consecutive isisRejectedAdjacency notifications
+             so that there is at least a 5-second gap
+             between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 13 }
+
+    isisLSPTooLargeToPropagate NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduLspSize,
+            isisPduLspId
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when we attempt to propagate
+             an LSP that is larger than the dataLinkBlockSize
+             for the circuit.
+
+             The agent must throttle the generation of
+             consecutive isisLSPTooLargeToPropagate notifications
+             so that there is at least a 5-second gap
+             between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 14 }
+
+    isisOrigLSPBuffSizeMismatch NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduLspId,
+            isisPduOriginatingBufferSize,
+            isisPduBufferSize
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when a Level 1 LSP or Level
+             2 LSP is received that is larger than the local
+             value for isisSysLevelOrigLSPBuffSize, or when an
+             LSP is received that contains the supported Buffer Size
+             option and the value in the PDU option field does
+             not match the local value for isisSysLevelOrigLSPBuffSize.
+             We pass up the size from the option field and the
+             size of the LSP when one of them exceeds our configuration.
+
+             The agent must throttle the generation of
+             consecutive isisOrigLSPBuffSizeMismatch notifications
+             so that there is at least a 5-second gap
+             between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 15 }
+
+    isisProtocolsSupportedMismatch NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduProtocolsSupported,
+            isisPduLspId,
+            isisPduFragment
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when a non-pseudonode
+             segment 0 LSP is received that has no matching
+             protocols supported.  This may be because the system
+             does not generate the field, or because there are no
+             common elements.  The list of protocols supported
+             should be included in the notification: it may be
+             empty if the TLV is not supported, or if the
+             TLV is empty.
+
+             The agent must throttle the generation of
+             consecutive isisProtocolsSupportedMismatch
+             notifications so that there is at least a 5-second
+             gap between notifications of this type.  When
+             notifications are throttled, they are dropped, not
+             queued for sending at a future time."
+    ::= { isisNotifications 16 }
+
+    isisAdjacencyChange NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduLspId,
+            isisAdjState
+        }
+        STATUS current
+        DESCRIPTION
+            "A notification sent when an adjacency changes
+             state, entering or leaving state up.
+             The first 6 bytes of the isisPduLspId are the
+             SystemID of the adjacent IS.
+             The isisAdjState is the new state of the adjacency."
+    ::= { isisNotifications 17 }
+
+    isisLSPErrorDetected NOTIFICATION-TYPE
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisPduLspId,
+            isisNotificationCircIfIndex,
+            isisPduFragment,
+            isisErrorOffset,
+            isisErrorTLVType
+        }
+        STATUS current
+        DESCRIPTION
+            "This notification is generated when we receive
+             an LSP with a parse error.  The isisCircIfIndex
+             holds an index of the circuit on which the PDU
+             arrived.  The isisPduFragment holds the start of the
+             LSP, and the isisErrorOffset points to the problem.
+
+             If the problem is a malformed TLV, isisErrorOffset
+             points to the start of the TLV, and isisErrorTLVType
+             holds the value of the type.
+
+             If the problem is with the LSP header, isisErrorOffset
+             points to the suspicious byte.
+
+             The number of such LSPs is accumulated in
+             isisSysStatLSPErrors."
+    ::= { isisNotifications 18 }
+
+-- Agent Conformance Definitions
+-- We define the objects a conformant agent must define
+
+isisCompliances OBJECT IDENTIFIER ::= { isisConformance 1 }
+isisGroups      OBJECT IDENTIFIER ::= { isisConformance 2 }
+
+-- compliance statements
+
+    isisCompliance MODULE-COMPLIANCE
+        STATUS current
+        DESCRIPTION
+            "The compliance statement for agents that support
+             the IS-IS MIB.
+
+             There are a number of INDEX objects that cannot be
+             represented in the form of OBJECT clauses in SMIv2,
+             but for which there are compliance requirements.
+             Those requirements and similar requirements for
+             related objects are expressed below, in
+             pseudo-OBJECT clause form, in this description:
+
+             -- OBJECT isisSummAddressType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4 Summary
+             --    Addresses and anticipates the support of
+             --    IPv6 addresses.
+             --
+             --
+             -- OBJECT isisRedistributeAddrType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4
+             --    Redistribution Addresses and anticipates
+             --    the support of IPv6 addresses."
+             --
+             --
+             -- OBJECT isisISAdjIPAddrType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4
+             --    Adjacency Addresses and anticipates the
+             --    support of IPv6 addresses.
+        MODULE -- this module
+            MANDATORY-GROUPS {
+                    isisSystemGroup,
+                    isisCircuitGroup,
+                    isisISAdjGroup,
+                    isisNotificationObjectGroup,
+                    isisNotificationGroup
+            }
+    ::= { isisCompliances 1 }
+
+    -- List of all groups, mandatory and optional
+    isisAdvancedCompliance MODULE-COMPLIANCE
+        STATUS current
+        DESCRIPTION
+            "The compliance statement for agents that fully
+             support the IS-IS MIB.
+
+             There are a number of INDEX objects that cannot be
+             represented in the form of OBJECT clauses in SMIv2,
+             but for which there are compliance requirements.
+             Those requirements and similar requirements for
+             related objects are expressed below, in
+             pseudo-OBJECT clause form, in this description:
+
+             -- OBJECT isisSummAddressType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4 Summary
+             --    Addresses and anticipates the support of
+             --    IPv6 addresses.
+             --
+             --
+             -- OBJECT isisRedistributeAddrType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4
+             --    Redistribution Addresses and anticipates
+             --    the support of IPv6 addresses."
+             --
+             --
+             -- OBJECT isisISAdjIPAddrType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4
+             --    Adjacency Addresses and anticipates the
+             --    support of IPv6 addresses.
+             --
+             --
+             -- OBJECT isisIPRADestType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4 RA
+             --    Addresses and anticipates the support of
+             --    IPv6 addresses.
+             --
+             --
+             -- OBJECT isisIPRANextHopType
+             -- SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+             --
+             -- DESCRIPTION
+             --    The MIB requires support for IPv4 NextHop
+             --    Addresses and anticipates the support of
+             --    IPv6 addresses.
+        MODULE -- this module
+            MANDATORY-GROUPS {
+                    isisSystemGroup,
+                    isisCircuitGroup,
+                    isisISAdjGroup,
+                    isisNotificationObjectGroup,
+                    isisNotificationGroup,
+                    isisISPDUCounterGroup,
+                    isisRATableGroup,
+                    isisISIPRADestGroup,
+                    isisLSPGroup
+            }
+    ::= { isisCompliances 2 }
+
+    isisReadOnlyCompliance MODULE-COMPLIANCE
+       STATUS     current
+       DESCRIPTION
+               "When this MIB is implemented without support for
+                read-create (i.e., in read-only mode), the
+                implementation can claim read-only compliance.  Such
+                a device can then be monitored but cannot be
+                configured with this MIB."
+       MODULE -- this module
+            MANDATORY-GROUPS {
+                    isisSystemGroup,
+                    isisCircuitGroup,
+                    isisISAdjGroup
+            }
+
+       OBJECT isisSysLevelType
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysID
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysMaxPathSplits
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysMaxLSPGenInt
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysPollESHelloRate
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysWaitTime
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysAdminState
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysL2toL1Leaking
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysMaxAge
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisManAreaAddrExistState
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelOrigLSPBuffSize
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelMinLSPGenInt
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelSetOverload
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelSetOverloadUntil
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelMetricStyle
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelSPFConsiders
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysLevelTEEnabled
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSysReceiveLSPBufferSize
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSummAddrExistState
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSummAddrMetric
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisSummAddrFullMetric
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisRedistributeAddrExistState
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircAdminState
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircExistState
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircType
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircExtDomain
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelType
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircPassiveCircuit
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircMeshGroupEnabled
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircMeshGroup
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircSmallHellos
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircExtendedCircID
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircIfIndex
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCirc3WayEnabled
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelMetric
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelWideMetric
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelISPriority
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelHelloMultiplier
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelHelloTimer
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelDRHelloTimer
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelLSPThrottle
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelMinLSPRetransInt
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelCSNPInterval
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+       OBJECT isisCircLevelPartSNPInterval
+       MIN-ACCESS read-only
+       DESCRIPTION
+            "Write access is not required."
+
+    ::= { isisCompliances 3 }
+
+-- MIB Grouping
+
+    isisSystemGroup OBJECT-GROUP
+        OBJECTS {
+            isisSysVersion,
+            isisSysLevelType,
+            isisSysID,
+            isisSysMaxPathSplits,
+            isisSysMaxLSPGenInt,
+            isisSysPollESHelloRate,
+            isisSysWaitTime,
+            isisSysAdminState,
+            isisSysL2toL1Leaking,
+            isisSysMaxAge,
+            isisSysProtSupported,
+            isisSysNotificationEnable,
+            isisManAreaAddrExistState,
+            isisSysLevelOrigLSPBuffSize,
+            isisSysLevelMinLSPGenInt,
+            isisSysLevelState,
+            isisSysLevelSetOverload,
+            isisSysLevelSetOverloadUntil,
+            isisSysLevelMetricStyle,
+            isisSysLevelSPFConsiders,
+            isisSysLevelTEEnabled,
+            isisSysReceiveLSPBufferSize,
+            isisSummAddrExistState,
+            isisSummAddrMetric,
+            isisAreaAddr,
+            isisSummAddrFullMetric,
+            isisRedistributeAddrExistState,
+            isisRouterHostName,
+            isisRouterID,
+            isisSysStatCorrLSPs,
+            isisSysStatLSPDbaseOloads,
+            isisSysStatManAddrDropFromAreas,
+            isisSysStatAttmptToExMaxSeqNums,
+            isisSysStatSeqNumSkips,
+            isisSysStatOwnLSPPurges,
+            isisSysStatIDFieldLenMismatches,
+            isisSysStatPartChanges,
+            isisSysStatSPFRuns,
+            isisSysStatAuthTypeFails,
+            isisSysStatAuthFails,
+            isisSysStatLSPErrors
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to manage an
+             IS-IS router."
+    ::= { isisGroups 1 }
+
+    isisCircuitGroup OBJECT-GROUP
+        OBJECTS {
+            isisNextCircIndex,
+            isisCircAdminState,
+            isisCircExistState,
+            isisCircType,
+            isisCircExtDomain,
+            isisCircLevelType,
+            isisCircAdjChanges,
+            isisCircNumAdj,
+            isisCircInitFails,
+            isisCircRejAdjs,
+            isisCircIDFieldLenMismatches,
+            isisCircMaxAreaAddrMismatches,
+            isisCircAuthTypeFails,
+            isisCircAuthFails,
+            isisCircLANDesISChanges,
+            isisCircPassiveCircuit,
+            isisCircMeshGroupEnabled,
+            isisCircMeshGroup,
+            isisCircSmallHellos,
+            isisCircLastUpTime,
+            isisCirc3WayEnabled,
+            isisCircExtendedCircID,
+            isisCircIfIndex,
+            isisCircLevelMetric,
+            isisCircLevelWideMetric,
+            isisCircLevelISPriority,
+            isisCircLevelIDOctet,
+            isisCircLevelID,
+            isisCircLevelDesIS,
+            isisCircLevelHelloMultiplier,
+            isisCircLevelHelloTimer,
+            isisCircLevelDRHelloTimer,
+            isisCircLevelLSPThrottle,
+            isisCircLevelMinLSPRetransInt,
+            isisCircLevelCSNPInterval,
+            isisCircLevelPartSNPInterval
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to describe an
+             IS-IS Circuit."
+    ::= { isisGroups 2 }
+
+    isisISAdjGroup OBJECT-GROUP
+        OBJECTS {
+            isisISAdjState,
+            isisISAdj3WayState,
+            isisISAdjNeighSNPAAddress,
+            isisISAdjNeighSysType,
+            isisISAdjNeighSysID,
+            isisISAdjNbrExtendedCircID,
+            isisISAdjUsage,
+            isisISAdjHoldTimer,
+            isisISAdjNeighPriority,
+            isisISAdjLastUpTime,
+            isisISAdjAreaAddress,
+            isisISAdjIPAddrType,
+            isisISAdjIPAddrAddress,
+            isisISAdjProtSuppProtocol
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to manage an
+             IS-IS Adjacency."
+    ::= { isisGroups 3 }
+
+    isisNotificationObjectGroup OBJECT-GROUP
+        OBJECTS {
+            isisNotificationSysLevelIndex,
+            isisNotificationCircIfIndex,
+            isisPduLspId,
+            isisPduFragment,
+            isisPduFieldLen,
+            isisPduMaxAreaAddress,
+            isisPduProtocolVersion,
+            isisPduLspSize,
+            isisPduOriginatingBufferSize,
+            isisPduBufferSize,
+            isisPduProtocolsSupported,
+            isisAdjState,
+            isisErrorOffset,
+            isisErrorTLVType,
+            isisNotificationAreaAddress
+        }
+        STATUS current
+        DESCRIPTION
+            "The objects used to record notification parameters."
+    ::= { isisGroups 4 }
+
+
+    isisNotificationGroup        NOTIFICATION-GROUP
+        NOTIFICATIONS {
+            isisDatabaseOverload,
+            isisManualAddressDrops,
+            isisCorruptedLSPDetected,
+            isisAttemptToExceedMaxSequence,
+            isisIDLenMismatch,
+            isisMaxAreaAddressesMismatch,
+            isisOwnLSPPurge,
+            isisSequenceNumberSkip,
+            isisAuthenticationTypeFailure,
+            isisAuthenticationFailure,
+            isisVersionSkew,
+            isisAreaMismatch,
+            isisRejectedAdjacency,
+            isisLSPTooLargeToPropagate,
+            isisOrigLSPBuffSizeMismatch,
+            isisProtocolsSupportedMismatch,
+            isisAdjacencyChange,
+            isisLSPErrorDetected
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of notifications sent by an IS."
+    ::= { isisGroups 5 }
+
+
+    isisISPDUCounterGroup OBJECT-GROUP
+        OBJECTS {
+            isisPacketCountIIHello,
+            isisPacketCountISHello,
+            isisPacketCountESHello,
+            isisPacketCountLSP,
+            isisPacketCountCSNP,
+            isisPacketCountPSNP,
+            isisPacketCountUnknown
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to count protocol PDUs."
+    ::= { isisGroups 6 }
+
+
+    isisRATableGroup OBJECT-GROUP
+        OBJECTS {
+            isisRAExistState,
+            isisRAAdminState,
+            isisRAAddrPrefix,
+            isisRAMapType,
+            isisRAMetric,
+            isisRAMetricType,
+            isisRASNPAAddress,
+            isisRASNPAMask,
+            isisRASNPAPrefix,
+            isisRAType
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to manage the
+             reachable NSAP prefixes."
+    ::= { isisGroups 7 }
+
+
+    isisISIPRADestGroup OBJECT-GROUP
+        OBJECTS {
+            isisIPRANextHopType,
+            isisIPRANextHop,
+            isisIPRAType,
+            isisIPRAExistState,
+            isisIPRAAdminState,
+            isisIPRAMetric,
+            isisIPRAFullMetric,
+            isisIPRAMetricType,
+            isisIPRASNPAAddress,
+            isisIPRASourceType
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to manage configured
+             IP addresses."
+    ::= { isisGroups 8 }
+
+    isisLSPGroup OBJECT-GROUP
+        OBJECTS {
+            isisLSPSeq,
+            isisLSPZeroLife,
+            isisLSPChecksum,
+            isisLSPLifetimeRemain,
+            isisLSPPDULength,
+            isisLSPAttributes,
+            isisLSPTLVSeq,
+            isisLSPTLVChecksum,
+            isisLSPTLVType,
+            isisLSPTLVLen,
+            isisLSPTLVValue
+        }
+        STATUS current
+        DESCRIPTION
+            "The collections of objects used to observe the LSP
+             Database."
+    ::= { isisGroups 9 }
+
+END
+

--- a/mibs/junos/mib-rfc4668.txt
+++ b/mibs/junos/mib-rfc4668.txt
@@ -1,0 +1,672 @@
+RADIUS-AUTH-CLIENT-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, OBJECT-IDENTITY,
+       Counter32, Integer32, Gauge32,
+       IpAddress, TimeTicks, mib-2      FROM SNMPv2-SMI
+       SnmpAdminString                  FROM SNMP-FRAMEWORK-MIB
+       InetAddressType, InetAddress,
+       InetPortNumber                   FROM INET-ADDRESS-MIB
+       MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF;
+
+
+radiusAuthClientMIB MODULE-IDENTITY
+       LAST-UPDATED "200608210000Z" -- 21 August 2006
+       ORGANIZATION "IETF RADIUS Extensions Working Group."
+       CONTACT-INFO
+             " Bernard Aboba
+             Microsoft
+             One Microsoft Way
+             Redmond, WA  98052
+             EMail: bernarda@microsoft.com"
+
+       DESCRIPTION
+             "The MIB module for entities implementing the client
+             side of the Remote Access Dialin User Service (RADIUS)
+             authentication protocol."
+       REVISION "9906110000Z"    -- 11 Jun 1999
+       DESCRIPTION "Initial version as published in RFC 2618"
+       ::= { radiusAuthentication 2 }
+
+radiusMIB OBJECT-IDENTITY
+       STATUS  current
+       DESCRIPTION
+             "The OID assigned to RADIUS MIB work by the IANA."
+       ::= { mib-2 67 }
+
+radiusAuthentication  OBJECT IDENTIFIER ::= {radiusMIB 1}
+
+radiusAuthClientMIBObjects     OBJECT IDENTIFIER ::=
+                                               { radiusAuthClientMIB 1 }
+
+radiusAuthClient  OBJECT IDENTIFIER ::= { radiusAuthClientMIBObjects 1 }
+
+radiusAuthClientInvalidServerAddresses OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Response packets
+              received from unknown addresses."
+       ::= { radiusAuthClient 1 }
+
+radiusAuthClientIdentifier OBJECT-TYPE
+       SYNTAX SnmpAdminString
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The NAS-Identifier of the RADIUS authentication client.
+              This is not necessarily the same as sysName in MIB II."
+       ::= { radiusAuthClient 2 }
+
+radiusAuthServerTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF RadiusAuthServerEntry
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+             "The (conceptual) table listing the RADIUS authentication
+              servers with which the client shares a secret."
+       ::= { radiusAuthClient 3 }
+
+radiusAuthServerEntry OBJECT-TYPE
+       SYNTAX     RadiusAuthServerEntry
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+             "An entry (conceptual row) representing a RADIUS
+              authentication server with which the client shares
+              a secret."
+       INDEX      { radiusAuthServerIndex }
+       ::= { radiusAuthServerTable 1 }
+
+RadiusAuthServerEntry ::= SEQUENCE {
+       radiusAuthServerIndex                           Integer32,
+       radiusAuthServerAddress                         IpAddress,
+       radiusAuthClientServerPortNumber                Integer32,
+       radiusAuthClientRoundTripTime                   TimeTicks,
+       radiusAuthClientAccessRequests                  Counter32,
+       radiusAuthClientAccessRetransmissions           Counter32,
+       radiusAuthClientAccessAccepts                   Counter32,
+       radiusAuthClientAccessRejects                   Counter32,
+       radiusAuthClientAccessChallenges                Counter32,
+       radiusAuthClientMalformedAccessResponses        Counter32,
+       radiusAuthClientBadAuthenticators               Counter32,
+       radiusAuthClientPendingRequests                   Gauge32,
+       radiusAuthClientTimeouts                        Counter32,
+       radiusAuthClientUnknownTypes                    Counter32,
+       radiusAuthClientPacketsDropped                  Counter32
+}
+
+radiusAuthServerIndex OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+             "A number uniquely identifying each RADIUS
+              Authentication server with which this client
+              communicates."
+       ::= { radiusAuthServerEntry 1 }
+
+radiusAuthServerAddress OBJECT-TYPE
+       SYNTAX     IpAddress
+       MAX-ACCESS read-only
+       STATUS     deprecated
+       DESCRIPTION
+             "The IP address of the RADIUS authentication server
+              referred to in this table entry."
+       ::= { radiusAuthServerEntry 2 }
+
+radiusAuthClientServerPortNumber  OBJECT-TYPE
+       SYNTAX Integer32 (0..65535)
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The UDP port the client is using to send requests to
+              this server."
+       ::= { radiusAuthServerEntry 3 }
+
+radiusAuthClientRoundTripTime  OBJECT-TYPE
+       SYNTAX TimeTicks
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The time interval (in hundredths of a second) between
+              the most recent Access-Reply/Access-Challenge and the
+              Access-Request that matched it from this RADIUS
+              authentication server."
+       ::= { radiusAuthServerEntry 4 }
+
+-- Request/Response statistics
+--
+-- TotalIncomingPackets = Accepts + Rejects + Challenges + UnknownTypes
+--
+-- TotalIncomingPackets - MalformedResponses - BadAuthenticators -
+-- UnknownTypes - PacketsDropped = Successfully received
+--
+-- AccessRequests + PendingRequests + ClientTimeouts =
+-- Successfully Received
+--
+--
+
+radiusAuthClientAccessRequests OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Request packets sent
+              to this server. This does not include retransmissions."
+       ::= { radiusAuthServerEntry 5 }
+
+radiusAuthClientAccessRetransmissions OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Request packets
+              retransmitted to this RADIUS authentication server."
+       ::= { radiusAuthServerEntry 6 }
+
+radiusAuthClientAccessAccepts OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Accept packets
+              (valid or invalid) received from this server."
+       ::= { radiusAuthServerEntry 7 }
+
+radiusAuthClientAccessRejects OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Reject packets
+              (valid or invalid) received from this server."
+       ::= { radiusAuthServerEntry  8 }
+
+radiusAuthClientAccessChallenges OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Challenge packets
+              (valid or invalid) received from this server."
+       ::= { radiusAuthServerEntry 9 }
+
+-- "Access-Response" includes an Access-Accept, Access-Challenge
+-- or Access-Reject
+
+radiusAuthClientMalformedAccessResponses OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of malformed RADIUS Access-Response
+              packets received from this server.
+              Malformed packets include packets with
+              an invalid length. Bad authenticators or
+              Signature attributes or unknown types are not
+              included as malformed access responses."
+       ::= { radiusAuthServerEntry 10 }
+
+radiusAuthClientBadAuthenticators OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Response packets
+              containing invalid authenticators or Signature
+              attributes received from this server."
+       ::= { radiusAuthServerEntry 11 }
+
+radiusAuthClientPendingRequests OBJECT-TYPE
+       SYNTAX Gauge32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Access-Request packets
+              destined for this server that have not yet timed out
+              or received a response. This variable is incremented
+              when an Access-Request is sent and decremented due to
+              receipt of an Acess-Accept, Access-Reject or
+              Access-Challenge, a timeout or retransmission."
+       ::= { radiusAuthServerEntry 12 }
+
+radiusAuthClientTimeouts OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of authentication timeouts to this server.
+              After a timeout the client may retry to the same
+              server, send to a different server, or
+              give up. A retry to the same server is counted as a
+              retransmit as well as a timeout. A send to a different
+              server is counted as a Request as well as a timeout."
+       ::= { radiusAuthServerEntry  13 }
+
+radiusAuthClientUnknownTypes OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type which
+              were received from this server on the authentication port."
+              ::= { radiusAuthServerEntry  14 }
+
+radiusAuthClientPacketsDropped OBJECT-TYPE
+       SYNTAX Counter32
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets of which were
+              received from this server on the authentication port
+              and dropped for some other reason."
+       ::= { radiusAuthServerEntry  15 }
+
+
+-- New MIB Objects in this revision
+
+radiusAuthServerExtTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF RadiusAuthServerExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "The (conceptual) table listing the RADIUS authentication
+              servers with which the client shares a secret."
+       ::= { radiusAuthClient 4 }
+
+radiusAuthServerExtEntry OBJECT-TYPE
+       SYNTAX     RadiusAuthServerExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+              "An entry (conceptual row) representing a RADIUS
+               authentication server with which the client shares
+               a secret."
+       INDEX      { radiusAuthServerExtIndex }
+       ::= { radiusAuthServerExtTable 1 }
+
+RadiusAuthServerExtEntry ::= SEQUENCE {
+       radiusAuthServerExtIndex                     Integer32,
+       radiusAuthServerInetAddressType              InetAddressType,
+       radiusAuthServerInetAddress                  InetAddress,
+       radiusAuthClientServerInetPortNumber         InetPortNumber,
+       radiusAuthClientExtRoundTripTime             TimeTicks,
+       radiusAuthClientExtAccessRequests            Counter32,
+       radiusAuthClientExtAccessRetransmissions     Counter32,
+       radiusAuthClientExtAccessAccepts             Counter32,
+       radiusAuthClientExtAccessRejects             Counter32,
+       radiusAuthClientExtAccessChallenges          Counter32,
+       radiusAuthClientExtMalformedAccessResponses  Counter32,
+       radiusAuthClientExtBadAuthenticators         Counter32,
+       radiusAuthClientExtPendingRequests           Gauge32,
+       radiusAuthClientExtTimeouts                  Counter32,
+       radiusAuthClientExtUnknownTypes              Counter32,
+       radiusAuthClientExtPacketsDropped            Counter32,
+       radiusAuthClientCounterDiscontinuity         TimeTicks
+}
+
+radiusAuthServerExtIndex OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "A number uniquely identifying each RADIUS
+              Authentication server with which this client
+              communicates."
+       ::= { radiusAuthServerExtEntry 1 }
+
+radiusAuthServerInetAddressType OBJECT-TYPE
+       SYNTAX     InetAddressType
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+             "The type of address format used for the
+              radiusAuthServerInetAddress object."
+       ::= { radiusAuthServerExtEntry 2 }
+
+radiusAuthServerInetAddress OBJECT-TYPE
+       SYNTAX     InetAddress
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+             "The IP address of the RADIUS authentication
+              server referred to in this table entry, using
+              the version-neutral IP address format."
+       ::= { radiusAuthServerExtEntry 3 }
+
+radiusAuthClientServerInetPortNumber  OBJECT-TYPE
+       SYNTAX InetPortNumber ( 1..65535 )
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The UDP port the client is using to send requests
+              to this server.  The value of zero (0) is invalid."
+              REFERENCE "RFC 2865 section 3"
+       ::= { radiusAuthServerExtEntry 4 }
+
+radiusAuthClientExtRoundTripTime  OBJECT-TYPE
+       SYNTAX TimeTicks
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The time interval (in hundredths of a second) between
+              the most recent Access-Reply/Access-Challenge and the
+              Access-Request that matched it from this RADIUS
+              authentication server."
+       REFERENCE "RFC 2865 section 2"
+       ::= { radiusAuthServerExtEntry 5 }
+
+-- Request/Response statistics
+--
+-- TotalIncomingPackets = Accepts + Rejects + Challenges +
+-- UnknownTypes
+--
+-- TotalIncomingPackets - MalformedResponses -
+-- BadAuthenticators - UnknownTypes - PacketsDropped =
+-- Successfully received
+--
+-- AccessRequests + PendingRequests + ClientTimeouts =
+-- Successfully received
+--
+--
+
+radiusAuthClientExtAccessRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Request packets sent
+              to this server.  This does not include retransmissions.
+              This counter may experience a discontinuity when the
+              RADIUS Client module within the managed entity is
+              reinitialized, as indicated by the current value of
+              radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.1"
+       ::= { radiusAuthServerExtEntry 6 }
+
+radiusAuthClientExtAccessRetransmissions OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Request packets
+              retransmitted to this RADIUS authentication server.
+              This counter may experience a discontinuity when
+              the RADIUS Client module within the managed entity
+              is reinitialized, as indicated by the current value
+              of radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 sections 2.5, 4.1"
+       ::= { radiusAuthServerExtEntry 7 }
+
+radiusAuthClientExtAccessAccepts OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Accept packets
+              (valid or invalid) received from this server.
+              This counter may experience a discontinuity when
+              the RADIUS Client module within the managed entity
+              is reinitialized, as indicated by the current value
+              of radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.2"
+       ::= { radiusAuthServerExtEntry 8 }
+
+radiusAuthClientExtAccessRejects OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Reject packets
+              (valid or invalid) received from this server.
+              This counter may experience a discontinuity when
+              the RADIUS Client module within the managed
+              entity is reinitialized, as indicated by the
+              current value of
+              radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.3"
+       ::= { radiusAuthServerExtEntry  9 }
+
+radiusAuthClientExtAccessChallenges OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Challenge packets
+              (valid or invalid) received from this server.
+              This counter may experience a discontinuity when
+              the RADIUS Client module within the managed
+              entity is reinitialized, as indicated by the
+              current value of
+              radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.4"
+       ::= { radiusAuthServerExtEntry 10 }
+
+-- "Access-Response" includes an Access-Accept, Access-Challenge,
+-- or Access-Reject
+
+radiusAuthClientExtMalformedAccessResponses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of malformed RADIUS Access-Response
+              packets received from this server.
+              Malformed packets include packets with
+              an invalid length.  Bad authenticators or
+              Message Authenticator attributes or unknown types
+              are not included as malformed access responses.
+              This counter may experience a discontinuity when
+              the RADIUS Client module within the managed entity
+              is reinitialized, as indicated by the current value
+              of radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 sections 3, 4"
+       ::= { radiusAuthServerExtEntry 11 }
+
+radiusAuthClientExtBadAuthenticators OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Response packets
+              containing invalid authenticators or Message
+              Authenticator attributes received from this server.
+              This counter may experience a discontinuity when
+              the RADIUS Client module within the managed entity
+              is reinitialized, as indicated by the current value
+              of radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 3"
+       ::= { radiusAuthServerExtEntry 12 }
+
+radiusAuthClientExtPendingRequests OBJECT-TYPE
+       SYNTAX Gauge32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Request packets
+              destined for this server that have not yet timed out
+              or received a response.  This variable is incremented
+              when an Access-Request is sent and decremented due to
+              receipt of an Access-Accept, Access-Reject,
+              Access-Challenge, timeout, or retransmission."
+              REFERENCE "RFC 2865 section 2"
+              ::= { radiusAuthServerExtEntry 13 }
+
+radiusAuthClientExtTimeouts OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "timeouts"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of authentication timeouts to this server.
+              After a timeout, the client may retry to the same
+              server, send to a different server, or
+              give up.  A retry to the same server is counted as a
+              retransmit as well as a timeout.  A send to a different
+              server is counted as a Request as well as a timeout.
+              This counter may experience a discontinuity when the
+              RADIUS Client module within the managed entity is
+              reinitialized, as indicated by the current value of
+              radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 sections 2.5, 4.1"
+       ::= { radiusAuthServerExtEntry  14 }
+
+radiusAuthClientExtUnknownTypes OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this server on the authentication
+              port.  This counter may experience a discontinuity
+              when the RADIUS Client module within the managed
+              entity is reinitialized, as indicated by the current
+              value of radiusAuthClientCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4"
+       ::= { radiusAuthServerExtEntry  15 }
+
+radiusAuthClientExtPacketsDropped OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets that were
+              received from this server on the authentication port
+              and dropped for some other reason.  This counter may
+              experience a discontinuity when the RADIUS Client
+              module within the managed entity is reinitialized,
+              as indicated by the current value of
+              radiusAuthClientCounterDiscontinuity."
+              ::= { radiusAuthServerExtEntry  16 }
+
+radiusAuthClientCounterDiscontinuity OBJECT-TYPE
+       SYNTAX TimeTicks
+       UNITS "centiseconds"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of centiseconds since the last discontinuity
+              in the RADIUS Client counters.  A discontinuity may
+              be the result of a reinitialization of the RADIUS
+              Client module within the managed entity."
+       ::= { radiusAuthServerExtEntry 17 }
+
+
+-- conformance information
+
+radiusAuthClientMIBConformance OBJECT IDENTIFIER
+       ::= { radiusAuthClientMIB 2 }
+
+radiusAuthClientMIBCompliances OBJECT IDENTIFIER
+       ::= { radiusAuthClientMIBConformance 1 }
+
+radiusAuthClientMIBGroups OBJECT IDENTIFIER
+        ::= { radiusAuthClientMIBConformance 2 }
+
+
+-- compliance statements
+
+radiusAuthClientMIBCompliance MODULE-COMPLIANCE
+       STATUS  deprecated
+       DESCRIPTION
+             "The compliance statement for authentication clients
+              implementing the RADIUS Authentication Client MIB.
+              Implementation of this module is for IPv4-only
+              entities, or for backwards compatibility use with
+              entities that support both IPv4 and IPv6."
+       MODULE  -- this module
+       MANDATORY-GROUPS { radiusAuthClientMIBGroup }
+
+       ::= { radiusAuthClientMIBCompliances 1 }
+
+radiusAuthClientExtMIBCompliance MODULE-COMPLIANCE
+       STATUS  current
+       DESCRIPTION
+             "The compliance statement for authentication
+              clients implementing the RADIUS Authentication
+              Client IPv6 Extensions MIB.  Implementation of
+              this module is for entities that support IPv6,
+              or support IPv4 and IPv6."
+       MODULE  -- this module
+       MANDATORY-GROUPS { radiusAuthClientExtMIBGroup }
+
+       OBJECT radiusAuthServerInetAddressType
+       SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+       DESCRIPTION
+             "An implementation is only required to support
+              IPv4 and globally unique IPv6 addresses."
+       OBJECT radiusAuthServerInetAddress
+       SYNTAX InetAddress ( SIZE (4|16) )
+       DESCRIPTION
+             "An implementation is only required to support
+              IPv4 and globally unique IPv6 addresses."
+       ::= { radiusAuthClientMIBCompliances 2 }
+
+
+-- units of conformance
+
+radiusAuthClientMIBGroup OBJECT-GROUP
+       OBJECTS { radiusAuthClientIdentifier,
+                 radiusAuthClientInvalidServerAddresses,
+                 radiusAuthServerAddress,
+                 radiusAuthClientServerPortNumber,
+                 radiusAuthClientRoundTripTime,
+                 radiusAuthClientAccessRequests,
+                 radiusAuthClientAccessRetransmissions,
+                 radiusAuthClientAccessAccepts,
+                 radiusAuthClientAccessRejects,
+                 radiusAuthClientAccessChallenges,
+                 radiusAuthClientMalformedAccessResponses,
+                 radiusAuthClientBadAuthenticators,
+                 radiusAuthClientPendingRequests,
+                 radiusAuthClientTimeouts,
+                 radiusAuthClientUnknownTypes,
+                 radiusAuthClientPacketsDropped
+               }
+       STATUS  deprecated
+       DESCRIPTION
+             "The basic collection of objects providing management of
+              RADIUS Authentication Clients."
+       ::= { radiusAuthClientMIBGroups 1 }
+
+
+radiusAuthClientExtMIBGroup OBJECT-GROUP
+       OBJECTS { radiusAuthClientIdentifier,
+                 radiusAuthClientInvalidServerAddresses,
+                 radiusAuthServerInetAddressType,
+                 radiusAuthServerInetAddress,
+                 radiusAuthClientServerInetPortNumber,
+                 radiusAuthClientExtRoundTripTime,
+                 radiusAuthClientExtAccessRequests,
+                 radiusAuthClientExtAccessRetransmissions,
+                 radiusAuthClientExtAccessAccepts,
+                 radiusAuthClientExtAccessRejects,
+                 radiusAuthClientExtAccessChallenges,
+                 radiusAuthClientExtMalformedAccessResponses,
+                 radiusAuthClientExtBadAuthenticators,
+                 radiusAuthClientExtPendingRequests,
+                 radiusAuthClientExtTimeouts,
+                 radiusAuthClientExtUnknownTypes,
+                 radiusAuthClientExtPacketsDropped,
+                 radiusAuthClientCounterDiscontinuity
+               }
+       STATUS  current
+       DESCRIPTION
+             "The collection of extended objects providing
+              management of RADIUS Authentication Clients
+              using version-neutral IP address format."
+       ::= { radiusAuthClientMIBGroups 2 }
+
+END

--- a/mibs/junos/mib-rfc4670.txt
+++ b/mibs/junos/mib-rfc4670.txt
@@ -1,0 +1,646 @@
+RADIUS-ACC-CLIENT-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, OBJECT-IDENTITY,
+       Counter32, Integer32, Gauge32,
+       IpAddress, TimeTicks, mib-2      FROM SNMPv2-SMI
+       SnmpAdminString                  FROM SNMP-FRAMEWORK-MIB
+       InetAddressType, InetAddress,
+       InetPortNumber                   FROM INET-ADDRESS-MIB
+       MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF;
+
+
+radiusAccClientMIB MODULE-IDENTITY
+       LAST-UPDATED "200608210000Z" -- 21 August 2006
+       ORGANIZATION "IETF RADIUS Extensions Working Group."
+       CONTACT-INFO
+             " Bernard Aboba
+               Microsoft
+               One Microsoft Way
+               Redmond, WA  98052
+               US
+               Phone: +1 425 936 6605
+               EMail: bernarda@microsoft.com"
+       DESCRIPTION
+             "The MIB module for entities implementing the client
+              side of the Remote Authentication Dial-In User Service
+              (RADIUS) accounting protocol.  Copyright (C) The
+              Internet Society (2006).  This version of this MIB
+              module is part of RFC 4670; see the RFC itself for
+              full legal notices."
+       REVISION "200608210000Z"  -- 21 August 2006
+       DESCRIPTION
+             "Revised version as published in RFC 4670.
+              This version obsoletes that of RFC 2620 by
+              deprecating the MIB table containing IPv4-only
+              address formats and defining a new table to add support
+              for version-neutral IP address formats.  The remaining
+              MIB objects from RFC 2620 are carried forward into this
+              version."
+       REVISION "199906110000Z"  -- 11 Jun 1999
+       DESCRIPTION "Initial version as published in RFC 2620."
+       ::= { radiusAccounting 2 }
+
+radiusMIB OBJECT-IDENTITY
+       STATUS  current
+       DESCRIPTION
+             "The OID assigned to RADIUS MIB work by the IANA."
+       ::= { mib-2 67 }
+
+radiusAccounting  OBJECT IDENTIFIER ::= {radiusMIB 2}
+
+radiusAccClientMIBObjects     OBJECT IDENTIFIER
+       ::= { radiusAccClientMIB 1 }
+
+radiusAccClient  OBJECT IDENTIFIER
+       ::= { radiusAccClientMIBObjects 1 }
+
+radiusAccClientInvalidServerAddresses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Response packets
+             received from unknown addresses."
+             ::= { radiusAccClient 1 }
+
+radiusAccClientIdentifier OBJECT-TYPE
+       SYNTAX SnmpAdminString
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The NAS-Identifier of the RADIUS accounting client.
+              This is not necessarily the same as sysName in MIB
+              II."
+       REFERENCE "RFC 2865 section 5.32"
+       ::= { radiusAccClient 2 }
+
+radiusAccServerTable OBJECT-TYPE
+       SYNTAX SEQUENCE OF RadiusAccServerEntry
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+             "The (conceptual) table listing the RADIUS accounting
+              servers with which the client shares a secret."
+       ::= { radiusAccClient 3 }
+
+radiusAccServerEntry OBJECT-TYPE
+       SYNTAX     RadiusAccServerEntry
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+             "An entry (conceptual row) representing a RADIUS
+              accounting server with which the client shares a
+              secret."
+       INDEX      { radiusAccServerIndex }
+       ::= { radiusAccServerTable 1 }
+
+RadiusAccServerEntry ::= SEQUENCE {
+       radiusAccServerIndex                           Integer32,
+       radiusAccServerAddress                         IpAddress,
+       radiusAccClientServerPortNumber                Integer32,
+       radiusAccClientRoundTripTime                   TimeTicks,
+       radiusAccClientRequests                        Counter32,
+       radiusAccClientRetransmissions                 Counter32,
+       radiusAccClientResponses                       Counter32,
+       radiusAccClientMalformedResponses              Counter32,
+       radiusAccClientBadAuthenticators               Counter32,
+       radiusAccClientPendingRequests                   Gauge32,
+       radiusAccClientTimeouts                        Counter32,
+       radiusAccClientUnknownTypes                    Counter32,
+       radiusAccClientPacketsDropped                  Counter32
+}
+
+radiusAccServerIndex OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     deprecated
+       DESCRIPTION
+             "A number uniquely identifying each RADIUS
+              Accounting server with which this client
+              communicates."
+       ::= { radiusAccServerEntry 1 }
+
+radiusAccServerAddress OBJECT-TYPE
+       SYNTAX     IpAddress
+       MAX-ACCESS read-only
+       STATUS     deprecated
+       DESCRIPTION
+             "The IP address of the RADIUS accounting server
+              referred to in this table entry."
+       ::= { radiusAccServerEntry 2 }
+
+radiusAccClientServerPortNumber  OBJECT-TYPE
+       SYNTAX Integer32 (0..65535)
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The UDP port the client is using to send requests to
+              this server."
+       REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccServerEntry 3 }
+
+radiusAccClientRoundTripTime  OBJECT-TYPE
+       SYNTAX TimeTicks
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The time interval between the most recent
+              Accounting-Response and the Accounting-Request that
+              matched it from this RADIUS accounting server."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerEntry 4 }
+
+-- Request/Response statistics
+--
+-- Requests = Responses + PendingRequests + ClientTimeouts
+--
+-- Responses - MalformedResponses - BadAuthenticators -
+-- UnknownTypes - PacketsDropped = Successfully received
+radiusAccClientRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              sent.  This does not include retransmissions."
+       REFERENCE "RFC 2866 section 4.1"
+       ::= { radiusAccServerEntry 5 }
+
+radiusAccClientRetransmissions OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              retransmitted to this RADIUS accounting server.
+              Retransmissions include retries where the
+              Identifier and Acct-Delay have been updated, as
+              well as those in which they remain the same."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerEntry 6 }
+
+radiusAccClientResponses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets received on the
+              accounting port from this server."
+       REFERENCE "RFC 2866 section 4.2"
+       ::= { radiusAccServerEntry 7 }
+
+radiusAccClientMalformedResponses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of malformed RADIUS Accounting-Response
+              packets received from this server.  Malformed packets
+              include packets with an invalid length.  Bad
+              authenticators and unknown types are not included as
+              malformed accounting responses."
+       REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccServerEntry 8 }
+
+radiusAccClientBadAuthenticators OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Accounting-Response
+              packets that contained invalid authenticators
+              received from this server."
+              REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccServerEntry 9 }
+
+radiusAccClientPendingRequests OBJECT-TYPE
+       SYNTAX Gauge32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              sent to this server that have not yet timed out or
+              received a response.  This variable is incremented
+              when an Accounting-Request is sent and decremented
+              due to receipt of an Accounting-Response, a timeout,
+              or a retransmission."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerEntry 10 }
+
+radiusAccClientTimeouts OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "timeouts"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of accounting timeouts to this server.
+              After a timeout, the client may retry to the same
+              server, send to a different server, or give up.
+              A retry to the same server is counted as a
+              retransmit as well as a timeout.  A send to a different
+              server is counted as an Accounting-Request as well as
+              a timeout."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerEntry  11 }
+
+radiusAccClientUnknownTypes OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this server on the accounting port."
+              REFERENCE "RFC 2866 section 4"
+              ::= { radiusAccServerEntry  12 }
+
+radiusAccClientPacketsDropped OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets that were received from
+              this server on the accounting port and dropped for some
+              other reason."
+       ::= { radiusAccServerEntry  13 }
+
+
+-- New MIB objects added in this revision
+
+radiusAccServerExtTable OBJECT-TYPE
+       SYNTAX SEQUENCE OF RadiusAccServerExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "The (conceptual) table listing the RADIUS accounting
+              servers with which the client shares a secret."
+       ::= { radiusAccClient 4 }
+
+radiusAccServerExtEntry OBJECT-TYPE
+       SYNTAX     RadiusAccServerExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "An entry (conceptual row) representing a RADIUS
+              accounting server with which the client shares a
+              secret."
+       INDEX      { radiusAccServerExtIndex }
+       ::= { radiusAccServerExtTable 1 }
+
+RadiusAccServerExtEntry ::= SEQUENCE {
+       radiusAccServerExtIndex                    Integer32,
+       radiusAccServerInetAddressType             InetAddressType,
+       radiusAccServerInetAddress                 InetAddress,
+       radiusAccClientServerInetPortNumber        InetPortNumber,
+       radiusAccClientExtRoundTripTime            TimeTicks,
+       radiusAccClientExtRequests                 Counter32,
+       radiusAccClientExtRetransmissions          Counter32,
+       radiusAccClientExtResponses                Counter32,
+       radiusAccClientExtMalformedResponses       Counter32,
+       radiusAccClientExtBadAuthenticators        Counter32,
+       radiusAccClientExtPendingRequests          Gauge32,
+       radiusAccClientExtTimeouts                 Counter32,
+       radiusAccClientExtUnknownTypes             Counter32,
+       radiusAccClientExtPacketsDropped           Counter32,
+       radiusAccClientCounterDiscontinuity        TimeTicks
+}
+
+radiusAccServerExtIndex OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "A number uniquely identifying each RADIUS
+              Accounting server with which this client
+              communicates."
+       ::= { radiusAccServerExtEntry 1 }
+
+
+radiusAccServerInetAddressType OBJECT-TYPE
+       SYNTAX     InetAddressType
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+             "The type of address format used for the
+              radiusAccServerInetAddress object."
+       ::= { radiusAccServerExtEntry 2 }
+
+
+radiusAccServerInetAddress OBJECT-TYPE
+       SYNTAX     InetAddress
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+             "The IP address of the RADIUS accounting
+              server referred to in this table entry, using
+              the version-neutral IP address format."
+              ::= { radiusAccServerExtEntry 3 }
+
+radiusAccClientServerInetPortNumber  OBJECT-TYPE
+       SYNTAX InetPortNumber ( 1..65535 )
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The UDP port the client is using to send requests
+              to this accounting server.  The value zero (0) is
+              invalid."
+       REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccServerExtEntry 4 }
+
+
+    radiusAccClientExtRoundTripTime  OBJECT-TYPE
+       SYNTAX TimeTicks
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The time interval between the most recent
+              Accounting-Response and the Accounting-Request that
+              matched it from this RADIUS accounting server."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerExtEntry 5 }
+
+-- Request/Response statistics
+--
+-- Requests = Responses + PendingRequests + ClientTimeouts
+--
+-- Responses - MalformedResponses - BadAuthenticators -
+-- UnknownTypes - PacketsDropped = Successfully received
+
+radiusAccClientExtRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              sent.  This does not include retransmissions.
+              This counter may experience a discontinuity when the
+              RADIUS Accounting Client module within the managed
+              entity is reinitialized, as indicated by the current
+              value of radiusAccClientCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 4.1"
+       ::= { radiusAccServerExtEntry 6 }
+
+    radiusAccClientExtRetransmissions OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              retransmitted to this RADIUS accounting server.
+              Retransmissions include retries where the
+              Identifier and Acct-Delay have been updated, as
+              well as those in which they remain the same.
+              This counter may experience a discontinuity when the
+              RADIUS Accounting Client module within the managed
+              entity is reinitialized, as indicated by the current
+              value of radiusAccClientCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerExtEntry 7 }
+
+radiusAccClientExtResponses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets received on the
+              accounting port from this server.  This counter
+              may experience a discontinuity when the RADIUS
+              Accounting Client module within the managed entity is
+              reinitialized, as indicated by the current value of
+              radiusAccClientCounterDiscontinuity."
+              REFERENCE "RFC 2866 section 4.2"
+       ::= { radiusAccServerExtEntry 8 }
+
+radiusAccClientExtMalformedResponses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of malformed RADIUS Accounting-Response
+              packets received from this server.  Malformed packets
+              include packets with an invalid length.  Bad
+              authenticators and unknown types are not included as
+              malformed accounting responses.  This counter may
+              experience a discontinuity when the RADIUS Accounting
+              Client module within the managed entity is
+              reinitialized, as indicated by the current
+              value of radiusAccClientCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccServerExtEntry 9 }
+
+radiusAccClientExtBadAuthenticators OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+              "The number of RADIUS Accounting-Response
+              packets that contained invalid authenticators
+              received from this server.  This counter may
+              experience a discontinuity when the RADIUS
+              Accounting Client module within the managed
+              entity is reinitialized, as indicated by the
+              current value of
+              radiusAccClientCounterDiscontinuity."
+              REFERENCE "RFC 2866 section 3"
+              ::= { radiusAccServerExtEntry 10 }
+
+radiusAccClientExtPendingRequests OBJECT-TYPE
+       SYNTAX Gauge32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              sent to this server that have not yet timed out or
+              received a response.  This variable is incremented
+              when an Accounting-Request is sent and decremented
+              due to receipt of an Accounting-Response, a timeout,
+              or a retransmission.  This counter may experience a
+              discontinuity when the RADIUS Accounting Client module
+              within the managed entity is reinitialized, as
+              indicated by the current value of
+              radiusAccClientCounterDiscontinuity."
+              REFERENCE "RFC 2866 section 2"
+              ::= { radiusAccServerExtEntry 11 }
+
+radiusAccClientExtTimeouts OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "timeouts"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of accounting timeouts to this server.
+              After a timeout, the client may retry to the same
+              server, send to a different server, or give up.
+              A retry to the same server is counted as a
+              retransmit as well as a timeout.  A send to a different
+              server is counted as an Accounting-Request as well as
+              a timeout.  This counter may experience a discontinuity
+              when the RADIUS Accounting Client module within the
+              managed entity is reinitialized, as indicated by the
+              current value of radiusAccClientCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 2"
+       ::= { radiusAccServerExtEntry  12 }
+
+radiusAccClientExtUnknownTypes OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this server on the accounting port.
+              This counter may experience a discontinuity when the
+              RADIUS Accounting Client module within the managed
+              entity is reinitialized, as indicated by the current
+              value of radiusAccClientCounterDiscontinuity."
+              REFERENCE "RFC 2866 section 4"
+       ::= { radiusAccServerExtEntry  13 }
+
+radiusAccClientExtPacketsDropped OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets that were received from
+              this server on the accounting port and dropped for some
+              other reason.  This counter may experience a
+              discontinuity when the RADIUS Accounting Client module
+              within the managed entity is reinitialized, as indicated
+              by the current value of
+              radiusAccClientCounterDiscontinuity."
+       ::= { radiusAccServerExtEntry  14 }
+
+radiusAccClientCounterDiscontinuity OBJECT-TYPE
+       SYNTAX TimeTicks
+       UNITS "centiseconds"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of centiseconds since the last
+              discontinuity in the RADIUS Accounting Client
+              counters.  A discontinuity may be the result of a
+              reinitialization of the RADIUS Accounting Client
+              module within the managed entity."
+       ::= { radiusAccServerExtEntry 15 }
+
+-- conformance information
+
+radiusAccClientMIBConformance  OBJECT IDENTIFIER
+       ::= { radiusAccClientMIB 2 }
+
+radiusAccClientMIBCompliances  OBJECT IDENTIFIER
+       ::= { radiusAccClientMIBConformance 1 }
+
+radiusAccClientMIBGroups  OBJECT IDENTIFIER
+       ::= { radiusAccClientMIBConformance 2 }
+
+
+-- units of conformance
+
+radiusAccClientMIBCompliance MODULE-COMPLIANCE
+       STATUS  deprecated
+       DESCRIPTION
+             "The compliance statement for accounting clients
+              implementing the RADIUS Accounting Client MIB.
+              Implementation of this module is for IPv4-only
+              entities, or for backwards compatibility use with
+              entities that support both IPv4 and IPv6."
+              MODULE  -- this module
+              MANDATORY-GROUPS { radiusAccClientMIBGroup }
+
+       ::= { radiusAccClientMIBCompliances 1 }
+
+
+radiusAccClientExtMIBCompliance MODULE-COMPLIANCE
+       STATUS  current
+       DESCRIPTION
+             "The compliance statement for accounting
+              clients implementing the RADIUS Accounting
+              Client IPv6 Extensions MIB.  Implementation of
+              this module is for entities that support IPv6,
+              or support IPv4 and IPv6."
+              MODULE  -- this module
+              MANDATORY-GROUPS { radiusAccClientExtMIBGroup }
+
+       OBJECT radiusAccServerInetAddressType
+       SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+       DESCRIPTION
+             "An implementation is only required to support
+              IPv4 and globally unique IPv6 addresses."
+
+       OBJECT radiusAccServerInetAddress
+       SYNTAX InetAddress ( SIZE (4|16) )
+       DESCRIPTION
+              "An implementation is only required to support
+               IPv4 and globally unique IPv6 addresses."
+
+       ::= { radiusAccClientMIBCompliances 2 }
+
+
+-- units of conformance
+
+radiusAccClientMIBGroup OBJECT-GROUP
+       OBJECTS { radiusAccClientIdentifier,
+                 radiusAccClientInvalidServerAddresses,
+                 radiusAccServerAddress,
+                 radiusAccClientServerPortNumber,
+                 radiusAccClientRoundTripTime,
+                 radiusAccClientRequests,
+                 radiusAccClientRetransmissions,
+                 radiusAccClientResponses,
+                 radiusAccClientMalformedResponses,
+                 radiusAccClientBadAuthenticators,
+                 radiusAccClientPendingRequests,
+                 radiusAccClientTimeouts,
+                 radiusAccClientUnknownTypes,
+                 radiusAccClientPacketsDropped
+              }
+       STATUS  deprecated
+       DESCRIPTION
+             "The basic collection of objects providing management of
+              RADIUS Accounting Clients."
+       ::= { radiusAccClientMIBGroups 1 }
+
+
+radiusAccClientExtMIBGroup OBJECT-GROUP
+       OBJECTS { radiusAccClientIdentifier,
+                 radiusAccClientInvalidServerAddresses,
+                 radiusAccServerInetAddressType,
+                 radiusAccServerInetAddress,
+                 radiusAccClientServerInetPortNumber,
+                 radiusAccClientExtRoundTripTime,
+                 radiusAccClientExtRequests,
+                 radiusAccClientExtRetransmissions,
+                 radiusAccClientExtResponses,
+                 radiusAccClientExtMalformedResponses,
+                 radiusAccClientExtBadAuthenticators,
+                 radiusAccClientExtPendingRequests,
+                 radiusAccClientExtTimeouts,
+                 radiusAccClientExtUnknownTypes,
+                 radiusAccClientExtPacketsDropped,
+                 radiusAccClientCounterDiscontinuity
+               }
+       STATUS  current
+       DESCRIPTION
+             "The basic collection of objects providing management of
+              RADIUS Accounting Clients."
+       ::= { radiusAccClientMIBGroups 2 }
+
+
+END

--- a/mibs/junos/mib-rfc5643.txt
+++ b/mibs/junos/mib-rfc5643.txt
@@ -1,0 +1,3945 @@
+OSPFV3-MIB DEFINITIONS ::= BEGIN
+
+    IMPORTS
+            MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, mib-2,
+            Counter32, Gauge32, Integer32, Unsigned32
+                    FROM SNMPv2-SMI
+            TEXTUAL-CONVENTION, TruthValue, RowStatus, TimeStamp
+                    FROM SNMPv2-TC
+            MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+                    FROM SNMPv2-CONF
+            InterfaceIndex
+                    FROM IF-MIB
+            InetAddressType, InetAddress, InetAddressPrefixLength,
+            InetAddressIPv6
+                    FROM INET-ADDRESS-MIB
+            Metric, BigMetric, Status,
+            HelloRange, DesignatedRouterPriority
+                    FROM OSPF-MIB;
+
+    ospfv3MIB MODULE-IDENTITY
+            LAST-UPDATED "200908130000Z"
+            ORGANIZATION "IETF OSPF Working Group"
+            CONTACT-INFO
+                "WG E-Mail: ospf@ietf.org
+                 WG Chairs: Acee Lindem
+                            acee@redback.com
+
+                            Abhay Roy
+                            akr@cisco.com
+
+                 Editors:   Dan Joyal
+                            Nortel
+                            600 Technology Park Drive
+                            Billerica, MA  01821, USA
+                            djoyal@nortel.com
+
+                            Vishwas Manral
+                            IP Infusion
+                            Almora, Uttarakhand
+                            India
+                            vishwas@ipinfusion.com"
+
+             DESCRIPTION
+                "The MIB module for OSPF version 3.
+
+                 Copyright (c) 2009 IETF Trust and the persons
+                 identified as authors of the code.  All rights
+                 reserved.
+
+                 Redistribution and use in source and binary forms, with
+                 or without modification, are permitted provided that
+                 the following conditions are met:
+
+                 - Redistributions of source code must retain the above
+                   copyright notice, this list of conditions and the
+                   following disclaimer.
+
+                - Redistributions in binary form must reproduce the
+                  above copyright notice, this list of conditions and
+                  the following disclaimer in the documentation and/or
+                  other materials provided with the distribution.
+
+                - Neither the name of Internet Society, IETF or IETF
+                  Trust, nor the names of specific contributors, may be
+                  used to endorse or promote products derived from this
+                  software without specific prior written permission.
+
+                  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+                  CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED
+                  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+                  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+                  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+                  THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+                  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+                  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+                  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+                  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+                  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+                  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+                  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+                  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+                  POSSIBILITY OF SUCH DAMAGE.
+
+                  This version of this MIB module is part of RFC 5643;
+                  see the RFC itself for full legal notices."
+
+             REVISION "200908130000Z"
+             DESCRIPTION
+                 "Initial version, published as RFC 5643"
+             ::= { mib-2 191 }
+
+    -- Textual conventions
+
+    Ospfv3UpToRefreshIntervalTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS        current
+             DESCRIPTION
+                  "The values one might be able to configure for
+                  variables bounded by the Refresh Interval."
+             REFERENCE
+                  "OSPF Version 2, Appendix B, Architectural Constants"
+             SYNTAX      Unsigned32 (1..1800)
+
+    Ospfv3DeadIntervalRangeTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS        current
+             DESCRIPTION
+                  "The range, in seconds, of dead interval value."
+             REFERENCE
+                  "OSPF for IPv6, Appendix C.3, Router Interface
+                  Parameters"
+             SYNTAX      Unsigned32 (1..'FFFF'h)
+
+    Ospfv3RouterIdTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS      current
+             DESCRIPTION
+                  "A 32-bit, unsigned integer uniquely identifying the
+                  router in the Autonomous System.  To ensure
+                  uniqueness, this may default to the value of one of
+                  the router's IPv4 host addresses if IPv4 is
+                  configured on the router."
+             REFERENCE
+                  "OSPF for IPv6, Appendix C.1, Global Parameters"
+             SYNTAX      Unsigned32 (1..'FFFFFFFF'h)
+
+    Ospfv3LsIdTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS      current
+             DESCRIPTION
+                  "A unique 32-bit identifier of the piece of the
+                  routing domain that is being described by a link
+                  state advertisement.  In contrast to OSPFv2, the
+                  Link State ID (LSID) has no addressing semantics."
+             REFERENCE
+                  "OSPF Version 2, Section 12.1.4, Link State ID"
+             SYNTAX      Unsigned32 (1..'FFFFFFFF'h)
+
+    Ospfv3AreaIdTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS      current
+             DESCRIPTION
+                  "An OSPFv3 Area Identifier.  A value of zero
+                  identifies the backbone area."
+             REFERENCE
+                  "OSPF for IPv6, Appendix C.3 Router Interface
+                  Parameters"
+             SYNTAX      Unsigned32 (0..'FFFFFFFF'h)
+
+    Ospfv3IfInstIdTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS      current
+             DESCRIPTION
+                  "An OSPFv3 Interface Instance ID."
+             REFERENCE
+                  "OSPF for IPv6, Appendix C.3, Router Interface
+                  Parameters"
+             SYNTAX      Unsigned32 (0..255)
+
+    Ospfv3LsaSequenceTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS      current
+             DESCRIPTION
+                "The sequence number field is a signed 32-bit
+                integer.  It is used to detect old and duplicate
+                link state advertisements.  The space of
+                sequence numbers is linearly ordered.  The
+                larger the sequence number, the more recent the
+                advertisement."
+             REFERENCE
+                "OSPF Version 2, Section 12.1.6, LS sequence
+                number"
+             SYNTAX      Integer32
+
+    Ospfv3LsaAgeTC ::= TEXTUAL-CONVENTION
+             DISPLAY-HINT "d"
+             STATUS      current
+             DESCRIPTION
+                "The age of the link state advertisement in
+                seconds.  The high-order bit of the LS age
+                field is considered the DoNotAge bit for
+                support of on-demand circuits."
+             REFERENCE
+                "OSPF Version 2, Section 12.1.1, LS age;
+                 Extending OSPF to Support Demand Circuits,
+                 Section 2.2, The LS age field"
+             SYNTAX      Unsigned32 (0..3600 | 32768..36368)
+
+    -- Top-level structure of MIB
+    ospfv3Notifications  OBJECT IDENTIFIER ::= { ospfv3MIB 0 }
+    ospfv3Objects        OBJECT IDENTIFIER ::= { ospfv3MIB 1 }
+    ospfv3Conformance    OBJECT IDENTIFIER ::= { ospfv3MIB 2 }
+
+    -- OSPFv3 General Variables
+
+    -- These parameters apply globally to the Router's
+    -- OSPFv3 Process.
+
+    ospfv3GeneralGroup OBJECT IDENTIFIER ::= { ospfv3Objects 1 }
+
+    ospfv3RouterId OBJECT-TYPE
+            SYNTAX         Ospfv3RouterIdTC
+            MAX-ACCESS     read-write
+            STATUS         current
+            DESCRIPTION
+                "A 32-bit unsigned integer uniquely identifying
+                the router in the Autonomous System.  To ensure
+                uniqueness, this may default to the 32-bit
+                unsigned integer representation of one of
+                the router's IPv4 interface addresses (if IPv4
+                is configured on the router).
+
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+            REFERENCE
+                  "OSPF for IPv6, Appendix C.1, Global Parameters"
+            ::= { ospfv3GeneralGroup 1 }
+
+    ospfv3AdminStatus OBJECT-TYPE
+            SYNTAX          Status
+            MAX-ACCESS      read-write
+            STATUS          current
+            DESCRIPTION
+                "The administrative status of OSPFv3 in the
+                router.  The value 'enabled' denotes that the
+                OSPFv3 Process is active on at least one
+                interface; 'disabled' disables it on all
+                interfaces.
+
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+            ::= { ospfv3GeneralGroup 2 }
+
+    ospfv3VersionNumber OBJECT-TYPE
+            SYNTAX          INTEGER { version3 (3) }
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The version number of OSPF for IPv6 is 3."
+            ::= { ospfv3GeneralGroup 3 }
+
+    ospfv3AreaBdrRtrStatus OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "A flag to denote whether this router is an area
+                border router.  The value of this object is true (1)
+                when the router is an area border router."
+            REFERENCE
+                "OSPF Version 2, Section 3, Splitting the AS into
+                Areas"
+            ::= { ospfv3GeneralGroup 4 }
+
+    ospfv3ASBdrRtrStatus OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-write
+            STATUS          current
+            DESCRIPTION
+                "A flag to note whether this router is
+                configured as an Autonomous System border router.
+
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+            REFERENCE
+                "OSPF Version 2, Section 3.3, Classification of
+                routers"
+            ::= { ospfv3GeneralGroup 5 }
+
+    ospfv3AsScopeLsaCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of AS-scope (e.g., AS-External) link state
+                advertisements in the link state database."
+            ::= { ospfv3GeneralGroup 6 }
+
+    ospfv3AsScopeLsaCksumSum OBJECT-TYPE
+            SYNTAX          Unsigned32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit unsigned sum of the LS checksums of
+                the AS-scoped link state advertisements
+                contained in the link state database.  This sum
+                can be used to determine if there has been a
+                change in a router's link state database or
+                to compare the link state database of two
+                routers."
+            ::= { ospfv3GeneralGroup 7 }
+
+    ospfv3OriginateNewLsas OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of new link state advertisements
+                that have been originated.  This number is
+                incremented each time the router originates a new
+                LSA.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3GeneralGroup 8 }
+
+    ospfv3RxNewLsas OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of link state advertisements
+                received that are determined to be new
+                instantiations.  This number does not include
+                newer instantiations of self-originated link state
+                advertisements.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3GeneralGroup 9 }
+
+    ospfv3ExtLsaCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                 "The number of External (LS type 0x4005) in the
+                 link state database."
+            ::= { ospfv3GeneralGroup 10 }
+
+    ospfv3ExtAreaLsdbLimit OBJECT-TYPE
+            SYNTAX          Integer32 (-1..'7FFFFFFF'h)
+            MAX-ACCESS      read-write
+            STATUS          current
+            DESCRIPTION
+                "The maximum number of non-default
+                AS-external-LSA entries that can be stored in the
+                link state database.  If the value is -1, then
+                there is no limit.
+
+                When the number of non-default AS-external-LSAs
+                in a router's link state database reaches
+                ospfv3ExtAreaLsdbLimit, the router enters Overflow
+                state.  The router never holds more than
+                ospfv3ExtAreaLsdbLimit non-default AS-external-LSAs
+                in its database.  ospfv3ExtAreaLsdbLimit MUST be set
+                identically in all routers attached to the OSPFv3
+                backbone and/or any regular OSPFv3 area (i.e.,
+                OSPFv3 stub areas and not-so-stubby-areas (NSSAs)
+                are excluded).
+
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+            ::= { ospfv3GeneralGroup 11 }
+
+    ospfv3ExitOverflowInterval OBJECT-TYPE
+            SYNTAX          Unsigned32
+            UNITS           "seconds"
+            MAX-ACCESS      read-write
+            STATUS          current
+            DESCRIPTION
+                "The number of seconds that, after entering
+                Overflow state, a router will attempt to leave
+                Overflow state.  This allows the router to again
+                originate non-default, AS-External-LSAs.  When
+                set to 0, the router will not leave Overflow
+                state until restarted.
+
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+            ::= { ospfv3GeneralGroup 12 }
+
+    ospfv3DemandExtensions OBJECT-TYPE
+            SYNTAX         TruthValue
+            MAX-ACCESS     read-write
+            STATUS         current
+            DESCRIPTION
+                "The router's support for demand circuits.
+                The value of this object is true (1) when
+                demand circuits are supported.
+
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+            REFERENCE
+                "OSPF Version 2; Extending OSPF to Support Demand
+                Circuits"
+            ::= { ospfv3GeneralGroup 13 }
+
+    ospfv3ReferenceBandwidth OBJECT-TYPE
+           SYNTAX       Unsigned32
+           UNITS        "kilobits per second"
+           MAX-ACCESS   read-write
+           STATUS       current
+           DESCRIPTION
+               "Reference bandwidth in kilobits per second for
+               calculating default interface metrics.  The
+               default value is 100,000 KBPS (100 MBPS).
+
+               This object is persistent, and when written, the
+               entity SHOULD save the change to non-volatile
+               storage."
+           REFERENCE
+               "OSPF Version 2, Appendix C.3, Router interface
+               parameters"
+           DEFVAL { 100000 }
+        ::= { ospfv3GeneralGroup 14 }
+
+    ospfv3RestartSupport OBJECT-TYPE
+           SYNTAX       INTEGER { none(1),
+                                  plannedOnly(2),
+                                  plannedAndUnplanned(3)
+                             }
+           MAX-ACCESS   read-write
+           STATUS       current
+           DESCRIPTION
+               "The router's support for OSPF graceful restart.
+               Options include no restart support, only planned
+               restarts, or both planned and unplanned restarts.
+
+               This object is persistent, and when written, the
+               entity SHOULD save the change to non-volatile
+               storage."
+           REFERENCE "Graceful OSPF Restart, Appendix B.1, Global
+                        Parameters (Minimum subset)"
+           ::= { ospfv3GeneralGroup 15 }
+
+    ospfv3RestartInterval OBJECT-TYPE
+           SYNTAX       Ospfv3UpToRefreshIntervalTC
+           UNITS        "seconds"
+           MAX-ACCESS   read-write
+           STATUS       current
+           DESCRIPTION
+               "Configured OSPF graceful restart timeout interval.
+
+               This object is persistent, and when written, the
+               entity SHOULD save the change to non-volatile
+               storage."
+           REFERENCE "Graceful OSPF Restart, Appendix B.1, Global
+                     Parameters (Minimum subset)"
+           DEFVAL { 120 }
+           ::= { ospfv3GeneralGroup 16 }
+
+    ospfv3RestartStrictLsaChecking OBJECT-TYPE
+          SYNTAX       TruthValue
+          MAX-ACCESS   read-write
+          STATUS       current
+          DESCRIPTION
+             "Indicates if strict LSA checking is enabled for
+             graceful restart.  A value of true (1) indicates that
+             strict LSA checking is enabled.
+
+             This object is persistent, and when written,
+             the entity SHOULD save the change to non-volatile
+             storage."
+          REFERENCE "Graceful OSPF Restart, Appendix B.2, Global
+                    Parameters (Optional)"
+          DEFVAL { true }
+          ::= { ospfv3GeneralGroup 17 }
+
+    ospfv3RestartStatus OBJECT-TYPE
+           SYNTAX       INTEGER { notRestarting(1),
+                                  plannedRestart(2),
+                                  unplannedRestart(3)
+                                }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "The current status of OSPF graceful restart capability."
+           ::= { ospfv3GeneralGroup 18 }
+
+    ospfv3RestartAge OBJECT-TYPE
+           SYNTAX       Ospfv3UpToRefreshIntervalTC
+           UNITS        "seconds"
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "Remaining time in the current OSPF graceful restart
+              interval."
+           ::= { ospfv3GeneralGroup 19 }
+
+    ospfv3RestartExitReason OBJECT-TYPE
+           SYNTAX       INTEGER { none(1),
+                                  inProgress(2),
+                                  completed(3),
+                                  timedOut(4),
+                                  topologyChanged(5)
+                                }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "Describes the outcome of the last attempt at a
+              graceful restart.
+
+              none:            no restart has yet been attempted.
+              inProgress:      a restart attempt is currently underway.
+              completed:       the last restart completed successfully.
+              timedOut:        the last restart timed out.
+              topologyChanged: the last restart was aborted due to
+                               a topology change."
+        ::= { ospfv3GeneralGroup 20 }
+
+    ospfv3NotificationEnable OBJECT-TYPE
+           SYNTAX TruthValue
+           MAX-ACCESS read-write
+           STATUS current
+           DESCRIPTION
+               "This object provides a coarse level of control
+                over the generation of OSPFv3 notifications.
+
+                If this object is set to true (1), then it enables
+                the generation of OSPFv3 notifications.  If it is
+                set to false (2), these notifications are not
+                generated.
+                This object is persistent, and when written, the
+                entity SHOULD save the change to non-volatile
+                storage."
+       ::= { ospfv3GeneralGroup 21 }
+
+   ospfv3StubRouterSupport OBJECT-TYPE
+        SYNTAX       TruthValue
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+            "The router's support for stub router functionality.  An
+            object value of true (1) indicates that stub router
+            functionality is supported."
+        REFERENCE
+            "OSPF Stub Router Advertisement"
+        ::= { ospfv3GeneralGroup 22 }
+
+    ospfv3StubRouterAdvertisement OBJECT-TYPE
+        SYNTAX       INTEGER {
+                           doNotAdvertise(1),
+                           advertise(2)
+                           }
+        MAX-ACCESS   read-write
+        STATUS       current
+        DESCRIPTION
+            "This object controls the advertisement of
+            stub LSAs by the router.  The value
+            doNotAdvertise (1) will result in the advertisement
+            of standard LSAs and is the default value.
+
+            This object is persistent, and when written,
+            the entity SHOULD save the change to non-volatile
+            storage."
+        REFERENCE
+            "OSPF Stub Router Advertisement, Section 2, Proposed
+            Solution"
+        DEFVAL { doNotAdvertise }
+        ::= { ospfv3GeneralGroup 23 }
+
+   ospfv3DiscontinuityTime OBJECT-TYPE
+       SYNTAX     TimeStamp
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+          "The value of sysUpTime on the most recent occasion
+           at which any one of this MIB's counters suffered
+           a discontinuity.
+           If no such discontinuities have occurred since the last
+           re-initialization of the local management subsystem,
+           then this object contains a zero value."
+       ::= { ospfv3GeneralGroup 24 }
+
+     ospfv3RestartTime OBJECT-TYPE
+         SYNTAX     TimeStamp
+         MAX-ACCESS read-only
+         STATUS     current
+         DESCRIPTION
+            "The value of sysUpTime on the most recent occasion
+             at which the ospfv3RestartExitReason was updated."
+         ::= { ospfv3GeneralGroup 25 }
+
+    -- The OSPFv3 Area Data Structure contains information
+    -- regarding the various areas.  The interfaces and
+    -- virtual links are configured as part of these areas.
+    -- Area 0, by definition, is the backbone area.
+
+    ospfv3AreaTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3AreaEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Information describing the configured
+                parameters and cumulative statistics of the router's
+                attached areas.  The interfaces and
+                virtual links are configured as part of these areas.
+                Area 0, by definition, is the backbone area."
+            REFERENCE
+                "OSPF Version 2, Section 6, The Area Data
+                Structure"
+            ::= { ospfv3Objects 2 }
+
+    ospfv3AreaEntry OBJECT-TYPE
+            SYNTAX          Ospfv3AreaEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Information describing the configured
+                parameters and cumulative statistics of one of the
+                router's attached areas.
+
+                The information in this table is persistent,
+                and when written, the entity SHOULD save the a
+                change to non-volatile storage."
+            INDEX           { ospfv3AreaId }
+            ::= { ospfv3AreaTable 1 }
+
+    Ospfv3AreaEntry ::= SEQUENCE {
+            ospfv3AreaId
+                    Ospfv3AreaIdTC,
+            ospfv3AreaImportAsExtern
+                    INTEGER,
+            ospfv3AreaSpfRuns
+                    Counter32,
+            ospfv3AreaBdrRtrCount
+                    Gauge32,
+            ospfv3AreaAsBdrRtrCount
+                    Gauge32,
+            ospfv3AreaScopeLsaCount
+                    Gauge32,
+            ospfv3AreaScopeLsaCksumSum
+                    Unsigned32,
+            ospfv3AreaSummary
+                    INTEGER,
+            ospfv3AreaRowStatus
+                    RowStatus,
+            ospfv3AreaStubMetric
+                    BigMetric,
+            ospfv3AreaNssaTranslatorRole
+                    INTEGER,
+            ospfv3AreaNssaTranslatorState
+                    INTEGER,
+            ospfv3AreaNssaTranslatorStabInterval
+                    Unsigned32,
+            ospfv3AreaNssaTranslatorEvents
+                    Counter32,
+            ospfv3AreaStubMetricType
+                    INTEGER,
+            ospfv3AreaTEEnabled
+                    TruthValue
+            }
+
+    ospfv3AreaId OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A 32-bit unsigned integer uniquely identifying an area.
+                Area ID 0 is used for the OSPFv3 backbone."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            ::= { ospfv3AreaEntry 1 }
+
+    ospfv3AreaImportAsExtern OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            importExternal(1),   -- normal area
+                            importNoExternal(2), -- stub area
+                            importNssa(3)        -- not-so-stubby-area
+                            }
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "Indicates whether an area is a stub area, NSSA, or
+                standard area.  AS-scope LSAs are not imported into stub
+                areas or NSSAs.  NSSAs import AS-External data as NSSA
+                LSAs that have Area-scope."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            DEFVAL { importExternal }
+            ::= { ospfv3AreaEntry 2 }
+
+    ospfv3AreaSpfRuns OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of times that the intra-area route
+                table has been calculated using this area's
+                link state database.  This is typically done
+                using Dijkstra's algorithm.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3AreaEntry 3 }
+
+    ospfv3AreaBdrRtrCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The total number of area border routers
+                reachable within this area.  This is initially zero,
+                and is calculated in each Shortest Path First (SPF)
+                pass."
+            DEFVAL { 0 }
+            ::= { ospfv3AreaEntry 4 }
+
+    ospfv3AreaAsBdrRtrCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The total number of Autonomous System border
+                routers reachable within this area.  This is
+                initially zero, and is calculated in each SPF
+                pass."
+            DEFVAL { 0 }
+            ::= { ospfv3AreaEntry 5 }
+
+    ospfv3AreaScopeLsaCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The total number of Area-scope link state
+                advertisements in this area's link state
+                database."
+             DEFVAL { 0 }
+            ::= { ospfv3AreaEntry 6 }
+
+    ospfv3AreaScopeLsaCksumSum OBJECT-TYPE
+            SYNTAX          Unsigned32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit unsigned sum of the Area-scope link state
+                advertisements' LS checksums contained in this
+                area's link state database.  The sum can be used
+                to determine if there has been a change in a
+                router's link state database or to compare the
+                link state database of two routers."
+            ::= { ospfv3AreaEntry 7 }
+
+    ospfv3AreaSummary OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            noAreaSummary(1),
+                            sendAreaSummary(2)
+                            }
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The variable ospfv3AreaSummary controls the
+                import of Inter-Area LSAs into stub and
+                NSSA areas.  It has no effect on other areas.
+                If it is noAreaSummary, the router will neither
+                originate nor propagate Inter-Area LSAs into the
+                stub or NSSA area.  It will only advertise a
+                default route.
+
+                If it is sendAreaSummary, the router will both
+                summarize and propagate Inter-Area LSAs."
+            DEFVAL   { sendAreaSummary }
+            ::= { ospfv3AreaEntry 8 }
+
+    ospfv3AreaRowStatus OBJECT-TYPE
+            SYNTAX          RowStatus
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This object permits management of the table by
+                facilitating actions such as row creation,
+                construction, and destruction.
+
+                The value of this object has no effect on
+                whether other objects in this conceptual row can be
+                modified."
+            ::= { ospfv3AreaEntry 9 }
+
+    ospfv3AreaStubMetric OBJECT-TYPE
+            SYNTAX          BigMetric
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The metric value advertised for the default route
+                into stub and NSSA areas.  By default, this equals the
+                least metric among the interfaces to other areas."
+            ::= { ospfv3AreaEntry 10 }
+
+    ospfv3AreaNssaTranslatorRole OBJECT-TYPE
+            SYNTAX          INTEGER { always(1), candidate(2) }
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "Indicates an NSSA border router's policy to
+                perform NSSA translation of NSSA-LSAs into
+                AS-External-LSAs."
+            DEFVAL { candidate }
+            ::= { ospfv3AreaEntry 11 }
+
+    ospfv3AreaNssaTranslatorState OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            enabled(1),
+                            elected(2),
+                            disabled(3)
+                            }
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                 "Indicates if and how an NSSA border router is
+                 performing NSSA translation of NSSA-LSAs into
+                 AS-External-LSAs.  When this object is set to
+                 'enabled', the NSSA border router's
+                 ospfv3AreaNssaTranslatorRole has been set to 'always'.
+                 When this object is set to 'elected', a candidate
+                 NSSA border router is translating NSSA-LSAs into
+                 AS-External-LSAs.  When this object is set to
+                 'disabled', a candidate NSSA Border router is NOT
+                 translating NSSA-LSAs into AS-External-LSAs."
+            ::= { ospfv3AreaEntry 12 }
+
+    ospfv3AreaNssaTranslatorStabInterval OBJECT-TYPE
+            SYNTAX          Unsigned32
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The stability interval defined as the number of
+                seconds after an elected translator determines its
+                services are no longer required that it should
+                continue to perform its translation duties."
+            DEFVAL { 40 }
+            ::= { ospfv3AreaEntry 13 }
+
+    ospfv3AreaNssaTranslatorEvents OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "Indicates the number of Translator state changes
+                that have occurred since the last start-up of the
+                OSPFv3 routing process.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3AreaEntry 14 }
+
+    ospfv3AreaStubMetricType OBJECT-TYPE
+            SYNTAX       INTEGER {
+                            ospfv3Metric(1),   -- OSPF Metric
+                            comparableCost(2), -- external type 1
+                            nonComparable(3)   -- external type 2
+                            }
+            MAX-ACCESS   read-create
+            STATUS       current
+            DESCRIPTION
+                "This variable assigns the type of metric
+                advertised as a default route."
+            DEFVAL { ospfv3Metric }
+            ::= { ospfv3AreaEntry 15 }
+
+    ospfv3AreaTEEnabled OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                   "Indicates whether or not traffic engineering
+                   is enabled in the area.  The object is set
+                   to the value true (1) to enable traffic engineering.
+                   Traffic engineering is disabled by default."
+            DEFVAL { false }
+            ::= { ospfv3AreaEntry 16 }
+
+    -- OSPFv3 AS-Scope Link State Database
+
+    ospfv3AsLsdbTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3AsLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 Process's AS-scope link state database
+                (LSDB).  The LSDB contains the AS-scope link state
+                advertisements from throughout the areas that the
+                device is attached to."
+            ::= { ospfv3Objects 3 }
+
+    ospfv3AsLsdbEntry OBJECT-TYPE
+            SYNTAX          Ospfv3AsLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A single AS-scope link state advertisement."
+            INDEX           { ospfv3AsLsdbType,
+                              ospfv3AsLsdbRouterId,
+                              ospfv3AsLsdbLsid }
+            ::= { ospfv3AsLsdbTable 1 }
+
+    Ospfv3AsLsdbEntry ::= SEQUENCE {
+            ospfv3AsLsdbType
+                    Unsigned32,
+            ospfv3AsLsdbRouterId
+                    Ospfv3RouterIdTC,
+            ospfv3AsLsdbLsid
+                    Ospfv3LsIdTC,
+            ospfv3AsLsdbSequence
+                    Ospfv3LsaSequenceTC,
+            ospfv3AsLsdbAge
+                    Ospfv3LsaAgeTC,
+            ospfv3AsLsdbChecksum
+                    Integer32,
+            ospfv3AsLsdbAdvertisement
+                    OCTET STRING,
+            ospfv3AsLsdbTypeKnown
+                    TruthValue
+            }
+
+    ospfv3AsLsdbType OBJECT-TYPE
+            SYNTAX          Unsigned32(0..'FFFFFFFF'h)
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The type of the link state advertisement.
+                Each link state type has a separate
+                advertisement format.  AS-scope LSAs not recognized
+                by the router may be stored in the database."
+            ::= { ospfv3AsLsdbEntry 1 }
+
+    ospfv3AsLsdbRouterId OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit number that uniquely identifies the
+                originating router in the Autonomous System."
+            REFERENCE
+                "OSPF Version 2, Appendix C.1, Global parameters"
+            ::= { ospfv3AsLsdbEntry 2 }
+
+    ospfv3AsLsdbLsid OBJECT-TYPE
+            SYNTAX          Ospfv3LsIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Link State ID is an LS type-specific field
+                containing a unique identifier;
+                it identifies the piece of the routing domain
+                that is being described by the advertisement.
+                In contrast to OSPFv2, the LSID has no
+                addressing semantics."
+            ::= { ospfv3AsLsdbEntry 3 }
+
+    -- Note that the OSPF sequence number is a 32-bit signed
+    -- integer.  It starts with the value '80000001'h
+    -- or -'7FFFFFFF'h, and increments until '7FFFFFFF'h.
+    -- Thus, a typical sequence number will be very negative.
+
+    ospfv3AsLsdbSequence OBJECT-TYPE
+            SYNTAX          Ospfv3LsaSequenceTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The sequence number field is a signed 32-bit
+                integer.  It is used to detect old and duplicate
+                link state advertisements.  The space of
+                sequence numbers is linearly ordered.  The
+                larger the sequence number, the more recent the
+                advertisement."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.6, LS sequence
+                number"
+            ::= { ospfv3AsLsdbEntry 4 }
+
+    ospfv3AsLsdbAge OBJECT-TYPE
+            SYNTAX          Ospfv3LsaAgeTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the age of the link state
+                advertisement in seconds.  The high-order bit
+                of the LS age field is considered the DoNotAge
+                bit for support of on-demand circuits."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.1, LS age;
+                 Extending OSPF to Support Demand Circuits,
+                 Section 2.2, The LS age field."
+            ::= { ospfv3AsLsdbEntry 5 }
+
+    ospfv3AsLsdbChecksum OBJECT-TYPE
+            SYNTAX          Integer32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the checksum of the complete
+                contents of the advertisement, excepting the
+                age field.  The age field is excepted so that
+                an advertisement's age can be incremented
+                without updating the checksum.  The checksum
+                used is the same that is used for ISO
+                connectionless datagrams; it is commonly
+                referred to as the Fletcher checksum."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.7, LS checksum"
+            ::= { ospfv3AsLsdbEntry 6 }
+
+    ospfv3AsLsdbAdvertisement OBJECT-TYPE
+            SYNTAX          OCTET STRING (SIZE (1..65535))
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The entire link state advertisement, including
+                its header."
+            ::= { ospfv3AsLsdbEntry 7 }
+
+    ospfv3AsLsdbTypeKnown OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The value true (1) indicates that the LSA type
+                is recognized by this router."
+            ::= { ospfv3AsLsdbEntry 8 }
+
+     --  OSPFv3 Area-Scope Link State Database
+
+    ospfv3AreaLsdbTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3AreaLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 Process's Area-scope LSDB.
+                The LSDB contains the Area-scope link state
+                advertisements from throughout the area that the
+                device is attached to."
+            ::= { ospfv3Objects 4 }
+
+    ospfv3AreaLsdbEntry OBJECT-TYPE
+            SYNTAX          Ospfv3AreaLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A single Area-scope link state advertisement."
+            INDEX           { ospfv3AreaLsdbAreaId,
+                              ospfv3AreaLsdbType,
+                              ospfv3AreaLsdbRouterId,
+                              ospfv3AreaLsdbLsid }
+            ::= { ospfv3AreaLsdbTable 1 }
+
+    Ospfv3AreaLsdbEntry ::= SEQUENCE {
+            ospfv3AreaLsdbAreaId
+                    Ospfv3AreaIdTC,
+            ospfv3AreaLsdbType
+                    Unsigned32,
+            ospfv3AreaLsdbRouterId
+                    Ospfv3RouterIdTC,
+            ospfv3AreaLsdbLsid
+                    Ospfv3LsIdTC,
+            ospfv3AreaLsdbSequence
+                    Ospfv3LsaSequenceTC,
+            ospfv3AreaLsdbAge
+                    Ospfv3LsaAgeTC,
+            ospfv3AreaLsdbChecksum
+                    Integer32,
+            ospfv3AreaLsdbAdvertisement
+                    OCTET STRING,
+            ospfv3AreaLsdbTypeKnown
+                    TruthValue
+            }
+
+    ospfv3AreaLsdbAreaId OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit identifier of the Area from which the
+                LSA was received."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            ::= { ospfv3AreaLsdbEntry 1 }
+
+    ospfv3AreaLsdbType OBJECT-TYPE
+            SYNTAX          Unsigned32(0..'FFFFFFFF'h)
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The type of the link state advertisement.
+                Each link state type has a separate
+                advertisement format.  Area-scope LSAs unrecognized
+                by the router are also stored in this database."
+            ::= { ospfv3AreaLsdbEntry 2 }
+
+    ospfv3AreaLsdbRouterId OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit number that uniquely identifies the
+                originating router in the Autonomous System."
+            REFERENCE
+                "OSPF Version 2, Appendix C.1, Global parameters"
+            ::= { ospfv3AreaLsdbEntry 3 }
+
+    ospfv3AreaLsdbLsid OBJECT-TYPE
+            SYNTAX          Ospfv3LsIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Link State ID is an LS type-specific field
+                containing a unique identifier;
+                it identifies the piece of the routing domain
+                that is being described by the advertisement.
+                In contrast to OSPFv2, the LSID has no
+                addressing semantics."
+            ::= { ospfv3AreaLsdbEntry 4 }
+
+    -- Note that the OSPF sequence number is a 32-bit signed
+    -- integer.  It starts with the value '80000001'h
+    -- or -'7FFFFFFF'h, and increments until '7FFFFFFF'h.
+    -- Thus, a typical sequence number will be very negative.
+
+    ospfv3AreaLsdbSequence OBJECT-TYPE
+            SYNTAX          Ospfv3LsaSequenceTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The sequence number field is a signed 32-bit
+                integer.  It is used to detect old and
+                duplicate link state advertisements.  The space
+                of sequence numbers is linearly ordered.  The
+                larger the sequence number, the more recent the
+                advertisement."
+
+            REFERENCE
+                "OSPF Version 2, Section 12.1.6, LS sequence
+                number"
+            ::= { ospfv3AreaLsdbEntry 5 }
+
+    ospfv3AreaLsdbAge OBJECT-TYPE
+            SYNTAX          Ospfv3LsaAgeTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the age of the link state
+                advertisement in seconds.  The high-order bit
+                of the LS age field is considered the DoNotAge
+                bit for support of on-demand circuits."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.1, LS age;
+                 Extending OSPF to Support Demand Circuits,
+                 Section 2.2, The LS age field."
+            ::= { ospfv3AreaLsdbEntry 6 }
+
+    ospfv3AreaLsdbChecksum OBJECT-TYPE
+            SYNTAX          Integer32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the checksum of the complete
+                contents of the advertisement, excepting the
+                age field.  The age field is excepted so that
+                an advertisement's age can be incremented
+                without updating the checksum.  The checksum
+                used is the same that is used for ISO
+                connectionless datagrams; it is commonly
+                referred to as the Fletcher checksum."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.7, LS checksum"
+            ::= { ospfv3AreaLsdbEntry 7 }
+
+    ospfv3AreaLsdbAdvertisement OBJECT-TYPE
+            SYNTAX          OCTET STRING (SIZE (1..65535))
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The entire link state advertisement, including
+                its header."
+            ::= { ospfv3AreaLsdbEntry 8 }
+
+    ospfv3AreaLsdbTypeKnown OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The value true (1) indicates that the LSA type is
+                recognized by this router."
+            ::= { ospfv3AreaLsdbEntry 9 }
+
+    -- OSPFv3 Link-Scope Link State Database, for non-virtual interfaces
+
+    ospfv3LinkLsdbTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3LinkLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 Process's Link-scope LSDB for non-virtual
+                interfaces.  The LSDB contains the Link-scope link
+                state advertisements from the interfaces that the
+                device is attached to."
+            ::= { ospfv3Objects 5 }
+
+    ospfv3LinkLsdbEntry OBJECT-TYPE
+            SYNTAX          Ospfv3LinkLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A single Link-scope link state advertisement."
+            INDEX           { ospfv3LinkLsdbIfIndex,
+                              ospfv3LinkLsdbIfInstId,
+                              ospfv3LinkLsdbType,
+                              ospfv3LinkLsdbRouterId,
+                              ospfv3LinkLsdbLsid }
+            ::= { ospfv3LinkLsdbTable 1 }
+
+    Ospfv3LinkLsdbEntry ::= SEQUENCE {
+            ospfv3LinkLsdbIfIndex
+                    InterfaceIndex,
+            ospfv3LinkLsdbIfInstId
+                    Ospfv3IfInstIdTC,
+            ospfv3LinkLsdbType
+                    Unsigned32,
+            ospfv3LinkLsdbRouterId
+                    Ospfv3RouterIdTC,
+            ospfv3LinkLsdbLsid
+                    Ospfv3LsIdTC,
+            ospfv3LinkLsdbSequence
+                    Ospfv3LsaSequenceTC,
+            ospfv3LinkLsdbAge
+                    Ospfv3LsaAgeTC,
+            ospfv3LinkLsdbChecksum
+                    Integer32,
+            ospfv3LinkLsdbAdvertisement
+                    OCTET STRING,
+            ospfv3LinkLsdbTypeKnown
+                    TruthValue
+            }
+
+    ospfv3LinkLsdbIfIndex OBJECT-TYPE
+            SYNTAX         InterfaceIndex
+            MAX-ACCESS     not-accessible
+            STATUS         current
+            DESCRIPTION
+                "The identifier of the link from which the LSA
+                was received."
+            ::= { ospfv3LinkLsdbEntry 1 }
+
+    ospfv3LinkLsdbIfInstId OBJECT-TYPE
+            SYNTAX         Ospfv3IfInstIdTC
+            MAX-ACCESS     not-accessible
+            STATUS         current
+            DESCRIPTION
+                "The identifier of the interface instance from
+                which the LSA was received."
+            ::= { ospfv3LinkLsdbEntry 2 }
+
+    ospfv3LinkLsdbType OBJECT-TYPE
+            SYNTAX          Unsigned32(0..'FFFFFFFF'h)
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The type of the link state advertisement.
+                Each link state type has a separate
+                advertisement format.  Link-scope LSAs unrecognized
+                by the router are also stored in this database."
+            ::= { ospfv3LinkLsdbEntry 3 }
+
+    ospfv3LinkLsdbRouterId OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit number that uniquely identifies the
+                originating router in the Autonomous System."
+            REFERENCE
+                "OSPF Version 2, Appendix C.1, Global parameters"
+            ::= { ospfv3LinkLsdbEntry 4 }
+
+    ospfv3LinkLsdbLsid OBJECT-TYPE
+            SYNTAX        Ospfv3LsIdTC
+            MAX-ACCESS    not-accessible
+            STATUS        current
+            DESCRIPTION
+                "The Link State ID is an LS type-specific field
+                containing a unique identifier;
+                it identifies the piece of the routing domain
+                that is being described by the advertisement.
+                In contrast to OSPFv2, the LSID has no
+                addressing semantics.  However, in OSPFv3
+                the Link State ID always contains the flooding
+                scope of the LSA."
+            ::= { ospfv3LinkLsdbEntry 5 }
+
+    -- Note that the OSPF sequence number is a 32-bit signed
+    -- integer.  It starts with the value '80000001'h
+    -- or -'7FFFFFFF'h, and increments until '7FFFFFFF'h.
+    -- Thus, a typical sequence number will be very negative.
+
+    ospfv3LinkLsdbSequence OBJECT-TYPE
+            SYNTAX          Ospfv3LsaSequenceTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The sequence number field is a signed 32-bit
+                integer.  It is used to detect old and duplicate
+                link state advertisements.  The space of
+                sequence numbers is linearly ordered.  The
+                larger the sequence number, the more recent the
+                advertisement."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.6, LS sequence
+                number"
+            ::= { ospfv3LinkLsdbEntry 6 }
+
+    ospfv3LinkLsdbAge OBJECT-TYPE
+            SYNTAX          Ospfv3LsaAgeTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the age of the link state
+                advertisement in seconds.  The high-order bit
+                of the LS age field is considered the DoNotAge
+                bit for support of on-demand circuits."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.1, LS age;
+                 Extending OSPF to Support Demand Circuits,
+                 Section 2.2, The LS age field."
+            ::= { ospfv3LinkLsdbEntry 7 }
+
+    ospfv3LinkLsdbChecksum OBJECT-TYPE
+            SYNTAX          Integer32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the checksum of the complete
+                contents of the advertisement, excepting the
+                age field.  The age field is excepted so that
+                an advertisement's age can be incremented
+                without updating the checksum.  The checksum
+                used is the same that is used for ISO
+                connectionless datagrams; it is commonly
+                referred to as the Fletcher checksum."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.7, LS checksum"
+            ::= { ospfv3LinkLsdbEntry 8 }
+
+    ospfv3LinkLsdbAdvertisement OBJECT-TYPE
+            SYNTAX          OCTET STRING (SIZE (1..65535))
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The entire link state advertisement, including
+                its header."
+            ::= { ospfv3LinkLsdbEntry 9 }
+
+    ospfv3LinkLsdbTypeKnown OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The value true (1) indicates that the LSA type is
+                recognized by this router."
+            ::= { ospfv3LinkLsdbEntry 10 }
+
+    -- OSPF Host Table
+
+    ospfv3HostTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3HostEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Host/Metric Table indicates what hosts are
+                directly attached to the router and their
+                corresponding metrics."
+            REFERENCE
+                "OSPF Version 2, Appendix C.7, Host route
+                parameters"
+            ::= { ospfv3Objects 6 }
+
+    ospfv3HostEntry OBJECT-TYPE
+            SYNTAX          Ospfv3HostEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A metric to be advertised when a given host is
+                reachable.
+
+                The information in this table is persistent, and
+                when written, the entity SHOULD save the change
+                to non-volatile storage."
+            INDEX           { ospfv3HostAddressType,
+                              ospfv3HostAddress }
+            ::= { ospfv3HostTable 1 }
+
+    Ospfv3HostEntry ::= SEQUENCE {
+            ospfv3HostAddressType
+                    InetAddressType,
+            ospfv3HostAddress
+                    InetAddress,
+            ospfv3HostMetric
+                    Metric,
+            ospfv3HostRowStatus
+                    RowStatus,
+            ospfv3HostAreaID
+                    Ospfv3AreaIdTC
+            }
+
+    ospfv3HostAddressType OBJECT-TYPE
+            SYNTAX          InetAddressType
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The address type of ospfv3HostAddress.  Only IPv6
+                global address type is expected."
+            REFERENCE
+                "OSPF Version 2, Appendix C.7, Host route
+                parameters"
+            ::= { ospfv3HostEntry 1 }
+
+    ospfv3HostAddress OBJECT-TYPE
+            SYNTAX          InetAddress
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The IPv6 address of the host.  Must be an
+                IPv6 global address."
+            REFERENCE
+                "OSPF Version 2, Appendix C.7, Host route
+                parameters"
+            ::= { ospfv3HostEntry 2 }
+
+    ospfv3HostMetric OBJECT-TYPE
+            SYNTAX          Metric
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The metric to be advertised."
+            REFERENCE
+                "OSPF Version 2, Appendix C.7, Host route
+                parameters"
+            ::= { ospfv3HostEntry 3 }
+
+    ospfv3HostRowStatus OBJECT-TYPE
+            SYNTAX          RowStatus
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This object permits management of the table by
+                facilitating actions such as row creation,
+                construction, and destruction.
+
+                The value of this object has no effect on
+                whether other objects in this conceptual row can be
+                modified."
+            ::= { ospfv3HostEntry 4 }
+
+    ospfv3HostAreaID OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The Area the host entry is to be found within.
+                By default, the area for the subsuming OSPFv3
+                interface, or Area 0 if there is no subsuming
+                interface."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            ::= { ospfv3HostEntry 5 }
+
+    -- OSPFv3 Interface Table
+
+    ospfv3IfTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3IfEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 Interface Table describes the
+                interfaces from the viewpoint of OSPFv3."
+            REFERENCE
+                "OSPF for IPv6, Appendix C.3, Router Interface
+                Parameters"
+            ::= { ospfv3Objects 7 }
+
+    ospfv3IfEntry OBJECT-TYPE
+            SYNTAX          Ospfv3IfEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 Interface Entry describes one
+                interface from the viewpoint of OSPFv3.
+
+                The information in this table is persistent,
+                and when written, the entity SHOULD save the
+                change to non-volatile storage."
+            INDEX           { ospfv3IfIndex,
+                              ospfv3IfInstId }
+            ::= { ospfv3IfTable 1 }
+
+    Ospfv3IfEntry ::= SEQUENCE {
+            ospfv3IfIndex
+                    InterfaceIndex,
+            ospfv3IfInstId
+                    Ospfv3IfInstIdTC,
+            ospfv3IfAreaId
+                    Ospfv3AreaIdTC,
+            ospfv3IfType
+                    INTEGER,
+            ospfv3IfAdminStatus
+                    Status,
+            ospfv3IfRtrPriority
+                    DesignatedRouterPriority,
+            ospfv3IfTransitDelay
+                    Ospfv3UpToRefreshIntervalTC,
+            ospfv3IfRetransInterval
+                    Ospfv3UpToRefreshIntervalTC,
+            ospfv3IfHelloInterval
+                    HelloRange,
+            ospfv3IfRtrDeadInterval
+                     Ospfv3DeadIntervalRangeTC,
+            ospfv3IfPollInterval
+                    Unsigned32,
+            ospfv3IfState
+                    INTEGER,
+            ospfv3IfDesignatedRouter
+                    Ospfv3RouterIdTC,
+            ospfv3IfBackupDesignatedRouter
+                    Ospfv3RouterIdTC,
+            ospfv3IfEvents
+                    Counter32,
+            ospfv3IfRowStatus
+                    RowStatus,
+            ospfv3IfDemand
+                    TruthValue,
+            ospfv3IfMetricValue
+                    Metric,
+            ospfv3IfLinkScopeLsaCount
+                    Gauge32,
+            ospfv3IfLinkLsaCksumSum
+                    Unsigned32,
+            ospfv3IfDemandNbrProbe
+                    TruthValue,
+            ospfv3IfDemandNbrProbeRetransLimit
+                    Unsigned32,
+            ospfv3IfDemandNbrProbeInterval
+                    Unsigned32,
+            ospfv3IfTEDisabled
+                    TruthValue,
+            ospfv3IfLinkLSASuppression
+                    TruthValue
+            }
+
+    ospfv3IfIndex OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The interface index of this OSPFv3 interface.
+                It corresponds to the interface index of the
+                IPv6 interface on which OSPFv3 is configured."
+            ::= { ospfv3IfEntry 1 }
+
+    ospfv3IfInstId OBJECT-TYPE
+            SYNTAX          Ospfv3IfInstIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Enables multiple interface instances of OSPFv3
+                to be run over a single link.  Each interface
+                instance would be assigned a separate ID.  This ID
+                has local link significance only."
+            ::= { ospfv3IfEntry 2 }
+
+    ospfv3IfAreaId OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "A 32-bit integer uniquely identifying the area
+                to which the interface connects.  Area ID
+                0 is used for the OSPFv3 backbone."
+            DEFVAL          { 0 }
+            ::= { ospfv3IfEntry 3 }
+
+    ospfv3IfType OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            broadcast(1),
+                            nbma(2),
+                            pointToPoint(3),
+                            pointToMultipoint(5)
+                            }
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 interface type."
+            ::= { ospfv3IfEntry 4 }
+
+    ospfv3IfAdminStatus OBJECT-TYPE
+            SYNTAX          Status
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 interface's administrative status.
+                The value formed on the interface; the interface
+                will be advertised as an internal route to some
+                area.  The value 'disabled' denotes that the
+                interface is external to OSPFv3.
+                Note that a value of 'disabled' for the object
+                ospfv3AdminStatus will override a value of
+                'enabled' for the interface."
+            DEFVAL          { enabled }
+            ::= { ospfv3IfEntry 5 }
+
+    ospfv3IfRtrPriority OBJECT-TYPE
+            SYNTAX          DesignatedRouterPriority
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The priority of this interface.  Used in
+                multi-access networks, this field is used in
+                the designated-router election algorithm.  The
+                value 0 signifies that the router is not
+                eligible to become the Designated Router on this
+                particular network.  In the event of a tie in
+                this value, routers will use their Router ID as
+                a tie breaker."
+            DEFVAL          { 1 }
+            ::= { ospfv3IfEntry 6 }
+
+    ospfv3IfTransitDelay OBJECT-TYPE
+            SYNTAX          Ospfv3UpToRefreshIntervalTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The estimated number of seconds it takes to transmit
+                a Link State Update packet over this interface.  LSAs
+                contained in the update packet must have their age
+                incremented by this amount before transmission.  This
+                value should take into account the transmission and
+                propagation delays of the interface."
+            REFERENCE
+                "OSPF for IPv6, Appendix C.3, Router Interface
+                Parameters."
+            DEFVAL          { 1 }
+            ::= { ospfv3IfEntry 7 }
+
+    ospfv3IfRetransInterval OBJECT-TYPE
+            SYNTAX          Ospfv3UpToRefreshIntervalTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The number of seconds between link state
+                advertisement retransmissions for adjacencies
+                belonging to this interface.  This value is
+                also used when retransmitting database
+                description and Link State Request packets."
+            DEFVAL          { 5 }
+            ::= { ospfv3IfEntry 8 }
+
+    ospfv3IfHelloInterval OBJECT-TYPE
+            SYNTAX          HelloRange
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The length of time, in seconds, between the
+                Hello packets that the router sends on the
+                interface.  This value must be the same for all
+                routers attached to a common network."
+            DEFVAL          { 10 }
+            ::= { ospfv3IfEntry 9 }
+
+    ospfv3IfRtrDeadInterval OBJECT-TYPE
+            SYNTAX          Ospfv3DeadIntervalRangeTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The number of seconds that a router's Hello
+                packets have not been seen before its
+                neighbors declare the router down on the interface.
+                This should be some multiple of the Hello interval.
+                This value must be the same for all routers attached
+                to a common network."
+            DEFVAL          { 40 }
+            ::= { ospfv3IfEntry 10 }
+
+    ospfv3IfPollInterval OBJECT-TYPE
+            SYNTAX          Unsigned32
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The larger time interval, in seconds, between
+                the Hello packets sent to an inactive,
+                non-broadcast multi-access neighbor."
+            DEFVAL          { 120 }
+            ::= { ospfv3IfEntry 11 }
+    ospfv3IfState OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            down(1),
+                            loopback(2),
+                            waiting(3),
+                            pointToPoint(4),
+                            designatedRouter(5),
+                            backupDesignatedRouter(6),
+                            otherDesignatedRouter(7),
+                            standby(8)
+                            }
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 interface state.  An interface may be
+                in standby state if there are multiple interfaces
+                on the link and another interface is active.  The
+                interface may be in Down state if the underlying
+                IPv6 interface is down or if the admin status is
+                'disabled' either globally or for the interface."
+            ::= { ospfv3IfEntry 12 }
+
+    ospfv3IfDesignatedRouter OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The Router ID of the Designated Router."
+            ::= { ospfv3IfEntry 13 }
+
+    ospfv3IfBackupDesignatedRouter OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The Router ID of the Backup Designated
+                Router."
+            ::= { ospfv3IfEntry 14 }
+
+    ospfv3IfEvents OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of times this OSPFv3 interface has
+                changed its state or an error has occurred.
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3IfEntry 15 }
+
+     ospfv3IfRowStatus OBJECT-TYPE
+            SYNTAX          RowStatus
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This object permits management of the table by
+                facilitating actions such as row creation,
+                construction, and destruction.
+
+                The value of this object has no effect on
+                whether other objects in this conceptual row can be
+                modified."
+            ::= { ospfv3IfEntry 16 }
+
+    ospfv3IfDemand OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "Indicates whether Demand OSPFv3 procedures
+                (Hello suppression to FULL neighbors and
+                setting the DoNotAge flag on propagated LSAs)
+                should be performed on this interface."
+            DEFVAL { false }
+            ::= { ospfv3IfEntry 17 }
+
+    ospfv3IfMetricValue OBJECT-TYPE
+            SYNTAX          Metric
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The metric assigned to this interface.
+                 The default value of the metric is
+                 'Reference Bandwidth / ifSpeed'.  The value
+                 of the reference bandwidth can be set
+                 in the ospfv3ReferenceBandwidth object."
+            ::= { ospfv3IfEntry 18 }
+
+     ospfv3IfLinkScopeLsaCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The total number of Link-scope link state
+                advertisements in this link's link state
+                database."
+            ::= { ospfv3IfEntry 19 }
+
+     ospfv3IfLinkLsaCksumSum OBJECT-TYPE
+            SYNTAX          Unsigned32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit unsigned sum of the Link-scope link state
+                advertisements' LS checksums contained in this
+                link's link state database.  The sum can be used
+                to determine if there has been a change in a
+                router's link state database or to compare the
+                link state database of two routers."
+            ::= { ospfv3IfEntry 20 }
+
+    ospfv3IfDemandNbrProbe OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                   "Indicates whether or not neighbor probing is
+                   enabled to determine whether or not the neighbor
+                   is inactive.  Neighbor probing is disabled by
+                   default."
+            DEFVAL { false }
+            ::= { ospfv3IfEntry 21 }
+
+   ospfv3IfDemandNbrProbeRetransLimit OBJECT-TYPE
+           SYNTAX       Unsigned32
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+              "The number of consecutive LSA retransmissions before
+              the neighbor is deemed inactive and the neighbor
+              adjacency is brought down."
+           DEFVAL          { 10 }
+           ::= { ospfv3IfEntry 22}
+
+   ospfv3IfDemandNbrProbeInterval OBJECT-TYPE
+           SYNTAX       Unsigned32
+           UNITS        "seconds"
+           MAX-ACCESS   read-create
+           STATUS       current
+           DESCRIPTION
+              "Defines how often the neighbor will be probed."
+           DEFVAL          { 120 }
+           ::= { ospfv3IfEntry 23 }
+
+    ospfv3IfTEDisabled OBJECT-TYPE
+           SYNTAX          TruthValue
+           MAX-ACCESS      read-create
+           STATUS          current
+           DESCRIPTION
+              "Indicates whether or not traffic engineering
+              is disabled on the interface when traffic
+              engineering is enabled in the area where the
+              interface is attached.  The object is set
+              to the value true (1) to disable traffic engineering
+              on the interface.  Traffic engineering is enabled
+              by default on the interface when traffic engineering
+              is enabled in the area where the interface is
+              attached."
+           DEFVAL { false }
+           ::= { ospfv3IfEntry 24 }
+
+    ospfv3IfLinkLSASuppression OBJECT-TYPE
+           SYNTAX          TruthValue
+           MAX-ACCESS      read-create
+           STATUS          current
+           DESCRIPTION
+              "Specifies whether or not link LSA origination is
+              suppressed for broadcast or NBMA interface types.
+              The object is set to value true (1) to suppress
+              the origination."
+           REFERENCE
+                "OSPF for IPv6, Appendix C.3, Router Interface
+                    Parameters"
+           DEFVAL { false }
+           ::= { ospfv3IfEntry 25 }
+
+    -- OSPFv3 Virtual Interface Table
+
+    ospfv3VirtIfTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3VirtIfEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Information about this router's virtual
+                interfaces that the OSPFv3 Process is configured
+                to carry on."
+            REFERENCE
+                "OSPF for IPv6, Appendix C.4, Virtual Link
+                Parameters"
+            ::= { ospfv3Objects 8 }
+
+    ospfv3VirtIfEntry OBJECT-TYPE
+            SYNTAX          Ospfv3VirtIfEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Information about a single virtual interface.
+
+                The information in this table is persistent,
+                and when written, the entity SHOULD save the
+                change to non-volatile storage."
+            INDEX           { ospfv3VirtIfAreaId,
+                              ospfv3VirtIfNeighbor }
+            ::= { ospfv3VirtIfTable 1 }
+
+    Ospfv3VirtIfEntry ::= SEQUENCE {
+            ospfv3VirtIfAreaId
+                    Ospfv3AreaIdTC,
+            ospfv3VirtIfNeighbor
+                    Ospfv3RouterIdTC,
+            ospfv3VirtIfIndex
+                    InterfaceIndex,
+            ospfv3VirtIfInstId
+                    Ospfv3IfInstIdTC,
+            ospfv3VirtIfTransitDelay
+                    Ospfv3UpToRefreshIntervalTC,
+            ospfv3VirtIfRetransInterval
+                    Ospfv3UpToRefreshIntervalTC,
+            ospfv3VirtIfHelloInterval
+                    HelloRange,
+            ospfv3VirtIfRtrDeadInterval
+                    Ospfv3DeadIntervalRangeTC,
+            ospfv3VirtIfState
+                    INTEGER,
+            ospfv3VirtIfEvents
+                    Counter32,
+            ospfv3VirtIfRowStatus
+                    RowStatus,
+            ospfv3VirtIfLinkScopeLsaCount
+                    Gauge32,
+            ospfv3VirtIfLinkLsaCksumSum
+                    Unsigned32
+            }
+
+    ospfv3VirtIfAreaId OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The transit area that the virtual link
+                traverses.  By definition, this is not
+                Area 0."
+            ::= { ospfv3VirtIfEntry 1 }
+
+    ospfv3VirtIfNeighbor OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Router ID of the virtual neighbor."
+            ::= { ospfv3VirtIfEntry 2 }
+
+    ospfv3VirtIfIndex OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The local interface index assigned by the
+                OSPFv3 Process to this OSPFv3 virtual interface.
+                It is advertised in Hellos sent over the virtual
+                link and in the router's router-LSAs."
+            ::= { ospfv3VirtIfEntry 3 }
+
+    ospfv3VirtIfInstId OBJECT-TYPE
+            SYNTAX          Ospfv3IfInstIdTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The local Interface Instance ID assigned by the
+                OSPFv3 Process to this OSPFv3 virtual interface."
+            ::= { ospfv3VirtIfEntry 4 }
+
+    ospfv3VirtIfTransitDelay OBJECT-TYPE
+            SYNTAX          Ospfv3UpToRefreshIntervalTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The estimated number of seconds it takes to
+                transmit a Link State Update packet over this
+                interface."
+            DEFVAL          { 1 }
+            ::= { ospfv3VirtIfEntry 5 }
+
+    ospfv3VirtIfRetransInterval OBJECT-TYPE
+            SYNTAX          Ospfv3UpToRefreshIntervalTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The number of seconds between link state
+                advertisement retransmissions for adjacencies
+                belonging to this interface.  This value is
+                also used when retransmitting database
+                description and Link State Request packets.  This
+                value should be well over the expected
+                round-trip time."
+            DEFVAL          { 5 }
+            ::= { ospfv3VirtIfEntry 6 }
+
+    ospfv3VirtIfHelloInterval OBJECT-TYPE
+            SYNTAX          HelloRange
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The length of time, in seconds, between the
+                Hello packets that the router sends on the
+                interface.  This value must be the same for the
+                virtual neighbor."
+            DEFVAL          { 10 }
+            ::= { ospfv3VirtIfEntry 7 }
+
+    ospfv3VirtIfRtrDeadInterval OBJECT-TYPE
+            SYNTAX          Ospfv3DeadIntervalRangeTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The number of seconds that a router's Hello
+                packets have not been seen before its
+                neighbors declare the router down.  This should
+                be some multiple of the Hello interval.  This
+                value must be the same for the virtual
+                neighbor."
+            DEFVAL          { 60 }
+            ::= { ospfv3VirtIfEntry 8 }
+
+    ospfv3VirtIfState OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            down(1),
+                            pointToPoint(4)
+                            }
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "OSPF virtual interface states.  The same encoding
+                as the ospfV3IfTable is used."
+            ::= { ospfv3VirtIfEntry 9 }
+
+    ospfv3VirtIfEvents OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of state changes or error events on
+                this virtual link.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3VirtIfEntry 10 }
+
+    ospfv3VirtIfRowStatus OBJECT-TYPE
+            SYNTAX          RowStatus
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This object permits management of the table by
+                facilitating actions such as row creation,
+                construction, and destruction.
+
+                The value of this object has no effect on
+                whether other objects in this conceptual row can be
+                modified."
+            ::= { ospfv3VirtIfEntry 11 }
+
+    ospfv3VirtIfLinkScopeLsaCount OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The total number of Link-scope link state
+                advertisements in this virtual link's link state
+                database."
+            ::= { ospfv3VirtIfEntry 12 }
+
+    ospfv3VirtIfLinkLsaCksumSum OBJECT-TYPE
+            SYNTAX          Unsigned32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit unsigned sum of the Link-scope link state
+                advertisements' LS checksums contained in this
+                virtual link's link state database.  The sum can be used
+                to determine if there has been a change in a
+                router's link state database or to compare the
+                link state database of two routers."
+            ::= { ospfv3VirtIfEntry 13 }
+
+    -- OSPFv3 Neighbor Table
+
+    ospfv3NbrTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3NbrEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A table describing all neighbors in the
+                locality of the OSPFv3 router."
+            REFERENCE
+                "OSPF Version 2, Section 10, The Neighbor Data
+                Structure"
+            ::= { ospfv3Objects 9 }
+
+    ospfv3NbrEntry OBJECT-TYPE
+            SYNTAX          Ospfv3NbrEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The information regarding a single neighbor."
+            REFERENCE
+                "OSPF Version 2, Section 10, The Neighbor Data
+                Structure"
+            INDEX           { ospfv3NbrIfIndex,
+                              ospfv3NbrIfInstId,
+                              ospfv3NbrRtrId }
+            ::= { ospfv3NbrTable 1 }
+
+    Ospfv3NbrEntry ::= SEQUENCE {
+            ospfv3NbrIfIndex
+                    InterfaceIndex,
+            ospfv3NbrIfInstId
+                    Ospfv3IfInstIdTC,
+            ospfv3NbrRtrId
+                    Ospfv3RouterIdTC,
+            ospfv3NbrAddressType
+                    InetAddressType,
+            ospfv3NbrAddress
+                    InetAddress,
+            ospfv3NbrOptions
+                    Integer32,
+            ospfv3NbrPriority
+                    DesignatedRouterPriority,
+            ospfv3NbrState
+                    INTEGER,
+            ospfv3NbrEvents
+                    Counter32,
+            ospfv3NbrLsRetransQLen
+                    Gauge32,
+            ospfv3NbrHelloSuppressed
+                    TruthValue,
+            ospfv3NbrIfId
+                    InterfaceIndex,
+            ospfv3NbrRestartHelperStatus
+                    INTEGER,
+            ospfv3NbrRestartHelperAge
+                    Ospfv3UpToRefreshIntervalTC,
+            ospfv3NbrRestartHelperExitReason
+                    INTEGER
+            }
+
+    ospfv3NbrIfIndex OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Local Link ID of the link over which the
+                 neighbor can be reached."
+            ::= { ospfv3NbrEntry 1 }
+
+    ospfv3NbrIfInstId OBJECT-TYPE
+            SYNTAX          Ospfv3IfInstIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Interface instance over which the neighbor
+                can be reached.  This ID has local link
+                significance only."
+            ::= { ospfv3NbrEntry 2 }
+
+    ospfv3NbrRtrId OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A 32-bit unsigned integer uniquely identifying the
+                neighboring router in the Autonomous System."
+            ::= { ospfv3NbrEntry 3 }
+
+    ospfv3NbrAddressType OBJECT-TYPE
+            SYNTAX          InetAddressType
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The address type of ospfv3NbrAddress.  Only IPv6
+                addresses without zone index are expected."
+            ::= { ospfv3NbrEntry 4 }
+
+    ospfv3NbrAddress OBJECT-TYPE
+            SYNTAX          InetAddress
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The IPv6 address of the neighbor associated with
+                the local link."
+            ::= { ospfv3NbrEntry 5 }
+
+    ospfv3NbrOptions OBJECT-TYPE
+            SYNTAX          Integer32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "A bit mask corresponding to the neighbor's
+                options field."
+            REFERENCE
+                "OSPF for IPv6, Appendix A.2, The Options Field"
+            ::= { ospfv3NbrEntry 6 }
+
+    ospfv3NbrPriority OBJECT-TYPE
+            SYNTAX          DesignatedRouterPriority
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The priority of this neighbor in the designated-
+                router election algorithm.  The value 0 signifies
+                that the neighbor is not eligible to become the
+                Designated Router on this particular network."
+            ::= { ospfv3NbrEntry 7 }
+
+    ospfv3NbrState OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            down(1),
+                            attempt(2),
+                            init(3),
+                            twoWay(4),
+                            exchangeStart(5),
+                            exchange(6),
+                            loading(7),
+                            full(8)
+                            }
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The state of the relationship with this
+                neighbor."
+            REFERENCE
+                "OSPF Version 2, Section 10.1, Neighbor states"
+            ::= { ospfv3NbrEntry 8 }
+
+    ospfv3NbrEvents OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of times this neighbor relationship
+                has changed state or an error has occurred.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3NbrEntry 9 }
+
+    ospfv3NbrLsRetransQLen OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The current length of the retransmission
+                queue."
+            ::= { ospfv3NbrEntry 10 }
+
+    ospfv3NbrHelloSuppressed OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "Indicates whether Hellos are being suppressed
+                to the neighbor."
+            ::= { ospfv3NbrEntry 11 }
+
+    ospfv3NbrIfId OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The Interface ID that the neighbor advertises
+                in its Hello packets on this link, that is, the
+                neighbor's local interface index."
+            ::= { ospfv3NbrEntry 12 }
+
+    ospfv3NbrRestartHelperStatus OBJECT-TYPE
+           SYNTAX       INTEGER { notHelping(1),
+                                  helping(2)
+                                }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "Indicates whether the router is acting
+              as a graceful restart helper for the neighbor."
+              ::= { ospfv3NbrEntry 13 }
+
+    ospfv3NbrRestartHelperAge OBJECT-TYPE
+           SYNTAX       Ospfv3UpToRefreshIntervalTC
+           UNITS        "seconds"
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "Remaining time in current OSPF graceful restart
+              interval, if the router is acting as a restart
+              helper for the neighbor."
+           ::= { ospfv3NbrEntry 14 }
+
+    ospfv3NbrRestartHelperExitReason OBJECT-TYPE
+           SYNTAX       INTEGER { none(1),
+                                  inProgress(2),
+                                  completed(3),
+                                  timedOut(4),
+                                  topologyChanged(5)
+                                }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+              "Describes the outcome of the last attempt at acting
+              as a graceful restart helper for the neighbor.
+
+              none:            no restart has yet been attempted.
+              inProgress:      a restart attempt is currently underway.
+              completed:       the last restart completed successfully.
+              timedOut:        the last restart timed out.
+              topologyChanged: the last restart was aborted due to
+                               a topology change."
+        ::= { ospfv3NbrEntry 15 }
+
+    -- OSPFv3 Configured Neighbor Table
+
+    ospfv3CfgNbrTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3CfgNbrEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A table describing all configured neighbors.
+
+                The Configured Neighbors table just gives
+                OSPFv3 information for sending OSPFv3 packets
+                to potential neighbors and is typically used
+                on NBMA and Point-to-Multipoint networks.
+                Once a Hello is received from a neighbor in
+                the Configured Neighbor table, an entry for
+                that neighbor is created in the Neighbor table
+                and adjacency state is maintained there.
+                Neighbors on multi-access or Point-to-Point
+                networks can use multicast addressing, so only
+                Neighbor table entries are created for them."
+            REFERENCE
+                "OSPF Version 2, Section 10, The Neighbor Data
+                Structure"
+            ::= { ospfv3Objects 10 }
+
+    ospfv3CfgNbrEntry OBJECT-TYPE
+            SYNTAX          Ospfv3CfgNbrEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The information regarding a single configured
+                neighbor.
+
+                The information in this table is persistent,
+                and when written, the entity SHOULD save the
+                change to non-volatile storage."
+            REFERENCE
+                "OSPF Version 2, Section 10, The Neighbor Data
+                Structure"
+            INDEX           { ospfv3CfgNbrIfIndex,
+                              ospfv3CfgNbrIfInstId,
+                              ospfv3CfgNbrAddressType,
+                              ospfv3CfgNbrAddress }
+            ::= { ospfv3CfgNbrTable 1 }
+
+    Ospfv3CfgNbrEntry ::= SEQUENCE {
+            ospfv3CfgNbrIfIndex
+                    InterfaceIndex,
+            ospfv3CfgNbrIfInstId
+                    Ospfv3IfInstIdTC,
+            ospfv3CfgNbrAddressType
+                    InetAddressType,
+            ospfv3CfgNbrAddress
+                    InetAddress,
+            ospfv3CfgNbrPriority
+                    DesignatedRouterPriority,
+            ospfv3CfgNbrRowStatus
+                    RowStatus
+            }
+
+    ospfv3CfgNbrIfIndex OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Local Link ID of the link over which the
+                 neighbor can be reached."
+            ::= { ospfv3CfgNbrEntry 1 }
+
+    ospfv3CfgNbrIfInstId OBJECT-TYPE
+            SYNTAX          Ospfv3IfInstIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Interface instance over which the neighbor
+                can be reached.  This ID has local link
+                significance only."
+            ::= { ospfv3CfgNbrEntry 2 }
+
+    ospfv3CfgNbrAddressType OBJECT-TYPE
+            SYNTAX          InetAddressType
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The address type of ospfv3NbrAddress.  Only IPv6
+                addresses without zone index are expected."
+            ::= { ospfv3CfgNbrEntry 3 }
+
+    ospfv3CfgNbrAddress OBJECT-TYPE
+            SYNTAX          InetAddress
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The IPv6 address of the neighbor associated with
+                the local link."
+            ::= { ospfv3CfgNbrEntry 4 }
+
+    ospfv3CfgNbrPriority OBJECT-TYPE
+            SYNTAX          DesignatedRouterPriority
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "The priority of this neighbor in the designated-
+                router election algorithm.  The value 0 signifies
+                that the neighbor is not eligible to become the
+                Designated Router on this particular network."
+            DEFVAL          { 1 }
+            ::= { ospfv3CfgNbrEntry 5 }
+
+    ospfv3CfgNbrRowStatus OBJECT-TYPE
+            SYNTAX          RowStatus
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This object permits management of the table by
+                facilitating actions such as row creation,
+                construction, and destruction.
+
+                The value of this object has no effect on
+                whether other objects in this conceptual row can be
+                modified."
+            ::= { ospfv3CfgNbrEntry 6 }
+
+    -- OSPFv3 Virtual Neighbor Table
+
+    ospfv3VirtNbrTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3VirtNbrEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A table describing all virtual neighbors."
+            REFERENCE
+                "OSPF Version 2, Section 15, Virtual Links"
+            ::= { ospfv3Objects 11 }
+
+    ospfv3VirtNbrEntry OBJECT-TYPE
+            SYNTAX          Ospfv3VirtNbrEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "Virtual neighbor information."
+            INDEX           { ospfv3VirtNbrArea,
+                              ospfv3VirtNbrRtrId }
+            ::= { ospfv3VirtNbrTable 1 }
+
+    Ospfv3VirtNbrEntry ::= SEQUENCE {
+            ospfv3VirtNbrArea
+                    Ospfv3AreaIdTC,
+            ospfv3VirtNbrRtrId
+                    Ospfv3RouterIdTC,
+            ospfv3VirtNbrIfIndex
+                    InterfaceIndex,
+            ospfv3VirtNbrIfInstId
+                    Ospfv3IfInstIdTC,
+            ospfv3VirtNbrAddressType
+                    InetAddressType,
+            ospfv3VirtNbrAddress
+                    InetAddress,
+            ospfv3VirtNbrOptions
+                    Integer32,
+            ospfv3VirtNbrState
+                    INTEGER,
+            ospfv3VirtNbrEvents
+                    Counter32,
+            ospfv3VirtNbrLsRetransQLen
+                    Gauge32,
+            ospfv3VirtNbrHelloSuppressed
+                    TruthValue,
+            ospfv3VirtNbrIfId
+                    InterfaceIndex,
+            ospfv3VirtNbrRestartHelperStatus
+                    INTEGER,
+            ospfv3VirtNbrRestartHelperAge
+                    Ospfv3UpToRefreshIntervalTC,
+            ospfv3VirtNbrRestartHelperExitReason
+                    INTEGER
+            }
+
+    ospfv3VirtNbrArea OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The transit area Identifier."
+            ::= { ospfv3VirtNbrEntry 1 }
+
+    ospfv3VirtNbrRtrId OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A 32-bit integer uniquely identifying the
+                neighboring router in the Autonomous System."
+            ::= { ospfv3VirtNbrEntry 2 }
+
+    ospfv3VirtNbrIfIndex OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The local Interface ID for the virtual link over
+                which the neighbor can be reached."
+            ::= { ospfv3VirtNbrEntry 3 }
+
+    ospfv3VirtNbrIfInstId OBJECT-TYPE
+            SYNTAX          Ospfv3IfInstIdTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The interface instance for the virtual link over
+                which the neighbor can be reached."
+            ::= { ospfv3VirtNbrEntry 4 }
+
+    ospfv3VirtNbrAddressType OBJECT-TYPE
+            SYNTAX          InetAddressType
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The address type of ospfv3VirtNbrAddress.  Only IPv6
+                addresses without zone index are expected."
+            ::= { ospfv3VirtNbrEntry 5 }
+
+    ospfv3VirtNbrAddress OBJECT-TYPE
+            SYNTAX          InetAddress
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The IPv6 address advertised by this virtual neighbor.
+                It must be a global scope address."
+            ::= { ospfv3VirtNbrEntry 6 }
+
+    ospfv3VirtNbrOptions OBJECT-TYPE
+            SYNTAX          Integer32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "A bit mask corresponding to the neighbor's options
+                field."
+            REFERENCE
+                "OSPF for IPv6, Appendix A.2, The Options Field"
+            ::= { ospfv3VirtNbrEntry 7 }
+
+    ospfv3VirtNbrState OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            down(1),
+                            attempt(2),
+                            init(3),
+                            twoWay(4),
+                            exchangeStart(5),
+                            exchange(6),
+                            loading(7),
+                            full(8)
+                            }
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The state of the virtual neighbor relationship."
+            ::= { ospfv3VirtNbrEntry 8 }
+
+    ospfv3VirtNbrEvents OBJECT-TYPE
+            SYNTAX          Counter32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The number of times this virtual link has
+                changed its state or an error has occurred.
+
+                Discontinuities in the value of this counter
+                can occur at re-initialization of the management
+                system and at other times as indicated by the
+                value of ospfv3DiscontinuityTime."
+            ::= { ospfv3VirtNbrEntry 9 }
+
+    ospfv3VirtNbrLsRetransQLen OBJECT-TYPE
+            SYNTAX          Gauge32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The current length of the retransmission
+                queue."
+            ::= { ospfv3VirtNbrEntry 10 }
+
+    ospfv3VirtNbrHelloSuppressed OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "Indicates whether Hellos are being suppressed
+                to the neighbor."
+            ::= { ospfv3VirtNbrEntry 11 }
+
+    ospfv3VirtNbrIfId OBJECT-TYPE
+            SYNTAX          InterfaceIndex
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The Interface ID that the neighbor advertises
+                in its Hello packets on this virtual link, that is,
+                the neighbor's local Interface ID."
+            ::= { ospfv3VirtNbrEntry 12 }
+
+   ospfv3VirtNbrRestartHelperStatus OBJECT-TYPE
+           SYNTAX       INTEGER { notHelping(1),
+                                  helping(2)
+                                }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "Indicates whether the router is acting
+               as a graceful restart helper for the neighbor."
+              ::= { ospfv3VirtNbrEntry 13 }
+
+    ospfv3VirtNbrRestartHelperAge OBJECT-TYPE
+           SYNTAX       Ospfv3UpToRefreshIntervalTC
+           UNITS        "seconds"
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "Remaining time in the current OSPF graceful restart
+               interval, if the router is acting as a restart
+               helper for the neighbor."
+           ::= { ospfv3VirtNbrEntry 14 }
+
+    ospfv3VirtNbrRestartHelperExitReason OBJECT-TYPE
+           SYNTAX       INTEGER { none(1),
+                                  inProgress(2),
+                                  completed(3),
+                                  timedOut(4),
+                                  topologyChanged(5)
+                                }
+           MAX-ACCESS   read-only
+           STATUS       current
+           DESCRIPTION
+               "Describes the outcome of the last attempt at acting
+               as a graceful restart helper for the neighbor.
+
+               none:            no restart has yet been attempted.
+               inProgress:      a restart attempt is currently underway.
+               completed:       the last restart completed successfully.
+               timedOut:        the last restart timed out.
+               topologyChanged: the last restart was aborted due to
+                                a topology change."
+        ::= { ospfv3VirtNbrEntry 15 }
+
+    --
+    -- The OSPFv3 Area Aggregate Table
+    --
+
+    ospfv3AreaAggregateTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3AreaAggregateEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Area Aggregate Table acts as an adjunct
+                to the Area Table.  It describes those address
+                aggregates that are configured to be propagated
+                from an area.  Its purpose is to reduce the amount
+                of information that is known beyond an area's
+                borders.
+
+                A range of IPv6 prefixes specified by a
+                prefix / prefix length pair.  Note that if
+                ranges are configured such that one range
+                subsumes another range, the most specific
+                match is the preferred one."
+            ::= { ospfv3Objects 12 }
+
+    ospfv3AreaAggregateEntry OBJECT-TYPE
+            SYNTAX          Ospfv3AreaAggregateEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A single area aggregate entry.
+
+                Information in this table is persistent, and
+                when this object is written, the entity SHOULD
+                save the change to non-volatile storage."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            INDEX           { ospfv3AreaAggregateAreaID,
+                              ospfv3AreaAggregateAreaLsdbType,
+                              ospfv3AreaAggregatePrefixType,
+                              ospfv3AreaAggregatePrefix,
+                              ospfv3AreaAggregatePrefixLength }
+            ::= { ospfv3AreaAggregateTable 1 }
+
+    Ospfv3AreaAggregateEntry ::= SEQUENCE {
+            ospfv3AreaAggregateAreaID
+                    Ospfv3AreaIdTC,
+            ospfv3AreaAggregateAreaLsdbType
+                    INTEGER,
+            ospfv3AreaAggregatePrefixType
+                    InetAddressType,
+            ospfv3AreaAggregatePrefix
+                    InetAddress,
+            ospfv3AreaAggregatePrefixLength
+                    InetAddressPrefixLength,
+            ospfv3AreaAggregateRowStatus
+                    RowStatus,
+            ospfv3AreaAggregateEffect
+                    INTEGER,
+            ospfv3AreaAggregateRouteTag
+                    Unsigned32
+            }
+
+    ospfv3AreaAggregateAreaID OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The area the Address Aggregate is to be found
+                within."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            ::= { ospfv3AreaAggregateEntry 1 }
+
+    ospfv3AreaAggregateAreaLsdbType OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            interAreaPrefixLsa(8195), -- 0x2003
+                            nssaExternalLsa(8199)     -- 0x2007
+                            }
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The type of the Address Aggregate.  This field
+                specifies the Area LSDB type that this Address
+                Aggregate applies to."
+            REFERENCE
+                "OSPF Version 2, Appendix A.4.1, The LSA header"
+            ::= { ospfv3AreaAggregateEntry 2 }
+
+    ospfv3AreaAggregatePrefixType OBJECT-TYPE
+            SYNTAX          InetAddressType
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The prefix type of ospfv3AreaAggregatePrefix.  Only
+                IPv6 addresses are expected."
+            ::= { ospfv3AreaAggregateEntry 3 }
+
+    ospfv3AreaAggregatePrefix OBJECT-TYPE
+            SYNTAX          InetAddress (SIZE (0..16))
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The IPv6 prefix."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            ::= { ospfv3AreaAggregateEntry 4 }
+
+    ospfv3AreaAggregatePrefixLength OBJECT-TYPE
+            SYNTAX          InetAddressPrefixLength (3..128)
+            UNITS           "bits"
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The length of the prefix (in bits).  A prefix can
+                not be shorter than 3 bits."
+            REFERENCE
+                "OSPF Version 2, Appendix C.2, Area parameters"
+            ::= { ospfv3AreaAggregateEntry 5 }
+
+    ospfv3AreaAggregateRowStatus OBJECT-TYPE
+            SYNTAX          RowStatus
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This object permits management of the table by
+                facilitating actions such as row creation,
+                construction, and destruction.
+
+                The value of this object has no effect on
+                whether other objects in this conceptual row can be
+                modified."
+            ::= { ospfv3AreaAggregateEntry 6 }
+
+    ospfv3AreaAggregateEffect OBJECT-TYPE
+            SYNTAX          INTEGER {
+                            advertiseMatching(1),
+                            doNotAdvertiseMatching(2)
+                            }
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "Prefixes subsumed by ranges will either trigger the
+                advertisement of the indicated aggregate
+                (advertiseMatching) or result in the prefix not
+                being advertised at all outside the area."
+            DEFVAL          { advertiseMatching }
+            ::= { ospfv3AreaAggregateEntry 7 }
+
+    ospfv3AreaAggregateRouteTag OBJECT-TYPE
+            SYNTAX          Unsigned32
+            MAX-ACCESS      read-create
+            STATUS          current
+            DESCRIPTION
+                "This tag is advertised only in the summarized
+                As-External LSA when summarizing from NSSA-LSAs to
+                AS-External-LSAs."
+            DEFVAL         { 0 }
+            ::= { ospfv3AreaAggregateEntry 8 }
+
+    -- OSPFv3 Link-Scope Link State Database, for virtual interfaces
+
+    ospfv3VirtLinkLsdbTable OBJECT-TYPE
+            SYNTAX          SEQUENCE OF Ospfv3VirtLinkLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The OSPFv3 Process's Link-scope LSDB for virtual
+                interfaces.  The LSDB contains the Link-scope link
+                state advertisements from virtual interfaces."
+            ::= { ospfv3Objects 13 }
+
+    ospfv3VirtLinkLsdbEntry OBJECT-TYPE
+            SYNTAX          Ospfv3VirtLinkLsdbEntry
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "A single Link-scope link state advertisement
+                for a virtual interface."
+            INDEX           { ospfv3VirtLinkLsdbIfAreaId,
+                              ospfv3VirtLinkLsdbIfNeighbor,
+                              ospfv3VirtLinkLsdbType,
+                              ospfv3VirtLinkLsdbRouterId,
+                              ospfv3VirtLinkLsdbLsid }
+            ::= { ospfv3VirtLinkLsdbTable 1 }
+
+    Ospfv3VirtLinkLsdbEntry ::= SEQUENCE {
+            ospfv3VirtLinkLsdbIfAreaId
+                    Ospfv3AreaIdTC,
+            ospfv3VirtLinkLsdbIfNeighbor
+                    Ospfv3RouterIdTC,
+            ospfv3VirtLinkLsdbType
+                    Unsigned32,
+            ospfv3VirtLinkLsdbRouterId
+                    Ospfv3RouterIdTC,
+            ospfv3VirtLinkLsdbLsid
+                    Ospfv3LsIdTC,
+            ospfv3VirtLinkLsdbSequence
+                    Ospfv3LsaSequenceTC,
+            ospfv3VirtLinkLsdbAge
+                    Ospfv3LsaAgeTC,
+            ospfv3VirtLinkLsdbChecksum
+                    Integer32,
+            ospfv3VirtLinkLsdbAdvertisement
+                    OCTET STRING,
+            ospfv3VirtLinkLsdbTypeKnown
+                    TruthValue
+            }
+
+    ospfv3VirtLinkLsdbIfAreaId OBJECT-TYPE
+            SYNTAX          Ospfv3AreaIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The transit area that the virtual link
+                traverses.  By definition, this is not
+                Area 0."
+            ::= { ospfv3VirtLinkLsdbEntry 1 }
+
+    ospfv3VirtLinkLsdbIfNeighbor OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The Router ID of the virtual neighbor."
+            ::= { ospfv3VirtLinkLsdbEntry 2 }
+
+    ospfv3VirtLinkLsdbType OBJECT-TYPE
+            SYNTAX          Unsigned32(0..'FFFFFFFF'h)
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The type of the link state advertisement.
+                Each link state type has a separate
+                advertisement format.  Link-scope LSAs unrecognized
+                by the router are also stored in this database."
+            ::= { ospfv3VirtLinkLsdbEntry 3 }
+
+    ospfv3VirtLinkLsdbRouterId OBJECT-TYPE
+            SYNTAX          Ospfv3RouterIdTC
+            MAX-ACCESS      not-accessible
+            STATUS          current
+            DESCRIPTION
+                "The 32-bit number that uniquely identifies the
+                originating router in the Autonomous System."
+            REFERENCE
+                "OSPF Version 2, Appendix C.1, Global parameters"
+            ::= { ospfv3VirtLinkLsdbEntry 4 }
+
+    ospfv3VirtLinkLsdbLsid OBJECT-TYPE
+            SYNTAX        Ospfv3LsIdTC
+            MAX-ACCESS    not-accessible
+            STATUS        current
+            DESCRIPTION
+                "The Link State ID is an LS type-specific field
+                containing a unique identifier;
+                it identifies the piece of the routing domain
+                that is being described by the advertisement.
+                In contrast to OSPFv2, the LSID has no
+                addressing semantics."
+            ::= { ospfv3VirtLinkLsdbEntry 5 }
+
+    -- Note that the OSPF sequence number is a 32-bit signed
+    -- integer.  It starts with the value '80000001'h
+    -- or -'7FFFFFFF'h, and increments until '7FFFFFFF'h.
+    -- Thus, a typical sequence number will be very negative.
+
+    ospfv3VirtLinkLsdbSequence OBJECT-TYPE
+            SYNTAX          Ospfv3LsaSequenceTC
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The sequence number field is a signed 32-bit
+                integer.  It is used to detect old and duplicate
+                link state advertisements.  The space of
+                sequence numbers is linearly ordered.  The
+                larger the sequence number, the more recent the
+                advertisement."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.6, LS sequence
+                number"
+            ::= { ospfv3VirtLinkLsdbEntry 6 }
+
+    ospfv3VirtLinkLsdbAge OBJECT-TYPE
+            SYNTAX          Ospfv3LsaAgeTC
+            UNITS           "seconds"
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the age of the link state
+                advertisement in seconds.  The high-order bit
+                of the LS age field is considered the DoNotAge
+                bit for support of on-demand circuits."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.1, LS age;
+                 Extending OSPF to Support Demand Circuits,
+                 Section 2.2, The LS age field."
+            ::= { ospfv3VirtLinkLsdbEntry 7 }
+
+    ospfv3VirtLinkLsdbChecksum OBJECT-TYPE
+            SYNTAX          Integer32
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "This field is the checksum of the complete
+                contents of the advertisement, excepting the
+                age field.  The age field is excepted so that
+                an advertisement's age can be incremented
+                without updating the checksum.  The checksum
+                used is the same that is used for ISO
+                connectionless datagrams; it is commonly
+                referred to as the Fletcher checksum."
+            REFERENCE
+                "OSPF Version 2, Section 12.1.7, LS checksum"
+            ::= { ospfv3VirtLinkLsdbEntry 8 }
+
+    ospfv3VirtLinkLsdbAdvertisement OBJECT-TYPE
+            SYNTAX          OCTET STRING (SIZE (1..65535))
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The entire link state advertisement, including
+                its header."
+            ::= { ospfv3VirtLinkLsdbEntry 9 }
+
+    ospfv3VirtLinkLsdbTypeKnown OBJECT-TYPE
+            SYNTAX          TruthValue
+            MAX-ACCESS      read-only
+            STATUS          current
+            DESCRIPTION
+                "The value true (1) indicates that the LSA type is
+                recognized by this router."
+            ::= { ospfv3VirtLinkLsdbEntry 10 }
+
+    -- The Ospfv3 Notification Table
+
+    -- The Ospfv3 Notification Table records fields that are
+    -- required for notifications.
+
+    ospfv3NotificationEntry OBJECT IDENTIFIER
+            ::= { ospfv3Objects 14 }
+
+    ospfv3ConfigErrorType OBJECT-TYPE
+        SYNTAX       INTEGER {
+                        badVersion(1),
+                        areaMismatch(2),
+                        unknownNbmaNbr(3), -- Router is DR eligible
+                        unknownVirtualNbr(4),
+                        helloIntervalMismatch(5),
+                        deadIntervalMismatch(6),
+                        optionMismatch(7),
+                        mtuMismatch(8),
+                        duplicateRouterId(9),
+                        noError(10) }
+        MAX-ACCESS   accessible-for-notify
+        STATUS   current
+        DESCRIPTION
+            "Potential types of configuration conflicts.
+            Used by the ospfv3ConfigError and
+            ospfv3ConfigVirtError notifications."
+        ::= { ospfv3NotificationEntry 1 }
+
+    ospfv3PacketType OBJECT-TYPE
+        SYNTAX       INTEGER {
+                        hello(1),
+                        dbDescript(2),
+                        lsReq(3),
+                        lsUpdate(4),
+                        lsAck(5),
+                        nullPacket(6) }
+        MAX-ACCESS   accessible-for-notify
+        STATUS       current
+        DESCRIPTION
+            "OSPFv3 packet types."
+        ::= { ospfv3NotificationEntry 2 }
+
+    ospfv3PacketSrc  OBJECT-TYPE
+        SYNTAX       InetAddressIPv6
+        MAX-ACCESS   accessible-for-notify
+        STATUS       current
+        DESCRIPTION
+            "The IPv6 address of an inbound packet that cannot
+            be identified by a neighbor instance.
+
+            Only IPv6 addresses without zone index are expected."
+        ::= { ospfv3NotificationEntry 3 }
+
+    -- Notification Definitions
+
+    -- The notifications need to be throttled so as to not overwhelm the
+    -- management agent in case of rapid changes to the OSPFv3 module.
+
+   ospfv3VirtIfStateChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId,  -- The originator of the notification
+                  ospfv3VirtIfState  -- The new state
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3VirtIfStateChange notification signifies that
+            there has been a change in the state of an OSPFv3 virtual
+            interface.
+
+            This notification should be generated when the interface
+            state regresses (e.g., goes from Point-to-Point to Down)
+            or progresses to a terminal state (i.e., Point-to-Point)."
+        ::= { ospfv3Notifications 1 }
+
+   ospfv3NbrStateChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+                  ospfv3NbrState  -- The new state
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3NbrStateChange notification signifies that
+            there has been a change in the state of a
+            non-virtual OSPFv3 neighbor.  This notification should be
+            generated when the neighbor state regresses
+            (e.g., goes from Attempt or Full to 1-Way or
+            Down) or progresses to a terminal state (e.g.,
+            2-Way or Full).  When a neighbor transitions
+            from or to Full on non-broadcast multi-access
+            and broadcast networks, the notification should be
+            generated by the Designated Router.  A Designated
+            Router transitioning to Down will be noted by
+            ospfIfStateChange."
+        ::= { ospfv3Notifications 2 }
+
+   ospfv3VirtNbrStateChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+                  ospfv3VirtNbrState  -- The new state
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3VirtNbrStateChange notification signifies
+            that there has been a change in the state of an OSPFv3
+            virtual neighbor.  This notification should be generated
+            when the neighbor state regresses (e.g., goes
+            from Attempt or Full to 1-Way or Down) or
+            progresses to a terminal state (e.g., Full)."
+        ::= { ospfv3Notifications 3 }
+
+   ospfv3IfConfigError NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3IfState,         -- State of the interface
+           ospfv3PacketSrc,       -- IPv6 address of source
+           ospfv3ConfigErrorType, -- Type of error
+           ospfv3PacketType       -- Type of packet
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3IfConfigError notification signifies that a
+            packet has been received on a non-virtual
+            interface from a router whose configuration
+            parameters conflict with this router's
+            configuration parameters.  Note that the event
+            optionMismatch should cause a notification only if it
+            prevents an adjacency from forming."
+        ::= { ospfv3Notifications 4 }
+
+   ospfv3VirtIfConfigError NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3VirtIfState,     -- State of the interface
+           ospfv3ConfigErrorType, -- Type of error
+           ospfv3PacketType
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3VirtIfConfigError notification signifies that a
+            packet has been received on a virtual interface
+            from a router whose configuration parameters
+            conflict with this router's configuration
+            parameters.  Note that the event optionMismatch
+            should cause a notification only if it prevents an
+            adjacency from forming."
+        ::= { ospfv3Notifications 5 }
+
+   ospfv3IfRxBadPacket NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3IfState,         -- State of the interface
+           ospfv3PacketSrc,       -- The source IPv6 address
+           ospfv3PacketType       -- Type of packet
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3IfRxBadPacket notification signifies that an
+            OSPFv3 packet that cannot be parsed has been received on a
+            non-virtual interface."
+        ::= { ospfv3Notifications 6 }
+
+   ospfv3VirtIfRxBadPacket NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+          ospfv3VirtIfState,      -- State of the interface
+          ospfv3PacketType        -- Type of packet
+          }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3VirtIfRxBadPacket notification signifies
+            that an OSPFv3 packet that cannot be parsed has been
+            received on a virtual interface."
+        ::= { ospfv3Notifications 7 }
+
+   ospfv3LsdbOverflow NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3ExtAreaLsdbLimit -- Limit on External LSAs
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3LsdbOverflow notification signifies that the
+            number of LSAs in the router's link state
+            database has exceeded ospfv3ExtAreaLsdbLimit."
+        ::= { ospfv3Notifications 8 }
+
+   ospfv3LsdbApproachingOverflow NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3ExtAreaLsdbLimit
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3LsdbApproachingOverflow notification signifies
+            that the number of LSAs in the router's
+            link state database has exceeded ninety percent of
+            ospfv3ExtAreaLsdbLimit."
+        ::= { ospfv3Notifications 9 }
+
+   ospfv3IfStateChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3IfState   -- The new state
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3IfStateChange notification signifies that there
+            has been a change in the state of a non-virtual
+            OSPFv3 interface.  This notification should be generated
+            when the interface state regresses (e.g., goes
+            from DR to Down) or progresses to a terminal
+            state (i.e., Point-to-Point, DR Other, DR, or
+            Backup)."
+        ::= { ospfv3Notifications 10 }
+
+   ospfv3NssaTranslatorStatusChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+           ospfv3AreaNssaTranslatorState  -- new state
+           }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3NssaTranslatorStatusChange notification
+            indicates that there has been a change in the router's
+            ability to translate OSPFv3 NSSA LSAs into OSPFv3 External
+            LSAs.  This notification should be generated when the
+            Translator Status transitions from or to any defined
+            status on a per-area basis."
+        ::= { ospfv3Notifications 11 }
+
+   ospfv3RestartStatusChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+                  ospfv3RestartStatus,  -- new status
+                  ospfv3RestartInterval,
+                  ospfv3RestartExitReason
+                }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3RestartStatusChange notification signifies that
+            there has been a change in the graceful restart
+            state for the router.  This notification should be
+            generated when the router restart status
+            changes."
+        ::= { ospfv3Notifications 12 }
+
+   ospfv3NbrRestartHelperStatusChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+                  ospfv3NbrRestartHelperStatus,  -- new status
+                  ospfv3NbrRestartHelperAge,
+                  ospfv3NbrRestartHelperExitReason
+                }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3NbrRestartHelperStatusChange notification
+            signifies that there has been a change in the
+            graceful restart helper state for the neighbor.
+            This notification should be generated when the
+            neighbor restart helper status transitions for a neighbor."
+        ::= { ospfv3Notifications 13 }
+
+   ospfv3VirtNbrRestartHelperStatusChange NOTIFICATION-TYPE
+        OBJECTS { ospfv3RouterId, -- The originator of the notification
+                  ospfv3VirtNbrRestartHelperStatus,  -- new status
+                  ospfv3VirtNbrRestartHelperAge,
+                  ospfv3VirtNbrRestartHelperExitReason
+                }
+        STATUS       current
+        DESCRIPTION
+            "An ospfv3VirtNbrRestartHelperStatusChange
+            notification signifies that there has been a
+            change in the graceful restart helper state for
+            the virtual neighbor.  This notification should be
+            generated when the virtual neighbor restart helper status
+            transitions for a virtual neighbor."
+        ::= { ospfv3Notifications 14 }
+
+    -- Conformance Information
+
+    ospfv3Groups      OBJECT IDENTIFIER ::= { ospfv3Conformance 1 }
+    ospfv3Compliances OBJECT IDENTIFIER ::= { ospfv3Conformance 2 }
+
+    -- Compliance Statements
+
+    ospfv3FullCompliance MODULE-COMPLIANCE
+            STATUS          current
+            DESCRIPTION     "The compliance statement"
+            MODULE          -- this module
+            MANDATORY-GROUPS {
+                            ospfv3BasicGroup,
+                            ospfv3AreaGroup,
+                            ospfv3IfGroup,
+                            ospfv3VirtIfGroup,
+                            ospfv3NbrGroup,
+                            ospfv3CfgNbrGroup,
+                            ospfv3VirtNbrGroup,
+                            ospfv3AreaAggregateGroup
+                            }
+
+            GROUP           ospfv3AsLsdbGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                display their AS-scope link state database."
+
+            GROUP           ospfv3AreaLsdbGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                display their Area-scope link state database."
+
+            GROUP           ospfv3LinkLsdbGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                display their Link-scope link state database
+                for non-virtual interfaces."
+
+            GROUP           ospfv3VirtLinkLsdbGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                display their Link-scope link state database
+                for virtual interfaces."
+
+            GROUP           ospfv3HostGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                support attached hosts."
+
+            GROUP           ospfv3NotificationObjectGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                support OSPFv3 notifications."
+
+            GROUP           ospfv3NotificationGroup
+            DESCRIPTION
+                "This group is required for OSPFv3 systems that
+                support OSPFv3 notifications."
+
+            OBJECT          ospfv3NbrAddressType
+            SYNTAX          InetAddressType { ipv6(2) }
+            DESCRIPTION
+                "An implementation is only required to support IPv6
+                address without zone index."
+
+            OBJECT          ospfv3NbrAddress
+            SYNTAX          InetAddress (SIZE (16))
+            DESCRIPTION
+                "An implementation is only required to support IPv6
+                address without zone index."
+
+            OBJECT          ospfv3VirtNbrAddressType
+            SYNTAX          InetAddressType { ipv6(2) }
+            DESCRIPTION
+                "An implementation is only required to support IPv6
+                address without zone index."
+
+            OBJECT          ospfv3VirtNbrAddress
+            SYNTAX          InetAddress (SIZE (16))
+            DESCRIPTION
+                "An implementation is only required to support IPv6
+                address without zone index."
+
+            ::= { ospfv3Compliances 1 }
+
+       ospfv3ReadOnlyCompliance MODULE-COMPLIANCE
+          STATUS     current
+          DESCRIPTION
+                  "When this MIB module is implemented without
+                  support for read-create (i.e., in read-only
+                  mode), the implementation can claim read-only
+                  compliance.  Such a device can then be monitored,
+                  but cannot be configured with this MIB."
+
+          MODULE -- this module
+               MANDATORY-GROUPS {
+                       ospfv3BasicGroup,
+                       ospfv3AreaGroup,
+                       ospfv3IfGroup,
+                       ospfv3VirtIfGroup,
+                       ospfv3NbrGroup,
+                       ospfv3CfgNbrGroup,
+                       ospfv3VirtNbrGroup,
+                       ospfv3AreaAggregateGroup
+                       }
+
+          GROUP           ospfv3AsLsdbGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              display their AS-scope link state database."
+
+          GROUP           ospfv3AreaLsdbGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              display their Area-scope link state database."
+
+          GROUP           ospfv3LinkLsdbGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              display their Link-scope link state database
+              for non-virtual interfaces."
+
+          GROUP           ospfv3VirtLinkLsdbGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              display their Link-scope link state database
+              for virtual interfaces."
+
+          GROUP           ospfv3HostGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              support attached hosts."
+
+          GROUP           ospfv3NotificationObjectGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              support OSPFv3 notifications."
+
+          GROUP           ospfv3NotificationGroup
+          DESCRIPTION
+              "This group is required for OSPFv3 systems that
+              support OSPFv3 notifications."
+
+          OBJECT ospfv3RouterId
+          MIN-ACCESS read-only
+
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AdminStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3ExtAreaLsdbLimit
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3ExitOverflowInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3DemandExtensions
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3ReferenceBandwidth
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3RestartSupport
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3RestartInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3RestartStrictLsaChecking
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3NotificationEnable
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3StubRouterAdvertisement
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaImportAsExtern
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaSummary
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaRowStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaStubMetric
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaNssaTranslatorRole
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaNssaTranslatorStabInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaStubMetricType
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaTEEnabled
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3HostMetric
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3HostRowStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3HostAreaID
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfAreaId
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfType
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfAdminStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfRtrPriority
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfTransitDelay
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfRetransInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfHelloInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfRtrDeadInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfPollInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfRowStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfDemand
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfMetricValue
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfDemandNbrProbe
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfDemandNbrProbeRetransLimit
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfDemandNbrProbeInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfTEDisabled
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3IfLinkLSASuppression
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3VirtIfTransitDelay
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3VirtIfRetransInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3VirtIfHelloInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3VirtIfRtrDeadInterval
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3VirtIfRowStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3CfgNbrPriority
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3CfgNbrRowStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+          OBJECT ospfv3AreaAggregateRowStatus
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaAggregateEffect
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+
+          OBJECT ospfv3AreaAggregateRouteTag
+          MIN-ACCESS read-only
+          DESCRIPTION
+               "Write access is not required."
+       ::= { ospfv3Compliances 2 }
+
+    -- units of conformance
+
+    ospfv3BasicGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3RouterId,
+                            ospfv3AdminStatus,
+                            ospfv3VersionNumber,
+                            ospfv3AreaBdrRtrStatus,
+                            ospfv3ASBdrRtrStatus,
+                            ospfv3AsScopeLsaCount,
+                            ospfv3AsScopeLsaCksumSum,
+                            ospfv3OriginateNewLsas,
+                            ospfv3RxNewLsas,
+                            ospfv3ExtLsaCount,
+                            ospfv3ExtAreaLsdbLimit,
+                            ospfv3ExitOverflowInterval,
+                            ospfv3DemandExtensions,
+                            ospfv3ReferenceBandwidth,
+                            ospfv3RestartSupport,
+                            ospfv3RestartInterval,
+                            ospfv3RestartStrictLsaChecking,
+                            ospfv3RestartStatus,
+                            ospfv3RestartAge,
+                            ospfv3RestartExitReason,
+                            ospfv3NotificationEnable,
+                            ospfv3StubRouterSupport,
+                            ospfv3StubRouterAdvertisement,
+                            ospfv3DiscontinuityTime,
+                            ospfv3RestartTime
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for managing/monitoring
+                OSPFv3 global parameters."
+            ::= { ospfv3Groups 1 }
+
+    ospfv3AreaGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3AreaImportAsExtern,
+                            ospfv3AreaSpfRuns,
+                            ospfv3AreaBdrRtrCount,
+                            ospfv3AreaAsBdrRtrCount,
+                            ospfv3AreaScopeLsaCount,
+                            ospfv3AreaScopeLsaCksumSum,
+                            ospfv3AreaSummary,
+                            ospfv3AreaRowStatus,
+                            ospfv3AreaStubMetric,
+                            ospfv3AreaNssaTranslatorRole,
+                            ospfv3AreaNssaTranslatorState,
+                            ospfv3AreaNssaTranslatorStabInterval,
+                            ospfv3AreaNssaTranslatorEvents,
+                            ospfv3AreaStubMetricType,
+                            ospfv3AreaTEEnabled
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for OSPFv3 systems
+                supporting areas."
+            ::= { ospfv3Groups 2 }
+
+    ospfv3AsLsdbGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3AsLsdbSequence,
+                            ospfv3AsLsdbAge,
+                            ospfv3AsLsdbChecksum,
+                            ospfv3AsLsdbAdvertisement,
+                            ospfv3AsLsdbTypeKnown
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for OSPFv3 systems
+                that display their AS-scope link state database."
+            ::= { ospfv3Groups 3 }
+
+    ospfv3AreaLsdbGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3AreaLsdbSequence,
+                            ospfv3AreaLsdbAge,
+                            ospfv3AreaLsdbChecksum,
+                            ospfv3AreaLsdbAdvertisement,
+                            ospfv3AreaLsdbTypeKnown
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for OSPFv3 systems
+                that display their Area-scope link state database."
+            ::= { ospfv3Groups 4 }
+
+    ospfv3LinkLsdbGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3LinkLsdbSequence,
+                            ospfv3LinkLsdbAge,
+                            ospfv3LinkLsdbChecksum,
+                            ospfv3LinkLsdbAdvertisement,
+                            ospfv3LinkLsdbTypeKnown
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for OSPFv3 systems
+                that display their Link-scope link state database
+                for non-virtual interfaces."
+            ::= { ospfv3Groups 5 }
+
+    ospfv3HostGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3HostMetric,
+                            ospfv3HostRowStatus,
+                            ospfv3HostAreaID
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for OSPFv3 systems
+                that support attached hosts."
+            ::= { ospfv3Groups 6 }
+
+    ospfv3IfGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3IfAreaId,
+                            ospfv3IfType,
+                            ospfv3IfAdminStatus,
+                            ospfv3IfRtrPriority,
+                            ospfv3IfTransitDelay,
+                            ospfv3IfRetransInterval,
+                            ospfv3IfHelloInterval,
+                            ospfv3IfRtrDeadInterval,
+                            ospfv3IfPollInterval,
+                            ospfv3IfState,
+                            ospfv3IfDesignatedRouter,
+                            ospfv3IfBackupDesignatedRouter,
+                            ospfv3IfEvents,
+                            ospfv3IfRowStatus,
+                            ospfv3IfDemand,
+                            ospfv3IfMetricValue,
+                            ospfv3IfLinkScopeLsaCount,
+                            ospfv3IfLinkLsaCksumSum,
+                            ospfv3IfDemandNbrProbe,
+                            ospfv3IfDemandNbrProbeRetransLimit,
+                            ospfv3IfDemandNbrProbeInterval,
+                            ospfv3IfTEDisabled,
+                            ospfv3IfLinkLSASuppression
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These interface objects are used for
+                managing/monitoring OSPFv3 interfaces."
+            ::= { ospfv3Groups 7 }
+
+    ospfv3VirtIfGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3VirtIfIndex,
+                            ospfv3VirtIfInstId,
+                            ospfv3VirtIfTransitDelay,
+                            ospfv3VirtIfRetransInterval,
+                            ospfv3VirtIfHelloInterval,
+                            ospfv3VirtIfRtrDeadInterval,
+                            ospfv3VirtIfState,
+                            ospfv3VirtIfEvents,
+                            ospfv3VirtIfRowStatus,
+                            ospfv3VirtIfLinkScopeLsaCount,
+                            ospfv3VirtIfLinkLsaCksumSum
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These virtual interface objects are used for
+                managing/monitoring OSPFv3 virtual interfaces."
+            ::= { ospfv3Groups 8 }
+
+    ospfv3NbrGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3NbrAddressType,
+                            ospfv3NbrAddress,
+                            ospfv3NbrOptions,
+                            ospfv3NbrPriority,
+                            ospfv3NbrState,
+                            ospfv3NbrEvents,
+                            ospfv3NbrLsRetransQLen,
+                            ospfv3NbrHelloSuppressed,
+                            ospfv3NbrIfId,
+                            ospfv3NbrRestartHelperStatus,
+                            ospfv3NbrRestartHelperAge,
+                            ospfv3NbrRestartHelperExitReason
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These neighbor objects are used for
+                managing/monitoring OSPFv3 neighbors."
+            ::= { ospfv3Groups 9 }
+
+    ospfv3CfgNbrGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3CfgNbrPriority,
+                            ospfv3CfgNbrRowStatus
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These configured neighbor objects are used for
+                managing/monitoring OSPFv3-configured neighbors."
+            ::= { ospfv3Groups 10 }
+
+    ospfv3VirtNbrGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3VirtNbrIfIndex,
+                            ospfv3VirtNbrIfInstId,
+                            ospfv3VirtNbrAddressType,
+                            ospfv3VirtNbrAddress,
+                            ospfv3VirtNbrOptions,
+                            ospfv3VirtNbrState,
+                            ospfv3VirtNbrEvents,
+                            ospfv3VirtNbrLsRetransQLen,
+                            ospfv3VirtNbrHelloSuppressed,
+                            ospfv3VirtNbrIfId,
+                            ospfv3VirtNbrRestartHelperStatus,
+                            ospfv3VirtNbrRestartHelperAge,
+                            ospfv3VirtNbrRestartHelperExitReason
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These virtual neighbor objects are used for
+                managing/monitoring OSPFv3 virtual neighbors."
+            ::= { ospfv3Groups 11 }
+
+    ospfv3AreaAggregateGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3AreaAggregateRowStatus,
+                            ospfv3AreaAggregateEffect,
+                            ospfv3AreaAggregateRouteTag
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These area aggregate objects are required for
+                aggregating OSPFv3 prefixes for summarization
+                across areas."
+            ::= { ospfv3Groups 12 }
+
+    ospfv3VirtLinkLsdbGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3VirtLinkLsdbSequence,
+                            ospfv3VirtLinkLsdbAge,
+                            ospfv3VirtLinkLsdbChecksum,
+                            ospfv3VirtLinkLsdbAdvertisement,
+                            ospfv3VirtLinkLsdbTypeKnown
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used for OSPFv3 systems
+                that display their Link-scope link state database
+                for virtual interfaces."
+            ::= { ospfv3Groups 13 }
+
+    ospfv3NotificationObjectGroup OBJECT-GROUP
+            OBJECTS         {
+                            ospfv3ConfigErrorType,
+                            ospfv3PacketType,
+                            ospfv3PacketSrc
+                            }
+            STATUS          current
+            DESCRIPTION
+                "These objects are used to record notification
+                parameters."
+            ::= { ospfv3Groups 14 }
+
+    ospfv3NotificationGroup NOTIFICATION-GROUP
+            NOTIFICATIONS   {
+                            ospfv3VirtIfStateChange,
+                            ospfv3NbrStateChange,
+                            ospfv3VirtNbrStateChange,
+                            ospfv3IfConfigError,
+                            ospfv3VirtIfConfigError,
+                            ospfv3IfRxBadPacket,
+                            ospfv3VirtIfRxBadPacket,
+                            ospfv3LsdbOverflow,
+                            ospfv3LsdbApproachingOverflow,
+                            ospfv3IfStateChange,
+                            ospfv3NssaTranslatorStatusChange,
+                            ospfv3RestartStatusChange,
+                            ospfv3NbrRestartHelperStatusChange,
+                            ospfv3VirtNbrRestartHelperStatusChange
+                            }
+            STATUS          current
+            DESCRIPTION
+                "This group is used for OSPFv3 notifications."
+            ::= { ospfv3Groups 15 }
+
+    END

--- a/mibs/junos/mib-rfc6527.txt
+++ b/mibs/junos/mib-rfc6527.txt
@@ -1,0 +1,954 @@
+VRRPV3-MIB DEFINITIONS ::= BEGIN  
+     
+    IMPORTS  
+        MODULE-IDENTITY, OBJECT-TYPE, 
+        NOTIFICATION-TYPE, Counter32, 
+        Integer32, mib-2, Unsigned32, 
+        Counter64, TimeTicks         
+            FROM SNMPv2-SMI                 -- RFC2578 
+ 
+        TEXTUAL-CONVENTION, RowStatus, 
+        MacAddress, TruthValue, TimeStamp, 
+        TimeInterval                         
+            FROM SNMPv2-TC                  -- RFC2579 
+     
+        MODULE-COMPLIANCE, OBJECT-GROUP,  
+        NOTIFICATION-GROUP                   
+            FROM SNMPv2-CONF                -- RFC2580 
+
+        ifIndex 
+            FROM IF-MIB                     -- RFC2863 
+        InetAddressType, InetAddress         
+
+            FROM INET-ADDRESS-MIB;          -- RFC4001 
+    
+   vrrpv3MIB  MODULE-IDENTITY  
+        LAST-UPDATED "201202130000Z"         -- Feb 13, 2012
+        ORGANIZATION "IETF VRRP Working Group"  
+        CONTACT-INFO  
+               "WG E-Mail: vrrp@ietf.org 
+ 
+                Editor:    Kalyan Tata   
+                           Nokia
+                           313 Fairchild Dr,
+                           Mountain View, CA 94043
+                           Tata_kalyan@yahoo.com"  
+ 
+        DESCRIPTION  
+            "This MIB describes objects used for managing Virtual  
+             Router Redundancy Protocol version 3 (VRRPv3).  
+  
+             Copyright (c) 2012 IETF Trust and the persons
+             identified as authors of the code.  All rights
+             reserved.
+
+             Redistribution and use in source and binary forms,
+             with or without modification, is permitted pursuant
+             to, and subject to the license terms contained in,
+             the Simplified BSD License set forth in Section
+             4.c of the IETF Trust's Legal Provisions Relating
+             to IETF Documents
+             (http://trustee.ietf.org/license-info).
+
+             This version of the MIB module is part of RFC 6527.
+             Please see the RFC for full legal notices."  
+
+        REVISION "201202120000Z"    -- Feb 13, 2012
+        DESCRIPTION "Initial version as published in RFC 6527."
+          
+          ::= { mib-2 207 }  
+ 
+-- Textual Conventions  
+     
+   Vrrpv3VrIdTC ::= TEXTUAL-CONVENTION  
+        DISPLAY-HINT "d" 
+        STATUS       current  
+        DESCRIPTION  
+            "The value of the Virtual Router Identifier noted as  
+            (VRID) in RFC 5798.  This, along with interface index
+            (ifIndex) and IP version, serves to uniquely identify
+            a virtual router on a given VRRP router." 
+        REFERENCE "RFC 5798 (Sections 3 and 5.2.3)" 
+        SYNTAX      Integer32 (1..255)  
+     
+--  VRRPv3 MIB Groups  
+    
+   vrrpv3Notifications   OBJECT IDENTIFIER ::= { vrrpv3MIB 0 } 
+   vrrpv3Objects         OBJECT IDENTIFIER ::= { vrrpv3MIB 1 } 
+   vrrpv3Conformance     OBJECT IDENTIFIER ::= { vrrpv3MIB 2 }  
+ 
+-- VRRPv3 MIB Objects  
+ 
+   vrrpv3Operations      OBJECT IDENTIFIER ::= { vrrpv3Objects 1 } 
+   vrrpv3Statistics      OBJECT IDENTIFIER ::= { vrrpv3Objects 2 }  
+ 
+--  VRRPv3 Operations Table  
+     
+    vrrpv3OperationsTable OBJECT-TYPE  
+        SYNTAX       SEQUENCE OF Vrrpv3OperationsEntry  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "Unified Operations table for a VRRP router that
+             consists of a sequence (i.e., one or more conceptual 
+             rows) of 'vrrpv3OperationsEntry' items each of which  
+             describe the operational characteristics of a virtual 
+             router." 
+ 
+        ::= { vrrpv3Operations 1 }  
+     
+    vrrpv3OperationsEntry OBJECT-TYPE  
+        SYNTAX       Vrrpv3OperationsEntry  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "An entry in the vrrpv3OperationsTable containing the   
+             operational characteristics of a virtual router.
+             On a VRRP router, a given virtual router is
+             identified by a combination of ifIndex, VRID, and
+             the IP version.  ifIndex represents an interface of
+             the router.
+     
+             A row must be created with vrrpv3OperationsStatus 
+             set to initialize(1) and cannot transition to 
+             backup(2) or master(3) until
+             vrrpv3OperationsRowStatus is transitioned to
+             active(1).
+     
+             The information in this table is persistent and when  
+             written the entity SHOULD save the change to non- 
+             volatile storage." 
+     
+        INDEX    { ifIndex, vrrpv3OperationsVrId,  
+                   vrrpv3OperationsInetAddrType 
+                  }  
+        ::= { vrrpv3OperationsTable 1 }  
+ 
+    Vrrpv3OperationsEntry ::=  
+ 
+        SEQUENCE {  
+            vrrpv3OperationsVrId  
+                Vrrpv3VrIdTC,  
+            vrrpv3OperationsInetAddrType  
+                InetAddressType,  
+            vrrpv3OperationsMasterIpAddr  
+                InetAddress,  
+            vrrpv3OperationsPrimaryIpAddr  
+                InetAddress,  
+            vrrpv3OperationsVirtualMacAddr  
+                MacAddress,  
+            vrrpv3OperationsStatus  
+                INTEGER,  
+            vrrpv3OperationsPriority  
+                Unsigned32, 
+            vrrpv3OperationsAddrCount 
+                Integer32,  
+            vrrpv3OperationsAdvInterval  
+                TimeInterval,  
+            vrrpv3OperationsPreemptMode  
+                TruthValue,  
+            vrrpv3OperationsAcceptMode  
+                TruthValue,  
+            vrrpv3OperationsUpTime  
+                TimeTicks,  
+            vrrpv3OperationsRowStatus  
+                RowStatus  
+    }  
+    vrrpv3OperationsVrId OBJECT-TYPE  
+        SYNTAX       Vrrpv3VrIdTC  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "This object contains the Virtual Router Identifier  
+             (VRID)."  
+        REFERENCE "RFC 4001" 
+        ::= { vrrpv3OperationsEntry 1 }  
+ 
+    vrrpv3OperationsInetAddrType OBJECT-TYPE  
+        SYNTAX       InetAddressType  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "The IP address type of Vrrpv3OperationsEntry and  
+             Vrrpv3AssociatedIpAddrEntry.  This value determines  
+             the type for vrrpv3OperationsMasterIpAddr,  
+             vrrpv3OperationsPrimaryIpAddr, and  
+             vrrpv3AssociatedIpAddrAddress.  
+ 
+             ipv4(1) and ipv6(2) are the only two values supported  
+             in this MIB module." 
+        REFERENCE "RFC 4001" 
+        ::= { vrrpv3OperationsEntry 2 } 
+   
+    vrrpv3OperationsMasterIpAddr OBJECT-TYPE  
+        SYNTAX       InetAddress  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The master router's real IP address.  The master router  
+            would set this address to vrrpv3OperationsPrimaryIpAddr  
+            while transitioning to master state.  For backup  
+            routers, this is the IP address listed as the source in 
+            VRRP advertisement last received by this virtual  
+            router."  
+        REFERENCE "RFC 5798" 
+        ::= { vrrpv3OperationsEntry 3 }  
+         
+    vrrpv3OperationsPrimaryIpAddr OBJECT-TYPE  
+        SYNTAX       InetAddress  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "In the case where there is more than one IP  
+            Address (associated IP addresses) for a given  
+            'ifIndex', this object is used to specify the IP  
+            address that will become the 
+            vrrpv3OperationsMasterIpAddr', should the virtual  
+            router transition from backup state to master."  
+        ::= { vrrpv3OperationsEntry 4 }  
+     
+ 
+    vrrpv3OperationsVirtualMacAddr OBJECT-TYPE  
+        SYNTAX       MacAddress  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The virtual MAC address of the virtual router.  
+            Although this object can be derived from the  
+            'vrrpv3OperationsVrId' object, it is defined so that it  
+            is easily obtainable by a management application and  
+            can be included in VRRP-related SNMP notifications."  
+        ::= { vrrpv3OperationsEntry 5 }  
+     
+    vrrpv3OperationsStatus OBJECT-TYPE  
+        SYNTAX       INTEGER {  
+            initialize(1),  
+            backup(2),  
+            master(3)  
+        }  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+     
+        DESCRIPTION  
+            "The current state of the virtual router.  This object   
+            has three defined values:  
+     
+              - 'initialize', which indicates that the  
+                virtual router is waiting for a startup event.  
+
+              - 'backup', which indicates that the virtual router is  
+                monitoring the availability of the master router.  
+     
+              - 'master', which indicates that the virtual router  
+                is forwarding packets for IP addresses that are  
+                associated with this router."  
+        REFERENCE "RFC 5798" 
+        ::= { vrrpv3OperationsEntry 6 }  
+
+    vrrpv3OperationsPriority OBJECT-TYPE  
+        SYNTAX       Unsigned32 (0..255)  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "This object specifies the priority to be used for the  
+            virtual router master election process; higher values  
+            imply higher priority.  
+     
+            A priority of '0', although not settable, is sent by  
+            the master router to indicate that this router has  
+            ceased to participate in VRRP, and a backup virtual  
+            router should transition to become a new master.  
+     
+            A priority of 255 is used for the router that owns the  
+            associated IP address(es) for VRRP over IPv4 and hence 
+            is not settable. 
+ 
+            Setting the values of this object to 0 or 255 should be
+            rejected by the agents implementing this MIB module.
+            For example, an SNMP agent would return 'badValue(3)'
+            when a user tries to set the values 0 or 255 for this
+            object."
+
+        REFERENCE "RFC 5798, Section 6.1" 
+        DEFVAL       { 100 }  
+        ::= { vrrpv3OperationsEntry 7 }  
+     
+    vrrpv3OperationsAddrCount OBJECT-TYPE  
+        SYNTAX       Integer32 (0..255)  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The number of IP addresses that are associated with  
+            this virtual router.  This number is equal to the  
+            number of rows in the vrrpv3AssociatedAddrTable that  
+            correspond to a given ifIndex/VRID/IP version."  
+        REFERENCE "RFC 5798, Section 6.1" 
+        ::= { vrrpv3OperationsEntry 8 }   
+     
+    vrrpv3OperationsAdvInterval OBJECT-TYPE  
+        SYNTAX       TimeInterval (1..4095)  
+        UNITS        "centiseconds"  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "The time interval, in centiseconds, between sending  
+            advertisement messages.  Only the master router sends  
+            VRRP advertisements."  
+        REFERENCE "RFC 5798, Section 6.1" 
+        DEFVAL       { 100}  
+        ::= { vrrpv3OperationsEntry 9 }  
+     
+    vrrpv3OperationsPreemptMode OBJECT-TYPE  
+        SYNTAX       TruthValue  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "Controls whether a higher priority virtual router will 
+            preempt a lower priority master."  
+        REFERENCE "RFC 5798, Section 6.1" 
+        DEFVAL       { true }  
+        ::= { vrrpv3OperationsEntry 10 } 
+ 
+    vrrpv3OperationsAcceptMode OBJECT-TYPE  
+        SYNTAX       TruthValue  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "Controls whether a virtual router in master state  
+            will accept packets addressed to the address owner's  
+            IPv6 address as its own if it is not the IPv6 address  
+            owner.  Default is false(2). 
+            This object is not relevant for rows representing VRRP 
+            over IPv4 and should be set to false(2)."  
+        DEFVAL       { false }  
+        ::= { vrrpv3OperationsEntry 11 }   
+     
+    vrrpv3OperationsUpTime OBJECT-TYPE  
+        SYNTAX       TimeTicks  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "This value represents the amount of time, in
+            TimeTicks (hundredth of a second), since this virtual  
+            router (i.e., the 'vrrpv3OperationsStatus')  
+            transitioned out of 'initialize'."  
+        REFERENCE "RFC 5798, Section 6.1" 
+        ::= { vrrpv3OperationsEntry 12 }  
+
+    vrrpv3OperationsRowStatus OBJECT-TYPE  
+        SYNTAX       RowStatus  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "The RowStatus variable should be used in accordance to 
+            installation and removal conventions for conceptual  
+            rows. 
+ 
+            To create a row in this table, a manager sets this  
+            object to either createAndGo(4) or createAndWait(5).  
+            Until instances of all corresponding columns are  
+            appropriately configured, the value of the  
+            corresponding instance of the  
+            'vrrpv3OperationsRowStatus' column will be read as  
+            notReady(3).   
+            In particular, a newly created row cannot be made  
+            active(1) until (minimally) the corresponding instance  
+            of vrrpv3OperationsInetAddrType, vrrpv3OperationsVrId,  
+            and vrrpv3OperationsPrimaryIpAddr has been set, and  
+            there is at least one active row in the  
+            'vrrpv3AssociatedIpAddrTable' defining an associated  
+            IP address. 
+ 
+            notInService(2) should be used to administratively  
+            bring the row down. 
+ 
+            A typical order of operation to add a row is: 
+            1. Create a row in vrrpv3OperationsTable with  
+            createAndWait(5). 
+            2. Create one or more corresponding rows in 
+            vrrpv3AssociatedIpAddrTable. 
+            3. Populate the vrrpv3OperationsEntry. 
+            4. Set vrrpv3OperationsRowStatus to active(1). 
+ 
+            A typical order of operation to delete an entry is: 
+            1. Set vrrpv3OperationsRowStatus to notInService(2). 
+            2. Set the corresponding rows in  
+            vrrpv3AssociatedIpAddrTable to destroy(6) to delete  
+            the entry.  
+            3. Set vrrpv3OperationsRowStatus to destroy(6) to  
+            delete the entry."  
+        ::= { vrrpv3OperationsEntry 13 }  
+ 
+--  VRRP Associated Address Table 
+     
+    vrrpv3AssociatedIpAddrTable OBJECT-TYPE  
+        SYNTAX       SEQUENCE OF Vrrpv3AssociatedIpAddrEntry  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "The table of addresses associated with each virtual  
+             router."  
+        ::= { vrrpv3Operations 2 }  
+     
+    vrrpv3AssociatedIpAddrEntry OBJECT-TYPE  
+        SYNTAX       Vrrpv3AssociatedIpAddrEntry  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "An entry in the table contains an IP address that is  
+            associated with a virtual router.  The number of rows  
+            for a given IP version, VrID, and ifIndex will equal  
+            the number of IP addresses associated (e.g., backed up)
+            by the virtual router (equivalent to
+            'vrrpv3OperationsIpAddrCount').  
+     
+            Rows in the table cannot be modified unless the value  
+            of 'vrrpv3OperationsStatus' for the corresponding entry
+            in the vrrpv3OperationsTable has transitioned to  
+            initialize(1). 
+ 
+            The information in this table is persistent and when  
+            written the entity SHOULD save the change to non- 
+            volatile storage." 
+     
+        INDEX    { ifIndex, vrrpv3OperationsVrId,  
+                   vrrpv3OperationsInetAddrType, 
+                   vrrpv3AssociatedIpAddrAddress } 
+
+        ::= { vrrpv3AssociatedIpAddrTable 1 }  
+     
+    Vrrpv3AssociatedIpAddrEntry ::=  
+        SEQUENCE {  
+            vrrpv3AssociatedIpAddrAddress  
+                InetAddress,  
+            vrrpv3AssociatedIpAddrRowStatus  
+                RowStatus  
+    }  
+         
+    vrrpv3AssociatedIpAddrAddress OBJECT-TYPE  
+        SYNTAX       InetAddress (SIZE (0|4|16)) 
+        MAX-ACCESS   not-accessible
+        STATUS       current  
+        DESCRIPTION  
+            "The assigned IP addresses that a virtual router is  
+            responsible for backing up. 
+ 
+            The IP address type is determined by the value of  
+            vrrpv3OperationsInetAddrType in the index of this 
+            row."
+        REFERENCE "RFC 5798"
+        ::= { vrrpv3AssociatedIpAddrEntry 1 }  
+  
+    vrrpv3AssociatedIpAddrRowStatus OBJECT-TYPE  
+        SYNTAX       RowStatus  
+        MAX-ACCESS   read-create
+        STATUS       current  
+        DESCRIPTION  
+            "The row status variable, used according to  
+            installation and removal conventions for conceptual  
+            rows.  To create a row in this table, a manager sets  
+            this object to either createAndGo(4) or  
+            createAndWait(5).  Setting this object to active(1)
+            results in the addition of an associated address for a  
+            virtual router.  Setting this object to notInService(2)
+            results in administratively bringing down the row. 
+ 
+            Destroying the entry or setting it to destroy(6)  
+            removes the associated address from the virtual router. 
+            The use of other values is implementation-dependent. 
+
+            Implementations should not allow deletion of the last 
+            row corresponding to an active row in  
+            vrrpv3OperationsTable. 
+ 
+            Refer to the description of vrrpv3OperationsRowStatus
+            for typical row creation and deletion scenarios."
+        ::= { vrrpv3AssociatedIpAddrEntry 2 }  
+     
+--  VRRP Router Statistics  
+  
+    vrrpv3RouterChecksumErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP packets received with an 
+            invalid VRRP checksum value. 
+ 
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3GlobalStatisticsDiscontinuityTime." 
+  
+        REFERENCE "RFC 5798, Section 5.2.8"
+        ::= { vrrpv3Statistics 1 }  
+     
+    vrrpv3RouterVersionErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP packets received with an  
+            unknown or unsupported version number. 
+ 
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3GlobalStatisticsDiscontinuityTime."  
+ 
+        REFERENCE "RFC 5798, Section 5.2.1"
+        ::= { vrrpv3Statistics 2 }  
+     
+    vrrpv3RouterVrIdErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+       STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP packets received with a 
+             VRID that is not valid for any virtual router on this 
+             router. 
+ 
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3GlobalStatisticsDiscontinuityTime."  
+ 
+        REFERENCE "RFC 5798, Section 5.2.3"
+        ::= { vrrpv3Statistics 3 }  
+ 
+   vrrpv3GlobalStatisticsDiscontinuityTime OBJECT-TYPE  
+       SYNTAX     TimeStamp  
+       MAX-ACCESS read-only  
+       STATUS     current  
+       DESCRIPTION  
+           "The value of sysUpTime on the most recent occasion at  
+            which one of vrrpv3RouterChecksumErrors,  
+            vrrpv3RouterVersionErrors, and vrrpv3RouterVrIdErrors
+            suffered a discontinuity. 
+     
+            If no such discontinuities have occurred since the last 
+            re-initialization of the local management subsystem,  
+            then this object contains a zero value." 
+     
+       ::= { vrrpv3Statistics 4 }  
+ 
+--  VRRP Router Statistics Table  
+
+    vrrpv3StatisticsTable OBJECT-TYPE  
+        SYNTAX       SEQUENCE OF Vrrpv3StatisticsEntry  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "Table of virtual router statistics."  
+        ::= { vrrpv3Statistics 5 }  
+     
+    vrrpv3StatisticsEntry OBJECT-TYPE  
+        SYNTAX       Vrrpv3StatisticsEntry  
+        MAX-ACCESS   not-accessible  
+        STATUS       current  
+        DESCRIPTION  
+            "An entry in the table containing statistics
+            information about a given virtual router."  
+        AUGMENTS    { vrrpv3OperationsEntry }  
+        ::= { vrrpv3StatisticsTable 1 }  
+ 
+    Vrrpv3StatisticsEntry ::=  
+        SEQUENCE {  
+            vrrpv3StatisticsMasterTransitions   
+                Counter32, 
+            vrrpv3StatisticsNewMasterReason 
+                INTEGER, 
+            vrrpv3StatisticsRcvdAdvertisements  
+                Counter64,  
+            vrrpv3StatisticsAdvIntervalErrors  
+                Counter64,  
+            vrrpv3StatisticsIpTtlErrors  
+                Counter64,  
+            vrrpv3StatisticsProtoErrReason 
+                INTEGER, 
+            vrrpv3StatisticsRcvdPriZeroPackets  
+                Counter64,  
+            vrrpv3StatisticsSentPriZeroPackets  
+                Counter64,  
+            vrrpv3StatisticsRcvdInvalidTypePackets  
+                Counter64,  
+            vrrpv3StatisticsAddressListErrors  
+                Counter64,  
+            vrrpv3StatisticsPacketLengthErrors  
+                Counter64,  
+            vrrpv3StatisticsRowDiscontinuityTime  
+                 TimeStamp,  
+            vrrpv3StatisticsRefreshRate 
+                 Unsigned32 
+        }  
+
+    vrrpv3StatisticsMasterTransitions OBJECT-TYPE  
+        SYNTAX       Counter32  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of times that this virtual router's  
+            state has transitioned to master state.
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+        ::= { vrrpv3StatisticsEntry 1 }  
+ 
+   vrrpv3StatisticsNewMasterReason OBJECT-TYPE  
+        SYNTAX        INTEGER { 
+            notMaster (0),  
+            priority  (1),  
+            preempted (2),  
+            masterNoResponse (3)  
+        }  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "This indicates the reason for the virtual router to  
+            transition to master state.  If the virtual router
+            never transitioned to master state, the value of this
+            object is notMaster(0).  Otherwise, this indicates the
+            reason this virtual router transitioned to master
+            state the last time.  Used by vrrpv3NewMaster
+            notification."
+        ::= { vrrpv3StatisticsEntry 2 }  
+ 
+    vrrpv3StatisticsRcvdAdvertisements OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP advertisements received by  
+            this virtual router.   
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+
+        ::= { vrrpv3StatisticsEntry 3 }  
+     
+    vrrpv3StatisticsAdvIntervalErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP advertisement packets  
+            received for which the advertisement interval is  
+            different from the vrrpv3OperationsAdvInterval  
+            configured on this virtual router. 
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+     
+        ::= { vrrpv3StatisticsEntry 4 }  
+     
+    vrrpv3StatisticsIpTtlErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current   
+        DESCRIPTION  
+            "The total number of VRRP packets received by the  
+            virtual router with IPv4 TTL (for VRRP over IPv4) or
+            IPv6 Hop Limit (for VRRP over IPv6) not equal to 255. 
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+        REFERENCE "RFC 5798, Section 5.1.1.3"
+        ::= { vrrpv3StatisticsEntry 5 } 
+ 
+   vrrpv3StatisticsProtoErrReason OBJECT-TYPE  
+        SYNTAX        INTEGER {  
+            noError (0),  
+            ipTtlError (1),  
+            versionError  (2),  
+            checksumError (3),  
+            vrIdError(4)  
+        }  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "This indicates the reason for the last protocol
+            error.  This SHOULD be set to noError(0) when no
+            protocol errors are encountered.  Used by
+            vrrpv3ProtoError notification."
+        ::= { vrrpv3StatisticsEntry 6 }  
+ 
+    vrrpv3StatisticsRcvdPriZeroPackets OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP packets received by the  
+            virtual router with a priority of '0'.   
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+        REFERENCE "RFC 5798, Section 5.2.4"
+        ::= { vrrpv3StatisticsEntry 7 }  
+     
+    vrrpv3StatisticsSentPriZeroPackets OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of VRRP packets sent by the virtual  
+            router with a priority of '0'.   
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+        REFERENCE "RFC 5798, Section 5.2.4" 
+        ::= { vrrpv3StatisticsEntry 8 }  
+     
+    vrrpv3StatisticsRcvdInvalidTypePackets OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The number of VRRP packets received by the virtual  
+            router with an invalid value in the 'type' field.   
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."   
+        ::= { vrrpv3StatisticsEntry 9 }  
+
+    vrrpv3StatisticsAddressListErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of packets received for which the  
+            address list does not match the locally configured 
+            list for the virtual router.   
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+        ::= { vrrpv3StatisticsEntry 10 }  
+     
+    vrrpv3StatisticsPacketLengthErrors OBJECT-TYPE  
+        SYNTAX       Counter64  
+        MAX-ACCESS   read-only  
+        STATUS       current  
+        DESCRIPTION  
+            "The total number of packets received with a packet  
+            length less than the length of the VRRP header.   
+     
+            Discontinuities in the value of this counter can occur  
+            at re-initialization of the management system, and at  
+            other times as indicated by the value of  
+            vrrpv3StatisticsRowDiscontinuityTime."  
+        ::= { vrrpv3StatisticsEntry 11 }  
+  
+   vrrpv3StatisticsRowDiscontinuityTime OBJECT-TYPE  
+       SYNTAX     TimeStamp  
+       MAX-ACCESS read-only  
+       STATUS     current  
+       DESCRIPTION  
+           "The value of sysUpTime on the most recent occasion at  
+            which any one or more of this entry's counters
+            suffered a discontinuity.
+     
+            If no such discontinuities have occurred since the last 
+            re-initialization of the local management subsystem,  
+            then this object contains a zero value." 
+       ::= { vrrpv3StatisticsEntry 12 }  
+     
+   vrrpv3StatisticsRefreshRate OBJECT-TYPE  
+       SYNTAX     Unsigned32  
+       UNITS "milliseconds"  
+       MAX-ACCESS read-only 
+       STATUS     current  
+       DESCRIPTION  
+           "The minimum reasonable polling interval for this entry. 
+            This object provides an indication of the minimum  
+            amount of time required to update the counters in this
+            entry." 
+       ::= { vrrpv3StatisticsEntry 13 }  
+
+--   Notification Definitions  
+--   Notifications may be controlled using SNMP-NOTIFICATION-MIB 
+       
+    vrrpv3NewMaster NOTIFICATION-TYPE  
+        OBJECTS      {  
+                       vrrpv3OperationsMasterIpAddr,  
+                       vrrpv3StatisticsNewMasterReason  
+                     }  
+        STATUS       current  
+        DESCRIPTION  
+            "The newMaster notification indicates that the sending 
+            agent has transitioned to master state."
+        ::= { vrrpv3Notifications 1 }  
+    
+    vrrpv3ProtoError NOTIFICATION-TYPE  
+        OBJECTS      {  
+                       vrrpv3StatisticsProtoErrReason  
+                     }  
+        STATUS       current  
+        DESCRIPTION  
+            "The notification indicates that the sending agent has  
+            encountered the protocol error indicated by  
+            vrrpv3StatisticsProtoErrReason."  
+        ::= { vrrpv3Notifications 2 }  
+ 
+--  Conformance Information  
+ 
+   vrrpv3Compliances  OBJECT IDENTIFIER ::= { vrrpv3Conformance 1 } 
+   vrrpv3Groups       OBJECT IDENTIFIER ::= { vrrpv3Conformance 2 } 
+     
+-- Compliance Statements  
+
+    vrrpv3FullCompliance MODULE-COMPLIANCE  
+        STATUS current  
+        DESCRIPTION  
+           "The compliance statement"  
+        MODULE -- this module  
+        MANDATORY-GROUPS  {  
+            vrrpv3OperationsGroup,  
+            vrrpv3StatisticsGroup,  
+            vrrpv3InfoGroup,  
+            vrrpv3NotificationsGroup  
+        }  
+        OBJECT        vrrpv3OperationsPriority 
+        WRITE-SYNTAX  Unsigned32 (1..254) 
+        DESCRIPTION  "Setable values are from 1 to 254." 
+        ::= { vrrpv3Compliances 1 }    
+  
+    vrrpv3ReadOnlyCompliance MODULE-COMPLIANCE  
+        STATUS current  
+        DESCRIPTION  
+           "When this MIB module is implemented without support
+           for read-create (i.e., in read-only mode), then such
+           an implementation can claim read-only compliance.
+           Such a device can then be monitored, but cannot be
+           configured with this MIB."
+     
+        MODULE -- this module  
+        MANDATORY-GROUPS  {  
+            vrrpv3OperationsGroup,  
+            vrrpv3StatisticsGroup, 
+            vrrpv3StatisticsDiscontinuityGroup, 
+            vrrpv3InfoGroup,  
+            vrrpv3NotificationsGroup  
+        }  
+     
+        OBJECT        vrrpv3OperationsPriority 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+
+        OBJECT        vrrpv3OperationsPrimaryIpAddr 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+        OBJECT        vrrpv3OperationsAdvInterval 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+ 
+        OBJECT        vrrpv3OperationsPreemptMode 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+ 
+        OBJECT        vrrpv3OperationsAcceptMode 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+
+        OBJECT        vrrpv3OperationsRowStatus 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+
+        OBJECT        vrrpv3AssociatedIpAddrRowStatus 
+        MIN-ACCESS    read-only 
+        DESCRIPTION  "Write access is not required." 
+
+        ::= { vrrpv3Compliances 2 } 
+
+-- Conformance Groups  
+ 
+    vrrpv3OperationsGroup   OBJECT-GROUP  
+        OBJECTS  {  
+            vrrpv3OperationsVirtualMacAddr,  
+            vrrpv3OperationsStatus,  
+            vrrpv3OperationsPriority,  
+            vrrpv3OperationsMasterIpAddr, 
+            vrrpv3OperationsAdvInterval,  
+            vrrpv3OperationsPreemptMode,  
+            vrrpv3OperationsAcceptMode, 
+            vrrpv3OperationsUpTime, 
+            vrrpv3OperationsRowStatus,  
+            vrrpv3OperationsAddrCount,  
+            vrrpv3OperationsPrimaryIpAddr, 
+            vrrpv3AssociatedIpAddrRowStatus  
+            }  
+        STATUS current  
+        DESCRIPTION  
+           "Conformance group for VRRPv3 operations."  
+        ::= { vrrpv3Groups 1 }  
+ 
+    vrrpv3StatisticsGroup  OBJECT-GROUP  
+        OBJECTS  {  
+            vrrpv3RouterChecksumErrors,  
+            vrrpv3RouterVersionErrors,  
+            vrrpv3RouterVrIdErrors,  
+            vrrpv3StatisticsMasterTransitions, 
+            vrrpv3StatisticsNewMasterReason,  
+            vrrpv3StatisticsRcvdAdvertisements,  
+            vrrpv3StatisticsAdvIntervalErrors,  
+            vrrpv3StatisticsRcvdPriZeroPackets,  
+            vrrpv3StatisticsSentPriZeroPackets,  
+            vrrpv3StatisticsRcvdInvalidTypePackets,  
+            vrrpv3StatisticsIpTtlErrors, 
+            vrrpv3StatisticsProtoErrReason, 
+            vrrpv3StatisticsAddressListErrors,   
+            vrrpv3StatisticsPacketLengthErrors,  
+            vrrpv3StatisticsRowDiscontinuityTime,  
+            vrrpv3StatisticsRefreshRate 
+            }  
+        STATUS current  
+        DESCRIPTION  
+           "Conformance group for VRRPv3 statistics."  
+        ::= { vrrpv3Groups 2 }  
+ 
+    vrrpv3StatisticsDiscontinuityGroup  OBJECT-GROUP  
+        OBJECTS  {  
+            vrrpv3GlobalStatisticsDiscontinuityTime 
+            }  
+        STATUS current  
+        DESCRIPTION  
+           "Objects providing information about counter
+            discontinuities."  
+        ::= { vrrpv3Groups 3 }  
+ 
+    vrrpv3InfoGroup  OBJECT-GROUP  
+        OBJECTS  {  
+            vrrpv3StatisticsProtoErrReason, 
+            vrrpv3StatisticsNewMasterReason 
+            }  
+        STATUS current  
+        DESCRIPTION  
+           "Conformance group for objects contained in VRRPv3
+            notifications."  
+        ::= { vrrpv3Groups 4 }  
+     
+    vrrpv3NotificationsGroup NOTIFICATION-GROUP  
+        NOTIFICATIONS {  
+            vrrpv3NewMaster,  
+            vrrpv3ProtoError  
+            }  
+        STATUS current  
+        DESCRIPTION  
+           "The VRRP MIB Notification Group."  
+        ::= { vrrpv3Groups 5 }  
+     
+END 

--- a/mibs/junos/mib-rtmib.txt
+++ b/mibs/junos/mib-rtmib.txt
@@ -1,43 +1,420 @@
 -- ******************************************************************
--- 	Include RFC 2096 IP forwarding table MIB as follows.
+-- 	Include RFC 4292 IP forwarding table MIB as follows.
 -- ******************************************************************
 
 
 IP-FORWARD-MIB DEFINITIONS ::= BEGIN
 
-IMPORTS
-    MODULE-IDENTITY, OBJECT-TYPE, IpAddress, Integer32, Gauge32
-        FROM SNMPv2-SMI
-    RowStatus
-        FROM SNMPv2-TC
-    ip
-        FROM RFC1213-MIB
-    MODULE-COMPLIANCE, OBJECT-GROUP
-        FROM SNMPv2-CONF;
+   IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE,
+       IpAddress, Integer32, Gauge32,
+       Counter32                          FROM SNMPv2-SMI
+       RowStatus                          FROM SNMPv2-TC
+      MODULE-COMPLIANCE, OBJECT-GROUP    FROM SNMPv2-CONF
+       InterfaceIndexOrZero               FROM IF-MIB
+       ip                                 FROM IP-MIB
+       IANAipRouteProtocol                FROM IANA-RTPROTO-MIB
+       InetAddress, InetAddressType,
+       InetAddressPrefixLength,
+       InetAutonomousSystemNumber         FROM INET-ADDRESS-MIB;
 
-ipForward MODULE-IDENTITY
-    LAST-UPDATED "9609190000Z"     -- Thu Sep 26 16:34:47 PDT 1996
-    ORGANIZATION "IETF OSPF Working Group"
-    CONTACT-INFO
-     "        Fred Baker
-      Postal: Cisco Systems
-              519 Lado Drive
-              Santa Barbara, California 93111
+   ipForward MODULE-IDENTITY
+       LAST-UPDATED "200602010000Z"
+       ORGANIZATION
+              "IETF IPv6 Working Group
+               http://www.ietf.org/html.charters/ipv6-charter.html"
+       CONTACT-INFO
+              "Editor:
+               Brian Haberman
+               Johns Hopkins University - Applied Physics Laboratory
+               Mailstop 17-S442
+               11100 Johns Hopkins Road
+               Laurel MD,  20723-6099  USA
 
-      Phone:  +1 805 681 0115
-      Email:  fred@cisco.com
-      "
+               Phone: +1-443-778-1319
+               Email: brian@innovationslab.net
+
+               Send comments to <ipv6@ietf.org>"
+       DESCRIPTION
+              "The MIB module for the management of CIDR multipath IP
+               Routes.
+
+               Copyright (C) The Internet Society (2006).  This version
+               of this MIB module is a part of RFC 4292; see the RFC
+               itself for full legal notices."
+
+       REVISION      "200602010000Z"
+       DESCRIPTION
+              "IPv4/v6 version-independent revision.  Minimal changes
+               were made to the original RFC 2096 MIB to allow easy
+               upgrade of existing IPv4 implementations to the
+               version-independent MIB.  These changes include:
+
+               Adding inetCidrRouteDiscards as a replacement for the
+               deprecated ipRoutingDiscards and ipv6DiscardedRoutes
+               objects.
+
+               Adding a new conformance statement to support the
+               implementation of the IP Forwarding MIB in a
+               read-only mode.
+
+
+               The inetCidrRouteTable replaces the IPv4-specific
+               ipCidrRouteTable, its related objects, and related
+               conformance statements.
+
+               Published as RFC 4292."
+
+       REVISION      "199609190000Z"
+       DESCRIPTION
+              "Revised to support CIDR routes.
+               Published as RFC 2096."
+
+       REVISION      "199207022156Z"
+       DESCRIPTION
+              "Initial version, published as RFC 1354."
+       ::= { ip 24 }
+
+inetCidrRouteNumber OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
     DESCRIPTION
-            "The MIB module for the display of CIDR multipath IP Routes."
-    REVISION      "9609190000Z"
+           "The number of current inetCidrRouteTable entries that
+            are not invalid."
+    ::= { ipForward 6 }
+
+inetCidrRouteDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
     DESCRIPTION
-            "Revisions made by the OSPF WG."
-    ::= { ip 24 }
+           "The number of valid route entries discarded from the
+            inetCidrRouteTable.  Discarded route entries do not
+            appear in the inetCidrRouteTable.  One possible reason
+            for discarding an entry would be to free-up buffer space
+            for other route table entries."
+    ::= { ipForward 8 }
+
+--  Inet CIDR Route Table
+
+--  The Inet CIDR Route Table deprecates and replaces the
+--  ipCidrRoute Table currently in the IP Forwarding Table MIB.
+--  It adds IP protocol independence.
+
+inetCidrRouteTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF InetCidrRouteEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "This entity's IP Routing table."
+    REFERENCE
+           "RFC 1213 Section 6.6, The IP Group"
+    ::= { ipForward 7 }
+
+inetCidrRouteEntry OBJECT-TYPE
+    SYNTAX     InetCidrRouteEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "A particular route to a particular destination, under a
+            particular policy (as reflected in the
+            inetCidrRoutePolicy object).
+
+            Dynamically created rows will survive an agent reboot.
+
+            Implementers need to be aware that if the total number
+            of elements (octets or sub-identifiers) in
+            inetCidrRouteDest, inetCidrRoutePolicy, and
+            inetCidrRouteNextHop exceeds 111, then OIDs of column
+            instances in this table will have more than 128 sub-
+            identifiers and cannot be accessed using SNMPv1,
+            SNMPv2c, or SNMPv3."
+    INDEX {
+        inetCidrRouteDestType,
+        inetCidrRouteDest,
+        inetCidrRoutePfxLen,
+        inetCidrRoutePolicy,
+        inetCidrRouteNextHopType,
+        inetCidrRouteNextHop
+        }
+    ::= { inetCidrRouteTable 1 }
+
+InetCidrRouteEntry ::= SEQUENCE {
+        inetCidrRouteDestType     InetAddressType,
+        inetCidrRouteDest         InetAddress,
+        inetCidrRoutePfxLen       InetAddressPrefixLength,
+        inetCidrRoutePolicy       OBJECT IDENTIFIER,
+        inetCidrRouteNextHopType  InetAddressType,
+        inetCidrRouteNextHop      InetAddress,
+        inetCidrRouteIfIndex      InterfaceIndexOrZero,
+        inetCidrRouteType         INTEGER,
+        inetCidrRouteProto        IANAipRouteProtocol,
+        inetCidrRouteAge          Gauge32,
+        inetCidrRouteNextHopAS    InetAutonomousSystemNumber,
+        inetCidrRouteMetric1      Integer32,
+        inetCidrRouteMetric2      Integer32,
+        inetCidrRouteMetric3      Integer32,
+        inetCidrRouteMetric4      Integer32,
+        inetCidrRouteMetric5      Integer32,
+        inetCidrRouteStatus       RowStatus
+    }
+
+inetCidrRouteDestType OBJECT-TYPE
+    SYNTAX     InetAddressType
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The type of the inetCidrRouteDest address, as defined
+            in the InetAddress MIB.
+
+            Only those address types that may appear in an actual
+            routing table are allowed as values of this object."
+    REFERENCE "RFC 4001"
+    ::= { inetCidrRouteEntry 1 }
+
+inetCidrRouteDest OBJECT-TYPE
+    SYNTAX     InetAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The destination IP address of this route.
+
+            The type of this address is determined by the value of
+            the inetCidrRouteDestType object.
+
+            The values for the index objects inetCidrRouteDest and
+            inetCidrRoutePfxLen must be consistent.  When the value
+            of inetCidrRouteDest (excluding the zone index, if one
+            is present) is x, then the bitwise logical-AND
+            of x with the value of the mask formed from the
+            corresponding index object inetCidrRoutePfxLen MUST be
+            equal to x.  If not, then the index pair is not
+            consistent and an inconsistentName error must be
+            returned on SET or CREATE requests."
+       ::= { inetCidrRouteEntry 2 }
+
+inetCidrRoutePfxLen OBJECT-TYPE
+    SYNTAX     InetAddressPrefixLength
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "Indicates the number of leading one bits that form the
+            mask to be logical-ANDed with the destination address
+            before being compared to the value in the
+            inetCidrRouteDest field.
+
+            The values for the index objects inetCidrRouteDest and
+            inetCidrRoutePfxLen must be consistent.  When the value
+            of inetCidrRouteDest (excluding the zone index, if one
+            is present) is x, then the bitwise logical-AND
+            of x with the value of the mask formed from the
+            corresponding index object inetCidrRoutePfxLen MUST be
+            equal to x.  If not, then the index pair is not
+            consistent and an inconsistentName error must be
+            returned on SET or CREATE requests."
+    ::= { inetCidrRouteEntry 3 }
+
+inetCidrRoutePolicy OBJECT-TYPE
+    SYNTAX     OBJECT IDENTIFIER
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "This object is an opaque object without any defined
+            semantics.  Its purpose is to serve as an additional
+            index that may delineate between multiple entries to
+            the same destination.  The value { 0 0 } shall be used
+            as the default value for this object."
+    ::= { inetCidrRouteEntry 4 }
+
+inetCidrRouteNextHopType OBJECT-TYPE
+    SYNTAX     InetAddressType
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "The type of the inetCidrRouteNextHop address, as
+            defined in the InetAddress MIB.
+
+            Value should be set to unknown(0) for non-remote
+            routes.
+
+            Only those address types that may appear in an actual
+            routing table are allowed as values of this object."
+    REFERENCE "RFC 4001"
+    ::= { inetCidrRouteEntry 5 }
+
+inetCidrRouteNextHop OBJECT-TYPE
+    SYNTAX     InetAddress
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+           "On remote routes, the address of the next system en
+            route.  For non-remote routes, a zero length string.
+
+            The type of this address is determined by the value of
+            the inetCidrRouteNextHopType object."
+    ::= { inetCidrRouteEntry 6 }
+
+inetCidrRouteIfIndex OBJECT-TYPE
+    SYNTAX     InterfaceIndexOrZero
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The ifIndex value that identifies the local interface
+            through which the next hop of this route should be
+            reached.  A value of 0 is valid and represents the
+            scenario where no interface is specified."
+    ::= { inetCidrRouteEntry 7 }
+
+inetCidrRouteType OBJECT-TYPE
+    SYNTAX     INTEGER {
+                other    (1), -- not specified by this MIB
+                reject   (2), -- route that discards traffic and
+                              --   returns ICMP notification
+                local    (3), -- local interface
+                remote   (4), -- remote destination
+                blackhole(5)  -- route that discards traffic
+                              --   silently
+             }
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The type of route.  Note that local(3) refers to a
+            route for which the next hop is the final destination;
+            remote(4) refers to a route for which the next hop is
+            not the final destination.
+
+            Routes that do not result in traffic forwarding or
+            rejection should not be displayed, even if the
+            implementation keeps them stored internally.
+
+            reject(2) refers to a route that, if matched, discards
+            the message as unreachable and returns a notification
+            (e.g., ICMP error) to the message sender.  This is used
+            in some protocols as a means of correctly aggregating
+            routes.
+
+            blackhole(5) refers to a route that, if matched,
+            discards the message silently."
+    ::= { inetCidrRouteEntry 8 }
+
+inetCidrRouteProto OBJECT-TYPE
+    SYNTAX     IANAipRouteProtocol
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The routing mechanism via which this route was learned.
+           Inclusion of values for gateway routing protocols is
+           not intended to imply that hosts should support those
+           protocols."
+    ::= { inetCidrRouteEntry 9 }
+
+inetCidrRouteAge OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The number of seconds since this route was last updated
+            or otherwise determined to be correct.  Note that no
+            semantics of 'too old' can be implied, except through
+            knowledge of the routing protocol by which the route
+            was learned."
+    ::= { inetCidrRouteEntry 10 }
+
+inetCidrRouteNextHopAS OBJECT-TYPE
+    SYNTAX     InetAutonomousSystemNumber
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The Autonomous System Number of the Next Hop.  The
+            semantics of this object are determined by the routing-
+            protocol specified in the route's inetCidrRouteProto
+            value.  When this object is unknown or not relevant, its
+            value should be set to zero."
+    DEFVAL { 0 }
+    ::= { inetCidrRouteEntry 11 }
+
+inetCidrRouteMetric1 OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The primary routing metric for this route.  The
+            semantics of this metric are determined by the routing-
+            protocol specified in the route's inetCidrRouteProto
+            value.  If this metric is not used, its value should be
+            set to -1."
+    DEFVAL { -1 }
+    ::= { inetCidrRouteEntry 12 }
+
+inetCidrRouteMetric2 OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "An alternate routing metric for this route.  The
+            semantics of this metric are determined by the routing-
+            protocol specified in the route's inetCidrRouteProto
+            value.  If this metric is not used, its value should be
+            set to -1."
+    DEFVAL { -1 }
+    ::= { inetCidrRouteEntry 13 }
+
+inetCidrRouteMetric3 OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "An alternate routing metric for this route.  The
+            semantics of this metric are determined by the routing-
+            protocol specified in the route's inetCidrRouteProto
+            value.  If this metric is not used, its value should be
+            set to -1."
+    DEFVAL { -1 }
+    ::= { inetCidrRouteEntry 14 }
+
+inetCidrRouteMetric4 OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "An alternate routing metric for this route.  The
+            semantics of this metric are determined by the routing-
+            protocol specified in the route's inetCidrRouteProto
+            value.  If this metric is not used, its value should be
+            set to -1."
+    DEFVAL { -1 }
+    ::= { inetCidrRouteEntry 15 }
+
+inetCidrRouteMetric5 OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "An alternate routing metric for this route.  The
+            semantics of this metric are determined by the routing-
+            protocol specified in the route's inetCidrRouteProto
+            value.  If this metric is not used, its value should be
+               set to -1."
+    DEFVAL { -1 }
+    ::= { inetCidrRouteEntry 16 }
+
+inetCidrRouteStatus OBJECT-TYPE
+    SYNTAX     RowStatus
+    MAX-ACCESS read-create
+    STATUS     current
+    DESCRIPTION
+           "The row status variable, used according to row
+            installation and removal conventions.
+
+            A row entry cannot be modified when the status is
+            marked as active(1)."
+    ::= { inetCidrRouteEntry 17 }
 
 ipCidrRouteNumber OBJECT-TYPE
     SYNTAX   Gauge32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The number of current ipCidrRouteTable entries
        that are not invalid."
@@ -55,7 +432,7 @@ ipCidrRouteNumber OBJECT-TYPE
 ipCidrRouteTable OBJECT-TYPE
     SYNTAX   SEQUENCE OF IpCidrRouteEntry
     MAX-ACCESS not-accessible
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "This entity's IP Routing table."
     REFERENCE
@@ -65,7 +442,7 @@ ipCidrRouteTable OBJECT-TYPE
 ipCidrRouteEntry OBJECT-TYPE
     SYNTAX   IpCidrRouteEntry
     MAX-ACCESS not-accessible
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "A particular route to  a  particular  destina-
        tion, under a particular policy."
@@ -116,7 +493,7 @@ IpCidrRouteEntry ::=
 ipCidrRouteDest OBJECT-TYPE
     SYNTAX   IpAddress
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The destination IP address of this route.
 
@@ -133,7 +510,7 @@ ipCidrRouteDest OBJECT-TYPE
 ipCidrRouteMask OBJECT-TYPE
     SYNTAX   IpAddress
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "Indicate the mask to be logical-ANDed with the
        destination  address  before  being compared to
@@ -161,7 +538,7 @@ ipCidrRouteMask OBJECT-TYPE
 ipCidrRouteTos OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The policy specifier is the IP TOS Field.  The encoding
        of IP TOS is as specified  by  the  following convention.
@@ -190,7 +567,7 @@ ipCidrRouteTos OBJECT-TYPE
 ipCidrRouteNextHop OBJECT-TYPE
     SYNTAX   IpAddress
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "On remote routes, the address of the next sys-
        tem en route; Otherwise, 0.0.0.0."
@@ -199,7 +576,7 @@ ipCidrRouteNextHop OBJECT-TYPE
 ipCidrRouteIfIndex OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The ifIndex value which identifies  the  local
        interface  through  which  the next hop of this
@@ -215,7 +592,7 @@ ipCidrRouteType OBJECT-TYPE
                 remote   (4)  -- remote destination
              }
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The type of route.  Note that local(3)  refers
        to  a route for which the next hop is the final
@@ -257,7 +634,7 @@ ipCidrRouteProto OBJECT-TYPE
                 ciscoEigrp (16)  -- Cisco EIGRP
              }
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The routing mechanism via which this route was
        learned.  Inclusion of values for gateway rout-
@@ -268,7 +645,7 @@ ipCidrRouteProto OBJECT-TYPE
 ipCidrRouteAge OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The number of seconds  since  this  route  was
        last  updated  or  otherwise  determined  to be
@@ -282,7 +659,7 @@ ipCidrRouteAge OBJECT-TYPE
 ipCidrRouteInfo OBJECT-TYPE
     SYNTAX   OBJECT IDENTIFIER
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "A reference to MIB definitions specific to the
        particular  routing protocol which is responsi-
@@ -299,7 +676,7 @@ ipCidrRouteInfo OBJECT-TYPE
 ipCidrRouteNextHopAS OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The Autonomous System Number of the Next  Hop.
        The  semantics of this object are determined by
@@ -313,7 +690,7 @@ ipCidrRouteNextHopAS OBJECT-TYPE
 ipCidrRouteMetric1 OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The primary routing  metric  for  this  route.
        The  semantics of this metric are determined by
@@ -326,7 +703,7 @@ ipCidrRouteMetric1 OBJECT-TYPE
 ipCidrRouteMetric2 OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "An alternate routing metric  for  this  route.
        The  semantics of this metric are determined by
@@ -339,7 +716,7 @@ ipCidrRouteMetric2 OBJECT-TYPE
 ipCidrRouteMetric3 OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "An alternate routing metric  for  this  route.
        The  semantics of this metric are determined by
@@ -352,7 +729,7 @@ ipCidrRouteMetric3 OBJECT-TYPE
 ipCidrRouteMetric4 OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "An alternate routing metric  for  this  route.
        The  semantics of this metric are determined by
@@ -365,7 +742,7 @@ ipCidrRouteMetric4 OBJECT-TYPE
 ipCidrRouteMetric5 OBJECT-TYPE
     SYNTAX   Integer32
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "An alternate routing metric  for  this  route.
        The  semantics of this metric are determined by
@@ -378,7 +755,7 @@ ipCidrRouteMetric5 OBJECT-TYPE
 ipCidrRouteStatus OBJECT-TYPE
     SYNTAX   RowStatus
     MAX-ACCESS read-only
-    STATUS   current
+    STATUS   deprecated
     DESCRIPTION
        "The row status variable, used according to
        row installation and removal conventions."


### PR DESCRIPTION
MIBS updated directly from the Juniper website.

This is needed to detect some new platforms.

Also update the juniper hardware rewrite. The current way is a bit silly as in essence it's just stripping jnxProductName off the response so I've added that to the bottom to replace that string with nothing.

tobiasa has confirmed this is working on both new and existing juniper kit.