### PR TITLE
Initialises $port_count if empty

### DIFF
--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -206,6 +206,9 @@ foreach (dbFetchRows($sql, $param) as $device) {
     $uptime = formatUptime($device['uptime'], 'short').'<br />'.$location;
     if ($subformat == 'detail') {
         $hostname .= '<br />'.$device['sysName'];
+        if (empty($port_count)) {
+            $port_count = 0;
+        }
         if ($port_count) {
             $col_port = ' <img src="images/icons/port.png" align=absmiddle /> '.$port_count.'<br />';
         }


### PR DESCRIPTION
Fix #1637 

When no ports are found then $col_port isn't set, if this is not the first device in the list then it means it will inherit the previous devices $col_port variable.

I've chosen to just set $port_count to 0 rather than declare $col_port so it will show to the users 0 ports  for that device.