### PR TITLE
Adding basic device support for Avaya IP Office controllers

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -634,6 +634,12 @@ $config['os'][$os]['icon']             = 'avaya';
 $config['os'][$os]['over'][0]['graph'] = 'device_bits';
 $config['os'][$os]['over'][0]['text']  = 'Device Traffic';
 
+$os = 'avaya-ipo';
+$config['os'][$os]['text']             = 'IP Office Firmware';
+$config['os'][$os]['type']             = 'network';
+$config['os'][$os]['icon']             = 'avaya';
+
+
 $os = 'arista_eos';
 $config['os'][$os]['text']             = 'Arista EOS';
 $config['os'][$os]['type']             = 'network';

--- a/includes/discovery/os/avaya-ipo.inc.php
+++ b/includes/discovery/os/avaya-ipo.inc.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!$os) {
+    if (strstr(snmp_get($device, 'ENTITY-MIB::entPhysicalDescr.1', '-Oqvn'), 'Avaya IP Office')) {
+        $os = "avaya-ipo";
+    }
+}

--- a/includes/polling/os/avaya-ipo.inc.php
+++ b/includes/polling/os/avaya-ipo.inc.php
@@ -1,8 +1,10 @@
 <?php
-
 echo 'Scanning Avaya IP Office...';
 
-$sysObjectID = snmp_get($device, 'sysObjectID.0', '-Oqvn');
+$physDevice = snmp_get($device, 'ENTITY-MIB::entPhysicalDescr.1', '-Oqvn');
 
-$version = snmp_get($device, 'SNMPv2-MIB::sysDescr.0', '-Oqvn');
-$hardware = snmp_get($device, 'ENTITY-MIB::entPhysicalDescr.1', '-Oqvn');
+if (strstr($physDevice, 'Avaya IP Office')) {
+    $hardware = $physDevice;
+}
+
+$version = $poll_device['sysDescr'];

--- a/includes/polling/os/avaya-ipo.inc.php
+++ b/includes/polling/os/avaya-ipo.inc.php
@@ -1,0 +1,8 @@
+<?php
+
+echo 'Scanning Avaya IP Office...';
+
+$sysObjectID = snmp_get($device, 'sysObjectID.0', '-Oqvn');
+
+$version = snmp_get($device, 'SNMPv2-MIB::sysDescr.0', '-Oqvn');
+$hardware = snmp_get($device, 'ENTITY-MIB::entPhysicalDescr.1', '-Oqvn');

--- a/mibs/avaya/AV-SME-PLATFORM-MIB.mib
+++ b/mibs/avaya/AV-SME-PLATFORM-MIB.mib
@@ -1,0 +1,334 @@
+--========================================================
+--
+-- MIB      : SME Platform Avaya Inc.
+--
+-- Version  : 0.03.00   11 January 2013
+--
+--========================================================
+--
+-- Copyright (c) 2013 Avaya Inc.
+-- All Rights Reserved.
+--
+--========================================================
+AV-SME-PLATFORM-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+    DateAndTime
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB
+    sysDescr
+        FROM SNMPv2-MIB
+    ItuPerceivedSeverity
+        FROM ITU-ALARM-TC-MIB
+    ifIndex
+        FROM IF-MIB
+    mibs
+        FROM AVAYAGEN-MIB
+;
+
+avSMEPlatformMIB MODULE-IDENTITY
+    LAST-UPDATED    "201301111405Z" -- 11 January 2013
+    ORGANIZATION    "Avaya Inc."
+    CONTACT-INFO
+        "Avaya Customer Services
+         Postal: Avaya, Inc.
+                 211 Mt Airy Rd.
+                 Basking Ridge, NJ 07920
+                 USA
+         Tel:    +1 908 953 6000
+
+         WWW:    http://www.avaya.com"
+    DESCRIPTION
+        "Avaya IP Office MIBs OID tree.
+
+         This MIB module defines the root items for MIBs for
+         use with Avaya SME Embedded Platform."
+
+
+    REVISION     "201301111405Z" -- 11 January 2013
+    DESCRIPTION
+        "Rev 0.03.00
+         Added the WebManagement application value for smepGTEventAppIdentity."
+    REVISION     "201007061347Z" -- 06 July 2010
+    DESCRIPTION
+        "Rev 0.02.00
+        Corrected base OID to one properly allocated in Avaya tree."
+    REVISION     "201007021437Z" -- 02 July 2010
+    DESCRIPTION
+        "Rev 0.01.00
+        The first rough draft of this MIB module."
+    ::= { mibs 48 }
+
+-- sub-tree for SME Embedded Platform wide objects and events
+-- irrespective of function
+smepGeneric         OBJECT IDENTIFIER ::= { avSMEPlatformMIB 1 }
+
+-- sub-tree for SME Embedded Platform functional MIBs
+smepGenMibs         OBJECT IDENTIFIER ::= { smepGeneric 1 }
+
+-- sub-tree for SME EMbedded Platform wide traps/notifications
+smepGenTraps        OBJECT IDENTIFIER ::= { smepGeneric 2 }
+
+-- sub-tree for SME Embedded Platform wide conformance information
+smepGenConformance  OBJECT IDENTIFIER ::= { smepGeneric 3 }
+
+--********************************************************************
+-- SME Embedded Platform wide traps/notifications
+--********************************************************************
+
+smepGTEvents  OBJECT IDENTIFIER ::= { smepGenTraps 0 }
+smepGTObjects OBJECT IDENTIFIER ::= { smepGenTraps 1 }
+
+--
+-- trap objects
+--
+
+smepGTEventStdSeverity OBJECT-TYPE
+    SYNTAX      ItuPerceivedSeverity
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Severity of the event that has occurred.
+
+        The event severity depends upon the type of
+        entity/notification that the operational state change event
+        relates to. The severity values that are normally used are
+        detailed below:
+
+        The enterprise versions of standard SNMP traps all have a
+        severity of major (4).
+
+        GenAppEvents:
+          Severity depends on event condition
+              crash       - severity is critical (3)"
+    ::= { smepGTObjects 1 }
+
+smepGTEventDateTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Date and time of the occurence of the event."
+    ::= { smepGTObjects 2 }
+
+smepGTEventDevID OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (10))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A unique textual identifier of the alarming device."
+    ::= { smepGTObjects 3 }
+
+smepGTEventAppEntity OBJECT-TYPE
+    SYNTAX      INTEGER {
+          voiceMailPro(1),
+          onex(2),
+          ipOffice(3),
+          jade(4),
+          webmanagement(5)
+		  }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The SME Embedded Platform application to which a
+        notification/trap relates."
+    ::= { smepGTObjects 4 }
+
+smepGTEventAppEvent OBJECT-TYPE
+    SYNTAX      INTEGER {
+          crash(1) -- severity: Critical
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "SME Embedded Platform application event states. The
+        associated event severity of the notification/trap the object
+        is carried in varies depending upon the event condition. The
+        appropriate severity is detailed against event enumeration."
+    ::= { smepGTObjects 5 }
+
+--
+-- traps
+--
+
+smepGenColdStartEvent NOTIFICATION-TYPE
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDateTime,
+        smepGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard coldstart trap featuring
+         device identification information. A coldStart trap
+         signifies that the sending protocol entity is reinitializing
+         itself such that the agent's configuration or the protocol
+         entity implementation may be altered."
+    ::= { smepGTEvents 1 }
+
+smepGenWarmStartEvent NOTIFICATION-TYPE
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDateTime,
+        smepGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard warmstart trap featuring
+         device identification information. A warmStart trap
+         signifies that the sending protocol entity is reinitializing
+         that neither the agent configuration nor the protocol entity
+         implementation is altered."
+    ::= { smepGTEvents 2 }
+
+smepGenLinkDownEvent NOTIFICATION-TYPE
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDateTime,
+        smepGTEventDevID,
+        sysDescr,
+        ifIndex
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard linkDown trap featuring device
+         identification information. A linkDown trap signifies that
+         the sending protocol entity recognizes a failure in one of
+         the communication links represented in the agent's
+         configuration."
+    ::= { smepGTEvents 3 }
+
+smepGenLinkUpEvent NOTIFICATION-TYPE
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDateTime,
+        smepGTEventDevID,
+        sysDescr,
+        ifIndex
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard linkUp trap featuring device
+         identification information. A linkUp trap signifies that the
+         sending protocol entity recognizes that one of the
+         communication links represented in the agent's configuration
+         has come up."
+    ::= { smepGTEvents 4 }
+
+smepGenAuthFailureEvent NOTIFICATION-TYPE
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDateTime,
+        smepGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard authenticationFailure trap
+         featuring device identification information. An
+         authenticationFailure trap signifies that the sending
+         protocol entity is the addressee of a protocol message that
+         is not properly authenticated. While implementations of the
+         SNMP must be capable of generating this trap, they must also
+         be capable of suppressing the emission of such traps via an
+         implementation- specific mechanism."
+    ::= { smepGTEvents 5 }
+
+smepGenAppEvent NOTIFICATION-TYPE
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDateTime,
+        smepGTEventDevID,
+        sysDescr,
+        smepGTEventAppEntity,
+        smepGTEventAppEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "A smepGenAppEvent notification is generated whenever a
+        application entity of the SME Embedded Platform experiences an
+        event. It signifies that the SNMP entity, acting as a proxy
+        for the application, has detected an event on the application
+        entity.
+
+        The event severity varies dependent upon the event condition."
+    ::= { smepGTEvents 6 }
+
+
+--********************************************************************
+-- SME Embedded Platform wide compliance
+--********************************************************************
+
+smepGenCompliances OBJECT IDENTIFIER ::= { smepGenConformance 1 }
+smepGenGroups      OBJECT IDENTIFIER ::= { smepGenConformance 2 }
+
+--
+-- compliance statements
+--
+
+smepGenCompliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for SME Embedded Platform agents
+         which implement this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        smepGenNotificationObjectsGroup,
+        smepGenEntGenNotificationsGroup,
+        smepGenAppNotificationsGroup
+    }	
+    ::= { smepGenCompliances 1 }
+
+--
+-- MIB groupings
+--
+
+smepGenNotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        smepGTEventStdSeverity,
+        smepGTEventDevID,
+        smepGTEventDateTime,
+        smepGTEventAppEntity,
+        smepGTEventAppEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "Objects that are contained in SME Embedded Platform wide
+        notifications."
+    ::= { smepGenGroups 1 }
+
+smepGenEntGenNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        smepGenColdStartEvent,
+        smepGenWarmStartEvent,
+        smepGenLinkDownEvent,
+        smepGenLinkUpEvent,
+        smepGenAuthFailureEvent
+   }
+    STATUS current
+    DESCRIPTION
+        "SME Embedded Platform Enterpise versions of the generic traps
+        as defined RFC1215 that provide more identification of the entity
+        concerned."
+    ::= { smepGenGroups 2 }
+
+smepGenAppNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        smepGenAppEvent
+   }
+    STATUS current
+    DESCRIPTION
+        "The service notifications which indicate specific changes in
+        the state of Applications on the SME Embedded Platform."
+    ::= { smepGenGroups 3 }
+
+END

--- a/mibs/avaya/AV-SME-PLATFORM-PROD-MIB.mib
+++ b/mibs/avaya/AV-SME-PLATFORM-PROD-MIB.mib
@@ -1,0 +1,288 @@
+--========================================================
+--
+-- MIB      : AV-SME-PLATFORM-PROD  Avaya Inc.
+--
+-- Version  : 0.14.00   30 May 2014
+--
+--========================================================
+--
+-- Copyright (c) 2010 - 2012 Avaya Inc.
+-- All Rights Reserved.
+--
+--========================================================
+AV-SME-PLATFORM-PROD-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-IDENTITY
+        FROM SNMPv2-SMI
+    products
+        FROM AVAYAGEN-MIB;
+
+avSMEPlatformProdMIB MODULE-IDENTITY
+    LAST-UPDATED        "201405301200Z" -- 30 May 2014
+    ORGANIZATION 	"Avaya Inc."
+    CONTACT-INFO
+        "Avaya Customer Services
+         Postal: Avaya, Inc.
+                 211 Mt Airy Rd.
+                 Basking Ridge, NJ 07920
+                 USA
+         Tel:    +1 908 953 6000
+
+         WWW:    http://www.avaya.com"
+    DESCRIPTION
+        "Avaya IP Office Products OID tree.
+
+         This MIB module defines the product/sysObjectID values for
+         use with Avaya IP Office family of telephone switches."
+
+    REVISION     "201405301200Z" -- 30 May 2014
+    DESCRIPTION
+        "Rev 0.14.00
+         Added configuration 11, 12, 13 for IP Office Server Edition Primary,
+         IP Office Server Edition Secondary and
+         IP Office Server Edition Expansion System (L) Select Mode"
+    REVISION     "201404031200Z" -- 03 April 2014
+    DESCRIPTION
+        "Rev 0.13.00
+         Updated service vendor values
+         Added Contact Recorder service"
+    REVISION     "201301231600Z" -- 23 January 2013
+    DESCRIPTION
+        "Rev 0.12.00
+         Updated branding for configuration 1 and 10"
+    REVISION     "201211291200Z" -- 29 November 2012
+    DESCRIPTION
+        "Rev 0.11.00
+         Updated branding for configuration 1.
+         Added configuration 10."
+    REVISION     "201205101235Z" -- 10 May 2012
+    DESCRIPTION
+        "Rev 0.10.00
+        Updated branding for configurations 7, 8 and 9."
+    REVISION     "201204091025Z" -- 09 Apr 2012
+    DESCRIPTION
+        "Rev 0.09.00
+        Updated branding for configurations 7, 8 and 9."
+    REVISION     "201203051005Z" -- 05 Mar 2012
+    DESCRIPTION
+        "Rev 0.08.00
+        Updated configurations 7, 8 and 9."
+    REVISION     "201112161330Z" -- 16 Dec 2011
+    DESCRIPTION
+        "Rev 0.07.01
+        Updated configuration 6."
+    REVISION     "201112141535Z" -- 14 Dec 2011
+    DESCRIPTION
+        "Rev 0.07.00
+        Added configuration 9, updated configurations 7 and 8."
+    REVISION     "201112071410Z" -- 07 Dec 2011
+    DESCRIPTION
+        "Rev 0.06.00
+        Added configurations 7 and 8."
+    REVISION     "201105031330Z" -- 03 May 2011
+    DESCRIPTION
+        "Rev 0.05.00
+        Added configuration 6."
+    REVISION     "201103300922Z" -- 30 March 2011
+    DESCRIPTION
+        "Rev 0.04.00
+        Added configuration 4 and 5."
+    REVISION     "201007071350Z" -- 07 July 2010
+    DESCRIPTION
+        "Rev 0.03.00
+        Simplified the structure."
+    REVISION     "201007061345Z" -- 06 July 2010
+    DESCRIPTION
+        "Rev 0.02.00
+        Corrected base OID to one properly allocated in Avaya tree."
+    REVISION     "201007021506Z" -- 02 July 2010
+    DESCRIPTION
+        "Rev 0.01.00
+        The first rough draft of this MIB module."
+    ::= { products 48 }
+
+-- Product Groups
+
+smepProdVariants      OBJECT IDENTIFIER ::= { avSMEPlatformProdMIB 1 }
+smepProdServices      OBJECT IDENTIFIER ::= { avSMEPlatformProdMIB 2 }
+smepProdPorts         OBJECT IDENTIFIER ::= { avSMEPlatformProdMIB 3 }
+smepProdDongleModules OBJECT IDENTIFIER ::= { avSMEPlatformProdMIB 4 }
+
+-- Configuration 1
+
+smepCfg1    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 1
+	of the SME Embedded Platform.
+        Configuration 1 = IP Office Application Server on Linux PC"
+    ::= { smepProdVariants 1 }
+
+-- Configuration 2
+
+smepCfg2   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 2
+	of the SME Embedded Platform.
+        Configuration 2 = IP Office on PC."
+    ::= { smepProdVariants 2 }
+
+-- Configuration 3
+
+smepCfg3   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 3
+	of the SME Embedded Platform.
+        Configuration 3 = IP Office on HP ProCurve"
+    ::= { smepProdVariants 3 }
+
+-- Configuration 4
+
+smepCfg4   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 4
+	of the SME Embedded Platform.
+        Configuration 4 = IP Office on Dell"
+    ::= { smepProdVariants 4 }
+
+-- Configuration 5
+
+smepCfg5   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 5
+	of the SME Embedded Platform.
+        Configuration 5 = Branch installations"
+    ::= { smepProdVariants 5 }
+
+-- Configuration 6
+
+smepCfg6   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 6
+	of the SME Embedded Platform.
+        Configuration 6 = Standalone Voice Mail"
+    ::= { smepProdVariants 6 }
+
+-- Configuration 7
+
+smepCfg7   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 7
+	of the SME Embedded Platform.
+        Configuration 7 = IP Office Server Edition Primary"
+    ::= { smepProdVariants 7 }
+
+-- Configuration 8
+
+smepCfg8   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 8
+	of the SME Embedded Platform.
+        Configuration 8 = IP Office Server Edition Secondary"
+    ::= { smepProdVariants 8 }
+
+-- Configuration 9
+
+smepCfg9   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Configuration 9
+	of the SME Embedded Platform.
+        Configuration 9 = IP Office Server Edition Expansion System (L)"
+    ::= { smepProdVariants 9 }
+
+-- Configuration 10
+
+smepCfg10 OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Configuration 10
+        of the SME Embedded Platform.
+        Configuration 10 = IP Office Application Server on UCM"
+    ::= { smepProdVariants 10 }
+
+-- Configuration 11
+
+smepCfg11 OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Configuration 11
+        of the SME Embedded Platform.
+        Configuration 11 = IP Office Server Edition Primary Select Mode"
+    ::= { smepProdVariants 11 }
+
+-- Configuration 12
+
+smepCfg12 OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Configuration 12
+        of the SME Embedded Platform.
+        Configuration 12 = IP Office Server Edition Secondary Select Mode"
+    ::= { smepProdVariants 12 }
+
+-- Configuration 13
+
+smepCfg13 OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Configuration 13
+        of the SME Embedded Platform.
+        Configuration 13 = IP Office Server Edition Expansion System (L) Select Mode"
+    ::= { smepProdVariants 13 }
+
+-- Application Services Groups
+
+smepProdServiceOneXPortal   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Avaya one-X Portal service
+         resident on Avaya IP Office on Linux server."
+    ::= { smepProdServices 1 }
+
+smepProdServiceVoicemailPro   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Avaya Voicemail Pro service
+        resident on Avaya IP Office on Linux server."
+    ::= { smepProdServices 2 }
+
+smepProdServiceContactRecorder   OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Avaya Contact Recorder service
+        resident on Avaya IP Office on Linux server."
+    ::= { smepProdServices 3 }
+
+
+-- Ports
+
+smepProdPortLAN  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Avaya IP Office LAN
+        (10BASE-T/100BASE-TX) Ports"
+    ::= { smepProdPorts 1 }
+
+
+-- Dongle
+
+smepProdGenericDongle    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for the Avaya IP Office License
+        Dongle - A single representation for three dongle types,
+        Parallel, Serial and USB. The Parallel and USB ones not truly
+        connected directly to the IP Office but the managing PC."
+    ::= { smepProdDongleModules 1 }
+
+
+END

