### PR TITLE
sentry3: add Sentry Smart CDU detection

### DIFF
--- a/includes/discovery/os/sentry3.inc.php
+++ b/includes/discovery/os/sentry3.inc.php
@@ -2,7 +2,7 @@
 
 if (!$os)
 {
-  if (preg_match("/^Sentry\ Switched /", $sysDescr)) { $os = "sentry3"; }
+  if (preg_match("/^Sentry\ (Switched|Smart) /", $sysDescr)) { $os = "sentry3"; }
 }
 
 ?>

--- a/includes/polling/os/sentry3.inc.php
+++ b/includes/polling/os/sentry3.inc.php
@@ -7,7 +7,7 @@
 $hardware = snmp_get($device, "towerModelNumber.1", "-Ovq", "Sentry3-MIB");
 $serial = snmp_get($device, "towerProductSN.1", "-Ovq", "Sentry3-MIB");
 $version = snmp_get($device, "systemVersion.0", "-Ovq", "Sentry3-MIB");
-$version = preg_split('/Sentry\ Switched\ CDU\ Version/', $version);
+$version = preg_split('/Sentry\ (Switched|Smart)\ CDU\ Version/', $version);
 $version = $version[1];
 
 ?>


### PR DESCRIPTION
The polled SNMP OIDs are the same as Switched CDU, thus match both.