### PR TITLE
Adding --daemon twice breaks collectd graphs

### DIFF
--- a/html/includes/graphs/device/collectd.inc.php
+++ b/html/includes/graphs/device/collectd.inc.php
@@ -197,7 +197,6 @@ if (isset($MetaGraphDefs[$type])) {
 
 if(isset($rrd_cmd))
 {
-  if ($config['rrdcached']) { $rrd_cmd .= " --daemon ".$config['rrdcached'] . " "; }
     if ($_GET['from'])  { $from   = mres($_GET['from']);   }
       if ($_GET['to'])    { $to   = mres($_GET['to']);   }
         $rrd_cmd .= " -s " . $from . " -e " . $to;


### PR DESCRIPTION
When using rrdcached [rrdtool.inc.php](https://github.com/librenms/librenms/blob/924c8e220b03a6bdfc968fbccfab4f722004d7aa/includes/rrdtool.inc.php#L163) already adds the necessary options. Collectd.inc.php adds them again which breaks drawing the graphs.