### PR TITLE
Allow per-OS definitions of bad_iftype, bad_if, bad_if_regexp

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -877,7 +877,11 @@ function is_port_valid($port, $device)
   } else {
     $valid = 1;
     $if = strtolower($port['ifDescr']);
-    foreach ($config['bad_if'] as $bi)
+    $fringe = $config['bad_if'];
+    if( is_array($config['os'][$device['os']]['bad_if']) ) {
+      $fringe = array_merge($config['bad_if'],$config['os'][$device['os']]['bad_if']);
+    }
+    foreach ($fringe as $bi)
     {
       if (strstr($if, $bi))
       {
@@ -887,7 +891,11 @@ function is_port_valid($port, $device)
     }
     if (is_array($config['bad_if_regexp']))
     {
-      foreach ($config['bad_if_regexp'] as $bi)
+      $fringe = $config['bad_if_regexp'];
+      if( is_array($config['os'][$device['os']]['bad_if_regexp']) ) {
+        $fringe = array_merge($config['bad_if_regexp'],$config['os'][$device['os']]['bad_if_regexp']);
+      }
+      foreach ($fringe as $bi)
       {
         if (preg_match($bi ."i", $if))
         {
@@ -898,7 +906,11 @@ function is_port_valid($port, $device)
     }
     if (is_array($config['bad_iftype']))
     {
-      foreach ($config['bad_iftype'] as $bi)
+      $fringe = $config['bad_iftype'];
+      if( is_array($config['os'][$device['os']]['bad_iftype']) ) {
+        $fringe = array_merge($config['bad_iftype'],$config['os'][$device['os']]['bad_iftype']);
+      }
+      foreach ($fringe as $bi)
       {
       if (strstr($port['ifType'], $bi))
         {


### PR DESCRIPTION
Related: #929 

Supported:
```php
	$config['os'][$os]['bad_if'][] = '...';
	$config['os'][$os]['bad_if_regexp'][] = '...';
	$config['os'][$os]['bad_iftype'][] = '...';
```
Best to be used in `includes/definitions.inc.php`