### PR TITLE
Dynamic use of nagios-service checks

### DIFF
--- a/check-services.php
+++ b/check-services.php
@@ -31,8 +31,16 @@ foreach (dbFetchRows('SELECT * FROM `devices` AS D, `services` AS S WHERE S.devi
             include $checker_script;
         }
         else {
-            $status = '2';
-            $check  = "Error : Script not found ($checker_script)";
+            $cmd = $config['nagios_plugins'] . "/check_" . $service['service_type'] . " -H " . ($service['service_ip'] ? $service['service_ip'] : $service['hostname']);
+            $cmd .= " ".$service['service_param'];
+            $check = shell_exec($cmd);
+            list($check, $time) = split("\|", $check);
+            if(stristr($check, "ok -")) {
+                $status = 1;
+            }
+            else {
+                $status = 0;
+            }
         }
 
             $update = array();

--- a/html/includes/print-service-add.inc.php
+++ b/html/includes/print-service-add.inc.php
@@ -47,6 +47,7 @@ echo "
         <input name='params' id='params' class='form-control input-sm'>
       </div>
       <div class='col-sm-5'>
+          This may be required based on the service check.
       </div>
     </div>
     <button type='submit' name='Submit' class='btn btn-success input-sm'>Add Service</button>

--- a/html/includes/print-service-edit.inc.php
+++ b/html/includes/print-service-edit.inc.php
@@ -26,6 +26,9 @@ if (isset($_POST['service']) && is_numeric($_POST['service'])) {
       <div class='col-sm-5'>
         <input name='params' id='params' value='".$service['service_param']."' class='form-control input-sm'>
       </div>
+      <div class='col-sm-5'>
+          This may be required based on the service check.
+      </div>
     </div>
     <button type='submit' id='confirm-editsrv' name='confirm-editsrv' value='yes' class='btn btn-primary input-sm'>Edit Service</button>
   </div>

--- a/html/includes/print-service.inc.php
+++ b/html/includes/print-service.inc.php
@@ -42,11 +42,11 @@ $popup .= "</div><img src=\'graph.php?id=".$service['service_id'].'&amp;type=ser
 $popup .= "', RIGHT".$config['overlib_defaults'].');" onmouseout="return nd();"';
 
 echo "
-       <tr style=\"background-color: $bg; padding: 5px;\">";
+       <tr>";
 
 if ($device_id) {
     if (!$samehost) {
-        echo "<td valign=top width=250><span style='font-weight:bold;'>".generate_device_link($device).'</span></td>';
+        echo "<td>".generate_device_link($device).'</span></td>';
     }
     else {
         echo '<td></td>';
@@ -54,14 +54,13 @@ if ($device_id) {
 }
 
 echo "
-         <td valign=top class=list-bold>
+         <td>
            $status
          </td>
-         <td valign=top><a $popup><img src='$mini_url'></a></td>
-         <td valign=top width=175>
+         <td>
            $since
          </td>
-         <td valign=top>
+         <td>
            <span class=box-desc>$message</span>
          </td>
        </tr>";

--- a/html/pages/addsrv.inc.php
+++ b/html/pages/addsrv.inc.php
@@ -21,7 +21,7 @@ else {
     if ($handle = opendir($config['nagios_plugins'])) {
         while (false !== ($file = readdir($handle))) {
             if ($file != '.' && $file != '..' && !strstr($file, '.') && strstr($file, 'check_')) {
-                list(,$check_name) = explode('_',$file);
+                list(,$check_name) = explode('_',$file,2);
                 $servicesform .= "<option value='$check_name'>$check_name</option>";
             }
         }

--- a/html/pages/addsrv.inc.php
+++ b/html/pages/addsrv.inc.php
@@ -9,7 +9,7 @@ else {
             $updated = '1';
 
             // FIXME should call add_service (needs more parameters)
-            $service_id = dbInsert(array('device_id' => $_POST['device'], 'service_ip' => $_POST['ip'], 'service_type' => $_POST['type'], 'service_desc' => $_POST['descr'], 'service_param' => $_POST['params'], 'service_ignore' => '0'), 'services');
+            $service_id = dbInsert(array('device_id' => $_POST['device'], 'service_ip' => $_POST['ip'], 'service_type' => $_POST['type'], 'service_desc' => $_POST['descr'], 'service_param' => $_POST['params'], 'service_ignore' => '0', 'service_status' => '0', 'service_checked' => '0', 'service_changed' => '0', 'service_message' => 'New check', 'service_disabled' => '0'), 'services');
 
             if ($service_id) {
                 $message       .= $message_break.'Service added ('.$service_id.')!';
@@ -18,10 +18,11 @@ else {
         }
     }
 
-    if ($handle = opendir($config['install_dir'].'/includes/services/')) {
+    if ($handle = opendir($config['nagios_plugins'])) {
         while (false !== ($file = readdir($handle))) {
-            if ($file != '.' && $file != '..' && !strstr($file, '.')) {
-                $servicesform .= "<option value='$file'>$file</option>";
+            if ($file != '.' && $file != '..' && !strstr($file, '.') && strstr($file, 'check_')) {
+                list(,$check_name) = explode('_',$file);
+                $servicesform .= "<option value='$check_name'>$check_name</option>";
             }
         }
 

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -68,7 +68,6 @@ echo '<div class="table-responsive">
     <tr>
         <th>Device</th>
         <th>Service</th>
-        <th>Status</th>
         <th>Changed</th>
         <th>Message</th>
     </tr>';

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -8,7 +8,6 @@ echo "<span style='font-weight: bold;'>Services</span> &#187; ";
 
 $menu_options = array(
     'basic'   => 'Basic',
-    'details' => 'Details',
 );
 
 $sql_param = array();


### PR DESCRIPTION
Fix #1792 
Fix #1037

This is a stab at providing this functionality. I added a service check for check_dig which doesn't exist as a current service check for us and this works fine.

It does make two assumptions:

1. The file is called check_*
2. That -H is required and passes the IP / hostname over.

Tidied up the table showing the checks and removed the broken graphs.

Also added the missing data for dbInsert to fix mysql strict bombing out.