--- a/mibs/avaya/AVAYAGEN-MIB.mib
+++ b/mibs/avaya/AVAYAGEN-MIB.mib
@@ -1,0 +1,104 @@
+--========================================================
+--
+-- MIB      : AvayaGen  Avaya Inc.
+--
+-- Version  : 1.4.0    27 January 2004
+-- ========================================================
+--- This AVAYA SNMP Management Information Base Specification (Specification) 
+-- embodies AVAYA confidential and Proprietary intellectual property.  
+-- AVAYA retains all Title and ownership in the Specification, including any 
+-- revisions.
+-- 
+-- It is AVAYA's intent to encourage the widespread use of this Specification 
+-- in connection with the management of AVAYA products. AVAYA grants vendors, 
+-- end-users, and other interested parties a non-exclusive license to use this 
+-- Specification in connection with the management of AVAYA products.
+-- 
+-- This Specification is supplied "as is," and AVAYA makes no warranty, either 
+-- express or implied, as to the use, operation, condition, or performance of 
+-- the Specification.
+--========================================================
+AVAYAGEN-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+	enterprises,MODULE-IDENTITY
+	FROM SNMPv2-SMI;
+avaya  MODULE-IDENTITY
+LAST-UPDATED 	"0401270900Z" -- 27 January 2004  
+ORGANIZATION 	"Avaya Inc."
+CONTACT-INFO 
+				"Avaya Customer Services
+				Postal: Avaya, Inc.
+				        211 Mt Airy Rd.
+				        Basking Ridge, NJ 07920
+				        USA
+				Tel:    +1 908 953 6000
+				WWW:    http://www.avaya.com
+				"
+DESCRIPTION
+    "Avaya top-level OID tree.
+    This MIB module deals defines the Avaya enterprise-specific tree.
+    Development organizations within Avaya who wish to register MIBs 
+    under the Avaya enterprise OID, should:
+    a. Contact the maintainer of this module, and get an organization OID and
+       group OID.
+    b. Import the definition of their Organization OID from this MIB.
+    "
+REVISION 	"0401270900Z" -- 27 January 2004
+DESCRIPTION
+    "Rev 1.4.0 - Meir Deutsch.
+    adds avGatewayProducts under avayaProducts.
+    adds avGatewayMibs under avayaMibs.  
+    "
+REVISION 	"0208150900Z" -- 15 August 2002
+DESCRIPTION
+    "Rev 1.3.0 - Itai Zilbershterin.
+    adds avayaSystemStats under lsg.
+    "
+REVISION 	"0207280900Z" -- 28 July 2002
+DESCRIPTION
+    "Rev 1.2.0 - Itai Zilbershterin.
+    adds avayaEISTopology under lsg.
+    "
+REVISION 	"0108091700Z" -- 09 August 2001
+DESCRIPTION
+    "Rev 1.1.0 - Itai Zilbershterin.
+    adds products OID to those defined.
+    "
+REVISION 	"0106211155Z" -- 21 June 2001
+DESCRIPTION
+    "Rev 1.0.0 - Itai Zilbershterin.
+    Fixed the mibs placement error. Avaya Mibs
+    reside under avaya.2 and not avaya.1.
+    The MIB branch is called avayaMibs."
+
+REVISION 	"0010151045Z" -- 15 Oct. 2000
+DESCRIPTION
+    "Rev 0.9.0 - Itai Zilbershterin.
+    The initial version of this MIB module. 
+
+    The following Organizational top-level groups are defined:
+    lsg - Mibs of the LAN System Group (Concord & Israel)."
+REVISION 	"0010151305Z" -- 15 Oct. 2000
+DESCRIPTION
+    "Rev 0.9.1 - Itai Zilbershterin.
+    Dates in Revisions changed from 'yyyymmddhhmm' to 'yymmddhhmm', to support
+    older development environments."
+::= {  enterprises 6889 }
+-- ****************************
+-- ****************************
+-- Product OIDs
+products	OBJECT IDENTIFIER ::= { avaya 1 }
+-- MIBs
+mibs	OBJECT IDENTIFIER ::= { avaya 2 }    
+-- Gateway
+avGatewayProducts OBJECT IDENTIFIER ::= { products 6 }
+avGatewayMibs OBJECT IDENTIFIER ::= { mibs 6 }
+-- **********************************
+-- LAN System Group's
+-- **********************************
+lsg	OBJECT IDENTIFIER ::= { mibs 1 }
+-- Sub branches which are NOT MIB modules (MIB modules directly under lsg
+-- will define their OID in relation to lsg)
+avayaEISTopology  OBJECT IDENTIFIER ::= {lsg 10 }
+avayaSystemStats  OBJECT IDENTIFIER ::= {lsg 11 }
+END

