### PR TITLE
Accept MySQL OK as the service active.

### DIFF
--- a/includes/services/mysql/check.inc
+++ b/includes/services/mysql/check.inc
@@ -7,7 +7,7 @@ $check = shell_exec($config['nagios_plugins'] . "/check_mysql -H ".$service['hos
 
 list($check, $time) = split("\|", $check);
 
-if(strstr($check, "Uptime:")) {
+if(strstr($check, "Uptime:") || strstr($check, "MySQL OK")) {
   $status = '1';
 } else {
   $status = '0';


### PR DESCRIPTION
Because if you run check_mysql with -n it returns MySQL OK.
