### PR TITLE
Using PERCENTNAN instead of PERCENT

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -64,5 +64,6 @@ Contributors to LibreNMS:
 - Donovan Bridoux <donovan.bridoux@gmail.com> (PandaWawawa)
 - Sebastian Neuner <sebastian@sneuner.org> (9er)
 - Robert Zollner <wolfit_ro@yahoo.com> (Lupul)
+- Richard Kojedzinszky <krichy@cflinux.hu> (rkojedzinszky)
 
 [1]: http://observium.org/ "Observium web site"

--- a/html/includes/graphs/generic_data.inc.php
+++ b/html/includes/graphs/generic_data.inc.php
@@ -78,16 +78,16 @@ $rrd_options .= ' CDEF:inbits_max=inoctets_max,8,*';
 
 if ($config['rrdgraph_real_95th']) {
     $rrd_options .= ' CDEF:highbits=inoctets,outoctets,MAX,8,*';
-    $rrd_options .= ' VDEF:95thhigh=highbits,95,PERCENT';
+    $rrd_options .= ' VDEF:95thhigh=highbits,95,PERCENTNAN';
 }
 
 $rrd_options .= ' VDEF:totin=inoctets,TOTAL';
 $rrd_options .= ' VDEF:totout=outoctets,TOTAL';
 $rrd_options .= ' VDEF:tot=octets,TOTAL';
 
-$rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
-$rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-$rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+$rrd_options .= ' VDEF:95thin=inbits,95,PERCENTNAN';
+$rrd_options .= ' VDEF:95thout=outbits,95,PERCENTNAN';
+$rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENTNAN';
 
 if ($format == 'octets' || $format == 'bytes') {
     $units  = 'Bps';

--- a/html/includes/graphs/generic_multi_bits.inc.php
+++ b/html/includes/graphs/generic_multi_bits.inc.php
@@ -55,9 +55,9 @@ if ($i) {
     $rrd_options .= ' CDEF:inbits=inoctets,8,*';
     $rrd_options .= ' CDEF:outbits=outoctets,8,*';
     $rrd_options .= ' CDEF:doutbits=doutoctets,8,*';
-    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
-    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENTNAN';
 
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= ' CDEF:'.$in.'octetsX='.$in_thingX.$pluses;
@@ -66,9 +66,9 @@ if ($i) {
         $rrd_options .= ' CDEF:inbitsX=inoctetsX,8,*';
         $rrd_options .= ' CDEF:outbitsX=outoctetsX,8,*';
         $rrd_options .= ' CDEF:doutbitsX=doutoctetsX,8,*';
-        $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENT';
-        $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENT';
-        $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENT';
+        $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENTNAN';
+        $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENTNAN';
+        $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENTNAN';
     }
 
     if ($legend == 'no' || $legend == '1') {

--- a/html/includes/graphs/generic_multi_data.inc.php
+++ b/html/includes/graphs/generic_multi_data.inc.php
@@ -64,9 +64,9 @@ if ($i) {
     $rrd_options .= ' CDEF:inbits=inoctets,8,*';
     $rrd_options .= ' CDEF:outbits=outoctets,8,*';
     $rrd_options .= ' CDEF:doutbits=doutoctets,8,*';
-    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
-    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENTNAN';
 
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= ' CDEF:'.$in.'octetsX='.$in_thingX.$pluses;
@@ -75,9 +75,9 @@ if ($i) {
         $rrd_options .= ' CDEF:inbitsX=inoctetsX,8,*';
         $rrd_options .= ' CDEF:outbitsX=outoctetsX,8,*';
         $rrd_options .= ' CDEF:doutbitsX=doutoctetsX,8,*';
-        $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENT';
-        $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENT';
-        $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENT';
+        $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENTNAN';
+        $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENTNAN';
+        $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENTNAN';
     }
 
     if ($legend == 'no' || $legend == '1') {

--- a/html/includes/graphs/generic_multi_data_separated.inc.php
+++ b/html/includes/graphs/generic_multi_data_separated.inc.php
@@ -109,9 +109,9 @@ if (!$nototal) {
     $rrd_options .= ' CDEF:outbits=outoctets,8,*';
     $rrd_options .= ' CDEF:doutbits=doutoctets,8,*';
 
-    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
-    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENTNAN';
 
     $rrd_options .= ' VDEF:totin=inoctets,TOTAL';
     $rrd_options .= ' VDEF:totout=outoctets,TOTAL';

--- a/html/includes/graphs/generic_multi_seperated.inc.php
+++ b/html/includes/graphs/generic_multi_seperated.inc.php
@@ -109,9 +109,9 @@ if ($_GET['previous'] == 'yes') {
     $rrd_options .= ' CDEF:outbitsX=outBX,8,*';
     $rrd_options .= ' CDEF:bitsX=inbitsX,outbitsX,+';
     $rrd_options .= ' CDEF:doutbitsX=doutBX,8,*';
-    $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENT';
-    $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENT';
+    $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENTNAN';
 }
 
 if ($_GET['previous'] == 'yes') {
@@ -130,9 +130,9 @@ if (!$args['nototal']) {
     $rrd_options .= ' CDEF:outbits=outB,8,*';
     $rrd_options .= ' CDEF:bits=inbits,outbits,+';
     $rrd_options .= ' CDEF:doutbits=doutB,8,*';
-    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
-    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' VDEF:95thin=inbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:95thout=outbits,95,PERCENTNAN';
+    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENTNAN';
     $rrd_options .= ' VDEF:totin=inB,TOTAL';
     $rrd_options .= ' VDEF:avein=inbits,AVERAGE';
     $rrd_options .= ' VDEF:totout=outB,TOTAL';


### PR DESCRIPTION
This would ignore NAN values from the dataset in the time range, for example drawing a 95 percent line in the negative range when there is not enough data.