### PR TITLE
Use fping6 instead of fping for hosts with udp6/tcp6 SNMP transports

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -46,7 +46,7 @@ $config['rrdtool'] = "/usr/bin/rrdtool";
 
 ```php
 $config['fping']            = "/usr/bin/fping";
-$config['fping6']           = "/usr/bin/fping6";
+$config['fping6']           = "fping6";
 $config['fping_options']['retries'] = 3;
 $config['fping_options']['timeout'] = 500;
 $config['fping_options']['count'] = 3;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -52,6 +52,7 @@ $config['own_hostname'] = 'localhost';
 // Location of executables
 $config['rrdtool']                  = '/usr/bin/rrdtool';
 $config['fping']                    = '/usr/bin/fping';
+$config['fping6']                   = '/usr/bin/fping6';
 $config['fping_options']['retries'] = 3;
 $config['fping_options']['timeout'] = 500;
 $config['fping_options']['count']   = 3;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -52,7 +52,7 @@ $config['own_hostname'] = 'localhost';
 // Location of executables
 $config['rrdtool']                  = '/usr/bin/rrdtool';
 $config['fping']                    = '/usr/bin/fping';
-$config['fping6']                   = '/usr/bin/fping6';
+$config['fping6']                   = 'fping6';
 $config['fping_options']['retries'] = 3;
 $config['fping_options']['timeout'] = 500;
 $config['fping_options']['count']   = 3;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1253,7 +1253,9 @@ function snmpTransportToAddressFamily($transport) {
         $transport = 'udp';
     }
 
-    if ($transport == 'udp6' || $transport == 'tcp6') {
+    $ipv6_snmp_transport_specifiers = array('udp6', 'udpv6', 'udpipv6', 'tcp6', 'tcpv6', 'tcpipv6');
+
+    if (in_array($transport, $ipv6_snmp_transport_specifiers)) {
         return AF_INET6;
     }
     else {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1248,6 +1248,18 @@ function get_last_commit() {
     return `git log -n 1|head -n1`;
 }//end get_last_commit
 
+/**
+ * Try to determine the address family (IPv4 or IPv6) associated with an SNMP
+ * transport specifier (like "udp", "udp6", etc.).
+ *
+ * @param string $transport The SNMP transport specifier, for example "udp",
+ *                          "udp6", "tcp", or "tcp6". See `man snmpcmd`,
+ *                          section "Agent Specification" for a full list.
+ *
+ * @return int The address family associated with the given transport
+ *             specifier: AF_INET for IPv4 (or local connections not associated
+ *             with an IP stack), AF_INET6 for IPv6.
+ */
 function snmpTransportToAddressFamily($transport) {
     if (!isset($transport)) {
         $transport = 'udp';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -502,6 +502,15 @@ function isSNMPable($device) {
     }
 }
 
+/**
+ * Check if the given host responds to ICMP echo requests ("pings").
+ *
+ * @param string $hostname The hostname or IP address to send ping requests to.
+ * @param int $address_family The address family (AF_INET for IPv4 or AF_INET6 for IPv6) to use. Defaults to IPv4. Will *not* be autodetected for IP addresses, so it has to be set to AF_INET6 when pinging an IPv6 address or an IPv6-only host.
+ * @param int $device_id This parameter is currently ignored.
+ *
+ * @return bool TRUE if the host responded to at least one ping request, FALSE otherwise.
+ */
 function isPingable($hostname,$address_family = AF_INET,$device_id = FALSE) {
     global $config;
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -511,7 +511,7 @@ function isSNMPable($device) {
  *
  * @return bool TRUE if the host responded to at least one ping request, FALSE otherwise.
  */
-function isPingable($hostname,$address_family = AF_INET,$device_id = FALSE) {
+function isPingable($hostname, $address_family = AF_INET, $device_id = FALSE) {
     global $config;
 
     $fping_params = '';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -276,7 +276,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
         if (ip_exists($ip) === false) {
             // Test reachability
             $address_family = snmpTransportToAddressFamily($transport);
-            if ($force_add == 1 || isPingable($host, $addressFamily)) {
+            if ($force_add == 1 || isPingable($host, $address_family)) {
                 if (empty($snmpver)) {
                     // Try SNMPv2c
                     $snmpver = 'v2c';

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -154,7 +154,9 @@ function poll_device($device, $options) {
         echo "Created directory : $host_rrd\n";
     }
 
-    $ping_response = isPingable($device['hostname'], $device['device_id']);
+    $address_family = snmpTransportToAddressFamily($device['transport']);
+
+    $ping_response = isPingable($device['hostname'], $address_family, $device['device_id']);
 
     $device_perf              = $ping_response['db'];
     $device_perf['device_id'] = $device['device_id'];


### PR DESCRIPTION
LibreNMS currently uses `fping` to try and ping hosts, even in cases where they have been configured to use SNMP via IPv6 and might not even have a public IPv4 address.
The code changed in this PR will detect the address family (IPv4 or IPv6) used for the SNMP connection and select `fping` or `fping6` accordingly.