### PR TITLE
Detect vcsa as vmware instead of generic

### DIFF
--- a/includes/discovery/os/vmware.inc.php
+++ b/includes/discovery/os/vmware.inc.php
@@ -4,4 +4,7 @@ if (!$os) {
     if (preg_match('/^VMware ESX/', $sysDescr)) {
         $os = 'vmware';
     }
+    if (preg_match('/^VMware-vCenter-Server-Appliance/', $sysDescr)) {
+        $os = 'vmware';
+    }
 }


### PR DESCRIPTION
This pull request will set the os of a vcenter server appliance to 'vmware' with the appropriate icon.