### PR TITLE
Fix broken repeated RRA config

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -191,14 +191,7 @@ $config['snmp']['v3'][0]['cryptopass'] = '';
 // Privacy (Encryption) Passphrase
 $config['snmp']['v3'][0]['cryptoalgo'] = 'AES';
 // AES | DES
-// RRD Format Settings
-// These should not normally be changed
-// Though one could conceivably increase or decrease the size of each RRA if one had performance problems
-// Or if one had a very fast I/O subsystem with no performance worries.
-$config['rrd_rra']  = ' RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1440 RRA:AVERAGE:0.5:24:1440 RRA:AVERAGE:0.5:288:1440 ';
-$config['rrd_rra'] .= ' RRA:MAX:0.5:1:720 RRA:MIN:0.5:6:1440     RRA:MIN:0.5:24:775     RRA:MIN:0.5:288:797 ';
-$config['rrd_rra'] .= ' RRA:MAX:0.5:1:720 RRA:MAX:0.5:6:1440     RRA:MAX:0.5:24:775     RRA:MAX:0.5:288:797 ';
-$config['rrd_rra'] .= ' RRA:LAST:0.5:1:1440 ';
+
 
 // Autodiscovery Settings
 $config['autodiscovery']['xdp'] = true;


### PR DESCRIPTION
Since d8693f0 the RRA config section repeats in the file - the second contains MAX instead of the first MIN definition.