### PR TITLE
Fix poller group query in discovery.php.

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -99,10 +99,9 @@ include("includes/sql-schema/update.php");
 $discovered_devices = 0;
 
 if ($config['distributed_poller'] === TRUE) {
-    $where .= " AND poller_group IN(?)";
-    $params = array($config['distributed_poller_group']);
+    $where .= " AND poller_group IN(".$config['distributed_poller_group'].")";
 }
-foreach (dbFetch("SELECT * FROM `devices` WHERE status = 1 AND disabled = 0 $where ORDER BY device_id DESC",$params) as $device)
+foreach (dbFetch("SELECT * FROM `devices` WHERE status = 1 AND disabled = 0 $where ORDER BY device_id DESC") as $device)
 {
   discover_device($device, $options);
 }


### PR DESCRIPTION
There was a bug in discovery.php.  The query was created incorrectly where `$config['distributed_poller_group']` was specified as a string.
`$config['distributed_poller_group']='0,2'` would create a SQL that looked like:
```mysql
 WHERE status = 1 AND disabled = 0 AND `last_discovered` IS NULL AND poller_group IN('0,2') 
```
The above won't match any devices.
This PR fixes that and makes it look like:
```mysql
WHERE status = 1 AND disabled = 0 AND `last_discovered` IS NULL AND poller_group IN(0,2)
```