### PR TITLE
Use more width rebased

### DIFF
--- a/html/ajax_setresolution.php
+++ b/html/ajax_setresolution.php
@@ -4,6 +4,3 @@ if(isset($_REQUEST['width']) AND isset($_REQUEST['height'])) {
     $_SESSION['screen_width'] = $_REQUEST['width'];
     $_SESSION['screen_height'] = $_REQUEST['height'];
 }
-
-echo $_SESSION['screen_width'];
-?>

--- a/html/ajax_setresolution.php
+++ b/html/ajax_setresolution.php
@@ -1,0 +1,9 @@
+<?php
+session_start();
+if(isset($_REQUEST['width']) AND isset($_REQUEST['height'])) {
+    $_SESSION['screen_width'] = $_REQUEST['width'];
+    $_SESSION['screen_height'] = $_REQUEST['height'];
+}
+
+echo $_SESSION['screen_width'];
+?>

--- a/html/ajax_setresolution.php
+++ b/html/ajax_setresolution.php
@@ -4,3 +4,5 @@ if(isset($_REQUEST['width']) AND isset($_REQUEST['height'])) {
     $_SESSION['screen_width'] = $_REQUEST['width'];
     $_SESSION['screen_height'] = $_REQUEST['height'];
 }
+echo $_SESSION['screen_width'];
+echo $_SESSION['screen_height'];

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1776,14 +1776,30 @@ label {
         max-width: 45px;
         max-height: 50px;
     }
+    .device-header-table .device_icon img {
+       max-width: 20px;
+       max-height: 20px;
+    }
+    .device-header-table img {
+       max-width: 115px;
+       max-height: 40px;
+    }
+    .device-header-table {font-size : 8px;}
+    .device-header-table a {font-size : 11px;}
 }
 
-@media only screen and (max-width: 720px) and (min-width: 481px) {
+@media only screen and (max-width: 768px) and (min-width: 481px) {
     .thumbnail_graph_table b { font-size : 8px;}
     .thumbnail_graph_table img {
         max-width: 60px;
         max-height: 55px;
     }
+    .device-header-table img {
+       max-width: 150px;
+       max-height: 50px;
+    }
+    .device-header-table {font-size : 10px;}
+    .device-header-table a {font-size : 17px;}
 }
 
 

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1765,6 +1765,43 @@ tr.search:nth-child(odd) {
 label {
     font-weight: normal;
 }
+
 .nav>li>a.dropdown-toggle {
     padding: 15px 6px;
+}
+
+@media only screen and (max-width: 480px) {
+    .thumbnail_graph_table b { font-size : 6px;}
+    .thumbnail_graph_table img {
+        max-width: 45px;
+        max-height: 50px;
+    }
+}
+
+@media only screen and (max-width: 720px) and (min-width: 481px) {
+    .thumbnail_graph_table b { font-size : 8px;}
+    .thumbnail_graph_table img {
+        max-width: 60px;
+        max-height: 55px;
+    }
+}
+
+
+@media only screen and (max-width: 800px) and (min-width: 721px) {
+    .thumbnail_graph_table b { font-size : 8px;}
+    .thumbnail_graph_table img {
+        max-width: 75px;
+        max-height: 60px;
+    }
+}
+
+@media only screen and (max-width: 1024px) and (min-width: 801px) {
+    .thumbnail_graph_table b { font-size : 9px;}
+    .thumbnail_graph_table img {
+        max-width: 105px;
+        max-height: 70px;
+    }
+}
+
+@media only screen and (min-width: 1024px) {
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1776,30 +1776,14 @@ label {
         max-width: 45px;
         max-height: 50px;
     }
-    .device-header-table .device_icon img {
-       max-width: 20px;
-       max-height: 20px;
-    }
-    .device-header-table img {
-       max-width: 115px;
-       max-height: 40px;
-    }
-    .device-header-table {font-size : 8px;}
-    .device-header-table a {font-size : 11px;}
 }
 
-@media only screen and (max-width: 768px) and (min-width: 481px) {
+@media only screen and (max-width: 720px) and (min-width: 481px) {
     .thumbnail_graph_table b { font-size : 8px;}
     .thumbnail_graph_table img {
         max-width: 60px;
         max-height: 55px;
     }
-    .device-header-table img {
-       max-width: 150px;
-       max-height: 50px;
-    }
-    .device-header-table {font-size : 10px;}
-    .device-header-table a {font-size : 17px;}
 }
 
 

--- a/html/includes/device-header.inc.php
+++ b/html/includes/device-header.inc.php
@@ -24,7 +24,7 @@ $image = getImage($device);
 
 echo '
             <tr bgcolor="'.$device_colour.'" class="alert '.$class.'">
-             <td width="40" align=center valign=middle style="padding: 21px;">'.$image.'</td>
+             <td width="40" align=center valign=middle style="padding: 21px;"><span class="device_icon">'.$image.'</span></td>
              <td valign=middle style="padding: 0 15px;"><span style="font-size: 20px;">'.generate_device_link($device).'</span>
              <br />'.$device['location'].'</td>
              <td>';

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -476,7 +476,7 @@ function generate_lazy_graph_tag($args) {
         $urlargs[] = $key."=".urlencode($arg);
     }
 
-    return '<img class="lazy" width="'.$w.'" height="'.$h.'" data-original="graph.php?' . implode('&amp;',$urlargs).'" border="0" />';
+    return '<img class="lazy graphs" width="'.$w.'" height="'.$h.'" data-original="graph.php?' . implode('&amp;',$urlargs).'" border="0" />';
 
 }//end generate_lazy_graph_tag()
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,22 +39,31 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 430 )/count($periods)+1;
+	   $graph_array['width'] = round(($_SESSION['screen_width'] - 430 )/count($periods)+1,0);
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }
 
