### PR TITLE
Treat Dell branded Wifi controllers as ArubaOS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -60,5 +60,6 @@ Contributors to LibreNMS:
 - Frederik Mogensen <frederik@server-1.dk> (mogensen)
 - Matthew Scully <matt@mattz0r.me.uk> (mattz0r)
 - Xavier Beaudouin <kiwi@oav.net> (xbeaudouin)
+- Falk Stern <falk@fourecks.de> (fstern)
 
 [1]: http://observium.org/ "Observium web site"

--- a/includes/discovery/os/powerconnect.inc.php
+++ b/includes/discovery/os/powerconnect.inc.php
@@ -2,7 +2,7 @@
 
 if (!$os) {
     // if (strstr($sysDescr, "Neyland 24T")) { $os = "powerconnect"; } /* Powerconnect 5324 */
-    if (stristr($sysDescr, 'PowerConnect ') && !stristr($sysDescr, 'ArubaOS') {
+    if (stristr($sysDescr, 'PowerConnect ') && !stristr($sysDescr, 'ArubaOS')) {
         $os = 'powerconnect';
     }
     else if (preg_match('/Dell.*Gigabit\ Ethernet/i', $sysDescr)) {

--- a/includes/discovery/os/powerconnect.inc.php
+++ b/includes/discovery/os/powerconnect.inc.php
@@ -2,7 +2,7 @@
 
 if (!$os) {
     // if (strstr($sysDescr, "Neyland 24T")) { $os = "powerconnect"; } /* Powerconnect 5324 */
-    if (stristr($sysDescr, 'PowerConnect ')) {
+    if (stristr($sysDescr, 'PowerConnect ') && !stristr($sysDescr, 'ArubaOS') {
         $os = 'powerconnect';
     }
     else if (preg_match('/Dell.*Gigabit\ Ethernet/i', $sysDescr)) {


### PR DESCRIPTION
Dell branded Wifi controllers are detected as Dell PowerConnect switches, because they include the string "PowerConnect" in their sysDescr. They also contain "ArubaOS", they are matched by both arubaos.inc.php and powerconnect.php. This patch makes librenms detect them as Aruba Wifi controllers, which is the correct way to treat them as they are just Dell branded. 