### PR TITLE
Add support for some UPS that use same card as multimatic

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -59,5 +59,6 @@ Contributors to LibreNMS:
 - Sławomir Paszkiewicz <paszczus@pld-linux.org> (paszczus)
 - Frederik Mogensen <frederik@server-1.dk> (mogensen)
 - Matthew Scully <matt@mattz0r.me.uk> (mattz0r)
+- Xavier Beaudouin <kiwi@oav.net> (xbeaudouin)
 
 [1]: http://observium.org/ "Observium web site"

--- a/includes/discovery/os/multimatic.inc.php
+++ b/includes/discovery/os/multimatic.inc.php
@@ -5,5 +5,8 @@ if (!$os) {
         if (strstr(snmp_get($device, 'UPS-MIB::upsIdentManufacturer.0', '-Oqv', ''), 'Multimatic')) {
             $os = 'multimatic';
         }
+        if (strstr(snmp_get($device, 'UPS-MIB::upsIdentManufacturer.0', '-Oqv', ''), 'S2S')) {
+            $os = 'multimatic';
+        }
     }
 }


### PR DESCRIPTION
There is some UPS that have same management card as a multimatic that use UPS-MIB.
This pull request add "simple" way to support them.