### PR TITLE
Move red map markers to foreground

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -62,5 +62,6 @@ Contributors to LibreNMS:
 - Xavier Beaudouin <kiwi@oav.net> (xbeaudouin)
 - Falk Stern <falk@fourecks.de> (fstern)
 - Donovan Bridoux <donovan.bridoux@gmail.com> (PandaWawawa)
+- Sebastian Neuner <sebastian@sneuner.org> (9er)
 
 [1]: http://observium.org/ "Observium web site"

--- a/html/includes/common/worldmap.inc.php
+++ b/html/includes/common/worldmap.inc.php
@@ -123,11 +123,13 @@ var greenMarker = L.AwesomeMarkers.icon({
         }
         foreach (dbFetchRows($sql, array($_SESSION['user_id'])) as $map_devices) {
             $icon = 'greenMarker';
+            $z_offset = 0;
             if ($map_devices['status'] == 0) {
                 $icon = 'redMarker';
+                $z_offset = 10000;  // move marker to foreground
             }
             $temp_output .= "var title = '<a href=\"" . generate_device_url($map_devices) . "\"><img src=\"".getImageSrc($map_devices)."\" width=\"32\" height=\"32\" alt=\"\">".$map_devices['hostname']."</a>';
-var marker = L.marker(new L.LatLng(".$map_devices['lat'].", ".$map_devices['lng']."), {title: title, icon: $icon});
+var marker = L.marker(new L.LatLng(".$map_devices['lat'].", ".$map_devices['lng']."), {title: title, icon: $icon, zIndexOffset: $z_offset});
 marker.bindPopup(title);
     markers.addLayer(marker);\n";
         }


### PR DESCRIPTION
Usually you're interested in the things that are broken, rather than the things that are fine, so this will set zIndexOffset to 10000 for the leaflet markers on the world map, if a device is down (red marker). They will then appear in the foreground and won't be hidden by green markers.

I assume that is what the "ORDER BY `status` ASC" in the SQL was meant for, but it didn't seem to have an effect on the leaflet marker order for me.