### PR TITLE
Add LDAP's 'pure' DN member groups

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -41,6 +41,7 @@ Contributors to LibreNMS:
 - Job Snijders <job@instituut.net> (job)
 - Rasmus Aberg <rasmus@sthix.net> (rasssta)
 - Jan Saner <jan@trick77.com> (trick77)
+- Mikhail Bratchikov <mbratchikov@odin.com> (pepyaka)
 
 [1]: http://observium.org/ "Observium web site"
 

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -203,9 +203,15 @@ function update_user($user_id, $realname, $level, $can_modify_passwd, $email) {
 
 
 function get_membername($username) {
-    global $config;
+    global $config, $ds;
     if ($config['auth_ldap_groupmembertype'] == 'fulldn') {
         $membername = $config['auth_ldap_prefix'].$username.$config['auth_ldap_suffix'];
+    }
+    elseif ($config['auth_ldap_groupmembertype'] == 'puredn') {
+        $filter  = '('.$config['auth_ldap_attr']['uid'].'='.$username.')';
+        $search  = ldap_search($ds, $config['auth_ldap_groupbase'], $filter);
+        $entries = ldap_get_entries($ds, $search);
+        $membername = $entries[0]['dn'];
     }
     else {
         $membername = $username;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -496,6 +496,7 @@ $config['auth_ldap_prefix'] = 'uid=';
 $config['auth_ldap_suffix'] = ',ou=People,dc=example,dc=com';
 $config['auth_ldap_group']  = 'cn=groupname,ou=groups,dc=example,dc=com';
 
+$config['auth_ldap_attr']['uid'] = "uid";
 $config['auth_ldap_groupbase']                  = 'ou=group,dc=example,dc=com';
 $config['auth_ldap_groups']['admin']['level']   = 10;
 $config['auth_ldap_groups']['pfy']['level']     = 7;


### PR DESCRIPTION
In case if LDAP bind name different from `dn`, and if group members is `dn` search through group members fail, and user level can not be assign. To resolve it ```$config['auth_ldap_groupmembertype'] == 'puredn'``` was adding. And bind uid can be changhed.