### PR TITLE
Add timeout on unix agent execution after connect.

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -621,4 +621,9 @@ $config['ipmi']['type'][]                                = "open";
 // Options needed for dyn config - do NOT edit
 $dyn_config['email_backend'] = array('mail','sendmail','smtp');
 $dyn_config['email_smtp_secure'] = array('', 'tls', 'ssl');
+
+// Unix-agent poller module config settings
+$config['unix-agent-connection-time-out'] 		= 10; //seconds
+$config['unix-agent-read-time-out'] 			= 10; //seconds
+
 ?>

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -12,13 +12,23 @@ if ($device['os_group'] == "unix")
   $agent_start = utime();
   $agent = fsockopen($device['hostname'], $agent_port, $errno, $errstr, 10);
 
+  // Set stream timeout (for timeouts during agent  fetch
+  stream_set_timeout($agent,10);
+  $agentinfo = stream_get_meta_data($agent);
+
   if (!$agent)
   {
     echo "Connection to UNIX agent failed on port ".$port.".";
   } else {
-    while (!feof($agent))
+    // fetch data while not eof and not timed-out
+    while ((!feof($agent)) && (!$agentinfo['timed_out']))
     {
       $agent_raw .= fgets($agent, 128);
+      $agentinfo = stream_get_meta_data($agent);
+    }
+    if ($agentinfo['timed_out'])
+    {
+      echo "Connection to UNIX agent timed out during fetch on port ".$port.".";
     }
   }
   

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -10,10 +10,10 @@ if ($device['os_group'] == "unix")
   $agent_port='6556';
 
   $agent_start = utime();
-  $agent = fsockopen($device['hostname'], $agent_port, $errno, $errstr, 10);
+  $agent = fsockopen($device['hostname'], $agent_port, $errno, $errstr, $config['unix-agent-connection-time-out'] );
 
   // Set stream timeout (for timeouts during agent  fetch
-  stream_set_timeout($agent,10);
+  stream_set_timeout($agent,$config['unix-agent-read-time-out']);
   $agentinfo = stream_get_meta_data($agent);
 
   if (!$agent)


### PR DESCRIPTION
I was seeing agent execution getting stuck but without time-out occurring.  I.e. the poller was connecting to the port but not streaming data which should result in timeout.  

This adds a stream time-out to fix that.