### PR TITLE
Provide clearer instructions for CentOS 6 users

### DIFF
--- a/doc/Installation/Installation-(RHEL-CentOS).md
+++ b/doc/Installation/Installation-(RHEL-CentOS).md
@@ -70,6 +70,9 @@ Install necessary software.  The packages listed below are an all-inclusive list
 
 Note if not using HTTPd (Apache): RHEL requires `httpd` to be installed regardless of of `nginx`'s (or any other web-server's) presence.
 
+# PHP 5.4+ is required, the standard version of PHP that's installed is 5.3 which returns the following error: PHP Parse error:  syntax error, unexpected '[' in /opt/librenms/includes/sql-schema/update.php on line 87.
+# I've loaded PHP 5.4 using a different repo via CentOS 6.X, which has cleared this error.
+
     yum install epel-release
     yum install php php-cli php-gd php-mysql php-snmp php-pear php-curl httpd net-snmp graphviz graphviz-php mysql ImageMagick jwhois nmap mtr rrdtool MySQL-python net-snmp-utils vixie-cron php-mcrypt fping git
     pear install Net_IPv4-1.3.4


### PR DESCRIPTION
http://docs.librenms.org/Installation/Installation-%28RHEL-CentOS%29/ - Currently following the guide found here - I've run into a problem.

1. Initiate the follow database with the following command: php build-base.php

returns:
PHP Warning:  mysqli_connect(): Headers and client library minor version mismatch. Headers:50173 Library:50312 in /opt/librenms/build-base.php on line 17
PHP Parse error:  syntax error, unexpected '[' in /opt/librenms/includes/sql-schema/update.php on line 87

PHP reports:
Client API version => 5.3.12-MariaDB
Client API library version => 5.3.12-MariaDB
Client API header version => 5.1.73
Client API version => 5.3.12-MariaDB

PHP 5.3.3 (cli) (built: Jul  9 2015 17:39:00) 

I loaded a different repo and uninstalled 5.3, then install 5.4. The process then completed without any errors.

PHP 5.4+ is required from what I can see.