### PR TITLE
Ability to override the ports ifAlias

### DIFF
--- a/html/includes/forms/update-ifalias.inc.php
+++ b/html/includes/forms/update-ifalias.inc.php
@@ -29,7 +29,7 @@ if (!empty($ifName) && is_numeric($port_id)) {
     }
     if (dbUpdate(array('ifAlias'=>$descr), 'ports', '`port_id`=?', array($port_id)) > 0) {
         $device = device_by_id_cache($device_id);
-        if (empty($descr)) {
+        if ($descr === 'repoll') {
             del_dev_attrib($device, 'ifName');
         }
         else {

--- a/html/includes/forms/update-ifalias.inc.php
+++ b/html/includes/forms/update-ifalias.inc.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2014 Neil Lathwood <https://github.com/laf/ http://www.lathwood.co.uk/fa>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+*/
+
+$status  = 'error';
+
+$descr = mres($_POST['descr']);
+$device_id = mres($POST['device_id']);
+$ifName = mres($_POST['ifName']);
+$port_id = mres($_POST['port_id']);
+
+if (!empty($ifName) && is_numeric($port_id)) {
+    // We have ifName and  port id so update ifAlias
+    if (dbUpdate(array('ifAlias'=>$descr), '`ports`', '`port_id`=?', array($port_id)) > 0) {
+        $device = device_by_id_cache($device_id);
+        if (empty($descr)) {
+            del_device_attrib($device, 'ifName');
+        }
+        else {
+            set_device_attrib($device, 'ifName', $ifName);
+        }
+        $status = 'ok';
+    }
+    else {
+        $status = 'na';
+    }
+}

--- a/html/includes/forms/update-ifalias.inc.php
+++ b/html/includes/forms/update-ifalias.inc.php
@@ -23,6 +23,10 @@ logfile($descr . ','. $device_id . ','. $ifName. ','. $port_id);
 
 if (!empty($ifName) && is_numeric($port_id)) {
     // We have ifName and  port id so update ifAlias
+    if (empty($descr)) {
+        $descr = 'repoll';
+        // Set to repoll so we avoid using ifDescr on port poll
+    }
     if (dbUpdate(array('ifAlias'=>$descr), 'ports', '`port_id`=?', array($port_id)) > 0) {
         $device = device_by_id_cache($device_id);
         if (empty($descr)) {

--- a/html/includes/forms/update-ifalias.inc.php
+++ b/html/includes/forms/update-ifalias.inc.php
@@ -15,19 +15,21 @@
 $status  = 'error';
 
 $descr = mres($_POST['descr']);
-$device_id = mres($POST['device_id']);
+$device_id = mres($_POST['device_id']);
 $ifName = mres($_POST['ifName']);
 $port_id = mres($_POST['port_id']);
 
+logfile($descr . ','. $device_id . ','. $ifName. ','. $port_id);
+
 if (!empty($ifName) && is_numeric($port_id)) {
     // We have ifName and  port id so update ifAlias
-    if (dbUpdate(array('ifAlias'=>$descr), '`ports`', '`port_id`=?', array($port_id)) > 0) {
+    if (dbUpdate(array('ifAlias'=>$descr), 'ports', '`port_id`=?', array($port_id)) > 0) {
         $device = device_by_id_cache($device_id);
         if (empty($descr)) {
-            del_device_attrib($device, 'ifName');
+            del_dev_attrib($device, 'ifName');
         }
         else {
-            set_device_attrib($device, 'ifName', $ifName);
+            set_dev_attrib($device, 'ifName', $ifName);
         }
         $status = 'ok';
     }
@@ -35,3 +37,8 @@ if (!empty($ifName) && is_numeric($port_id)) {
         $status = 'na';
     }
 }
+
+$response = array(
+    'status'        => $status,
+);
+echo _json_encode($response);

--- a/html/includes/table/edit-ports.inc.php
+++ b/html/includes/table/edit-ports.inc.php
@@ -64,7 +64,7 @@ foreach (dbFetchRows($sql, $param) as $port) {
                        <input type="hidden" name="olddis_'.$port['port_id'].'" value="'.($port['disabled'] ? 1 : 0).'"">',
         'ignore' => '<input type="checkbox" class="ignore-check" name="ignore_'.$port['port_id'].'"'.($port['ignore'] ? 'checked' : '').'>
                      <input type="hidden" name="oldign_'.$port['port_id'].'" value="'.($port['ignore'] ? 1 : 0).'"">',
-        'ifAlias' => '<input class="form-control input-sm if-alias" id="if-alias" name="if-alias" data-ifIndex="'.$port['ifIndex'].'" data-ifName="'.$port['ifname'].'" value="'.$port['ifAlias'].'">'
+        'ifAlias' => '<div class="form-group"><input class="form-control input-sm" id="if-alias" name="if-alias" data-device_id="'.$port['device_id'].'" data-port_id="'.$port['port_id'].'" data-ifName="'.$port['ifName'].'" value="'.$port['ifAlias'].'"><span class="glyphicon form-control-feedback" aria-hidden="true"></span></div>'
     );
 
 }//end foreach

--- a/html/includes/table/edit-ports.inc.php
+++ b/html/includes/table/edit-ports.inc.php
@@ -64,7 +64,7 @@ foreach (dbFetchRows($sql, $param) as $port) {
                        <input type="hidden" name="olddis_'.$port['port_id'].'" value="'.($port['disabled'] ? 1 : 0).'"">',
         'ignore' => '<input type="checkbox" class="ignore-check" name="ignore_'.$port['port_id'].'"'.($port['ignore'] ? 'checked' : '').'>
                      <input type="hidden" name="oldign_'.$port['port_id'].'" value="'.($port['ignore'] ? 1 : 0).'"">',
-        'ifAlias' => $port['ifAlias']
+        'ifAlias' => '<input class="form-control input-sm if-alias" id="if-alias" name="if-alias" data-ifIndex="'.$port['ifIndex'].'" data-ifName="'.$port['ifname'].'" value="'.$port['ifAlias'].'">'
     );
 
 }//end foreach

--- a/html/pages/device/edit/ports.inc.php
+++ b/html/pages/device/edit/ports.inc.php
@@ -5,7 +5,8 @@
     <input type='hidden' name='ignoreport' value='yes'>
     <input type='hidden' name='type' value='update-ports'>
     <input type='hidden' name='device' value='<?php echo $device['device_id'];?>'>
-    <table id='edit-ports' class='table table-condensed table-responsive table-striped'>
+    <div class='table-responsibe'>
+    <table id='edit-ports' class='table table-striped'>
         <thead>
             <tr>
                 <th data-column-id='ifIndex'>Index</th>
@@ -18,19 +19,23 @@
             </tr>
         </thead>
     </table>
+    </div>
 </form>
 <script>
 
     $(document).on('blur', "[name='if-alias']", function (){
         var $this = $(this);
-        var ifIndex = $this.data('ifIndex');
+        var descr = $this.val();
+        var device_id = $this.data('device_id');
+        var port_id = $this.data('port_id');
         var ifName = $this.data('ifName');
         $.ajax({
             type: 'POST',
             url: 'ajax_form.php',
-            data: {type: "update-ifalias", ifIndex: ifIndex, ifName: ifName},
+            data: {type: "update-ifalias", descr: descr, ifName: ifName, port_id: port_id},
             dataType: "json",
             success: function (data) {
+            alert(data.status);
                 if (data.status == 'ok') {
                     $this.closest('.form-group').addClass('has-success');
                     $this.next().addClass('glyphicon-ok');
@@ -38,6 +43,8 @@
                         $this.closest('.form-group').removeClass('has-success');
                         $this.next().removeClass('glyphicon-ok');
                     }, 2000);
+                } else if (data.status == 'na') {
+
                 } else {
                     $(this).closest('.form-group').addClass('has-error');
                     $this.next().addClass('glyphicon-remove');

--- a/html/pages/device/edit/ports.inc.php
+++ b/html/pages/device/edit/ports.inc.php
@@ -1,3 +1,4 @@
+</form>
 <span id="message"><small><div class="alert alert-danger">n.b For the first time, please click any button twice.</div></small></span>
 
 <form id='ignoreport' name='ignoreport' method='post' action='' role='form' class='form-inline'>
@@ -20,6 +21,42 @@
 </form>
 <script>
 
+    $(document).on('blur', "[name='if-alias']", function (){
+        var $this = $(this);
+        var ifIndex = $this.data('ifIndex');
+        var ifName = $this.data('ifName');
+        $.ajax({
+            type: 'POST',
+            url: 'ajax_form.php',
+            data: {type: "update-ifalias", ifIndex: ifIndex, ifName: ifName},
+            dataType: "json",
+            success: function (data) {
+                if (data.status == 'ok') {
+                    $this.closest('.form-group').addClass('has-success');
+                    $this.next().addClass('glyphicon-ok');
+                    setTimeout(function(){
+                        $this.closest('.form-group').removeClass('has-success');
+                        $this.next().removeClass('glyphicon-ok');
+                    }, 2000);
+                } else {
+                    $(this).closest('.form-group').addClass('has-error');
+                    $this.next().addClass('glyphicon-remove');
+                    setTimeout(function(){
+                        $this.closest('.form-group').removeClass('has-error');
+                        $this.next().removeClass('glyphicon-remove');
+                    }, 2000);
+                }
+            },
+            error: function () {
+                $(this).closest('.form-group').addClass('has-error');
+                $this.next().addClass('glyphicon-remove');
+                setTimeout(function(){
+                   $this.closest('.form-group').removeClass('has-error');
+                   $this.next().removeClass('glyphicon-remove');
+                }, 2000);
+            }
+        });
+    });
     $(document).ready(function() {
         $('form#ignoreport').submit(function (event) {
             $('#disable-toggle').click(function (event) {
@@ -96,6 +133,7 @@
             });
             event.preventDefault();
         });
+
     });
 
     var grid = $("#edit-ports").bootgrid({

--- a/html/pages/device/edit/ports.inc.php
+++ b/html/pages/device/edit/ports.inc.php
@@ -28,14 +28,13 @@
         var descr = $this.val();
         var device_id = $this.data('device_id');
         var port_id = $this.data('port_id');
-        var ifName = $this.data('ifName');
+        var ifName = $this.data('ifname');
         $.ajax({
             type: 'POST',
             url: 'ajax_form.php',
-            data: {type: "update-ifalias", descr: descr, ifName: ifName, port_id: port_id},
+            data: {type: "update-ifalias", descr: descr, ifName: ifName, port_id: port_id, device_id: device_id},
             dataType: "json",
             success: function (data) {
-            alert(data.status);
                 if (data.status == 'ok') {
                     $this.closest('.form-group').addClass('has-success');
                     $this.next().addClass('glyphicon-ok');

--- a/includes/common.php
+++ b/includes/common.php
@@ -435,8 +435,13 @@ function get_dev_entity_state($device) {
     return $state;
 }
 
-function get_dev_attrib($device, $attrib_type) {
-    if ($row = dbFetchRow("SELECT attrib_value FROM devices_attribs WHERE `device_id` = ? AND `attrib_type` = ?", array($device['device_id'], $attrib_type))) {
+function get_dev_attrib($device, $attrib_type, $attrib_value='') {
+    $params = array($device['device_id'], $attrib_type);
+    if (!empty($attrib_value)) {
+        $sql = " AND `attrib_value`=?";
+        array_push($params, $attrib_value);
+    }
+    if ($row = dbFetchRow("SELECT attrib_value FROM devices_attribs WHERE `device_id` = ? AND `attrib_type` = ? $sql", $params)) {
         return $row['attrib_value'];
     }
     else {

--- a/includes/common.php
+++ b/includes/common.php
@@ -436,6 +436,7 @@ function get_dev_entity_state($device) {
 }
 
 function get_dev_attrib($device, $attrib_type, $attrib_value='') {
+    $sql = '';
     $params = array($device['device_id'], $attrib_type);
     if (!empty($attrib_value)) {
         $sql = " AND `attrib_value`=?";

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -333,6 +333,13 @@ foreach ($ports as $port) {
 
         // Update IF-MIB data
         foreach ($data_oids as $oid) {
+
+            if ($oid == 'ifAlias') {
+                if (get_dev_attrib($device, 'ifName', $port['ifName'])) {
+                    $this_port['ifAlias'] = $port['ifAlias'];
+                }
+            }
+
             if ($port[$oid] != $this_port[$oid] && !isset($this_port[$oid])) {
                 $port['update'][$oid] = array('NULL');
                 log_event($oid.': '.$port[$oid].' -> NULL', $device, 'interface', $port['port_id']);


### PR DESCRIPTION
Fix #1689 

WebUI has been updated in Device -> Edit -> Port Settings. You can now edit the Description which is updated on change. A devices_attrib entry is then stored to indicate that the port description has been manually set.

If the user removes the description it will then be re-polled.

Honours the port parser code so you can manually set say Cust: Customer A and have it pick the port up as a customer port and do everything else you would expect.

Updated get_dev_attrib() to accept the value to be looked up as well to save checking the output of get_dev_attrib to see if the ifName is the one we are currently checking against. values are stored against ifName so this shouldn't break if a port is deleted and re-added say for a ppoe port.