### PR TITLE
Updated devices Graphs links to use non-static time references

### DIFF
--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -99,8 +99,8 @@ $(document).ready(function() {
 });
 
 function submitCustomRange(frmdata) {
-    var reto = /to=([0-9])+/g;
-    var refrom = /from=([0-9])+/g;
+    var reto = /to=([0-9a-zA-Z\-])+/g;
+    var refrom = /from=([0-9a-zA-Z\-])+/g;
     var tsto = moment(frmdata.dtpickerto.value).unix();
     var tsfrom = moment(frmdata.dtpickerfrom.value).unix();
     frmdata.selfaction.value = frmdata.selfaction.value.replace(reto, 'to=' + tsto);

--- a/html/pages/devices.inc.php
+++ b/html/pages/devices.inc.php
@@ -51,7 +51,7 @@ foreach ($menu_options as $option => $text) {
     if ($vars['format'] == 'graph_'.$option) {
         echo("<span class='pagemenu-selected'>");
     }
-    echo('<a href="' . generate_url($vars, array('format' => 'graph_'.$option, 'from' => $config['time']['day'], 'to' => $config['time']['now'])) . '">' . $text . '</a>');
+    echo('<a href="' . generate_url($vars, array('format' => 'graph_'.$option, 'from' => '-24h', 'to' => 'now')) . '">' . $text . '</a>');
     if ($vars['format'] == 'graph_'.$option) {
         echo("</span>");
     }

--- a/html/pages/devices.inc.php
+++ b/html/pages/devices.inc.php
@@ -91,13 +91,13 @@ list($format, $subformat) = explode("_", $vars['format'], 2);
 
 if($format == "graph") {
 
-    if (!is_numeric($vars['from'])) {
+    if (empty($vars['from'])) {
         $graph_array['from'] = $config['time']['day'];
     }
     else {
         $graph_array['from'] = $vars['from'];
     }
-    if (!is_numeric($vars['to'])) {
+    if (empty($vars['to'])) {
         $graph_array['to'] = $config['time']['now'];
     }
     else {


### PR DESCRIPTION
Fix #2200 

Also worth considering rolling this out to the port graphs as well, When you go to the port graphs they are given a from / to which doesn't change so refreshes don't do anything.