+echo $graph_array['width'];
+
+if( $graph_array['width'] < 215) {
+    $graph_array['width'] = 215;
+}
+
 if($_SESSION['screen_height']) {
     if($_SESSION['screen_width'] > 960) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/5;
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/5,0);
     }
     else {
-        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/2;
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/2,0);
     }
 }
 
+if($graph_array['height'] < 100 ) {
+    $graph_array['height'] = 100;
+}
 
 $graph_array['to'] = $config['time']['now'];
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,6 +37,17 @@ else {
     );
 }//end if
 
+if($_SESSION['screen_width'])
+{
+   $graph_array['width'] = $_SESSION['screen_width']/5.5;
+}
+
+if($_SESSION['screen_height'])
+{
+  $graph_array['height'] = $_SESSION['screen_height']/6;
+}
+
+
 $graph_array['to'] = $config['time']['now'];
 
 $graph_data = array();

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,8 +39,9 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }else {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
+   }
+   else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -38,8 +38,8 @@ else {
 }//end if
 
 if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
+   if($_SESSION['screen_width'] > 800) {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
@@ -47,7 +47,12 @@ if($_SESSION['screen_width']) {
 }
 
 if($_SESSION['screen_height']) {
-  $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
+    if($_SESSION['screen_width'] > 960) {
+        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
+    }
+    else {
+        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/2;
+    }
 }
 
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,7 +39,7 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 430 )/count($periods)+1;
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
@@ -48,7 +48,7 @@ if($_SESSION['screen_width']) {
 
 if($_SESSION['screen_height']) {
     if($_SESSION['screen_width'] > 960) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
+        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/5;
     }
     else {
         $graph_array['height'] = ($_SESSION['screen_height'] - 250)/2;

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,10 +39,10 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = round(($_SESSION['screen_width'] - 430 )/count($periods)+1,0);
+	   $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/count($periods)+1,0);
    }
    else {
-	$graph_array['width'] = $_SESSION['screen_width'] - 155;
+	$graph_array['width'] = $_SESSION['screen_width'] - 70;
    }
 }
 
@@ -51,11 +51,11 @@ if( $graph_array['width'] < 215) {
 }
 
 if($_SESSION['screen_height']) {
-    if($_SESSION['screen_width'] > 960) {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/5,0);
+    if($_SESSION['screen_height'] > 960) {
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/4,0);
     }
     else {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/2,0);
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/3,0);
     }
 }
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,19 +37,15 @@ else {
     );
 }//end if
 
-if($_SESSION['screen_width'])
-{
-   if($_SESSION['screen_width'] >= 800)
-   {
+if($_SESSION['screen_width']) {
+   if($_SESSION['screen_width'] >= 800) {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }else
-   {
+   }else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }
 
-if($_SESSION['screen_height'])
-{
+if($_SESSION['screen_height']) {
   $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
 }
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -46,8 +46,6 @@ if($_SESSION['screen_width']) {
    }
 }
 
-echo $graph_array['width'];
-
 if( $graph_array['width'] < 215) {
     $graph_array['width'] = 215;
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,7 +39,7 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
    }else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -38,30 +38,20 @@ else {
 }//end if
 
 if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/count($periods)+1,0);
-   }
-   else {
-	$graph_array['width'] = $_SESSION['screen_width'] - 70;
-   }
-}
-
-if( $graph_array['width'] < 215) {
-    $graph_array['width'] = 215;
-}
-
-if($_SESSION['screen_height']) {
-    if($_SESSION['screen_height'] > 960) {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/4,0);
+    if($_SESSION['screen_width'] < 1024 && $_SESSION['screen_width'] > 700) {
+        $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/2,0);
     }
     else {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/3,0);
