### PR TITLE
Ubiquiti EdgeOS - Fix missing CPU load graphs

### DIFF
--- a/includes/discovery/processors/hrdevice.inc.php
+++ b/includes/discovery/processors/hrdevice.inc.php
@@ -29,6 +29,8 @@ if (is_array($hrDevice_array))
       if ($device['os'] == "routeros" && !isset($entry['hrDeviceDescr'])) { $descr = "Processor"; }
       // Workaround to set fake description for Engenius who don't populate hrDeviceDescr
       if ($device['os'] == "engenius" && empty($entry['hrDeviceDescr'])) { $descr = "Processor"; }
+      // Workaround to set fake description for Ubiquiti EdgeOS who don't populate hrDeviceDescr
+      if ($device['os'] == "edgeos" && empty($entry['hrDeviceDescr'])) { $descr = "Processor"; }
 
       $descr = str_replace("CPU ", "", $descr);
       $descr = str_replace("(TM)", "", $descr);


### PR DESCRIPTION
- No graphs were generated for the CPU load, now fixed. Tested on
EdgeRouter Lite 3-Port