### PR TITLE
Enhance WatchGuard OS Detection

### DIFF
--- a/includes/discovery/os/watchguard.inc.php
+++ b/includes/discovery/os/watchguard.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!$os) {
-    if (preg_match('/^WatchGuard\ Fireware/', $sysDescr)) {
+    if (preg_match('/^WatchGuard\ Fireware/', $sysDescr) || strpos($sysObjectId, '1.3.6.1.4.1.3097.1.5') !== false) {
         $os = 'firebox';
     }
 }


### PR DESCRIPTION
Fix #2024 

Should catch all in the XTM family.

Info from:
http://www.oidview.com/mibs/3097/WATCHGUARD-PRODUCTS-MIB.html