### PR TITLE
Fix datepicker timezone issue(s) #1374, #1239, #1241

### DIFF
--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -145,10 +145,10 @@ if (!$auth)
     </form>
     <script type="text/javascript">
         $(function () {
-            $("#dtpickerfrom").value = $("#dtpickerfrom").value - (new Date().getTimezoneOffset());
-            $("#dtpickerto").value = $("#dtpickerto").value - (new Date().getTimezoneOffset());
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
+            $("#dtpickerfrom").value = $("#dtpickerfrom").value - (new Date().getTimezoneOffset());
+            $("#dtpickerto").value = $("#dtpickerto").value - (new Date().getTimezoneOffset());
         });
     </script>
 

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,8 +118,8 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value.replace(' ', 'T')+":00.000Z");
-            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace(' ', 'T')+":00.000Z");
+            var tsto = new Date(frmdata.dtpickerto.value.replace('-', '/')+":00");
+            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace('-', '/')+":00");
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,9 +118,8 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value+":00");
-            alert(frmdata.dtpickerto.value+":00")
-            var tsfrom = new Date(frmdata.dtpickerfrom.value+":00");
+            var tsto = new Date(frmdata.dtpickerto.value.replace(' ', 'T')+":00.000Z");
+            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace(' ', 'T')+":00.000Z");
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -145,10 +145,12 @@ if (!$auth)
     </form>
     <script type="text/javascript">
         $(function () {
+            var strfrom = new Date($("#dtpickerfrom").value - (new Date().getTimezoneOffset()));
+            $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
+            var strto = new Date($("#dtpickerto").value - (new Date().getTimezoneOffset()));
+            $("#dtpickerto").value = strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes()
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
-            $("#dtpickerfrom").value = $("#dtpickerfrom").value - (new Date().getTimezoneOffset());
-            $("#dtpickerto").value = $("#dtpickerto").value - (new Date().getTimezoneOffset());
         });
     </script>
 

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,13 +118,13 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value)//.replace(' ','T'));
-            var tsfrom = new Date(frmdata.dtpickerfrom.value)//.replace(' ','T'));
+            var tsto = new Date(frmdata.dtpickerto.value);
+            var tsfrom = new Date(frmdata.dtpickerfrom.value);
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);
             frmdata.selfaction.value = frmdata.selfaction.value.replace(refrom, 'from=' + tsfrom);
