### PR TITLE
Remove last logical operator from generated SQL in GenGroupSQL

### DIFF
--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -46,6 +46,7 @@ function GenGroupSQL($pattern, $search='') {
             $pattern  = str_replace($opt, $tmpp[0].'.'.$tmpp[1], $pattern);
         }
     }
+    $pattern = substr($pattern, 0, -3);
 
     $tables = array_keys(array_flip($tables));
     $x      = sizeof($tables);


### PR DESCRIPTION
Previously this function would output invalid SQL as a logical operator would be included after every condition. This change removes the final logical operator so the SQL is valid.

For example, previously the single rule:

![screenshot from 2015-11-20 14-54-21](https://cloud.githubusercontent.com/assets/747138/11302942/f269daa6-8f97-11e5-8c26-5aef7312832a.png)


Would generate:
```
SELECT DISTINCT(bgpPeers.device_id) FROM bgpPeers WHERE device_id=? && (bgpPeers.bgpPeerRemoteAs = "6939" &&) LIMIT 1
```

This changes means it will generate:
```
SELECT DISTINCT(bgpPeers.device_id) FROM bgpPeers WHERE device_id=? && (bgpPeers.bgpPeerRemoteAs = "6939") LIMIT 1
```


My understanding is that this would be entirely broken previously, which seems odd. The only thing I can think is that maybe MySQL allowed this whereas MariaDB does not (sorry I don't have a MySQL DB to test this on)?

Thanks