--- a/mibs/avaya/IPO-MIB.mib
+++ b/mibs/avaya/IPO-MIB.mib
@@ -1,0 +1,2499 @@
+--========================================================
+--
+-- MIB      : IPO  Avaya Inc.
+--
+-- Version  : 2.00.25   04 July 2014
+--
+--========================================================
+--
+-- Copyright (c) 2003 - 2014 Avaya Inc.
+-- All Rights Reserved.
+--
+--========================================================
+IPO-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    NOTIFICATION-TYPE, Unsigned32, Integer32,
+    IpAddress
+        FROM SNMPv2-SMI
+    DateAndTime
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB
+    sysDescr
+        FROM SNMPv2-MIB
+    ItuPerceivedSeverity
+        FROM ITU-ALARM-TC-MIB
+    ifIndex
+        FROM IF-MIB
+    mibs
+        FROM AVAYAGEN-MIB
+;
+
+ipoMIB MODULE-IDENTITY
+    LAST-UPDATED    "201407040000Z" -- 04 July 2014
+    ORGANIZATION    "Avaya Inc."
+    CONTACT-INFO
+        "Avaya Customer Services
+         Postal: Avaya, Inc.
+                 211 Mt Airy Rd.
+                 Basking Ridge, NJ 07920
+                 USA
+         Tel:    +1 908 953 6000
+
+         WWW:    http://www.avaya.com"
+    DESCRIPTION
+        "Avaya IP Office MIBs OID tree.
+
+         This MIB module defines the root items for MIBs for
+         use with Avaya IP Office family of telephone switches."
+    REVISION    "201407040000Z" -- 04 July 2014
+    DESCRIPTION
+        "Rev 2.00.25
+         Added new value serviceAMServerNotAvailable"
+    REVISION    "201406250000Z" -- 25 June 2014
+    DESCRIPTION
+        "Rev 2.00.24
+         Added new value serviceCCRNotSupported"
+    REVISION    "201406250000Z" -- 25 June 2014
+    DESCRIPTION
+        "Rev 2.00.23
+         Added new value serviceNonSelectAlarm"
+    REVISION    "201406160000Z" -- 16 June 2014
+    DESCRIPTION
+        "Rev 2.00.22
+         Added new values serviceGeneralAlarm and serviceSystemInfo"
+    REVISION    "201406040000Z" -- 04 June 2014
+    DESCRIPTION
+        "Rev 2.00.21
+         Added new value serviceIPDECTSystemError "
+    REVISION    "201405230000Z" -- 23 May 2014
+    DESCRIPTION
+        "Rev 2.00.20
+         Added new value monitorLogStamped "
+    REVISION    "201405080000Z" -- 08 May 2014
+    DESCRIPTION
+        "Rev 2.00.19
+         Added new values trunkSIPDNSInvalidConfig and trunkSIPDNSTransportError "
+    REVISION    "201401060000Z" -- 06 January 2014
+    DESCRIPTION
+        "Rev 2.00.18
+         Added oneXPortal values for ipoGTEventAppEntity"
+    REVISION    "201310080000Z" -- 08 October 2013
+    DESCRIPTION
+        "Rev 2.00.17
+         Added new values serviceSystemHardDriveAlarm and serviceAdditionalHardDriveAlarm "
+    REVISION    "201308060000Z" -- 06 August 2013
+    DESCRIPTION
+        "Rev 2.00.16
+        Added new values of serviceACCSAlarm for
+        ipoGTEventReason object"
+    REVISION    "201304241900Z" -- 24 April 2013
+    DESCRIPTION
+        "Rev 2.00.15
+        Added new values for ipoGTEventReason object
+        serviceCpuAlarm, serviceCpuIOAlarm, serviceMemoryAlarm"
+    REVISION    "201304241518Z" -- 24 April 2013
+    DESCRIPTION
+        "Rev 2.00.14
+        Added new value of serviceLocalBackup for
+        ipoGTEventReason object"
+    REVISION    "201211171511Z" --  17 November 2012
+    DESCRIPTION
+        "Rev 2.00.13
+        Added new notification: ipoGenEmergencyCallSvcEvent
+        Added new value of serviceEmergencyCall to the ipoGTEventReason object."        
+    REVISION    "201202281300Z" --  28 February 2012
+    DESCRIPTION
+        "Rev 2.00.12
+        Added new values for ipoGTEventReason object from
+        servicePortRangeExhausted to serviceWebservicesUWSError."
+    REVISION    "201111012200Z" --  1 November 2011
+    DESCRIPTION
+        "Rev 2.00.11
+        Added new values for ipoGTEventReason object from
+        servicePlannedMaintenance to serviceSslVpnServerReportedError."
+    REVISION    "201109271130Z" --  27 September 2011
+    DESCRIPTION
+        "Rev 2.00.10
+        Added new value of testAlarm for ipoGTEventReason object."
+    REVISION    "201103151517Z" -- 15 March 2011
+    DESCRIPTION
+        "Rev 2.00.09
+        Added new value of securityError for
+        ipoGTEventReason object"
+    REVISION    "201010131417Z" -- 13 October 2010
+    DESCRIPTION
+        "Rev 2.00.08
+        Added new value of serviceLicenseFileInvalid for
+        ipoGTEventReason object"
+    REVISION    "201007121345Z" -- 12 July 2010
+    DESCRIPTION
+        "Rev 2.00.07
+        Introduced new notifications, see ipoGenSvcMiscNotificationsGroup
+        and new objects, see ipoGenSvcMiscNotificationObjectsGroup"
+    REVISION    "200910190735Z" -- 19 October 2009
+    DESCRIPTION
+        "Rev 2.00.06
+        System Running Backup, Invalid Memory Card, No Licence Key Dongle
+        Notifications added.  Corrections to MIB syntax for System
+        Shutdown Notification."
+    REVISION    "200910091347Z" -- 09 October 2009
+    DESCRIPTION
+        "Rev 2.00.05
+        System shutdown Notification added."
+    REVISION    "200909110950Z" -- 11 September 2009
+    DESCRIPTION
+        "Rev 2.00.04
+        QOS Monitoring Notification added."
+    REVISION    "200909071620Z" -- 07 September 2009
+    DESCRIPTION
+        "Rev 2.00.03
+        smallBusinessContactCenter(3) value for
+        ipoGTEventAppEntity changed to customerCallReporter."
+    REVISION    "200804281640Z" -- 28 April 2008
+    DESCRIPTION
+        "Rev 2.00.02
+        Added smallBusinessContactCenter(3) value to
+        ipoGTEventAppEntity."
+    REVISION    "200804181450Z" -- 18 April 2008
+    DESCRIPTION
+        "Rev 2.00.01
+        Added traps related to Universal PRI licensing."
+    REVISION    "200606290000Z" -- 29 June 2006
+    DESCRIPTION
+        "Rev 2.00.00
+        Traps/notifications revised to provide more information about
+        the entity and device concerned."
+    REVISION    "200410060000Z" -- 06 October 2004
+    DESCRIPTION
+        "Rev 1.00.08
+        Corrected description of event severities for physical
+        entities."
+    REVISION    "200408270000Z" -- 27 August 2004
+    DESCRIPTION
+        "Rev 1.00.07
+        Corrected mandatory groups after addition of SOG event
+        related objects and notifications."
+    REVISION    "200408060000Z" -- 06 August 2004
+    DESCRIPTION
+        "Rev 1.00.06
+        Added SOG event related object and notifications."
+    REVISION     "200407100000Z" -- 10 July 2004
+    DESCRIPTION
+        "Rev 1.00.05
+        Added application event related object and notifications.
+        Corrected description of ipoGenLKSCommsOperationalEvent."
+    REVISION     "200405280000Z" -- 28 May 2004
+    DESCRIPTION
+        "Rev 1.00.04
+        Revised usage description for ipoGTEventSeverity."
+    REVISION     "200403030000Z" -- 03 March 2004
+    DESCRIPTION
+        "Rev 1.00.03
+        Revised for external publication."
+    REVISION     "200312150000Z" -- 15 December 2003
+    DESCRIPTION
+        "Rev 1.00.02
+        Added loopback object and notification."
+    REVISION     "200311110000Z" -- 11 November 2003
+    DESCRIPTION
+        "Rev 1.00.01
+        Corrected ipoGTEventEntity MAX-ACCESS."
+    REVISION     "200310100000Z" -- 10 October 2003
+    DESCRIPTION
+        "Rev 1.00.00
+        The first published version of this MIB module."
+    ::= { mibs 2 }
+
+-- sub-tree for IP Office wide objects and events irrespective of function
+ipoGeneric         OBJECT IDENTIFIER ::= { ipoMIB 1 }
+
+-- sub-tree for IP Office functional MIBs
+ipoGenMibs         OBJECT IDENTIFIER ::= { ipoGeneric 1 }
+
+-- sub-tree for IP Office wide traps/notifications
+ipoGenTraps        OBJECT IDENTIFIER ::= { ipoGeneric 2 }
+
+-- sub-tree for IP Office wide conformance information
+ipoGenConformance  OBJECT IDENTIFIER ::= { ipoGeneric 3 }
+
+--********************************************************************
+-- IP Office wide traps/notifications
+--********************************************************************
+
+ipoGTEvents  OBJECT IDENTIFIER ::= { ipoGenTraps 0 }
+ipoGTObjects OBJECT IDENTIFIER ::= { ipoGenTraps 1 }
+
+--
+-- trap objects
+--
+
+ipoGTEventSeverity OBJECT-TYPE
+    SYNTAX      INTEGER {
+        critical(1),
+        major(2),
+        minor(3)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "Severity of the event that has occurred.
+
+        The event severity depends upon the type of
+        entity/notification that the operational state change event
+        relates to:
+
+        GenEntityEvents:
+
+        Type of physical   Severity
+        entity
+        container          critical
+        module             major
+        port               major
+
+        Known transient errors for entities have a severity of minor.
+
+        LKSCommsEvents:
+        Severity is major
+
+        GenLoopbackEvent:
+        Severity is major
+
+        GenAppEvents:
+        Severity depends on sub-event
+        Failure/Operational - severity is major
+        Event               - severity depends on event condition
+
+        ipoGenSogEvents:
+        Severity depends on sub-event
+        HostFailure         - severity is Major
+        ModeChange:
+          - Mode survivable: severity is Major
+          - Mode subTending: severity is Minor
+
+        PhoneChangeEvents:
+        Severity is minor
+
+        **NOTE: This object is deprecated and replaced by
+          ipoGTEventStdSeverity."
+    ::= { ipoGTObjects 1 }
+
+ipoGTEventDateTime OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Date and time of the occurence of the event."
+    ::= { ipoGTObjects 2 }
+
+ipoGTEventEntity OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A reference, by entPhysicalIndex value, to the
+        EntPhysicalEntry representing the physical entity that an
+        event is associated with in an entity MIB instantiation within
+        the IP Office agent."
+    ::= { ipoGTObjects 3 }
+
+ipoGTEventLoopbackStatus OBJECT-TYPE
+    SYNTAX      Integer32 (1..127)
+    MAX-ACCESS  accessible-for-notify
+    STATUS      deprecated
+    DESCRIPTION
+        "This variable represents the current state of the
+         loopback on the DS1 interface.  It contains
+         information about loopbacks established by a
+         manager and remotely from the far end.
+
+         The ipoGTEventLoopbackStatus is a bit map represented as
+         a sum, therefore is can represent multiple
+         loopbacks simultaneously.
+
+         The various bit positions are:
+          1  noLoopback
+          2  nearEndPayloadLoopback
+          4  nearEndLineLoopback
+          8  nearEndOtherLoopback
+         16  nearEndInwardLoopback
+         32  farEndPayloadLoopback
+         64  farEndLineLoopback"
+    ::= { ipoGTObjects 4 }
+
+ipoGTEventAppEntity OBJECT-TYPE
+    SYNTAX      INTEGER {
+          voiceMail(1),
+          deltaServer(2),
+          customerCallReporter(3),
+          oneXPortal(4)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The IP Office application to which a notification/trap
+        relates."
+    ::= { ipoGTObjects 5 }
+
+ipoGTEventAppEvent OBJECT-TYPE
+    SYNTAX      INTEGER {
+                   storageFull(1), -- severity: Critical
+             storageNearlyFull(2), -- severity: Major
+                   storageOkay(3), -- severity: Minor
+      backupCommunicationError(4), -- severity: Major
+               backupFileError(5), -- severity: Major
+                   httpFailure(6), -- severity: Major
+          httpSslAcceptFailure(7), -- severity: Major
+             httpSslConnection(8), -- severity: Major
+                httpSslFailure(9), -- severity: Major
+           httpSslPortFailure(10), -- severity: Major
+              ignoringRequest(11), -- severity: Major
+     imapInitializationFailed(12), -- severity: Major
+             imapInvalidMsgNr(13), -- severity: Major
+          imapMailboxNotExist(14), -- severity: Major
+           imapMessageInvalid(15), -- severity: Major
+          imapMessageNotExist(16), -- severity: Major
+        imapMessageNrNotExist(17), -- severity: Major
+        imapMissingConnection(18), -- severity: Major
+          imapMissingSettings(19), -- severity: Major
+                imapNoLicence(20), -- severity: Major
+            imapNotConfigured(21), -- severity: Major
+          imapShiftConnection(22), -- severity: Major
+     mapiInitializationFailed(23), -- severity: Major
+          mapiMissingSettings(24), -- severity: Major
+         mapiConnectionFailed(25), -- severity: Major
+          mapiShiftConnection(26), -- severity: Major
+                      licence(27), -- severity: Major
+           licenceDistributed(28), -- severity: Major
+               licenceExpired(29), -- severity: Major
+                   licenceSOG(30), -- severity: Major
+                 loginFailure(31), -- severity: Major
+   loginFailureInvalidMailbox(32), -- severity: Major
+              mailboxNotFound(33), -- severity: Major
+           makeLiveFileAccess(34), -- severity: Major
+          makeLiveMissingFile(35), -- severity: Major
+              offlineMakeLive(36), -- severity: Major
+                    onexError(37), -- severity: Major
+            pbxConnectionLost(38), -- severity: Major
+           pbxIncompatibility(39), -- severity: Major
+            smgrSettingsError(40), -- severity: Major
+         smtpConnectionFailed(41), -- severity: Major
+        smtpConnectionTimeout(42), -- severity: Major
+                    smtpError(43), -- severity: Major
+   smtpSecureConnectionFailed(44), -- severity: Major
+           smtpUnexpectedData(45), -- severity: Major
+           smtpUnsuportedData(46), -- severity: Major
+          socketAbortingError(47), -- severity: Major
+              socketBindError(48), -- severity: Major
+socketClientDisconnectedError(49), -- severity: Major
+        socketConnectionError(50), -- severity: Major
+        socketNoresponseError(51), -- severity: Major
+            socketOptionError(52), -- severity: Major
+           socketReceiveError(53), -- severity: Major
+        socketRecvFailedError(54), -- severity: Major
+        socketSendFailedError(55), -- severity: Major
+            socketSelectError(56), -- severity: Major
+          socketTimedOutError(57), -- severity: Major
+            switchedToPrimary(58), -- severity: Major
+          switchedToSecondary(59), -- severity: Major
+               tcpAcceptError(60), -- severity: Major
+               tcpListenError(61), -- severity: Major
+               tcpSelectError(62), -- severity: Major
+                     tcpError(63), -- severity: Major
+              testTimeExpired(64), -- severity: Major
+          tftpConnectionError(65), -- severity: Major
+          tftpMonitoringError(66), -- severity: Major
+             tftpReadingError(67), -- severity: Major
+           tftpReceivingError(68), -- severity: Major
+            tftpWrittingError(69), -- severity: Major
+               tooManyClients(70), -- severity: Major
+                 updateEerror(71), -- severity: Major
+                updateSuccess(72), -- severity: Major
+                     vmScript(73)  -- severity: Major
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office application event states.  The associated event
+        severity of the notification/trap the object is carried in
+        varies depending upon the event condition. The appropriate
+        severity is detailed against event enumeration."
+    ::= { ipoGTObjects 6 }
+
+ipoGTEventHostAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Address of an IP Office Small Office Gateway Subtending Host."
+    ::= { ipoGTObjects 7 }
+
+ipoGTEventSOGMode OBJECT-TYPE
+    SYNTAX      INTEGER {
+                survivable(1), -- severity: Major
+                subTending(2)  -- severity: Minor
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office Small Office Gateway operating modes.  
+        survivable(1) indicates the control unit has no current host, 
+        either through confguration error or communication failure.  
+        subTending(2) indicates normal operation to a valid Sub-
+        tending Host."
+    ::= { ipoGTObjects 8 }
+
+ipoGTEventStdSeverity OBJECT-TYPE
+    SYNTAX      ItuPerceivedSeverity
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "Severity of the event that has occurred.
+
+        The event severity depends upon the type of
+        entity/notification that the operational state change event
+        relates to. The severity values that are normally used are
+        detailed below:
+
+        The enterprise versions of standard SNMP traps all have a
+        severity of major (4).
+
+        Operational events which notify the transition back to an
+        operational state from a failure state have a severity of
+        cleared (1).
+
+
+        GenEntityEvents:
+          Operational - severity is cleared (1)
+
+          Failure event severity levels
+            Type of physical   Severity for failure
+            entity
+            container          critical (3)
+            module             major (4)
+            port               major (4)
+
+          Error
+            Known transient errors for entities have a severity of
+            warning (6).
+
+          Change - severity is major (4)
+
+        LKSCommsSvcEvents:
+          Operational - severity is cleared (1)
+          Failure -     severity is major (4)
+
+        GenLoopbackSvcEvent:
+          Severity is major (4)
+
+        GenAppSvcEvents:
+          Severity depends on sub-event
+          Operational - severity is cleared (1)
+          Failure -     severity is major (4)
+          Event -       severity depends on event condition
+            For voicemail storage conditions the severity is as
+            follows:
+              storageOkay       - severity is cleared (1)
+              storageNearlyFull - severity is warning (6)
+                (Only warning severity as it could be transitory.)
+              storageFull       - severity is critical (3)
+
+        GenSogSvcEvents:
+          Severity depends on sub-event
+          HostFailure         - severity is Major (4)
+          ModeChange:
+            - Mode survivable: severity is Major (4)
+            - Mode subTending: severity is Minor (5)
+
+        GenUPriLicSvcEvents:
+          Severity depends on sub-event
+          ChansReduced        - severity is Major (4)
+          CallRejected        - severity is Minor (5)
+
+        GenQoSMonSvcEvent:
+          QoSWarning        - severity is Warning (6)
+
+        PhoneChangeSvcEvents:
+          Severity is minor (5)
+
+        ipoGenSystemRunningBackupEvent:
+          Severity is cleared (1)
+          Severity is critical (3)
+                
+        ipoGenInvalidMemoryCardEvent:
+          Severity is cleared (1)
+          Severity is Major (4)
+
+        ipoGenNoLicenceKeyDongleEvent:
+          Severity is cleared (1)
+          Severity is warning (6)
+          Severity is critical (3)
+
+        ipoGenMemoryCardCapacityEvent:
+          Severity depends on sub-event
+              storageOkay       - severity is cleared (1)
+              storageNearlyFull - severity is warning (6)
+              storageFull       - severity is critical (3)"
+    ::= { ipoGTObjects 9 }
+
+ipoGTEventDevID OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (10))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "A unique textual identifier of the alarming device."
+    ::= { ipoGTObjects 10 }
+
+ipoGTEventEntityName OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..64))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "The textual name of the alarming physical entity. The
+        contents of this object is made of concatenated
+        entPhysicalName values that fully identify the object with the
+        overall IP Office entity. Examples values are:
+
+        Controller, Trunk Slot B, Trunk Module, T1 PRI 2
+          = T1 PRI Port 2, on a dual T1 Trunk Module, in Trunk Slot B,
+            on the IP Office Controller Unit
+
+        Controller, VCM Slot 1, VCM 1
+          = VCM Card, in VCM Slot 1, on the IP Office Controller Unit
+
+        Controller, EXP 1, DS EXP 16, DS 12
+          = DS Phone Port 12, on a DS16 Expansion Module, attached to
+          Expansion Port 1, on the IP Office Controller Unit"
+    ::= { ipoGTObjects 11 }
+
+ipoGTEventLoopbackStatusBits OBJECT-TYPE
+    SYNTAX      BITS {
+        noLoopback(0),
+        nearEndPayloadLoopback(1),
+        nearEndLineLoopback(2),
+        nearEndOtherLoopback(3),
+        nearEndInwardLoopback(4),
+        farEndPayloadLoopback(5),
+        farEndLineLoopback(6)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable represents the current state of the loopback on
+         the DS1 interface.  It contains information about loopbacks
+         established by a manager and remotely from the far end.
+
+         The ipoGTEventLoopbackStatus is a bit map therefore is can
+         represent multiple loopbacks simultaneously."
+    ::= { ipoGTObjects 12 }
+
+ipoGTEventQoSMonJitter OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Received Jitter time in milliseconds."
+    ::= { ipoGTObjects 13 }
+
+ipoGTEventQoSMonRndTrip OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Round Trip Delay time in milliseconds."
+    ::= { ipoGTObjects 14 }
+
+ipoGTEventQoSMonPktLoss OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Received Packet Loss."
+    ::= { ipoGTObjects 15 }
+
+ipoGTEventQoSMonCallId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Call Identifier."
+    ::= { ipoGTObjects 16 }
+
+ipoGTEventQoSMonDevType OBJECT-TYPE
+    SYNTAX      INTEGER {
+                line(1),
+                extn(2)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Device Type."
+    ::= { ipoGTObjects 17 }
+
+ipoGTEventQoSMonDevId OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Device Identifier."
+    ::= { ipoGTObjects 18 }
+
+ipoGTEventQoSMonExtnNo OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "IP Office QoS monitoring Extension Number."
+    ::= { ipoGTObjects 19 }
+
+ipoGTEventSystemShutdownSource OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..255))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable represents the source from where the system
+        shutdown was performed.
+        
+        Possible values are:
+        
+        DTE-Port
+            - if the system shutdown is performed using the DTE,
+        AUX-Button
+            - if the system shutdown is performed using the AUX
+            button (available only for IP500v2),
+        Phone <user name>
+            - if the system shutdown is performed from a phone,
+        Manager <security user name>
+            - if the system shutdown is performed from Manager,
+        SSA <security user name>
+            - if the system shutdown is performed from SSA."
+    ::= { ipoGTObjects 20 }
+
+ipoGTEventSystemShutdownTimeout OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable represents the period of time the system will be in
+        the shutdown state for. Possible values are in the 5 to 1440 minutes
+        range, 0 meaning infinite."
+    ::= { ipoGTObjects 21 }
+
+ipoGTEventMemoryCardSlotId OBJECT-TYPE
+    SYNTAX      INTEGER {
+                compactFlash(1),
+                systemSD(2),
+                optionalSD(3)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable indicates a memory card physical position identifier.
+        System(2) and Optional(3) are valid for the IP500 V2.  CF(1) valid 
+        for the IP500."
+    ::= { ipoGTObjects 22 }
+
+ipoGTEventNoValidKeyReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                noReason(1),
+                notPresent(2),
+                noRegisterAccess(3),
+                invalidRegisters(4),
+                invalidWatermark(5),
+                invalidClusterSize(6),
+                invalidVolume(7),
+                invalidHeaderFiles(8),
+                nonSpecificError(9)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable indicates the reason no valid licence feature key is 
+        assumed.  This is also the order of importance and check precedence.
+                noReason(1) - cleared condition
+                notPresent(2) - license feature key no present
+                noRegisterAccess(3) - license feature key present, but no access
+                invalidRegisters(4) - invalid register values
+                invalidWatermark(5) - watermark invalid or not present
+                invalidClusterSize(6) - filesystem not as expected"
+    ::= { ipoGTObjects 23 }
+
+ipoGTEventReason OBJECT-TYPE
+    SYNTAX      INTEGER {
+                configurationAgentNotTargeted(1),
+                configurationSCNDialPlanConflict(2),
+                configurationNoIncomingCallRoute(3),
+                configurationHWTypeFailure(4),
+                serviceFeatureLicenseMissing(5),
+                serviceAllLicensesInUse(6),
+                serviceClockSourceChanged(7),
+                serviceLogonFailed(8),
+                serviceNoFreeChannelsAvail(9),
+                serviceHoldMusicFileFailure(10),
+                serviceAllResourcesInUse(11),
+                serviceAlarm(12),
+                serviceNetworkInterconnectFailure(13),
+                trunkSeizeFailure(14),
+                trunkIncomingCallOutgoingTrunk(15),
+                trunkCLINotDelivered(16),
+                trunkDDIIncomplete(17),
+                trunkLOS(18),
+                trunkOOS(19),
+                trunkRedAlarm(20),
+                trunkBlueAlarm(21),
+                trunkYellowAlarm(22),
+                trunkIPConnectFail(23),
+                trunkSCNInvalidConnection(24),
+                linkDeviceChanged(25),
+                linkLDAPServerCommFailure(26),
+                linkResourceDown(27),
+                linkSMTPServerCommFailure(28),
+                linkVMProConnFailure(29),
+                serviceTimeServerAlarm(30),
+                serviceLicenseFileInvalid(31),
+                serviceLicenseError(32),
+                securityError(33),
+                codecError(34),
+                scepNoRespError(35),
+                configAppsProcAlarm(36),
+                serviceAppsProcAlarm(37),
+                serviceLicenseServerError(38),
+                testAlarm(39),
+                servicePlannedMaintenance(40),
+                serviceNetworkDisconnection(41), 
+                serviceFailedTlsNegotiation(42), 
+                serviceFailedTlsRenegotiation(43),
+                serviceLackOfResources(44),
+                serviceInternalError(45),
+                serviceTooManyMissedHeartbeats(46),
+                serviceFailedDnsResolution(47),
+                serviceDuplicateIpAddress(48),
+                serviceAuthenticationFailure(49),
+                serviceSslVpnStackProtocolError(50),
+                serviceSslVpnServerReportedError(51),
+                servicePortRangeExhausted(52),
+                serviceWebservicesUWSError(53),
+                trunkNoFreeVoIPChannel(54),
+                serviceEmergencyCall(55),
+                serviceLocationCongestion(56),
+                serviceCpuAlarm(57),
+                serviceCpuIOAlarm(58),
+                serviceMemoryAlarm(59),
+                serviceLocalBackup(60),
+                trunkSMConnectAsSIP(61),
+                trunkSIPConnectAsSM(62),
+                serviceSipRxPacketSizeError(63),
+                serviceACCSAlarm(64),
+                serviceSystemHardDriveAlarm(65),
+                serviceAdditionalHardDriveAlarm(66),
+                linkDialerConnFailure(67),
+                trunkSIPDNSInvalidConfig(68),
+                trunkSIPDNSTransportError(69),
+                monitorLogStamped(70),
+                trunkSCNInvalidSubOperMode(71),
+                serviceIPDECTSystemError(72),
+                serviceIPOCCAlarm(73),
+                serviceGeneralAlarm(74),
+                serviceSystemInfo(75),
+                serviceNonSelectAlarm(76),
+                serviceCCRNotSupported(77),
+                serviceAMServerNotAvailable(78),
+                trunkMediaSecuritySettingsIncompatible(79)
+    }
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable indicates what event took place within Configuration, Service, Trunk
+        or Link category alarm"
+    ::= { ipoGTObjects 24 }
+
+ipoGTEventData OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..255))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable contains opaque data that can be used to provide additional information
+        when the ipoGTEventReason value is not sufficient."
+    ::= { ipoGTObjects 25 }
+
+ipoGTEventAlarmDescription OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..255))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable describes the alarm"
+    ::= { ipoGTObjects 26 }
+
+ipoGTEventAlarmRemedialAction OBJECT-TYPE
+    SYNTAX      SnmpAdminString (SIZE (0..255))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION
+        "This variable describes the remedial action of the alarm"
+    ::= { ipoGTObjects 27 }
+
+
+
+--
+-- traps
+--
+
+ipoGenEntityFailureEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventEntity
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenEntityFailureEvent notification is generated whenever a
+        physical entity on the IP Office fails in its operation. It
+        signifies that the SNMP entity, acting in an agent role, has
+        detected that the state of a physical entity of the system has
+        transitioned from the operational to the failed state
+
+        **NOTE: This notification is deprecated and replaced by 
+        ipoGenEntityFailureSvcEvent"
+    ::= { ipoGTEvents 1 }
+
+ipoGenEntityOperationalEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventEntity
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenEntityOperationalEvent notification is generated whenever
+        a physical entity on the IP Office becomes operational again
+        after having failed. It signifies that the SNMP entity, acting
+        in an agent role, has detected that the state of a physical
+        entity of the system has transitioned from the failed to the
+        operational state
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenEntityOperationalSvcEvent."
+    ::= { ipoGTEvents 2 }
+
+ipoGenEntityErrorEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventEntity
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenEntityErrorEvent notification is generated whenever a
+        physical entity on the IP Office experiences a temporary
+        error. It signifies that the SNMP entity, acting in an agent
+        role, has detected a transitory error on a physical entity of
+        the system.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenEntityErrorSvcEvent."
+    ::= { ipoGTEvents 3 }
+
+ipoGenEntityChangeEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventEntity
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenEntityChangeEvent notification is generated whenever
+        a physical entity on the IP Office experiences a change itself
+        or with other entities associated with it. It signifies that
+        the SNMP entity, acting in an agent role, has detected a non
+        error/failure change for a physical entity on the system.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenEntityChangeSvcEvent."
+   ::= { ipoGTEvents 4 }
+
+ipoGenLKSCommsFailureEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenLKSCommsFailureEvent notification is generated
+        whenever communication with a Licence Key Server fails.  It
+        signifies that the SNMP entity, acting in an agent role, has
+        detected that the state of the communications between the
+        Licence Key Server has transitioned from the operational to
+        the failed state.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenLKSCommsFailureSvcEvent."
+    ::= { ipoGTEvents 5 }
+
+ipoGenLKSCommsOperationalEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenLKSCommsOperationalEvent notification is generated
+        whenever communication with a Licence Key Server becomes
+        operational again after having failed.  It signifies that the
+        SNMP entity, acting in an agent role, has detected that the
+        state of the communications between the Licence Key Server has
+        transitioned from the failed to the operational state.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenLKSCommsOperationalSvcEvent."
+    ::= { ipoGTEvents 6 }
+
+ipoGenLKSCommsErrorEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenLKSCommsErrorEvent notification is generated whenever
+         a IP Office experiences a temporary error with License Key
+         Server communication. It signifies that the SNMP entity,
+         acting in an agent role, has detected a transitory error with
+         the communication between the License Key Server and Client
+         on the system.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenLKSCommsErrorSvcEvent."
+    ::= { ipoGTEvents 7 }
+
+ipoGenLKSCommsChangeEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenLKSCommsChangeEvent notification is generated
+        whenever a IP Office experiences a change a non error change
+        License Key Server communication operation.  It signifies that
+        the SNMP entity, acting in an agent role, has detected a non
+        error/failure change with the License Key Server and Client
+        operation on the system.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenLKSCommsChangeSvcEvent."
+   ::= { ipoGTEvents 8 }
+
+ipoGenLoopbackEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventEntity,
+        ipoGTEventLoopbackStatus
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenLoopbackEvent notification is generated whenever a IP
+        Office T1 (DS1) interface operating as a CSU actions a loopback
+        status change.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenLoopbackSvcEvent."
+   ::= { ipoGTEvents 9 }
+
+ipoGenAppFailureEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventAppEntity
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenAppFailureEvent notification is generated whenever
+        communication between a IP Office switch and a IP Office
+        application fails.  It signifies that the SNMP entity, acting
+        in an agent role, has detected that the state of the
+        communications between the IP Office switch and a IP Office
+        application has transitioned from the operational to the
+        failed state.  The IP Office application between which
+        communication has been lost is identified by the value of
+        ipoGTEventAppEntity.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenAppFailureSvcEvent."
+    ::= { ipoGTEvents 10 }
+
+ipoGenAppOperationalEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventAppEntity
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenAppOperationalEvent notification is generated
+        whenever communication between a IP Office switch and a IP
+        Office application becomes operational again after having
+        failed.  It signifies that the SNMP entity, acting in an agent
+        role, has detected that the state of the communications
+        between the IP Office switch and a IP Office application has
+        transitioned from the failed to the operational state.  The IP
+        Office application between which communication has been lost
+        is identified by the value of ipoGTEventAppEntity.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenAppOperationalSvcEvent."
+    ::= { ipoGTEvents 11 }
+
+ipoGenAppEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventAppEntity,
+        ipoGTEventAppEvent
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A ipoGenAppEvent notification is generated whenever a
+        application entity of the IP Office system experiences an event.
+        It signifies that the SNMP entity, acting as a proxy for
+        the application, has detected an event on the application
+        entity of the overall IP Office system.
+        The event severity varies dependent upon the event condition.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenAppSvcEvent."
+    ::= { ipoGTEvents 12 }
+
+ipoGenSogHostFailureEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventHostAddress
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "An ipoGenSogFailureEvent notification is generated whenever a
+        previously valid Sub-tending host fails during Small Office 
+        Gateway operation.
+        The ipAddress field indicates the address of the failed host.
+        The event severity will always indicate Major.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenSogHostFailureSvcEvent."
+    ::= { ipoGTEvents 13 }
+
+ipoGenSogModeChangeEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventSOGMode
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "An ipoGenSogModeChangeEvent notification is generated whenever 
+        the Small Office Gateway operating mode changes. This also
+        includes entry to the initial mode.
+        The ipoGTEventSOGMode field indicates the new operating mode.
+        The event severity will be major(2) for a ipoGTEventSOGMode value
+        of survivable(1), and minor(3) for a ipoGTEventSOGMode value of
+        subTending(2).
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoGenSogModeChangeSvcEvent."
+    ::= { ipoGTEvents 14 }
+
+ipoGenColdStartSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard coldstart trap featuring
+         device identification information.  A coldStart trap
+         signifies that the sending protocol entity is reinitializing
+         itself such that the agent's configuration or the protocol
+         entity implementation may be altered."
+    ::= { ipoGTEvents 15 }
+
+ipoGenWarmStartSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard warmstart trap featuring
+         device identification information.  A warmStart trap
+         signifies that the sending protocol entity is reinitializing
+         that neither the agent configuration nor the protocol entity
+         implementation is altered."
+    ::= { ipoGTEvents 16 }
+
+ipoGenLinkDownSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ifIndex
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard linkDown trap featuring device
+         identification information.  A linkDown trap signifies that
+         the sending protocol entity recognizes a failure in one of
+         the communication links represented in the agent's
+         configuration."
+    ::= { ipoGTEvents 17 }
+
+ipoGenLinkUpSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ifIndex
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard linkUp trap featuring device
+         identification information.  A linkUp trap signifies that the
+         sending protocol entity recognizes that one of the
+         communication links represented in the agent's configuration
+         has come up."
+    ::= { ipoGTEvents 18 }
+
+ipoGenAuthFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "Enterprise version of standard authenticationFailure trap
+         featuring device identification information.  An
+         authenticationFailure trap signifies that the sending
+         protocol entity is the addressee of a protocol message that
+         is not properly authenticated.  While implementations of the
+         SNMP must be capable of generating this trap, they must also
+         be capable of suppressing the emission of such traps via an
+         implementation- specific mechanism."
+    ::= { ipoGTEvents 19 }
+
+ipoGenEntityFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventEntity,
+        ipoGTEventEntityName
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenEntityFailureSvcEvent notification is generated
+        whenever a physical entity on the IP Office fails in its
+        operation. It signifies that the SNMP entity, acting in an
+        agent role, has detected that the state of a physical entity
+        of the system has transitioned from the operational to the
+        failed state"
+    ::= { ipoGTEvents 20 }
+
+ipoGenEntityOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventEntity,
+        ipoGTEventEntityName
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenEntityOperationalSvcEvent notification is generated
+        whenever a physical entity on the IP Office becomes
+        operational again after having failed. It signifies that the
+        SNMP entity, acting in an agent role, has detected that the
+        state of a physical entity of the system has transitioned from
+        the failed to the operational state"
+    ::= { ipoGTEvents 21 }
+
+ipoGenEntityErrorSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventEntity,
+        ipoGTEventEntityName
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenEntityErrorSvcEvent notification is generated
+        whenever a physical entity on the IP Office experiences a
+        temporary error. It signifies that the SNMP entity, acting in
+        an agent role, has detected a transitory error on a physical
+        entity of the system."
+    ::= { ipoGTEvents 22 }
+
+ipoGenEntityChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventEntity,
+        ipoGTEventEntityName
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenEntityChangeSvcEvent notification is generated
+        whenever a physical entity on the IP Office experiences a
+        change itself or with other entities associated with it. It
+        signifies that the SNMP entity, acting in an agent role, has
+        detected a non error/failure change for a physical entity on
+        the system."
+    ::= { ipoGTEvents 23 }
+
+ipoGenLKSCommsFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLKSCommsFailureSvcEvent notification is generated
+        whenever communication with a Licence Key Server fails.  It
+        signifies that the SNMP entity, acting in an agent role, has
+        detected that the state of the communications between the
+        Licence Key Server has transitioned from the operational to
+        the failed state."
+    ::= { ipoGTEvents 24 }
+
+ipoGenLKSCommsOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLKSCommsOperationalSvcEvent notification is generated
+        whenever communication with a Licence Key Server becomes
+        operational again after having failed.  It signifies that the
+        SNMP entity, acting in an agent role, has detected that the
+        state of the communications between the Licence Key Server has
+        transitioned from the failed to the operational state."
+    ::= { ipoGTEvents 25 }
+
+ipoGenLKSCommsErrorSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLKSCommsErrorSvcEvent notification is generated
+         whenever a IP Office experiences a temporary error with
+         License Key Server communication. It signifies that the SNMP
+         entity, acting in an agent role, has detected a transitory
+         error with the communication between the License Key Server
+         and Client on the system."
+    ::= { ipoGTEvents 26 }
+
+ipoGenLKSCommsChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLKSCommsChangeSvcEvent notification is generated
+        whenever a IP Office experiences a change a non error change
+        License Key Server communication operation.  It signifies that
+        the SNMP entity, acting in an agent role, has detected a non
+        error/failure change with the License Key Server and Client
+        operation on the system."
+    ::= { ipoGTEvents 27 }
+
+ipoGenLoopbackSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventEntity,
+        ipoGTEventEntityName,
+        ipoGTEventLoopbackStatusBits
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLoopbackSvcEvent notification is generated whenever a
+        IP Office T1 (DS1) interface operating as a CSU actions a
+        loopback status change."
+   ::= { ipoGTEvents 28 }
+
+ipoGenAppFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventAppEntity
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenAppFailureSvcEvent notification is generated whenever
+        communication between a IP Office switch and a IP Office
+        application fails.  It signifies that the SNMP entity, acting
+        in an agent role, has detected that the state of the
+        communications between the IP Office switch and a IP Office
+        application has transitioned from the operational to the
+        failed state.  The IP Office application between which
+        communication has been lost is identified by the value of
+        ipoGTEventAppEntity."
+    ::= { ipoGTEvents 29 }
+
+ipoGenAppOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventAppEntity
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenAppOperationalSvcEvent notification is generated
+        whenever communication between a IP Office switch and a IP
+        Office application becomes operational again after having
+        failed.  It signifies that the SNMP entity, acting in an agent
+        role, has detected that the state of the communications
+        between the IP Office switch and a IP Office application has
+        transitioned from the failed to the operational state.  The IP
+        Office application between which communication has been lost
+        is identified by the value of ipoGTEventAppEntity."
+    ::= { ipoGTEvents 30 }
+
+ipoGenAppSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventAppEntity,
+        ipoGTEventAppEvent,
+        ipoGTEventAlarmDescription
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenAppSvcEvent notification is generated whenever a
+        application entity of the IP Office system experiences an
+        event.  It signifies that the SNMP entity, acting as a proxy
+        for the application, has detected an event on the application
+        entity of the overall IP Office system.
+
+        The event severity varies dependent upon the event condition."
+    ::= { ipoGTEvents 31 }
+
+ipoGenSogHostFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventHostAddress
+    }
+    STATUS current
+    DESCRIPTION
+        "An ipoGenSogFailureSvcEvent notification is generated
+        whenever a previously valid Sub-tending host fails during
+        Small Office Gateway operation.
+
+        The ipAddress field indicates the address of the failed host.
+        The event severity will always indicate major(4)."
+    ::= { ipoGTEvents 32 }
+
+ipoGenSogModeChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventSOGMode
+    }
+    STATUS current
+    DESCRIPTION
+        "An ipoGenSogModeChangeSvcEvent notification is generated
+        whenever the Small Office Gateway operating mode changes. This
+        also includes entry to the initial mode.
+
+        The ipoGTEventSOGMode field indicates the new operating mode.
+        The event severity will be major(4) for a ipoGTEventSOGMode
+        value of survivable(1), and minor(5) for a ipoGTEventSOGMode
+        value of subTending(2)."
+    ::= { ipoGTEvents 33 }
+
+ipoGenUPriLicChansReducedSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenUPriLicChansReducedSvcEvent notification is generated
+        whenever the number of Universal PRI Licensed channels has
+        been reduced. It signifies that the SNMP entity, acting in an
+        agent role, has detected a reduction in the licensed channels
+        on a Univeral PRI trunk."
+    ::= { ipoGTEvents 34 }
+
+ipoGenUPriLicCallRejectedSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenUPriLicCallRejectedSvcEvent notification is generated
+        whenever a call on a Universal PRI is rejected due to a
+        licensed channel not being available.  It signifies that the
+        SNMP entity, acting in an agent role, has detected a licensed
+        channel not available in order to make a call on a Univeral
+        PRI trunk."
+    ::= { ipoGTEvents 35 }
+
+ipoGenQoSMonSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventQoSMonJitter,
+        ipoGTEventQoSMonRndTrip,
+        ipoGTEventQoSMonPktLoss,
+        ipoGTEventQoSMonCallId,
+        ipoGTEventQoSMonDevType,
+        ipoGTEventQoSMonDevId,
+        ipoGTEventQoSMonExtnNo
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenQoSMonSvcEvent notification is generated when one of
+        the monitored QoS parameters (e.g. round trip delay, jitter,
+        packet loss, etc) exceeds its pre-selected threshold during
+        the duration of the call. It signifies that the SNMP entity,
+        acting in an agent role, has detected a state that one of the
+        monitored QoS parameters for the call exceeded its
+        pre-selected threshold.
+
+        The ipoGTEventQOSMonExtnNo value is only valid when the device
+        monitored is an extension rather than a line."
+    ::= { ipoGTEvents 36 }
+
+ipoGenSystemShutdownSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventSystemShutdownSource,
+        ipoGTEventSystemShutdownTimeout
+    }
+    STATUS current
+    DESCRIPTION
+        "An ipoGenSystemShutdownSvcEvent notification is generated when a
+        system shutdown is performed. It signifies that the
+        SNMP entity has detected a system shutdown."
+    ::= { ipoGTEvents 37 }
+
+ipoGenSystemRunningBackupEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr
+    }
+    STATUS current
+    DESCRIPTION
+        "An ipoGenSystemRunningBackup notification is generated when a
+        system is running partially or wholly from alternate/backup 
+        software and/or configuration data.
+        In the case of an IP500 V2, it indicates that the current boot location
+        is not the System SD card slot, \system\primary."
+    ::= { ipoGTEvents 38 }
+
+ipoGenInvalidMemoryCardEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventMemoryCardSlotId
+    }
+    STATUS current
+    DESCRIPTION
+        "An ipoGenInvalidMemoryCard notification is generated when a memory
+        card is detected present but cannot be used due to failure in the 
+        filesystem or card type checks.
+        The checks are carried out on startup and whenever a memory card is
+        inserted."
+    ::= { ipoGTEvents 39 }
+
+ipoGenNoLicenceKeyDongleEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventNoValidKeyReason
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenNoLicenceKeyDongle notification is generated if a system
+        either does not detect presence, or fails to validate a Licence Feature
+        Key Dongle.
+        In the case of an IP500 V2, it indicates that either the System SD card
+        is not present, or that one of the validation checks has failed.  Note
+        that removing the System SD card will cause this event immediately,
+        however the licences will remain valid for approximately 2 hours.
+
+        ipoGTEventStdSeverity will indicate the events state:
+          Severity is cleared(1): license dongle OK
+          Severity is warning(6): license dongle not OK, in grace period
+          Severity is critical(3): license dongle not OK, grace period expired
+        
+        The first check to fail is contained within ipoGTEventNoKeyReason."
+    ::= { ipoGTEvents 40 }
+
+ipoGenMemoryCardCapacityEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventMemoryCardSlotId,
+        ipoGTEventAppEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenMemoryCardCapacityEvent notification is generated if a memory
+        card passes one of the preset capacity thresholds.
+        In the case of an IP500 V2, the thresholds shall be
+            storageFull(1) - greater than  99% of nominal capacity
+            storageNearlyFull(2) - greater than 90% of nominal capacity
+            storageOkay(3) - less than 90% of nominal capacity."
+    ::= { ipoGTEvents 41 }
+
+
+
+ipoGenConfigFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenConfigFailureSvcEvent notification is generated
+        whenever a configuration component fails in its operation. It signifies
+        that the SNMP entity,acting in an agent role,has detected that
+        the state of a configuration component has transitioned from the
+        operational to the failed state. 
+        
+        This notification event is associated with a configuration 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 42}
+
+ipoGenConfigOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenConfigOperationalSvcEvent notification is generated
+        whenever a configuration component becomes operational again
+        after having failed.It signifies that the SNMP entity,acting in an
+        agent role,has detected that the state of a configuration component 
+        of thesystem has transitioned from the failed to the operational state.
+
+        This notification event is associated with a configuration 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 43}
+
+ipoGenConfigErrorSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenConfigErrorSvcEvent notification is generated
+        whenever a configuration component experiences a
+        temporary error.It signifies that the SNMP entity, acting
+        in an agent role,has detected a transitory error on a
+        configuration component of the system.
+        
+        This notification event is associated with a configuration 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 44}
+
+ipoGenConfigChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenConfigChangeSvcEvent notification is generated
+        whenever a configuration component experiences a change
+        or a non error change event.It signifies that the SNMP entity, acting
+        in an agent role,has detected a non error/failure change on a
+        configuration component of the system.
+        
+        This notification event is associated with a configuration 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 45}
+
+
+ipoGenServiceFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenServiceFailureSvcEvent notification is generated
+        whenever a Service component fails in its operation. It signifies
+        that the SNMP entity,acting in an agent role,has detected that
+        the state of a Service component has transitioned from the
+        operational to the failed state. 
+        
+        This notification event is associated with a service 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 46}
+
+ipoGenServiceOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenServiceOperationalSvcEvent notificationis generated
+        whenever a service component becomes operational again
+        after having failed.It signifiest hat the SNMP entity, acting in an
+        agent role, has detected that the state of a service component 
+        of the system has transitioned from the failed to the operational state.
+        
+        This notification event is associated with a service 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 47}
+
+ipoGenServiceErrorSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenServiceErrorSvcEvent notification is generated
+        whenever a service component experiences a
+        temporary error. It signifiest hat the SNMP entity, acting
+        in an agent role,has detected a transitory error on a
+        service component of the system.
+        
+        This notification event is associated with a service 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 48}
+
+ipoGenServiceChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenServiceChangeSvcEvent notification is generated
+        whenever a service component experiences a change
+        or a non error change event. It signifies that the SNMP entity, acting
+        in an agent role,has detected a non error/failure change on a
+        service component of the system.
+        
+        This notification event is associated with a service 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 49}
+
+ipoGenTrunkFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenTrunkFailureSvcEvent notification is generated
+        whenever a trunk component fails in its operation. It signifies
+        that the SNMP entity,acting in an agent role,has detected that
+        the state of a Trunk component has transitioned from the
+        operational to the failed state. 
+        
+        This notification event is associated with a trunk 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 50}
+
+ipoGenTrunkOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenTrunkOperationalSvcEvent notificationis generated
+        whenever a trunk component becomes operational again
+        after having failed. It signifies that the SNMP entity, acting in an
+        agent role,has detected that the state of a trunk component 
+        of the system has transitioned from the failed to the operational state.
+
+        This notification event is associated with a trunk 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 51}
+
+ipoGenTrunkErrorSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenTrunkErrorSvcEvent notification is generated
+        whenever a trunk component experiences a
+        temporary error. It signifies that the SNMP entity, acting
+        in an agent role, has detected a transitory error on a
+        trunk component of the system.
+        
+        This notification event is associated with a trunk 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 52}
+
+ipoGenTrunkChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenTrunkChangeSvcEvent notification is generated
+        whenever a trunk component experiences a change
+        or a non error change event. It signifies that the SNMP entity, acting
+        in an agent role, has detected a non error/failure change on a
+        trunk component of the system.
+        
+        This notification event is associated with a trunk 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 53}
+
+ipoGenLinkFailureSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLinkFailureSvcEvent notification is generated
+        whenever a Link component fails in its operation. It signifies
+        that the SNMP entity,acting in an agent role,has detected that
+        the state of a Link component has transitioned from the
+        operational to the failed state. 
+        
+        This notification event is associated with a link 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 54}
+
+ipoGenLinkOperationalSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLinkOperationalSvcEvent notification is generated
+        whenever a link component becomes operational again
+        after having failed. It signifies that the SNMP entity, acting in an
+        agent role, hasdetected that the state of a link component 
+        of the system has transitioned from the failed to the operational state.
+
+        This notification event is associated with a link 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 55}
+
+ipoGenLinkErrorSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLinkErrorSvcEvent notification is generated
+        whenever a link component experiences a
+        temporary error. It signifies that the SNMP entity, acting
+        in an agent role,has detected a transitory error on a
+        link component of thesystem.
+        
+        This notification event is associated with a link 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 56}
+
+ipoGenLinkChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenLinkChangeSvcEvent notification is generated
+        whenever a link component experiences a change
+        or a non error change event. It signifies that the SNMP entity, acting
+        in an agent role,has detected a non error/failure change on a
+        link component of the system.
+        
+        This notification event is associated with a link 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 57}
+
+    ipoGenEmergencyCallSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+        ipoGTEventStdSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventDevID,
+        sysDescr,
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "A ipoGenEmergencyCallSvcEvent notification is generated
+        whenever an emergency call is made, regardless whether successfully or not.
+        It signifies that the SNMP entity, acting
+        in an agent role, has detected an emergency call attempt on the system.
+        
+        This notification event is associated with a service 
+        system status category alarm. Details about the alarm are 
+        provided in the included object variables."
+    ::= { ipoGTEvents 58}
+
+
+--********************************************************************
+-- IP Office wide compliance
+--********************************************************************
+
+ipoGenCompliances OBJECT IDENTIFIER ::= { ipoGenConformance 1 }
+ipoGenGroups      OBJECT IDENTIFIER ::= { ipoGenConformance 2 }
+
+--
+-- compliance statements
+--
+
+ipoGenCompliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+         up to and including version 1.00.05 of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenNotificationObjectsGroup,
+        ipoGenNotificationsGroup
+    }
+    ::= { ipoGenCompliances 1 }
+
+ipoGen2Compliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+         version 1.00.06 and later versions of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenNotificationObjectsGroup,
+        ipoGenNotificationsGroup
+    }
+    GROUP ipoGenSOGNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+        GROUP ipoGenSOGNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    ::= { ipoGenCompliances 2 }
+
+ipoGen3Compliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+         version 1.01.01 and later versions of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenv2NotificationObjectsGroup,
+        ipoGenEntGenNotificationsGroup,
+        ipoGenSvcNotificationsGroup
+    }
+    GROUP ipoGenSOGNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenSvcSOGNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    ::= { ipoGenCompliances 3 }
+
+ipoGen4Compliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+         version 2.00.01 and later versions of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenv2NotificationObjectsGroup,
+        ipoGenEntGenNotificationsGroup,
+        ipoGenSvcNotificationsGroup
+    }
+    GROUP ipoGenSOGNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenSvcSOGNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenUPriLicSvcNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the Universal PRI trunk module such as
+         the IP500."
+    ::= { ipoGenCompliances 4 }
+
+ipoGen5Compliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+        version 2.00.04 and later versions of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenv2NotificationObjectsGroup,
+        ipoGenEntGenNotificationsGroup,
+        ipoGenSvcNotificationsGroup
+    }
+    GROUP ipoGenSOGNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenSvcSOGNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenUPriLicSvcNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the Universal PRI trunk module such as
+         the IP500."
+    GROUP ipoGenQosMonNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the QoS monitoring such as the IP500."
+    GROUP ipoGenSvcQoSMonNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the QoS monitoring such as the IP500."
+    ::= { ipoGenCompliances 5 }
+    
+ipoGen6Compliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+         version 2.00.03 and later versions of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenv2NotificationObjectsGroup,
+        ipoGenEntGenNotificationsGroup,
+        ipoGenSvcNotificationsGroup
+    }
+    GROUP ipoGenSOGNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenSvcSOGNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenUPriLicSvcNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the Universal PRI trunk module such as
+         the IP500."
+    GROUP ipoGenSvcQoSMonNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the QoS monitoring such as the IP500."
+    GROUP ipoGenSvcSystemShutdownNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the system shutdown such as the IP406v2,
+         IP412, IP500 and IP500v2."
+    GROUP ipoGenSvcSystemShutdownObjectGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the system shutdown such as the IP406v2,
+         IP412, IP500 and IP500v2."
+    GROUP ipoGenSDcardNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support an SD Card for primary operation"
+    GROUP ipoGenSDcardNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support an SD Card for primary operation"
+    ::= { ipoGenCompliances 6 }
+
+ipoGen7Compliance MODULE-COMPLIANCE
+    STATUS current
+    DESCRIPTION
+        "The compliance statement for IP Office agents which implement
+         version 2.00.07 and later versions of this MIB."
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoGenv2NotificationObjectsGroup,
+        ipoGenEntGenNotificationsGroup,
+        ipoGenSvcNotificationsGroup,
+        ipoGenSvcMiscNotificationsGroup,
+        ipoGenSvcMiscNotificationObjectsGroup
+    }
+    GROUP ipoGenSOGNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenSvcSOGNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         SOG devices."
+    GROUP ipoGenUPriLicSvcNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the Universal PRI trunk module such as
+         the IP500."
+    GROUP ipoGenSvcQoSMonNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the QoS monitoring such as the IP500."
+    GROUP ipoGenSvcSystemShutdownNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the system shutdown such as the IP406v2,
+         IP412, IP500 and IP500v2."
+    GROUP ipoGenSvcSystemShutdownObjectGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support the system shutdown such as the IP406v2,
+         IP412, IP500 and IP500v2."
+    GROUP ipoGenSDcardNotificationsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support an SD Card for primary operation"
+    GROUP ipoGenSDcardNotificationObjectsGroup
+    DESCRIPTION
+        "Implementation of this group is only mandatory for IP Office
+         systems that support an SD Card for primary operation"
+    ::= { ipoGenCompliances 7 }
+
+--
+-- MIB groupings
+--
+
+ipoGenNotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventSeverity,
+        ipoGTEventDateTime,
+        ipoGTEventEntity,
+        ipoGTEventLoopbackStatus,
+        ipoGTEventAppEntity,
+        ipoGTEventAppEvent
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "Objects that are contained in IP Office wide notifications.
+
+        **NOTE: This group is deprecated and replaced by
+          ipoGenv2NotificationObjectsGroup."
+    ::= { ipoGenGroups 1 }
+
+ipoGenNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenEntityFailureEvent,
+        ipoGenEntityOperationalEvent,
+        ipoGenEntityErrorEvent,
+        ipoGenEntityChangeEvent,
+        ipoGenLKSCommsFailureEvent,
+        ipoGenLKSCommsOperationalEvent,
+        ipoGenLKSCommsErrorEvent,
+        ipoGenLKSCommsChangeEvent,
+        ipoGenLoopbackEvent,
+        ipoGenAppOperationalEvent,
+        ipoGenAppFailureEvent,
+        ipoGenAppEvent
+   }
+    STATUS deprecated
+    DESCRIPTION
+        "The notifications which indicate specific changes in the
+        state of the IP Office system.
+
+        **NOTE: This group is deprecated and replaced by
+          ipoGenSvcNotificationsGroup."
+    ::= { ipoGenGroups 2 }
+
+ipoGenSOGNotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventHostAddress,
+        ipoGTEventSOGMode
+    }
+    STATUS current
+    DESCRIPTION
+        "Objects that are contained in IP Office SOG notifications."
+    ::= { ipoGenGroups 3 }
+
+ipoGenSOGNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenSogHostFailureEvent,
+        ipoGenSogModeChangeEvent
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "The notifications which indicate specific changes in the
+        state of the IP Office SOG system.
+
+        **NOTE: This group is deprecated and replaced by
+          ipoGenSvcNotificationsGroup."
+    ::= { ipoGenGroups 4 }
+
+ipoGenv2NotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventDateTime,
+        ipoGTEventEntity,
+        ipoGTEventAppEntity,
+        ipoGTEventAppEvent,
+        ipoGTEventStdSeverity,
+        ipoGTEventDevID,
+        ipoGTEventEntityName,
+        ipoGTEventLoopbackStatusBits
+    }
+    STATUS current
+    DESCRIPTION
+        "Objects that are contained in IP Office wide notifications."
+    ::= { ipoGenGroups 5 }
+
+ipoGenEntGenNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenColdStartSvcEvent,
+        ipoGenWarmStartSvcEvent,
+        ipoGenLinkDownSvcEvent,
+        ipoGenLinkUpSvcEvent,
+        ipoGenAuthFailureSvcEvent
+   }
+    STATUS current
+    DESCRIPTION
+        "IP Office Enterpise versions of the generic traps as defined
+        RFC1215 that provide more identification of the entity
+        concerned."
+    ::= { ipoGenGroups 6 }
+
+ipoGenSvcNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenEntityFailureSvcEvent,
+        ipoGenEntityOperationalSvcEvent,
+        ipoGenEntityErrorSvcEvent,
+        ipoGenEntityChangeSvcEvent,
+        ipoGenLKSCommsFailureSvcEvent,
+        ipoGenLKSCommsOperationalSvcEvent,
+        ipoGenLKSCommsErrorSvcEvent,
+        ipoGenLKSCommsChangeSvcEvent,
+        ipoGenLoopbackSvcEvent,
+        ipoGenAppOperationalSvcEvent,
+        ipoGenAppFailureSvcEvent,
+        ipoGenAppSvcEvent
+   }
+    STATUS current
+    DESCRIPTION
+        "The service notifications which indicate specific changes in
+        the state of the IP Office system."
+    ::= { ipoGenGroups 7 }
+
+ipoGenSvcSOGNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenSogHostFailureSvcEvent,
+        ipoGenSogModeChangeSvcEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "The service notifications which indicate specific changes in
+        the state of the IP Office SOG system."
+    ::= { ipoGenGroups 8 }
+
+ipoGenUPriLicSvcNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenUPriLicChansReducedSvcEvent,
+        ipoGenUPriLicCallRejectedSvcEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "The service notifications which indicate specific changes
+        related to the state licensing and Universal PRI trunks on the
+        IP Office system."
+    ::= { ipoGenGroups 9 }
+
+ipoGenQosMonNotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventQoSMonJitter,
+        ipoGTEventQoSMonRndTrip,
+        ipoGTEventQoSMonPktLoss,
+        ipoGTEventQoSMonCallId,
+        ipoGTEventQoSMonDevType,
+        ipoGTEventQoSMonDevId,
+        ipoGTEventQoSMonExtnNo
+    }
+    STATUS current
+    DESCRIPTION
+        "Additional objects that are contained in IP Office QOS
+        Monitoring notifications."
+    ::= { ipoGenGroups 10 }
+
+ipoGenSvcQoSMonNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenQoSMonSvcEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "The service notifications which indicate specific changes
+        related to the value of QoS parameters for a call on a physical
+        entity on the IP Office system."
+    ::= { ipoGenGroups 11 }
+
+ipoGenSvcSystemShutdownObjectGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventSystemShutdownSource,
+        ipoGTEventSystemShutdownTimeout
+    }
+    STATUS current
+    DESCRIPTION
+        "Additional objects that are contained in the system shutdown 
+        notification"
+    ::= { ipoGenGroups 12 }    
+    
+ipoGenSvcSystemShutdownNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenSystemShutdownSvcEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "The service notifications which indicate specific changes
+        related to the system shutdown performed on the IP Office system."
+    ::= { ipoGenGroups 13 }    
+
+
+ipoGenSDcardNotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventMemoryCardSlotId,
+        ipoGTEventNoValidKeyReason
+    }
+    STATUS current
+    DESCRIPTION
+        "Additional objects that are contained in IP Office SD card
+        notifications."
+    ::= { ipoGenGroups 14 }
+
+ipoGenSDcardNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenAppOperationalSvcEvent,
+        ipoGenAppFailureSvcEvent,
+        ipoGenAppSvcEvent,
+        ipoGenSystemRunningBackupEvent,
+        ipoGenInvalidMemoryCardEvent,
+        ipoGenNoLicenceKeyDongleEvent,
+        ipoGenMemoryCardCapacityEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "The notifications associated with IP Office SD card usage."
+    ::= { ipoGenGroups 15 }    
+
+ipoGenSvcMiscNotificationObjectsGroup OBJECT-GROUP
+    OBJECTS {
+        ipoGTEventReason,
+        ipoGTEventData,
+        ipoGTEventAlarmDescription,
+        ipoGTEventAlarmRemedialAction
+    }
+    STATUS current
+    DESCRIPTION
+        "Additional objects that are contained in IP Office
+        notifications to provide additional information to
+        end user"
+    ::= { ipoGenGroups 16 }
+
+ipoGenSvcMiscNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoGenConfigFailureSvcEvent,
+        ipoGenConfigOperationalSvcEvent,
+        ipoGenConfigErrorSvcEvent,
+        ipoGenConfigChangeSvcEvent,
+        ipoGenServiceFailureSvcEvent,
+        ipoGenServiceOperationalSvcEvent,
+        ipoGenServiceErrorSvcEvent,
+        ipoGenServiceChangeSvcEvent,
+        ipoGenTrunkFailureSvcEvent,
+        ipoGenTrunkOperationalSvcEvent,
+        ipoGenTrunkErrorSvcEvent,
+        ipoGenTrunkChangeSvcEvent,
+        ipoGenLinkFailureSvcEvent,
+        ipoGenLinkOperationalSvcEvent,
+        ipoGenLinkErrorSvcEvent,
+        ipoGenLinkChangeSvcEvent,
+        ipoGenEmergencyCallSvcEvent
+    }
+    STATUS current
+    DESCRIPTION
+        "The notifications indicating change in status
+        related to four areas: Configuration, Sevice,
+        Trunk and Link"
+    ::= { ipoGenGroups 17 }
+
+
+
+
+END

