### PR TITLE
add dell networking n switches as powerconnect

### DIFF
--- a/includes/discovery/os/dnos.inc.php
+++ b/includes/discovery/os/dnos.inc.php
@@ -4,4 +4,7 @@ if (!$os) {
     if (strstr($sysObjectId, '.1.3.6.1.4.1.6027.1.')) {
         $os = 'dnos';
     }
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.674.10895.3042')) {
+        $os = 'dnos';
+    }
 }

--- a/includes/discovery/os/powerconnect.inc.php
+++ b/includes/discovery/os/powerconnect.inc.php
@@ -5,9 +5,6 @@ if (!$os) {
     if (stristr($sysDescr, 'PowerConnect ')) {
         $os = 'powerconnect';
     }
-    else if (stristr($sysDescr, 'Dell Networking N')) {
-        $os = 'powerconnect';
-    }
     else if (preg_match('/Dell.*Gigabit\ Ethernet/i', $sysDescr)) {
         $os = 'powerconnect';
     } //end if

--- a/includes/discovery/os/powerconnect.inc.php
+++ b/includes/discovery/os/powerconnect.inc.php
@@ -5,6 +5,9 @@ if (!$os) {
     if (stristr($sysDescr, 'PowerConnect ')) {
         $os = 'powerconnect';
     }
+    else if (stristr($sysDescr, 'Dell Networking N')) {
+        $os = 'powerconnect';
+    }
     else if (preg_match('/Dell.*Gigabit\ Ethernet/i', $sysDescr)) {
         $os = 'powerconnect';
     } //end if


### PR DESCRIPTION
Some Dell Powerconnects like the [8100's](http://www.dell.com/us/business/p/powerconnect-8100/pd) identify themselves as "Dell Networking N" switches.