### PR TITLE
Add config option for librenms user + validate.php support

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -14,6 +14,10 @@ $config['memcached']['enable']  = FALSE;
 $config['memcached']['host']    = "localhost";
 $config['memcached']['port']    = 11211;
 
+// This is the user LibreNMS will run as
+//Please ensure this user is created and has the correct permissions to your install
+$config['user'] = 'librenms';
+
 ### Locations - it is recommended to keep the default
 #$config['install_dir']  = "/opt/librenms";
 

--- a/doc/Support/Install Validation.md
+++ b/doc/Support/Install Validation.md
@@ -11,6 +11,9 @@ So, to try and help with some of the general issues people come across we've put
  - Checks if you are running the older alerting system.
  - Checks your rrd directory setup if not running rrdcached.
  - Checks disk space for where /opt/librenms is installed.
+ - Checks location to fping
+ - Tests MySQL strict mode being enabled
+ - Tests for files not owned by librenms user (if configured)
 
 Optionally you can also pass -m and a module name for that to be tested. Current modules are:
 

--- a/html/install.php
+++ b/html/install.php
@@ -375,6 +375,10 @@ $config_file = <<<"EOD"
 \$config\['db_name'\] = "$dbname";
 \$config\['db'\]\['extension'\] = "mysqli";// mysql or mysqli
 
+// This is the user LibreNMS will run as
+//Please ensure this user is created and has the correct permissions to your install
+\$config['user'] = 'librenms';
+
 ### Memcached config - We use this to store realtime usage
 \$config\['memcached'\]\['enable'\]  = FALSE;
 \$config\['memcached'\]\['host'\]    = "localhost";

--- a/validate.php
+++ b/validate.php
@@ -59,6 +59,25 @@ require_once 'includes/definitions.inc.php';
 require_once 'includes/functions.php';
 require_once $config['install_dir'].'/includes/alerts.inc.php';
 
+// Let's test the user configured if we have it
+if (isset($config['user'])) {
+    $tmp_user = $config['user'];
+    $tmp_dir = $config['install_dir'];
+    $tmp_log = $config['log_dir'];
+    $find_result = rtrim(`find $tmp_dir \! -user $tmp_user -not -path $tmp_log`);
+    if (!empty($find_result)) {
+        // This isn't just the log directory, let's print the list to the user
+        $files = explode(PHP_EOL, $find_result);
+        if (is_array($files)) {
+            print_fail("We have found some files that are owned by a different user than $tmp_user, this will stop you updating automatically and / or rrd files being updated causing graphs to fail:\n");
+            foreach ($files as $file) {
+                echo "$file\n";
+            }
+            echo "\n";
+        }
+    }
+}
+
 // Run test on MySQL
 $test_db = @mysqli_connect($config['db_host'], $config['db_user'], $config['db_pass'], $config['db_name']);
 if (mysqli_connect_error()) {


### PR DESCRIPTION
At present we ask people to create a librenms user (some may do this, some may run as root and some may choose their own user). However we have no idea what has been done.

I've added a config.php option $config['user'] that is now set within the users config (not in defaults.inc.php as I don't want to add this to everyone - some are not running librenms as librenms user).

We then use that in validate.php to tell people when files are no longer owned by that user and print the list. logs is excluded as this is by the web server user.