-            frmdata.action = frmdata.selfaction.value
+            frmdata.action = frmdata.selfaction.value;
             return true;
         }
     </script>

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,8 +118,8 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value);
-            var tsfrom = new Date(frmdata.dtpickerfrom.value);
+            var tsto = new Date(frmdata.dtpickerto.value+":00");
+            var tsfrom = new Date(frmdata.dtpickerfrom.value+":00");
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -146,11 +146,19 @@ if (!$auth)
     <script type="text/javascript">
         $(function () {
             var strfrom = new Date($("#dtpickerfrom").val()*1000);
-            $("#dtpickerfrom").val(strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes());
-            alert(strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes());
+            $("#dtpickerfrom").val(strfrom.getFullYear()+"-"+
+              ("0"+(strfrom.getMonth()+1)).slice(-2)+"-"+
+              ("0"+strfrom.getDate()).slice(-2)+" "+
+              ("0"+strfrom.getHours()).slice(-2)+":"+
+              ("0"+strfrom.getMinutes()).slice(-2)
+            );
             var strto = new Date($("#dtpickerto").val()*1000);
-            $("#dtpickerto").val(strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes());
-            alert(strto);
+            $("#dtpickerto").val(strto.getFullYear()+"-"+
+              ("0"+(strto.getMonth()+1)).slice(-2)+"-"+
+              ("0"+strto.getDate()).slice(-2)+" "+
+              ("0"+strto.getHours()).slice(-2)+":"+
+              ("0"+strto.getMinutes()).slice(-2)
+            );
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
         });

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,10 +118,8 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var strto = frmdata.dtpickerto.value.replace(' ', 'T')+':00Z0400';
-            var tsto = new Date(strto);
-            var strfrom = frmdata.dtpickerfrom.value.replace(' ', 'T')+':00Z0400';
-            var tsfrom = new Date(strfrom);
+            var tsto = new Date(frmdata.dtpickerto.value.replace(' ','T'));
+            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace(' ','T'));
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);
@@ -137,16 +135,18 @@ if (!$auth)
   echo('
         <div class="form-group">
             <label for="dtpickerfrom">From</label>
-            <input type="text" class="form-control" id="dtpickerfrom" maxlength="16" value="' . date($config['dateformat']['byminute'], $graph_array['from']) . '" data-date-format="YYYY-MM-DD HH:mm">
+            <input type="text" class="form-control" id="dtpickerfrom" maxlength="16" value="' . $graph_array['from'] . '" data-date-format="YYYY-MM-DD HH:mm">
         </div>
         <div class="form-group">
             <label for="dtpickerto">To</label>
-            <input type="text" class="form-control" id="dtpickerto" maxlength=16 value="' . date($config['dateformat']['byminute'], $graph_array['to']) . '" data-date-format="YYYY-MM-DD HH:mm">
+            <input type="text" class="form-control" id="dtpickerto" maxlength=16 value="' . $graph_array['to'] . '" data-date-format="YYYY-MM-DD HH:mm">
         </div>
         <input type="submit" class="btn btn-default" id="submit" value="Update" onclick="javascript:submitCustomRange(this.form);">
     </form>
     <script type="text/javascript">
         $(function () {
+            $("#dtpickerfrom").value = $("#dtpickerfrom").value - (new Date().getTimezoneOffset());
+            $("#dtpickerto").value = $("#dtpickerto").value - (new Date().getTimezoneOffset());
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
         });

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,8 +118,8 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value//.replace(' ','T'));
-            var tsfrom = new Date(frmdata.dtpickerfrom.value//.replace(' ','T'));
+            var tsto = new Date(frmdata.dtpickerto.value)//.replace(' ','T'));
+            var tsfrom = new Date(frmdata.dtpickerfrom.value)//.replace(' ','T'));
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -120,8 +120,6 @@ if (!$auth)
             var refrom = /from=([0-9])+/g;
             var tsto = moment(frmdata.dtpickerto.value).unix();
             var tsfrom = moment(frmdata.dtpickerfrom.value).unix();
-            //tsto = tsto.getTime() / 1000;
-            //tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);
             frmdata.selfaction.value = frmdata.selfaction.value.replace(refrom, 'from=' + tsfrom);
             frmdata.action = frmdata.selfaction.value;

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -148,8 +148,10 @@ if (!$auth)
             alert("function");
             var strfrom = new Date($("#dtpickerfrom").value - (new Date().getTimezoneOffset()));
             $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
+            alert(strfrom);
             var strto = new Date($("#dtpickerto").value - (new Date().getTimezoneOffset()));
             $("#dtpickerto").value = strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes()
+            alert(strto);
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
         });

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -147,7 +147,7 @@ if (!$auth)
         $(function () {
             var strfrom = new Date($("#dtpickerfrom").val()*1000);
             $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
-            alert(strfrom);
+            alert(strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes());
             var strto = new Date($("#dtpickerto").val()*1000);
             $("#dtpickerto").value = strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes()
             alert(strto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -119,6 +119,7 @@ if (!$auth)
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
             var tsto = new Date(frmdata.dtpickerto.value+":00");
+            alert(frmdata.dtpickerto.value+":00")
             var tsfrom = new Date(frmdata.dtpickerfrom.value+":00");
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -145,6 +145,7 @@ if (!$auth)
     </form>
     <script type="text/javascript">
         $(function () {
+            alert("function");
             var strfrom = new Date($("#dtpickerfrom").value - (new Date().getTimezoneOffset()));
             $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
             var strto = new Date($("#dtpickerto").value - (new Date().getTimezoneOffset()));

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,8 +118,8 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value.replace(' ','T'));
-            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace(' ','T'));
+            var tsto = new Date(frmdata.dtpickerto.value//.replace(' ','T'));
+            var tsfrom = new Date(frmdata.dtpickerfrom.value//.replace(' ','T'));
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -145,11 +145,10 @@ if (!$auth)
     </form>
     <script type="text/javascript">
         $(function () {
-            alert("function");
-            var strfrom = new Date($("#dtpickerfrom").value - ((new Date().getTimezoneOffset())*60));
+            var strfrom = new Date($("#dtpickerfrom").val()*1000);
             $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
             alert(strfrom);
-            var strto = new Date($("#dtpickerto").value - ((new Date().getTimezoneOffset())*60));
+            var strto = new Date($("#dtpickerto").val()*1000);
             $("#dtpickerto").value = strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes()
             alert(strto);
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,10 +118,10 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value.replace('-', '/')+":00");
-            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace('-', '/')+":00");
-            tsto = tsto.getTime() / 1000;
-            tsfrom = tsfrom.getTime() / 1000;
+            var tsto = moment(frmdata.dtpickerto.value).unix();
+            var tsfrom = moment(frmdata.dtpickerfrom.value).unix();
+            //tsto = tsto.getTime() / 1000;
+            //tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);
             frmdata.selfaction.value = frmdata.selfaction.value.replace(refrom, 'from=' + tsfrom);
             frmdata.action = frmdata.selfaction.value;

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -118,8 +118,10 @@ if (!$auth)
         function submitCustomRange(frmdata) {
             var reto = /to=([0-9])+/g;
             var refrom = /from=([0-9])+/g;
-            var tsto = new Date(frmdata.dtpickerto.value.replace(' ','T'));
-            var tsfrom = new Date(frmdata.dtpickerfrom.value.replace(' ','T'));
+            var strto = frmdata.dtpickerto.value.replace(' ', 'T')+':00Z0400';
+            var tsto = new Date(strto);
+            var strfrom = frmdata.dtpickerfrom.value.replace(' ', 'T')+':00Z0400';
+            var tsfrom = new Date(strfrom);
             tsto = tsto.getTime() / 1000;
             tsfrom = tsfrom.getTime() / 1000;
             frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -146,10 +146,10 @@ if (!$auth)
     <script type="text/javascript">
         $(function () {
             alert("function");
-            var strfrom = new Date($("#dtpickerfrom").value - (new Date().getTimezoneOffset()));
+            var strfrom = new Date($("#dtpickerfrom").value - ((new Date().getTimezoneOffset())*60));
             $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
             alert(strfrom);
-            var strto = new Date($("#dtpickerto").value - (new Date().getTimezoneOffset()));
+            var strto = new Date($("#dtpickerto").value - ((new Date().getTimezoneOffset())*60));
             $("#dtpickerto").value = strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes()
             alert(strto);
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -146,10 +146,10 @@ if (!$auth)
     <script type="text/javascript">
         $(function () {
             var strfrom = new Date($("#dtpickerfrom").val()*1000);
-            $("#dtpickerfrom").value = strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes() 
+            $("#dtpickerfrom").val(strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes());
             alert(strfrom.getFullYear()+"-"+(strfrom.getMonth()+1)+"-"+strfrom.getDate()+" "+strfrom.getHours()+":"+strfrom.getMinutes());
             var strto = new Date($("#dtpickerto").val()*1000);
-            $("#dtpickerto").value = strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes()
+            $("#dtpickerto").val(strto.getFullYear()+"-"+(strto.getMonth()+1)+"-"+strto.getDate()+" "+strto.getHours()+":"+strto.getMinutes());
             alert(strto);
             $("#dtpickerfrom").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});
             $("#dtpickerto").datetimepicker({useCurrent: true, sideBySide: true, useStrict: false});


### PR DESCRIPTION
Basically, passing the unix timestamp straight from PHP without a format, and then using javascript to format the date on page load. With this, javascript automatically converts the format to browser time.

On form submission, changed the parsing to be done by moment.js since we already have it loaded and it seems to do better with cross browser compatibility, and again auto handles the browser's time conversion.

Also fixed a missing semicolon in the same code block.

Fixes: #1374, #1239, #1241