### PR TITLE
Spelling correction

### DIFF
--- a/html/includes/print-alert-rules.php
+++ b/html/includes/print-alert-rules.php
@@ -41,7 +41,7 @@ if (isset($_POST['create-default'])) {
         'severity'  => 'critical',
         'extra'     => '{"mute":false,"count":"1","delay":"300"}',
         'disabled'  => 0,
-        'name'      => 'BGP Session establised',
+        'name'      => 'BGP Session established',
     );
     $default_rules[] = array(
         'device_id' => '-1',


### PR DESCRIPTION
I've set up some awesome BGP monitoring for my Quagga BGP sessions and it just did not look cool enough to show off with that "establised" spelling error in the notifications.