### PR TITLE
Change reference parameter for rrdtool's pipe_close to mitigate *some* zombies.

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -60,7 +60,7 @@ function rrdtool_pipe_open(&$rrd_process, &$rrd_pipes)
  * @param array rrd_pipes
  */
 
-function rrdtool_pipe_close(&$rrd_process, &$rrd_pipes)
+function rrdtool_pipe_close($rrd_process, &$rrd_pipes)
 {
   global $debug;
 


### PR DESCRIPTION
Related #443 
This is not a fix for the issue!

It does however minimize the risk of running into zombies for certain distribution's php5.x packages.
It's been said it works for:
	Ubuntu 14.04.2 under Apache2's Mod-PHP using php5.5
	OpenSuSE 13.2 under Apache2's Mod-PHP using php5.6
	Debian 8 under Apache2's Mod-PHP and PHP-FPM using php5.6