### PR TITLE
Add option to include a list of additional pollergroups.

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -603,6 +603,7 @@ $config['api_demo']                                      = 0;// Set this to 1 if
 $config['distributed_poller']                            = false;
 $config['distributed_poller_name']                       = file_get_contents('/proc/sys/kernel/hostname');
 $config['distributed_poller_group']                      = 0;
+$config['distributed_poller_group_also_poll']		 = array(); //array of other groups to also poll (empty by default)
 $config['distributed_poller_memcached_host']             = 'example.net';
 $config['distributed_poller_memcached_port']             = '11211';
 

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -195,7 +195,10 @@ except:
 """
 # (c) 2015, GPLv3, Daniel Preussker <f0o@devilcode.org> <<<EOC2
 if poller_group is not False:
-    query = "select device_id from devices where poller_group = " + poller_group + " and disabled = 0 order by last_polled_timetaken desc"
+    query = "select device_id from devices where poller_group = " + poller_group
+    for pgroup in config['distributed_poller_group_also_poll']:
+        query = query + " or poller_group = " + str(pgroup)
+    query = query + " and disabled = 0 order by last_polled_timetaken desc"
 else:
     query = "select device_id from devices where disabled = 0 order by last_polled_timetaken desc"
 # EOC2


### PR DESCRIPTION
This allows pollers to share poller groups but also have their own group.
So poller 1 can poll group 1 and also poll the default group 0.
Poller 2 can poll group 2 only or also the default group 0.
Poller 3 can poll group 3 and poll group 2.
Maximum flexibility. 