### PR TITLE
Improve daily.sh robustness

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -1,15 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-cd $(dirname $0) || exit 1
+set -eu
 
-if [ $(php daily.php -f update) -eq 1 ]; then 
-  git pull --quiet
-  php includes/sql-schema/update.php
+cd "$(dirname "$0")"
+
+if [ "$(php daily.php -f update)" -eq 1 ]; then
+    git pull --quiet
+    php includes/sql-schema/update.php
 fi
 
 php daily.php -f syslog
 php daily.php -f eventlog
 php daily.php -f authlog
-php daily.php -f perf_times 
+php daily.php -f perf_times
 php daily.php -f callback
 php daily.php -f device_perf


### PR DESCRIPTION
Although the crontab now uses cronic to run the `daily.sh` script to email on errors, the `daily.sh` script itself was not set up in a robust way. For instance if `git pull --quiet` fails because of a file permission error, the daily.sh script will not end with non-zero exit status, thus not triggering cronic. `set -e` fixes this: the script will just abort if any of the commands fail and return exit 1.

I added quotes to protect against accidental introduction of whitespaces. Fixed formatting as well.