### PR TITLE
Allow a user-defined window to add tolerance to delay-values

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -191,7 +191,7 @@ function RunAlerts() {
 			$noiss = true;
 		}
 		if( !empty($rextra['delay']) ) {
-			if( (time()-strtotime($alert['time_logged'])) < $rextra['delay'] || (!empty($alert['details']['delay']) && (time()-$alert['details']['delay']) < $rextra['delay']) ) {
+			if( (time()-strtotime($alert['time_logged'])+$config['alert']['tolerance-window']) < $rextra['delay'] || (!empty($alert['details']['delay']) && (time()-$alert['details']['delay']+$config['alert']['tolerance-window']) < $rextra['delay']) ) {
 				continue;
 			} else {
 				$alert['details']['delay'] = time();

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -152,8 +152,8 @@ $config['email_smtp_auth']                 = FALSE;                // Whether or
 $config['email_smtp_username']             = NULL;                 // SMTP username.
 $config['email_smtp_password']             = NULL;                 // Password for SMTP authentication.
 
-$config['alerts']['email']['default_only'] = FALSE;                // Only send alerts to default-contact
-$config['alerts']['email']['default']      = NULL;                 // Default-Contact
+$config['alert']['default_only']           = false;                //Only issue to default_mail
+$config['alert']['default_mail']           = '';                   //Default email
 ```
 
 ## <a name="transports-api">API</a>

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -237,6 +237,7 @@ $config['alert'] = array(
 	'admins' => false,                    //Issue to administrators
 	'default_only' => false,              //Only issue to default
 	'default_mail' => '',                 //Default email
+	'tolerance-window' => 10,             //Allow +/-10s tolerance to delay values to counter cron-irregularities
 );
 
 //Legacy options


### PR DESCRIPTION
This is to counter cronjob irregularities as they arent always executed on *:00 dead

Defaults to:
`$config['alert']['tolerance-window'] = 10`


#950 