### PR TITLE
Ad-auth need to add user to db for dashboards to work properly

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -69,5 +69,5 @@ Contributors to LibreNMS:
 - Rob Gormley <robert@gormley.me> (rgormley)
 - Richard Kojedzinszky <krichy@nmdps.net> (rkojedzinszky)
 - Tony Murray <murraytony@gmail.com> (murrant)
-- Peter Lamperud <peter.lamperud@gmail.com> (vizay)
+- Peter Lamperud <peter.lamperud@gmail.com>  (vizay)
 [1]: http://observium.org/ "Observium web site"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -69,4 +69,5 @@ Contributors to LibreNMS:
 - Rob Gormley <robert@gormley.me> (rgormley)
 - Richard Kojedzinszky <krichy@nmdps.net> (rkojedzinszky)
 - Tony Murray <murraytony@gmail.com> (murrant)
+- Peter Lamperud <peter.lamperud@gmail.com> (vizay)
 [1]: http://observium.org/ "Observium web site"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -69,5 +69,5 @@ Contributors to LibreNMS:
 - Rob Gormley <robert@gormley.me> (rgormley)
 - Richard Kojedzinszky <krichy@nmdps.net> (rkojedzinszky)
 - Tony Murray <murraytony@gmail.com> (murrant)
-- Peter Lamperud <peter.lamperud@gmail.com>  (vizay)
+- Peter Lamperud <peter.lamperud@gmail.com> (vizay)
 [1]: http://observium.org/ "Observium web site"

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -94,7 +94,7 @@ function adduser($username) {
 }
 
 function user_exists_in_db($username) {
-    $return = @dbFetchCell('SELECT COUNT(*) FROM users WHERE username = ?', array($username), true);
+    $return = dbFetchCell('SELECT COUNT(*) FROM users WHERE username = ?', array($username), true);
     return $return;
 }
 

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 // easier to rewrite for Active Directory than to bash it into existing LDAP implementation
+// TODO: Add user in database if auth success and user doesn't already exist in db
 
 // disable certificate checking before connect if required
 if (isset($config['auth_ad_check_certificates']) &&

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 // easier to rewrite for Active Directory than to bash it into existing LDAP implementation
-// TODO: Add user in database if auth success and user doesn't already exist in db
 
 // disable certificate checking before connect if required
 if (isset($config['auth_ad_check_certificates']) &&
@@ -36,6 +35,7 @@ function authenticate($username, $password) {
                     if (isset($config['auth_ad_groups'][$group_cn]['level'])) {
                         // user is in one of the defined groups
                         $user_authenticated = 1;
+                        adduser($username);
                     } 
                 }
 
@@ -44,6 +44,7 @@ function authenticate($username, $password) {
             }
             else {
                 // group membership is not required and user is valid
+                adduser($username);
                 return 1;
             }
         }
@@ -82,11 +83,20 @@ function auth_usermanagement() {
 }
 
 
-function adduser() {
-    // not supported so return 0
-    return 0;
+function adduser($username) {
+    // Check to see if user is already added in the database
+    if (!user_exists_in_db($username)) {
+        return dbInsert(array('username' => $username, 'user_id' => get_userid($username), 'level' => "0", 'can_modify_passwd' => 0, 'twofactor' => 0), 'users');
+    }
+    else {
+        return false;
+    }
 }
 
+function user_exists_in_db($username) {
+    $return = @dbFetchCell('SELECT COUNT(*) FROM users WHERE username = ?', array($username), true);
+    return $return;
+}
 
 function user_exists($username) {
     global $config, $ds;


### PR DESCRIPTION
The dashboard functionality relies on the fact that the user exists in the database. Currently the AD-authentication functionality doesn't implement this feature which breaks the usage of dashboards for anyone except the local admin account.

adduser inserts:
- user_id to the user ID fetched from the AD
- username to the sAMAccountname
- level to 0 (security measure)
- can_modify_passwd to 0 (security measure)

I've chosen to not implement the insertion of AD-users passwords into the database to keep things safer. 
A thing to be considered here would be the "caching" (i.e insert password into the database) of AD-users in case of connection loss towards the AD, however I felt it was out of scope for this fix.