### PR TITLE
Improved the discovery of IP based devices

### DIFF
--- a/includes/discovery/discovery-arp.inc.php
+++ b/includes/discovery/discovery-arp.inc.php
@@ -69,17 +69,10 @@ foreach (dbFetchRows($sql, array($deviceid)) as $entry)
 	}
 	arp_discovery_add_cache($ip);
 
-	// Log reverse DNS failures so the administrator can take action.
 	$name = gethostbyaddr($ip);
-	if ($name != $ip) {		// gethostbyaddr returns the original argument on failure
-		echo("+");
-		$names[] = $name;
-		$ips[$name] = $ip;
-	}
-	else {
-		echo("-");
-		log_event("ARP discovery of $ip failed due to absent reverse DNS", $deviceid, 'interface', $if);
-	}
+	echo("+");
+	$names[] = $name;
+	$ips[$name] = $ip;
 }
 echo("\n");
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -22,12 +22,14 @@ function discover_new_device($hostname)
     }
     if ($debug) { echo("discovering $dst_host\n"); }
     $ip = gethostbyname($dst_host);
-    if ($ip == $dst_host) {
-      if ($debug) { echo("name lookup of $dst_host failed\n"); }
-      return FALSE;
-    } else {
-      if ($debug) { echo("ip lookup result: $ip\n"); }
+    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === FALSE && filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === FALSE) {
+        // $ip isn't a valid IP so it must be a name.
+        if ($ip == $dst_host) {
+            if ($debug) { echo("name lookup of $dst_host failed\n"); }
+            return FALSE;
+        }
     }
+    if ($debug) { echo("ip lookup result: $ip\n"); }
 
     $dst_host = rtrim($dst_host, '.');	// remove trailing dot
 


### PR DESCRIPTION
The two changes are:

 includes/discovery/discovery-arp.inc.php

Removed the reverse dns check, we still try and grab the name but no longer care if it's not a hostname and try and add.

includes/discovery/functions.inc.php

Add a check that $ip is a hostname before carrying on. This was tested by a user and found to work.

Be good to double test this properly as it would affect adding devices.