### PR TITLE
Pass service parameters to check_ssh.

### DIFF
--- a/includes/services/ssh/check.inc
+++ b/includes/services/ssh/check.inc
@@ -1,6 +1,6 @@
 <?php
 
-$check = shell_exec($config['nagios_plugins'] . "/check_ssh -H ".$service['hostname']);
+$check = shell_exec($config['nagios_plugins'] . "/check_ssh -H ".$service['hostname']." ".$service['service_param']);
 
 list($check, $time) = split("\|", $check);
 


### PR DESCRIPTION
Service parameter wasn't passed to check_ssh.  Now we can specify and alternative port for ssh for example using the -p flag. 