### PR TITLE
Change fa-desktop to fa-trash for Delete Device icon

### DIFF
--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -144,7 +144,7 @@ if ($config['show_locations'])
             <li role="presentation" class="divider"></li>
             <li><a href="'.generate_url(array('page'=>'device-groups')).'"><i class="fa fa-th fa-fw fa-lg"></i> Manage Groups</a></li>
             <li><a href="addhost/"><i class="fa fa-desktop fa-col-success fa-fw fa-lg"></i> Add Device</a></li>
-            <li><a href="delhost/"><i class="fa fa-desktop fa-col-info fa-fw fa-lg"></i> Delete Device</a></li>');
+            <li><a href="delhost/"><i class="fa fa-trash fa-col-info fa-fw fa-lg"></i> Delete Device</a></li>');
 }
 
 if ($links['count'] > 0) {

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -143,7 +143,7 @@ if ($config['show_locations'])
   echo('
             <li role="presentation" class="divider"></li>
             <li><a href="'.generate_url(array('page'=>'device-groups')).'"><i class="fa fa-th fa-fw fa-lg"></i> Manage Groups</a></li>
-            <li><a href="addhost/"><i class="fa fa-desktop fa-col-success fa-fw fa-lg"></i> Add Device</a></li>
+            <li><a href="addhost/"><i class="fa fa-plus fa-col-success fa-fw fa-lg"></i> Add Device</a></li>
             <li><a href="delhost/"><i class="fa fa-trash fa-col-info fa-fw fa-lg"></i> Delete Device</a></li>');
 }
 

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -255,8 +255,8 @@ foreach (dbFetchRows("SELECT * FROM `ports` AS P, `devices` as D WHERE P.`delete
 }
 ?>
 
-            <li><a href="ports/state=down/"><i class="fa fa-chain-broken fa-col-success fa-fw fa-lg"></i> Down</a></li>
-            <li><a href="ports/state=admindown/"><i class="fa fa-chain-broken fa-col-info fa-fw fa-lg"></i> Disabled</a></li>
+            <li><a href="ports/state=down/"><i class="fa fa-arrow-down fa-col-danger fa-fw fa-lg"></i> Down</a></li>
+            <li><a href="ports/state=admindown/"><i class="fa fa-pause fa-col-info fa-fw fa-lg"></i> Disabled</a></li>
 <?php
 
 if ($deleted_ports) { echo('            <li><a href="deleted-ports/"><i class="fa fa-minus-circle fa-col-primary fa-fw fa-lg"></i> Deleted ('.$deleted_ports.')</a></li>'); }

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -255,7 +255,7 @@ foreach (dbFetchRows("SELECT * FROM `ports` AS P, `devices` as D WHERE P.`delete
 }
 ?>
 
-            <li><a href="ports/state=down/"><i class="fa fa-arrow-down fa-col-danger fa-fw fa-lg"></i> Down</a></li>
+            <li><a href="ports/state=down/"><i class="fa fa-exclamation-triangle fa-col-danger fa-fw fa-lg"></i> Down</a></li>
             <li><a href="ports/state=admindown/"><i class="fa fa-pause fa-col-info fa-fw fa-lg"></i> Disabled</a></li>
 <?php
 


### PR DESCRIPTION
The fa-desktop is too common to use for both, add and delete. Keeping different icons for each would be good.