### PR TITLE
Add macro `%macros.sensor` to filter out ignored sensors

### DIFF
--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -49,6 +49,7 @@ Rules must consist of at least 3 elements: An __Entity__, a __Condition__ and a 
 Rules can contain braces and __Glues__.  
 __Entities__ are provided as `%`-Noted pair of Table and Field. For Example: `%ports.ifOperStatus`.  
 __Conditions__ can be any of:
+
 - Equals `=`
 - Not Equals `!=`
 - Matches `~`
@@ -67,6 +68,7 @@ Arithmetics are allowed as well.
 ## <a name="rules-examples">Examples</a>
 
 Alert when:
+
 - Device goes down: `%devices.status != '1'`
 - Any port changes: `%ports.ifOperStatus != 'up'`
 - Root-directory gets too full: `%storage.storage_descr = '/' && %storage.storage_perc >= '75'`
@@ -81,12 +83,14 @@ The template-parser understands `if` and `foreach` controls and replaces certain
 ## <a name="templates-syntax">Syntax</a>
 
 Controls:
+
 - if-else (Else can be omitted):  
 `{if %placeholder == 'value'}Some Text{else}Other Text{/if}`
 - foreach-loop:  
 `{foreach %placeholder}Key: %key<br/>Value: %value{/foreach}`
 
 Placeholders:
+
 - Hostname of the Device: `%hostname`
 - Title for the Alert: `%title`
 - Time Elapsed, Only available on recovery (`%state == 0`): `%elapsed`
@@ -490,3 +494,11 @@ Example: `%macros.past_5m` is Last 5 Minutes.
 Resolution: 5,10,15,30,60
 
 Source: `DATE_SUB(NOW(),INTERVAL $ MINUTE)`
+
+## <a name="macros-sensors">Sensors</a> (Boolean)
+
+Entity: `%macros.sensor`
+
+Description: Only select sensors that aren't ignored.
+
+Source: `(%sensors.sensor_alert = 1)`

--- a/sql-schema/055.sql
+++ b/sql-schema/055.sql
@@ -1,0 +1,1 @@
+insert into config (config_name,config_value,config_default,config_descr,config_group,config_group_order,config_sub_group,config_sub_group_order,config_hidden,config_disabled) values ('alert.macros.rule.sensor','(%sensors.sensor_alert = 1)','(%sensors.sensor_alert = 1)','Sensors of interest','alerting',0,'macros',0,1,0);


### PR DESCRIPTION
#1243 

Adds a SQL-Schema because of Dyn-Config.