### PR TITLE
Removed lower limit for sensor graphs so negative values will show

### DIFF
--- a/html/includes/graphs/device/sensor.inc.php
+++ b/html/includes/graphs/device/sensor.inc.php
@@ -4,7 +4,7 @@ include("includes/graphs/common.inc.php");
 
 if ($_GET['width'] > "300") { $descr_len = "40"; } else { $descr_len = "22"; }
 
-$rrd_options .= " -l 0 -E ";
+$rrd_options .= " -E ";
 $iter = "1";
 $rrd_options .= " COMMENT:'".str_pad($unit_long,$descr_len)."    Cur     Min    Max\\n'";
 


### PR DESCRIPTION
Fixes #1121.

A hard limit of 0 was set for lower limit, removing this means it will go to whichever value is the lowest so negative sensor values will work.