### PR TITLE
Added ability to globally disable sending alerts

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -48,7 +48,7 @@ require_once $config['install_dir'].'/includes/definitions.inc.php';
 require_once $config['install_dir'].'/includes/functions.php';
 require_once $config['install_dir'].'/includes/alerts.inc.php';
 
-if (!defined('TEST')) {
+if (!defined('TEST') && $config['alert']['disable'] != 'true') {
     echo 'Start: '.date('r')."\r\n";
     echo "RunFollowUp():\r\n";
     RunFollowUp();

--- a/html/pages/settings/alerting.inc.php
+++ b/html/pages/settings/alerting.inc.php
@@ -196,6 +196,10 @@ else {
 $callback = urlencode($callback);
 
 $general_conf = array(
+    array('name'               => 'alert.disable',
+          'descr'              => 'Disable alerting',
+          'type'               => 'checkbox',
+    ),
     array('name'               => 'alert.admins',
           'descr'              => 'Issue alerts to admins',
           'type'               => 'checkbox',

--- a/sql-schema/075.sql
+++ b/sql-schema/075.sql
@@ -1,0 +1,1 @@
+INSERT INTO config (config_name,config_value,config_default,config_descr,config_group,config_group_order,config_sub_group,config_sub_group_order,config_hidden,config_disabled) values ('alert.disable','false','false','Stop alerts being generated','alerting',0,'general',0,'0','0');


### PR DESCRIPTION
Fix #2360 

It's a good thing to have, people might want to just disable all alerting without disabling cron so I agree it's a good idea. Feel free to merge or not though.