### PR TITLE
Network map sql update + fix for duplicate links

### DIFF
--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -35,7 +35,7 @@ if (is_admin() === false && is_read() === false) {
 $tmp_devices = array();
 $tmp_ids = array();
 $tmp_links = array();
-
+$tmp_link_ids = array();
 
 $ports = dbFetchRows("SELECT
                              `D1`.`device_id` AS `local_device_id`,
@@ -161,6 +161,10 @@ foreach ($list as $items) {
     }
     $link_color = $config['map_legend'][$link_used];
     $tmp_links[] = array('from'=>$items['local_device_id'],'to'=>$items['remote_device_id'],'label'=>shorten_interface_type($items['local_ifname']) . ' > ' . shorten_interface_type($items['remote_ifname']),'title'=>generate_port_link($local_port, "<img src='graph.php?type=port_bits&amp;id=".$items['local_port_id']."&amp;from=".$config['time']['day']."&amp;to=".$config['time']['now']."&amp;width=100&amp;height=20&amp;legend=no&amp;bg=".str_replace("#","", $row_colour)."'>",'',0,1),'width'=>$width,'color'=>$link_color);
+    if (!in_array($items['remote_port_id'],$tmp_link_ids)) {
+        $tmp_links[] = array('from'=>$items['local_device_id'],'to'=>$items['remote_device_id'],'label'=>shorten_interface_type($items['local_ifname']) . ' > ' . shorten_interface_type($items['remote_ifname']),'title'=>generate_port_link($local_port, "<img src='graph.php?type=port_bits&amp;id=".$items['local_port_id']."&amp;from=".$config['time']['day']."&amp;to=".$config['time']['now']."&amp;width=100&amp;height=20&amp;legend=no&amp;bg=".str_replace("#","", $row_colour)."'>",'',0,1),'width'=>$width,'color'=>$link_color);
+    }
+    array_push($tmp_link_ids,$items['local_port_id']);
 }
 
 $node_devices = $tmp_devices;

--- a/sql-schema/057.sql
+++ b/sql-schema/057.sql
@@ -1,0 +1,3 @@
+ALTER TABLE  `ipv4_mac` CHANGE  `mac_address`  `mac_address` VARCHAR( 32 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL , CHANGE  `ipv4_address`  `ipv4_address` VARCHAR( 32 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL
+ALTER TABLE  `ipv4_mac` ADD INDEX (  `port_id`), ADD INDEX (`mac_address` )
+ALTER TABLE `ipv4_mac` DROP INDEX `interface_id`, DROP INDEX `interface_id_2`


### PR DESCRIPTION
@Rosiak pointed out the load time for his map was high (9k+ ipv4_mac entries). After some debugging this is due to a missing index (mainly mac_address). I've tidied up the current indexes pointing to old column names and re-added the correct index and his query has gone from over 20 seconds to < 1 second.

In my testing with 40000 mac addresses but less ports I went from > 6 seconds to < 0.05 seconds.

I've also fixed duplicate links showing up with this as well.