### PR TITLE
Escape quotes for ifAlias, since it breaks overlib if such appears.

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -583,7 +583,7 @@ function generate_port_link($port, $text=null, $type=null, $overlib=1, $single_g
 
     $content = '<div class=list-large>'.$port['hostname'].' - '.fixifName($port['label']).'</div>';
     if ($port['ifAlias']) {
-        $content .= $port['ifAlias'].'<br />';
+        $content .= escape_quotes($port['ifAlias']).'<br />';
     }
 
     $content              .= "<div style=\'width: 850px\'>";


### PR DESCRIPTION
Discovered when trying to mouse-over "inside" and "outside" interfaces on Cisco ASA firewalls from within the device overview page and the top-interfaces widget, with default aliases in the following form: "Adaptive Security Appliance 'inside' interface".