### PR TITLE
Use browser width to scale cpu and bandwidth graphs on device overview

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -473,8 +473,15 @@ function generate_lazy_graph_tag($args) {
             case 'height':
                 $h = $arg;
                 break;
+            case 'lazy_w':
+                $lazy_w = $arg;
+                break;
         }
         $urlargs[] = $key."=".urlencode($arg);
+    }
+
+    if(isset($lazy_w)) {
+        $w=$lazy_w;
     }
 
     if ($config['enable_lazy_load'] === true) {

--- a/html/pages/device/overview/ports.inc.php
+++ b/html/pages/device/overview/ports.inc.php
@@ -12,12 +12,14 @@ if ($ports['total']) {
 
     if($_SESSION['screen_width']) {
         if($_SESSION['screen_width'] > 970) {
-            $graph_array['width'] = round(($_SESSION['screen_width'] - 190 )/2,0);
+            $graph_array['width'] = round(($_SESSION['screen_width'] - 390 )/2,0);
             $graph_array['height'] = round($graph_array['width'] /3);
+            $graph_array['lazy_w'] = $graph_array['width'] + 80;
         }
         else {
-            $graph_array['width'] = $_SESSION['screen_width'] - 110;
+            $graph_array['width'] = $_SESSION['screen_width'] - 190;
             $graph_array['height'] = round($graph_array['width'] /3);
+            $graph_array['lazy_w'] = $graph_array['width'] + 80;
         }
     }
 

--- a/html/pages/device/overview/ports.inc.php
+++ b/html/pages/device/overview/ports.inc.php
@@ -10,8 +10,17 @@ if ($ports['total']) {
             </div>
             <table class="table table-hover table-condensed table-striped">';
 
-    $graph_array['height'] = '100';
-    $graph_array['width']  = '485';
+    if($_SESSION['screen_width']) {
+        if($_SESSION['screen_width'] > 970) {
+            $graph_array['width'] = round(($_SESSION['screen_width'] - 190 )/2,0);
+            $graph_array['height'] = round($graph_array['width'] /3);
+        }
+        else {
+            $graph_array['width'] = $_SESSION['screen_width'] - 110;
+            $graph_array['height'] = round($graph_array['width'] /3);
+        }
+    }
+
     $graph_array['to']     = $config['time']['now'];
     $graph_array['device'] = $device['device_id'];
     $graph_array['type']   = 'device_bits';
@@ -19,6 +28,9 @@ if ($ports['total']) {
     $graph_array['legend'] = 'no';
     $graph = generate_lazy_graph_tag($graph_array);
 
+    #Generate tooltip
+    $graph_array['width'] = 210;
+    $graph_array['height'] = 100;
     $link_array         = $graph_array;
     $link_array['page'] = 'graphs';
     unset($link_array['height'], $link_array['width']);

--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -64,9 +64,18 @@ if (count($processors)) {
     if ($config['cpu_details_overview'] === false)
     {
 
+        if($_SESSION['screen_width']) {
+            if($_SESSION['screen_width'] > 970) {
+                $graph_array['width'] = round(($_SESSION['screen_width'] - 190 )/2,0);
+                $graph_array['height'] = round($graph_array['width'] /3);
+            }
+            else {
+                $graph_array['width'] = $_SESSION['screen_width'] - 110;
+                $graph_array['height'] = round($graph_array['width'] /3);
+            }
+        }
+
         //Generate average cpu graph
-        $graph_array['height'] = '100';
-        $graph_array['width']  = '485';
         $graph_array['device'] = $device['device_id'];
         $graph_array['type']   = 'device_processor';
         $graph = generate_lazy_graph_tag($graph_array);
@@ -78,7 +87,8 @@ if (count($processors)) {
         $link = generate_url($link_array);
 
         //Generate tooltip
-        $graph_array['width'] = '210';
+        $graph_array['width']=210;
+        $graph_array['height']=100;
         $overlib_content      = generate_overlib_content($graph_array, $device['hostname'].' - CPU usage');
 
         echo '<tr>

--- a/html/pages/device/overview/processors.inc.php
+++ b/html/pages/device/overview/processors.inc.php
@@ -66,12 +66,14 @@ if (count($processors)) {
 
         if($_SESSION['screen_width']) {
             if($_SESSION['screen_width'] > 970) {
-                $graph_array['width'] = round(($_SESSION['screen_width'] - 190 )/2,0);
+                $graph_array['width'] = round(($_SESSION['screen_width'] - 390 )/2,0);
                 $graph_array['height'] = round($graph_array['width'] /3);
+                $graph_array['lazy_w'] = $graph_array['width'] + 80;
             }
             else {
-                $graph_array['width'] = $_SESSION['screen_width'] - 110;
+                $graph_array['width'] = $_SESSION['screen_width'] - 190;
                 $graph_array['height'] = round($graph_array['width'] /3);
+                $graph_array['lazy_w'] = $graph_array['width'] + 80;
             }
         }
 


### PR DESCRIPTION
Hi ,

Following what was done in  PR #2510 this is an attempt to have the graphs in the device overview to scale according to the size of the browser.

Current : 
![deviceoverview](https://cloud.githubusercontent.com/assets/1701397/11531384/6cc5dcd6-98f4-11e5-8d9c-dbc7b6fbb715.PNG)

Changes : 
![deviceoverviewchanges](https://cloud.githubusercontent.com/assets/1701397/11531369/454cb44a-98f4-11e5-928a-c162d00bb7c7.PNG)
