### PR TITLE
Fixed API graphs not loading

### DIFF
--- a/html/includes/graphs/graph.inc.php
+++ b/html/includes/graphs/graph.inc.php
@@ -38,7 +38,9 @@ $graphfile = $config['temp_dir'] . "/"  . strgen() . ".png";
 $type = $graphtype['type'];
 $subtype = $graphtype['subtype'];
 
-$auth = is_client_authorized($_SERVER['REMOTE_ADDR']);
+if ($auth !== true && $auth != 1) {
+    $auth = is_client_authorized($_SERVER['REMOTE_ADDR']);
+}
 include($config['install_dir'] . "/html/includes/graphs/$type/auth.inc.php");
 
 if ($auth === true && is_file($config['install_dir'] . "/html/includes/graphs/$type/$subtype.inc.php")) {


### PR DESCRIPTION
$auth was overwriten since the mib poller update, this now checks if it was previously set.