### PR TITLE
entropy DS name is value.

### DIFF
--- a/html/includes/collectd/definitions.php
+++ b/html/includes/collectd/definitions.php
@@ -397,9 +397,9 @@ function load_graph_definitions($logarithmic = false, $tinylegend = false) {
 		'GPRINT:avg:LAST:%4.1lf\l');
 	$GraphDefs['entropy'] = array(
 		#'-v', 'Bits',
-		'DEF:avg={file}:entropy:AVERAGE',
-		'DEF:min={file}:entropy:MIN',
-		'DEF:max={file}:entropy:MAX',
+		'DEF:avg={file}:value:AVERAGE',
+		'DEF:min={file}:value:MIN',
+		'DEF:max={file}:value:MAX',
 		'COMMENT:         Min       Avg       Max       Cur\l',
 		"AREA:max#$HalfBlue",
 		"AREA:min#$Canvas",


### PR DESCRIPTION
Another bug in collectd graphs. The DS name for the entropy graph has been [changed](https://github.com/collectd/collectd/commit/77a6905147798210ec17173bd5e4410adcc3a112#diff-b138149db048c7bd5b0481fd7a0cc1abL62) in collectd from 'entropy' to 'value'.