### PR TITLE
Removed code that performs hostname check

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -285,9 +285,6 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
   // Test Database Exists
   if (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($host)) == '0')
   {
-    // Test if IP or Hostname
-    if (!(inet_pton($host))) 
-    {
       // Test reachability
       if ($force_add == 1 || isPingable($host))
       {
@@ -372,10 +369,6 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
         // failed Reachability
         if($quiet == '0') { print_error("Could not ping $host"); }
       }
-    } else {
-      // Failed DNS lookup
-      if($quiet == '0') { print_error("$host looks like an IP address, please use FQDN"); }
-    }
   } else {
     // found in database
     if($quiet == '0') { print_error("Already got host $host"); }


### PR DESCRIPTION
This is the first stage for enabling IP only devices to be added.

This doesn't affect auto discovery code as discover_new_device still has code in place to double check hostnames. I've got a branch that removes this but it needs more code to perform validation on IP only devices so releasing this first.