### PR TITLE
Real-time graphs: fix for graph wraps

### DIFF
--- a/html/data.php
+++ b/html/data.php
@@ -31,14 +31,14 @@ if (is_numeric($_GET['id']) && ($config['allow_unauth_graphs'] || port_permitted
     $auth   = true;
 }
 
-$in  = snmp_get($device, 'ifInOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
-$out = snmp_get($device, 'ifOutOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
+$in = snmp_get($device, 'ifHCInOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
 if (empty($in)) {
-    $in = snmp_get($device, 'ifHCInOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
+    $in  = snmp_get($device, 'ifInOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
 }
 
+$out = snmp_get($device, 'ifHCOutOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
 if (empty($out)) {
-    $out = snmp_get($device, 'ifHCOutOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
+    $out = snmp_get($device, 'ifOutOctets.'.$port['ifIndex'], '-OUqnv', 'IF-MIB');
 }
 
 $time = time();


### PR DESCRIPTION
FIX is by querying the HC counters first, and fall back to snmpv1 oids
in case of no answer.