### PR TITLE
update documentation for Centos 7

### DIFF
--- a/doc/Installation/Installation-(RHEL-CentOS).md
+++ b/doc/Installation/Installation-(RHEL-CentOS).md
@@ -99,7 +99,8 @@ Note if not using HTTPd (Apache): RHEL requires `httpd` to be installed regardle
 
 **CentOS 7**
 ```bash
-    yum install php php-cli php-gd php-mysql php-snmp php-pear php-curl httpd net-snmp graphviz graphviz-php mariadb ImageMagick jwhois nmap mtr rrdtool MySQL-python net-snmp-utils vixie-cron php-mcrypt fping git
+    yum install epel-release
+    yum install php php-cli php-gd php-mysql php-snmp php-pear php-curl httpd net-snmp graphviz graphviz-php mariadb ImageMagick jwhois nmap mtr rrdtool MySQL-python net-snmp-utils cronie php-mcrypt fping git
     pear install Net_IPv4-1.3.4
     pear install Net_IPv6-1.2.2b2
 ```


### PR DESCRIPTION
epel is required for fping and php-mcrypt, vixie-cron is replaced by
cronie.