### PR TITLE
fix issue-1559

### DIFF
--- a/includes/discovery/current/apc.inc.php
+++ b/includes/discovery/current/apc.inc.php
@@ -60,7 +60,7 @@ if ($device['os'] == 'apc') {
     unset($oids);
 
     // v2 firmware- first bank is total, v3 firmware, 3rd bank is total
-    $oids = snmp_walk($device, 'rPDULoadBankConfigIndex', '-OsqnU', 'PowerNet-MIB');
+    $oids = snmp_walk($device, 'rPDULoadStatusIndex', '-OsqnU', 'PowerNet-MIB');
     // should work with firmware v2 and v3
     if ($oids) {
         echo 'APC PowerNet-MIB Banks ';


### PR DESCRIPTION
This fixes the problem.

The issue I was seeing was that rPDULoadBankConfigIndex was reporting 2 banks instead of 3(Bank 1, Bank 2, Bank Total). For that reason I was only seeing data for Bank 1 && Bank Total.

I've tested this fix on:
AP7822 B2
AP8853 02
AP8858 02

No issues here.