### PR TITLE
Updated rrdtool_update() to use new array format

### DIFF
--- a/check-services.php
+++ b/check-services.php
@@ -52,16 +52,4 @@ foreach (dbFetchRows('SELECT * FROM `devices` AS D, `services` AS S WHERE S.devi
         $status = '0';
     }//end if
 
-    $rrd = $config['rrd_dir'].'/'.$service['hostname'].'/'.safename('service-'.$service['service_type'].'-'.$service['service_id'].'.rrd');
-
-    if (!is_file($rrd)) {
-        rrdtool_create($rrd, 'DS:status:GAUGE:600:0:1 '.$config['rrd_rra']);
-    }
-
-    if ($status == '1' || $status == '0') {
-        rrdtool_update($rrd, 'N:'.$status);
-    }
-    else {
-        rrdtool_update($rrd, 'N:U');
-    }
 } //end foreach

--- a/includes/polling/altiga-ssl.inc.php
+++ b/includes/polling/altiga-ssl.inc.php
@@ -13,7 +13,7 @@ if ($device['os'] == 'asa' || $device['os'] == 'pix') {
         'alSslStatsPostEncryptOctets',
     );
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
 
     $rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('altiga-ssl.rrd');
 
@@ -28,7 +28,7 @@ if ($device['os'] == 'asa' || $device['os'] == 'pix') {
 
     $data_array = snmpwalk_cache_oid($device, $proto, array(), 'ALTIGA-SSL-STATS-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data_array[0][$oid])) {
@@ -37,13 +37,12 @@ if ($device['os'] == 'asa' || $device['os'] == 'pix') {
         else {
             $value = '0';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     if ($data_array[0]['alSslStatsTotalSessions'] || is_file($rrdfile)) {
-        rrdtool_update($rrdfile, $rrdupdate);
+        rrdtool_update($rrdfile, $fields);
     }
 
-    unset($rrdfile, $rrdupdate, $data_array);
+    unset($rrdfile, $fields, $data_array);
 }//end if

--- a/includes/polling/applications/apache.inc.php
+++ b/includes/polling/applications/apache.inc.php
@@ -46,4 +46,27 @@ if (!is_file($rrd_filename)) {
     );
 }//end if
 
-rrdtool_update($rrd_filename, "N:$total_access:$total_kbyte:$cpuload:$uptime:$reqpersec:$bytespersec:$bytesperreq:$busyworkers:$idleworkers:$score_wait:$score_start:$score_reading:$score_writing:$score_keepalive:$score_dns:$score_closing:$score_logging:$score_graceful:$score_idle:$score_open");
+$fields = array(
+                'access'       => $total_access,
+                'kbyte'        => $total_kbyte,
+                'cpu'          => $cpuload,
+                'uptime'       => $uptime,
+                'reqpersec'    => $reqpersec,
+                'bytespersec'  => $bytespersec,
+                'byesperreq'   => $bytesperreq,
+                'busyworkers'  => $busyworkers,
+                'idleworkers'  => $idleworkers,
+                'sb_wait'      => $score_wait,
+                'sb_start'     => $score_start,
+                'sb_reading'   => $score_reading,
+                'sb_writing'   => $score_writing,
+                'sb_keepalive' => $score_keepalive,
+                'sb_dns'       => $score_dns,
+                'sb_closing'   => $score_closing,
+                'sb_logging'   => $score_logging,
+                'sb_graceful'  => $score_graceful,
+                'sb_idle'      => $score_idle,
+                'sb_open'      => $score_open,
+);
+
+rrdtool_update($rrd_filename, $fields);

--- a/includes/polling/applications/bind.inc.php
+++ b/includes/polling/applications/bind.inc.php
@@ -86,5 +86,19 @@ if (!empty($agent_data['app']['bind']) && $app['app_id'] > 0) {
         );
     }
 
-    rrdtool_update($rrd_filename, 'N:'.((int) $bind_parsed['incoming_queries']['any']).':'.((int) $bind_parsed['incoming_queries']['a']).':'.((int) $bind_parsed['incoming_queries']['aaaa']).':'.((int) $bind_parsed['incoming_queries']['cname']).':'.((int) $bind_parsed['incoming_queries']['mx']).':'.((int) $bind_parsed['incoming_queries']['ns']).':'.((int) $bind_parsed['incoming_queries']['ptr']).':'.((int) $bind_parsed['incoming_queries']['soa']).':'.((int) $bind_parsed['incoming_queries']['srv']).':'.((int) $bind_parsed['incoming_queries']['spf']));
+    $fields = array(
+                    'any'   => ((int) $bind_parsed['incoming_queries']['any']),
+                    'a'     => ((int) $bind_parsed['incoming_queries']['a']),
+                    'aaaa'  => ((int) $bind_parsed['incoming_queries']['aaaa']),
+                    'cname' => ((int) $bind_parsed['incoming_queries']['cname']),
+                    'mx'    => ((int) $bind_parsed['incoming_queries']['mx']),
+                    'ns'    => ((int) $bind_parsed['incoming_queries']['ns']),
+                    'ptr'   => ((int) $bind_parsed['incoming_queries']['ptr']),
+                    'soa'   => ((int) $bind_parsed['incoming_queries']['soa']),
+                    'srv'   => ((int) $bind_parsed['incoming_queries']['srv']),
+                    'spf'   => ((int) $bind_parsed['incoming_queries']['spf']),
+    );
+
+    rrdtool_update($rrd_filename, $fields);
+
 }//end if

--- a/includes/polling/applications/drbd.inc.php
+++ b/includes/polling/applications/drbd.inc.php
@@ -27,25 +27,20 @@ if (!is_file($rrd_filename)) {
     );
 }
 
-$ds_list = array(
-    'ns',
-    'nr',
-    'dw',
-    'dr',
-    'al',
-    'bm',
-    'lo',
-    'pe',
-    'ua',
-    'ap',
-    'oos',
+$fields = array(
+    'ns'  => $drbd['ns'],
+    'nr'  => $drbd['nr'],
+    'dw'  => $drbd['dw'],
+    'dr'  => $drbd['dr'],
+    'al'  => $drbd['al'],
+    'bm'  => $drbd['bm'],
+    'lo'  => $drbd['lo'],
+    'pe'  => $drbd['pe'],
+    'ua'  => $drbd['ua'],
+    'ap'  => $drbd['ap'],
+    'oos' => $drbd['oos'],
 );
-foreach ($ds_list as $ds) {
-    if (empty($drbd[$ds])) {
-        $drbd[$ds] = 'U';
-    }
-}
 
-rrdtool_update($rrd_filename, 'N:'.$drbd['ns'].':'.$drbd['nr'].':'.$drbd['dw'].':'.$drbd['dr'].':'.$drbd['al'].':'.$drbd['bm'].':'.$drbd['lo'].':'.$drbd['pe'].':'.$drbd['ua'].':'.$drbd['ap'].':'.$drbd['oop']);
+rrdtool_update($rrd_filename, $fields);
 
 unset($drbd);

--- a/includes/polling/applications/mailscanner.inc.php
+++ b/includes/polling/applications/mailscanner.inc.php
@@ -25,4 +25,14 @@ if (!is_file($rrd_filename)) {
     );
 }
 
-rrdtool_update($rrd_filename, "N:$msg_recv:$msg_rejected:$msg_relay:$msg_sent:$msg_waiting:$spam:$virus");
+$fields = array(
+                'msg_recv'     => $msg_recv,
+                'msg_rejected' => $msg_rejected,
+                'msg_relay'    => $msg_relay,
+                'msg_sent'     => $msg_sent,
+                'msg_waiting'  => $msg_waiting,
+                'spam'         => $spam,
+                'virus'        => $virus,
+);
+
+rrdtool_update($rrd_filename, $fields);

--- a/includes/polling/applications/memcached.inc.php
+++ b/includes/polling/applications/memcached.inc.php
@@ -32,30 +32,25 @@ if (!is_file($rrd_filename)) {
     );
 }
 
