### PR TITLE
Updated remaining MyIsam tables to innodb

### DIFF
--- a/sql-schema/052.sql
+++ b/sql-schema/052.sql
@@ -1,0 +1,8 @@
+ALTER TABLE  `munin_plugins` CHANGE  `mplug_type`  `mplug_type` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL;
+ALTER TABLE slas ENGINE=InnoDB; 
+ALTER TABLE packages ENGINE=InnoDB;
+ALTER TABLE munin_plugins_ds ENGINE=InnoDB;
+ALTER TABLE munin_plugins ENGINE=InnoDB; 
+ALTER TABLE loadbalancer_vservers ENGINE=InnoDB;
+ALTER TABLE loadbalancer_rservers ENGINE=InnoDB;
+ALTER TABLE ipsec_tunnels ENGINE=InnoDB;


### PR DESCRIPTION
It's using 052.sql as the next update which is only correct once the dynconfig pr gets merged in.

This is in relation to #337.

I've added ALTER TABLE  `munin_plugins` CHANGE  `mplug_type`  `mplug_type` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL; as at 256 this wouldn't convert over to InnoDB.

