### PR TITLE
Stops full POE polling for every port!

### DIFF
--- a/includes/polling/port-poe.inc.php
+++ b/includes/polling/port-poe.inc.php
@@ -35,8 +35,8 @@ $peth_oids = array(
     'pethMainPseConsumptionPower',
 );
 
-$port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
-$port_stats = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats, 'CISCO-POWER-ETHERNET-EXT-MIB');
+//$port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
+//$port_stats = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats, 'CISCO-POWER-ETHERNET-EXT-MIB');
 
 if ($port_stats[$port['ifIndex']]
     && $port['ifType'] == 'ethernetCsmacd'

--- a/includes/polling/port-poe.inc.php
+++ b/includes/polling/port-poe.inc.php
@@ -35,9 +35,6 @@ $peth_oids = array(
     'pethMainPseConsumptionPower',
 );
 
-//$port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
-//$port_stats = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats, 'CISCO-POWER-ETHERNET-EXT-MIB');
-
 if ($port_stats[$port['ifIndex']]
     && $port['ifType'] == 'ethernetCsmacd'
     && isset($port_stats[$port['ifIndex']]['dot3StatsIndex'])) {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -145,6 +145,11 @@ if ($device['adsl_count'] > '0') {
     $port_stats = snmpwalk_cache_oid($device, '.1.3.6.1.2.1.10.94.1.1.7.1.7', $port_stats, 'ADSL-LINE-MIB');
 }//end if
 
+if ($config['enable_ports_poe']) {
+    $port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
+    $port_stats = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats, 'CISCO-POWER-ETHERNET-EXT-MIB');
+}
+
 // FIXME This probably needs re-enabled. We need to clear these things when they get unset, too.
 // foreach ($etherlike_oids as $oid) { $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, "EtherLike-MIB"); }
 // foreach ($cisco_oids as $oid)     { $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, "OLD-CISCO-INTERFACES-MIB"); }


### PR DESCRIPTION
When poe support is enabled, a full snmpwalk is done against the complete poe tree for _every_ port. 

This moves the initial snmpwalk to outside the loop, before then including the poe file as before.

For those with poe enabled - polling time will reduce. The graph below is from an ASR9k with a reasonable number of ports.

![image](https://cloud.githubusercontent.com/assets/3941142/9429581/0d19b53a-49cd-11e5-8f02-e3d149c1ae97.png)