--- a/mibs/avaya/IPO-PHONES-MIB.mib
+++ b/mibs/avaya/IPO-PHONES-MIB.mib
@@ -1,0 +1,691 @@
+--========================================================
+--
+-- MIB      : IPO-PHONES  Avaya Inc.
+--
+-- Version  : 2.00.06   9 February 2011
+--
+--========================================================
+--
+-- Copyright (c) 2003 - 2011 Avaya Inc.
+-- All Rights Reserved.
+--
+--========================================================
+IPO-PHONES-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    NOTIFICATION-TYPE, Integer32, Unsigned32, IpAddress
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString, PhysAddress
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+    sysDescr
+        FROM SNMPv2-MIB
+    IndexInteger
+        FROM DIFFSERV-MIB
+    ipoGenMibs, ipoGTEventDateTime, ipoGTEventSeverity,
+    ipoGTEventStdSeverity, ipoGTEventDevID, ipoGTEventEntityName
+        FROM IPO-MIB
+	;
+
+ipoPhonesMIB  MODULE-IDENTITY
+    LAST-UPDATED    "201102091521Z" -- 9 February 2011
+    ORGANIZATION    "Avaya Inc."
+    CONTACT-INFO
+        "Avaya Customer Services
+         Postal: Avaya, Inc.
+                 211 Mt Airy Rd.
+                 Basking Ridge, NJ 07920
+                 USA
+         Tel:    +1 908 953 6000
+
+         WWW:    http://www.avaya.com"
+    DESCRIPTION
+        "Avaya IP Office Phones MIB
+
+         The MIB module for representing the phones present on a Avaya
+         IP Office stack."
+
+
+    REVISION    "201102091521Z" -- 9 February 2011
+    DESCRIPTION
+        "Rev 2.00.06
+        PhoneType: adding more original Nortel phone sets."
+    REVISION    "200902181309Z" -- 18 February 2009
+    DESCRIPTION
+        "Rev 2.00.05
+        PhoneType enumerations for a number of SIP phones,
+        the 1400 phones and PhoneManager IP SoftPhone added."
+    REVISION    "200806121506Z" -- 12 June 2008
+    DESCRIPTION
+        "Rev 2.00.04
+        PhoneType enumerations for the 1700 phones added."
+    REVISION    "200804171630Z" -- 17 April 2008
+    DESCRIPTION
+        "Rev 2.00.03
+        Added descriptions for new PhoneType enumerations
+        and corrected versioning."
+    REVISION    "200703281209Z" -- 28 March 2007
+    DESCRIPTION
+        "Rev 2.00.02
+        Added the port number, module number, ip address,
+        and physical address, to the ipoPhonesTable"
+    REVISION    "200702241209Z" -- 24 February 2007
+    DESCRIPTION
+        "Rev 2.00.01
+        Added descriptions for new PhoneType enumerations
+        and corrected versioning."
+    REVISION    "200606290000Z" -- 29 June 2006
+    DESCRIPTION
+        "Rev 2.00.00
+        Traps/notifications revised to provide more information about
+        the entity and device concerned."
+    REVISION 	"200601310000Z" -- 31 January 2006
+    DESCRIPTION
+        "Rev 1.00.08
+        Corrected enumeration for 5621 IP phones." 
+    REVISION 	"200511220000Z" -- 22 November 2005
+    DESCRIPTION
+        "Rev 1.00.07
+        Revised for 5621 IP phones." 
+    REVISION 	"200507211050Z" -- 21 July 2005
+    DESCRIPTION
+        "Rev 1.00.06
+        Revised for 4621 IP phones." 
+    REVISION 	"200507211030Z" -- 21 July 2005
+    DESCRIPTION
+        "Rev 1.00.05
+        Revised for 5601 and 5602 Phones"
+    REVISION 	"200503040000Z" -- 4 March 2005
+    DESCRIPTION
+        "Rev 1.00.04
+        Revised for IP Soft Phones"
+    REVISION 	"200501060000Z" -- 6 January 2005
+    DESCRIPTION
+        "Rev 1.00.03
+        Revised for 5610/5620 IP phones."
+    REVISION 	"200412200000Z" -- 20 December 2004
+    DESCRIPTION
+        "Rev 1.00.02
+        Revised for additional phone support."
+    REVISION 	"200403030000Z" -- 3 March 2004
+    DESCRIPTION
+        "Rev 1.00.01
+        Revised for external publication."
+    REVISION 	"200310100000Z" -- 10 October 2003
+    DESCRIPTION
+        "Rev 1.0.0
+        The first published version of this MIB module."
+    ::= {  ipoGenMibs 1 }
+
+ipoPhonesMibNotifications  OBJECT IDENTIFIER ::= { ipoPhonesMIB 0 }
+ipoPhonesMibObjects        OBJECT IDENTIFIER ::= { ipoPhonesMIB 1 }
+ipoPhonesConformance       OBJECT IDENTIFIER ::= { ipoPhonesMIB 2 }
+
+--********************************************************************
+-- IPOPhone Textual Conventions
+--********************************************************************
+
+PhoneType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+        "This data type is used as the syntax of the ipoPhoneType
+        object in the ipoPhonesTable."
+    SYNTAX  INTEGER {
+       noPhone(1),              -- no phone actually connected
+       genericPhone(2),         -- for phone found that we can handle in
+                                -- some way but exact type not recognised
+                                -- may or may not be needed
+       potPhone(3),             -- Generic Analogue/POT Phone
+       dtPhone(4),              -- Generic DT Phone
+       a4406Dplus(5),           -- Avaya 4406D+ DCP Phone
+       a4412Dplus(6),           -- Avaya 4412D+ DCP Phone
+       a4424Dplus(7),           -- Avaya 4424D+ DCP Phone
+       a4424LDplus(8),          -- Avaya 4424LD+ DCP Phone
+       a9040TransTalk(9),       -- Avaya 9040 TransTalk
+       a6408Dplus(10),          -- Avaya 6408D+ DCP Phone
+       a6416Dplus(11),          -- Avaya 6416D+ DCP Phone
+       a6424Dplus(12),          -- Avaya 6424D+ DCP Phone
+       a4606ip(13),             -- Avaya 4606 IP Phone
+       a4612ip(14),             -- Avaya 4612 IP Phone
+       a4624ip(15),             -- Avaya 4624 IP Phone
+       a4620ip(16),             -- Avaya 4620 IP Phone
+       a4602ip(17),             -- Avaya 4602 IP Phone
+       a2420(18),               -- Avaya 2420 DCP Phone
+       a2010dt(19),             -- Avaya 2010 DT Phone
+       a2020dt(20),             -- Avaya 2020 DT Phone
+       a2030dt(21),             -- Avaya 2030 DT Phone
+       a2050dt(22),             -- Avaya 2050 DT Phone
+       act5(23),                -- Avaya CT5 Phone
+       att3(24),                -- Avaya TT3 Phone
+       att5(25),                -- Avaya TT5 Phone
+       a5420(26),               -- Avaya 5420 DCP Phone
+       a5410(27),               -- Avaya 5410 DCP Phone
+       a4601ip(28),             -- Avaya 4601 IP Phone
+       a4610ip(29),             -- Avaya 4610 IP Phone
+       ablf(30),                -- Avaya BLF Phone
+       a2402(31),               -- Avaya 2402 DCP Phone
+       a2410(32),               -- Avaya 2410 DCP Phone
+       a5610ip(33),             -- Avaya 5610 IP Phone
+       a5620ip(34),             -- Avaya 5620 IP Phone
+       softIPPhone(35),         -- Avaya IP Soft Phone
+       a5601ip(36),             -- Avaya 5601 IP Phone
+       a5602ip(37),             -- Avaya 5602 IP Phone
+       a4621ip(38),             -- Avaya 4621 IP Phone
+       a5621ip(39),             -- Avaya 5621 IP Phone
+       a4625ip(40),             -- Avaya 4625 IP Phone
+       a5402(41),               -- Avaya 5402 DCP Phone
+       h323Phone(42),           -- Generic H.323 Phone
+       sipPhone(43),            -- Generic SIP Phone
+       t3Compact(44),           -- Avaya T3 Compact Phone
+       t3Classic(45),           -- Avaya T3 Classic Phone
+       t3Comfort(46),           -- Avaya T3 Comfort Phone
+       t3Phone(47),             -- Avaya T3 Generic Phone
+       t3compactIP(48),         -- Avaya T3 Compact IP Phone
+       t3classicIP(49),         -- Avaya T3 Classic IP Phone
+       t3comfortIP(50),         -- Avaya T3 Comfort IP Phone
+       avayaSip(51),            -- Avaya Generic SIP Phone
+       admmPhone(52),           -- Avaya Generic ADMM (IP DECT) Phone
+       a9620ip(53),             -- Avaya 9620 IP Phone
+       a9630ip(54),             -- Avaya 9630 IP Phone
+       telecommuter(55),        -- Telecommuting homeworker
+       mobiletwin(56),          -- Mobile one-X phone
+       a9640ip(57),             -- Avaya 9640 IP Phone
+       a9650ip(58),             -- Avaya 9650 IP Phone
+       a9610ip(59),             -- Avaya 9610 IP Phone
+       a1603ip(60),             -- Avaya 1603 IP Phone
+       a1608ip(61),             -- Avaya 1608 IP Phone
+       a1616ip(62),             -- Avaya 1616 IP Phone
+       a1703ip(63),             -- Avaya 1703 IP Phone
+       a1708ip(64),             -- Avaya 1708 IP Phone
+       a1716ip(65),             -- Avaya 1716 IP Phone
+       s60Sip(66),              -- S60 SIP
+       sp320Sip(67),            -- SP320 SIP
+       sp601Sip(68),            -- SP601 SIP
+       a10ataSip(69),           -- A10ATA SIP
+       pmataSip(70),            -- Patton M-ATA SIP
+       ip22Sip(71),             -- Innovaphone IP22 SIP
+       ip24Sip(72),             -- Innovaphone IP24 SIP
+       gxp2000Sip(73),          -- Grandstream GXP2000 SIP
+       gxp2020Sip(74),          -- Grandstream GXP2000 SIP
+       eyebeamSip(75),          -- CounterPath eyeBeam SIP
+       a1403(76),               -- Avaya 1403 Phone
+       a1408(77),               -- Avaya 1408 Phone
+       a1416(78),               -- Avaya 1416 Phone
+       a1450(79),               -- Avaya 1450 Phone
+       ip28Sip(80),
+       phoneManagerIP(81),      -- Phone Manager IP
+       a1503(82),               -- Avaya 1503 Phone
+       a1508(83),               -- Avaya 1508 Phone
+       a1516(84),               -- Avaya 1516 Phone
+       a1550(85),               -- Avaya 1550 Phone
+       a1603Lip(86),            -- Avaya 1603L IP Phone
+       a1608Lip(87),            -- Avaya 1608L IP Phone
+       a1616Lip(88),            -- Avaya 1616L IP Phone
+       softPhoneSip(89),        -- SIP SoftPhone
+       etr34d(90),              -- ETR-34D
+       etr18d(91),              -- ETR-18D
+       etr6d(92),               -- ETR-6D
+       etr34(93),               -- ETR-34
+       etr18(94),               -- ETR-18
+       etr6(95),                -- ETR-6
+       etrpots(96),             -- ETR Pots
+       doorphone1(97),          -- Door phone 1
+       doorphone2(98),          -- Door phone 2
+       bstT7316e(99),           -- BST 7316E
+       a9620Sip(100),           -- Avaya 9620L/C SIP Phone
+       a9630Sip(101),           -- Avaya 9630G SIP Phone
+       a9640Sip(102),           -- Avaya 9640/G SIP Phone
+       a9650Sip(103),           -- Avaya 9650/C SIP Phone
+       a96xxSip(104),           -- Avaya 96xx SIP Phone
+       a1603Sip(105),           -- Avaya 1603 Blaze SIP Phone
+       a9404(106),              -- Avaya 9404 Phone
+       a9408(107),              -- Avaya 9408 Phone
+       a9504(108),              -- Avaya 9504 Phone
+       a9508(109),              -- Avaya 9508 Phone
+       a9608ip(110),            -- Avaya 9608 IP Phone
+       a9611ip(111),            -- Avaya 9611 IP Phone
+       a9621ip(112),            -- Avaya 9621 IP Phone
+       a9641ip(113),            -- Avaya 9641 IP Phone
+       a3720Admm(114),          -- Avaya 3720 ADMM (IP DECT) Phone
+       a3725Admm(115),          -- Avaya 3725 ADMM (IP DECT) Phone
+       a1010Sip(116),           -- Avaya 1010 SIP Video Phone
+       a1040Sip(117),           -- Avaya 1040 SIP Video Phone
+       a1120ESip(118),          -- Avaya 1120E SIP Phone
+       a1140ESip(119),          -- Avaya 1140E SIP Phone
+       a1220Sip(120),           -- Avaya 1220 SIP Phone
+       a1230Sip(121),           -- Avaya 1230 SIP Phone
+       a1692Sip(122),           -- Avaya 1692 SIP Phone
+       pvvxSip(123),            -- Polycom VVX SIP
+       gxv3140Sip(124),         -- Grandstream GXV3140 SIP
+       a3740Admm(125),          -- Avaya 3740 ADMM (IP DECT) Phone
+       a3749Admm(126),          -- Avaya 3749 ADMM (IP DECT) Phone
+       bstT7316(127),           -- Original Nortel T7316 BST Phone
+       bstT7208(128),           -- Original Nortel T7208 BST Phone
+       bstM7208(129),           -- Original Nortel M7208 BST Phone
+       bstM7310(130),           -- Original Nortel M7310 BST Phone
+       bstM7310blf(131),        -- Original Nortel M7310 BST Phone with BLF Module
+       bstM7324(132),           -- Original Nortel M7324 BST Phone with BLF Module
+       bstM7100(133),           -- Original Nortel M7100 BST Phone with BLF Module
+       bstT7100(134),           -- Original Nortel T7100 BST Phone with BLF Module
+       bstT7000(135),           -- Original Nortel T7000 BST Phone with BLF Module
+       bstDectA(136),           -- Original Nortel Dect handset model a
+       bstDectB(137),           -- Original Nortel Dect handset model b
+       bstDectC(138),           -- Original Nortel Dect handset model c
+       bstDoorphone(139),       -- Original Nortel Doorphone
+       bstT7406(140),           -- Original Nortel T7406 cordless phone
+       bstT7406E(141),          -- Original Nortel T7406E cordless phone
+       bstM7310N(142),          -- Original Nortel M7310N stimulus phone
+       bstAcu(143),             -- Original Nortel Audio Conferencing Unit
+       bstM7100N(144),          -- Original Nortel M7100N stimulus phone
+       bstM7324N (145),         -- Original Nortel M7324N stimulus phone
+       bstM7208N(146),          -- Original Nortel M7208N stimulus phone
+       aB179Sip(147),           -- Avaya B179 Sip Phone (Konftel 300IP)
+       bstAta(148),             -- Bst ATA
+       aA175Sip(149),           -- Avaya A175 Sip Phone
+       aOneXSip(150),           -- Avaya oneX Sip Phone
+       aFlareSip(151),          -- Avaya Flare Sip Phone
+       aD100(152),              -- Avaya D100 Sip Phone
+       aRadvisionXT1000(153),   -- Avaya RadvisionXT1000 Sip Phone
+       aRadvisionXT1200(154),   -- Avaya RadvisionXT1200 Sip Phone
+       aRadvisionXT4000(155),   -- Avaya RadvisionXT4000 Sip Phone
+       aRadvisionXT4200(156),   -- Avaya RadvisionXT4200 Sip Phone
+       aRadvisionXT5000(157),   -- Avaya RadvisionXT5000 Sip Phone
+       aRadvisionXTPiccolo(158),-- Avaya RadvisionXTPiccolo Sip Phone
+       aRadvisionScopiaMCU(159),-- Avaya RadvisionScopiaMCU Sip Phone
+       aRadvisionScopiaVC240(160),-- Avaya RadvisionScopiaVC240 Sip Phone
+       aOneXSipMobile(161),     -- Avaya OneX Sip Mobile Phone
+       aACCSServer(162),        -- Avaya Contact Center ACCS
+       aCIEServer(163),         -- Avaya Contact Center CIE
+       aE129SIP(164),           -- Avaya E129 SIP phone (Grandstream OEM)
+       aE159SIP(165),           -- Avaya E159 SIP phone (Invoxia OEM)
+       aE169SIP(166),           -- Avaya E169 SIP phone (Invoxia OEM)
+       aOneXMsiSIP(167),        -- Avaya Microsoft Lync SIP plugin
+       aRadvisionXT240(168),    -- Avaya Radvision XT240 Scopia SIP phone
+       aWebRTCSIP(169),         -- Avaya WebRTC Client
+       softPhoneSipMac(170)     -- SIP Mac SoftPhone
+    }
+
+--********************************************************************
+-- IPOPhone Objects
+--********************************************************************
+
+-- MIB contains a single group
+
+ipoPhones OBJECT IDENTIFIER ::= { ipoPhonesMibObjects 1 }
+
+ipoPhonesNumber  OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of phone interfaces (regardless of their current
+        state) present on this system."
+    ::= { ipoPhones 1 }
+
+-- the Phones table
+
+-- The Phones table contains information on the phones connected to a
+-- IP Office stack entity.
+
+ipoPhonesTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IpoPhonesEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A list of phone entries.  The number of entries is given by
+        the value of ipoPhonesNumber."
+    ::= { ipoPhones 2 }
+
+ipoPhonesEntry OBJECT-TYPE
+    SYNTAX      IpoPhonesEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "An entry containing management information applicable to a
+        particular IP Office phone."
+    INDEX   { ipoPhonesIndex }
+    ::= { ipoPhonesTable 1 }
+
+IpoPhonesEntry ::=
+    SEQUENCE {
+        ipoPhonesIndex                 IndexInteger,
+        ipoPhonesExtID                 Integer32,
+        ipoPhonesExtNumber             Integer32,
+        ipoPhonesUserShort             DisplayString,
+        ipoPhonesUserLong              DisplayString,
+        ipoPhonesType                  PhoneType,
+        ipoPhonesPort                  Unsigned32,
+        ipoPhonesPortNumber            Unsigned32,
+        ipoPhonesModuleNumber          Unsigned32,
+        ipoPhonesIPAddress             IpAddress,
+        ipoPhonesPhysAddress           PhysAddress
+    }
+
+ipoPhonesIndex OBJECT-TYPE
+    SYNTAX      IndexInteger
+    MAX-ACCESS  read-only -- for SMIv1 compatability rather than not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A unique value, greater than zero, for each phone.  It is
+         recommended that values are assigned contiguously starting
+         from 1.  The value for each phone sub-layer must remain
+         constant at least from one re-initialization of the entity's
+         network management system to the next re- initialization."
+    ::= { ipoPhonesEntry 1 }
+
+ipoPhonesExtID OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The numerical logical extension entity identifier assigned to
+         the phone on the IP Office entity."
+    ::= { ipoPhonesEntry 2 }
+
+ipoPhonesExtNumber OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number that should be dialed to reach this phone on the
+        IP Office entity."
+    ::= { ipoPhonesEntry 3 }
+
+ipoPhonesUserShort OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..15))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The short form of the name of the user of this phone which is
+        used in caller display. This is quite often the forename of
+        the user."
+    ::= { ipoPhonesEntry 4 }
+
+ipoPhonesUserLong OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..31))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The long form of the name of the user of this phone. This is
+        normally the full name (forename and surname) of the user."
+    ::= { ipoPhonesEntry 5 }
+
+ipoPhonesType OBJECT-TYPE
+    SYNTAX      PhoneType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The type of phone that is connected to this IP Office logical
+        phone extension."
+    ::= { ipoPhonesEntry 6 }
+
+ipoPhonesPort OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A reference, by entPhysicalIndex value, to the
+        EntPhysicalEntry representing the physical port entity that
+        this phone entry is associated with in an entity MIB
+        instantiation within the IP Office agent. If no MIB
+        definitions specific to the particular media are available, or
+        the entry is for a IP phone which may not be connected to a
+        physical port on the IP Office, the value should be set to the
+        value 0."
+    ::= { ipoPhonesEntry 7 }
+
+ipoPhonesPortNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The port number on the module that the operator uses to
+        identify the port.
+
+        The port numbers on the expansion modules will follow standard 
+        numbering, beginning at 1 and incrementing until the last port.
+        The phone ports on the base units, however, are numbered 
+        according to how they are collected into 'banks' on the unit.
+
+        IP Office IP500
+            The entire front of the product consists of 4 plug-in modules. 
+            Each module has its own numbering from 1..12.
+            So from the left: 101..112, 201..212, etc.
+
+        IP Office IP412 
+            There is no way to plug phones into the unit, so only 
+            expansion modules should be present. 
+
+        IP Office IP406v2
+            The leftmost bank of ports are Digital (DS/DT) and labeled 
+            as 1-8 on the product, and so are labelled ports 101..108 
+            in the mib.
+
+            The next bank of ports are Analogue and labeled as 1-2 
+            on the product and so are labelled ports 201..202 in the mib.
+
+            The next bank of phones are LAN and labeled as 1-8 on the 
+            product. Not phones, so not in this mib.
+
+        IP Office Small Office Edition
+            The leftmost bank of 4 ports are Trunk ports, and so are not 
+            available in this mib.
+
+            The next bank of 8 ports are Digital (DS/DT), and so are 
+            labelled ports 101..108 in the mib.
+
+            The next bank of 4 ports are Analogue, and so are labelled 
+            ports 201..204 in the mib.
+
+            The next bank of ports are LAN, and so are not available in 
+            this mib."
+    ::= { ipoPhonesEntry 8 }
+
+ipoPhonesModuleNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number that the operator uses to
+        identify the module.
+
+        The module numbers are assigned according to the expansion 
+        port number that it's plugged into on the Control unit.
+
+        Example: Module number '2' = Expansion unit plugged into 
+        expansion port 2 on the Control unit.
+
+        Module number '0' is reserved for the Control unit itself."
+    ::= { ipoPhonesEntry 9 }
+
+ipoPhonesIPAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The IP Address of the phone. In network-byte order. In the usual
+        IP Address format - xxx.xxx.xxx.xxx.
+
+        The IP address will only be present if the phone is an IP phone. If
+        it is not, it will contain zeros (0.0.0.0)."
+        
+    ::= { ipoPhonesEntry 10 }
+
+ipoPhonesPhysAddress OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The Physical Address of the phone, such as the MAC Address.
+
+        The physical address will only be present if the phone is an IP 
+        phone. If it is not, it will contain zeros (00.00.00.00.00.00)."
+        
+    ::= { ipoPhonesEntry 11 }
+
+--********************************************************************
+-- IPOPhone Notifications
+--********************************************************************
+
+--
+-- Notifications
+--
+
+ipoPhonesChangeEvent NOTIFICATION-TYPE
+    OBJECTS {
+	ipoGTEventSeverity,
+	ipoGTEventDateTime,
+        ipoPhonesExtID,
+        ipoPhonesType,
+        ipoPhonesPort
+	}
+    STATUS deprecated
+    DESCRIPTION
+	"This notification is generated whenever the type of phone
+	connected to a logical extension entity is detected as having
+	changed after completion of normal start up of the Agent
+	entity.
+
+	Its purpose is to allow a management application to identify
+	the removal or switching of phone types on the IP Office
+	entity.
+
+        **NOTE: This notification is deprecated and replaced by
+          ipoPhonesChangeSvcEvent."
+    ::= { ipoPhonesMibNotifications 1 }
+
+ipoPhonesChangeSvcEvent NOTIFICATION-TYPE
+    OBJECTS {
+	ipoGTEventStdSeverity,
+	ipoGTEventDateTime,
+	ipoGTEventDevID,
+	sysDescr,
+        ipoPhonesExtID,
+        ipoPhonesType,
+        ipoPhonesPort,
+        ipoGTEventEntityName
+	}
+    STATUS current
+    DESCRIPTION
+	"This notification is generated whenever the type of phone
+	connected to a logical extension entity is detected as having
+	changed after completion of normal start up of the Agent
+	entity.
+
+	Its purpose is to allow a management application to identify
+	the removal or switching of phone types on the IP Office
+	entity.
+
+        Newer implementations of this MIB should put in place this
+        event in favour of ipoPhonesChangeEvent."
+    ::= { ipoPhonesMibNotifications 2 }
+
+--********************************************************************
+-- IPO-PHONES compliance
+--********************************************************************
+
+ipoPhonesCompliances OBJECT IDENTIFIER ::= { ipoPhonesConformance 1 }
+ipoPhonesGroups      OBJECT IDENTIFIER ::= { ipoPhonesConformance 2 }
+
+--
+-- compliance statements
+--
+
+ipoPhonesCompliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+	"The compliance statement for the IP Office Phones MIB"
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoPhonesGroup,
+        ipoPhonesNotificationsGroup
+    }
+    ::= { ipoPhonesCompliances 1 }
+
+ipoPhonesv2Compliance MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+	"The compliance statement for the IP Office Phones MIB"
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoPhonesGroup,
+        ipoPhonesv2NotificationsGroup
+    }
+    ::= { ipoPhonesCompliances 2 }
+
+ipoPhonesv3Compliance MODULE-COMPLIANCE
+    STATUS current
+    DESCRIPTION
+	"The compliance statement for the IP Office Phones MIB"
+    MODULE -- this module
+    MANDATORY-GROUPS {
+        ipoPhonesGroup,
+        ipoPhones2Group,
+        ipoPhonesv2NotificationsGroup
+    }
+    ::= { ipoPhonesCompliances 3 }
+
+--
+-- MIB groupings
+--
+
+ipoPhonesGroup OBJECT-GROUP
+    OBJECTS {
+        ipoPhonesNumber,
+        ipoPhonesIndex,
+        ipoPhonesExtID,
+        ipoPhonesExtNumber,
+        ipoPhonesUserShort,
+        ipoPhonesUserLong,
+        ipoPhonesType,
+        ipoPhonesPort
+    }
+    STATUS current
+    DESCRIPTION
+	"The collection of objects which are used to represent IP
+	Office phones, for which a single agent provides management
+	information."
+    ::= { ipoPhonesGroups 1 }
+
+ipoPhonesNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoPhonesChangeEvent
+    }
+    STATUS deprecated
+    DESCRIPTION
+	"The notifications which indicate specific changes in the
+	state of IP Office phones."
+    ::= { ipoPhonesGroups 2 }
+
+ipoPhonesv2NotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        ipoPhonesChangeSvcEvent
+    }
+    STATUS current
+    DESCRIPTION
+	"The notifications which indicate specific changes in the
+	state of IP Office phones for newer implementations of this
+	MIB."
+    ::= { ipoPhonesGroups 3 }
+
+ipoPhones2Group OBJECT-GROUP
+    OBJECTS {
+        ipoPhonesPortNumber,
+        ipoPhonesModuleNumber,
+        ipoPhonesIPAddress,
+        ipoPhonesPhysAddress
+    }
+    STATUS current
+    DESCRIPTION
+	"Additional collection of objects which are used to represent
+	physical information about IP Office phones, for which a
+	single agent provides management information.  These objects
+	provide more information on where phones are directly
+	connected to an IP Office and further details on IP Phones for
+	their identification."
+    ::= { ipoPhonesGroups 4 }
+
+END

