### PR TITLE
Removed device_traffic_descr entry to resolv graphs

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -531,7 +531,6 @@ $config['device_traffic_iftype'][] = '/ppp/';
 $config['device_traffic_descr'][] = '/loopback/';
 $config['device_traffic_descr'][] = '/vlan/';
 $config['device_traffic_descr'][] = '/tunnel/';
-$config['device_traffic_descr'][] = '/:\d+/';
 $config['device_traffic_descr'][] = '/bond/';
 $config['device_traffic_descr'][] = '/null/';
 $config['device_traffic_descr'][] = '/dummy/';


### PR DESCRIPTION
Fix #2217 

I've debugged this twice now for two separate people with D-link and Extreme devices where total traffic graphs don't work. So far removing this fixes the issues. I can't see any devices I have that would miss this, if we find some then we can add more specific regexes.