### PR TITLE
Eventlog query now uses event_id as already indexed

### DIFF
--- a/html/includes/table/eventlog.inc.php
+++ b/html/includes/table/eventlog.inc.php
@@ -29,7 +29,7 @@ if (isset($searchPhrase) && !empty($searchPhrase)) {
     $sql .= " AND (`D`.`hostname` LIKE '%$searchPhrase%' OR `E`.`datetime` LIKE '%$searchPhrase%' OR `E`.`message` LIKE '%$searchPhrase%' OR `E`.`type` LIKE '%$searchPhrase%')";
 }
 
-$count_sql = "SELECT COUNT(datetime) $sql";
+$count_sql = "SELECT COUNT(event_id) $sql";
 $total     = dbFetchCell($count_sql, $param);
 if (empty($total)) {
     $total = 0;


### PR DESCRIPTION
Fix #2435 

event_id is already indexed:

PRIMARY KEY (`event_id`),

```sql
mysql> EXPLAIN SELECT COUNT(DATETIME) FROM eventlog AS E LEFT JOIN devices AS D ON E.host=D.device_id;
+----+-------------+-------+--------+---------------+---------+---------+-----------------+------+-------------+
| id | select_type | table | type   | possible_keys | key     | key_len | ref             | rows | Extra       |
+----+-------------+-------+--------+---------------+---------+---------+-----------------+------+-------------+
|  1 | SIMPLE      | E     | ALL    | NULL          | NULL    | NULL    | NULL            |   72 |             |
|  1 | SIMPLE      | D     | eq_ref | PRIMARY       | PRIMARY | 4       | librenms.E.host |    1 | Using index |
+----+-------------+-------+--------+---------------+---------+---------+-----------------+------+-------------+
```
to
```sql
mysql> EXPLAIN SELECT COUNT(event_id) FROM eventlog AS E LEFT JOIN devices AS D ON E.host=D.device_id;
+----+-------------+-------+--------+---------------+---------+---------+-----------------+------+-------------+
| id | select_type | table | type   | possible_keys | key     | key_len | ref             | rows | Extra       |
+----+-------------+-------+--------+---------------+---------+---------+-----------------+------+-------------+
|  1 | SIMPLE      | E     | index  | NULL          | host    | 4       | NULL            |   72 | Using index |
|  1 | SIMPLE      | D     | eq_ref | PRIMARY       | PRIMARY | 4       | librenms.E.host |    1 | Using index |
+----+-------------+-------+--------+---------------+---------+---------+-----------------+------+-------------+
```