### PR TITLE
Revert change which skips over ports that are down / admin down

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -348,10 +348,6 @@ foreach ($ports as $port) {
                     echo $oid.' ';
                 }
             }
-
-            if (( $oid == 'ifOperStatus' || $oid == 'ifAdminStatus' ) && $this_port[$oid] == 'down') {
-                break;
-            }
         }//end foreach
 
         // Parse description (usually ifAlias) if config option set


### PR DESCRIPTION
With this change in place, ports that are down never have the ifType found until the port goes up.