### PR TITLE
PBN devices support CDP but does not output like Cisco so using a dif…

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -41,7 +41,12 @@ if ($device['os'] == 'ironware' && $config['autodiscovery']['xdp'] === true) {
 echo ' CISCO-CDP-MIB: ';
 unset($cdp_array);
 if ($config['autodiscovery']['xdp'] === true) {
-    $cdp_array = snmpwalk_cache_twopart_oid($device, 'cdpCache', array(), 'CISCO-CDP-MIB');
+    if ($device['os'] == 'pbn') {
+        $cdp_array = snmpwalk_cache_oid($device, 'cdpCache', array(), 'CISCO-CDP-MIB');
+    }
+    else {
+        $cdp_array = snmpwalk_cache_twopart_oid($device, 'cdpCache', array(), 'CISCO-CDP-MIB');
+    }
     d_echo($cdp_array);
     if ($cdp_array) {
         unset($cdp_links);


### PR DESCRIPTION
…ferent function to grab the first array needed

Fix #1566 

Based on the debug output, the initial snmpwalk is different from Cisco, added a check for PBN os and used a different lookup which should cache the correct info into the needed array.