### PR TITLE
Added option to display errored ports in device summary

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -143,6 +143,7 @@ $config['show_locations']          = 1;  # Enable Locations on menu
 $config['show_locations_dropdown'] = 1;  # Enable Locations dropdown on menu
 $config['show_services']           = 0;  # Enable Services on menu
 $config['int_customers']           = 1;  # Enable Customer Port Parsing
+$config['summary_errors']          = 0;  # Show Errored ports in summary boxes on the dashboard
 $config['customers_descr']         = 'cust'; // The description to look for in ifDescr. Can be an array as well array('cust','cid');
 $config['transit_descr']           = ""; // Add custom transit descriptions (can be an array)
 $config['peering_descr']           = ""; // Add custom peering descriptions (can be an array)

--- a/html/includes/common/device-summary-horiz.inc.php
+++ b/html/includes/common/device-summary-horiz.inc.php
@@ -12,6 +12,7 @@ $temp_output = '
       <th>Down</th>
       <th>Ignored</th>
       <th>Disabled</th>
+      '.($config['summary_errors'] ? '<th>Errored</th>' : '').'
     </tr>
   </thead>
   <tbody>
@@ -22,6 +23,7 @@ $temp_output = '
       <td><a href="devices/state=down/format=list_detail/"><span class="red"> '.$devices['down'].'</span></a></td>
       <td><a href="devices/ignore=1/format=list_detail/"><span class="grey"> '.$devices['ignored'].'</span></a></td>
       <td><a href="devices/disabled=1/format=list_detail/"><span class="black"> '.$devices['disabled'].'</span></a></td>
+      '.($config['summary_errors'] ? '<td>-</td>' : '').'
     </tr>
     <tr class="active">
       <td><a href="ports/">Ports</a></td>
@@ -30,6 +32,7 @@ $temp_output = '
       <td><a href="ports/format=list_detail/state=down/"><span class="red"> '.$ports['down'].'</span></a></td>
       <td><a href="ports/format=list_detail/ignore=1/"><span class="grey"> '.$ports['ignored'].'</span></a></td>
       <td><a href="ports/format=list_detail/state=admindown/"><span class="black"> '.$ports['shutdown'].'</span></a></td>
+      '.($config['summary_errors'] ? '<td><a href="ports/format=list_detail/errors=1/"><span class="black"> '.$ports['errored'].'</span></a></td>' : '').'
     </tr>';
 if ($config['show_services']) {
 
@@ -41,6 +44,7 @@ $temp_output .= '
       <td><a href="services/state=down/view=details/"><span class="red"> '.$services['down'].'</span></a></td>
       <td><a href="services/ignore=1/view=details/"><span class="grey"> '.$services['ignored'].'</span></a></td>
       <td><a href="services/disabled=1/view=details/"><span class="black"> '.$services['disabled'].'</span></a></td>
+      '.($config['summary_errors'] ? '<td>-</td>' : '').'
     </tr>';
 }
 $temp_output .= '

--- a/html/includes/common/device-summary-vert.inc.php
+++ b/html/includes/common/device-summary-vert.inc.php
@@ -83,6 +83,21 @@ if ($config['show_services']) {
 
 }
 
+if ($config['summary_errors']) {
+    $temp_output .= '
+    </tr>
+    <tr class="active">
+      <th><span class="black">Errored</span></th>
+      <td>-</td>
+      <td><a href="ports/format=list_detail/errors=1/"><span class="black"> '.$ports['errored'].'</span></a></td>
+';
+    if ($config['show_services']) {
+        $temp_output .= '
+      <td>-</td>
+';
+    }
+}
+
 $temp_output .= '
     </tr>
     <tr class="active">

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -783,3 +783,6 @@ $config['gui']['network-map']['style']                  = 'new';//old is also va
 
 // Navbar variables
 $config['navbar']['manage_groups']['hide']              = 0;
+
+// Show errored ports in the summary table on the dashboard
+$config['summary_errors']                               = 0;


### PR DESCRIPTION
Introduces a new config, `$config['summary_errors']` that allows the user to add errored ports to the summary table/widget

Tagging #1785 