### PR TITLE
Remain PHP Backwards compatibility

### DIFF
--- a/includes/sql-schema/update.php
+++ b/includes/sql-schema/update.php
@@ -83,8 +83,8 @@ if ($handle = opendir($config['install_dir'].'/sql-schema')) {
 }
 
 asort($filelist);
-
-if (explode('.', max($filelist), 2)[0] <= $db_rev) {
+$tmp = explode('.', max($filelist), 2);
+if ($tmp[0] <= $db_rev) {
     if ($debug) {
         echo "DB Schema already up to date.\n";
     }


### PR DESCRIPTION
#1584 introduced a shorthand in `includes/sql-schema/update.php` that doesnt parse for older PHP versions.