### PR TITLE
Now save the connection value selected and remove when not needed

### DIFF
--- a/html/forms/create-device-group.inc.php
+++ b/html/forms/create-device-group.inc.php
@@ -23,8 +23,6 @@ $desc = mres($_POST['desc']);
 
 if( is_array($pattern) ) {
 	$pattern = implode(" ", $pattern);
-	$pattern = rtrim($pattern,'&&');
-	$pattern = rtrim($pattern,'||');
 } elseif( !empty($_POST['pattern']) && !empty($_POST['condition']) && !empty($_POST['value']) ) {
 	$pattern = '%'.$_POST['pattern'].' '.$_POST['condition'].' ';
 	if( is_numeric($_POST['value']) ) {

--- a/html/forms/parse-device-group.inc.php
+++ b/html/forms/parse-device-group.inc.php
@@ -22,7 +22,11 @@ if(is_numeric($group_id) && $group_id > 0) {
     $group = dbFetchRow("SELECT * FROM `device_groups` WHERE `id` = ? LIMIT 1",array($group_id));
     $group_split = preg_split('/([a-zA-Z0-9_\-\.\=\%\<\>\ \"\'\!\~\(\)\*\/\@]+[&&\|\|]+)/',$group['pattern'], -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
     $count = count($group_split) - 1;
-    $group_split[$count] = $group_split[$count].'  &&';
+    if (preg_match("/\&\&$/",$group_split[$count]) == 1 || preg_match("/\|\|$/", $group_split[$count]) == 1) {
+        $group_split[$count] = $group_split[$count];
+    } else { 
+        $group_split[$count] = $group_split[$count].'  &&';
+    }
     $output = array('name'=>$group['name'],'desc'=>$group['desc'],'pattern'=>$group_split);
     echo _json_encode($output);
 }

--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -63,6 +63,8 @@ function GenGroupSQL($pattern,$search='') {
  */
 function GetDevicesFromGroup($group_id) {
 	$pattern = dbFetchCell("SELECT pattern FROM device_groups WHERE id = ?",array($group_id));
+        $pattern = rtrim($pattern,'&&');
+        $pattern = rtrim($pattern,'||');
 	if( !empty($pattern) ) {
 		return dbFetchRows(GenGroupSQL($pattern));
 	}


### PR DESCRIPTION
Fixes #1348 

we now save the connection value in the DB rather then prepending &&. We then strip out && or || from the end of the pattern when we come to use it so maintains backwards compatibility with whatever may use the pattern.

We also check if && or || exist at the end of the current DB entries and display with the default && if not to again maintain backwards compatibility.