### PR TITLE
Distro script: Ubuntu regression fix, future-proof OpenSUSE support, code beautification

### DIFF
--- a/scripts/distro
+++ b/scripts/distro
@@ -42,7 +42,9 @@ elif [ "${OS}" = "Linux" ] ; then
     REV="" # Omit version since Arch Linux uses rolling releases
   elif [ -f /etc/UnitedLinux-release ] ; then
     DIST="${DIST}[`cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//`]"
-  elif [ -f /etc/lsb-release ] ; then
+  fi
+
+  if [ -f /etc/lsb-release ] ; then
     LSB_DIST="`cat /etc/lsb-release | grep DISTRIB_ID | cut -d "=" -f2`"
     LSB_REV="`cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2`"
     if [ "$LSB_DIST" != "" ] ; then

--- a/scripts/distro
+++ b/scripts/distro
@@ -27,9 +27,6 @@ elif [ "${OS}" = "Linux" ] ; then
 
     PSEUDONAME=`cat /etc/redhat-release | sed s/.*\(// | sed s/\)//`
     REV=`cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
-  elif [ -f /etc/SuSE-release ] ; then
-    DIST=`cat /etc/SuSE-release | tr "\n" ' '| sed s/VERSION.*//`
-    REV=`cat /etc/SuSE-release | tr "\n" ' ' | sed s/.*=\ //`
   elif [ -f /etc/mandrake-release ] ; then
     DIST='Mandrake'
     PSEUDONAME=`cat /etc/mandrake-release | sed s/.*\(// | sed s/\)//`
@@ -52,6 +49,9 @@ elif [ "${OS}" = "Linux" ] ; then
       DIST=$LSB_DIST
       REV=$LSB_REV
     fi
+  elif [ -f /etc/os-release ] ; then
+    DIST="$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
+    REV="$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
   fi
 
   if [ -n "${REV}" ]

--- a/scripts/distro
+++ b/scripts/distro
@@ -9,10 +9,13 @@ if [ "${OS}" = "SunOS" ] ; then
   OS=Solaris
   ARCH=`uname -p`
   OSSTR="${OS} ${REV}(${ARCH} `uname -v`)"
+
 elif [ "${OS}" = "AIX" ] ; then
   OSSTR="${OS} `oslevel` (`oslevel -r`)"
+
 elif [ "${OS}" = "Linux" ] ; then
   KERNEL=`uname -r`
+
   if [ -f /etc/redhat-release ] ; then
     DIST=$(cat /etc/redhat-release | awk '{print $1}')
     if [ "${DIST}" = "CentOS" ]; then
@@ -27,20 +30,25 @@ elif [ "${OS}" = "Linux" ] ; then
 
     PSEUDONAME=`cat /etc/redhat-release | sed s/.*\(// | sed s/\)//`
     REV=`cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
+
   elif [ -f /etc/mandrake-release ] ; then
     DIST='Mandrake'
     PSEUDONAME=`cat /etc/mandrake-release | sed s/.*\(// | sed s/\)//`
     REV=`cat /etc/mandrake-release | sed s/.*release\ // | sed s/\ .*//`
+
   elif [ -f /etc/debian_version ] ; then
     DIST="Debian `cat /etc/debian_version`"
     REV=""
+
   elif [ -f /etc/gentoo-release ] ; then
     DIST="Gentoo"
     REV=$(tr -d '[[:alpha:]]' </etc/gentoo-release | tr -d " ")
+
   elif [ -f /etc/arch-release ] ; then
     DIST="Arch Linux"
     REV="" # Omit version since Arch Linux uses rolling releases
     IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
+
   elif [ -f /etc/os-release ] ; then
     DIST=$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '"')
     REV=$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '"')

--- a/scripts/distro
+++ b/scripts/distro
@@ -43,6 +43,9 @@ elif [ "${OS}" = "Linux" ] ; then
     IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
   elif [ -f /etc/UnitedLinux-release ] ; then
     DIST="${DIST}[`cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//`]"
+  elif [ -f /etc/os-release ] ; then
+    DIST="$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
+    REV="$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
   fi
 
   if [ -f /etc/lsb-release -a "${IGNORE_LSB}" != 1 ] ; then
@@ -52,9 +55,6 @@ elif [ "${OS}" = "Linux" ] ; then
       DIST=$LSB_DIST
       REV=$LSB_REV
     fi
-  elif [ -f /etc/os-release ] ; then
-    DIST="$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
-    REV="$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
   fi
 
   if [ -n "${REV}" ]

--- a/scripts/distro
+++ b/scripts/distro
@@ -41,8 +41,6 @@ elif [ "${OS}" = "Linux" ] ; then
     DIST="Arch Linux"
     REV="" # Omit version since Arch Linux uses rolling releases
     IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
-  elif [ -f /etc/UnitedLinux-release ] ; then
-    DIST="${DIST}[`cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//`]"
   elif [ -f /etc/os-release ] ; then
     DIST="$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
     REV="$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '\"')"

--- a/scripts/distro
+++ b/scripts/distro
@@ -42,8 +42,8 @@ elif [ "${OS}" = "Linux" ] ; then
     REV="" # Omit version since Arch Linux uses rolling releases
     IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
   elif [ -f /etc/os-release ] ; then
-    DIST="$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
-    REV="$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '\"')"
+    DIST=$(grep '^NAME=' /etc/os-release | cut -d= -f2- | tr -d '"')
+    REV=$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2- | tr -d '"')
   fi
 
   if [ -f /etc/lsb-release -a "${IGNORE_LSB}" != 1 ] ; then

--- a/scripts/distro
+++ b/scripts/distro
@@ -40,11 +40,12 @@ elif [ "${OS}" = "Linux" ] ; then
   elif [ -f /etc/arch-release ] ; then
     DIST="Arch Linux"
     REV="" # Omit version since Arch Linux uses rolling releases
+    IGNORE_LSB=1 # /etc/lsb-release would overwrite $REV with "rolling"
   elif [ -f /etc/UnitedLinux-release ] ; then
     DIST="${DIST}[`cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//`]"
   fi
 
-  if [ -f /etc/lsb-release ] ; then
+  if [ -f /etc/lsb-release -a "${IGNORE_LSB}" != 1 ] ; then
     LSB_DIST="`cat /etc/lsb-release | grep DISTRIB_ID | cut -d "=" -f2`"
     LSB_REV="`cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2`"
     if [ "$LSB_DIST" != "" ] ; then


### PR DESCRIPTION
Turns out PR #1978 broke something after all: at least on Ubuntu, the distro script relies on having the information from `/etc/debian_version` overwritten with information from `/etc/lsb-release`. That's fixed (= reverted) now, along with a patch to get a nice version string on Arch Linux regardless.

Someone on the IRC also reported a problem with the OS detection on OpenSUSE, which turned out to be a problem reported by a completely different software package, but made me notice that `/etc/SuSE-release` is planned to be removed in future OpenSUSE versions. The recommended replacement is `/etc/os-release`, which is also used by a few other distributions. I have thus removed the SUSE-specific code (which also happened to be ugly and broken already) and added a rudimentary parser for `/etc/os-release`, which will take care of SUSE from now on.

The script also contains code for United Linux, which has been officially discontinued in 2004, so I removed that part.
Mandrake/Mandriva, whose last release was in 2011 and whose website has gone offline in 2015. We should probably consider removing those two as well at some point.