### PR TITLE
Adding the ability to use multiple poller groups for a poller.

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -28,7 +28,7 @@ if (isset($options['g']) && $options['g'] >= 0) {
     array_shift($argv);
     array_unshift($argv, $cmd);
     $poller_group = $options['g'];
-} elseif ($config['distributed_poller_group'] > 0 && $config['distributed_poller'] === TRUE) {
+} elseif ($config['distributed_poller'] === TRUE) {
     $poller_group = $config['distributed_poller_group'];
 }
 

--- a/discovery.php
+++ b/discovery.php
@@ -99,7 +99,7 @@ include("includes/sql-schema/update.php");
 $discovered_devices = 0;
 
 if ($config['distributed_poller'] === TRUE) {
-    $where .= " AND poller_group=?";
+    $where .= " AND poller_group IN(?)";
     $params = array($config['distributed_poller_group']);
 }
 foreach (dbFetch("SELECT * FROM `devices` WHERE status = 1 AND disabled = 0 $where ORDER BY device_id DESC",$params) as $device)

--- a/doc/Extensions/Distributed-Poller.md
+++ b/doc/Extensions/Distributed-Poller.md
@@ -11,6 +11,7 @@ It is also required that all pollers can access the central memcached to communi
 In order to enable distributed polling, set `$config['distributed_poller'] = true` and your memcached details into `$config['distributed_poller_memcached_host']` and `$config['distributed_poller_memcached_port']`.  
 By default, all hosts are shared and have the `poller_group = 0`. To pin a device to a poller, set it to a value greater than 0 and set the same value in the poller's config with `$config['distributed_poller_group']`.  
 Usually the poller's name is equal to the machine's hostname, if you want to change it set `$config['distributed_poller_name']`.
+One can also specify a comma seperated string of poller groups in $config['distributed_poller_group'].  The poller will then poll devices from any of the groups listed.  If new devices get added from the poller they will be assigned to the first poller group in the list unless the group is specified when adding the device.
 
 ## Configuration
 ```php

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -530,14 +530,36 @@ function utime()
   return $sec + $usec;
 }
 
+function getpollergroup($poller_group='0')
+{
+  //Is poller group an integer
+  if (is_int($poller_group) || ctype_digit($poller_group)) {
+    return $poller_group;
+  } else {
+    //Check if it contains a comma
+    if (strpos($poller_group,',')!== FALSE) {
+      //If it has a comma use the first element as the poller group
+      $poller_group=explode(',',$poller_group)[0];
+      return getpollergroup($poller_group);
+    } else {
+      if ($config['distributed_poller_group']) {
+        //If not use the poller's group from the config
+        return getpollergroup($config['distributed_poller_group']);
+      } else {
+        //If all else fails use default
+        return '0';
+      }
+    }
+  }
+}
+
 function createHost($host, $community = NULL, $snmpver, $port = 161, $transport = 'udp', $v3 = array(), $poller_group='0')
 {
   global $config;
   $host = trim(strtolower($host));
 
-  if (is_numeric($poller_group) === FALSE) {
-      $poller_group = $config['distributed_poller_group'];
-  }
+  $poller_group=getpollergroup($poller_group);
+
   $device = array('hostname' => $host,
                   'sysName' => $host,
                   'community' => $community,

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -195,7 +195,7 @@ except:
 """
 # (c) 2015, GPLv3, Daniel Preussker <f0o@devilcode.org> <<<EOC2
 if poller_group is not False:
-    query = "select device_id from devices where poller_group = " + poller_group + " and disabled = 0 order by last_polled_timetaken desc"
+    query = "select device_id from devices where poller_group IN(" + poller_group + ") and disabled = 0 order by last_polled_timetaken desc"
 else:
     query = "select device_id from devices where disabled = 0 order by last_polled_timetaken desc"
 # EOC2


### PR DESCRIPTION
This adds the ability to specify multiple poller groups for a poller as a comma separated string.  When adding hosts from a poller with multiple groups it will use the first group in the list as the group for the added host (unless otherwise specified).

This remains backward compatible with specifying a single group as an integer.
