### PR TITLE
Fixed deleting poller groups in Firefox

### DIFF
--- a/html/includes/modal/poller_groups.inc.php
+++ b/html/includes/modal/poller_groups.inc.php
@@ -84,11 +84,10 @@ if(is_admin() === false) {
 $('#confirm-delete').on('show.bs.modal', function(e) {
     group_id = $(e.relatedTarget).data('group_id');
     $("#group_id").val(group_id);
-    event.preventDefault();
 });
 
 $('#group-removal').click('', function(e) {
-    event.preventDefault();
+    e.preventDefault();
     group_id = $("#group_id").val();
     $.ajax({
         type: "POST",


### PR DESCRIPTION
Self explanatory really.

In FF you can't delete poller groups at the moment. This enables that to work now. Works in Chrome still as well.