### PR TITLE
Add aggregates on multi_bits_separate graphs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,7 @@ Contributors to LibreNMS:
 - Stuart Henderson <stu@spacehopper.org> (sthen)
 - Filippo Giunchedi <filippo@esaurito.net> (filippog)
 - Lasse Leegaard <lasse@brandbil.dk> (lasseleegaard)
+- Mickael Marchand <mmarchand@corp.free.fr> (mmarchand)
 
 [1]: http://observium.org/ "Observium web site"
 

--- a/html/includes/graphs/common.inc.php
+++ b/html/includes/graphs/common.inc.php
@@ -7,6 +7,8 @@ if($config['trim_tobias']) { $width+=12; }
 if ($_GET['height'])  { $height = mres($_GET['height']); }
 if ($_GET['inverse']) { $in = 'out'; $out = 'in'; $inverse=TRUE; } else { $in = 'in'; $out = 'out'; }
 if ($_GET['legend'] == "no")  { $rrd_options .= " -g"; }
+if ($_GET['nototal']) { $nototal=TRUE;} else { $nototal=FALSE;}
+if ($_GET['nodetails']) { $nodetails=TRUE; } else { $nodetails=FALSE; }
 
 if ($_GET['title'] == "yes")  { $rrd_options .= " --title='".$graph_title."' "; }
 if (isset($_GET['graph_title']))  { $rrd_options .= " --title='".$_GET['graph_title']."' "; }

