### PR TITLE
Updated to disable auto-discovery by ip

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -261,6 +261,11 @@ $config['autodiscovery']['nets-exclude'][] = "240.0.0.0/4";
 ```
 Arrays of subnets to exclude in auto discovery mode.
 
+```php
+$config['discovery_by_ip'] = true;
+```
+Enable auto discovery by IP. By default we only discover based on hostnames but manually adding by IP is allowed.
+
 #### Email configuration
 
 > You can configure these options within the WebUI now, please avoid setting these options within config.php

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -265,6 +265,7 @@ Arrays of subnets to exclude in auto discovery mode.
 $config['discovery_by_ip'] = true;
 ```
 Enable auto discovery by IP. By default we only discover based on hostnames but manually adding by IP is allowed.
+Please note this could lead to duplicate devices being added based on IP, Hostname or sysName.
 
 #### Email configuration
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -215,6 +215,8 @@ $config['autodiscovery']['nets-exclude'][] = '127.0.0.0/8';
 $config['autodiscovery']['nets-exclude'][] = '169.254.0.0/16';
 $config['autodiscovery']['nets-exclude'][] = '224.0.0.0/4';
 $config['autodiscovery']['nets-exclude'][] = '240.0.0.0/4';
+// Autodiscover by IP
+$config['discovery_by_ip'] = false;// Set to true if you want to enable auto discovery by IP.
 
 $config['alerts']['email']['enable'] = false;
 // Enable email alerts

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -34,6 +34,12 @@ function discover_new_device($hostname, $device='', $method='', $interface='') {
             return false;
         }
     }
+    else {
+        if ($config['discovery_by_ip'] === false) {
+            d_echo('Discovery by IP disabled, skipping ' . $dst_host);
+            return false;
+        }
+    }
 
     d_echo("ip lookup result: $ip\n");
 


### PR DESCRIPTION
Fix #1846 
Fix #1762 

So it doesn't look like we can realistically find a way to counter duplicate devices being added when people are using a mix of hostnames, shortnames and IPs. This PR will now disable the auto discovery of devices via IP. You will need to enable the support via a config option. Adding devices via IP via cli/webui/api is still possible as this is manually fed.