### PR TITLE
Change poller-service upstart script to wait before respawn and keep trying.

### DIFF
--- a/poller-service.conf
+++ b/poller-service.conf
@@ -12,9 +12,15 @@ stop on runlevel [016]
 # Automatically restart process if crashed
 respawn
 
+# Restart an unlimited amount of times
+respawn limit unlimited
+
 chdir /opt/librenms
 setuid librenms
 setgid librenms
 
 # Start the process
 exec /opt/librenms/poller-service.py
+
+# Wait 60 seconds before restart
+post-stop exec sleep 60


### PR DESCRIPTION
I had a tunnel to mysql database go down.  What happened is that the poller-service stopped because it respawned too many times in a short interval and upstart stopped it.  This happened before the tunnel was back up.  

This change makes it wait 60 seconds before restarting but also respawn an unlimited number of times.  Logic is to give whatever cause the process to fail some time to fix.  And to keep trying.