### PR TITLE
Added function to check if ip already exists and updated addHost to use it

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -285,6 +285,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
   // Test Database Exists
   if (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($host)) == '0')
   {
+    if (filter_var($host, FILTER_VALIDATE_IP) && ip_exists($host) === false) {
       // Test reachability
       if ($force_add == 1 || isPingable($host))
       {
@@ -369,6 +370,11 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
         // failed Reachability
         if($quiet == '0') { print_error("Could not ping $host"); }
       }
+    } else {
+        if ($quiet == 0) {
+            print_error("Already have host with this IP $host");
+        }
+    }
   } else {
     // found in database
     if($quiet == '0') { print_error("Already got host $host"); }
@@ -1207,6 +1213,21 @@ function fix_integer_value($value) {
         $return = 4294967296+$value;
     } else {
         $return = $value;
+    }
+    return $return;
+}
+
+function ip_exists($ip) {
+    // Function to check if an IP exists in the DB already
+    $return = true; // Default to assuming it does.
+    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== FALSE) {
+        if (!dbFetchRow("SELECT `ipv6_address_id` FROM `ipv6_addresses` WHERE `ipv6_address` = ? OR `ipv6_compressed` = ?", array($ip,$ip))) {
+            $return = false;
+        }
+    } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== FALSE) {
+        if (!dbFetchRow("SELECT `ipv4_address_id` FROM `ipv4_addresses` WHERE `ipv4_address` = ?", array($ip))) {
+            $return = false;
+        }
     }
     return $return;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1219,17 +1219,16 @@ function fix_integer_value($value) {
 
 function ip_exists($ip) {
     // Function to check if an IP exists in the DB already
-    $return = true; // Default to assuming it does.
     if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== FALSE) {
         if (!dbFetchRow("SELECT `ipv6_address_id` FROM `ipv6_addresses` WHERE `ipv6_address` = ? OR `ipv6_compressed` = ?", array($ip,$ip))) {
-            $return = false;
+            return false;
         }
     } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== FALSE) {
         if (!dbFetchRow("SELECT `ipv4_address_id` FROM `ipv4_addresses` WHERE `ipv4_address` = ?", array($ip))) {
-            $return = false;
+            return false;
         }
     } else {
-        $return = false;
+        return false;
     }
-    return $return;
+    return true;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -285,7 +285,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
   // Test Database Exists
   if (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($host)) == '0')
   {
-    if (filter_var($host, FILTER_VALIDATE_IP) && ip_exists($host) === false) {
+    if (ip_exists($host) === false) {
       // Test reachability
       if ($force_add == 1 || isPingable($host))
       {
@@ -1228,6 +1228,8 @@ function ip_exists($ip) {
         if (!dbFetchRow("SELECT `ipv4_address_id` FROM `ipv4_addresses` WHERE `ipv4_address` = ?", array($ip))) {
             $return = false;
         }
+    } else {
+        $return = false;
     }
     return $return;
 }


### PR DESCRIPTION
Ok, this is to finish off all the auto-discover devices that might just use IP.

When addHost is called, if it's an IP that's passed then it's checked against the ip_exists() function, if that returns true then either something has gone wrong or the IP does exist in the DB and the addHost function will not continue.

This means adding a device by hostname will continue to work as normal just in case people have an odd requirement to point multiple names at the same device.