### PR TITLE
Changed config db options from double quotes to single

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -3,15 +3,15 @@
 ## Have a look in includes/defaults.inc.php for examples of settings you can set here. DO NOT EDIT defaults.inc.php!
 
 ### Database config
-$config['db_host'] = "localhost";
-$config['db_user'] = "USERNAME";
-$config['db_pass'] = "PASSWORD";
-$config['db_name'] = "librenms";
+$config['db_host'] = 'localhost";
+$config['db_user'] = 'USERNAME";
+$config['db_pass'] = 'PASSWORD';
+$config['db_name'] = 'librenms';
 $config['db']['extension'] = 'mysqli';// mysql or mysqli
 
 ### Memcached config - We use this to store realtime usage
 $config['memcached']['enable']  = FALSE;
-$config['memcached']['host']    = "localhost";
+$config['memcached']['host']    = 'localhost';
 $config['memcached']['port']    = 11211;
 
 ### Locations - it is recommended to keep the default

--- a/config.php.default
+++ b/config.php.default
@@ -3,8 +3,8 @@
 ## Have a look in includes/defaults.inc.php for examples of settings you can set here. DO NOT EDIT defaults.inc.php!
 
 ### Database config
-$config['db_host'] = 'localhost";
-$config['db_user'] = 'USERNAME";
+$config['db_host'] = 'localhost';
+$config['db_user'] = 'USERNAME';
 $config['db_pass'] = 'PASSWORD';
 $config['db_name'] = 'librenms';
 $config['db']['extension'] = 'mysqli';// mysql or mysqli

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -24,10 +24,10 @@ Log files created by LibreNMS will be stored within this directory.
 These are the configuration options you will need to use to specify to get started.
 
 ```php
-$config['db_host'] = "127.0.0.1";
-$config['db_user'] = "";
-$config['db_pass'] = "";
-$config['db_name'] = "";
+$config['db_host'] = '127.0.0.1';
+$config['db_user'] = '';
+$config['db_pass'] = '';
+$config['db_name'] = '';
 ```
 
 You can also select between the mysql and mysqli php extensions:

--- a/html/install.php
+++ b/html/install.php
@@ -369,10 +369,10 @@ $config_file = <<<"EOD"
 ## Have a look in defaults.inc.php for examples of settings you can set here. DO NOT EDIT defaults.inc.php!
 
 ### Database config
-\$config\['db_host'\] = \"$dbhost\";
-\$config\['db_user'\] = "$dbuser";
-\$config\['db_pass'\] = "$dbpass";
-\$config\['db_name'\] = "$dbname";
+\$config\['db_host'\] = '$dbhost';
+\$config\['db_user'\] = '$dbuser';
+\$config\['db_pass'\] = '$dbpass';
+\$config\['db_name'\] = '$dbname';
 \$config\['db'\]\['extension'\] = "mysqli";// mysql or mysqli
 
 ### Memcached config - We use this to store realtime usage


### PR DESCRIPTION
I've changed our config.php.default, install.php and the docs to use single quotes so that anyone using $ in those config options won't have issues.

You can just do db_pass but there is no reason to interpret any of those config options imho.