### PR TITLE
Strip && and || from query for alerts in polling

### DIFF
--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -47,6 +47,9 @@ function GenGroupSQL($pattern, $search='') {
         }
     }
 
+    $pattern = rtrim($pattern, '&&');
+    $pattern = rtrim($pattern, '||');
+
     $tables = array_keys(array_flip($tables));
     $x      = sizeof($tables);
     $i      = 0;


### PR DESCRIPTION
Fix #2468

&& and || is stripped in WebUI but not in the polling code. Updated now to make it work in both areas.