### PR TITLE
Exclude Cisco's from Zyxel IES Discovery

### DIFF
--- a/includes/discovery/os/ies.inc.php
+++ b/includes/discovery/os/ies.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!$os) {
-    if (strstr($sysDescr, 'IES-')) {
+    if (strstr($sysDescr, 'IES-') && !strstr($sysDescr, 'Cisco Systems')) {
         $os = 'ies';
     }
 }


### PR DESCRIPTION
A nicer fix would be knowing a full sysDescr.0 from a Zyxel IES DSLAM to be more specific with the matching.

Tagging #1771 