### PR TITLE
add arrows to edges

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -339,6 +339,9 @@ $config['network_map_vis_options'] = '{
       randomSeed:2
   },
   "edges": {
+    arrows: {
+          to:     {enabled: true, scaleFactor:0.5},
+    },
     "smooth": {
         enabled: false
     },


### PR DESCRIPTION
I meant something like this

http://imgur.com/FQ337D6
here is the left connection (10.10.100.30 to 10.10.100.31) reversed, you can see that the both arrows (one in text line ">" an one on the end of line) are not in sync.

http://imgur.com/CkdOd4G
here are all arrows in line (right direction)

we need to proof if this works safe in all cases, it seems to working for me.

another idea would be to write the whole path in the text line.
e.g. 
10.10.100.30:GigaEth0/2 > 10.10.100.31:GigaEth0/1
instead of
GigaEth0/2 > GigaEth0/1

but i could be to long in some cases.

what do you think about it?