### PR TITLE
Updated installer

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -50,6 +50,13 @@ if (strpos($_SERVER['PATH_INFO'], "debug"))
 
 // Set variables
 $msg_box = array();
+// Check for install.inc.php
+if (!file_exists('../config.php') && $_SERVER['PATH_INFO'] != '/install.php')
+{
+  // no config.php does so let's redirect to the install
+  header('Location: /install.php');
+  exit;
+}
 
 include("../includes/defaults.inc.php");
 include("../config.php");
@@ -59,14 +66,6 @@ include("includes/functions.inc.php");
 include("includes/vars.inc.php");
 include('includes/plugins.inc.php');
 Plugins::start();
-
-// Check for install.inc.php
-if (!file_exists('../config.php') && $_SERVER['PATH_INFO'] != '/install.php')
-{
-  // no config.php does so let's redirect to the install
-  header('Location: /install.php');
-  exit;
-}
 
 $runtime_start = utime();
 

--- a/html/install.php
+++ b/html/install.php
@@ -48,10 +48,10 @@ include("includes/functions.inc.php");
 if($stage == 2)
 {
   $test_db = mysqli_connect($dbhost,$dbuser,$dbpass,$dbname);
-  if(mysqli_connect_errno($test_db))
+  if(mysqli_connect_error())
   {
     $stage = 1;
-    $msg = "Couldn't connect to the database, please check your details";
+    $msg = "Couldn't connect to the database, please check your details<br /> " . mysqli_connect_error();
   }
   else
   {
@@ -404,7 +404,6 @@ $config_file = <<<"EOD"
 \$config\['poller-wrapper'\]\['alerter'\] = FALSE;
 # Uncomment the next line to disable daily updates
 #\$config\['update'\] = 0;
-?>
 EOD;
 
   if(!file_exists("../config.php"))


### PR DESCRIPTION
1. Will now redirect from / to /install.php when no config.php file exists.

2. Error connecting to mysql when testing db details is now the mysql error response.

3. Removed ?> from config.php that is generated for users.

In response to issue #886 