### PR TITLE
Drac voltage alert

### DIFF
--- a/includes/discovery/voltages/drac.inc.php
+++ b/includes/discovery/voltages/drac.inc.php
@@ -23,7 +23,7 @@ if ($device['os'] == "drac") {
             $current       = snmp_get($device, $voltage_oid, "-Oqv", "IDRAC-MIB-SMIv2");
             $high_limit     = snmp_get($device, $limit_oid, "-Oqv", "IDRAC-MIB-SMIv2");
             $divisor       = "1";
-            discover_sensor($valid['sensor'], 'voltage', $device, $voltage_oid, $index, 'drac', $descr, $divisor, '1', NULL, NULL, NULL, $high_limit, $current);
+            discover_sensor($valid['sensor'], 'voltage', $device, $voltage_oid, $index, 'drac', $descr, $divisor, '1', 0, NULL, NULL, $high_limit, $current);
         }
     }
 }

--- a/includes/discovery/voltages/drac.inc.php
+++ b/includes/discovery/voltages/drac.inc.php
@@ -21,9 +21,9 @@ if ($device['os'] == "drac") {
             $descr         = trim(snmp_get($device, $descr_oid, "-Oqv", "IDRAC-MIB-SMIv2"),'"');
             $descr         = preg_replace("/(Status)/","", $descr);
             $current       = snmp_get($device, $fan_oid, "-Oqv", "IDRAC-MIB-SMIv2");
-            $low_limit     = snmp_get($device, $limit_oid, "-Oqv", "IDRAC-MIB-SMIv2");
+            $high_limit     = snmp_get($device, $limit_oid, "-Oqv", "IDRAC-MIB-SMIv2");
             $divisor       = "1";
-            discover_sensor($valid['sensor'], 'voltage', $device, $voltage_oid, $index, 'drac', $descr, $divisor, '1', $low_limit, NULL, NULL, NULL, $current);
+            discover_sensor($valid['sensor'], 'voltage', $device, $voltage_oid, $index, 'drac', $descr, $divisor, '1', NULL, NULL, NULL, $high_limit, $current);
         }
     }
 }

--- a/includes/discovery/voltages/drac.inc.php
+++ b/includes/discovery/voltages/drac.inc.php
@@ -20,7 +20,7 @@ if ($device['os'] == "drac") {
             $limit_oid     = "powerSupplyMaximumInputVoltage.1.$index";
             $descr         = trim(snmp_get($device, $descr_oid, "-Oqv", "IDRAC-MIB-SMIv2"),'"');
             $descr         = preg_replace("/(Status)/","", $descr);
-            $current       = snmp_get($device, $fan_oid, "-Oqv", "IDRAC-MIB-SMIv2");
+            $current       = snmp_get($device, $voltage_oid, "-Oqv", "IDRAC-MIB-SMIv2");
             $high_limit     = snmp_get($device, $limit_oid, "-Oqv", "IDRAC-MIB-SMIv2");
             $divisor       = "1";
             discover_sensor($valid['sensor'], 'voltage', $device, $voltage_oid, $index, 'drac', $descr, $divisor, '1', NULL, NULL, NULL, $high_limit, $current);


### PR DESCRIPTION
Fixes a bug with Dell Drac voltage detection. The maximum voltage is detected as a minimum voltage, causing the sensor under limit alert to fire.