### PR TITLE
Removed ignored,deleted and disabled ports from query

### DIFF
--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -338,17 +338,17 @@ foreach ($vars as $var => $value) {
             break;
         case 'state':
             if ($value == "down") {
-                $where .= "AND I.ifAdminStatus = ? AND I.ifOperStatus = ?";
+                $where .= " AND I.ifAdminStatus = ? AND I.ifOperStatus = ?";
                 $param[] = "up";
                 $param[] = "down";
             }
             elseif($value == "up") {
-                $where .= "AND I.ifAdminStatus = ? AND I.ifOperStatus = ?  AND I.ignore = '0' AND D.ignore='0' AND I.deleted='0'";
+                $where .= " AND I.ifAdminStatus = ? AND I.ifOperStatus = ?";
                 $param[] = "up";
                 $param[] = "up";
             }
             elseif($value == "admindown") {
-                $where .= "AND I.ifAdminStatus = ? AND D.ignore = 0";
+                $where .= " AND I.ifAdminStatus = ? AND D.ignore = 0";
                 $param[] = "down";
             }
             break;


### PR DESCRIPTION
Fix #2201 

I'm not 100% sure on this one, I've fixed the issue anyway but I believe the reason it was like that is so you only see up ports which aren't disabled, ignored or deleted which kind of makes more sense.

Feel free to merge or not :)