### PR TITLE
- added env php to top of file

### DIFF
--- a/scripts/gen_smokeping.php
+++ b/scripts/gen_smokeping.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /*
 * LibreNMS


### PR DESCRIPTION
This is CLI script which should be able to be run by "./gen_smokeping.php" instead of "php gen_smokeping.php"