### PR TITLE
Function and use to get main cisco serial number

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -374,7 +374,6 @@ function get_main_serial($device) {
 
     if ($device['os_group'] == 'cisco') {
         $serial_output = snmp_get_multi($device, "entPhysicalSerialNum.1 entPhysicalSerialNum.1001", "-OQUs", "ENTITY-MIB:OLD-CISCO-CHASSIS-MIB");
-        $serial = "";
         if (!empty($serial_output[1]['entPhysicalSerialNum'])) {
             return $serial_output[1]['entPhysicalSerialNum'];
         } elseif (!empty($serial_output[1001]['entPhysicalSerialNum'])) {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 
 function poll_sensor($device, $class, $unit)
 {
@@ -370,4 +370,16 @@ function rrd_create_update($device, $name, $def, $val, $step = 300)
     rrdtool_update($rrd, $val);
 }
 
-?>
+function get_main_serial($device) {
+
+    if ($device['os_group'] == 'cisco') {
+        $serial_output = snmp_get_multi($device, "entPhysicalSerialNum.1 entPhysicalSerialNum.1001", "-OQUs", "ENTITY-MIB:OLD-CISCO-CHASSIS-MIB");
+        $serial = "";
+        if (!empty($serial_output[1]['entPhysicalSerialNum'])) {
+            return $serial_output[1]['entPhysicalSerialNum'];
+        } elseif (!empty($serial_output[1001]['entPhysicalSerialNum'])) {
+            return $serial_output[1001]['entPhysicalSerialNum'];
+        }
+    }
+
+}

--- a/includes/polling/os/cisco.inc.php
+++ b/includes/polling/os/cisco.inc.php
@@ -44,5 +44,5 @@ if ($data[1]['entPhysicalContainedIn'] == "0")
 if(empty($hardware)) {   $hardware = snmp_get($device, "sysObjectID.0", "-Osqv", "SNMPv2-MIB:CISCO-PRODUCTS-MIB"); }
 
 #if(isset($cisco_hardware_oids[$poll_device['sysObjectID']])) { $hardware = $cisco_hardware_oids[$poll_device['sysObjectID']]; }
+$serial = get_main_serial($device);
 
-?>

--- a/includes/polling/os/ios.inc.php
+++ b/includes/polling/os/ios.inc.php
@@ -48,5 +48,5 @@ else
 if(empty($hardware)) {   $hardware = snmp_get($device, "sysObjectID.0", "-Osqv", "SNMPv2-MIB:CISCO-PRODUCTS-MIB"); }
 
 #if(isset($cisco_hardware_oids[$poll_device['sysObjectID']])) { $hardware = $cisco_hardware_oids[$poll_device['sysObjectID']]; }
+$serial = get_main_serial($device);
 
-?>

--- a/includes/polling/os/iosxr.inc.php
+++ b/includes/polling/os/iosxr.inc.php
@@ -11,6 +11,7 @@ else
   # It is not an IOS-XR ... What should we do ?
 }
 
+$serial = get_main_serial($device);
+
 echo("\n".$poll_device['sysDescr']."\n");
 
-?>


### PR DESCRIPTION
Adds serial number detection for Cisco devices.

New function to do this, currently only used for cisco devices but can be extended further if we have other OSes that have multiple files but common lookups for serial.

Fixes #1293