### PR TITLE
Added a new db field to record when custom high/low limits are set and stop them being overwrote

### DIFF
--- a/html/forms/health-update.inc.php
+++ b/html/forms/health-update.inc.php
@@ -21,7 +21,7 @@ if(!is_numeric($_POST['device_id']) || !is_numeric($_POST['sensor_id']) || (empt
 }
 else
 {
-  $update = dbUpdate(array($_POST['value_type'] => $_POST['data']), 'sensors', '`sensor_id` = ? AND `device_id` = ?', array($_POST['sensor_id'],$_POST['device_id']));
+  $update = dbUpdate(array($_POST['value_type'] => $_POST['data'], 'sensor_custom' => 'Yes'), 'sensors', '`sensor_id` = ? AND `device_id` = ?', array($_POST['sensor_id'],$_POST['device_id']));
   if(!empty($update) || $update == '0')
   {
     echo('success');

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -223,7 +223,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
       list($high_limit, $low_limit) = array($low_limit, $high_limit);
     }
 
-    if ($high_limit != $sensor_entry['sensor_limit'])
+    if ($high_limit != $sensor_entry['sensor_limit'] && $sensor_entry['sensor_custom'] == 'No')
     {
       $update = array('sensor_limit' => ($high_limit == NULL ? array('NULL') : $high_limit));
       $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', array($sensor_entry['sensor_id']));
@@ -232,7 +232,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
       log_event("Sensor High Limit Updated: ".mres($class)." ".mres($type)." ". mres($index)." ".mres($descr)." (".$high_limit.")", $device, 'sensor', $sensor_id);
     }
 
-    if ($sensor_entry['sensor_limit_low'] != $low_limit)
+    if ($sensor_entry['sensor_limit_low'] != $low_limit && $sensor_entry['sensor_custom'] == 'No')
     {
       $update = array('sensor_limit_low' => ($low_limit == NULL ? array('NULL') : $low_limit));
       $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', array($sensor_entry['sensor_id']));
@@ -241,7 +241,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
       log_event("Sensor Low Limit Updated: ".mres($class)." ".mres($type)." ". mres($index)." ".mres($descr)." (".$low_limit.")", $device, 'sensor', $sensor_id);
     }
 
-    if ($warn_limit != $sensor_entry['sensor_limit_warn'])
+    if ($warn_limit != $sensor_entry['sensor_limit_warn'] && $sensor_entry['sensor_custom'] == 'No')
     {
       $update = array('sensor_limit_warn' => ($warn_limit == NULL ? array('NULL') : $warn_limit));
       $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', array($sensor_entry['sensor_id']));
@@ -250,7 +250,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
       log_event("Sensor Warn High Limit Updated: ".mres($class)." ".mres($type)." ". mres($index)." ".mres($descr)." (".$warn_limit.")", $device, 'sensor', $sensor_id);
     }
 
-    if ($sensor_entry['sensor_limit_low_warn'] != $low_warn_limit)
+    if ($sensor_entry['sensor_limit_low_warn'] != $low_warn_limit && $sensor_entry['sensor_custom'] == 'No')
     {
       $update = array('sensor_limit_low_warn' => ($low_warn_limit == NULL ? array('NULL') : $low_warn_limit));
       $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', array($sensor_entry['sensor_id']));

--- a/sql-schema/050.sql
+++ b/sql-schema/050.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `sensors` ADD  `sensor_custom` ENUM(  'No',  'Yes' ) NOT NULL DEFAULT  'No' AFTER  `sensor_alert` ;


### PR DESCRIPTION
This fixes #975.

When you now set a custom limit within the web ui, discovery will no longer over write the values.