### PR TITLE
Removed bold from .gridster css

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1664,7 +1664,6 @@ tr.search:nth-child(odd) {
 
 .gridster li {
     font-size: 1em;
-    font-weight: bold;
     text-align: center;
     line-height: 100%;
 }


### PR DESCRIPTION
For @paulgear :)

Makes tiles overview cleaner.