### PR TITLE
Added fallback for poller_group if empty

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -526,8 +526,12 @@ function utime()
 
 function createHost($host, $community = NULL, $snmpver, $port = 161, $transport = 'udp', $v3 = array(), $poller_group='0')
 {
+  global $config;
   $host = trim(strtolower($host));
 
+  if (is_numeric($poller_group) === FALSE) {
+      $poller_group = $config['distributed_poller_group'];
+  }
   $device = array('hostname' => $host,
                   'sysName' => $host,
                   'community' => $community,


### PR DESCRIPTION
Fixes #1116 for me.

poller_group could be empty so we now just sanity check and fall back to default config if empty.