### PR TITLE
Merge all cpu in one graph in device overview

### DIFF
--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-$graph_type = 'processor_usage';
-
 $processors = dbFetchRows('SELECT * FROM `processors` WHERE device_id = ?', array($device['device_id']));
 
 if (count($processors)) {
@@ -16,40 +14,38 @@ if (count($processors)) {
     echo '</div>
         <table class="table table-hover table-condensed table-striped">';
 
+    $graph_array           = array();
+    $graph_array['to']     = $config['time']['now'];
+    $graph_array['type']   = 'processor_usage';
+    $graph_array['from']   = $config['time']['day'];
+    $graph_array['legend'] = 'no';
+
     $totalPercent=0;
 
     foreach ($processors as $proc) {
         $text_descr = rewrite_entity_descr($proc['processor_descr']);
 
-        // disable short hrDeviceDescr. need to make this prettier.
-        // $text_descr = short_hrDeviceDescr($proc['processor_descr']);
         $percent      = $proc['processor_usage'];
         if ($config['cpu_details_overview'] === true)
         {
 
             $background   = get_percentage_colours($percent);
-            $graph_colour = str_replace('#', '', $row_colour);
 
-            $graph_array           = array();
+            $graph_array['id']     = $proc['processor_id'];
+
+            //Generate tooltip graphs
             $graph_array['height'] = '100';
             $graph_array['width']  = '210';
-            $graph_array['to']     = $config['time']['now'];
-            $graph_array['id']     = $proc['processor_id'];
-            $graph_array['type']   = $graph_type;
-            $graph_array['from']   = $config['time']['day'];
-            $graph_array['legend'] = 'no';
-
             $link_array         = $graph_array;
             $link_array['page'] = 'graphs';
             unset($link_array['height'], $link_array['width'], $link_array['legend']);
             $link = generate_url($link_array);
-
             $overlib_content = generate_overlib_content($graph_array, $device['hostname'].' - '.$text_descr);
 
+            //Generate the minigraph
             $graph_array['width']  = 80;
             $graph_array['height'] = 20;
-            $graph_array['bg']     = 'ffffff00';
-            // the 00 at the end makes the area transparent.
+            $graph_array['bg']     = 'ffffff00'; // the 00 at the end makes the area transparent.
             $minigraph =  generate_lazy_graph_tag($graph_array);
 
             echo '<tr>
@@ -65,22 +61,23 @@ if (count($processors)) {
 
     }//end foreach
 
-    if ($config['cpu_details_overview'] !== true)
+    if ($config['cpu_details_overview'] === false)
     {
+
+        //Generate average cpu graph
         $graph_array['height'] = '100';
         $graph_array['width']  = '485';
-        $graph_array['to']     = $config['time']['now'];
         $graph_array['device'] = $device['device_id'];
         $graph_array['type']   = 'device_processor';
-        $graph_array['from']   = $config['time']['day'];
-        $graph_array['legend'] = 'no';
         $graph = generate_lazy_graph_tag($graph_array);
 
+        //Generate link to graphs
         $link_array         = $graph_array;
         $link_array['page'] = 'graphs';
         unset($link_array['height'], $link_array['width']);
         $link = generate_url($link_array);
 
+        //Generate tooltip
         $graph_array['width'] = '210';
         $overlib_content      = generate_overlib_content($graph_array, $device['hostname'].' - CPU usage');
 
@@ -90,10 +87,13 @@ if (count($processors)) {
         echo '  </td>
             </tr>';
 
+        //Add a row with CPU desc, count and percent graph
         $totalPercent=$totalPercent/count($processors);
+        $background   = get_percentage_colours($totalPercent);
+
          echo '<tr>
              <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
-             <td>x'.count($processors).'</td>
+             <td>'.overlib_link($link,'x'.count($processors),$overlib_content).'</td>
              <td>'.overlib_link($link, print_percentage_bar(200, 20, $totalPercent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'</td>
            </tr>';
 

--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -10,11 +10,14 @@ if (count($processors)) {
         <div class="col-md-12 ">
           <div class="panel panel-default panel-condensed">
             <div class="panel-heading">
-';
+   ';
     echo '<a href="device/device='.$device['device_id'].'/tab=health/metric=processor/">';
     echo "<img src='images/icons/processor.png'> <strong>Processors</strong></a>";
-    echo '</div>
-        <table class="table table-hover table-condensed table-striped">';
+    echo '</div>';
+
+    echo '<table class="table table-hover table-condensed table-striped">';
+
+    $totalPercent=0;
 
     foreach ($processors as $proc) {
         $text_descr = rewrite_entity_descr($proc['processor_descr']);
@@ -22,38 +25,79 @@ if (count($processors)) {
         // disable short hrDeviceDescr. need to make this prettier.
         // $text_descr = short_hrDeviceDescr($proc['processor_descr']);
         $percent      = $proc['processor_usage'];
-        $background   = get_percentage_colours($percent);
-        $graph_colour = str_replace('#', '', $row_colour);
+	if ($config['cpu_details_overview'] === true)
+	{
 
-        $graph_array           = array();
+	        $background   = get_percentage_colours($percent);
+        	$graph_colour = str_replace('#', '', $row_colour);
+
+	        $graph_array           = array();
+	        $graph_array['height'] = '100';
+        	$graph_array['width']  = '210';
+	        $graph_array['to']     = $config['time']['now'];
+        	$graph_array['id']     = $proc['processor_id'];
+	        $graph_array['type']   = $graph_type;
+        	$graph_array['from']   = $config['time']['day'];
+	        $graph_array['legend'] = 'no';
+
+        	$link_array         = $graph_array;
+	        $link_array['page'] = 'graphs';
+        	unset($link_array['height'], $link_array['width'], $link_array['legend']);
+	        $link = generate_url($link_array);
+
+        	$overlib_content = generate_overlib_content($graph_array, $device['hostname'].' - '.$text_descr);
+
+	        $graph_array['width']  = 80;
+        	$graph_array['height'] = 20;
+	        $graph_array['bg']     = 'ffffff00';
+        	// the 00 at the end makes the area transparent.
+	        $minigraph =  generate_lazy_graph_tag($graph_array);
+
+        	echo '<tr>
+	           <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
+        	   <td>'.overlib_link($link, $minigraph, $overlib_content).'</td>
+	           <td>'.overlib_link($link, print_percentage_bar(200, 20, $percent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'
+        	   </a></td>
+	         </tr>';
+	}
+	else {
+		$totalPercent = $totalPercent + $percent;
+	}
+
+    }//end foreach
+
+    if ($config['cpu_details_overview'] !== true)
+    {
         $graph_array['height'] = '100';
-        $graph_array['width']  = '210';
+        $graph_array['width']  = '485';
         $graph_array['to']     = $config['time']['now'];
-        $graph_array['id']     = $proc['processor_id'];
-        $graph_array['type']   = $graph_type;
+        $graph_array['device'] = $device['device_id'];
+        $graph_array['type']   = 'device_processor';
         $graph_array['from']   = $config['time']['day'];
         $graph_array['legend'] = 'no';
+        $graph = generate_lazy_graph_tag($graph_array);
 
         $link_array         = $graph_array;
         $link_array['page'] = 'graphs';
-        unset($link_array['height'], $link_array['width'], $link_array['legend']);
+        unset($link_array['height'], $link_array['width']);
         $link = generate_url($link_array);
 
-        $overlib_content = generate_overlib_content($graph_array, $device['hostname'].' - '.$text_descr);
-
-        $graph_array['width']  = 80;
-        $graph_array['height'] = 20;
-        $graph_array['bg']     = 'ffffff00';
-        // the 00 at the end makes the area transparent.
-        $minigraph =  generate_lazy_graph_tag($graph_array);
+        $graph_array['width'] = '210';
+        $overlib_content      = generate_overlib_content($graph_array, $device['hostname'].' - CPU usage');
 
         echo '<tr>
-           <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
-           <td>'.overlib_link($link, $minigraph, $overlib_content).'</td>
-           <td>'.overlib_link($link, print_percentage_bar(200, 20, $percent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'
-           </a></td>
-         </tr>';
-    }//end foreach
+              <td colspan="4">';
+        echo overlib_link($link, $graph, $overlib_content, null);
+        echo '  </td>
+            </tr>';
+
+	$totalPercent=$totalPercent/count($processors);
+	echo '<tr>
+	    <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
+            <td>'.overlib_link($link, print_percentage_bar(200, 20, $totalPercent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'</td>
+            </tr>';
+
+    }
 
     echo '</table>
         </div>

--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -24,44 +24,44 @@ if (count($processors)) {
         // disable short hrDeviceDescr. need to make this prettier.
         // $text_descr = short_hrDeviceDescr($proc['processor_descr']);
         $percent      = $proc['processor_usage'];
-	if ($config['cpu_details_overview'] === true)
-	{
+        if ($config['cpu_details_overview'] === true)
+        {
 
             $background   = get_percentage_colours($percent);
             $graph_colour = str_replace('#', '', $row_colour);
 
-	    $graph_array           = array();
-	    $graph_array['height'] = '100';
+            $graph_array           = array();
+            $graph_array['height'] = '100';
             $graph_array['width']  = '210';
-	    $graph_array['to']     = $config['time']['now'];
+            $graph_array['to']     = $config['time']['now'];
             $graph_array['id']     = $proc['processor_id'];
-	    $graph_array['type']   = $graph_type;
+            $graph_array['type']   = $graph_type;
             $graph_array['from']   = $config['time']['day'];
-	    $graph_array['legend'] = 'no';
+            $graph_array['legend'] = 'no';
 
             $link_array         = $graph_array;
-	    $link_array['page'] = 'graphs';
+            $link_array['page'] = 'graphs';
             unset($link_array['height'], $link_array['width'], $link_array['legend']);
-	    $link = generate_url($link_array);
+            $link = generate_url($link_array);
 
             $overlib_content = generate_overlib_content($graph_array, $device['hostname'].' - '.$text_descr);
 
-	    $graph_array['width']  = 80;
+            $graph_array['width']  = 80;
             $graph_array['height'] = 20;
-	    $graph_array['bg']     = 'ffffff00';
+            $graph_array['bg']     = 'ffffff00';
             // the 00 at the end makes the area transparent.
-	    $minigraph =  generate_lazy_graph_tag($graph_array);
+            $minigraph =  generate_lazy_graph_tag($graph_array);
 
             echo '<tr>
-	        <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
+                <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
                 <td>'.overlib_link($link, $minigraph, $overlib_content).'</td>
-	        <td>'.overlib_link($link, print_percentage_bar(200, 20, $percent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'
+                <td>'.overlib_link($link, print_percentage_bar(200, 20, $percent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'
                 </a></td>
-	      </tr>';
-	}
-	else {
-		$totalPercent = $totalPercent + $percent;
-	}
+              </tr>';
+        }
+        else {
+            $totalPercent = $totalPercent + $percent;
+        }
 
     }//end foreach
 
@@ -90,11 +90,11 @@ if (count($processors)) {
         echo '  </td>
             </tr>';
 
-	$totalPercent=$totalPercent/count($processors);
-	echo '<tr>
-	    <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
-            <td>'.overlib_link($link, print_percentage_bar(200, 20, $totalPercent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'</td>
-          </tr>';
+        $totalPercent=$totalPercent/count($processors);
+         echo '<tr>
+             <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
+             <td>'.overlib_link($link, print_percentage_bar(200, 20, $totalPercent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'</td>
+           </tr>';
 
     }
 

--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -93,6 +93,7 @@ if (count($processors)) {
         $totalPercent=$totalPercent/count($processors);
          echo '<tr>
              <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
+             <td>x'.count($processors).'</td>
              <td>'.overlib_link($link, print_percentage_bar(200, 20, $totalPercent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'</td>
            </tr>';
 

--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -10,12 +10,11 @@ if (count($processors)) {
         <div class="col-md-12 ">
           <div class="panel panel-default panel-condensed">
             <div class="panel-heading">
-   ';
+';
     echo '<a href="device/device='.$device['device_id'].'/tab=health/metric=processor/">';
     echo "<img src='images/icons/processor.png'> <strong>Processors</strong></a>";
-    echo '</div>';
-
-    echo '<table class="table table-hover table-condensed table-striped">';
+    echo '</div>
+        <table class="table table-hover table-condensed table-striped">';
 
     $totalPercent=0;
 
@@ -28,37 +27,37 @@ if (count($processors)) {
 	if ($config['cpu_details_overview'] === true)
 	{
 
-	        $background   = get_percentage_colours($percent);
-        	$graph_colour = str_replace('#', '', $row_colour);
+            $background   = get_percentage_colours($percent);
+            $graph_colour = str_replace('#', '', $row_colour);
 
-	        $graph_array           = array();
-	        $graph_array['height'] = '100';
-        	$graph_array['width']  = '210';
-	        $graph_array['to']     = $config['time']['now'];
-        	$graph_array['id']     = $proc['processor_id'];
-	        $graph_array['type']   = $graph_type;
-        	$graph_array['from']   = $config['time']['day'];
-	        $graph_array['legend'] = 'no';
+	    $graph_array           = array();
+	    $graph_array['height'] = '100';
+            $graph_array['width']  = '210';
+	    $graph_array['to']     = $config['time']['now'];
+            $graph_array['id']     = $proc['processor_id'];
+	    $graph_array['type']   = $graph_type;
+            $graph_array['from']   = $config['time']['day'];
+	    $graph_array['legend'] = 'no';
 
-        	$link_array         = $graph_array;
-	        $link_array['page'] = 'graphs';
-        	unset($link_array['height'], $link_array['width'], $link_array['legend']);
-	        $link = generate_url($link_array);
+            $link_array         = $graph_array;
+	    $link_array['page'] = 'graphs';
+            unset($link_array['height'], $link_array['width'], $link_array['legend']);
+	    $link = generate_url($link_array);
 
-        	$overlib_content = generate_overlib_content($graph_array, $device['hostname'].' - '.$text_descr);
+            $overlib_content = generate_overlib_content($graph_array, $device['hostname'].' - '.$text_descr);
 
-	        $graph_array['width']  = 80;
-        	$graph_array['height'] = 20;
-	        $graph_array['bg']     = 'ffffff00';
-        	// the 00 at the end makes the area transparent.
-	        $minigraph =  generate_lazy_graph_tag($graph_array);
+	    $graph_array['width']  = 80;
+            $graph_array['height'] = 20;
+	    $graph_array['bg']     = 'ffffff00';
+            // the 00 at the end makes the area transparent.
+	    $minigraph =  generate_lazy_graph_tag($graph_array);
 
-        	echo '<tr>
-	           <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
-        	   <td>'.overlib_link($link, $minigraph, $overlib_content).'</td>
-	           <td>'.overlib_link($link, print_percentage_bar(200, 20, $percent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'
-        	   </a></td>
-	         </tr>';
+            echo '<tr>
+	        <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
+                <td>'.overlib_link($link, $minigraph, $overlib_content).'</td>
+	        <td>'.overlib_link($link, print_percentage_bar(200, 20, $percent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'
+                </a></td>
+	      </tr>';
 	}
 	else {
 		$totalPercent = $totalPercent + $percent;
@@ -95,7 +94,7 @@ if (count($processors)) {
 	echo '<tr>
 	    <td>'.overlib_link($link, $text_descr, $overlib_content).'</td>
             <td>'.overlib_link($link, print_percentage_bar(200, 20, $totalPercent, null, 'ffffff', $background['left'], $percent.'%', 'ffffff', $background['right']), $overlib_content).'</td>
-            </tr>';
+          </tr>';
 
     }
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -408,6 +408,8 @@ $config['network_map_vis_options'] = '{
 // Device page options
 $config['show_overview_tab'] = true;
 
+$config['cpu_details_overview'] = true; //By default show all cpus in the overview
+
 // The device overview page options
 $config['overview_show_sysDescr'] = true;
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -408,7 +408,7 @@ $config['network_map_vis_options'] = '{
 // Device page options
 $config['show_overview_tab'] = true;
 
-$config['cpu_details_overview'] = true; //By default show all cpus in the overview
+$config['cpu_details_overview'] = false; //By default show only average cpu in device overview
 
 // The device overview page options
 $config['overview_show_sysDescr'] = true;


### PR DESCRIPTION
Hi,

This provide a way to hide all separate graphs in the device overview and replace it by the average cpu usage.

This make the overview easier to read and render the page a bit faster as there is less graphs to draw.

This is an optional feature, disabled by default.

Just add in your config.php : 

$config['cpu_details_overview'] = false;

This is related to issue #2218


![cpuovreview](https://cloud.githubusercontent.com/assets/1701397/11304592/a9dfd19c-8fa0-11e5-85f5-2fdcede6a53f.PNG)

![cpuovreviewchange](https://cloud.githubusercontent.com/assets/1701397/11304597/ac43f788-8fa0-11e5-85c3-10ce173be456.PNG)
