### PR TITLE
Updated BGP discovery code to perform autodiscovery if enabled

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -93,6 +93,15 @@ if ($config['enable_bgp'])
       if (dbFetchCell("SELECT COUNT(*) from `bgpPeers` WHERE device_id = ? AND bgpPeerIdentifier = ?",array($device['device_id'], $peer['ip'])) < '1')
       {
         $add = dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'bgpPeerRemoteAs' => $peer['as']), 'bgpPeers');
+        if ($config['autodiscovery']['bgp'] === true) {
+            $name = gethostbyaddr($peer['ip']);
+            $remote_device_id = discover_new_device($name);
+            if ($remote_device_id) {
+                log_event("Device $name (" . $peer['ip'] .") autodiscovered through BGP on ".$device['hostname'], $remote_device_id, 'system');
+            }  else {
+                log_event("BGP discovery of $name (" . $peer['ip'] . ") failed - check ping and SNMP access", $device['device_id'], 'system');
+            }
+        }
         echo("+");
       } else {
         $update = dbUpdate(array('bgpPeerRemoteAs' => $peer['as'], 'astext' => mres($astext)), 'bgpPeers', 'device_id=? AND bgpPeerIdentifier=?',array($device['device_id'],$peer['ip']));

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -95,12 +95,7 @@ if ($config['enable_bgp'])
         $add = dbInsert(array('device_id' => $device['device_id'], 'bgpPeerIdentifier' => $peer['ip'], 'bgpPeerRemoteAs' => $peer['as']), 'bgpPeers');
         if ($config['autodiscovery']['bgp'] === true) {
             $name = gethostbyaddr($peer['ip']);
-            $remote_device_id = discover_new_device($name);
-            if ($remote_device_id) {
-                log_event("Device $name (" . $peer['ip'] .") autodiscovered through BGP on ".$device['hostname'], $remote_device_id, 'system');
-            }  else {
-                log_event("BGP discovery of $name (" . $peer['ip'] . ") failed - check ping and SNMP access", $device['device_id'], 'system');
-            }
+            $remote_device_id = discover_new_device($name,$device,'BGP');
         }
         echo("+");
       } else {

--- a/includes/discovery/discovery-arp.inc.php
+++ b/includes/discovery/discovery-arp.inc.php
@@ -85,13 +85,7 @@ echo("\n");
 
 // Run device discovery on each of the devices we've detected so far.
 foreach ($names as $name) {
-	$remote_device_id = discover_new_device($name);
-	if ($remote_device_id) {
-		log_event("Device $name (" . $ips[$name] .") autodiscovered through ARP on $hostname", $remote_device_id, 'interface', $if);
-	}
-	else {
-		log_event("ARP discovery of $name (" . $ips[$name] . ") failed - check ping and SNMP access", $deviceid, 'interface', $if);
-	}
+	$remote_device_id = discover_new_device($name,$device,'ARP');
 }
 
 unset($names);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -11,7 +11,7 @@
  * See COPYING for more details.
  */
 
-function discover_new_device($hostname)
+function discover_new_device($hostname,$device,$method)
 {
     global $config, $debug;
 
@@ -44,6 +44,11 @@ function discover_new_device($hostname)
         echo("+[".$remote_device['hostname']."(".$remote_device['device_id'].")]");
         discover_device($remote_device);
         device_by_id_cache($remote_device_id, 1);
+        if ($remote_device_id) {
+            log_event("Device $". $remote_device['hostname'] ." ($ip) autodiscovered through $method on ".$device['hostname'], $remote_device_id, 'system');
+        }  else {
+            log_event("$method discovery of ". $remote_device['hostname'] ." ($ip) failed - check ping and SNMP access", $device['device_id'], 'system');
+        }
         return $remote_device_id;
       }
     } else {


### PR DESCRIPTION
Even though we had a config option to enable discovery via BGP no code existed. Now added.

Fixes issue #1197 