### PR TITLE
Added proper indexes to the device_perf table

### DIFF
--- a/sql-schema/061.sql
+++ b/sql-schema/061.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `device_perf` DROP INDEX  `id` , ADD INDEX  `id` (  `id` ), ADD INDEX (  `device_id` );


### PR DESCRIPTION
I know the drop index id looks add as we add it back in but the current index id actually has id AND device_id in it so it needs both to satisfy that index.

This gives a noticeable increase in performance for the performance page.