--- a/mibs/avaya/IPO-PROD-MIB.mib
+++ b/mibs/avaya/IPO-PROD-MIB.mib
@@ -1,0 +1,1202 @@
+--========================================================
+--
+-- MIB      : IPO-PROD  Avaya Inc.
+--
+-- Version  : 1.0.26   06 Aug 2014
+--
+--========================================================
+--
+-- Copyright (c) 2003 - 2012 Avaya Inc.
+-- All Rights Reserved.
+--
+--========================================================
+IPO-PROD-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-IDENTITY
+        FROM SNMPv2-SMI
+    products
+        FROM AVAYAGEN-MIB;
+
+ipoProdMIB MODULE-IDENTITY
+    LAST-UPDATED    "201408060000Z" -- 06 Aug 2014
+    ORGANIZATION 	"Avaya Inc."
+    CONTACT-INFO
+        "Avaya Customer Services
+         Postal: Avaya, Inc.
+                 211 Mt Airy Rd.
+                 Basking Ridge, NJ 07920
+                 USA
+         Tel:    +1 908 953 6000
+
+         WWW:    http://www.avaya.com"
+
+    DESCRIPTION
+        "Avaya IP Office Products OID tree.
+
+         This MIB module defines the product/sysObjectID values for
+         use with Avaya IP Office family of telephone switches."
+
+    REVISION    "201408060000Z" -- 06 Aug 2014
+    DESCRIPTION
+         "Rev 1.00.26
+          J Modules are now part of IP500v2."
+
+    REVISION    "201405300000Z" -- 30 May 2014
+    DESCRIPTION
+         "Rev 1.00.25
+          Additional IOD for IP500v2 Select and 
+          IP Office Server Edition Expansion Select Mode."
+    REVISION    "201402270000Z" -- 27 Feb 2014
+    DESCRIPTION
+         "Rev 1.00.24
+          Additional IOD for IP 500 UCM V2 module"
+    REVISION    "201312100000Z" -- 10 Dec 2013
+    DESCRIPTION
+         "Rev 1.00.23
+          Update description for Unified Communications Module"
+    REVISION    "201207230000Z" -- 23 July 2012
+    DESCRIPTION
+         "Rev 1.00.22
+         Additional IOD for IP 500 ATM4U V2 module."
+    REVISION    "201203260000Z" -- 26 March 2012
+    DESCRIPTION
+         "Rev 1.00.21
+         Additional IOD for IP 500 VCM module."
+    REVISION    "201111141128Z" -- 14 November 2011
+    DESCRIPTION
+        "Rev 1.00.20
+        Additional OID for IP Office Server Edition Expansion Mode."
+    REVISION    "201108111658Z" -- 11 August 2011
+    DESCRIPTION
+        "Rev 1.00.19
+        Added new C110 UCP Module."
+    REVISION    "201102101457Z" -- 10 February 2011
+    DESCRIPTION
+        "Rev 1.00.18
+        Added new OID for TCM 8 card."
+    REVISION    "201102011457Z" -- 01 February 2011
+    DESCRIPTION
+        "Rev 1.00.17
+        Added new OID for DS30A  Expansion module."
+    REVISION    "201101111630Z" -- 11 January 2011
+    DESCRIPTION
+        "Rev 1.00.16
+        Avaya Inside OIDs removed.
+        Additional OIDs added for Norstar, Branch and Quick IP Office
+        modes."
+    REVISION    "201006091515Z" -- 09 June 2010
+    DESCRIPTION
+        "Rev 1.00.15
+        Added new OID for Combo Card VCM sub module."
+    REVISION    "201004281626Z" -- 28 April 2010
+    DESCRIPTION
+        "Rev 1.00.14
+        Added new OID for Avaya Inside."
+    REVISION    "200908261713Z" -- 26 August 2009
+    DESCRIPTION
+        "Rev 1.00.13
+        Added new OIDs for IP500v2, combo card and ETR card."
+    REVISION    "200908051048Z" -- 05 August 2009
+    DESCRIPTION
+        "Rev 1.00.12
+        Added a new OID for IP500 4 Port Expansion Module."
+    REVISION    "200608161100Z" -- 16 August 2006
+    DESCRIPTION
+        "Rev 1.00.11
+        Corrected PRI module defined for IP500 and revised description
+        for Ethernet wAN link ports to make common across units."
+    REVISION    "200608021752Z" -- 02 August 2006
+    DESCRIPTION
+        "Rev 1.00.10
+        Added a new OID for Universal PRI module and revised
+        descriptions for LAN ports used on IP412."
+    REVISION    "200607132220Z" -- 13 July 2006
+    DESCRIPTION
+        "Rev 1.00.09
+        Added further OIDs for missing modules.
+        Replaced references to IP408 with IP500"
+    REVISION    "200606101416Z" -- 10 June 2006
+    DESCRIPTION
+        "Rev 1.00.08
+        Added new OIDs for IP500 chassis and plug-in cards."
+    REVISION    "200606071014Z" -- 07 June 2006
+    DESCRIPTION
+        "Rev 1.00.07
+        Added new OID for generic IP Office License dongle."
+    REVISION    "200605241620Z" -- 24 May 2006
+    DESCRIPTION
+        "Rev 1.00.06
+        Added new OID for revised variant of ATM4U
+        trunk module."
+    REVISION    "200605241615Z" -- 24 May 2006
+    DESCRIPTION
+        "Rev 1.00.05
+        Corrected descriptions of E1 R2 modules/ports."
+    REVISION    "200604040000Z" -- 04 April 2006
+    DESCRIPTION
+        "Rev 1.00.04
+        Added new OIDs for revised (v2) variants of DS and POTS
+        expansion modules."
+    REVISION    "200408060000Z" -- 06 August 2004
+    DESCRIPTION
+        "Rev 1.00.03
+        Added SOG family products."
+    REVISION 	"200403030000Z" -- 03 March 2004
+    DESCRIPTION
+        "Rev 1.00.02
+        Revised for external publication."
+    REVISION 	"200401060000Z" -- 06 January 2004
+    DESCRIPTION
+        "Rev 1.0.1
+        New OIDs added for revised 403 and 406 variants."
+    REVISION 	"200310100000Z" -- 10 October 2003
+    DESCRIPTION
+        "Rev 1.0.0
+        The first published version of this MIB module."
+    ::= { products 2 }
+
+-- Product Groups
+
+ipoProdControllers      OBJECT IDENTIFIER ::= { ipoProdMIB 1 }
+ipoProdExpModules       OBJECT IDENTIFIER ::= { ipoProdMIB 2 }
+ipoProdSlots            OBJECT IDENTIFIER ::= { ipoProdMIB 3 }
+ipoProdSlotModules      OBJECT IDENTIFIER ::= { ipoProdMIB 4 }
+ipoProdPorts            OBJECT IDENTIFIER ::= { ipoProdMIB 5 }
+ipoProdDongleModules    OBJECT IDENTIFIER ::= { ipoProdMIB 6 }
+ipoProdSubModules       OBJECT IDENTIFIER ::= { ipoProdMIB 7 }
+ipoProdUCModules        OBJECT IDENTIFIER ::= { ipoProdMIB 8 }
+
+-- Controller Product families
+
+ipoProd401Family   OBJECT IDENTIFIER ::= { ipoProdControllers 1 }
+ipoProd403Family   OBJECT IDENTIFIER ::= { ipoProdControllers 2 }
+ipoProd406Family   OBJECT IDENTIFIER ::= { ipoProdControllers 3 }
+ipoProd412Family   OBJECT IDENTIFIER ::= { ipoProdControllers 4 }
+ipoProdSmallOfficeEditionFamily OBJECT IDENTIFIER ::= { ipoProdControllers 5 }
+ipoProdR403Family  OBJECT IDENTIFIER ::= { ipoProdControllers 6 }
+ipoProdR406Family  OBJECT IDENTIFIER ::= { ipoProdControllers 7 }
+ipoProdSogFamily   OBJECT IDENTIFIER ::= { ipoProdControllers 8 }
+ipoProd500Family   OBJECT IDENTIFIER ::= { ipoProdControllers 9 }
+ipoProd500v2Family OBJECT IDENTIFIER ::= { ipoProdControllers 10 }
+
+-- IP Office 401 Family units
+
+ipoProd401DT2    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP401
+	Compact Office DT 2 Telephone Switch"
+    ::= { ipoProd401Family 1 }
+
+ipoProd401DT4    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP401
+	Compact Office DT 4 Telephone Switch"
+    ::= { ipoProd401Family 2 }
+
+ipoProd401DS2    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP401
+	Compact Office DS 2 Telephone Switch"
+    ::= { ipoProd401Family 3 }
+
+ipoProd401DS4    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP401
+	Compact Office DS 4 Telephone Switch"
+    ::= { ipoProd401Family 4 }
+
+-- IP Office 403 Family units
+
+ipoProd403DT    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP403 DT
+	 Office Platform Telephone Switch Controller Unit"
+    ::= { ipoProd403Family 1 }
+
+ipoProd403DS    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP403 DS
+	 Office Platform Telephone Switch Controller Unit"
+    ::= { ipoProd403Family 2 }
+
+-- IP Office 406 Family units
+
+ipoProd406    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP406
+	 Office Platform Telephone Switch Controller Unit"
+    ::= { ipoProd406Family 1 }
+
+-- IP Office 412 Family units
+
+ipoProd412    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP412
+	Office Platform Telephone Switch Controller Unit"
+    ::= { ipoProd412Family 1 }
+
+-- IP Office - Small Office Edition Family units
+
+ipoProdSmallOfficeEditionPOTS4  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office -
+	Small Office Edition Telephone Switch POTS 4"
+    ::= { ipoProdSmallOfficeEditionFamily 1 }
+
+ipoProdSmallOfficeEditionPOTS8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office -
+	Small Office Edition Telephone Switch POTS 8"
+    ::= { ipoProdSmallOfficeEditionFamily 2 }
+
+ipoProdSmallOfficeEditionDT8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office -
+	Small Office Edition Telephone Switch DT 8"
+    ::= { ipoProdSmallOfficeEditionFamily 3 }
+
+ipoProdSmallOfficeEditionDS8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office -
+	Small Office Edition Telephone Switch DS 8"
+    ::= { ipoProdSmallOfficeEditionFamily 4 }
+
+-- IP Office Revised 403 Family units
+
+ipoProdR403DT    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised IP403 DT
+	 Office Platform Telephone Switch Controller Unit"
+    ::= { ipoProdR403Family 1 }
+
+ipoProdR403DS    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised IP403 DS
+	 Office Platform Telephone Switch Controller Unit"
+    ::= { ipoProdR403Family 2 }
+
+-- IP Office Revised 406 Family units
+
+ipoProdR406    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised IP406
+	 Office Platform Telephone Switch Controller Unit (2 POTs, no DS)"
+    ::= { ipoProdR406Family 1 }
+
+ipoProdR406DT    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised IP406
+	 Office Platform Telephone Switch Controller Unit (2 POTs, 8 DT)"
+    ::= { ipoProdR406Family 2 }
+
+ipoProdR406DS    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised IP406
+	 Office Platform Telephone Switch Controller Unit (2 POTs, 8 DS)"
+    ::= { ipoProdR406Family 3 }
+
+ipoProdR406Full    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised IP406
+	 Office Platform Telephone Switch Controller Unit (Full version)"
+    ::= { ipoProdR406Family 4 }
+
+-- IP Office - SOG Family units
+
+ipoProdSogSOEPOTS4  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for the Avaya IP Office -
+        Small Office Edition Telephone Switch POTS 4"
+    ::= { ipoProdSogFamily 1 }
+
+ipoProdSogSOEPOTS8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for the Avaya IP Office -
+        Small Office Edition Telephone Switch POTS 8"
+    ::= { ipoProdSogFamily 2 }
+
+ipoProdSogSOEDT8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for the Avaya IP Office -
+        Small Office Edition Telephone Switch DT 8"
+    ::= { ipoProdSogFamily 3 }
+
+ipoProdSogSOEDS8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for the Avaya IP Office -
+        Small Office Edition Telephone Switch DS 8"
+    ::= { ipoProdSogFamily 4 }
+
+-- IP Office 500 Family units
+
+ipoProd500Slot4    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500
+	 Office Platform Telephone Switch 4 Slot Controller Unit"
+    ::= { ipoProd500Family 1 }
+
+ipoProd500Slot8    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500
+	 Office Platform Telephone Switch 8 Slot Controller Unit"
+    ::= { ipoProd500Family 2 }
+
+-- IP Office 500v2 Family units
+
+ipoProd500v2IPOffice    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in IP Office Mode"
+    ::= { ipoProd500v2Family 1 }
+
+ipoProd500v2Partner    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in Partner Mode"
+    ::= { ipoProd500v2Family 2 }
+
+ipoProd500v2Norstar    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in Norstar Mode"
+    ::= { ipoProd500v2Family 3 }
+
+ipoProd500v2Branch    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in Branch Gateway Mode"
+    ::= { ipoProd500v2Family 4 }
+
+ipoProd500v2Quick    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in Quick Mode"
+    ::= { ipoProd500v2Family 5 }
+
+ipoProd500v2SEditionExpansion    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in Server Edition Expansion Mode"
+    ::= { ipoProd500v2Family 6 }
+
+ipoProd500v2IPOfficeSelect    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in IP Office Select Mode"
+    ::= { ipoProd500v2Family 7 }
+
+ipoProd500v2SEditionExpansionSelect    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500v2
+	 Office Platform Telephone Switch in Server Edition Expansion Select Mode"
+    ::= { ipoProd500v2Family 8 }
+    
+-- Expansion Modules
+
+ipoProdExpModDT       OBJECT IDENTIFIER ::= { ipoProdExpModules 1 }
+ipoProdExpModDS       OBJECT IDENTIFIER ::= { ipoProdExpModules 2 }
+ipoProdExpModPhone    OBJECT IDENTIFIER ::= { ipoProdExpModules 3 }
+ipoProdExpModS0       OBJECT IDENTIFIER ::= { ipoProdExpModules 4 }
+ipoProdExpModAnalog   OBJECT IDENTIFIER ::= { ipoProdExpModules 5 }
+ipoProdExpModWAN      OBJECT IDENTIFIER ::= { ipoProdExpModules 6 }
+ipoProdExpModRDS      OBJECT IDENTIFIER ::= { ipoProdExpModules 7 }
+ipoProdExpModRPhone   OBJECT IDENTIFIER ::= { ipoProdExpModules 8 }
+ipoProdExpModDSA      OBJECT IDENTIFIER ::= { ipoProdExpModules 9 }
+
+ipoProdExpModDT16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Digital
+	Terminal 16"
+    ::= { ipoProdExpModDT 1 }
+
+ipoProdExpModDT30  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Digital
+	Terminal 30"
+    ::= { ipoProdExpModDT 2 }
+
+ipoProdExpModDS16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Digital
+	Station 16"
+    ::= { ipoProdExpModDS 1 }
+
+ipoProdExpModDS30  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Digital
+	Station 30"
+    ::= { ipoProdExpModDS 2 }
+
+ipoProdExpModPhone8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Phone 8"
+    ::= { ipoProdExpModPhone 1 }
+
+ipoProdExpModPhone16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Phone 16"
+    ::= { ipoProdExpModPhone 2 }
+
+ipoProdExpModPhone30  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Phone 30"
+    ::= { ipoProdExpModPhone 3 }
+
+ipoProdExpModS08  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office S0 8"
+    ::= { ipoProdExpModS0 1 }
+
+ipoProdExpModS016  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office S0 16"
+    ::= { ipoProdExpModS0 2 }
+
+ipoProdExpModATM8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Analog Trunk 16"
+    ::= { ipoProdExpModAnalog 1 }
+
+ipoProdExpModATM16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Analog Trunk 16"
+    ::= { ipoProdExpModAnalog 2 }
+
+ipoProdExpModWAN3  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office WAN 3"
+    ::= { ipoProdExpModWAN 1 }
+
+ipoProdExpModRDS16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(V2) Digital Station 16"
+    ::= { ipoProdExpModRDS 1 }
+
+ipoProdExpModRDS30  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(V2) Digital Station 30"
+    ::= { ipoProdExpModRDS 2 }
+
+ipoProdExpModRPhone8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(V2) Phone 8"
+    ::= { ipoProdExpModRPhone 1 }
+
+ipoProdExpModRPhone16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(V2) Phone 16"
+    ::= { ipoProdExpModRPhone 2 }
+
+ipoProdExpModRPhone30  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(V2) Phone 30"
+    ::= { ipoProdExpModRPhone 3 }
+
+ipoProdExpModDSA16RJ21  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(Adaptive) Digital Station 16 RJ21"
+    ::= { ipoProdExpModDSA 1 }
+
+ipoProdExpModDSA30RJ21  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(Adaptive) Digital Station 30 RJ21"
+    ::= { ipoProdExpModDSA 2 }
+
+ipoProdExpModDSA16RJ45  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(Adaptive) Digital Station 16 RJ45"
+    ::= { ipoProdExpModDSA 3 }
+
+ipoProdExpModDSA30RJ45  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Revised
+	(Adaptive) Digital Station 30 RJ45"
+    ::= { ipoProdExpModDSA 4 }
+
+-- Slots
+
+ipoProdSlotVCM  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office VCM Slot"
+    ::= { ipoProdSlots 1 }
+
+ipoProdSlotModems  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Modem Slot"
+    ::= { ipoProdSlots 2 }
+
+ipoProdSlotVmailMemory  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP401
+	Voicemail Memory Slot"
+    ::= { ipoProdSlots 3 }
+
+ipoProdSlotWAN  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP401 WAN
+	Slot"
+    ::= { ipoProdSlots 4 }
+
+ipoProdSlotPCCard  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office PC-Card
+	Slot"
+    ::= { ipoProdSlots 5 }
+
+ipoProdSlotTrunks  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Trunk
+	Slot"
+    ::= { ipoProdSlots 6 }
+
+ipoProdSlotExpansion  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Expansion
+	Slot"
+    ::= { ipoProdSlots 7 }
+
+ipoProdSlot500Generic  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500
+	Generic Expansion Slot"
+    ::= { ipoProdSlots 8 }
+
+ipoProdSlotMezzanine  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500
+	Mezzanine Slot"
+    ::= { ipoProdSlots 9 }
+
+ipoProdSlotCarrierVCM  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500
+	Carrier Module VCM Slot"
+    ::= { ipoProdSlots 10 }
+
+ipoProdSlotCarrierTrunk  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office IP500
+	Carrier Module Trunk Slot"
+    ::= { ipoProdSlots 11 }
+
+
+-- Slot Module Groups
+
+ipoProdIntegralModules  OBJECT IDENTIFIER ::= { ipoProdSlotModules 1 }
+ipoProdTrunkModules     OBJECT IDENTIFIER ::= { ipoProdSlotModules 2 }
+ipoProdPCCardModules    OBJECT IDENTIFIER ::= { ipoProdSlotModules 3 }
+ipoProdCarrierModules   OBJECT IDENTIFIER ::= { ipoProdSlotModules 4 }
+ipoProdPhonePortModules OBJECT IDENTIFIER ::= { ipoProdSlotModules 5 }
+ipoProdVCMModules       OBJECT IDENTIFIER ::= { ipoProdSlotModules 6 }
+ipoProdExpansionModules OBJECT IDENTIFIER ::= { ipoProdSlotModules 7 }
+ipoProdUCPModules         OBJECT IDENTIFIER ::= { ipoProdSlotModules 8 }
+
+-- Integral Modules
+
+ipoProdIntModVCM        OBJECT IDENTIFIER ::= { ipoProdIntegralModules 1 }
+ipoProdIntModModem      OBJECT IDENTIFIER ::= { ipoProdIntegralModules 2 }
+ipoProdIntModWAN        OBJECT IDENTIFIER ::= { ipoProdIntegralModules 3 }
+ipoProdIntModMem        OBJECT IDENTIFIER ::= { ipoProdIntegralModules 4 }
+
+ipoProdIntModVCM3  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 3 Module"
+    ::= { ipoProdIntModVCM 1 }
+
+ipoProdIntModVCM5  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 5 Module"
+    ::= { ipoProdIntModVCM 2 }
+
+ipoProdIntModVCM6  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 6 Module"
+    ::= { ipoProdIntModVCM 3 }
+
+ipoProdIntModVCM8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 8
+	Module."
+    ::= { ipoProdIntModVCM 4 }
+
+ipoProdIntModVCM10  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 10 Module"
+    ::= { ipoProdIntModVCM 5 }
+
+ipoProdIntModVCM12  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 12 Module"
+    ::= { ipoProdIntModVCM 6 }
+
+ipoProdIntModVCM16  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 16
+	Module."
+    ::= { ipoProdIntModVCM 7 }
+
+ipoProdIntModVCM20  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 20 Module"
+    ::= { ipoProdIntModVCM 8 }
+
+ipoProdIntModVCM30  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 30
+	Module."
+    ::= { ipoProdIntModVCM 9 }
+
+ipoProdIntModVCM24  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 24
+	Module."
+    ::= { ipoProdIntModVCM 10 }
+
+ipoProdIntModVCM4  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office VCM 4
+	Module."
+    ::= { ipoProdIntModVCM 11 }
+
+ipoProdIntModModemDual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Dual Modem Module"
+    ::= { ipoProdIntModModem 1 }
+
+ipoProdIntModModemMulti  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Multi Modem Module"
+    ::= { ipoProdIntModModem 2 }
+
+ipoProdIntModWANModule  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office WAN Module"
+    ::= { ipoProdIntModWAN 1 }
+
+ipoProdIntModMemVmail  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Voicemail
+	Memory Module"
+    ::= { ipoProdIntModMem 1 }
+
+
+-- Trunk Modules
+
+ipoProdTrunkAnalogQuad  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Quad Analog
+	Trunk Module"
+    ::= { ipoProdTrunkModules 1 }
+
+ipoProdTrunkBRIQuad  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Quad BRI
+	Trunk Module"
+    ::= { ipoProdTrunkModules 2 }
+
+ipoProdTrunkE1PRISingle  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Single PRI 30
+	E1 Trunk Module"
+    ::= { ipoProdTrunkModules 3 }
+
+ipoProdTrunkE1PRIDual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Dual PRI 60
+	E1 Trunk Module"
+    ::= { ipoProdTrunkModules 4 }
+
+ipoProdTrunkJ1PRISingle  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+      Single PRI 24J Trunk Module"
+    ::= { ipoProdTrunkModules 5 }
+
+ipoProdTrunkJ1PRIDual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500 
+      Dual PRI 48J Trunk Module"
+    ::= { ipoProdTrunkModules 6 }
+
+ipoProdTrunkT1PRISingle  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Single PRI 24
+	T1 Trunk Module"
+    ::= { ipoProdTrunkModules 7 }
+
+ipoProdTrunkT1PRIDual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Dual PRI 48
+	T1 Trunk Module"
+    ::= { ipoProdTrunkModules 8 }
+
+ipoProdTrunkIndex  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Index Module"
+    ::= { ipoProdTrunkModules 9 }
+
+ipoProdTrunkR2Single  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Single E1 R2 30
+	Trunk Module"
+    ::= { ipoProdTrunkModules 10 }
+
+ipoProdTrunkR2Dual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Dual E1 R2 60
+	Trunk Module"
+    ::= { ipoProdTrunkModules 11 }
+
+ipoProdTrunkR2CoAxSingle  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Single E1 R2
+	CO-AX 30 Trunk Module"
+    ::= { ipoProdTrunkModules 12 }
+
+ipoProdTrunkR2CoAxDual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Single E1 R2
+	CO-AX 30 Trunk Module"
+    ::= { ipoProdTrunkModules 13 }
+
+ipoProdTrunkRAnalogQuad  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Revised Quad
+	Analog Trunk Module"
+    ::= { ipoProdTrunkModules 14 }
+
+ipoProdTrunk500AnalogQuad  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Quad Analog Trunk Module"
+    ::= { ipoProdTrunkModules 15 }
+
+ipoProdTrunk500BRIDual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Dual BRI Trunk Module"
+    ::= { ipoProdTrunkModules 16 }
+
+ipoProdTrunk500BRIQuad  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Quad BRI Trunk Module"
+    ::= { ipoProdTrunkModules 17 }
+
+ipoProdTrunkUniversalPRIDS0Single  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Single Universal PRI (DS0) Trunk Module
+        24 Channels in T1 configuration
+        30 Channels in E1 configuration"
+    ::= { ipoProdTrunkModules 18 }
+
+ipoProdTrunkUniversalPRIDS0Dual  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Single Universal PRI (DS0) Trunk Module
+        48 Channels across two ports in T1 configuration
+        60 Channels across two ports in E1 configuration"
+    ::= { ipoProdTrunkModules 19 }
+
+ipoProdTrunk500AnalogQuadV2  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Quad Analog Trunk Module V2"
+    ::= { ipoProdTrunkModules 20 }
+
+
+-- PC-Card Modules
+
+ipoProdPCCardMemVmail  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office PC-Card
+	Voicemail Memory Module"
+    ::= { ipoProdPCCardModules 1 }
+
+ipoProdPCCardWLAN     OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office PC-Card
+	WLAN Module"
+    ::= { ipoProdPCCardModules 2 }
+
+-- Carrier Modules
+
+ipoProdCarrier  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Carrier Module for older IP Office plug-in modules"
+    ::= { ipoProdCarrierModules 1 }
+
+-- Phone Port Modules
+
+ipoProdPhonePortPOT8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	POT 8 Phone Port Module"
+    ::= { ipoProdPhonePortModules 1 }
+
+ipoProdPhonePortDS8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	Digital Station 8 Phone Port Module"
+    ::= { ipoProdPhonePortModules 2 }
+
+ipoProdPhonePortPOT2  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500
+	POT 2 Phone Port Module"
+    ::= { ipoProdPhonePortModules 3 }
+
+ipoProdPhonePortCombo  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+        "The authoritative reference for Avaya IP Office IP500v2 Combo
+        Phone Port and trunk Module which provides a 10 channel VCM, 6
+        Digital Station Phone Ports, 2 POT Phone Ports and either a 4
+        port ATM trunk module or a 4 port BRI module."
+    ::= { ipoProdPhonePortModules 4 }
+
+ipoProdPhonePortETR6  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500v2
+	ETR 6 Phone Port Module"
+    ::= { ipoProdPhonePortModules 5 }
+
+ipoProdPhonePortTCM8  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office IP500v2
+	TCM 8 Phone Port Module"
+    ::= { ipoProdPhonePortModules 6 }
+
+-- VCM Modules
+
+ipoProdVCMMod32  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office DSP based
+	VCM 32 Module."
+    ::= { ipoProdVCMModules 1 }
+
+ipoProdVCMMod64  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office DSP based
+	VCM 64 Module."
+    ::= { ipoProdVCMModules 2 }
+
+ipoProdVCMMod32V2  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office DSP based
+	VCM 32 V2 Module."
+    ::= { ipoProdVCMModules 3 }
+
+ipoProdVCMMod64V2  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office DSP based
+	VCM 64 V2 Module."
+    ::= { ipoProdVCMModules 4 }
+
+-- Expansion Modules
+
+ipoProdExpMod4Port  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office 4 Port
+	Expansion Module."
+    ::= { ipoProdExpansionModules 1 }
+
+-- Ports
+
+ipoProdPortBRI  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office BRI Ports"
+    ::= { ipoProdPorts 1 }
+
+ipoProdPortE1PRI  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office E1 PRI Ports"
+    ::= { ipoProdPorts 2 }
+
+ipoProdPortJ1PRI  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office J1 PRI Ports"
+    ::= { ipoProdPorts 3 }
+
+ipoProdPortT1PRI  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office T1 PRI Ports"
+    ::= { ipoProdPorts 4 }
+
+ipoProdPortR2  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office E1 R2 Ports"
+    ::= { ipoProdPorts 5 }
+
+ipoProdPortR2CoAx  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office E1 R2 CO-AX
+	Ports"
+    ::= { ipoProdPorts 6 }
+
+ipoProdPortWAN  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office WAN Ports"
+    ::= { ipoProdPorts 7 }
+
+ipoProdPortAnalog  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Analog Ports"
+    ::= { ipoProdPorts 8 }
+
+ipoProdPortPower  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office Power Port"
+    ::= { ipoProdPorts 9 }
+
+ipoProdPortDT  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office DT Phone Ports"
+    ::= { ipoProdPorts 10 }
+
+ipoProdPortDS  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office DS Phone Ports"
+    ::= { ipoProdPorts 11 }
+
+ipoProdPortPOT  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office POT Ports"
+    ::= { ipoProdPorts 12 }
+
+ipoProdPortS0  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office ISDN BRI S-Bus Ports"
+    ::= { ipoProdPorts 13 }
+
+ipoProdPortLAN  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office LAN
+	(10BASE-T/100BASE-TX) Ports"
+    ::= { ipoProdPorts 14 }
+
+ipoProdPortWLAN  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office LAN
+	WLAN (802.11) Ports"
+    ::= { ipoProdPorts 15 }
+
+ipoProdPortDTE  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office DTE Port"
+    ::= { ipoProdPorts 16 }
+
+ipoProdPortUSB  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office USB Port"
+    ::= { ipoProdPorts 17 }
+
+ipoProdPortAudio  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Audio I/P Port"
+    ::= { ipoProdPorts 18 }
+
+ipoProdPortEtherWANLink  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office Fast
+	Ethernet (10BASE-T/100BASE-TX) WAN Link Port"
+    ::= { ipoProdPorts 19 }
+
+ipoProdPortExtOP  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office - Small
+	Office Edition Telephone Switch Ethernet Ext O/P Port"
+    ::= { ipoProdPorts 20 }
+
+ipoProdPortNet1  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office
+	Fast Ethernet (10BASE-T/100BASE-TX) Network 1 Port"
+    ::= { ipoProdPorts 21 }
+
+ipoProdPortNet2  OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office
+	Fast Ethernet (10BASE-T/100BASE-TX) Network 2 Port"
+    ::= { ipoProdPorts 22 }
+
+ipoProdGenericDongle    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the Avaya IP Office License
+	Dongle - A single representation for three dongle types,
+	Parallel, Serial and USB. The Parallel and USB ones not truly
+	connected directly to the IP Office but the managing PC."
+    ::= { ipoProdDongleModules 1 }
+
+ipoProdSubModVCM10    OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for the 10 channel VCM sub module
+	resident on the Avaya IP Office IP500v2 Combo Phone Port and
+	trunk Module."
+    ::= { ipoProdSubModules 1 }
+
+
+ -- Unified Communications Module
+
+ipoProdC110UCM OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office
+	Unified Communications Module. model C110"
+    ::= { ipoProdUCModules 1 }
+    
+ipoProdC110UCMV2 OBJECT-IDENTITY
+    STATUS    current
+    DESCRIPTION
+	"The authoritative reference for Avaya IP Office
+	Unified Communications Module V2. model C110"
+    ::= { ipoProdUCModules 2 }
+
+END


### PR DESCRIPTION
1st commit adding MIB files for Avaya IP Office. Available after signing up to their support website at https://support.avaya.com/downloads/

2nd commit adding files and editing definitions.inc.php to include basic discovery support for Avaya IP Office controller devices.

fixes #1921 