### PR TITLE
Add innodb config example to daily

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -37,6 +37,7 @@ The ' . $config['project_name'] . ' team.';
             echo 'Current size: '.($pool_size / 1024 / 1024).' MiB'.PHP_EOL;
             echo 'Minimum Required: '.($pool_used / 1024 / 1024).' MiB'.PHP_EOL;
             echo 'To ensure integrity, we\'re not going to pull any updates until the buffersize has been adjusted.'.PHP_EOL;
+            echo 'Config proposal: "innodb_buffer_pool_size = '.pow(2,ceil(log(($pool_used / 1024 / 1024),2))).'M"'.PHP_EOL;
         }
         exit(2);
     }


### PR DESCRIPTION
Fix issue-2400

```
[root@librenms librenms]# ./daily.sh 
InnoDB Buffersize too small.
Current size: 4 MiB
Minimum Required: 4.734375 MiB
To ensure integrity, we're not going to pull any updates until the buffersize has been adjusted.
Config proposal: "innodb_buffer_pool_size = 8M"
```