### PR TITLE
Add a config flag to control whether ips of hostnames are checked.

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -169,6 +169,14 @@ $config['enable_footer'] = 1;
 ```
 Disable the footer of the WebUI by setting `enable_footer` to 0.
 
+#### Add host settings
+The following setting controls how hosts are added.  If a host is added as an ip address it is checked to ensure the ip is not already present.  If the ip is present the host is not added.
+If host is added by hostname this check is not performed.  If the setting is true hostnames are resovled and the check is also performed.  This helps prevents accidental duplicate hosts.
+```php
+$config['addhost_alwayscheckip']   = FALSE; #TRUE - check for duplicate ips even when adding host by name.
+                                            #FALSE- only check when adding host by ip.
+```
+
 #### SNMP Settings
 
 ```php

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -148,6 +148,8 @@ $config['show_services'] = 0;
 // Enable Services on menu
 $config['ports_page_default'] = 'details';
 // eg "details" or "basic"
+// Adding Host Settings
+$config['addhost_alwayscheckip']   = FALSE;   # TRUE - check for duplicate ips even when adding host by name. FALSE- only check when adding host by ip.
 // SNMP Settings - Timeouts/Retries disabled as default
 // $config['snmp']['timeout'] = 1;            # timeout in seconds
 // $config['snmp']['retries'] = 5;            # how many times to retry the query

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -270,7 +270,12 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
     list($hostshort) = explode(".", $host);
     // Test Database Exists
     if (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($host)) == '0') {
-        if (ip_exists($host) === false) {
+        if ($config['addhost_alwayscheckip'] === TRUE) {
+            $ip = gethostbyname($host);
+        } else {
+            $ip = $host;
+        }
+        if (ip_exists($ip) === false) {
             // Test reachability
             if ($force_add == 1 || isPingable($host)) {
                 if (empty($snmpver)) {


### PR DESCRIPTION
Currently when adding a host by ip the ip is checked if it's already in the database and the host is not added if the ip is present.
This config setting allows one to enforce the same behaviour when adding by hostname. The hostname is resolved and checked as above.
