### PR TITLE
Fixed issue when truncating UTF-8 strings.

### DIFF
--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -155,7 +155,7 @@ foreach (dbFetchRows($sql, $param) as $device) {
             $hostname = generate_device_link($device);
             $platform = $device['hardware'] . '<br />' . $device['features'];
             $os = $device['os_text'] . '<br />' . $device['version'];
-            $uptime = formatUptime($device['uptime'], 'short') . '<br />' . truncate($device['location'],32, '');
+            $uptime = formatUptime($device['uptime'], 'short') . '<br />' . mb_substr($device['location'], 0, 32, 'utf8');
             if ($subformat == "detail") {
                 $hostname .= '<br />' . $device['sysName'];
                 if ($port_count) {


### PR DESCRIPTION
Some chars have a length of more than 1, which before made it truncate only a part of a single character.