### PR TITLE
Add netgear OID to os discovery

### DIFF
--- a/includes/discovery/os/netgear.inc.php
+++ b/includes/discovery/os/netgear.inc.php
@@ -4,4 +4,7 @@ if (!$os) {
     if (stristr($sysDescr, 'ProSafe')) {
         $os = 'netgear';
     }
+    elseif (strpos($sysObjectId, '1.3.6.1.4.1.4526') !== FALSE) {
+        $os = 'netgear';
+    }
 }


### PR DESCRIPTION
I have a GS110TP and it's `sysDescr` is just `GS110TP` but it has an object id in netgear's space so use that as an indicator as well.