### PR TITLE
Reordering voltage and current sensor items (fixes librenms/librenms#1260)

### DIFF
--- a/includes/discovery/current/rfc1628.inc.php
+++ b/includes/discovery/current/rfc1628.inc.php
@@ -37,7 +37,7 @@ if (isset($config['modules_compat']['rfc1628'][$device['os']]) && $config['modul
     $current    = snmp_get($device, $current_oid, "-Oqv");
     $type       = "rfc1628";
     $precision  = 1;
-    $index      = $i;
+    $index      = 300+$i;
 
     discover_sensor($valid['sensor'], 'current', $device, $current_oid, $index, $type, $descr, '1', '1', NULL, NULL, NULL, NULL, $current);
   }

--- a/includes/discovery/voltages/rfc1628.inc.php
+++ b/includes/discovery/voltages/rfc1628.inc.php
@@ -22,7 +22,7 @@ if (isset($config['modules_compat']['rfc1628'][$device['os']]) && $config['modul
       $volt = snmp_get($device, $volt_oid, "-O vq") / $divisor;
       $descr = "Battery" . (count(explode("\n",$oids)) == 1 ? '' : ' ' . ($volt_id+1));
       $type = "rfc1628";
-      $index = "1.2.5.".$volt_id;
+      $index = 500+$current_id;
 
       discover_sensor($valid['sensor'], 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', NULL, NULL, NULL, NULL, $volt);
     }
@@ -38,7 +38,7 @@ if (isset($config['modules_compat']['rfc1628'][$device['os']]) && $config['modul
     $type     = "rfc1628";
     $divisor  = 10; if ($device['os'] == "netmanplus") { $divisor = 1; };
     $current  = snmp_get($device, $volt_oid, "-Oqv") / $divisor;
-    $index    = $i;
+    $index    = 300+$i;
 
     discover_sensor($valid['sensor'], 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', NULL, NULL, NULL, NULL, $current);
   }


### PR DESCRIPTION
Changed $index values so "Output phase 1", "Output phase 2" and "Output phase 3" are listed together.