### PR TITLE
Update modal so deletion is possible - grrr javascript

### DIFF
--- a/html/includes/modal/delete_alert_map.inc.php
+++ b/html/includes/modal/delete_alert_map.inc.php
@@ -41,8 +41,7 @@ if(is_admin() === false) {
 
 <script>
 $('#confirm-delete').on('show.bs.modal', function(event) {
-    event.preventDefault();
-    map_id = $(e.relatedTarget).data('map_id');
+    map_id = $(event.relatedTarget).data('map_id');
     $("#map_id").val(map_id);
 });
 


### PR DESCRIPTION
Fixes issue #843 

I'm not sure why this wasn't working. event.preventDefault is used elsewhere without issue - including in similar code. Anyway, removed and it's not causing an issue. Deletion is now possible.