### PR TITLE
updated alert template mapping to own table

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -93,7 +93,7 @@ function IssueAlert($alert) {
 	}
 	$obj = DescribeAlert($alert);
 	if( is_array($obj) ) {
-		$tpl = dbFetchRow('SELECT template FROM alert_templates WHERE rule_id LIKE "%,'.$alert['rule_id'].',%"');
+                $tpl = dbFetchRow("SELECT `template` FROM `alert_templates` JOIN `alert_template_map` ON `alert_template_map`.`alert_templates_id`=`alert_templates`.`id` WHERE `alert_template_map`.`alert_rule_id`=?", array($alert['rule_id']));
 		if( isset($tpl['template']) ) {
 			$tpl = $tpl['template'];
 		} else {

--- a/html/forms/attach-alert-template.inc.php
+++ b/html/forms/attach-alert-template.inc.php
@@ -20,12 +20,22 @@ if(!is_numeric($_POST['template_id'])) {
     echo('ERROR: No template selected');
     exit;
 } else {
-      if(dbUpdate(array('rule_id' => mres($_POST['rule_id'])), 'alert_templates', '`id`=?', array($_POST['template_id'])) >= 0) {
-      echo('Alert rules have been attached to this template.');
-      exit;
-    } else {
-      echo('ERROR: Alert rules have not been attached to this template.');
-      exit;
+    $rules = preg_split("/,/",mres($_POST['rule_id']));
+    $success = FALSE;
+    foreach ($rules as $rule_id) {
+        $db_id = dbInsert(array('alert_rule_id' => $rule_id, 'alert_templates_id' => mres($_POST['template_id'])), 'alert_template_map');
+        if ($db_id > 0) {
+            $success = TRUE;
+            $ids[] = $db_id;
+        } else {
+            echo('ERROR: Alert rules have not been attached to this template.');
+            exit;
+        }
+    }
+    if ($success === TRUE) {
+        dbDelete('alert_template_map',"id NOT IN (".implode(',',$ids).")");
+        echo "Alert rules have been attached to this template. $template_map_ids";
+        exit;
     }
 }
 

--- a/html/forms/parse-template-rules.inc.php
+++ b/html/forms/parse-template-rules.inc.php
@@ -19,8 +19,9 @@ if(is_admin() === false) {
 $template_id = ($_POST['template_id']);
 
 if(is_numeric($template_id) && $template_id > 0) {
-    $template = dbFetchCell("SELECT `rule_id` FROM `alert_templates` WHERE `id` = ? LIMIT 1",array($template_id));
-    $rule_id = split(",", $template);
-    $output = array('rule_id'=>$rule_id);
+    foreach (dbFetchRows("SELECT `alert_rule_id` FROM `alert_template_map` WHERE `alert_templates_id` = ?",array($template_id)) as $rule) {
+        $rules[] = $rule['alert_rule_id'];
+    }
+    $output = array('rule_id'=>$rules);
     echo _json_encode($output);
 }

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -79,7 +79,7 @@ $('#alert-template-attach').click('', function(event) {
     $('#rules_list :selected').each(function(i, selectedElement) {
         items.push($(selectedElement).val());
     });
-    var rules = items.join(', ');
+    var rules = items.join(',');
     $.ajax({
         type: 'POST',
         url: '/ajax_form.php',

--- a/sql-schema/053.sql
+++ b/sql-schema/053.sql
@@ -1,0 +1,1 @@
+CREATE TABLE `alert_template_map` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,`alert_templates_id` INT NOT NULL ,`alert_rule_id` INT NOT NULL ,INDEX (  `alert_templates_id` ,  `alert_rule_id` )) ENGINE = INNODB


### PR DESCRIPTION
Fixes #1279 

Alert mappings are now recorded in own table, alerts.php updated to use this and so is webui.

Anyone having created a mapping previously will have to redo as a bug meant it wouldn't work - can't maintain backwards compatibility.