### PR TITLE
Fix missing path info on nginx.

### DIFF
--- a/doc/Installation/Installation-(RHEL-CentOS).md
+++ b/doc/Installation/Installation-(RHEL-CentOS).md
@@ -186,6 +186,7 @@ server {
   try_files $uri $uri/ @librenms;
  }
  location ~ \.php {
+  fastcgi_param PATH_INFO $fastcgi_path_info;
   include fastcgi.conf;
   fastcgi_split_path_info ^(.+\.php)(/.+)$;
   fastcgi_pass unix:/var/run/php5-fpm.sock;

--- a/html/index.php
+++ b/html/index.php
@@ -12,11 +12,13 @@
  *
  */
 
-if( strstr($_SERVER['SERVER_SOFTWARE'],"nginx") ) {
-    $_SERVER['PATH_INFO'] = str_replace($_SERVER['PATH_TRANSLATED'].$_SERVER['PHP_SELF'],"",$_SERVER['ORIG_SCRIPT_FILENAME']);
-}
-else {
-    $_SERVER['PATH_INFO'] = !empty($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : (!empty($_SERVER['ORIG_PATH_INFO']) ? $_SERVER['ORIG_PATH_INFO'] : '');
+if (empty($_SERVER['PATH_INFO'])) {
+    if( strstr($_SERVER['SERVER_SOFTWARE'],"nginx") ) {
+        $_SERVER['PATH_INFO'] = str_replace($_SERVER['PATH_TRANSLATED'].$_SERVER['PHP_SELF'],"",$_SERVER['ORIG_SCRIPT_FILENAME']);
+    }
+    else {
+        $_SERVER['PATH_INFO'] = !empty($_SERVER['ORIG_PATH_INFO']) ? $_SERVER['ORIG_PATH_INFO'] : '';
+    }
 }
 
 function logErrors($errno, $errstr, $errfile, $errline) {


### PR DESCRIPTION
Update nginx documentation to set the PATH_INFO variable.
Avoid hacks in index.php if it PATH_INFO is already set for both nginx and apache.

Does this look sane?  I'm not sure if there are any security implications here.