### PR TITLE
Oxidized: use the actual group when fetching configs

### DIFF
--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -98,13 +98,13 @@ if ($_SESSION['userlevel'] >= '7') {
             list($oid,$date,$version) = explode('|',mres($_POST['config']));
             $text = file_get_contents($config['oxidized']['url'].'/node/version/view?node='.$device['hostname'].'&group=&oid='.$oid.'&date='.urlencode($date).'&num='.$version.'&format=text');
             if ($text == 'node not found') {
-                $text = file_get_contents($config['oxidized']['url'].'/node/version/view?node='.$device['hostname'].'&group='.$device['os'].'&oid='.$oid.'&date='.urlencode($date).'&num='.$version.'&format=text');
+                $text = file_get_contents($config['oxidized']['url'].'/node/version/view?node='.$device['hostname'].'&group='.(is_array($node_info) ? $node_info['group'] : $device['os']).'&oid='.$oid.'&date='.urlencode($date).'&num='.$version.'&format=text');
             }
         }
         else {
             $text      = file_get_contents($config['oxidized']['url'].'/node/fetch/'.$device['hostname']);
             if ($text == 'node not found') {
-                $text = file_get_contents($config['oxidized']['url'].'/node/fetch/'.$device['os'].'/'.$device['hostname']);
+                $text = file_get_contents($config['oxidized']['url'].'/node/fetch/'.(is_array($node_info) ? $node_info['group'] : $device['os']).'/'.$device['hostname']);
             }
         }
         if ($config['oxidized']['features']['versioning'] === true) {


### PR DESCRIPTION
Oxidized: use the actual group as collected from node_info instead of assuming group == $device['os']

Left $device['os'] as a fallback.
