### PR TITLE
Capitalised a few words when deleting device groups

### DIFF
--- a/html/forms/delete-device-group.inc.php
+++ b/html/forms/delete-device-group.inc.php
@@ -27,10 +27,10 @@ if(!is_numeric($_POST['group_id'])) {
           include('forms/delete-alert-map.inc.php');
         }
       }
-      echo('group has been deleted.');
+      echo('Group has been deleted.');
       exit;
     } else {
-      echo('ERROR: group has not been deleted.');
+      echo('ERROR: Group has not been deleted.');
       exit;
     }
 }


### PR DESCRIPTION
I know this is not super important, but it does really look unprofessional when the messages starts with a lowercase letter.