### PR TITLE
Removed d_echo from memcache

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1664,7 +1664,6 @@ if ($config['memcached']['enable'] === true) {
     if (class_exists('Memcached')) {
         $memcache = new Memcached();
         $memcache->addServer($config['memcached']['host'], $config['memcached']['port']);
-        d_echo($memcache->getStats());
     }
     else {
         echo "WARNING: You have enabled memcached but have not installed the PHP bindings. Disabling memcached support.\n";

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1664,6 +1664,7 @@ if ($config['memcached']['enable'] === true) {
     if (class_exists('Memcached')) {
         $memcache = new Memcached();
         $memcache->addServer($config['memcached']['host'], $config['memcached']['port']);
+        $memcache->getStats();
     }
     else {
         echo "WARNING: You have enabled memcached but have not installed the PHP bindings. Disabling memcached support.\n";


### PR DESCRIPTION
This is causing people who having memcache setup to fail when running schema update as d_echo() isn't available at that time.

As we really need to deprecate or fix memcache support I've removed the line for now.