### PR TITLE
De-dupe checks for hostname when adding hosts

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -243,7 +243,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
 
     list($hostshort) = explode(".", $host);
     // Test Database Exists
-    if (dup_host_check($host) === false) {
+    if (host_exists($host) === false) {
         if ($config['addhost_alwayscheckip'] === TRUE) {
             $ip = gethostbyname($host);
         } else {
@@ -583,7 +583,7 @@ function createHost($host, $community = NULL, $snmpver, $port = 161, $transport 
 
     if ($device['os']) {
 
-        if (dup_host_check($host) === false) {
+        if (host_exists($host) === false) {
             $device_id = dbInsert($device, 'devices');
             if ($device_id) {
                 return($device_id);
@@ -1269,7 +1269,7 @@ function snmpTransportToAddressFamily($transport) {
  * @return bool true if hostname already exists
  *              false if hostname doesn't exist
 **/
-function dup_host_check($hostname) {
+function host_exists($hostname) {
     $count = dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($hostname));
     if ($count > 0) {
         return true;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -243,7 +243,7 @@ function addHost($host, $snmpver, $port = '161', $transport = 'udp', $quiet = '0
 
     list($hostshort) = explode(".", $host);
     // Test Database Exists
-    if (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($host)) == '0') {
+    if (dup_host_check($host) === false) {
         if ($config['addhost_alwayscheckip'] === TRUE) {
             $ip = gethostbyname($host);
         } else {
@@ -583,13 +583,17 @@ function createHost($host, $community = NULL, $snmpver, $port = 161, $transport 
 
     if ($device['os']) {
 
-        $device_id = dbInsert($device, 'devices');
-
-        if ($device_id) {
-            return($device_id);
+        if (dup_host_check($host) === false) {
+            $device_id = dbInsert($device, 'devices');
+            if ($device_id) {
+                return($device_id);
+            }
+            else {
+                return false;
+            }
         }
         else {
-            return FALSE;
+            return false;
         }
     }
     else {
@@ -1254,5 +1258,23 @@ function snmpTransportToAddressFamily($transport) {
     }
     else {
         return AF_INET;
+    }
+}
+
+/**
+ * Checks if the $hostname provided exists in the DB already
+ *
+ * @param string $hostname The hostname to check for
+ *
+ * @return bool true if hostname already exists
+ *              false if hostname doesn't exist
+**/
+function dup_host_check($hostname) {
+    $count = dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `hostname` = ?", array($hostname));
+    if ($count > 0) {
+        return true;
+    }
+    else {
+        return false;
     }
 }


### PR DESCRIPTION
Fix #2105 

Central function now for checking for duplicate hostnames.

This is called twice now, once as it was before to save on a load of icmp / snmp queries if the device already exists but then again just at the end before the DB insert to stop race conditions happening due to slow icmp / snmp queries.

This _should_ stop devices being added with the same hostname from things like auto-discovery.