### PR TITLE
allow detecting OpenBSD's own snmpd by sysObjectId

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,6 +20,7 @@ Contributors to LibreNMS:
 - Joubert RedRat <me+github@redrat.com.br> (joubertredrat)
 - Len Lin <Ultra2D@users.noreply.github.com> (Ultra2D)
 - Christopher Freas <code@packetbusters.net> (nwautomator)
+- Stuart Henderson <stu@spacehopper.org> (sthen)
 
 [1]: http://observium.org/ "Observium web site"
 

--- a/includes/discovery/os/openbsd.inc.php
+++ b/includes/discovery/os/openbsd.inc.php
@@ -2,7 +2,8 @@
 
 if (!$os)
 {
-  if (preg_match("/OpenBSD/", $sysDescr)) { $os = "openbsd"; }
+  if (strstr($sysObjectId, ".1.3.6.1.4.1.30155.23.1")) { $os = "openbsd"; } # snmpd
+  if (preg_match("/OpenBSD/", $sysDescr)) { $os = "openbsd"; } # Net-SNMP
 }
 
 ?>


### PR DESCRIPTION
OpenBSD has its own native snmpd, it is autodetected by LibreNMS when it's left at default settings, but if sysDescr has been adjusted this no longer identifies the OS automatically. Diff just adds sysObjectId as an alternative (while leaving the previous detection in place for people using Net-SNMP instead).