### PR TITLE
Updated discovery to log new type + updated eventlog page to show this

### DIFF
--- a/html/includes/common/eventlog.inc.php
+++ b/html/includes/common/eventlog.inc.php
@@ -20,6 +20,8 @@ var grid = $("#eventlog").bootgrid({
     {
         return {
             id: "eventlog",
+            device: "' .mres($vars['device']) .'",
+            type: "' .mres($vars['type']) .'",
         };
     },
     url: "/ajax_table.php"

--- a/html/includes/table/eventlog.inc.php
+++ b/html/includes/table/eventlog.inc.php
@@ -7,6 +7,11 @@ if (is_numeric($_POST['device'])) {
     $param[] = $_POST['device'];
 }
 
+if (!empty($_POST['type'])) {
+    $where .= ' AND `E`.`type` = ?';
+    $param[] = $_POST['type'];
+}
+
 if ($_POST['string']) {
     $where  .= ' AND E.message LIKE ?';
     $param[] = '%'.$_POST['string'].'%';
@@ -54,7 +59,7 @@ foreach (dbFetchRows($sql, $param) as $eventlog) {
         $type    = '<b>'.generate_port_link($this_if, makeshortif(strtolower($this_if['label']))).'</b>';
     }
     else {
-        $type = 'System';
+        $type = $eventlog['type'];;
     }
 
     $response[] = array(

--- a/html/pages/eventlog.inc.php
+++ b/html/pages/eventlog.inc.php
@@ -37,6 +37,25 @@ print_optionbar_start();
         ?>
       </select>
     </div>
+    <div class="form-group">
+        <label>
+            <strong>Type: </strong>
+        </label>
+        <select name="type" id="type" class="form-control input-sm">
+            <option value="">All types</option>
+<?php
+
+foreach (dbFetchRows("SELECT `type` FROM `eventlog` GROUP BY `type`") as $types) {
+    echo '<option value="'.$types['type'].'"';
+    if ($types['type'] === $_POST['type']) {
+        echo ' selected';
+    }
+    echo '>'.$types['type'].'</option>';
+}
+
+?>
+        </select>
+    </div>
     <button type="submit" class="btn btn-default input-sm">Filter</button>
 </form>
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -67,10 +67,10 @@ function discover_new_device($hostname, $device='', $method='', $interface='') {
                     $extra_log = ' (port '.$int['label'].') ';
                 }
 
-                log_event('Device $'.$remote_device['hostname']." ($ip) $extra_log autodiscovered through $method on ".$device['hostname'], $remote_device_id, 'system');
+                log_event('Device $'.$remote_device['hostname']." ($ip) $extra_log autodiscovered through $method on ".$device['hostname'], $remote_device_id, 'discovery');
             }
             else {
-                log_event("$method discovery of ".$remote_device['hostname']." ($ip) failed - check ping and SNMP access", $device['device_id'], 'system');
+                log_event("$method discovery of ".$remote_device['hostname']." ($ip) failed - check ping and SNMP access", $device['device_id'], 'discovery');
             }
 
             return $remote_device_id;


### PR DESCRIPTION
Fix #740 

I've changed autodiscover to now use 'discovery' as a new type for eventlog so they will be separated out in the eventlog page. Also added the ability to filter eventlogs via type so you can specifically pick out discovery items.

Should clear up the requirement asked for in #740.