### PR TITLE
Fixes width of disabled devices badge

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1608,5 +1608,5 @@ tr.search:nth-child(odd) {
 
 .threeqtr-width {
     display:block;
-    width: 75%;
+    min-width: 75%;
 }


### PR DESCRIPTION
Old:
http://pasteboard.co/2L8D3aS7.png

New:
http://pasteboard.co/2L8EXd0T.png

disabled was cut off - this will still maintain a smaller badge unless the text length warrants it.