### PR TITLE
Updated hpilo temp discovery to test for current value

### DIFF
--- a/includes/discovery/temperatures/hpilo.inc.php
+++ b/includes/discovery/temperatures/hpilo.inc.php
@@ -21,7 +21,9 @@
       $threshold_oid = "1.3.6.1.4.1.232.6.2.6.8.1.5.$temperature_id";
       $threshold = snmp_get($device,$threshold_oid,"-Oqv","");
 
-      discover_sensor($valid['sensor'], 'temperature', $device, $temperature_oid, $oid, 'hpilo', $descr, '1', '1', NULL, NULL, NULL, $threshold, $temperature);
+      if (!empty($temperature)) {
+          discover_sensor($valid['sensor'], 'temperature', $device, $temperature_oid, $oid, 'hpilo', $descr, '1', '1', NULL, NULL, NULL, $threshold, $temperature);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes issue #1213 

Simple test to ensure we have a current value before running discover_sensor.