### PR TITLE
Make test-alert an 'alert' instead of 'recovery'

### DIFF
--- a/html/includes/forms/test-transport.inc.php
+++ b/html/includes/forms/test-transport.inc.php
@@ -34,7 +34,7 @@ $obj = array(
     "name"      => "Test-Rule",
     "timestamp" => date("Y-m-d H:i:s"),
     "contacts"  => $tmp['contacts'],
-    "state"     => "0",
+    "state"     => "1",
     "msg"       => "This is a test alert",
 );
 


### PR DESCRIPTION
Fixes #1848 