### PR TITLE
Add support for SonicWALL CPU and memory graphs

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -854,8 +854,10 @@ $config['os'][$os]['text']             = 'SonicWALL';
 $config['os'][$os]['type']             = 'firewall';
 $config['os'][$os]['over'][0]['graph'] = 'device_bits';
 $config['os'][$os]['over'][0]['text']  = 'Traffic';
-$config['os'][$os]['over'][1]['graph'] = 'device_mempool';
-$config['os'][$os]['over'][1]['text']  = 'Memory Utilization';
+$config['os'][$os]['over'][1]['graph'] = 'device_processor';
+$config['os'][$os]['over'][1]['text']  = 'CPU';
+$config['os'][$os]['over'][2]['graph'] = 'device_mempool';
+$config['os'][$os]['over'][2]['text']  = 'Memory';
 
 $os = 'zywall';
 $config['os'][$os]['text']             = 'ZyXEL ZyWALL';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -854,6 +854,8 @@ $config['os'][$os]['text']             = 'SonicWALL';
 $config['os'][$os]['type']             = 'firewall';
 $config['os'][$os]['over'][0]['graph'] = 'device_bits';
 $config['os'][$os]['over'][0]['text']  = 'Traffic';
+$config['os'][$os]['over'][1]['graph'] = 'device_mempool';
+$config['os'][$os]['over'][1]['text']  = 'Memory Utilization';
 
 $os = 'zywall';
 $config['os'][$os]['text']             = 'ZyXEL ZyWALL';

--- a/includes/discovery/mempools/sonicwall.inc.php
+++ b/includes/discovery/mempools/sonicwall.inc.php
@@ -11,9 +11,9 @@
  */
 
 if ($device['os'] == 'sonicwall') {
-      echo 'SonicWALL-MEMORY-POOL: ';
-      $usage = snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-Ovq');
-      if (is_numeric($usage)) {
-          discover_mempool($valid_mempool, $device, 0, 'sonicwall-mem', 'Memory Utilization', '100', null, null);
-      }
+    echo 'SonicWALL-MEMORY-POOL: ';
+    $usage = snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-Ovq');
+    if (is_numeric($usage)) {
+        discover_mempool($valid_mempool, $device, 0, 'sonicwall-mem', 'Memory Utilization', '100', null, null);
+    }
 }

--- a/includes/discovery/mempools/sonicwall.inc.php
+++ b/includes/discovery/mempools/sonicwall.inc.php
@@ -1,9 +1,19 @@
 <?php
