### PR TITLE
fixed a bug where stale link/device data would lead to broken map

### DIFF
--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -53,6 +53,7 @@ if (is_array($tmp_devices[0])) {
     $tmp_links = array();
     foreach (dbFetchRows("SELECT local_device_id, remote_device_id, `remote_hostname`,`ports`.*, `remote_port` FROM `links` LEFT JOIN `ports` ON `local_port_id`=`ports`.`port_id` LEFT JOIN `devices` ON `ports`.`device_id`=`devices`.`device_id` WHERE (`local_device_id` IN ($tmp_ids) AND `remote_device_id` IN ($tmp_ids))") as $link_devices) {
         foreach ($tmp_devices as $k=>$v) {
+	    $port='';
             if ($v['id'] == $link_devices['local_device_id']) {
                 $from = $v['id'];
                 $port = shorten_interface_type($link_devices['ifName']);
@@ -60,7 +61,7 @@ if (is_array($tmp_devices[0])) {
             }
             if ($v['id'] == $link_devices['remote_device_id']) {
                 $to = $v['id'];
-                $port = ' > ' .shorten_interface_type($link_devices['remote_port']);
+                $port .= ' > ' .shorten_interface_type($link_devices['remote_port']);
             }
         }
         $speed = $link_devices['ifSpeed']/1000/1000;

--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -52,8 +52,8 @@ $nodes = json_encode($tmp_devices);
 if (is_array($tmp_devices[0])) {
     $tmp_links = array();
     foreach (dbFetchRows("SELECT local_device_id, remote_device_id, `remote_hostname`,`ports`.*, `remote_port` FROM `links` LEFT JOIN `ports` ON `local_port_id`=`ports`.`port_id` LEFT JOIN `devices` ON `ports`.`device_id`=`devices`.`device_id` WHERE (`local_device_id` IN ($tmp_ids) AND `remote_device_id` IN ($tmp_ids))") as $link_devices) {
+	$port='';
         foreach ($tmp_devices as $k=>$v) {
-	    $port='';
             if ($v['id'] == $link_devices['local_device_id']) {
                 $from = $v['id'];
                 $port = shorten_interface_type($link_devices['ifName']);

--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -12,7 +12,11 @@
  * the source code distribution for details.
  */
 
+//Don't know where this should come from, but it is used later, so I just define it here.
+$row_colour="#ffffff";
+
 $tmp_devices = array();
+$sql_array= array();
 if (!empty($device['hostname'])) {
     $sql = ' WHERE `devices`.`hostname`=?';
     $sql_array = array($device['hostname']);
@@ -20,17 +24,22 @@ if (!empty($device['hostname'])) {
     $sql = ' WHERE 1';
 }
 
-$sql .= ' AND `local_device_id` != 0 AND `remote_device_id` != 0';
+$sql .= ' AND `local_device_id` != 0 AND `remote_device_id` != 0 ';
+$sql .= ' AND `local_device_id` IS NOT NULL AND `remote_device_id` IS NOT NULL ';
 
 $tmp_ids = array();
 foreach (dbFetchRows("SELECT DISTINCT least(`devices`.`device_id`, `remote_device_id`) AS `remote_device_id`, GREATEST(`remote_device_id`,`devices`.`device_id`) AS `local_device_id` FROM `links` LEFT JOIN `ports` ON `local_port_id`=`ports`.`port_id` LEFT JOIN `devices` ON `ports`.`device_id`=`devices`.`device_id` $sql", $sql_array) as $link_devices) {
     if (!in_array($link_devices['local_device_id'], $tmp_ids) && device_permitted($link_devices['local_device_id'])) {
         $link_dev = dbFetchRow("SELECT * FROM `devices` WHERE `device_id`=?",array($link_devices['local_device_id']));
-        $tmp_devices[] = array('id'=>$link_devices['local_device_id'],'label'=>$link_dev['hostname'],'title'=>generate_device_link($link_dev,'',array(),'','','',0),'group'=>$link_dev['location'],'shape'=>'box');
+	if (!empty($link_dev)) {
+            $tmp_devices[] = array('id'=>$link_devices['local_device_id'],'label'=>$link_dev['hostname'],'title'=>generate_device_link($link_dev,'',array(),'','','',0),'group'=>$link_dev['location'],'shape'=>'box');
+	}
     }
     if (!in_array($link_devices['remote_device_id'], $tmp_ids) && device_permitted($link_devices['remote_device_id'])) {
         $link_dev = dbFetchRow("SELECT * FROM `devices` WHERE `device_id`=?",array($link_devices['remote_device_id']));
-        $tmp_devices[] = array('id'=>$link_devices['remote_device_id'],'label'=>$link_dev['hostname'],'title'=>generate_device_link($link_dev,'',array(),'','','',0),'group'=>$link_dev['location'],'shape'=>'box');
+	if (!empty($link_dev)) {
+            $tmp_devices[] = array('id'=>$link_devices['remote_device_id'],'label'=>$link_dev['hostname'],'title'=>generate_device_link($link_dev,'',array(),'','','',0),'group'=>$link_dev['location'],'shape'=>'box');
+        }
     }
     array_push($tmp_ids,$link_devices['local_device_id']);
     array_push($tmp_ids,$link_devices['remote_device_id']);
@@ -51,7 +60,7 @@ if (is_array($tmp_devices[0])) {
             }
             if ($v['id'] == $link_devices['remote_device_id']) {
                 $to = $v['id'];
-                $port .= ' > ' .shorten_interface_type($link_devices['remote_port']);
+                $port = ' > ' .shorten_interface_type($link_devices['remote_port']);
             }
         }
         $speed = $link_devices['ifSpeed']/1000/1000;
@@ -81,7 +90,7 @@ if (is_array($tmp_devices[0])) {
         }
         $link_color = $config['map_legend'][$link_used];
 
-        $tmp_links[] = array('from'=>$from,'to'=>$to,'label'=>$port,'title'=>generate_port_link($port_data, "<img src='graph.php?type=port_bits&amp;id=".$port['port_id']."&amp;from=".$config['time']['day']."&amp;to=".$config['time']['now']."&amp;width=100&amp;height=20&amp;legend=no&amp;bg=".str_replace("#","", $row_colour)."'>",'',0,1),'width'=>$width,'color'=>$link_color);
+        $tmp_links[] = array('from'=>$from,'to'=>$to,'label'=>$port,'title'=>generate_port_link($port_data, "<img src='graph.php?type=port_bits&amp;id=".$port_data['port_id']."&amp;from=".$config['time']['day']."&amp;to=".$config['time']['now']."&amp;width=100&amp;height=20&amp;legend=no&amp;bg=".str_replace("#","", $row_colour)."'>",'',0,1),'width'=>$width,'color'=>$link_color);
     }
  
     $edges = json_encode($tmp_links);


### PR DESCRIPTION
As discussed in IRC (cut down to just the interesting bits):
```
[15:12]	f0o: einhirn: did you get around that map bug?
[15:22]	einhirn: f0o: I analyzed the json data a bit and found a place where "label" is "null".
[15:22]	einhirn: just have to find out why.
[15:29]	einhirn: f0o: look here http://pastebin.com/NZNVEPmN there's a "NULL" in the query results...
```
(since Pastebin's set to 1 Week expiry)

```
mysql> SELECT DISTINCT least(`devices`.`device_id`, `remote_device_id`) AS `remote_device_id`, devices.hostname, GREATEST(`remote_device_id`,`devices`.`device_id`) AS `local_device_id` FROM `links` LEFT JOIN `ports` ON `local_port_id`=`ports`.`port_id` LEFT JOIN `devices` ON `ports`.`device_id`=`devices`.`device_id`  AND `local_device_id` != 0 AND `remote_device_id` != 0;
+------------------+----------------+-----------------+
| remote_device_id | hostname       | local_device_id |
+------------------+----------------+-----------------+
|             NULL | NULL           |            NULL |
|               18 |blah |              56 |
|               16 | bleh   |              18 |
|               18 | blubb    |              19 |
```
(on with IRC log)
```
[15:36]	f0o: einhirn: maybe add a NOT NULL or something
[15:36]	f0o: would be nice if it's that trivial
[15:37]	lafwood: einhirn: I wonder if you've got stale data in your links table
[15:38]	einhirn: probably - why else would there be a "NULL"...
[15:38]	einhirn: First I want to fix the map so this problem doesn't happen any more. Then I can maybe dive in the stored data *g*
[15:44]	lafwood: einhirn: Maybe add AND local_port_id > 0 to the end of that query
[15:48]	einhirn: Didn't help - there still is a device that has a "NULL" hostname.
[15:48]	einhirn: That's the problem.
[15:48]	einhirn: So I need to add the "IS NOT NULL" to the query for the hostname.
[15:57]	einhirn: hmm...
[15:57]	einhirn: How do I see if dbFetchRow returned nothing?
[15:58]	einhirn: I'd just skip "empty" device ids when Building the node list.
```