### PR TITLE
No longer show disabled ports on main ports page

### DIFF
--- a/html/pages/device/ports.inc.php
+++ b/html/pages/device/ports.inc.php
@@ -95,7 +95,7 @@ if ($vars['view'] == 'minigraphs')
 
   global $port_cache, $port_index_cache;
 
-  $ports = dbFetchRows("SELECT * FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' AND `disabled` = 0 ORDER BY `ifIndex` ASC", array($device['device_id']));
+  $ports = dbFetchRows("SELECT * FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' ORDER BY `ifIndex` ASC", array($device['device_id']));
   // As we've dragged the whole database, lets pre-populate our caches :)
   // FIXME - we should probably split the fetching of link/stack/etc into functions and cache them here too to cut down on single row queries.
   foreach ($ports as $port)

--- a/html/pages/device/ports.inc.php
+++ b/html/pages/device/ports.inc.php
@@ -95,7 +95,7 @@ if ($vars['view'] == 'minigraphs')
 
   global $port_cache, $port_index_cache;
 
-  $ports = dbFetchRows("SELECT * FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' ORDER BY `ifIndex` ASC", array($device['device_id']));
+  $ports = dbFetchRows("SELECT * FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' AND `disabled` = 0 ORDER BY `ifIndex` ASC", array($device['device_id']));
   // As we've dragged the whole database, lets pre-populate our caches :)
   // FIXME - we should probably split the fetching of link/stack/etc into functions and cache them here too to cut down on single row queries.
   foreach ($ports as $port)

--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -226,8 +226,8 @@ foreach ($ports as $data)
       <div class="form-group">
         <label for="ignore">Ignored</label>
         <input type=checkbox id="ignore" name="ignore" value="1" class="" <?php if ($vars['ignore']) { echo("checked"); } ?> ></input>
-        <label for="disable">Disabled</label>
-        <input type=checkbox id="disable" name="disable" value=1 class="" <?php if ($vars['disable']) { echo("checked"); } ?> ></input>
+        <label for="disabled">Disabled</label>
+        <input type=checkbox id="disabled" name="disabled" value=1 class="" <?php if ($vars['disabled']) { echo("checked"); } ?> ></input>
         </label>
         <label for="deleted">Deleted</label>
         <input type=checkbox id="deleted" name="deleted" value=1 class="" <?php if ($vars['deleted']) { echo("checked"); } ?> ></input>
@@ -303,7 +303,7 @@ foreach ($vars as $var => $value)
           $where .= " AND (I.ignore = 1 OR D.ignore = 1) AND I.deleted = 0";
         }
         break;
-      case 'disable':
+      case 'disabled':
       case 'ifSpeed':
         if (is_numeric($value))
         {


### PR DESCRIPTION
This fixes #1141 

In the issue it's shown that ports disabled are showing in eventlog, I can't see that this is possible in the code so that bit hasn't been touched.

However we now no longer show ports marked as disabled in the Webui for all ports or the devices ports. This makes sense as the option is there for the users to control and isn't what we poll / discover.