### PR TITLE
Added ICMP service-check

### DIFF
--- a/includes/services/icmp/check.inc
+++ b/includes/services/icmp/check.inc
@@ -1,0 +1,12 @@
+<?php
+$check = shell_exec($config['nagios_plugins'] . "/check_icmp ".($service['service_ip'] ? $service['service_ip'] : $service['hostname']));
+
+list($check, $time) = split("\|", $check);
+
+if(strstr($check, "OK - ")) {
+  $status = '1';
+} else {
+  $status = '0';
+}
+
+?>


### PR DESCRIPTION
This requires Nagios-Plugins like all other service checks.
Also the cron should be running, Do we actually got this somewhere in the docs??
Anyhow - Allows doing ICMP-only checks for IPs, in case they dont know SNMP or you just want to see if your ISP's gateway is still alive and that sort.