+/*
+ * LibreNMS SonicWALL CPU information module
+ *
+ * Copyright (c) 2015 Mark Nagel <mnagel@willingminds.com>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
 
 if ($device['os'] == 'sonicwall') {
-    echo 'SonicWALL-MEMORY-POOL: ';
-    $usage = snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-Ovq');
-    if (is_numeric($usage)) {
-        discover_mempool($valid_mempool, $device, 0, 'sonicwall-mem', 'Memory Utilization', '100', null, null);
-    }
+      echo 'SonicWALL-MEMORY-POOL: ';
+      $usage = snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-Ovq');
+      if (is_numeric($usage)) {
+          discover_mempool($valid_mempool, $device, 0, 'sonicwall-mem', 'Memory Utilization', '100', null, null);
+      }
 }

--- a/includes/discovery/processors/sonicwall.inc.php
+++ b/includes/discovery/processors/sonicwall.inc.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * LibreNMS SonicWALL CPU information module
+ *
+ * Copyright (c) 2015 Mark Nagel <mnagel@willingminds.com>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+if ($device['os'] == 'sonicwall') {
+    echo 'SonicWALL CPU: ';
+
+    $usage_oid = 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentCPUUtil.0';
+    $usage = snmp_get($device, $usage_oid, '-Ovqn');
+    if (is_numeric($usage)) {
+        discover_processor($valid['processor'], $device, $usage_oid, '0', 'sonicwall', 'CPU', '1', $usage, null, null);
+    }
+}
+
+unset($processors_array);

--- a/includes/polling/mempools/sonicwall-mem.inc.php
+++ b/includes/polling/mempools/sonicwall-mem.inc.php
@@ -1,12 +1,21 @@
 <?php
-
+/*
+ * LibreNMS SonicWALL CPU information module
+ *
+ * Copyright (c) 2015 Mark Nagel <mnagel@willingminds.com>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
 if ($device['os'] == 'sonicwall') {
-  echo 'SonicWALL-MEMORY-POOL: ';
-  $perc = str_replace('"', "", snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-OvQ'));
-  if (is_numeric($perc)) {
-    $mempool['perc'] = $perc;
-    $mempool['used'] = $perc;
-    $mempool['total'] = 100;
-    $mempool['free'] = 100 - $perc;
-  }
+    echo 'SonicWALL-MEMORY-POOL: ';
+    $perc = str_replace('"', "", snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-OvQ'));
+    if (is_numeric($perc)) {
+        $mempool['perc'] = $perc;
+        $mempool['used'] = $perc;
+        $mempool['total'] = 100;
+        $mempool['free'] = 100 - $perc;
+    }
 }

--- a/includes/polling/mempools/sonicwall-mem.inc.php
+++ b/includes/polling/mempools/sonicwall-mem.inc.php
@@ -1,0 +1,12 @@
+<?php
+
+if ($device['os'] == 'sonicwall') {
+  echo 'SonicWALL-MEMORY-POOL: ';
+  $perc = str_replace('"', "", snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-OvQ'));
+  if (is_numeric($perc)) {
+    $mempool['perc'] = $perc;
+    $mempool['used'] = $perc;
+    $mempool['total'] = 100;
+    $mempool['free'] = 100 - $perc;
+  }
+}

--- a/mibs/SONICWALL-FIREWALL-IP-STATISTICS-MIB
+++ b/mibs/SONICWALL-FIREWALL-IP-STATISTICS-MIB
@@ -1,0 +1,252 @@
+-- *****************************************************************
+-- SONICWALL-FIREWALL-IP-STATISTICS
+--
+-- June 2002, Initial Version, Srikanth  Nayani
+-- Apr  2003,   Change Postal, Susan Yan
+-- Nov 2005, Add CPU and RAM Utilizations, GM Anderson
+-- 03-10-08 - Removed Imports that are not used to prevent warnings
+--            in MIB compilation, Mike Uy 
+-- 04-17-09 - Updated E-mail CONTACT-INFO, Rosalea Real
+-- 11-11-09 - Renamed this file from
+--            sonic_stats.mib to
+--            SONICWALL-FIREWALL-IP-STATISTICS-MIB.MIB, Mike Uy
+-- 11-11-09 - Updated SonicWALL company address, Mike Uy
+--
+-- Copyright (c) 2001 - 2009 by SonicWall, Inc.
+-- All rights reserved.
+-- *****************************************************************
+
+SONICWALL-FIREWALL-IP-STATISTICS-MIB DEFINITIONS ::= BEGIN
+
+
+IMPORTS
+    DisplayString                               FROM SNMPv2-TC
+
+    IpAddress,
+    OBJECT-TYPE,
+        MODULE-IDENTITY             FROM SNMPv2-SMI
+        Counter                                         FROM RFC1155-SMI
+
+    sonicwallFw                         FROM SONICWALL-SMI;
+
+sonicwallFwStatsModule MODULE-IDENTITY
+        LAST-UPDATED "200911110000Z"
+        ORGANIZATION "SonicWall, Inc."
+        CONTACT-INFO
+                "       SonicWall Inc.
+
+                   Postal: 2001 Logic Drive
+                                   San Jose, CA 95124-3452
+                                   USA
+
+                   Tel: +1 408 745 9600
+                   Fax: +1 408 745 9300
+
+                E-mail: products@sonicwall.com"
+        DESCRIPTION
+                "The MIB Module for SonicWALL Firewall Ipsec Statistics."
+        REVISION      "200511090000Z"
+        DESCRIPTION
+                "Initial Version"
+    ::= { sonicwallFw 3 }
+
+-- =======================
+-- sonic Firewall Statistics
+-- =======================
+
+
+sonicwallFwStats OBJECT IDENTIFIER ::= {sonicwallFwStatsModule 1}
+
+sonicMaxConnCacheEntries OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                " Maximum number of connection cache entries allowed through the firewall"
+        ::= { sonicwallFwStats 1 }
+
+sonicCurrentConnCacheEntries OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                " Number of active connection cache entries through the firewall"
+        ::= { sonicwallFwStats 2 }
+
+sonicCurrentCPUUtil OBJECT-TYPE
+        SYNTAX Gauge
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                " Instantaneous CPU Utilization in percent"
+        ::= { sonicwallFwStats 3 }
+
+sonicCurrentRAMUtil OBJECT-TYPE
+        SYNTAX Gauge
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                " Instantaneous RAM Utilization in percent"
+        ::= { sonicwallFwStats 4 }
+
+sonicwallFwVPNStats OBJECT IDENTIFIER ::= {sonicwallFwStatsModule 2}
+
+sonicwallFwVpnIPSecStats OBJECT IDENTIFIER ::= {sonicwallFwVPNStats 1}
+
+
+-- =======================
+-- sonic IPsec Statistics Table
+-- =======================
+
+sonicSAStatTable OBJECT-TYPE
+        SYNTAX SEQUENCE OF SonicSAStatEntry 
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+                "This table provides statistics for each Security Association."
+        ::= { sonicwallFwVpnIPSecStats 1 }
+
+sonicSAStatEntry OBJECT-TYPE
+        SYNTAX SonicSAStatEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+                "Entries in table cannot be added or deleted. This table is
+                completely controlled by the agent. Each SA statistics will be
+                represented by an entry in this table. "
+        INDEX { sonicIpsecSaIndex}
+        ::= { sonicSAStatTable 1 }
+
+SonicSAStatEntry ::= SEQUENCE {
+        sonicIpsecSaIndex                          Counter,
+        sonicSAStatPeerGateway         IpAddress,
+        sonicSAStatSrcAddrBegin        IpAddress,
+        sonicSAStatSrcAddrEnd          IpAddress,
+        sonicSAStatDstAddrBegin        IpAddress,
+        sonicSAStatDstAddrEnd          IpAddress,
+        sonicSAStatCreateTime          DisplayString,
+        sonicSAStatEncryptPktCount     Counter,
+        sonicSAStatEncryptByteCount    Counter,
+        sonicSAStatDecryptPktCount     Counter,
+        sonicSAStatDecryptByteCount    Counter,
+        sonicSAStatInFragPktCount      Counter,
+        sonicSAStatOutFragPktCount     Counter,
+    sonicSAStatUserName            DisplayString
+        }
+
+
+sonicIpsecSaIndex OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                " Phase2  SA index."
+        ::= { sonicSAStatEntry 1 }
+
+sonicSAStatPeerGateway OBJECT-TYPE
+        SYNTAX IpAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Peer gateway address where the tunnel gets terminated ."
+        ::= { sonicSAStatEntry 2 }
+
+sonicSAStatSrcAddrBegin OBJECT-TYPE
+        SYNTAX IpAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "First address of the Source network for the phase2 SA ."
+        ::= { sonicSAStatEntry 3 }
+
+sonicSAStatSrcAddrEnd OBJECT-TYPE
+        SYNTAX IpAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Last address of the Source network for the phase2 SA ."
+        ::= { sonicSAStatEntry 4 }
+
+sonicSAStatDstAddrBegin OBJECT-TYPE
+        SYNTAX IpAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "First address of the destination network for the phase2 SA ."
+        ::= { sonicSAStatEntry 5 }
+
+sonicSAStatDstAddrEnd OBJECT-TYPE
+        SYNTAX IpAddress
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Last address of the destination network for the phase2 SA ."
+        ::= { sonicSAStatEntry 6 }
+
+sonicSAStatCreateTime OBJECT-TYPE
+        SYNTAX DisplayString
+    MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+        "Time this phase2 SA was actually created in GMT."
+        ::= { sonicSAStatEntry 7 }
+
+sonicSAStatEncryptPktCount OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Total encrypted packet count for this phase2 SA."
+        ::= { sonicSAStatEntry 8 }
+
+sonicSAStatEncryptByteCount OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Total encrypted byte count for this phase2 SA."
+        ::= { sonicSAStatEntry 9 }
+
+sonicSAStatDecryptPktCount OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Total decrypted packet count for this phase2 SA."
+        ::= { sonicSAStatEntry  10}
+
+sonicSAStatDecryptByteCount OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Total decrypted byte count for this phase2 SA."
+        ::= { sonicSAStatEntry  11 }
+
+sonicSAStatInFragPktCount OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Incoming Fragmented packet count for this phase2 SA"
+        ::= { sonicSAStatEntry 12 }
+
+sonicSAStatOutFragPktCount OBJECT-TYPE
+        SYNTAX Counter
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+                "Outgoing Fragmented packet count for this phase2 SA"
+        ::= { sonicSAStatEntry 13 }
+
+
+sonicSAStatUserName  OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Name of the security policy used for creating this phase2 SA."
+        ::= { sonicSAStatEntry 14 }
+
+
+END

--- a/mibs/SONICWALL-SMI
+++ b/mibs/SONICWALL-SMI
@@ -1,0 +1,105 @@
+-- *****************************************************************
+-- SONICWALL-SMI.MIB
+--
+-- February 2001, Susan Yan
+-- Apr  2003,     Change Postal, Susan Yan
+-- Nov  2007,     Added sonicwallCommon, Mike Uy
+-- Sep 19, 2008   Added sonicwallEmailSec, Mike Uy
+-- Jan 28, 2009   Added sonicwallDataCenter, Mike Uy
+-- Apr 07, 2009   Inserted sonicwallGMS Group, Mike Uy
+--                at index 3, bumped up sonicwallEmailSec to 4
+--                and sonicwallDataCenter to 5
+-- 04-17-09       Updated E-mail CONTACT-INFO, Rosalea Real
+-- 09-17-09       Added sonicwallSSLVPN and sonicwallCDP 
+--                groups; cosmetic/text changes, Mike Uy
+-- 11-11-09       Renamed this file from
+--                SW-SMI.MIB to
+--                SONICWALL-SMI.MIB, Mike Uy
+-- 07-23-12       Updated company copyright and 
+--                organization, Mike Uy
+--
+-- Copyright (c) 2012 DELL Inc.
+-- All rights reserved.
+-- *****************************************************************
+
+
+SONICWALL-SMI
+ 
+--FORCE-INCLUDE <mib.h>
+--FORCE-INCLUDE <snmpdefs.h>
+--FORCE-INCLUDE "swPrivMibhand.h"
+
+
+DEFINITIONS ::= BEGIN
+
+IMPORTS
+        MODULE-IDENTITY,
+        OBJECT-IDENTITY,
+        enterprises
+                FROM SNMPv2-SMI;
+
+sonicwall MODULE-IDENTITY
+        LAST-UPDATED "201207230000Z"
+        ORGANIZATION "DELL SonicWALL"
+        CONTACT-INFO
+                "       DELL SonicWall
+
+                Postal: 2001 Logic Drive
+                        San Jose, CA 95124-3452
+                        USA
+
+                   Tel: +1 408 745 9600
+                   Fax: +1 408 745 9300
+
+                E-mail: products@sonicwall.com"
+        DESCRIPTION
+                "The MIB Module for SonicWALL enterprise."
+        REVISION      "200304220000Z"
+        DESCRIPTION
+                "Initial version."
+        ::= { enterprises 8741 }
+
+
+sonicwallFw OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "sonicwallFw is the subtree for the SonicWALL firewall products."
+        ::= { sonicwall 1 }
+
+sonicwallCommon OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "Subtree for MIBs common for all SonicWALL products"
+        ::= { sonicwall 2 }
+
+sonicwallGMS OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "sonicwallGMS is the subtree for the SonicWALL Global Management System products."
+        ::= { sonicwall 3 }
+
+sonicwallEmailSec OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "sonicwallEmailSec is the subtree for SonicWALL email security products."
+        ::= { sonicwall 4 }
+
+sonicwallDataCenter OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "sonicwallDataCenter is the subtree for SonicWALL datacenter operations."
+        ::= { sonicwall 5 }
+
+sonicwallSSLVPN OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "sonicwallSSLVPN is the subtree for SonicWALL SSL VPN products."
+        ::= { sonicwall 6 }
+
+sonicwallCDP OBJECT-IDENTITY
+        STATUS  current
+        DESCRIPTION
+                "sonicwallCDP is the subtree for SonicWALL CDP products."
+        ::= { sonicwall 7 }
+
+END


### PR DESCRIPTION
Please note - this depends on a pending pull request in librenms-mibs for the SonicWALL MIBs used in these changes.  Memory is only reported in percent, so incorrectly reports as bytes.  It would be nice to adjust presentation to include units optionally for this sort of situation.