### PR TITLE
Fix a port-name issue for recent snmp versions for linux.

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -91,6 +91,7 @@ $config['os'][$os]['type']              = "server";
 $config['os'][$os]['group']             = "unix";
 $config['os'][$os]['text']              = "Linux";
 $config['os'][$os]['ifXmcbc']           = 1;
+$config['os'][$os]['ifname']            = 1;
 $config['os'][$os]['over'][0]['graph']  = "device_processor";
 $config['os'][$os]['over'][0]['text']   = "Processor Usage";
 $config['os'][$os]['over'][1]['graph']  = "device_ucd_memory";


### PR DESCRIPTION
In Debian Jessie, ifDescr is now populated with `Device $Major:$Minor`, this patch renames it back to the usual name reported by udev (`ethX`,`enpXsZ`, ...)