### PR TITLE
Added debug to discovery protocols + stop them running if not configured

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -580,7 +580,12 @@ function edit_service($service, $descr, $service_ip, $service_param = "", $servi
 function d_echo($text, $no_debug_text = null) {
     global $debug;
     if ($debug) {
-        echo "$text";
+        if (is_array($text)) {
+            print_r($text);
+        }
+        else {
+            echo "$text";
+        }
     }
     elseif ($no_debug_text) {
         echo "$no_debug_text";

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -9,11 +9,13 @@ $community = $device['community'];
 if ($device['os'] == 'ironware' && $config['autodiscovery']['xdp'] === true) {
     echo ' Brocade FDP: ';
     $fdp_array = snmpwalk_cache_twopart_oid($device, 'snFdpCacheEntry', array(), 'FOUNDRY-SN-SWITCH-GROUP-MIB');
+    d_echo($fdp_array);
     if ($fdp_array) {
         unset($fdp_links);
         foreach (array_keys($fdp_array) as $key) {
             $interface    = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?', array($device['device_id'], $key));
             $fdp_if_array = $fdp_array[$key];
+            d_echo($fdp_if_array);
             foreach (array_keys($fdp_if_array) as $entry_key) {
                 $fdp              = $fdp_if_array[$entry_key];
                 $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']));
@@ -38,83 +40,93 @@ if ($device['os'] == 'ironware' && $config['autodiscovery']['xdp'] === true) {
 
 echo ' CISCO-CDP-MIB: ';
 unset($cdp_array);
-$cdp_array = snmpwalk_cache_twopart_oid($device, 'cdpCache', array(), 'CISCO-CDP-MIB');
-if ($cdp_array && $config['autodiscovery']['xdp'] === true) {
-    unset($cdp_links);
-    foreach (array_keys($cdp_array) as $key) {
-        $interface        = dbFetchRow('SELECT * FROM `ports` WHERE device_id = ? AND `ifIndex` = ?', array($device['device_id'], $key));
-        $cdp_if_array = $cdp_array[$key];
-        foreach (array_keys($cdp_if_array) as $entry_key) {
-            $cdp = $cdp_if_array[$entry_key];
-            if (is_valid_hostname($cdp['cdpCacheDeviceId'])) {
-                $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']));
+if ($config['autodiscovery']['xdp'] === true) {
+    $cdp_array = snmpwalk_cache_twopart_oid($device, 'cdpCache', array(), 'CISCO-CDP-MIB');
+    d_echo($cdp_array);
+    if ($cdp_array) {
+        unset($cdp_links);
+        foreach (array_keys($cdp_array) as $key) {
+            $interface        = dbFetchRow('SELECT * FROM `ports` WHERE device_id = ? AND `ifIndex` = ?', array($device['device_id'], $key));
+            $cdp_if_array = $cdp_array[$key];
+            d_echo($cdp_if_array);
+            foreach (array_keys($cdp_if_array) as $entry_key) {
+                $cdp = $cdp_if_array[$entry_key];
+                if (is_valid_hostname($cdp['cdpCacheDeviceId'])) {
+                    $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']));
 
-                if (!$remote_device_id) {
-                    $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
-                }
+                    if (!$remote_device_id) {
+                        $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
+                    }
 
-                if ($remote_device_id) {
-                    $if             = $cdp['cdpCacheDevicePort'];
-                    $remote_port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $remote_device_id));
+                    if ($remote_device_id) {
+                        $if             = $cdp['cdpCacheDevicePort'];
+                        $remote_port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $remote_device_id));
+                    }
+                    else {
+                        $remote_port_id = '0';
+                    }
+
+                    if ($interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
+                        discover_link($interface['port_id'], 'cdp', $remote_port_id, $cdp['cdpCacheDeviceId'], $cdp['cdpCacheDevicePort'], $cdp['cdpCachePlatform'], $cdp['cdpCacheVersion'], $device['device_id'], $remote_device_id);
+                    }
                 }
                 else {
-                    $remote_port_id = '0';
-                }
-
-                if ($interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
-                    discover_link($interface['port_id'], 'cdp', $remote_port_id, $cdp['cdpCacheDeviceId'], $cdp['cdpCacheDevicePort'], $cdp['cdpCachePlatform'], $cdp['cdpCacheVersion'], $device['device_id'], $remote_device_id);
-                }
-            }
-            else {
-                echo 'X';
-            }//end if
+                    echo 'X';
+                }//end if
+            }//end foreach
         }//end foreach
-    }//end foreach
+    }//end if
 }//end if
 
 echo ' LLDP-MIB: ';
 
 unset($lldp_array);
-$lldp_array  = snmpwalk_cache_threepart_oid($device, 'lldpRemoteSystemsData', array(), 'LLDP-MIB');
-$dot1d_array = snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', array(), 'BRIDGE-MIB');
 
-if ($lldp_array && $config['autodiscovery']['xdp'] === true) {
-    $lldp_links = '';
-    foreach (array_keys($lldp_array) as $key) {
-        $lldp_if_array = $lldp_array[$key];
-        foreach (array_keys($lldp_if_array) as $entry_key) {
-            if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
-                $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
-            }
-            else {
-                $ifIndex = $entry_key;
-            }
-
-            $interface     = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?', array($device['device_id'], $ifIndex));
-            $lldp_instance = $lldp_if_array[$entry_key];
-            foreach (array_keys($lldp_instance) as $entry_instance) {
-                $lldp             = $lldp_instance[$entry_instance];
-                $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
-
-                if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
-                    $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
-                }
-
-                if ($remote_device_id) {
-                    $if             = $lldp['lldpRemPortDesc'];
-                    $id             = $lldp['lldpRemPortId'];
-                    $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_device_id));
+if ($config['autodiscovery']['xdp'] === true) {
+    $lldp_array  = snmpwalk_cache_threepart_oid($device, 'lldpRemoteSystemsData', array(), 'LLDP-MIB');
+    d_echo($lldp_array);
+    $dot1d_array = snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', array(), 'BRIDGE-MIB');
+    d_echo($dot1d_array);
+    if ($lldp_array) {
+        $lldp_links = '';
+        foreach (array_keys($lldp_array) as $key) {
+            $lldp_if_array = $lldp_array[$key];
+            d_echo($lldp_if_array);
+            foreach (array_keys($lldp_if_array) as $entry_key) {
+                if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
+                    $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
                 }
                 else {
-                    $remote_port_id = '0';
+                    $ifIndex = $entry_key;
                 }
 
-                if (is_numeric($interface['port_id']) && isset($lldp['lldpRemSysName']) && isset($lldp['lldpRemPortId'])) {
-                    discover_link($interface['port_id'], 'lldp', $remote_port_id, $lldp['lldpRemSysName'], $lldp['lldpRemPortId'], null, $lldp['lldpRemSysDesc'], $device['device_id'], $remote_device_id);
-                }
+                $interface     = dbFetchRow('SELECT * FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?', array($device['device_id'], $ifIndex));
+                $lldp_instance = $lldp_if_array[$entry_key];
+                d_echo($lldp_instance);
+                foreach (array_keys($lldp_instance) as $entry_instance) {
+                    $lldp             = $lldp_instance[$entry_instance];
+                    $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
+
+                    if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
+                        $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+                    }
+
+                    if ($remote_device_id) {
+                        $if             = $lldp['lldpRemPortDesc'];
+                        $id             = $lldp['lldpRemPortId'];
+                        $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_device_id));
+                    }
+                    else {
+                        $remote_port_id = '0';
+                    }
+
+                    if (is_numeric($interface['port_id']) && isset($lldp['lldpRemSysName']) && isset($lldp['lldpRemPortId'])) {
+                        discover_link($interface['port_id'], 'lldp', $remote_port_id, $lldp['lldpRemSysName'], $lldp['lldpRemPortId'], null, $lldp['lldpRemSysDesc'], $device['device_id'], $remote_device_id);
+                    }
+                }//end foreach
             }//end foreach
         }//end foreach
-    }//end foreach
+    }//end if
 }//end if
 
 echo 'OSPF Discovery: ';


### PR DESCRIPTION
I've updated the function d_echo() to accept an array as the $text element, if it's detected as an array then it will print_r() otherwise it will echo() as before.

Used that then to add some debugging code to discovery-protocols to aid in debugging #1566 