-$dslist = array(
-    'uptime',
-    'threads',
-    'rusage_user_microseconds',
-    'rusage_system_microseconds',
-    'curr_items',
-    'total_items',
-    'limit_maxbytes',
-    'curr_connections',
-    'total_connections',
-    'connection_structures',
-    'bytes',
-    'cmd_get',
-    'cmd_set',
-    'get_hits',
-    'get_misses',
-    'evictions',
-    'bytes_read',
-    'bytes_written',
+$fields = array(
+    'uptime'            => $data['uptime'],
+    'threads'           => $data['threads'],
+    'rusage_user_ms'    => $data['rusage_user_microseconds'],
+    'rusage_system_ms'  => $data['rusage_system_microseconds'],
+    'curr_items'        => $data['curr_items'],
+    'total_items'       => $data['total_items'],
+    'limit_maxbytes'    => $data['limit_maxbytes'],
+    'curr_connections'  => $data['curr_connections'],
+    'total_connections' => $data['total_connections'],
+    'conn_structures'   => $data['connection_structures'],
+    'bytes'             => $data['bytes'],
+    'cmd_get'           => $data['cmd_get'],
+    'cmd_set'           => $data['cmd_set'],
+    'get_hits'          => $data['get_hits'],
+    'get_misses'        => $data['get_misses'],
+    'evictions'         => $data['evictions'],
+    'bytes_read'        => $data['bytes_read'],
+    'bytes_written'     => $data['bytes_written'],
 );
 
-$values = array();
-foreach ($dslist as $ds) {
-    $values[] = isset($data[$ds]) ? $data[$ds] : (-1);
-}
-
-rrdtool_update($rrd_filename, 'N:'.implode(':', $values));
+rrdtool_update($rrd_filename, $fields);

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -109,8 +109,8 @@ $mapping = array(
 );
 
 $values = array();
-foreach ($mapping as $key) {
-    $values[] = isset($map[$key]) ? $map[$key] : (-1);
+foreach ($mapping as $k => $v) {
+    $fields[$k] = isset($map[$v]) ? $map[$v] : (-1);
 }
 
 $string = implode(':', $values);
@@ -201,7 +201,7 @@ if (!is_file($mysql_rrd)) {
     );
 }//end if
 
-rrdtool_update($mysql_rrd, "N:$string");
+rrdtool_update($mysql_rrd, $fields);
 
 // Process state statistics
 $mysql_status_rrd = $config['rrd_dir'].'/'.$device['hostname'].'/app-mysql-'.$app['app_id'].'-status.rrd';
@@ -227,8 +227,9 @@ $mapping_status = array(
 
 $values     = array();
 $rrd_create = '';
+unset($fields);
 foreach ($mapping_status as $desc => $id) {
-    $values[]    = isset($map[$id]) ? $map[$id] : (-1);
+    $fields[$desc]    = isset($map[$id]) ? $map[$id] : (-1);
     $rrd_create .= ' DS:'.$id.':GAUGE:600:0:125000000000';
 }
 
@@ -238,4 +239,4 @@ if (!is_file($mysql_status_rrd)) {
     rrdtool_create($mysql_status_rrd, '--step 300 '.$rrd_create.' '.$config['rrd_rra']);
 }
 
-rrdtool_update($mysql_status_rrd, "N:$string");
+rrdtool_update($mysql_status_rrd, $fields);

--- a/includes/polling/applications/nginx.inc.php
+++ b/includes/polling/applications/nginx.inc.php
@@ -26,7 +26,15 @@ if (!is_file($nginx_rrd)) {
 }
 
 print "active: $active reading: $reading writing: $writing waiting: $waiting Requests: $req";
-rrdtool_update($nginx_rrd, "N:$req:$active:$reading:$writing:$waiting");
+$fields = array(
+                'Requests' => $req,
+                'Active'   => $active,
+                'Reading'  => $reading,
+                'Writing'  => $writing,
+                'Waiting'  => $waiting,
+);
+
+rrdtool_update($nginx_rrd, $fields);
 
 // Unset the variables we set here
 unset($nginx);

--- a/includes/polling/applications/ntp-client.inc.php
+++ b/includes/polling/applications/ntp-client.inc.php
@@ -23,4 +23,12 @@ if (!is_file($rrd_filename)) {
     );
 }
 
-rrdtool_update($rrd_filename, "N:$offset:$frequency:$jitter:$noise:$stability");
+$fields = array(
+                'offset'    => $offset,
+                'frequency' => $frequency,
+                'jitter'    => $jitter,
+                'noise'     => $noise,
+                'stability' => $stability,
+);
+
+rrdtool_update($rrd_filename, $fields);

--- a/includes/polling/applications/ntpd-server.inc.php
+++ b/includes/polling/applications/ntpd-server.inc.php
@@ -34,4 +34,21 @@ if (!is_file($rrd_filename)) {
     );
 }
 
-rrdtool_update($rrd_filename, "N:$stratum:$offset:$frequency:$jitter:$noise:$stability:$uptime:$buffer_recv:$buffer_free:$buffer_used:$packets_drop:$packets_ignore:$packets_recv:$packets_sent");
+$fields = array(
+    'stratum'        => $stratum,
+    'offset'         => $offset,
+    'frequency'      => $frequency,
+    'jitter'         => $jitter,
+    'noise'          => $noise,
+    'stability'      => $stability,
+    'uptime'         => $uptime,
+    'buffer_recv'    => $buffer_recv,
+    'buffer_free'    => $buffer_free,
+    'buffer_used'    => $buffer_used,
+    'packets_drop'   => $packets_drop,
+    'packets_ignore' => $packets_ignore,
+    'packets_recv'   => $packets_recv,
+    'packets_sent'   => $packets_sent,
+);
+
+rrdtool_update($rrd_filename, $fields);

--- a/includes/polling/applications/powerdns.inc.php
+++ b/includes/polling/applications/powerdns.inc.php
@@ -44,4 +44,29 @@ if (!is_file($rrd_filename)) {
     );
 }//end if
 
-rrdtool_update($rrd_filename, "N:$corrupt:$def_cacheInserts:$def_cacheLookup:$latency:$pc_hit:$pc_miss:$pc_size:$qsize:$qc_hit:$qc_miss:$rec_answers:$rec_questions:$servfail:$tcp_answers:$tcp_queries:$timedout:$udp_answers:$udp_queries:$udp4_answers:$udp4_queries:$udp6_answers:$udp6_queries");
+$fields = array(
+                'corruptPackets'     => $corrupt,
+                'def_cacheInserts'   => $def_cacheInserts,
+                'def_cacheLookup'    => $def_cacheLookup,
+                'latency'            => $latency,
+                'pc_hit'             => $pc_hit,
+                'pc_miss'            => $pc_miss,
+                'pc_size'            => $pc_size,
+                'qsize'              => $qsize,
+                'qc_hit'             => $qc_hit,
+                'qc_miss'            => $qc_miss,
+                'rec_answers'        => $rec_answers,
+                'rec_questions'      => $req_questions,
+                'servfailPackets'    => $servfail,
+                'q_tcpAnswers'       => $tcp_answers,
+                'q_tcpQueries'       => $tcp_queries,
+                'q_timedout'         => $timedout,
+                'q_udpAnswers'       => $udp_answers,
+                'q_udpQueries'       => $udp_queries,
+                'q_udp4Answers'      => $udp4_answers,
+                'q_udp4Queries'      => $udp4_queries,
+                'q_udp6Answers'      => $udp6_answers,
+                'q_udp6Queries'      => $udp6_queries,
+);
+
+rrdtool_update($rrd_filename, $fields);

--- a/includes/polling/applications/shoutcast.inc.php
+++ b/includes/polling/applications/shoutcast.inc.php
@@ -41,6 +41,18 @@ foreach ($servers as $item => $server) {
             );
         }
 
-        rrdtool_update($rrdfile, "N:$bitrate:$traf_in:$traf_out:$current:$status:$peak:$max:$unique");
+        $fields = array(
+                        'bitrate'    => $bitrate,
+                        'traf_in'    => $traf_in,
+                        'traf_out'   => $traf_out,
+                        'current'    => $current,
+                        'status'     => $status,
+                        'peak'       => $peak,
+                        'max'        => $max,
+                        'unique'     => $unique,
+        );
+
+        rrdtool_update($rrdfile, $fields);
+
     }//end if
 }//end foreach

--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -50,8 +50,11 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
         rrdtool_create($rrdfile, ' --step 300 DS:NUMAPS:GAUGE:600:0:12500000000 DS:NUMCLIENTS:GAUGE:600:0:12500000000 '.$config['rrd_rra']);
     }
 
-    $cont_rrd_update = "$polled:".$aruba_stats[0]['wlsxSwitchTotalNumAccessPoints'].':'.$aruba_stats[0]['wlsxSwitchTotalNumStationsAssociated'];
-    $ret             = rrdtool_update($rrdfile, $cont_rrd_update);
+    $fields = array(
+        'NUMAPS'     => $aruba_stats[0]['wlsxSwitchTotalNumAccessPoints'],
+        'NUMCLIENTS' => $aruba_stats[0]['wlsxSwitchTotalNumStationsAssociated'],
+    );
+    $ret             = rrdtool_update($rrdfile, $fields);
 
     // also save the info about how many clients in the same place as the wireless module
     $wificlientsrrd = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('wificlients-radio1.rrd');
@@ -60,7 +63,10 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
         rrdtool_create($wificlientsrrd, '--step 300 DS:wificlients:GAUGE:600:-273:10000 '.$config['rrd_rra']);
     }
 
-    rrdtool_update($wificlientsrrd, 'N:'.$aruba_stats[0]['wlsxSwitchTotalNumStationsAssociated']);
+    $fields = array(
+        'wificlients' => $aruba_stats[0]['wlsxSwitchTotalNumStationsAssociated'],
+    );
+    rrdtool_update($wificlientsrrd, $fields);
 
     $graphs['wifi_clients'] = true;
 
