### PR TITLE
Collectd flush

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -305,6 +305,11 @@ $config['collectd_dir']                 = '/var/lib/collectd/rrd';
 Specify the location of the collectd rrd files.
 
 ```php
+$config['collectd_sock']                 = 'unix:///var/run/collectd.sock';
+```
+Specify the location of the collectd unix socket. Using a socket allows the collectd graphs to be flushed to disk before being drawn. Be sure that your web server has permissions to write to this socket.
+
+```php
 $config['smokeping']['dir']             = "/var/lib/smokeping/";
 ```
 Set the smokeping directory location.

--- a/html/includes/collectd/config.php
+++ b/html/includes/collectd/config.php
@@ -87,12 +87,6 @@ $config['rrd_colors'] = array(
     'f_13' => '555555',
 );
 /*
- * URL to collectd's unix socket (unixsock plugin)
- *  enabled:  'unix:///var/run/collectd/collectd-unixsock'
- *  disabled: null
- */
-$config['collectd_sock'] = null;
-/*
  * Path to TTF font file to use in error images
  * (fallback when file does not exist is GD fixed font)
  */

--- a/html/includes/collectd/functions.php
+++ b/html/includes/collectd/functions.php
@@ -330,26 +330,6 @@ function collectd_flush($identifier) {
         return false;
     }
 
-    if (is_null($host) || !is_string($host) || strlen($host) == 0) {
-        return false;
-    }
-
-    if (is_null($plugin) || !is_string($plugin) || strlen($plugin) == 0) {
-        return false;
-    }
-
-    if (is_null($pinst) || !is_string($pinst)) {
-        return false;
-    }
-
-    if (is_null($type) || !is_string($type) || strlen($type) == 0) {
-        return false;
-    }
-
-    if (is_null($tinst) || (is_array($tinst) && count($tinst) == 0) || !(is_string($tinst) || is_array($tinst))) {
-        return false;
-    }
-
     $u_errno  = 0;
     $u_errmsg = '';
     if ($socket = @fsockopen($config['collectd_sock'], 0, $u_errno, $u_errmsg)) {


### PR DESCRIPTION
This enables the `collectd_sock` option which allows the collectd graph page to issue a flush command to the collectd socket before drawing the graph.

The code was already there but basically disabled.