### PR TITLE
Add MIBs for other Cisco SB switches (SG200 series)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -66,5 +66,5 @@ Contributors to LibreNMS:
 - Robert Zollner <wolfit_ro@yahoo.com> (Lupul)
 - Richard Hartmann <richih@debian.org> (RichiH)
 - Robert Gornall <roblnm@khobbits.co.uk (KHobbits)
-
+- Rob Gormley <robert@gormley.me> (rgormley)
 [1]: http://observium.org/ "Observium web site"

--- a/includes/discovery/os/ciscosb.inc.php
+++ b/includes/discovery/os/ciscosb.inc.php
@@ -7,4 +7,16 @@ if (!$os) {
     if (strstr($sysObjectId, '.1.3.6.1.4.1.9.6.1.83')) {
         $os = 'ciscosb';
     }
+
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.9.6.1.85')) {
+        $os = 'ciscosb';
+    }
+
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.9.6.1.88')) {
+        $os = 'ciscosb';
+    }
+
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.9.6.1.89')) {
+        $os = 'ciscosb';
+    }
 }


### PR DESCRIPTION
Cisco SG200-26 switch (and other SG200-) are not detected as Cisco devices but generic. These MIBs should add that detection.