### PR TITLE
Do not rewrite server-status

### DIFF
--- a/html/.htaccess
+++ b/html/.htaccess
@@ -9,6 +9,7 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI} !\.(js|ico|txt|gif|jpg|png|css|php)
 RewriteRule ^api/v0(.*)$ api_v0.php/$1 [L]
+RewriteCond %{REQUEST_URI} !=/server-status
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI} !\.(js|ico|txt|gif|jpg|png|css|php)


### PR DESCRIPTION
Currently users cannot use the check_mk apache plugin to monitor the apache instance that is running librenms. Excluding server-status from the rewrite rules allows users to use mod_status.