### PR TITLE
Updated addhost.php to use distributed_poller_group if set

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -28,7 +28,10 @@ if (isset($options['g']) && $options['g'] >= 0) {
     array_shift($argv);
     array_unshift($argv, $cmd);
     $poller_group = $options['g'];
+} elseif ($config['distributed_poller_group'] > 0 && $config['distributed_poller'] === TRUE) {
+    $poller_group = $config['distributed_poller_group'];
 }
+
 if (isset($options['f']) && $options['f'] == 0) {
     $cmd = array_shift($argv);
     array_shift($argv);


### PR DESCRIPTION
Using ./addhost.php with distributed polling configured will now use $config['distributed_poller_group'] if it's set to more than 0 and $config['distributed_poller'] is set to TRUE.

Can be overridden by using -g as always.