@@ -109,7 +115,18 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
                 rrdtool_create($rrd_file, "--step 300 $dslist ".$config['rrd_rra']);
             }
 
-            rrdtool_update($rrd_file, "$polled:".$channel.':'.$txpow.':'.$radioutil.':'.$nummonclients.':'.$nummonbssid.':'.$numasoclients.':'.$interference);
+            $fields = array(
+                'channel'         => $channel,
+                'txpow'           => $txpow,
+                'radioutil'       => $radioutil,
+                'nummonclients'   => $nummonclients,
+                'nummonbssid'     => $nummonbssid,
+                'numasoclients'   => $numasoclients,
+                'interference'    => $interference,
+            );
+
+            rrdtool_update($rrd_file, $fields);
+
         }
 
         // generate the mac address

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -158,7 +158,14 @@ if ($config['enable_bgp']) {
             rrdtool_create($peerrrd, $create_rrd);
         }
 
-        rrdtool_update("$peerrrd", "N:$bgpPeerOutUpdates:$bgpPeerInUpdates:$bgpPeerOutTotalMessages:$bgpPeerInTotalMesages:$bgpPeerFsmEstablishedTime");
+        $fields = array(
+            'bgpPeerOutUpdates'    => $bgpPeerOutUpdates,
+            'bgpPeerInUpdates'     => $bgpPeerInUpdates,
+            'bgpPeerOutTotal'      => $bgpPeerOutTotalMessages,
+            'bgpPeerInTotal'       => $bgpPeerInTotalMessages,
+            'bgpPeerEstablished'   => $bgpPeerFsmEstablishedTime,
+        );
+        rrdtool_update("$peerrrd", $fields);
 
         $peer['update']['bgpPeerState']              = $bgpPeerState;
         $peer['update']['bgpPeerAdminStatus']        = $bgpPeerAdminStatus;
@@ -321,7 +328,15 @@ if ($config['enable_bgp']) {
                     rrdtool_create($cbgp_rrd, $rrd_create);
                 }
 
-                rrdtool_update("$cbgp_rrd", "N:$cbgpPeerAcceptedPrefixes:$cbgpPeerDeniedPrefixes:$cbgpPeerAdvertisedPrefixes:$cbgpPeerSuppressedPrefixes:$cbgpPeerWithdrawnPrefixes");
+                $fields = array(
+                    'AcceptedPrefixes'    => $cbgpPeerAcceptedPrefixes,
+                    'DeniedPrefixes'      => $cbgpPeerDeniedPrefixes,
+                    'AdvertisedPrefixes'  => $cbgpPeerAdvertisedPrefixes,
+                    'SuppressedPrefixes'  => $cbgpPeerSuppressedPrefixes,
+                    'WithdrawnPrefixes'   => $cbgpPeerWithdrawnPrefixes,
+                );
+                rrdtool_update("$cbgp_rrd", $fields);
+
             } //end foreach
         } //end if
         echo "\n";

