### PR TITLE
Swapped 2012 Datacenter / Non-DC around

### DIFF
--- a/includes/polling/os/windows.inc.php
+++ b/includes/polling/os/windows.inc.php
@@ -120,7 +120,7 @@ else if ($poll_device['sysObjectID'] == '.1.3.6.1.4.1.311.1.1.3.1.2') {
     }
 
     if (strstr($poll_device['sysDescr'], 'Build 9600')) {
-        $version = 'Server 2012 R2 (NT 6.3)';
+        $version = 'Server 2012 R2 Datacenter (NT 6.3)';
     }
 
 }
@@ -162,7 +162,7 @@ else if ($poll_device['sysObjectID'] == '.1.3.6.1.4.1.311.1.1.3.1.3') {
     }
 
     if (strstr($poll_device['sysDescr'], 'Build 9600')) {
-        $version = 'Server 2012 R2 Datacenter (NT 6.3)';
+        $version = 'Server 2012 R2 (NT 6.3)';
     }
 
 }//end if


### PR DESCRIPTION
It looks like Windows 2012 R2 Datacenter / Non-Datacenter have swapped between the sysObjectIDs they've previously used.

Fix #1657 