### PR TITLE
Updated search pages to fix broken elements

### DIFF
--- a/html/includes/table/address-search.inc.php
+++ b/html/includes/table/address-search.inc.php
@@ -3,21 +3,35 @@
 $where = 1;
 $param = array();
 
+list($address,$prefix) = explode("/", $_POST['address']);
 if ($_POST['search_type'] == 'ipv4') {
     $sql = " FROM `ipv4_addresses` AS A, `ports` AS I, `devices` AS D, `ipv4_networks` AS N WHERE I.port_id = A.port_id AND I.device_id = D.device_id AND N.ipv4_network_id = A.ipv4_network_id ";
+    if (!empty($address)) {
+        $sql .= " AND ipv4_address LIKE '%".$address."%'";
+    }
+    if (!empty($prefix)) {
+        $sql .= " AND ipv4_prefixlen='?'";
+        $param[] = array($prefix);
+    }
 } elseif ($_POST['search_type'] == 'ipv6') {
     $sql = " FROM `ipv6_addresses` AS A, `ports` AS I, `devices` AS D, `ipv6_networks` AS N WHERE I.port_id = A.port_id AND I.device_id = D.device_id AND N.ipv6_network_id = A.ipv6_network_id ";
+    if (!empty($address)) {
+        $sql .= " AND (ipv6_address LIKE '%".$address."%' OR ipv6_compressed LIKE '%".$address."%')";
+    }
+    if (!empty($prefix)) {
+        $sql .= " AND ipv6_prefixlen = '$prefix'";
+    }
 } elseif ($_POST['search_type'] == 'mac') {
-    $sql = " FROM `ports` AS I, `devices` AS D WHERE I.device_id = D.device_id AND `ifPhysAddress` LIKE ? ";
-    $param = array("%".str_replace(array(':', ' ', '-', '.', '0x'),'',mres($_POST['address']))."%");
+    $sql = " FROM `ports` AS I, `devices` AS D WHERE I.device_id = D.device_id AND `ifPhysAddress` LIKE '%?%' ";
+    $param[] = array("%".str_replace(array(':', ' ', '-', '.', '0x'),'',mres($_POST['address']))."%");
 }
 if (is_numeric($_POST['device_id'])) {
     $sql  .= " AND I.device_id = ?";
-    $param[] = $_POST['device_id'];
+    $param[] = array($_POST['device_id']);
 }
 if ($_POST['interface']) {
     $sql .= " AND I.ifDescr LIKE '?'";
-    $param[] = $_POST['interface'];
+    $param[] = array($_POST['interface']);
 }
 
 if ($_POST['search_type'] == 'ipv4') {
@@ -50,53 +64,31 @@ if ($rowCount != -1) {
 $sql = "SELECT *,`I`.`ifDescr` AS `interface` $sql";
 
 foreach (dbFetchRows($sql, $param) as $interface) {
-    if ($_POST['address']) {
-        list($addy, $mask) = explode("/", $_POST['address']);
-        if ($_POST['search_type']) {
-            $tmp_mask = '128';
-            if (!Net_IPv6::isInNetmask($interface['ipv6_address'], $addy, $mask)) {
-                $ignore = 1;
-            } else {
-                $ignore = 0;
-            }
-        } else {
-            $tmp_mask = '32';
-            if (!match_network($addy . "/" . $mask, $interface['ipv4_address'])) {
-                $ignore = 1;
-            }
-        }
-        if (!$mask) {
-            $mask = $tmp_mask;
-        }
-    }
-    if (!$ignore) {
-        $speed = humanspeed($interface['ifSpeed']);
-        $type = humanmedia($interface['ifType']);
+    $speed = humanspeed($interface['ifSpeed']);
+    $type = humanmedia($interface['ifType']);
 
-        if ($_POST['search_type'] == 'ipv6') {
-            list($prefix, $length) = explode("/", $interface['ipv6_network']);
-            $address = Net_IPv6::compress($interface['ipv6_address']) . '/'.$length;
-        } elseif ($_POST['search_type'] == 'mac') {
-            $address = formatMac($interface['ifPhysAddress']);
-        } else {
-            list($prefix, $length) = explode("/", $interface['ipv4_network']);
-            $address = $interface['ipv4_address'] . '/' .$length;
-        }
-
-        if ($interface['in_errors'] > 0 || $interface['out_errors'] > 0) {
-            $error_img = generate_port_link($interface,"<img src='images/16/chart_curve_error.png' alt='Interface Errors' border=0>",errors);
-        } else {
-            $error_img = "";
-        }
-        if (port_permitted($interface['port_id'])) {
-            $interface = ifLabel ($interface, $interface);
-            $response[] = array('hostname'=>generate_device_link($interface),
-                                'interface'=>generate_port_link($interface) . ' ' . $error_img,
-                                'address'=>$address,
-                                'description'=>$interface['ifAlias']);
-        }
+    if ($_POST['search_type'] == 'ipv6') {
+        list($prefix, $length) = explode("/", $interface['ipv6_network']);
+        $address = Net_IPv6::compress($interface['ipv6_address']) . '/'.$length;
+    } elseif ($_POST['search_type'] == 'mac') {
+        $address = formatMac($interface['ifPhysAddress']);
+    } else {
+        list($prefix, $length) = explode("/", $interface['ipv4_network']);
+        $address = $interface['ipv4_address'] . '/' .$length;
     }
-    unset($ignore);
+
+    if ($interface['in_errors'] > 0 || $interface['out_errors'] > 0) {
+        $error_img = generate_port_link($interface,"<img src='images/16/chart_curve_error.png' alt='Interface Errors' border=0>",errors);
+    } else {
+        $error_img = "";
+    }
+    if (port_permitted($interface['port_id'])) {
+        $interface = ifLabel ($interface, $interface);
+        $response[] = array('hostname'=>generate_device_link($interface),
+                            'interface'=>generate_port_link($interface) . ' ' . $error_img,
+                            'address'=>$address,
+                            'description'=>$interface['ifAlias']);
+    }
 }
 
 $output = array('current'=>$current,'rowCount'=>$rowCount,'rows'=>$response,'total'=>$total);

--- a/html/pages/search/mac.inc.php
+++ b/html/pages/search/mac.inc.php
@@ -62,7 +62,7 @@ if ($_POST['interface'] == "Vlan%") {
                "<input type=\"text\" name=\"address\" id=\"address\" value=\""+
 <?php
 
-echo($_POST['address']);
+echo('"'.$_POST['address'].'"+');
 ?>
 
                "\" class=\"form-control input-sm\" placeholder=\"Mac Address\"/>"+


### PR DESCRIPTION
Fixes issue #842 

Couple of things, the old way grabbed the data then processed the IP addresses to work out what was in the different subnets - not that it seems to have worked very well.

Using the bootgrid tables we can't do this as any post processing of data to be included breaks the way it works.

If you search for:

1.1.1.1 it will work
1.1.1.1/27 and the IP and prefix is 1.1.1.1/27 it will work
1.1.1.1/32 and the IP and prefix is 1.1.1.1/27 it won't work.

I think this is a good trade off as it stands. maybe we can do better querying directly in sql but for now this at least gets the search working.