--- a/html/includes/graphs/common.inc.php
+++ b/html/includes/graphs/common.inc.php
@@ -9,6 +9,7 @@ if ($_GET['inverse']) { $in = 'out'; $out = 'in'; $inverse=TRUE; } else { $in = 
 if ($_GET['legend'] == "no")  { $rrd_options .= " -g"; }
 if ($_GET['nototal']) { $nototal=TRUE;} else { $nototal=FALSE;}
 if ($_GET['nodetails']) { $nodetails=TRUE; } else { $nodetails=FALSE; }
+if ($_GET['noagg']) { $noagg=TRUE; } else { $noagg=FALSE; }
 
 if ($_GET['title'] == "yes")  { $rrd_options .= " --title='".$graph_title."' "; }
 if (isset($_GET['graph_title']))  { $rrd_options .= " --title='".$_GET['graph_title']."' "; }

--- a/html/includes/graphs/generic_multi_bits_separated.inc.php
+++ b/html/includes/graphs/generic_multi_bits_separated.inc.php
@@ -15,12 +15,12 @@ $unit_text = "Bits/sec";
 
 if($width > "500")
 {
-  $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."    Current      Average     Maximum      '";
+  $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."    Current      Average     Maximum    '";
   if (!$nototal) { $rrd_options .= " COMMENT:'Total      '"; }
   $rrd_options .= " COMMENT:'\l'";
 } else {
+  $nototal=TRUE;
   $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."     Now         Ave          Max\l'";
-
 }
 
 if(!isset($multiplier)) { $multiplier = "8"; }
@@ -32,15 +32,16 @@ foreach ($rrd_list as $rrd)
   $colour_in=$config['graph_colours'][$colours_in][$iter];
   $colour_out=$config['graph_colours'][$colours_out][$iter];
 
-  if (isset($rrd['descr_in']))
-  {
-    $descr     = rrdtool_escape($rrd['descr_in'], $descr_len) . "  In";
-  } else {
-    $descr     = rrdtool_escape($rrd['descr'], $descr_len) . "  In";
+  if (!$nodetails) {
+    if (isset($rrd['descr_in'])) {
+      $descr     = rrdtool_escape($rrd['descr_in'], $descr_len) . "  In";
+    } else {
+      $descr     = rrdtool_escape($rrd['descr'], $descr_len) . "  In";
+    }
+    $descr_out = rrdtool_escape($rrd['descr_out'], $descr_len) . " Out";
+    $descr     = str_replace("'", "", $descr); // FIXME does this mean ' should be filtered in rrdtool_escape? probably...
+    $descr_out = str_replace("'", "", $descr_out);
   }
-  $descr_out = rrdtool_escape($rrd['descr_out'], $descr_len) . " Out";
-  $descr     = str_replace("'", "", $descr); // FIXME does this mean ' should be filtered in rrdtool_escape? probably...
-  $descr_out = str_replace("'", "", $descr_out);
 
   $rrd_options .= " DEF:".$in.$i."=".$rrd['filename'].":".$ds_in.":AVERAGE ";
   $rrd_options .= " DEF:".$out.$i."=".$rrd['filename'].":".$ds_out.":AVERAGE ";
@@ -49,8 +50,7 @@ foreach ($rrd_list as $rrd)
   $rrd_options .= " CDEF:outB".$i."_neg=outB".$i.",-1,*";
   $rrd_options .= " CDEF:octets".$i."=inB".$i.",outB".$i.",+";
 
-  if (!$args['nototal'])
-  {
+  if (!$nototal) {
     $rrd_options .= " VDEF:totin".$i."=inB".$i.",TOTAL";
     $rrd_options .= " VDEF:totout".$i."=outB".$i.",TOTAL";
     $rrd_options .= " VDEF:tot".$i."=octets".$i.",TOTAL";
@@ -59,23 +59,68 @@ foreach ($rrd_list as $rrd)
   if ($i) { $stack="STACK"; }
 
   $rrd_options .= " AREA:inB".$i."#" . $colour_in . ":'" . $descr . "':$stack";
-  $rrd_options .= " GPRINT:inB".$i.":LAST:%6.2lf%s$units";
-  $rrd_options .= " GPRINT:inB".$i.":AVERAGE:%6.2lf%s$units";
-  $rrd_options .= " GPRINT:inB".$i.":MAX:%6.2lf%s$units\l";
-
-  if (!$nototal) { $rrd_options .= " GPRINT:totin".$i.":%6.2lf%s$total_units"; }
+  if (!$nodetails) {
+    $rrd_options .= " GPRINT:inB".$i.":LAST:%6.2lf%s$units";
+    $rrd_options .= " GPRINT:inB".$i.":AVERAGE:%6.2lf%s$units";
+    $rrd_options .= " GPRINT:inB".$i.":MAX:%6.2lf%s$units";
+    if (!$nototal) {
+      $rrd_options .= " GPRINT:totin".$i.":%6.2lf%s$total_units"; 
+    }
+    $rrd_options .= "\l";
+  }
 
   $rrd_options  .= " 'HRULE:0#" . $colour_out.":".$descr_out."'";
   $rrd_optionsb .= " 'AREA:outB".$i."_neg#" . $colour_out . "::$stack'";
-  $rrd_options  .= " GPRINT:outB".$i.":LAST:%6.2lf%s$units";
-  $rrd_options  .= " GPRINT:outB".$i.":AVERAGE:%6.2lf%s$units";
-  $rrd_options  .= " GPRINT:outB".$i.":MAX:%6.2lf%s$units\l";
 
-  if (!$nototal) { $rrd_options .= " GPRINT:totout".$i.":%6.2lf%s$total_unit"; }
+  if (!$nodetails) {
+    $rrd_options  .= " GPRINT:outB".$i.":LAST:%6.2lf%s$units";
+    $rrd_options  .= " GPRINT:outB".$i.":AVERAGE:%6.2lf%s$units";
+    $rrd_options  .= " GPRINT:outB".$i.":MAX:%6.2lf%s$units";
+    if (!$nototal) { 
+      $rrd_options .= " GPRINT:totout".$i.":%6.2lf%s$total_unit"; 
+    }
+    $rrd_options .= "\l";
+  }
 
   $rrd_options .= " 'COMMENT:\l'";
+
+  if ($i >= 1) {
+    $aggr_in .= ",";
+    $aggr_out .= ",";
+  }
+  if ($i > 1) {
+    $aggr_in .= "ADDNAN,";
+    $aggr_out .= "ADDNAN,";
+  }
+  $aggr_in .= $in.$i ;
+  $aggr_out .= $out.$i ;
+
   $i++; $iter++;
 }
+
+$rrd_options .= " CDEF:aggr".$in."bytes=" . $aggr_in.",ADDNAN";
+$rrd_options .= " CDEF:aggr".$out."bytes=" . $aggr_out.",ADDNAN";
+$rrd_options .= " CDEF:aggrinbits=aggrinbytes,".$multiplier.",*";
+$rrd_options .= " CDEF:aggroutbits=aggroutbytes,".$multiplier.",*";
+$rrd_options .= " VDEF:totalin=aggrinbytes,TOTAL";
+$rrd_options .= " VDEF:totalout=aggroutbytes,TOTAL";
+$rrd_options .= " COMMENT:' \\\\n'";
+$rrd_options .= " COMMENT:'".substr(str_pad("Aggregate In", $descr_len+5),0,$descr_len+5)."'";
+$rrd_options .= " GPRINT:aggrinbits:LAST:%6.2lf%s$units";
+$rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.2lf%s$units";
+$rrd_options .= " GPRINT:aggrinbits:MAX:%6.2lf%s$units";
+if (!$nototal) {
+  $rrd_options .= " GPRINT:totalin:%6.2lf%s$total_units";
+}
+$rrd_options .= "\\\\n";
+$rrd_options .= " COMMENT:'".substr(str_pad("Aggregate Out", $descr_len+5),0,$descr_len+5)."'";
+$rrd_options .= " GPRINT:aggroutbits:LAST:%6.2lf%s$units";
+$rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.2lf%s$units";
+$rrd_options .= " GPRINT:aggroutbits:MAX:%6.2lf%s$units";
+if (!$nototal) {
+  $rrd_options .= " GPRINT:totalout:%6.2lf%s$total_units";
+}
+$rrd_options .= "\\\\n";
 
 if ($custom_graph) { $rrd_options .= $custom_graph; }
 

--- a/html/includes/graphs/generic_multi_bits_separated.inc.php
+++ b/html/includes/graphs/generic_multi_bits_separated.inc.php
@@ -13,14 +13,15 @@ if($width > "500")
 
 $unit_text = "Bits/sec";
 
-if($width > "500")
-{
-  $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."    Current      Average     Maximum    '";
-  if (!$nototal) { $rrd_options .= " COMMENT:'Total      '"; }
-  $rrd_options .= " COMMENT:'\l'";
-} else {
-  $nototal=TRUE;
-  $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."     Now         Ave          Max\l'";
+if (!$noagg || !$nodetails) {
+  if($width > "500") {
+    $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."    Current      Average     Maximum    '";
+    if (!$nototal) { $rrd_options .= " COMMENT:'Total      '"; }
+    $rrd_options .= " COMMENT:'\l'";
+  } else {
+    $nototal=TRUE;
+    $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, $descr_len+5),0,$descr_len+5)."     Now         Ave          Max\l'";
+  }
 }
 
 if(!isset($multiplier)) { $multiplier = "8"; }

--- a/html/includes/graphs/generic_multi_bits_separated.inc.php
+++ b/html/includes/graphs/generic_multi_bits_separated.inc.php
@@ -98,29 +98,31 @@ foreach ($rrd_list as $rrd)
   $i++; $iter++;
 }
 
-$rrd_options .= " CDEF:aggr".$in."bytes=" . $aggr_in.",ADDNAN";
-$rrd_options .= " CDEF:aggr".$out."bytes=" . $aggr_out.",ADDNAN";
-$rrd_options .= " CDEF:aggrinbits=aggrinbytes,".$multiplier.",*";
-$rrd_options .= " CDEF:aggroutbits=aggroutbytes,".$multiplier.",*";
-$rrd_options .= " VDEF:totalin=aggrinbytes,TOTAL";
-$rrd_options .= " VDEF:totalout=aggroutbytes,TOTAL";
-$rrd_options .= " COMMENT:' \\\\n'";
-$rrd_options .= " COMMENT:'".substr(str_pad("Aggregate In", $descr_len+5),0,$descr_len+5)."'";
-$rrd_options .= " GPRINT:aggrinbits:LAST:%6.2lf%s$units";
-$rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.2lf%s$units";
-$rrd_options .= " GPRINT:aggrinbits:MAX:%6.2lf%s$units";
-if (!$nototal) {
-  $rrd_options .= " GPRINT:totalin:%6.2lf%s$total_units";
+if (!$noagg){
+  $rrd_options .= " CDEF:aggr".$in."bytes=" . $aggr_in.",ADDNAN";
+  $rrd_options .= " CDEF:aggr".$out."bytes=" . $aggr_out.",ADDNAN";
+  $rrd_options .= " CDEF:aggrinbits=aggrinbytes,".$multiplier.",*";
+  $rrd_options .= " CDEF:aggroutbits=aggroutbytes,".$multiplier.",*";
+  $rrd_options .= " VDEF:totalin=aggrinbytes,TOTAL";
+  $rrd_options .= " VDEF:totalout=aggroutbytes,TOTAL";
+  $rrd_options .= " COMMENT:' \\\\n'";
+  $rrd_options .= " COMMENT:'".substr(str_pad("Aggregate In", $descr_len+5),0,$descr_len+5)."'";
+  $rrd_options .= " GPRINT:aggrinbits:LAST:%6.2lf%s$units";
+  $rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.2lf%s$units";
+  $rrd_options .= " GPRINT:aggrinbits:MAX:%6.2lf%s$units";
+  if (!$nototal) {
+    $rrd_options .= " GPRINT:totalin:%6.2lf%s$total_units";
+  }
+  $rrd_options .= "\\\\n";
+  $rrd_options .= " COMMENT:'".substr(str_pad("Aggregate Out", $descr_len+5),0,$descr_len+5)."'";
+  $rrd_options .= " GPRINT:aggroutbits:LAST:%6.2lf%s$units";
+  $rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.2lf%s$units";
+  $rrd_options .= " GPRINT:aggroutbits:MAX:%6.2lf%s$units";
+  if (!$nototal) {
+    $rrd_options .= " GPRINT:totalout:%6.2lf%s$total_units";
+  }
+  $rrd_options .= "\\\\n";
 }
-$rrd_options .= "\\\\n";
-$rrd_options .= " COMMENT:'".substr(str_pad("Aggregate Out", $descr_len+5),0,$descr_len+5)."'";
-$rrd_options .= " GPRINT:aggroutbits:LAST:%6.2lf%s$units";
-$rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.2lf%s$units";
-$rrd_options .= " GPRINT:aggroutbits:MAX:%6.2lf%s$units";
-if (!$nototal) {
-  $rrd_options .= " GPRINT:totalout:%6.2lf%s$total_units";
-}
-$rrd_options .= "\\\\n";
 
 if ($custom_graph) { $rrd_options .= $custom_graph; }
 


### PR DESCRIPTION
Adds an aggregate legend with the total of all ports specified
Add nodetails option to lighten the legend when adding lots of ports on one graph
Small fix for nototal which was not working anymore

I am just not sure about padding of texts ... it works here though (adding some pics as examples of all options combinations)
 
I agree to the conditions of the Contributor Agreement contained in doc/General/Contributing.md

graph.php?height=140&width=520&legend=yes&id=357,358,359&type=multiport_bits_separate&from=-8h&nodetails=1&nototal=1
![nodetailnototal](https://cloud.githubusercontent.com/assets/1297584/7555039/8d5d6204-f73f-11e4-8309-ac2d5d07c8d2.png)
graph.php?height=140&width=520&legend=yes&id=357,358,359&type=multiport_bits_separate&from=-8h&nodetails=1
![nodetails](https://cloud.githubusercontent.com/assets/1297584/7555040/8d609f1e-f73f-11e4-8f16-292701b6c4a3.png)
graph.php?height=140&width=520&legend=yes&id=357,358,359&type=multiport_bits_separate&from=-8h&nototal=1
![nototal](https://cloud.githubusercontent.com/assets/1297584/7555041/8d65cab6-f73f-11e4-84df-b1f265943a44.png)
graph.php?height=140&width=520&legend=yes&id=357,358,359&type=multiport_bits_separate&from=-8h
![withdetails](https://cloud.githubusercontent.com/assets/1297584/7555042/8d680e66-f73f-11e4-900d-3dbead5908e6.png)

