### PR TITLE
Added using cronic for poller-wrapper, this will now allow email alerts from cron

### DIFF
--- a/cronic
+++ b/cronic
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Cronic v2 - cron job report wrapper
+# Copyright 2007 Chuck Houpt. No rights reserved, whatsoever.
+# Public Domain CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+set -eu
+
+OUT=/tmp/cronic.out.$$
+ERR=/tmp/cronic.err.$$
+TRACE=/tmp/cronic.trace.$$
+
+set +e
+"$@" >$OUT 2>$TRACE
+RESULT=$?
+set -e
+
+PATTERN="^${PS4:0:1}\\+${PS4:1}"
+if grep -aq "$PATTERN" $TRACE
+then
+    ! grep -av "$PATTERN" $TRACE > $ERR
+else
+    ERR=$TRACE
+fi
+
+if [ $RESULT -ne 0 -o -s "$ERR" ]
+    then
+    echo "Cronic detected failure or error output for the command:"
+    echo "$@"
+    echo
+    echo "RESULT CODE: $RESULT"
+    echo
+    echo "ERROR OUTPUT:"
+    cat "$ERR"
+    echo
+    echo "STANDARD OUTPUT:"
+    cat "$OUT"
+    if [ $TRACE != $ERR ]
+    then
+        echo
+        echo "TRACE-ERROR OUTPUT:"
+        cat "$TRACE"
+    fi
+fi
+
+rm -f "$OUT"
+rm -f "$ERR"
+rm -f "$TRACE"

--- a/librenms.cron
+++ b/librenms.cron
@@ -2,6 +2,6 @@
 
 33  */6   * * *   root    /opt/librenms/discovery.php -h all >> /dev/null 2>&1
 */5  *    * * *   root    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
-*/5  *    * * *   root    /opt/librenms/poller-wrapper.py 16 >> /dev/null 2>&1
+*/5  *    * * *   root    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
 15   0    * * *   root    sh /opt/librenms/daily.sh >> /dev/null 2>&1
 *    *    * * *   root    /opt/librenms/alerts.php >> /dev/null 2>&1

--- a/librenms.nonroot.cron
+++ b/librenms.nonroot.cron
@@ -2,6 +2,6 @@
 
 33  */6   * * *   librenms    /opt/librenms/discovery.php -h all >> /dev/null 2>&1
 */5  *    * * *   librenms    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
-*/5  *    * * *   librenms    /opt/librenms/poller-wrapper.py 16 >> /dev/null 2>&1
+*/5  *    * * *   librenms    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
 15   0    * * *   librenms    sh /opt/librenms/daily.sh >> /dev/null 2>&1
 *    *    * * *   librenms    /opt/librenms/alerts.php >> /dev/null 2>&1


### PR DESCRIPTION
Fixes issue #1290 

This will now generate an email from cron as you would normally expect if poller-wrapper.py dies because of coding / syntax issues.

/opt/librenms/cronic /opt/librenms/poller-wrapper.py
Cronic detected failure or error output for the command:
/opt/librenms/poller-wrapper.py

RESULT CODE: 1

ERROR OUTPUT:
Traceback (most recent call last):
  File "/opt/librenms/poller-wrapper.py", line 2, in <module>
    dsads
NameError: name 'dsads' is not defined

STANDARD OUTPUT: