### PR TITLE
Pass snmp-auth parameters enclosed by single-quotes

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -748,7 +748,7 @@ function snmp_gen_auth(&$device) {
     $cmd = '';
 
     if ($device['snmpver'] === 'v3') {
-        $cmd = ' -v3 -n "" -l '.$device['authlevel'];
+        $cmd = " -v3 -n '' -l '".$device['authlevel']."'";
 
         if ($device['authlevel'] === 'noAuthNoPriv') {
             // We have to provide a username anyway (see Net-SNMP doc)
@@ -756,16 +756,16 @@ function snmp_gen_auth(&$device) {
             $cmd .= ' -u root';
         }
         else if ($device['authlevel'] === 'authNoPriv') {
-            $cmd .= ' -a '.$device['authalgo'];
-            $cmd .= ' -A "'.$device['authpass'].'"';
-            $cmd .= ' -u '.$device['authname'];
+            $cmd .= " -a '".$device['authalgo']."'";
+            $cmd .= " -A '".$device['authpass']."'";
+            $cmd .= " -u '".$device['authname']."'";
         }
         else if ($device['authlevel'] === 'authPriv') {
-            $cmd .= ' -a '.$device['authalgo'];
-            $cmd .= ' -A "'.$device['authpass'].'"';
-            $cmd .= ' -u '.$device['authname'];
-            $cmd .= ' -x '.$device['cryptoalgo'];
-            $cmd .= ' -X "'.$device['cryptopass'].'"';
+            $cmd .= " -a '".$device['authalgo']."'";
+            $cmd .= " -A '".$device['authpass']."'";
+            $cmd .= " -u '".$device['authname']."'";
+            $cmd .= " -x '".$device['cryptoalgo']."'";
+            $cmd .= " -X '".$device['cryptopass']."'";
         }
         else {
             if ($debug) {


### PR DESCRIPTION
Fixes #1728 