### PR TITLE
Added support for fetching model and software of Cisco ASA 5585-SSP40

### DIFF
--- a/includes/polling/os/asa.inc.php
+++ b/includes/polling/os/asa.inc.php
@@ -11,16 +11,20 @@
  * the source code distribution for details.
 */
 
-$oids = "entPhysicalModelName.1 entPhysicalSoftwareRev.1 entPhysicalSerialNum.1";
+$oids = "entPhysicalModelName.1 entPhysicalSoftwareRev.1 entPhysicalSerialNum.1 entPhysicalModelName.4 entPhysicalSoftwareRev.4";
 
 $data = snmp_get_multi($device, $oids, "-OQUs", "ENTITY-MIB");
 
 if (isset($data[1]['entPhysicalSoftwareRev']) && $data[1]['entPhysicalSoftwareRev'] != "") {
     $version = $data[1]['entPhysicalSoftwareRev'];
+} elseif (isset($data[4]['entPhysicalSoftwareRev']) && $data[4]['entPhysicalSoftwareRev'] != "") {
+    $version = $data[4]['entPhysicalSoftwareRev'];
 }
 
 if (isset($data[1]['entPhysicalModelName']) && $data[1]['entPhysicalModelName'] != "") {
     $hardware = $data[1]['entPhysicalModelName'];
+} elseif (isset($data[4]['entPhysicalSoftwareRev']) && $data[4]['entPhysicalSoftwareRev'] != "") {
+    $hardware = $data[4]['entPhysicalModelName'];
 }
 
 if (isset($data[1]['entPhysicalSerialNum']) && $data[1]['entPhysicalSerialNum'] != "") {


### PR DESCRIPTION
ASA5585 before:
Hardware:  Version:  Features:  Serial: JMX153770CU

ASA5585 after:
Hardware: ASA5585-SSP-40 Version: 9.2(2)4 Features:  Serial: JMX153770CU


Also tried on a ASA5510 to make sure it didnt break:
ASA5510 before:
Hardware: ASA5510 Version: 9.1(6)1 Features:  Serial: JMX1533L15J

ASA5510 after:
Hardware: ASA5510 Version: 9.1(6)1 Features:  Serial: JMX1533L15J
