### PR TITLE
Issued alerts add to the eventlog

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -252,7 +252,7 @@ function ExtTransports($obj) {
 			eval('$tmp = function($obj,$opts) { global $config; '.file_get_contents($config['install_dir']."/includes/alerts/transport.".$transport.".php").' };');
 			$tmp = $tmp($obj,$opts);
 			echo ($tmp ? "OK" : "ERROR")."; ";
-            log_event("Issued ".$severity." alert for rule ".$obj['name']." to transport".$transport,$obj['hostname'],"Alerts");
+                        log_event("Issued ".$obj['severity']." alert for rule '".$obj['name']."' to transport '".$transport."'",$obj['device_id']);
 		}
 	}
 }

--- a/alerts.php
+++ b/alerts.php
@@ -252,7 +252,7 @@ function ExtTransports($obj) {
 			eval('$tmp = function($obj,$opts) { global $config; '.file_get_contents($config['install_dir']."/includes/alerts/transport.".$transport.".php").' };');
 			$tmp = $tmp($obj,$opts);
 			echo ($tmp ? "OK" : "ERROR")."; ";
-                        log_event("Issued ".$obj['severity']." alert for rule '".$obj['name']."' to transport '".$transport."'",$obj['device_id']);
+			log_event("Issued ".$obj['severity']." alert for rule '".$obj['name']."' to transport '".$transport."'",$obj['device_id']);
 		}
 	}
 }

--- a/alerts.php
+++ b/alerts.php
@@ -252,6 +252,7 @@ function ExtTransports($obj) {
 			eval('$tmp = function($obj,$opts) { global $config; '.file_get_contents($config['install_dir']."/includes/alerts/transport.".$transport.".php").' };');
 			$tmp = $tmp($obj,$opts);
 			echo ($tmp ? "OK" : "ERROR")."; ";
+            log_event("Issued ".$severity." alert for rule ".$obj['name']." to transport".$transport,$obj['hostname'],"Alerts");
 		}
 	}
 }


### PR DESCRIPTION
Added code to ExtTransports() function to also write an entry to the eventlog to indicate that an external transport has been used to send a notification.