### PR TITLE
Removed required option for community - breaks v3

### DIFF
--- a/html/pages/device/edit/snmp.inc.php
+++ b/html/pages/device/edit/snmp.inc.php
@@ -123,7 +123,7 @@ echo "      </select>
     <div class='form-group'>
     <label for='community' class='col-sm-2 control-label'>SNMP Community</label>
     <div class='col-sm-4'>
-    <input id='community' class='form-control' name='community' value='".$device['community']."' required/>
+    <input id='community' class='form-control' name='community' value='".$device['community']."'/>
     </div>
     </div>
     </div>


### PR DESCRIPTION
Community for V3 isn't displayed but Firefox still requires this field to be completed.

Removing this.