### PR TITLE
Add in discover_sensor function additional check oid

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -142,7 +142,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
     list($warn_limit, $low_warn_limit) = array($low_warn_limit, $warn_limit);
   }
 
-  if (dbFetchCell("SELECT COUNT(sensor_id) FROM `sensors` WHERE `poller_type`= ? AND `sensor_class` = ? AND `device_id` = ? AND sensor_type = ? AND `sensor_index` = ?", array($poller_type, $class, $device['device_id'], $type, $index)) == '0')
+  if (dbFetchCell("SELECT COUNT(sensor_id) FROM `sensors` WHERE `poller_type`= ? AND `sensor_class` = ? AND `device_id` = ? AND sensor_type = ? AND `sensor_index` = ? AND `sensor_oid` = ?", array($poller_type, $class, $device['device_id'], $type, $index, $oid)) == '0')
   {
     if (!$high_limit) { $high_limit = sensor_limit($class, $current); }
     if (!$low_limit)  { $low_limit  = sensor_low_limit($class, $current); }
@@ -186,7 +186,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
   }
   else
   {
-    $sensor_entry = dbFetchRow("SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ? AND `sensor_type` = ? AND `sensor_index` = ?", array($class, $device['device_id'], $type, $index));
+    $sensor_entry = dbFetchRow("SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ? AND `sensor_type` = ? AND `sensor_index` = ? AND `sensor_oid` = ?", array($class, $device['device_id'], $type, $index, $oid));
 
     if (!isset($high_limit))
     {

--- a/includes/discovery/temperatures/dsm.inc.php
+++ b/includes/discovery/temperatures/dsm.inc.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2015 Steve Calvário <https://github.com/Calvario/>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+
 if ($device['os'] == 'dsm') {
 
 	echo "DSM temperature ";


### PR DESCRIPTION
In reponse to #1245.
It's ok for you @paulgear @laf ?

I checked that the change in the function file does not interfere with the discovery.
Works for me without problems.
But I have no more than two disk in mine, so I emulate a third in the code to test with that.

discover_sensor($valid['sensor'], 'temperature', $device, .1.3.6.1.4.1.6574.2.1.1.6.3', 3, 'snmp', 'Fake disk for test', '1', '1', NULL, NULL, NULL, NULL, 50);

Result (sorry only 10 minutes)
![sans titre](https://cloud.githubusercontent.com/assets/12759754/8143784/caef7556-11bd-11e5-9970-94862e2160c5.png)