+        if($_SESSION['screen_width'] > 1024) {
+            $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/count($periods)+1,0);
+        }
+        else {
+            $graph_array['width'] = $_SESSION['screen_width'] - 70;
+        }
     }
 }
 
-if($graph_array['height'] < 100 ) {
-    $graph_array['height'] = 100;
-}
+$graph_array['height'] = round($graph_array['width'] /2.15);
 
 $graph_array['to'] = $config['time']['now'];
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,11 +37,13 @@ else {
     );
 }//end if
 
-if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] > 800) {
+if($_SESSION['screen_width'])
+{
+   if($_SESSION['screen_width'] >= 800)
+   {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }
-   else {
+   }else
+   {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -40,7 +40,8 @@ else {
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] >= 800) {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
-   }else {
+   }
+   else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -38,8 +38,8 @@ else {
 }//end if
 
 if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
+   if($_SESSION['screen_width'] > 800) {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,12 +39,18 @@ else {
 
 if($_SESSION['screen_width'])
 {
-   $graph_array['width'] = $_SESSION['screen_width']/5.5;
+   if($_SESSION['screen_width'] >= 800)
+   {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
+   }else
+   {
+	$graph_array['width'] = $_SESSION['screen_width'] - 155;
+   }
 }
 
 if($_SESSION['screen_height'])
 {
-  $graph_array['height'] = $_SESSION['screen_height']/6;
+  $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
 }
 
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,13 +37,10 @@ else {
     );
 }//end if
 
-if($_SESSION['screen_width'])
-{
-   if($_SESSION['screen_width'] >= 800)
-   {
+if($_SESSION['screen_width']) {
+   if($_SESSION['screen_width'] >= 800) {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }else
-   {
+   }else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/index.php
+++ b/html/index.php
@@ -184,6 +184,10 @@ else {
 
 <?php
 
+if(empty($_SESSION['screen_width']) && empty($_SESSION['screen_height'])) {
+    echo "<script>updateResolution();</script>";
+}
+
 if ((isset($vars['bare']) && $vars['bare'] != "yes") || !isset($vars['bare'])) {
     if ($_SESSION['authenticated']) {
         require 'includes/print-menubar.php';

--- a/html/js/lazyload.js
+++ b/html/js/lazyload.js
@@ -32,5 +32,5 @@ $(document).ready(function(){
 function lazyload_done() {
     //Since RRD takes the width and height params for only the canvas, we must unset them 
     //from the final (larger) image to prevent the browser from resizing them.
-    $(this).removeAttr('width').removeAttr('height').removeClass('lazy');
+    $(this).removeAttr('height').removeClass('lazy');
 }

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -140,7 +140,7 @@ function submitCustomRange(frmdata) {
     return true;
 }
 
-function updateResolution()
+function updateResolution(refresh)
 {
     $.post('ajax_setresolution.php', 
         {
@@ -148,6 +148,9 @@ function updateResolution()
             height:$(window).height()
         },
         function(data) {
+            if(refresh == true) {
+                location.reload();
+            }
         },'json'
     );
 }
@@ -155,6 +158,8 @@ function updateResolution()
 var rtime;
 var timeout = false;
 var delta = 500;
+var newH;
+var newW;
 
 $(window).on('resize', function(){
     rtime = new Date();
@@ -169,16 +174,22 @@ function resizeend() {
         setTimeout(resizeend, delta);
     } 
     else {
+        newH=$(window).height();
+        newW=$(window).width();
         timeout = false;
-        updateResolution();
-        resizeGraphs();
+        if(Math.abs(oldW - newW) >= 200)
+        {
+            refresh = true;
+        }
+        else {
+            refresh = false;
+            resizeGraphs();
+        }
+        updateResolution(refresh);
     }  
 };
 
 function resizeGraphs() {
-    newH=$(window).height();
-    newW=$(window).width();
-
     ratioW=newW/oldW;
     ratioH=newH/oldH;
 

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -137,6 +137,18 @@ function submitCustomRange(frmdata) {
     return true;
 }
 
+function updateResolution()
+{
+    $.post(
+        'ajax_setresolution.php', 
+        {width: $(window).width(),height:$(window).height()},
+        function(json) {},
+        'json'
+    );
+}
+
+$(window).on('resize', function(){ updateResolution();});
+
 $(document).on("click", '.collapse-neighbors', function(event)
 {
     var caller = $(this);
@@ -144,24 +156,14 @@ $(document).on("click", '.collapse-neighbors', function(event)
     var list = caller.find('.neighbors-interface-list');
     var continued = caller.find('.neighbors-list-continued');
 
-    if(button.hasClass("glyphicon-plus"))
-    {
+    if(button.hasClass("glyphicon-plus")) {
         button.addClass('glyphicon-minus').removeClass('glyphicon-plus');
-    }else
-    {
+    }else {
         button.addClass('glyphicon-plus').removeClass('glyphicon-minus');
     }
    
     list.toggle();
     continued.toggle();
 });
-
-function updateResolution()
-{
-     $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
-    },'json');
-}
-
-$(window).on('resize', function(){ updateResolution();});
 
 

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -157,7 +157,8 @@ $(document).on("click", '.collapse-neighbors', function(event)
 
     if(button.hasClass("glyphicon-plus")) {
         button.addClass('glyphicon-minus').removeClass('glyphicon-plus');
-    }else {
+    }
+    else {
         button.addClass('glyphicon-plus').removeClass('glyphicon-minus');
     }
    

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -1,3 +1,5 @@
+var oldH;
+var oldW;
 $(document).ready(function() {
     // Device override ajax calls
     $("[name='override_config']").bootstrapSwitch('offColor','danger');
@@ -123,6 +125,8 @@ $(document).ready(function() {
         });
     });
 
+    oldW=$(window).width();
+    oldH=$(window).height();
 });
 
 function submitCustomRange(frmdata) {
@@ -144,14 +148,13 @@ function updateResolution()
             height:$(window).height()
         },
         function(data) {
-            location.reload();
         },'json'
     );
 }
 
 var rtime;
 var timeout = false;
-var delta = 300;
+var delta = 500;
 
 $(window).on('resize', function(){
     rtime = new Date();
@@ -168,8 +171,25 @@ function resizeend() {
     else {
         timeout = false;
         updateResolution();
+        resizeGraphs();
     }  
 };
+
+function resizeGraphs() {
+    newH=$(window).height();
+    newW=$(window).width();
+
+    ratioW=newW/oldW;
+    ratioH=newH/oldH;
+
+    $('.graphs').each(function (){
+        var img = jQuery(this);
+        img.attr('width',img.width() * ratioW);
+    });
+    oldH=newH;
+    oldW=newW;
+}
+
 
 $(document).on("click", '.collapse-neighbors', function(event)
 {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -155,3 +155,7 @@ $(document).on("click", '.collapse-neighbors', function(event)
     continued.toggle();
 });
 
+$(function() {
+    $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
+    },'json');
+});

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,6 +123,7 @@ $(document).ready(function() {
         });
     });
 
+    updateResolution();
 });
 
 function submitCustomRange(frmdata) {
@@ -165,5 +166,3 @@ $(document).on("click", '.collapse-neighbors', function(event)
     list.toggle();
     continued.toggle();
 });
-
-

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,7 +123,6 @@ $(document).ready(function() {
         });
     });
 
-    updateResolution();
 });
 
 function submitCustomRange(frmdata) {
@@ -165,7 +164,8 @@ $(window).on('resize', function(){
 function resizeend() {
     if (new Date() - rtime < delta) {
         setTimeout(resizeend, delta);
-    } else {
+    } 
+    else {
         timeout = false;
         updateResolution();
     }  

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -139,15 +139,37 @@ function submitCustomRange(frmdata) {
 
 function updateResolution()
 {
-    $.post(
-        'ajax_setresolution.php', 
-        {width: $(window).width(),height:$(window).height()},
-        function(json) {},
-        'json'
+    $.post('ajax_setresolution.php', 
+        {
+            width: $(window).width(),
+            height:$(window).height()
+        },
+        function(data) {
+            location.reload();
+        },'json'
     );
 }
 
-$(window).on('resize', function(){ updateResolution();});
+var rtime;
+var timeout = false;
+var delta = 300;
+
+$(window).on('resize', function(){
+    rtime = new Date();
+    if (timeout === false) {
+        timeout = true;
+        setTimeout(resizeend, delta);
+    }
+});
+
+function resizeend() {
+    if (new Date() - rtime < delta) {
+        setTimeout(resizeend, delta);
+    } else {
+        timeout = false;
+        updateResolution();
+    }  
+};
 
 $(document).on("click", '.collapse-neighbors', function(event)
 {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,6 +123,7 @@ $(document).ready(function() {
         });
     });
 
+    updateResolution();
 });
 
 function submitCustomRange(frmdata) {
@@ -155,7 +156,12 @@ $(document).on("click", '.collapse-neighbors', function(event)
     continued.toggle();
 });
 
-$(function() {
-    $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
+function updateResolution()
+{
+     $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
     },'json');
-});
+}
+
+$(window).on('resize', function(){ updateResolution();});
+
+

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,7 +123,6 @@ $(document).ready(function() {
         });
     });
 
-    updateResolution();
 });
 
 function submitCustomRange(frmdata) {

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -33,7 +33,7 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
     }
 
     echo '<div class="panel panel-default">';
-        echo '<table style="margin: 0px 7px 7px 7px;" cellspacing="0" class="devicetable" width="99%">';
+        echo '<table class="device-header-table" style="margin: 0px 7px 7px 7px;" cellspacing="0" class="devicetable" width="99%">';
         require 'includes/device-header.inc.php';
     echo '</table>';
     echo '</div>';

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -112,21 +112,11 @@ else {
     $graph_array['width']  = $graph_width;
 
     if($_SESSION['screen_width']) {
-        if($_SESSION['screen_width'] > 800) {
-            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/10));
-        }
-        else {
-            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/4));
-        }
+        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
     }
 
     if($_SESSION['screen_height']) {
-        if($_SESSION['screen_height'] > 960 ) { 
-            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
-        }
-        else {
-            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/1.5));
-        }
+        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
     }
 
     echo("<hr />");

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -111,6 +111,14 @@ else {
     $graph_array['height'] = "300";
     $graph_array['width']  = $graph_width;
 
+    if($_SESSION['screen_width']) {
+        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
+    }
+
+    if($_SESSION['screen_height']) {
+        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+    }
+
     echo("<hr />");
 
     include_once 'includes/print-date-selector.inc.php';

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -85,7 +85,7 @@ else {
     $thumb_array = array('sixhour' => '6 Hours', 'day' => '24 Hours', 'twoday' => '48 Hours', 'week' => 'One Week', 'twoweek' => 'Two Weeks',
         'month' => 'One Month', 'twomonth' => 'Two Months','year' => 'One Year', 'twoyear' => 'Two Years');
 
-    echo('<table width=100%><tr>');
+     echo('<table width=100% class="thumbnail_graph_table"><tr>');
 
     foreach ($thumb_array as $period => $text) {
         $graph_array['from']   = $config['time'][$period];
@@ -112,11 +112,21 @@ else {
     $graph_array['width']  = $graph_width;
 
     if($_SESSION['screen_width']) {
-        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
+        if($_SESSION['screen_width'] > 800) {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/10));
+        }
+        else {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/4));
+        }
     }
 
     if($_SESSION['screen_height']) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        if($_SESSION['screen_height'] > 960 ) { 
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        }
+        else {
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/1.5));
+        }
     }
 
     echo("<hr />");

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -112,11 +112,21 @@ else {
     $graph_array['width']  = $graph_width;
 
     if($_SESSION['screen_width']) {
-        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
+        if($_SESSION['screen_width'] > 800) {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/10));
+        }
+        else {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/4));
+        }
     }
 
     if($_SESSION['screen_height']) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        if($_SESSION['screen_height'] > 960 ) { 
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        }
+        else {
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/1.5));
+        }
     }
 
     echo("<hr />");


### PR DESCRIPTION
Hi,

This was PR #2461 which is not mergeable because of my bad rebase.

This is an attempt to allow the php code to size the graphs according the available width and height.
It uses an ajax call to populate the width and height of the browser.

To determine the size of each graph I divide the width by the number of graph to be drawn minus an arbitrary number of pixel to account for both side margins.

I have also decided to make graphs take the whole row if there is less than 800px available.

This is related to issue  #2410. 

Without modification : 
![normalwidth](https://cloud.githubusercontent.com/assets/1701397/11272987/96dc4be4-8ec8-11e5-8260-d6e72b9df00f.PNG)

With modification : 

![usemorewidth](https://cloud.githubusercontent.com/assets/1701397/11272994/a25cec9e-8ec8-11e5-8015-1bcaa7371696.PNG)
