### PR TITLE
Equalogic sensor

### DIFF
--- a/includes/discovery/fanspeeds/equallogic.inc.php
+++ b/includes/discovery/fanspeeds/equallogic.inc.php
@@ -24,7 +24,7 @@ if ($device['os'] == 'equallogic') {
                 $num_index        = $part_oid.'.'.$num_index;
                 $base_oid         = '.1.3.6.1.4.1.12740.2.1.7.1.3.1.';
                 $oid              = $base_oid.$num_index;
-                $extra            = snmp_get_multi($device, "eqlMemberHealthDetailsFanValue.3.329840783.$index eqlMemberHealthDetailsFanCurrentState.3.329840783.$index eqlMemberHealthDetailsFanHighCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsFanHighWarningThreshold.3.329840783.$index eqlMemberHealthDetailsFanLowCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsFanLowWarningThreshold.3.329840783.$index", '-OQUs', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
+                $extra            = snmp_get_multi($device, "eqlMemberHealthDetailsFanValue.1.$num_index eqlMemberHealthDetailsFanCurrentState.1.$num_index eqlMemberHealthDetailsFanHighCriticalThreshold.1.$num_index eqlMemberHealthDetailsFanHighWarningThreshold.1.$num_index eqlMemberHealthDetailsFanLowCriticalThreshold.1.$num_index eqlMemberHealthDetailsFanLowWarningThreshold.1.$num_index", '-OQUs', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
                 $keys             = array_keys($extra);
                 $temperature      = $extra[$keys[0]]['eqlMemberHealthDetailsFanValue'];
                 $low_limit        = $extra[$keys[0]]['eqlMemberHealthDetailsFanLowCriticalThreshold'];

--- a/includes/discovery/temperatures/equallogic.inc.php
+++ b/includes/discovery/temperatures/equallogic.inc.php
@@ -1,42 +1,49 @@
 <?php
 
 if ($device['os'] == 'equallogic') {
-    $oids = snmp_walk($device, 'eqlMemberHealthDetailsTemperatureEntry', '-OQ', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
+    $oids = snmp_walk($device, 'eqlMemberHealthDetailsTemperatureName', '-OQn', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
+
+    /*
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.4 = Control module 0 processor
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.5 = Control module 0 chipset
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.6 = Control module 1 processor
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.7 = Control module 1 chipset
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.8 = Control module 0 SAS Controller
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.9 = Control module 0 SAS Expander
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.10 = Control module 0 SES Enclosure
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.11 = Control module 1 SAS Controller
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.12 = Control module 1 SAS Expander
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.17 = Control module 0 Battery
+        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.18 = Control module 1 Battery
+    **/
 
     d_echo($oids."\n");
     if (!empty($oids)) {
         echo 'EQLCONTROLLER-MIB ';
-        $temps = [];
         foreach (explode("\n", $oids) as $data) {
             $data = trim($data);
             if (!empty($data)) {
-                list($oid,$val) = explode(' = ', $data, 2);
-                $oid = explode('::', $oid, 2)[1];
-                $oid = explode('.', $oid);
-                $key = $oid[0];
-                $part = $oid[-1];
-
-                if not array_key_exists($part, $temps) {
-                    $temps[$part] = [];
-                } //end if
-
-                $temps[$part][$key] = $val;
-            }//end if
-        }//end foreach
-
-        foreach ($temps as $part => $vals) {
-            discover_sensor($valid['sensor'], 'temperature', $device, $vals['eqlMemberHealthDetailsTemperatureName']
-        }// end foreach
-    }//end if
-}//end if
-
+                list($oid,$descr) = explode(' = ', $data, 2);
+                $split_oid        = explode('.', $oid);
+                $num_index        = $split_oid[(count($split_oid) - 1)];
+                $index            = $num_index;
+                $part_oid         = $split_oid[(count($split_oid) - 2)];
+                $num_index        = $part_oid.'.'.$num_index;
+                $base_oid         = '.1.3.6.1.4.1.12740.2.1.6.1.3.1.';
+                $oid              = $base_oid.$num_index;
+                $extra            = snmp_get_multi($device, "eqlMemberHealthDetailsTemperatureValue.3.329840783.$index eqlMemberHealthDetailsTemperatureCurrentState.3.329840783.$index eqlMemberHealthDetailsTemperatureHighCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureHighWarningThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureLowCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureLowWarningThreshold.3.329840783.$index", '-OQUs', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
+                $keys             = array_keys($extra);
                 $temperature      = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureValue'];
                 $low_limit        = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureLowCriticalThreshold'];
                 $low_warn         = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureLowWarningThreshold'];
                 $high_limit       = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureHighCriticalThreshold'];
                 $high_warn        = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureHighWarningThreshold'];
+                $index            = (100 + $index);
 
                 if ($extra[$keys[0]]['eqlMemberHealthDetailsTemperatureCurrentState'] != 'unknown') {
                     discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, 'snmp', $descr, 1, 1, $low_limit, $low_warn, $high_limit, $high_warn, $temperature);
-
-EqlMemberHealthDetailsTemperatureEntry
+                }
+            }//end if
+        }//end foreach
+    }//end if
+}//end if

--- a/includes/discovery/temperatures/equallogic.inc.php
+++ b/includes/discovery/temperatures/equallogic.inc.php
@@ -1,49 +1,42 @@
 <?php
 
 if ($device['os'] == 'equallogic') {
-    $oids = snmp_walk($device, 'eqlMemberHealthDetailsTemperatureName', '-OQn', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
-
-    /*
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.4 = Control module 0 processor
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.5 = Control module 0 chipset
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.6 = Control module 1 processor
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.7 = Control module 1 chipset
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.8 = Control module 0 SAS Controller
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.9 = Control module 0 SAS Expander
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.10 = Control module 0 SES Enclosure
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.11 = Control module 1 SAS Controller
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.12 = Control module 1 SAS Expander
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.17 = Control module 0 Battery
-        .1.3.6.1.4.1.12740.2.1.6.1.2.1.329840783.18 = Control module 1 Battery
-    **/
+    $oids = snmp_walk($device, 'eqlMemberHealthDetailsTemperatureEntry', '-OQ', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
 
     d_echo($oids."\n");
     if (!empty($oids)) {
         echo 'EQLCONTROLLER-MIB ';
+        $temps = [];
         foreach (explode("\n", $oids) as $data) {
             $data = trim($data);
             if (!empty($data)) {
-                list($oid,$descr) = explode(' = ', $data, 2);
-                $split_oid        = explode('.', $oid);
-                $num_index        = $split_oid[(count($split_oid) - 1)];
-                $index            = $num_index;
-                $part_oid         = $split_oid[(count($split_oid) - 2)];
-                $num_index        = $part_oid.'.'.$num_index;
-                $base_oid         = '.1.3.6.1.4.1.12740.2.1.6.1.3.1.';
-                $oid              = $base_oid.$num_index;
-                $extra            = snmp_get_multi($device, "eqlMemberHealthDetailsTemperatureValue.3.329840783.$index eqlMemberHealthDetailsTemperatureCurrentState.3.329840783.$index eqlMemberHealthDetailsTemperatureHighCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureHighWarningThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureLowCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureLowWarningThreshold.3.329840783.$index", '-OQUs', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
-                $keys             = array_keys($extra);
+                list($oid,$val) = explode(' = ', $data, 2);
+                $oid = explode('::', $oid, 2)[1];
+                $oid = explode('.', $oid);
+                $key = $oid[0];
+                $part = $oid[-1];
+
+                if not array_key_exists($part, $temps) {
+                    $temps[$part] = [];
+                } //end if
+
+                $temps[$part][$key] = $val;
+            }//end if
+        }//end foreach
+
+        foreach ($temps as $part => $vals) {
+            discover_sensor($valid['sensor'], 'temperature', $device, $vals['eqlMemberHealthDetailsTemperatureName']
+        }// end foreach
+    }//end if
+}//end if
+
                 $temperature      = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureValue'];
                 $low_limit        = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureLowCriticalThreshold'];
                 $low_warn         = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureLowWarningThreshold'];
                 $high_limit       = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureHighCriticalThreshold'];
                 $high_warn        = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureHighWarningThreshold'];
-                $index            = (100 + $index);
 
                 if ($extra[$keys[0]]['eqlMemberHealthDetailsTemperatureCurrentState'] != 'unknown') {
                     discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, 'snmp', $descr, 1, 1, $low_limit, $low_warn, $high_limit, $high_warn, $temperature);
-                }
-            }//end if
-        }//end foreach
-    }//end if
-}//end if
+
+EqlMemberHealthDetailsTemperatureEntry

--- a/includes/discovery/temperatures/equallogic.inc.php
+++ b/includes/discovery/temperatures/equallogic.inc.php
@@ -31,7 +31,7 @@ if ($device['os'] == 'equallogic') {
                 $num_index        = $part_oid.'.'.$num_index;
                 $base_oid         = '.1.3.6.1.4.1.12740.2.1.6.1.3.1.';
                 $oid              = $base_oid.$num_index;
-                $extra            = snmp_get_multi($device, "eqlMemberHealthDetailsTemperatureValue.3.329840783.$index eqlMemberHealthDetailsTemperatureCurrentState.3.329840783.$index eqlMemberHealthDetailsTemperatureHighCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureHighWarningThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureLowCriticalThreshold.3.329840783.$index eqlMemberHealthDetailsTemperatureLowWarningThreshold.3.329840783.$index", '-OQUs', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
+                $extra            = snmp_get_multi($device, "eqlMemberHealthDetailsTemperatureValue.1.$num_index eqlMemberHealthDetailsTemperatureCurrentState.1.$num_index eqlMemberHealthDetailsTemperatureHighCriticalThreshold.1.$num_index eqlMemberHealthDetailsTemperatureHighWarningThreshold.1.$num_index eqlMemberHealthDetailsTemperatureLowCriticalThreshold.1.$num_index eqlMemberHealthDetailsTemperatureLowWarningThreshold.1.$num_index", '-OQUs', 'EQLMEMBER-MIB', $config['install_dir'].'/mibs/equallogic');
                 $keys             = array_keys($extra);
                 $temperature      = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureValue'];
                 $low_limit        = $extra[$keys[0]]['eqlMemberHealthDetailsTemperatureLowCriticalThreshold'];


### PR DESCRIPTION
Fixes a bug getting thresholds for temperatures and fanspeeds on equalogic SANs. Without this fix, all limits are 0 causing the alerts for sensor over limit to fire.