### PR TITLE
Added mouseclick / mouseleave to stop map zooming around

### DIFF
--- a/html/includes/common/worldmap.inc.php
+++ b/html/includes/common/worldmap.inc.php
@@ -64,6 +64,15 @@ foreach (dbFetchRows("SELECT `device_id`,`hostname`,`os`,`status`,`lat`,`lng` FR
 }
 
 $temp_output .= 'map.addLayer(markers);
+map.scrollWheelZoom.disable();
+$(document).ready(function(){
+    $("#leaflet-map").on("click", function(event) {  
+        map.scrollWheelZoom.enable();
+    });
+    $("#leaflet-map").mouseleave(function(event) {  
+        map.scrollWheelZoom.disable();
+    });
+});
 </script>';
 
 } else {


### PR DESCRIPTION
Fix #1795 

This will stop the map zooming around as you try and scroll over it. Now you need to click to enable zooming and when you're done and move the mouse away it will disable zooming again.