### PR TITLE
Fix for 4 Digit CPU%

### DIFF
--- a/includes/discovery/processors/datacom.inc.php
+++ b/includes/discovery/processors/datacom.inc.php
@@ -1,11 +1,11 @@
 <?php
 if ($device['os'] == "datacom") {
-   echo("Datacom Switch : ");
-   $descr = "Processor";
-   $usage = snmp_get($device, "swCpuUsage.0", "-Ovq", "DMswitch-MIB");
-   echo $usage."\n";
-   if (is_numeric($usage)) {
-      discover_processor($valid['processor'], $device, "swCpuUsage", "0", "datacom", $descr, "1", $usage, NULL, NULL);
-   }
+    echo("Datacom Switch : ");
+    $descr = "Processor";
+    $usage = snmp_get($device, "swCpuUsage.0", "-Ovq", "DMswitch-MIB");
+    echo $usage."\n";
+    if (is_numeric($usage)) {
+        discover_processor($valid['processor'], $device, "swCpuUsage", "0", "datacom", substr($descr,0,2), "1", $usage, NULL, NULL);
+    }
 }
 ?>

--- a/includes/polling/processors/datacom.inc.php
+++ b/includes/polling/processors/datacom.inc.php
@@ -1,3 +1,3 @@
 <?php
-   $proc = snmp_get($device, "swCpuUsage.0", "-Ovq", "DMswitch-MIB");
+   $proc = substr(snmp_get($device, "swCpuUsage.0", "-Ovq", "DMswitch-MIB"),0,2);
 ?>


### PR DESCRIPTION
Some firmware versions return 4 digit in CPU usage instead of 2.