### PR TITLE
FIX 95th percent lines in negative range

### DIFF
--- a/html/includes/graphs/generic_data.inc.php
+++ b/html/includes/graphs/generic_data.inc.php
@@ -87,7 +87,7 @@ $rrd_options .= ' VDEF:tot=octets,TOTAL';
 
 $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
 $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-$rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+$rrd_options .= ' CDEF:d95thoutn=doutbits,-1,* VDEF:d95thoutn95=d95thoutn,95,PERCENT CDEF:d95thoutn95n=doutbits,doutbits,-,d95thoutn95,-1,*,+ VDEF:d95thout=d95thoutn95n,FIRST';
 
 if ($format == 'octets' || $format == 'bytes') {
     $units  = 'Bps';

--- a/html/includes/graphs/generic_multi_bits.inc.php
+++ b/html/includes/graphs/generic_multi_bits.inc.php
@@ -57,7 +57,7 @@ if ($i) {
     $rrd_options .= ' CDEF:doutbits=doutoctets,8,*';
     $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
     $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' CDEF:d95thoutn=doutbits,-1,* VDEF:d95thoutn95=d95thoutn,95,PERCENT CDEF:d95thoutn95n=doutbits,doutbits,-,d95thoutn95,-1,*,+ VDEF:d95thout=d95thoutn95n,FIRST';
 
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= ' CDEF:'.$in.'octetsX='.$in_thingX.$pluses;
@@ -68,7 +68,7 @@ if ($i) {
         $rrd_options .= ' CDEF:doutbitsX=doutoctetsX,8,*';
         $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENT';
         $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENT';
-        $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENT';
+        $rrd_options .= ' CDEF:d95thoutXn=doutbitsX,-1,* VDEF:d95thoutXn95=d95thoutXn,95,PERCENT CDEF:d95thoutXn95n=doutbitsX,doutbitsX,-,d95thoutXn95,-1,*,+ VDEF:d95thoutX=d95thoutXn95n,FIRST';
     }
 
     if ($legend == 'no' || $legend == '1') {

--- a/html/includes/graphs/generic_multi_data.inc.php
+++ b/html/includes/graphs/generic_multi_data.inc.php
@@ -66,7 +66,7 @@ if ($i) {
     $rrd_options .= ' CDEF:doutbits=doutoctets,8,*';
     $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
     $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' CDEF:d95thoutn=doutbits,-1,* VDEF:d95thoutn95=d95thoutn,95,PERCENT CDEF:d95thoutn95n=doutbits,doutbits,-,d95thoutn95,-1,*,+ VDEF:d95thout=d95thoutn95n,FIRST';
 
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= ' CDEF:'.$in.'octetsX='.$in_thingX.$pluses;
@@ -77,7 +77,7 @@ if ($i) {
         $rrd_options .= ' CDEF:doutbitsX=doutoctetsX,8,*';
         $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENT';
         $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENT';
-        $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENT';
+        $rrd_options .= ' CDEF:d95thoutXn=doutbitsX,-1,* VDEF:d95thoutXn95=d95thoutXn,95,PERCENT CDEF:d95thoutXn95n=doutbitsX,doutbitsX,-,d95thoutXn95,-1,*,+ VDEF:d95thoutX=d95thoutXn95n,FIRST';
     }
 
     if ($legend == 'no' || $legend == '1') {

--- a/html/includes/graphs/generic_multi_data_separated.inc.php
+++ b/html/includes/graphs/generic_multi_data_separated.inc.php
@@ -111,7 +111,7 @@ if (!$nototal) {
 
     $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
     $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' CDEF:d95thoutn=doutbits,-1,* VDEF:d95thoutn95=d95thoutn,95,PERCENT CDEF:d95thoutn95n=doutbits,doutbits,-,d95thoutn95,-1,*,+ VDEF:d95thout=d95thoutn95n,FIRST';
 
     $rrd_options .= ' VDEF:totin=inoctets,TOTAL';
     $rrd_options .= ' VDEF:totout=outoctets,TOTAL';

--- a/html/includes/graphs/generic_multi_seperated.inc.php
+++ b/html/includes/graphs/generic_multi_seperated.inc.php
@@ -111,7 +111,7 @@ if ($_GET['previous'] == 'yes') {
     $rrd_options .= ' CDEF:doutbitsX=doutBX,8,*';
     $rrd_options .= ' VDEF:95thinX=inbitsX,95,PERCENT';
     $rrd_options .= ' VDEF:95thoutX=outbitsX,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thoutX=doutbitsX,5,PERCENT';
+    $rrd_options .= ' CDEF:d95thoutXn=doutbitsX,-1,* VDEF:d95thoutXn95=d95thoutXn,95,PERCENT CDEF:d95thoutXn95n=doutbitsX,doutbitsX,-,d95thoutXn95,-1,*,+ VDEF:d95thoutX=d95thoutXn95n,FIRST';
 }
 
 if ($_GET['previous'] == 'yes') {
@@ -132,7 +132,7 @@ if (!$args['nototal']) {
     $rrd_options .= ' CDEF:doutbits=doutB,8,*';
     $rrd_options .= ' VDEF:95thin=inbits,95,PERCENT';
     $rrd_options .= ' VDEF:95thout=outbits,95,PERCENT';
-    $rrd_options .= ' VDEF:d95thout=doutbits,5,PERCENT';
+    $rrd_options .= ' CDEF:d95thoutn=doutbits,-1,* VDEF:d95thoutn95=d95thoutn,95,PERCENT CDEF:d95thoutn95n=doutbits,doutbits,-,d95thoutn95,-1,*,+ VDEF:d95thout=d95thoutn95n,FIRST';
     $rrd_options .= ' VDEF:totin=inB,TOTAL';
     $rrd_options .= ' VDEF:avein=inbits,AVERAGE';
     $rrd_options .= ' VDEF:totout=outB,TOTAL';


### PR DESCRIPTION
This is a very ugly hack to show 95th lines in the negative ranges where even one data sample is missing in the time range.