### PR TITLE
Added flag to disable port relationship in ports list for a device

### DIFF
--- a/html/includes/print-interface.inc.php
+++ b/html/includes/print-interface.inc.php
@@ -143,7 +143,7 @@ if (strpos($port['label'], "oopback") === false && !$graph_type)
 
   unset($br);
 
-  if ($port_details)
+  if ($port_details && $config['enable_port_relationship'] === TRUE)
   { // Show which other devices are on the same subnet as this interface
     foreach (dbFetchRows("SELECT `ipv4_network_id` FROM `ipv4_addresses` WHERE `port_id` = ? AND `ipv4_address` NOT LIKE '127.%'", array($port['port_id'])) as $net)
     {
@@ -187,7 +187,7 @@ if (strpos($port['label'], "oopback") === false && !$graph_type)
     }
   }
 
-  if ($port_details)
+  if ($port_details && $config['enable_port_relationship'] === TRUE)
   {
          foreach ($int_links as $int_link)
          {
@@ -208,7 +208,7 @@ if (strpos($port['label'], "oopback") === false && !$graph_type)
 #     unset($int_links, $int_links_v6, $int_links_v4, $int_links_phys, $br);
 }
 
-if ($port_details)
+if ($port_details && $config['enable_port_relationship'] === TRUE)
 {
        foreach (dbFetchRows("SELECT * FROM `pseudowires` WHERE `port_id` = ?", array($port['port_id'])) as $pseudowire)
        {

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -637,6 +637,7 @@ $config['dateformat']['compact']                          = "Y-m-d H:i:s";
 $config['dateformat']['time']                             = "H:i:s";
 
 $config['enable_clear_discovery']                        = 1;// Set this to 0 if you want to disable the web option to rediscover devices
+$config['enable_port_relationship']                      = TRUE;// Set this to false to not display neighbour relationships for ports
 
 $config['enable_footer']                                 = 1;// Set this to 0 if you want to disable the footer copyright in the web interface
 $config['api_demo']                                      = 0;// Set this to 1 if you want to disable some untrusting features for the API


### PR DESCRIPTION
For large installs when you view the ports page for a device, it builds a large number of queries to work out port / device relationship from IPs and interfaces (on my install this equates to 9k mysql queries - yes I'm not joking).

I've added this as a quick fix to disable the support of this until more time can be spent on it. We're running it on our installs. Cuts our page load times down by a half.