### PR TITLE
Added text to let users know refresh is disabled

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -363,6 +363,18 @@ if ($no_refresh !== TRUE && $config['page_refresh'] != 0) {
         });
     </script>');
 
+} else {
+
+echo('<script type="text/javascript">
+    $(document).ready(function() {
+        $("#countdown_timer").html("Refresh disabled");
+        $("#countdown_timer_status").html("<i class=\"fa fa-pause fa-fw\"></i>");
+        $("#countdown_timer_status").click("", function(event) {
+            event.preventDefault();
+        });
+     });
+</script>');
+
 }
 
 ?>


### PR DESCRIPTION
As reported in issue #881.

On pages where refresh is disabled, menu system looked odd. I've now added a message to inform users it's disabled.