### PR TITLE
Some *nix systems do not provide a descr :(

### DIFF
--- a/includes/discovery/processors/hrdevice.inc.php
+++ b/includes/discovery/processors/hrdevice.inc.php
@@ -53,6 +53,12 @@ if (is_array($hrDevice_array)) {
                 $descr = 'Processor';
             }
 
+            // Workaround for Linux where some CPUs don't have a description
+            if ($device['os'] == 'linux' && empty($entry['hrDeviceDescr'])) {
+                $descr = 'Processor';
+            }
+
+
             $descr = str_replace('CPU ', '', $descr);
             $descr = str_replace('(TM)', '', $descr);
             $descr = str_replace('(R)', '', $descr);


### PR DESCRIPTION
This will check for empty descr (as we do for other processor disco's) and if empty on linux set it to Processor.