### PR TITLE
Added detection for window height for map page

### DIFF
--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -88,6 +88,10 @@ if (is_array($tmp_devices[0])) {
  
 ?>
  
+<script>
+var height = $(window).height() - 100;
+$('#visualization').css('height', height + 'px');
+</script>
 <div id="visualization"></div>
 <script src="js/vis.min.js"></script>
 <script type="text/javascript">


### PR DESCRIPTION
This now gets the window height and removes 100 (top and bottom nav height combined) then sets the visualization div to be that height via jquery.

Fixes issue #879 