### PR TITLE
Spelling, JS and update to attaching templates

### DIFF
--- a/html/forms/alert-templates.inc.php
+++ b/html/forms/alert-templates.inc.php
@@ -61,7 +61,7 @@ if(!empty($name)) {
         if(dbInsert(array('template' => $_REQUEST['template'], 'name' => $name), "alert_templates")) {
             $ok = "Alert template has been created.";
         } else {
-            $error = "Could not create aler template";
+            $error = "Could not create alert template";
         }
     } else {
         $error = "We could not work out what you wanted to do!";

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -33,8 +33,8 @@ if(is_admin() === false) {
                             <option></option>
 <?php
 
-    foreach(dbFetchRows("SELECT `id`,`rule` FROM `alert_rules` where `disabled` = 0", array()) as $rule) {
-        echo '<option value="'.$rule['id'].'">'.$rule['rule'].'</option>';
+    foreach(dbFetchRows("SELECT `id`,`rule`,`name` FROM `alert_rules`", array()) as $rule) {
+        echo '<option value="'.$rule['id'].'">'.$rule['name'].'</option>';
     }
 ?>
                         </select>
@@ -56,7 +56,6 @@ if(is_admin() === false) {
 
 <script>
 $('#attach-alert-template').on('show.bs.modal', function(e) {
-    event.preventDefault();
     template_id = $(e.relatedTarget).data('template_id');
     $("#template_id").val(template_id);
     $.ajax({


### PR DESCRIPTION
Attaching templates didn't work in Chrome before.

Spelling mistake

Used alert_rule name rather than showing the rule.