--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -79,7 +79,7 @@ foreach ($ipsec_array as $index => $tunnel) {
         $rrd_create .= " DS:$oid_ds:COUNTER:600:U:1000000000";
     }
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($tunnel[$oid])) {
@@ -88,18 +88,16 @@ foreach ($ipsec_array as $index => $tunnel) {
         else {
             $value = '0';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     if (isset($tunnel['cikeTunRemoteValue'])) {
         if (!file_exists($rrd_file)) {
             rrdtool_create($rrd_file, $rrd_create);
         }
-
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         // $graphs['ipsec_tunnels'] = TRUE;
     }
 }//end foreach
 
-unset($rrd_file,$rrd_create,$rrdupdate,$oids, $data, $data_array, $oid, $tunnel);
+unset($rrd_file,$rrd_create,$fields,$oids, $data, $data_array, $oid, $tunnel);

--- a/includes/polling/cisco-ace-loadbalancer.inc.php
+++ b/includes/polling/cisco-ace-loadbalancer.inc.php
@@ -39,7 +39,7 @@ foreach ($rserver_array as $index => $serverfarm) {
         $rrd_create .= " DS:$oid_ds:GAUGE:600:-1:100000000";
     }
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($serverfarm[$oid])) {
@@ -48,8 +48,7 @@ foreach ($rserver_array as $index => $serverfarm) {
         else {
             $value = '0';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     $rrd_create .= ' '.$config['rrd_rra'];
@@ -58,8 +57,7 @@ foreach ($rserver_array as $index => $serverfarm) {
         if (!file_exists($rrd_file)) {
             rrdtool_create($rrd_file, $rrd_create);
         }
-
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
     }
 }//end foreach
 

--- a/includes/polling/cisco-ace-serverfarms.inc.php
+++ b/includes/polling/cisco-ace-serverfarms.inc.php
@@ -45,7 +45,7 @@ foreach ($serverfarm_array as $index => $vserver) {
         $rrd_create .= " DS:$oid_ds:COUNTER:600:U:1000000000";
     }
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($vserver[$oid])) {
@@ -54,16 +54,14 @@ foreach ($serverfarm_array as $index => $vserver) {
         else {
             $value = '0';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     if (isset($classmaps[$classmap])) {
         if (!file_exists($rrd_file)) {
             rrdtool_create($rrd_file, $rrd_create);
         }
-
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
     }
 }//end foreach
 

--- a/includes/polling/cisco-asa-firewall.inc.php
+++ b/includes/polling/cisco-asa-firewall.inc.php
@@ -39,13 +39,14 @@ if ($device['os_group'] == 'cisco' && $device['os'] == 'asa' && $device['type'] 
             rrdtool_create($rrd_filename, $rrd_create);
         }
 
-        $rrd_update  = 'N';
-        $rrd_update .= ':'.$data['currentInUse']['data'];
+        $fields = array(
+            'connections' => $data['currentInUse']['data'],
+        );
 
-        rrdtool_update($rrd_filename, $rrd_update);
+        rrdtool_update($rrd_filename, $fields);
         $graphs['asa_conns'] = true;
         echo ' ASA Connections';
     }
 
-    unset($data,$rrd_filename,$rrd_create,$rrd_update);
+    unset($data,$rrd_filename,$rrd_create);
 }//end if

--- a/includes/polling/cisco-cef.inc.php
+++ b/includes/polling/cisco-cef.inc.php
@@ -86,7 +86,13 @@ if ($device['os_group'] == 'cisco') {
 
                     dbUpdate($cef_stat['update'], 'cef_switching', '`device_id` = ? AND `entPhysicalIndex` = ? AND `afi` = ? AND `cef_index` = ?', array($device['device_id'], $entity, $afi, $path));
 
-                    $ret = rrdtool_update("$filename", array($cef_stat['cefSwitchingDrop'], $cef_stat['cefSwitchingPunt'], $cef_stat['cefSwitchingPunt2Host']));
+                    $fields = array(
+                        'drop'      => $cef_stat['cefSwitchingDrop'],
+                        'punt'      => $cef_stat['cefSwitchingPunt'],
+                        'hostpunt'  => $cef_stat['cefSwitchingPunt2Host'],
+                    );
+
+                    $ret = rrdtool_update("$filename", $fields);
 
                     echo "\n";
                 }//end foreach

--- a/includes/polling/cisco-ipsec-flow-monitor.inc.php
+++ b/includes/polling/cisco-ipsec-flow-monitor.inc.php
@@ -81,30 +81,30 @@ if ($device['os_group'] == 'cisco') {
             rrdtool_create($rrd_filename, $rrd_create);
         }
 
-        $rrd_update   = array();
-        $rrd_update[] = $data['cipSecGlobalActiveTunnels'];
-        $rrd_update[] = $data['cipSecGlobalInOctets'];
-        $rrd_update[] = $data['cipSecGlobalOutOctets'];
-        $rrd_update[] = $data['cipSecGlobalInDecompOctets'];
-        $rrd_update[] = $data['cipSecGlobalOutUncompOctets'];
-        $rrd_update[] = $data['cipSecGlobalInPkts'];
-        $rrd_update[] = $data['cipSecGlobalOutPkts'];
-        $rrd_update[] = $data['cipSecGlobalInDrops'];
-        $rrd_update[] = $data['cipSecGlobalInReplayDrops'];
-        $rrd_update[] = $data['cipSecGlobalOutDrops'];
-        $rrd_update[] = $data['cipSecGlobalInAuths'];
-        $rrd_update[] = $data['cipSecGlobalOutAuths'];
-        $rrd_update[] = $data['cipSecGlobalInAuthFails'];
-        $rrd_update[] = $data['cipSecGlobalOutAuthFails'];
-        $rrd_update[] = $data['cipSecGlobalInDecrypts'];
-        $rrd_update[] = $data['cipSecGlobalOutEncrypts'];
-        $rrd_update[] = $data['cipSecGlobalInDecryptFails'];
-        $rrd_update[] = $data['cipSecGlobalOutEncryptFails'];
-        $rrd_update[] = $data['cipSecGlobalProtocolUseFails'];
-        $rrd_update[] = $data['cipSecGlobalNoSaFails'];
-        $rrd_update[] = $data['cipSecGlobalSysCapFails'];
-
-        rrdtool_update($rrd_filename, $rrd_update);
+        $fields = array(
+            'Tunnels'          => $data['cipSecGlobalActiveTunnels'],
+            'InOctets'         => $data['cipSecGlobalInOctets'],
+            'OutOctets'        => $data['cipSecGlobalOutOctets'],
+            'InDecompOctets'   => $data['cipSecGlobalInDecompOctets'],
+            'OutUncompOctets'  => $data['cipSecGlobalOutUncompOctets'],
+            'InPkts'           => $data['cipSecGlobalInPkts'],
+            'OutPkts'          => $data['cipSecGlobalOutPkts'],
+            'InDrops'          => $data['cipSecGlobalInDrops'],
+            'InReplayDrops'    => $data['cipSecGlobalInReplayDrops'],
+            'OutDrops'         => $data['cipSecGlobalOutDrops'],
+            'InAuths'          => $data['cipSecGlobalInAuths'],
+            'OutAuths'         => $data['cipSecGlobalOutAuths'],
+            'InAuthFails'      => $data['cipSecGlobalInAuthFails'],
+            'OutAuthFails'     => $data['cipSecGlobalOutAuthFails'],
+            'InDencrypts'      => $data['cipSecGlobalInDecrypts'],
+            'OutEncrypts'      => $data['cipSecGlobalOutEncrypts'],
+            'InDecryptFails'   => $data['cipSecGlobalInDecryptFails'],
+            'OutEncryptFails'  => $data['cipSecGlobalOutEncryptFails'],
+            'ProtocolUseFails' => $data['cipSecGlobalProtocolUseFails'],
+            'NoSaFails'        => $data['cipSecGlobalNoSaFails'],
+            'SysCapFails'      => $data['cipSecGlobalSysCapFails'],
+        );
+        rrdtool_update($rrd_filename, $fields);
 
         $graphs['cipsec_flow_tunnels'] = true;
         $graphs['cipsec_flow_pkts']    = true;

--- a/includes/polling/cisco-mac-accounting.inc.php
+++ b/includes/polling/cisco-mac-accounting.inc.php
@@ -77,13 +77,13 @@ if ($device['os_group'] == 'cisco') {
             }
 
             // FIXME - use memcached to make sure these values don't go backwards?
-            $rrdupdate = array(
-                $b_in,
-                $b_out,
-                $p_in,
-                $p_out,
+            $fields = array(
+                'IN'   => $b_in,
+                'OUT'  => $b_out,
+                'PIN'  => $p_in,
+                'POUT' => $p_out,
             );
-            rrdtool_update($rrdfile, $rrdupdate);
+            rrdtool_update($rrdfile, $fields);
 
             if ($acc['update']) {
                 // Do Updates

--- a/includes/polling/cisco-remote-access-monitor.inc.php
+++ b/includes/polling/cisco-remote-access-monitor.inc.php
@@ -50,19 +50,20 @@ if ($device['os_group'] == 'cisco') {
             rrdtool_create($rrd_filename, $rrd_create);
         }
 
-        $rrd_update  = 'N';
-        $rrd_update .= ':'.$data['crasEmailNumSessions'];
-        $rrd_update .= ':'.$data['crasIPSecNumSessions'];
-        $rrd_update .= ':'.$data['crasL2LNumSessions'];
-        $rrd_update .= ':'.$data['crasLBNumSessions'];
-        $rrd_update .= ':'.$data['crasSVCNumSessions'];
-        $rrd_update .= ':'.$data['crasWebvpnNumSessions'];
+        $fields = array(
+            'email'   => $data['crasEmailNumSessions'],
+            'ipsec'   => $data['crasIPSecNumSessions'],
+            'l2l'     => $data['crasL2LNumSessions'],
+            'lb'      => $data['crasLBNumSessions'],
+            'svc'     => $data['crasSVCNumSessions'],
+            'webvpn'  => $data['crasWebvpnNumSessions'],
+        );
 
-        rrdtool_update($rrd_filename, $rrd_update);
+        rrdtool_update($rrd_filename, $fields);
 
         $graphs['cras_sessions'] = true;
         echo ' CRAS Sessions';
     }
 
-    unset($data, $$rrd_filename, $rrd_create, $rrd_update);
+    unset($data, $$rrd_filename, $rrd_create, $fields);
 }//end if

--- a/includes/polling/cisco-sla.inc.php
+++ b/includes/polling/cisco-sla.inc.php
@@ -50,15 +50,17 @@ foreach (dbFetchRows('SELECT * FROM `slas` WHERE `device_id` = ? AND `deleted` =
     if (isset($sla_table[$sla['sla_nr']])) {
         $slaval = $sla_table[$sla['sla_nr']];
         echo $slaval['CompletionTime'].'ms at '.$slaval['TimeStr'];
-        $ts  = $slaval['UnixTime'];
         $val = $slaval['CompletionTime'];
     }
     else {
         echo 'NaN';
-        $ts  = 'N';
         $val = 'U';
     }
 
-    rrdtool_update($slarrd, $ts.':'.$val);
+    $fields = array(
+        'rtt' => $val,
+    );
+
+    rrdtool_update($slarrd, $fields);
     echo "\n";
 }//end foreach

--- a/includes/polling/cisco-voice/cisco-iosdsp.inc.php
+++ b/includes/polling/cisco-voice/cisco-iosdsp.inc.php
@@ -29,7 +29,13 @@ if ($device['os_group'] == "cisco") {
         if (!file_exists ($rrd_filename)) {
             rrdtool_create ($rrd_filename, " DS:total:GAUGE:600:0:U DS:active:GAUGE:600:0:U" . $config['rrd_rra']);
         }
-        rrdtool_update ($rrd_filename, "N:" . $total . ":" . $active);
+
+        $fields = array(
+            'total'  => $total,
+            'active' => $active,
+        );
+
+        rrdtool_update ($rrd_filename, $fields);
 
         $graphs['cisco-iosdsp'] = TRUE;
         echo (" Cisco IOS DSP ");

--- a/includes/polling/cisco-voice/cisco-iosmtp.inc.php
+++ b/includes/polling/cisco-voice/cisco-iosmtp.inc.php
@@ -28,7 +28,13 @@ if ($device['os_group'] == "cisco") {
         if (!file_exists ($rrd_filename)) {
             rrdtool_create ($rrd_filename, " DS:total:GAUGE:600:0:U DS:active:GAUGE:600:0:U" . $config['rrd_rra']);
         }
-        rrdtool_update ($rrd_filename, "N:" . $total . ":" . $active);
+
+        $fields = array(
+            'total'  => $total,
+            'active' => $active,
+        );
+
+        rrdtool_update ($rrd_filename, $fields);
 
         $graphs['cisco-iosmtp'] = TRUE;
         echo (" Cisco IOS MTP ");

--- a/includes/polling/cisco-voice/cisco-iospri.inc.php
+++ b/includes/polling/cisco-voice/cisco-iospri.inc.php
@@ -33,7 +33,13 @@ if ($device['os_group'] == "cisco") {
         if (!file_exists ($rrd_filename)) {
             rrdtool_create ($rrd_filename, " DS:total:GAUGE:600:0:U DS:active:GAUGE:600:0:U" . $config['rrd_rra']);
         }
-        rrdtool_update ($rrd_filename, "N:" . $total . ":" . $active);
+
+        $fields = array(
+            'total'  => $total,
+            'active' => $active,
+        );
+
+        rrdtool_update ($rrd_filename, $fields);
 
         $graphs['cisco-iospri'] = TRUE;
         echo (" Cisco IOS PRI ");

--- a/includes/polling/cisco-voice/cisco-iosxcode.inc.php
+++ b/includes/polling/cisco-voice/cisco-iosxcode.inc.php
@@ -28,7 +28,13 @@ if ($device['os_group'] == "cisco") {
         if (!file_exists ($rrd_filename)) {
             rrdtool_create ($rrd_filename, " DS:total:GAUGE:600:0:U DS:active:GAUGE:600:0:U" . $config['rrd_rra']);
         }
-        rrdtool_update ($rrd_filename, "N:" . $total . ":" . $active);
+
+        $fields = array(
+            'total'  => $total,
+            'active' => $active,
+        );
+
+        rrdtool_update ($rrd_filename, $fields);
 
         $graphs['cisco-iosxcode'] = TRUE;
         echo (" Cisco IOS Transcoder ");

--- a/includes/polling/cisco-vpdn.inc.php
+++ b/includes/polling/cisco-vpdn.inc.php
@@ -18,7 +18,13 @@ if ($device['os_group'] == 'cisco') {
                 rrdtool_create($rrd_filename, ' DS:tunnels:GAUGE:600:0:U DS:sessions:GAUGE:600:0:U DS:denied:COUNTER:600:0:100000'.$config['rrd_rra']);
             }
 
-            rrdtool_update($rrd_filename, array($vpdn['cvpdnSystemTunnelTotal'], $vpdn['cvpdnSystemSessionTotal'], $vpdn['cvpdnSystemDeniedUsersTotal']));
+            $fields = array(
+                'tunnels'   => $vpdn['cvpdnSystemTunnelTotal'],
+                'sessions'  => $vpdn['cvpdnSystemSessionTotal'],
+                'denied'    => $vpdn['cvpdnSystemDeniedUsersTotal'],
+            );
+
+            rrdtool_update($rrd_filename, $fields);
 
             $graphs['vpdn_sessions_'.$type] = true;
             $graphs['vpdn_tunnels_'.$type]  = true;

--- a/includes/polling/entity-physical.inc.php
+++ b/includes/polling/entity-physical.inc.php
@@ -24,11 +24,13 @@ if ($device['os'] == 'ios') {
             $entPhysical_state[$index][$subindex][$group][$key] = $value;
         }
 
-        $chan_update  = $entry['cc6kxbarStatisticsInUtil'];
-        $chan_update .= ':'.$entry['cc6kxbarStatisticsOutUtil'];
-        $chan_update .= ':'.$entry['cc6kxbarStatisticsOutDropped'];
-        $chan_update .= ':'.$entry['cc6kxbarStatisticsOutErrors'];
-        $chan_update .= ':'.$entry['cc6kxbarStatisticsInErrors'];
+        $fields = array(
+            'inutil'      => $entry['cc6kxbarStatisticsInUtil'],
+            'oututil'     => $entry['cc6kxbarStatisticsOutUtil'],
+            'outdropped'  => $entry['cc6kxbarStatisticsOutDropped'],
+            'outerrors'   => $entry['cc6kxbarStatisticsOutErrors'],
+            'inerrors'    => $entry['cc6kxbarStatisticsInErrors'],
+        );
 
         $rrd = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('c6kxbar-'.$index.'-'.$subindex.'.rrd');
 
@@ -48,7 +50,8 @@ if ($device['os'] == 'ios') {
             );
         }
 
-        rrdtool_update($rrd, "N:$chan_update");
+        rrdtool_update($rrd, $fields);
+
     }//end foreach
 
     // print_r($entPhysical_state);

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -367,6 +367,7 @@ function poll_mib_def($device, $mib_name_table, $mib_subdir, $mib_oids, $mib_gra
     }
 
     $oid_count = 0;
+    $fields = array();
     foreach ($oidglist as $fulloid) {
         list($splitoid, $splitindex) = explode('.', $fulloid, 2);
         if (is_numeric($snmpdata[$splitindex][$splitoid])) {

--- a/includes/polling/hr-mib.inc.php
+++ b/includes/polling/hr-mib.inc.php
@@ -17,7 +17,11 @@ if (is_numeric($hrSystem[0]['hrSystemProcesses'])) {
         );
     }
 
-    rrdtool_update($rrd_file, 'N:'.$hrSystem[0]['hrSystemProcesses']);
+    $fields = array(
+        'procs' => $hrSystem[0]['hrSystemProcesses'],
+    );
+
+    rrdtool_update($rrd_file, $fields);
     $graphs['hr_processes'] = true;
     echo ' Processes';
 }
@@ -32,7 +36,11 @@ if (is_numeric($hrSystem[0]['hrSystemNumUsers'])) {
         );
     }
 
-    rrdtool_update($rrd_file, 'N:'.$hrSystem[0]['hrSystemNumUsers']);
+    $fields = array(
+        'users' => $hrSystem[0]['hrSystemNumUsers'],
+    );
+
+    rrdtool_update($rrd_file, $fields);
     $graphs['hr_users'] = true;
     echo ' Users';
 }

--- a/includes/polling/ipSystemStats.inc.php
+++ b/includes/polling/ipSystemStats.inc.php
@@ -94,12 +94,12 @@ if ($ipSystemStats) {
             $stats['ipSystemStatsOutForwDatagrams'] = $stats['ipSystemStatsHCOutForwDatagrams'];
         }
 
-        unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+        unset($snmpstring, $files, $snmpdata, $snmpdata_cmd, $rrd_create);
 
         $rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('ipSystemStats-'.$af.'.rrd');
 
         $rrd_create = $config['rrd_rra'];
-        $rrdupdate  = 'N';
+        $fields  = array();
 
         foreach ($oids as $oid) {
             $oid_ds          = str_replace('ipSystemStats', '', $oid);
@@ -108,17 +108,16 @@ if ($ipSystemStats) {
             if (strstr($stats[$oid], 'No') || strstr($stats[$oid], 'd') || strstr($stats[$oid], 's')) {
                 $stats[$oid] = '0';
             }
-
-            $rrdupdate .= ':'.$stats[$oid];
+            $fields[$oid] = $stats[$oid];
         }
 
         if (!file_exists($rrdfile)) {
             rrdtool_create($rrdfile, $rrd_create);
         }
 
-        rrdtool_update($rrdfile, $rrdupdate);
+        rrdtool_update($rrdfile, $fields);
 
-        unset($rrdupdate, $rrd_create);
+        unset($fields, $rrd_create);
 
         // FIXME per-AF?
         $graphs['ipsystemstats_'.$af]         = true;

--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -43,7 +43,11 @@ if ($ipmi['host'] = get_dev_attrib($device, 'ipmi_hostname')) {
 
         echo $sensor." $unit\n";
 
-        rrdtool_update($rrd_file, "N:$sensor");
+        $fields = array(
+            'sensor' => $sensor,
+        );
+
+        rrdtool_update($rrd_file, $fields);
 
         // FIXME warnings in event & mail not done here yet!
         dbUpdate(array('sensor_current' => $sensor), 'sensors', 'poller_type = ? AND sensor_class = ? AND sensor_id = ?', array('ipmi', $ipmisensors['sensor_class'], $ipmisensors['sensor_id']));

--- a/includes/polling/junose-atm-vp.inc.php
+++ b/includes/polling/junose-atm-vp.inc.php
@@ -53,7 +53,19 @@ if (count($vp_rows)) {
             );
         }
 
-        rrdtool_update($rrd, "N:$vp_update");
+        $fields = array(
+            'incells'         => $t_vp['juniAtmVpStatsInCells'],
+            'outcells'        => $t_vp['juniAtmVpStatsOutCells'],
+            'inpackets'       => $t_vp['juniAtmVpStatsInPackets'],
+            'outpackets'      => $t_vp['juniAtmVpStatsOutPackets'],
+            'inpacketoctets'  => $t_vp['juniAtmVpStatsInPacketOctets'],
+            'outpacketoctets' => $t_vp['juniAtmVpStatsOutPacketOctets'],
+            'inpacketerrors'  => $t_vp['juniAtmVpStatsInPacketErrors'],
+            'outpacketerrors' => $t_vp['juniAtmVpStatsOutPacketErrors'],
+        );
+
+        rrdtool_update($rrd, $fields);
+
     }//end foreach
 
     echo "\n";

--- a/includes/polling/mempools.inc.php
+++ b/includes/polling/mempools.inc.php
@@ -26,7 +26,11 @@ foreach (dbFetchRows('SELECT * FROM mempools WHERE device_id = ?', array($device
         rrdtool_create($mempool_rrd, '--step 300 DS:used:GAUGE:600:0:U DS:free:GAUGE:600:0:U '.$config['rrd_rra']);
     }
 
-    rrdtool_update($mempool_rrd, 'N:'.$mempool['used'].':'.$mempool['free']);
+    $fields = array(
+        'used' => $mempool['used'],
+        'free' => $mempool['free'],
+    );
+    rrdtool_update($mempool_rrd, $fields);
 
     $mempool['state'] = array(
                          'mempool_used'  => $mempool['used'],

--- a/includes/polling/netscaler-stats.inc.php
+++ b/includes/polling/netscaler-stats.inc.php
@@ -95,7 +95,7 @@ if ($device['os'] == 'netscaler') {
 
     $oids = array_merge($oids_gauge, $oids_counter);
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/netscaler-stats-tcp.rrd';
 
     $rrd_create = $config['rrd_rra'];
@@ -112,22 +112,23 @@ if ($device['os'] == 'netscaler') {
 
     $data = snmpwalk_cache_oid($device, 'nsTcpStatsGroup', array(), 'NS-ROOT-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data[0][$oid])) {
-            $rrdupdate .= ':'.$data[0][$oid];
+            $rrdupdate = ':'.$data[0][$oid];
         }
         else {
-            $rrdupdate .= ':U';
+            $rrdupdate = 'U';
         }
+        $fields[$oid] = $rrdupdate;
     }
 
     if (!file_exists($rrd_file)) {
         rrdtool_create($rrd_file, $rrd_create);
     }
 
-    rrdtool_update($rrd_file, $rrdupdate);
+    rrdtool_update($rrd_file, $fields);
     $graphs['netscaler_tcp_conn'] = true;
     $graphs['netscaler_tcp_bits'] = true;
     $graphs['netscaler_tcp_pkts'] = true;

--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -55,7 +55,7 @@ if ($device['os'] == 'netscaler') {
 
     $oids = array_merge($oids_gauge, $oids_counter);
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
 
     $rrd_create = $config['rrd_rra'];
 
@@ -85,14 +85,14 @@ if ($device['os'] == 'netscaler') {
         if (isset($vsvr['vsvrName'])) {
             $vsvr_exist[$vsvr['vsvrName']] = 1;
             $rrd_file  = $config['rrd_dir'].'/'.$device['hostname'].'/netscaler-vsvr-'.safename($vsvr['vsvrName']).'.rrd';
-            $rrdupdate = 'N';
 
+            $fields = array();
             foreach ($oids as $oid) {
                 if (is_numeric($vsvr[$oid])) {
-                    $rrdupdate .= ':'.$vsvr[$oid];
+                    $fields[$oid] = $vsvr[$oid];
                 }
                 else {
-                    $rrdupdate .= ':U';
+                    $fields[$oid] = 'U';
                 }
             }
 
@@ -123,9 +123,9 @@ if ($device['os'] == 'netscaler') {
                 rrdtool_create($rrd_file, $rrd_create);
             }
 
-                rrdtool_update($rrd_file, $rrdupdate);
+            rrdtool_update($rrd_file, $fields);
 
-                echo "\n";
+            echo "\n";
         }//end if
     }//end foreach
 

--- a/includes/polling/netstats-icmp.inc.php
+++ b/includes/polling/netstats-icmp.inc.php
@@ -33,7 +33,7 @@ if ($device['os'] != 'Snom') {
         'icmpOutAddrMaskReps',
     );
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/netstats-icmp.rrd';
 
     $rrd_create = $config['rrd_rra'];
@@ -46,7 +46,7 @@ if ($device['os'] != 'Snom') {
 
     $data_array = snmpwalk_cache_oid($device, 'icmp', array(), 'IP-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data_array[0][$oid])) {
@@ -55,8 +55,7 @@ if ($device['os'] != 'Snom') {
         else {
             $value = 'U';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     unset($snmpstring);
@@ -66,7 +65,7 @@ if ($device['os'] != 'Snom') {
             rrdtool_create($rrd_file, $rrd_create);
         }
 
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         $graphs['netstat_icmp']      = true;
         $graphs['netstat_icmp_info'] = true;
     }

--- a/includes/polling/netstats-ip.inc.php
+++ b/includes/polling/netstats-ip.inc.php
@@ -23,7 +23,7 @@ if ($device['os'] != 'Snom') {
         'ipInAddrErrors',
     );
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/netstats-ip.rrd';
 
     $rrd_create = $config['rrd_rra'];
@@ -36,7 +36,7 @@ if ($device['os'] != 'Snom') {
 
     $data = snmp_get_multi($device, $snmpstring, '-OQUs', 'IP-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data[0][$oid])) {
@@ -45,8 +45,7 @@ if ($device['os'] != 'Snom') {
         else {
             $value = 'U';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     if (isset($data[0]['ipOutRequests']) && isset($data[0]['ipInReceives'])) {
@@ -54,7 +53,7 @@ if ($device['os'] != 'Snom') {
             rrdtool_create($rrd_file, $rrd_create);
         }
 
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         $graphs['netstat_ip']      = true;
         $graphs['netstat_ip_frag'] = true;
     }

--- a/includes/polling/netstats-ip_forward.inc.php
+++ b/includes/polling/netstats-ip_forward.inc.php
@@ -6,7 +6,7 @@ if ($device['os'] != 'Snom') {
     // Below have more oids, and are in trees by themselves, so we can snmpwalk_cache_oid them
     $oids = array('ipCidrRouteNumber');
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/netstats-ip_forward.rrd';
 
     $rrd_create = $config['rrd_rra'];
@@ -20,7 +20,7 @@ if ($device['os'] != 'Snom') {
 
     $data = snmp_get_multi($device, $snmpstring, '-OQUs', 'IP-FORWARD-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data[0][$oid])) {
@@ -29,8 +29,7 @@ if ($device['os'] != 'Snom') {
         else {
             $value = 'U';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     if (isset($data[0]['ipCidrRouteNumber'])) {
@@ -38,7 +37,7 @@ if ($device['os'] != 'Snom') {
             rrdtool_create($rrd_file, $rrd_create);
         }
 
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         $graphs['netstat_ip_forward'] = true;
     }
 }

--- a/includes/polling/netstats-snmp.inc.php
+++ b/includes/polling/netstats-snmp.inc.php
@@ -36,7 +36,7 @@ if ($device['os'] != 'Snom') {
         'snmpProxyDrops',
     );
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('netstats-snmp.rrd');
 
     $rrd_create = $config['rrd_rra'];
@@ -48,7 +48,7 @@ if ($device['os'] != 'Snom') {
 
     $data_array = snmpwalk_cache_oid($device, 'snmp', array(), 'SNMPv2-MIB');
 
-    $rrdupdate = array();
+    $fields = array();
     foreach ($oids as $oid) {
         if (is_numeric($data_array[0][$oid])) {
             $value = $data_array[0][$oid];
@@ -56,8 +56,7 @@ if ($device['os'] != 'Snom') {
         else {
             $value = 'U';
         }
-
-        $rrdupdate[] = $value;
+        $fields[$oid] = $value;
     }
 
     if (isset($data_array[0]['snmpInPkts']) && isset($data_array[0]['snmpOutPkts'])) {
@@ -65,7 +64,7 @@ if ($device['os'] != 'Snom') {
             rrdtool_create($rrd_file, $rrd_create);
         }
 
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         $graphs['netstat_snmp']     = true;
         $graphs['netstat_snmp_pkt'] = true;
     }

--- a/includes/polling/netstats-tcp.inc.php
+++ b/includes/polling/netstats-tcp.inc.php
@@ -19,7 +19,7 @@ if ($device['os'] != 'Snom') {
     // $oids['tcp_collect'] = $oids['tcp'];
     // $oids['tcp_collect'][] = 'tcpHCInSegs';
     // $oids['tcp_collect'][] = 'tcpHCOutSegs';
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/netstats-tcp.rrd';
 
     $rrd_create = $config['rrd_rra'];
@@ -36,7 +36,7 @@ if ($device['os'] != 'Snom') {
 
     $data = snmp_get_multi($device, $snmpstring, '-OQUs', 'TCP-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data[0][$oid])) {
@@ -45,8 +45,7 @@ if ($device['os'] != 'Snom') {
         else {
             $value = 'U';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     unset($snmpstring);
@@ -56,7 +55,7 @@ if ($device['os'] != 'Snom') {
             rrdtool_create($rrd_file, $rrd_create);
         }
 
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         $graphs['netstat_tcp'] = true;
     }
 

--- a/includes/polling/netstats-udp.inc.php
+++ b/includes/polling/netstats-udp.inc.php
@@ -11,7 +11,7 @@ if ($device['os'] != 'Snom') {
         'udpNoPorts',
     );
 
-    unset($snmpstring, $rrdupdate, $snmpdata, $snmpdata_cmd, $rrd_create);
+    unset($snmpstring, $fields, $snmpdata, $snmpdata_cmd, $rrd_create);
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/netstats-udp.rrd';
 
     $rrd_create = $config['rrd_rra'];
@@ -25,7 +25,7 @@ if ($device['os'] != 'Snom') {
 
     $data = snmp_get_multi($device, $snmpstring, '-OQUs', 'UDP-MIB');
 
-    $rrdupdate = 'N';
+    $fields = array();
 
     foreach ($oids as $oid) {
         if (is_numeric($data[0][$oid])) {
@@ -34,8 +34,7 @@ if ($device['os'] != 'Snom') {
         else {
             $value = 'U';
         }
-
-        $rrdupdate .= ":$value";
+        $fields[$oid] = $value;
     }
 
     if (isset($data[0]['udpInDatagrams']) && isset($data[0]['udpOutDatagrams'])) {
@@ -43,7 +42,7 @@ if ($device['os'] != 'Snom') {
             rrdtool_create($rrd_file, $rrd_create);
         }
 
-        rrdtool_update($rrd_file, $rrdupdate);
+        rrdtool_update($rrd_file, $fields);
         $graphs['netstat_udp'] = true;
     }
 }//end if

--- a/includes/polling/os/fortigate.inc.php
+++ b/includes/polling/os/fortigate.inc.php
@@ -23,7 +23,13 @@ if (is_numeric($sessions)) {
     }
 
     print "Sessions: $sessions\n";
-    rrdtool_update($sessrrd, 'N:'.$sessions);
+
+    $fields = array(
+        'sessions' => $sessions,
+    );
+
+    rrdtool_update($sessrrd, $fields);
+
     $graphs['fortigate_sessions'] = true;
 }
 
@@ -36,6 +42,12 @@ if (is_numeric($cpu_usage)) {
     }
 
     echo "CPU: $cpu_usage%\n";
-    rrdtool_update($cpurrd, " N:$cpu_usage");
+
+    $fields = array(
+        'LOAD' => $cpu_usage,
+    );
+
+    rrdtool_update($cpurrd, $fields);
+
     $graphs['fortigate_cpu'] = true;
 }

--- a/includes/polling/os/panos.inc.php
+++ b/includes/polling/os/panos.inc.php
@@ -13,6 +13,11 @@ if (is_numeric($sessions)) {
         rrdtool_create($sessrrd, ' --step 300 DS:sessions:GAUGE:600:0:3000000 '.$config['rrd_rra']);
     }
 
-    rrdtool_update($sessrrd, "N:$sessions");
+    $fields = array(
+        'sessions' => $sessions,
+    );
+
+    rrdtool_update($sessrrd, $fields);
+
     $graphs['panos_sessions'] = true;
 }

--- a/includes/polling/os/procurve.inc.php
+++ b/includes/polling/os/procurve.inc.php
@@ -44,7 +44,11 @@ if (is_numeric($FdbAddressCount)) {
         );
     }
 
-    rrdtool_update($fdb_rrd_file, "N:$FdbAddressCount");
+    $fields = array(
+        'value' => $FdbAddressCount,
+    );
+
+    rrdtool_update($fdb_rrd_file, $fields);
 
     $graphs['fdb_count'] = true;
 

--- a/includes/polling/os/screenos.inc.php
+++ b/includes/polling/os/screenos.inc.php
@@ -19,6 +19,12 @@ if (!is_file($sessrrd)) {
     );
 }
 
-rrdtool_update("$sessrrd", "N:$sessalloc:$sessmax:$sessfailed");
+$fields = array(
+    'allocate'  => $sessalloc,
+    'max'       => $sessmax,
+    'failed'    => $sessfailed,
+);
+
+rrdtool_update("$sessrrd", $fields);
 
 $graphs['screenos_sessions'] = true;

--- a/includes/polling/os/snom.inc.php
+++ b/includes/polling/os/snom.inc.php
@@ -36,5 +36,13 @@ if (!is_file($rrdfile)) {
     );
 }
 
-$rrdupdate = "N:$rxbytes:$txbytes:$rxpkts:$rxbytes:$calls:$registrations";
-rrdtool_update("$rrdfile", $rrdupdate);
+$fields = array(
+    'INOCTETS'      => $rxbytes,
+    'OUTOCTETS'     => $txbytes,
+    'INPKTS'        => $rxpkts,
+    'OUTPKTS'       => $rxbytes,
+    'CALLS'         => $calls,
+    'REGISTRATIONS' => $registrations,
+);
+
+rrdtool_update("$rrdfile", $fields);

--- a/includes/polling/ospf.inc.php
+++ b/includes/polling/ospf.inc.php
@@ -372,8 +372,13 @@ if (!is_file($filename)) {
                     );
 }
 
-$rrd_update = 'N:'.$ospf_instance_count.':'.$ospf_area_count.':'.$ospf_port_count.':'.$ospf_neighbour_count;
-$ret        = rrdtool_update("$filename", $rrd_update);
+$fields = array(
+    'instances'   => $ospf_instance_count,
+    'areas'       => $ospf_area_count,
+    'ports'       => $ospf_port_count,
+    'neighbours'  => $ospf_neighbour_count,
+);
+$ret        = rrdtool_update("$filename", $fields);
 
 unset($ospf_ports_db);
 unset($ospf_ports_poll);

--- a/includes/polling/port-adsl.inc.php
+++ b/includes/polling/port-adsl.inc.php
@@ -151,7 +151,7 @@ if (isset($port_stats[$port['ifIndex']]['adslLineCoding'])) {
         $this_port['adslAturCurrSnrMgn'] = 'U';
     }
 
-    $rrdupdate = 'N';
+    $fields = array();
     foreach ($adsl_oids as $oid) {
         $oid  = 'adsl'.$oid;
         $data = str_replace('"', '', $this_port[$oid]);
@@ -159,15 +159,14 @@ if (isset($port_stats[$port['ifIndex']]['adslLineCoding'])) {
         if (!is_numeric($data)) {
             $data = 'U';
         }
-
-        $rrdupdate .= ":$data";
+        $fields[$oid] = $data;
     }
 
     if (!is_file($rrdfile)) {
         rrdtool_create($rrdfile, $rrd_create);
     }
 
-    rrdtool_update($rrdfile, $rrdupdate);
+    rrdtool_update($rrdfile, $fields);
 
     echo 'ADSL ('.$this_port['adslLineCoding'].'/'.formatRates($this_port['adslAtucChanCurrTxRate']).'/'.formatRates($this_port['adslAturChanCurrTxRate']).')';
 }//end if

--- a/includes/polling/port-etherlike.inc.php
+++ b/includes/polling/port-etherlike.inc.php
@@ -25,13 +25,13 @@ if ($port_stats[$port['ifIndex']] &&
         }
     }
 
-    $rrdupdate = 'N';
+    $fields = array();
     foreach ($etherlike_oids as $oid) {
         $data           = ($this_port[$oid] + 0);
-        $rrdupdate .= ":$data";
+        $fields[$oid] = $data;
     }
 
-    rrdtool_update($rrdfile, $rrdupdate);
+    rrdtool_update($rrdfile, $fields);
 
     echo 'EtherLike ';
 }

--- a/includes/polling/port-poe.inc.php
+++ b/includes/polling/port-poe.inc.php
@@ -59,7 +59,15 @@ if ($port_stats[$port['ifIndex']]
     }
 
     $upd = "$polled:".$port['cpeExtPsePortPwrAllocated'].':'.$port['cpeExtPsePortPwrAvailable'].':'.$port['cpeExtPsePortPwrConsumption'].':'.$port['cpeExtPsePortMaxPwrDrawn'];
-    $ret = rrdtool_update("$rrdfile", $upd);
+
+    $fields = array(
+        'PortPwrAllocated'   => $port['cpeExtPsePortPwrAllocated'],
+        'PortPwrAvailable'   => $port['cpeExtPsePortPwrAvailable'],
+        'PortConsumption'    => $port['cpeExtPsePortPwrConsumption'],
+        'PortMaxPwrDrawn'    => $port['cpeExtPsePortMaxPwrDrawn'],
+    );
+
+    $ret = rrdtool_update("$rrdfile", $fields);
 
     echo 'PoE ';
 }//end if

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -491,25 +491,25 @@ foreach ($ports as $port) {
             );
         }//end if
 
-        $this_port['rrd_update'] = array(
-            $this_port['ifInOctets'],
-            $this_port['ifOutOctets'],
-            $this_port['ifInErrors'],
-            $this_port['ifOutErrors'],
-            $this_port['ifInUcastPkts'],
-            $this_port['ifOutUcastPkts'],
-            $this_port['ifInNUcastPkts'],
-            $this_port['ifOutNUcastPkts'],
-            $this_port['ifInDiscards'],
-            $this_port['ifOutDiscards'],
-            $this_port['ifInUnknownProtos'],
-            $this_port['ifInBroadcastPkts'],
-            $this_port['ifOutBroadcastPkts'],
-            $this_port['ifInMulticastPkts'],
-            $this_port['ifOutMulticastPkts'],
+        $fields = array(
+            'INOCTETS'         => $this_port['ifInOctets'],
+            'OUTOCTETS'        => $this_port['ifOutOctets'],
+            'INERRORS'         => $this_port['ifInErrors'],
+            'OUTERRORS'        => $this_port['ifOutErrors'],
+            'INUCASTPKTS'      => $this_port['ifInUcastPkts'],
+            'OUTUCASTPKTS'     => $this_port['ifOutUcastPkts'],
+            'INNUCASTPKTS'     => $this_port['ifInNUcastPkts'],
+            'OUTNUCASTPKTS'    => $this_port['ifOutNUcastPkts'],
+            'INDISCARDS'       => $this_port['ifInDiscards'],
+            'OUTDISCARDS'      => $this_port['ifOutDiscards'],
+            'INUNKNOWNPROTOS'  => $this_port['ifInUnknownProtos'],
+            'INBROADCASTPKTS'  => $this_port['ifInBroadcastPkts'],
+            'OUTBROADCASTPKTS' => $this_port['ifOutBroadcastPkts'],
+            'INMULTICASTPKTS'  => $this_port['ifInMulticastPkts'],
+            'OUTMULTICASTPKTS' => $this_port['ifOutMulticastPkts'],
         );
 
-        rrdtool_update("$rrdfile", $this_port['rrd_update']);
+        rrdtool_update("$rrdfile", $fields);
         // End Update IF-MIB
         // Update PAgP
         if ($this_port['pagpOperationMode'] || $port['pagpOperationMode']) {

--- a/includes/polling/processors.inc.php
+++ b/includes/polling/processors.inc.php
@@ -31,6 +31,11 @@ foreach (dbFetchRows('SELECT * FROM processors WHERE device_id = ?', array($devi
 
     echo $proc."%\n";
 
-    rrdtool_update($procrrd, "N:$proc");
+    $fields = array(
+        'usage' => $proc,
+    );
+
+    rrdtool_update($procrrd, $fields);
+
     dbUpdate(array('processor_usage' => $proc), 'processors', '`processor_id` = ?', array($processor['processor_id']));
 }//end foreach

--- a/includes/polling/storage.inc.php
+++ b/includes/polling/storage.inc.php
@@ -32,7 +32,12 @@ foreach (dbFetchRows('SELECT * FROM storage WHERE device_id = ?', array($device[
 
     echo $percent.'% ';
 
-    rrdtool_update($storage_rrd, 'N:'.$storage['used'].':'.$storage['free']);
+    $fields = array(
+        'used'   => $storage['used'],
+        'free'   => $storage['free'],
+    );
+
+    rrdtool_update($storage_rrd, $fields);
 
     if ($config['memcached']['enable'] === true) {
         $memcache->set('storage-'.$storage['storage_id'].'-used', $storage['used']);

--- a/includes/polling/system.inc.php
+++ b/includes/polling/system.inc.php
@@ -74,7 +74,11 @@ if (is_numeric($uptime)) {
         rrdtool_create($uptime_rrd, 'DS:uptime:GAUGE:600:0:U '.$config['rrd_rra']);
     }
 
-    rrdtool_update($uptime_rrd, 'N:'.$uptime);
+    $fields = array(
+        'uptime' => $uptime,
+    );
+
+    rrdtool_update($uptime_rrd, $fields);
 
     $graphs['uptime'] = true;
 

--- a/includes/polling/toner.inc.php
+++ b/includes/polling/toner.inc.php
@@ -30,7 +30,11 @@ if ($config['enable_printers']) {
 
         echo $tonerperc." %\n";
 
-        rrdtool_update($tonerrrd, "N:$tonerperc");
+        $fields = array(
+            'toner' => $tonerperc,
+        );
+
+        rrdtool_update($tonerrrd, $fields);
 
         // FIXME should report for toner out... :)
         // Log toner swap

--- a/includes/polling/ucd-diskio.inc.php
+++ b/includes/polling/ucd-diskio.inc.php
@@ -36,7 +36,14 @@ if (count($diskio_data)) {
             );
         }
 
-        rrdtool_update($rrd, array($entry['diskIONReadX'], $entry['diskIONWrittenX'], $entry['diskIOReads'], $entry['diskIOWrites']));
+        $fields = array(
+            'read'    => $entry['diskIONReadX'],
+            'written' => $entry['diskIONWrittenX'],
+            'reads'   => $entry['diskIOReads'],
+            'writes'  => $entry['diskIOWrites'],
+        );
+
+        rrdtool_update($rrd, $fields);
     }//end foreach
 
     echo "\n";

--- a/includes/polling/ucd-mib.inc.php
+++ b/includes/polling/ucd-mib.inc.php
@@ -48,7 +48,14 @@ if (is_numeric($ss['ssCpuRawUser']) && is_numeric($ss['ssCpuRawNice']) && is_num
         rrdtool_create($cpu_rrd, $cpu_rrd_create);
     }
 
-    rrdtool_update($cpu_rrd, array($ss['ssCpuRawUser'], $ss['ssCpuRawSystem'], $ss['ssCpuRawNice'], $ss['ssCpuRawIdle']));
+    $fields = array(
+        'user'    => $ss['ssCpuRawUser'],
+        'system'  => $ss['ssCpuRawSystem'],
+        'nice'    => $ss['ssCpuRawNice'],
+        'idle'    => $ss['ssCpuRawIdle'],
+    );
+
+    rrdtool_update($cpu_rrd, $fields);
     $graphs['ucd_cpu'] = true;
 }
 
@@ -78,7 +85,11 @@ foreach ($collect_oids as $oid) {
             rrdtool_create($filename, ' --step 300 DS:value:COUNTER:600:0:U '.$config['rrd_rra']);
         }
 
-        rrdtool_update($filename, 'N:'.$value);
+        $fields = array(
+            'value' => $value,
+        );
+
+        rrdtool_update($filename, $fields);
         $graphs['ucd_cpu'] = true;
     }
 }
@@ -141,7 +152,19 @@ if (is_numeric($memTotalReal) && is_numeric($memAvailReal) && is_numeric($memTot
         rrdtool_create($mem_rrd, $mem_rrd_create);
     }
 
-    rrdtool_update($mem_rrd, array($memTotalSwap, $memAvailSwap, $memTotalReal, $memAvailReal, $memTotalFree, $memShared, $memBuffer, $memCached));
+    $fields = array(
+        'totalswap'    => $memTotalSwap,
+        'availswap'    => $memAvailSwap,
+        'totalreal'    => $memTotalReal,
+        'availreal'    => $memAvailReal,
+        'totalfree'    => $memTotalFree,
+        'shared'       => $memShared,
+        'buffered'     => $memBuffer,
+        'cached'       => $memCached,
+    );
+
+    rrdtool_update($mem_rrd, $fields);
+
     $graphs['ucd_memory'] = true;
 }
 
@@ -158,7 +181,13 @@ if (is_numeric($load_raw[2]['laLoadInt'])) {
         rrdtool_create($load_rrd, ' --step 300 DS:1min:GAUGE:600:0:5000 DS:5min:GAUGE:600:0:5000 DS:15min:GAUGE:600:0:5000 '.$config['rrd_rra']);
     }
 
-    rrdtool_update($load_rrd, array($load_raw[1]['laLoadInt'], $load_raw[2]['laLoadInt'], $load_raw[3]['laLoadInt']));
+    $fields = array(
+        '1min'   => $load_raw[1]['laLoadInt'],
+        '5min'   => $load_raw[2]['laLoadInt'],
+        '15min'  => $load_raw[3]['laLoadInt'],
+    );
+
+    rrdtool_update($load_rrd, $fields);
     $graphs['ucd_load'] = 'TRUE';
 }
 

--- a/includes/polling/unix-agent.inc.php
+++ b/includes/polling/unix-agent.inc.php
@@ -40,7 +40,11 @@ if ($device['os_group'] == 'unix') {
             rrdtool_create($agent_rrd, 'DS:time:GAUGE:600:0:U '.$config['rrd_rra']);
         }
 
-        rrdtool_update($agent_rrd, 'N:'.$agent_time);
+        $fields = array(
+            'time' => $agent_time,
+        );
+ 
+        rrdtool_update($agent_rrd, $fields);
         $graphs['agent'] = true;
 
         foreach (explode('<<<', $agent_raw) as $section) {

--- a/includes/polling/unix-agent/munin-plugins.inc.php
+++ b/includes/polling/unix-agent/munin-plugins.inc.php
@@ -109,7 +109,11 @@ if (!empty($agent_data['munin'])) {
                     rrdtool_create($filename, $cmd);
                 }
 
-                rrdtool_update($filename, 'N:'.$data['value']);
+                $fields = array(
+                    'val' => $data['value'],
+                );
+
+                rrdtool_update($filename, $fields);
 
                 if (empty($ds_list[$ds_uniq])) {
                     $insert = array(

--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -79,7 +79,11 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
             );
         }
 
-        rrdtool_update($wificlientsrrd, array($wificlients1));
+        $fields = array(
+            'wificlients' => $wificlients1,
+        );
+
+        rrdtool_update($wificlientsrrd, $fields);
 
         $graphs['wifi_clients'] = true;
     }
@@ -95,7 +99,11 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
             );
         }
 
-        rrdtool_update($wificlientsrrd, array($wificlients2));
+        $fields = array(
+            'wificlients' => $wificlients2,
+        );
+
+        rrdtool_update($wificlientsrrd, $fields);
 
         $graphs['wifi_clients'] = true;
     }

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -240,20 +240,23 @@ function rrdtool_create($filename, $options) {
 function rrdtool_update($filename, $options) {
     $values = array();
     // Do some sanitisation on the data if passed as an array.
+
     if (is_array($options)) {
         $values[] = 'N';
-        foreach ($options as $value) {
-            if (!is_numeric($value)) {
-                $value = U;
+        foreach ($options as $k => $v) {
+            if (!is_numeric($v)) {
+                $v = U;
             }
 
-            $values[] = $value;
+            $values[] = $v;
         }
 
         $options = implode(':', $values);
+        return rrdtool('update', $filename, $options);
     }
-
-    return rrdtool('update', $filename, $options);
+    else {
+        return 'Bad options passed to rrdtool_update';
+    }
 
 }
 

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1088,7 +1088,7 @@ function save_mibs($device, $mibname, $oids, $mibdef, &$graphs) {
                     $index,
                 ),
                 array('DS:'.$mibdef[$oid]['dsname'].":$type"),
-                "N:$val"
+                array($mibdef[$oid]['dsname'] => $val)
             );
         }
     }


### PR DESCRIPTION
This is in preparation for moving to other backends than rrd.

Basically we now use only an array for the values being passed to rrdtool_update so we can then pass the same array to other functions. This new array includes key names as well as values so that we can use the keys as well.

It shouldn't affect the way anything currently works assuming I've made no mistakes :)

The first push of this is to kick off a scrut and CI run so I can see if anything needs fixing.