### PR TITLE
Added Full Screen Mobile support

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -121,6 +121,7 @@ if (empty($config['favicon'])) {
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="images/favicon-72.png">
   <link rel="apple-touch-icon-precomposed" href="images/favicon-57.png">
   <link rel="icon" href="images/favicon-32.png" sizes="32x32">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="msapplication-TileImage" content="images/favicon-144.png">
 <?php
 }


### PR DESCRIPTION
Full screen suport when creating shortcuts on mobile browsers.
Before:
![screenshot_2015-09-29-09-33-55](https://cloud.githubusercontent.com/assets/1170503/10164481/1bb22156-6690-11e5-81c0-c18cd10cb1bc.png)
After:
![screenshot_2015-09-29-09-35-17](https://cloud.githubusercontent.com/assets/1170503/10164487/21a308d2-6690-11e5-8f70-8507581028b3.png)

