### PR TITLE
Basic Ubiquiti EdgeSwitch implementation

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -404,6 +404,9 @@ $config['bad_iftype'][] = "mpls";
 $config['bad_if_regexp'][] = "/^ng[0-9]+$/";
 $config['bad_if_regexp'][] = "/^sl[0-9]/";
 
+// Rewrite Interfaces
+$config['rewrite_if_regexp']['/^cpu interface/'] = 'Mgmt';
+
 $config['processor_filter'][] = "An electronic chip that makes the computer work.";
 
 $config['ignore_mount_removable']  = 1; # Ignore removable disk storage

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1079,6 +1079,15 @@ $config['os'][$os]['text']              = "Datacom";
 $config['os'][$os]['type']              = "network";
 $config['os'][$os]['icon']              = "datacom";
 
+// UBNT EdgeSwitch 750W
+$os = "edgeswitch";
+$config['os'][$os]['text']              = "EdgeSwitch";
+$config['os'][$os]['type']              = "network";
+$config['os'][$os]['icon']              = "ubiquiti";
+$config['os'][$os]['over'][0]['graph']  = "device_bits";
+$config['os'][$os]['over'][0]['text']   = "Device Traffic";
+$config['os'][$os]['ifname']            = 1;
+
 foreach ($config['os'] as $this_os => $blah)
 {
   if (isset($config['os'][$this_os]['group']))

--- a/includes/discovery/os/edgeswitch.inc.php
+++ b/includes/discovery/os/edgeswitch.inc.php
@@ -1,0 +1,6 @@
+<?php
+if (!$os) {
+	if (strstr($sysObjectId, ".1.3.6.1.4.1.4413")) {
+		$os = "edgeswitch";
+	}
+}

--- a/includes/polling/os/edgeswitch.inc.php
+++ b/includes/polling/os/edgeswitch.inc.php
@@ -1,0 +1,7 @@
+<?php
+//SNMPv2-MIB::sysDescr.0 = STRING: EdgeSwitch 48-Port 750W, 1.1.2.4767216, Linux 3.6.5-f4a26ed5
+if( preg_match('/^(EdgeSwitch .*), (.*), Linux .*$/', $poll_device['sysDescr'], $regexp_result)) {
+	$hardware = $regexp_result[1];
+	$version = $regexp_result[2];
+	$serial = trim(snmp_get($device, ".1.3.6.1.2.1.47.1.1.1.1.11.1", "-Ovq") , '" ');
+}


### PR DESCRIPTION
Very basic Ubiquiti EdgeSwitch detection based on EdgeSwitch 48-Port 750W
Logo already exists.

What works:
- Ports
- VLANs
- Netstats
- OS
- Location
- Contact
- Firmware
- Version

What does not work:
- CPU+Mem metrics (Doesn't seem available)
- PoE Stats (if any, wasn't looked at)

What hasn't been tested:
- ARP-Table
- Radius
- Link-Aggregation Interfaces

Requires #946 to rewrite the `CPU Interface` to `Mgmt`.