### PR TITLE
Stop the worldmap needing coords before displaying

### DIFF
--- a/html/includes/common/worldmap.inc.php
+++ b/html/includes/common/worldmap.inc.php
@@ -23,7 +23,7 @@
  */
 
 if ($config['map']['engine'] == 'leaflet') {
-    if ((defined('show_settings') || empty($widget_settings)) && $config['front_page'] == "pages/front/tiles.php") {
+    if (defined('show_settings') && $config['front_page'] == "pages/front/tiles.php") {
         $temp_output = '
 <form class="form" onsubmit="widget_settings(this); return false;">
   <div class="form-group">
@@ -77,7 +77,7 @@ if ($config['map']['engine'] == 'leaflet') {
 <div id="leaflet-map"></div>
 <script>
         ';
-        if (!empty($widget_settings)) {
+        if (!empty($widget_settings) && !empty($widget_settings['init_lat']) && !empty($widget_settings['init_lng'])) {
             $init_lat = $widget_settings['init_lat'];
             $init_lng = $widget_settings['init_lng'];
             $init_zoom = $widget_settings['init_zoom'];

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -773,7 +773,7 @@ $config['map']['engine']                                = 'leaflet';
 $config['mapael']['default_map']                        = 'maps/world_countries.js';
 $config['leaflet']['default_lat']                       = '51.4800';
 $config['leaflet']['default_lng']                       = '0';
-$config['leaflet']['default_zoom']                       = 1;
+$config['leaflet']['default_zoom']                       = 2;
 
 // General GUI options
 $config['gui']['network-map']['style']                  = 'new';//old is also valid

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -771,9 +771,9 @@ $config['geoloc']['latlng']                             = false; // True to enab
 $config['geoloc']['engine']                             = 'google';
 $config['map']['engine']                                = 'leaflet';
 $config['mapael']['default_map']                        = 'maps/world_countries.js';
-$config['leaflet']['default_lat']                       = '50.898482';
-$config['leaflet']['default_lng']                       = '-3.401402';
-$config['leaflet']['default_zoom']                       = 2;
+$config['leaflet']['default_lat']                       = '51.4800';
+$config['leaflet']['default_lng']                       = '0';
+$config['leaflet']['default_zoom']                       = 1;
 
 // General GUI options
 $config['gui']['network-map']['style']                  = 'new';//old is also valid


### PR DESCRIPTION
At present when you add the world map you need to set default coords even though we have some in includes/defaults.inc.php.

I've removed this requirement (you can still edit the widget to set your coords). Also falls back to defaults if no coords are specified (map fails to load if you leave coords blank)

Also updated the default coords and zoom so it shows the world by default.