### PR TITLE
Adding VRF-lite

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -72,4 +72,5 @@ Contributors to LibreNMS:
 - Peter Lamperud <peter.lamperud@gmail.com> (vizay)
 - Louis Bailleul <louis.bailleul@gmail.com> (alucardfh)
 - Rick Hodger <rick@fuzzi.org.uk> (Tatermen)
+- Eldon Koyle <ekoyle@gmail.com> (ekoyle)
 [1]: http://observium.org/ "Observium web site"

--- a/daily.php
+++ b/daily.php
@@ -35,7 +35,17 @@ The ' . $config['project_name'] . ' team.';
         exit(2);
     }
     else {
-        exit((int) $config['update']);
+        if ($config['update']) {
+            if ($config['update_channel'] == 'master') {
+                exit(1);
+            }
+            elseif ($config['update_channel'] == 'release') {
+                exit(3);
+            }
+        }
+        else {
+            exit(0);
+        }
     }
 }
 

--- a/daily.sh
+++ b/daily.sh
@@ -1,19 +1,77 @@
 #!/usr/bin/env bash
-
-set -eu
+# Copyright (C) 2015 Daniel Preussker, QuxLabs UG <preussker@quxlabs.com>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 cd "$(dirname "$0")"
+arg="$1"
 
-up=$(php daily.php -f update >&2; echo $?)
-if [ "$up" -eq 1 ]; then
-    git pull --quiet
-    php includes/sql-schema/update.php
+# Fancy-Print and run commands
+# @arg    Text
+# @arg    Command
+# @return Exit-Code of Command
+status_run() {
+    printf "%-50s" "$1"
+    echo "$1" >> logs/daily.log
+    bash -c "$2" &>> logs/daily.log
+    ex=$?
+    echo "Returned: $ex" >> logs/daily.log
+    [ $ex -eq 0 ] && echo -e ' \033[0;32mOK\033[0m' || echo -e ' \033[0;31mFAIL\033[0m'
+    return $ex
+}
+
+if [ -z "$arg" ]; then
+    up=$(php daily.php -f update >&2; echo $?)
+    if [ "$up" -eq 1 ]; then
+        # Update to Master-Branch
+        status_run 'Updating to latest codebase' 'git pull --quiet'
+    elif [ "$up" -eq 3 ]; then
+        # Update to last Tag
+        status_run 'Updating to latest release' 'git fetch --tags && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))'
+    fi
+
+    cnf=$(echo $(grep '\[.distributed_poller.\]' config.php | egrep -v -e '^//' -e '^#' | cut -d = -f 2 | sed 's/;//g'))
+    cnd=${cnf,,}
+    if [ -z "$cnf" ] || [ "$cnf" == "0" ] || [ "$cnf" == "false" ]; then
+        # Call ourself again in case above pull changed or added something to daily.sh
+        $0 post-pull
+    fi
+else
+    case $arg in
+        post-pull)
+            # List all tasks to do after pull in the order of execution
+            status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'
+            status_run 'Updating submodules' "$0 submodules"
+            status_run 'Cleaning up DB' "$0 cleanup"
+            status_run 'Fetching notifications' "$0 notifications"
+        ;;
+        cleanup)
+            # DB-Cleanups
+            php daily.php -f syslog
+            php daily.php -f eventlog
+            php daily.php -f authlog
+            php daily.php -f perf_times
+            php daily.php -f callback
+            php daily.php -f device_perf
+        ;;
+        submodules)
+            # Init+Update our submodules
+            git submodule --quiet init
+            git submodule --quiet update
+        ;;
+        notifications)
+            # Get notifications
+            php daily.php -f notifications
+        ;;
+    esac
 fi
-
-php daily.php -f syslog
-php daily.php -f eventlog
-php daily.php -f authlog
-php daily.php -f perf_times
-php daily.php -f callback
-php daily.php -f device_perf
-php daily.php -f notifications

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -33,6 +33,10 @@ Table of Content:
     - [Device](#macros-device)
     - [Port](#macros-port)
     - [Time](#macros-time)
+- [Additional Options](#extra)
+   - [Max](#extra-max)
+   - [Delay](#extra-delay)
+   - [Interval](#extra-interval)
 
 
 # <a name="about">About</a>
@@ -633,4 +637,18 @@ Description: Packet loss % value for the device within the last 15 minutes.
 
 Example: `%macros.packet_loss_15m` > 50
 
+# <a name="extra">Additional Options</a>
 
+Here are some of the other available options for an alert rule.
+
+## <a name="extra-max">Max</a>
+
+The maximum number of alerts sent for the event.  `-1` means unlimited.
+
+## <a name="extra-delay">Delay</a>
+
+The amount of time to wait after a rule is matched before sending an alert.
+
+## <a name="extra-interval">Interval</a>
+
+The interval of time between alerts for an event until Max is reached.

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -34,9 +34,6 @@ Table of Content:
     - [Port](#macros-port)
     - [Time](#macros-time)
 - [Additional Options](#extra)
-   - [Max](#extra-max)
-   - [Delay](#extra-delay)
-   - [Interval](#extra-interval)
 
 
 # <a name="about">About</a>
@@ -639,16 +636,12 @@ Example: `%macros.packet_loss_15m` > 50
 
 # <a name="extra">Additional Options</a>
 
-Here are some of the other available options for an alert rule.
+Here are some of the other options available when adding an alerting rule:
 
-## <a name="extra-max">Max</a>
-
-The maximum number of alerts sent for the event.  `-1` means unlimited.
-
-## <a name="extra-delay">Delay</a>
-
-The amount of time to wait after a rule is matched before sending an alert.
-
-## <a name="extra-interval">Interval</a>
-
-The interval of time between alerts for an event until Max is reached.
+- Rule name: The name associated with the rule.
+- Severity: How "important" the rule is.
+- Max alerts: The maximum number of alerts sent for the event.  `-1` means unlimited.
+- Delay: The amount of time to wait after a rule is matched before sending an alert.
+- Interval: The interval of time between alerts for an event until Max is reached.
+- Mute alerts: Disable sending alerts for this rule.
+- Invert match: Invert the matching rule (ie. alert on items that _don't_ match the rule).

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -40,3 +40,10 @@ You will need to configure default credentials for your devices, LibreNMS doesn'
 ```
 
 If you have devices which you do not wish to appear in Oxidized then you can edit those devices in Device -> Edit -> Misc and enable "Exclude from Oxidized?"
+
+It's also possible to exclude certain device types and OS' from being output via the API. This is currently only possible via config.php:
+
+```php
+$config['oxidized']['ignore_types'] = array('server');
+$config['oxidized']['ignore_os'] = array('linux');
+```

--- a/doc/General/Changelog.md
+++ b/doc/General/Changelog.md
@@ -79,7 +79,7 @@
     - Added support for LigoWave Infinity AP's (PR2456)
   - Alerting:
     - Added ability to globally disable sending alerts (PR2385)
-    - Added support for Clickatell and PlaySMS (PR24104, PR2443)
+    - Added support for Clickatell, PlaySMS and VictorOps (PR24104, PR2443)
   - Documnetation:
     - Improved CentOS install docs (PR2462)
     - Improved Proxmox setup docs (PR2483)

--- a/doc/General/Changelog.md
+++ b/doc/General/Changelog.md
@@ -1,3 +1,96 @@
+### December 2015
+
+#### Bug fixes
+  - WebUI:
+    - Fixed regex for negative lat/lng coords (PR2524)
+    - Fixed map page looping due to device connected to itself (PR2545)
+    - Fixed PATH_INFO for nginx (PR2551)
+  - Discovery / Polling:
+    - Pointed snmp calls for Huawei to correct MIB folder (PR2541)
+  - Alerting:
+    - Fix glue-expansion for alerts (PR2522)
+  - Documentation:
+    - Removed duplicate mysql-client install from Debian/Ubuntu install docs (PR2543)
+
+#### Improvements
+  - WebUI:
+    - Converted sensors page to use bootgrid (PR2531)
+  - Discovery / Polling
+    - Added traffic bits as default for Cambium devices (PR2525)
+    - Overwrite eth0 port data from UniFi MIBs for AirFibre devices (PR2544)
+  - API:
+    - Added ability to filter devices by type and os for Oxidized API call (PR2539)
+  - Documentation:
+    - Improved alerting docs explaining more options (PR2560)
+  - Added detection for:
+    - Updated Netonix switch MIBs (PR2523)
+    - Updated Fotinet MIBs (PR2529, PR2534)
+
+### November 2015
+
+#### Bug fixes
+  - WebUI:
+    - getRates should return in and out average rates (PR2375)
+    - Fix 95th percent lines in negative range (PR2405)
+    - Fix percentage bar for billing pages (PR2419)
+    - Use HC counters first in realtime graphs (PR2420)
+    - Fix netcmd.php URI for sub dir installations (PR2428)
+    - Fixed Oxidized fetch config with groups (PR2501)
+    - Fixed background colour to white for some graphs (PR2516)
+  - API:
+    - Added missing quotes for MySQL queries (PR2382)
+  - Discovery / Polling:
+    - Specified MIB used when polling ntpd-server (PR2418)
+    - Added missing fields when inserting data into applications table (PR2445)
+    - Fix auto-discovery failing (PR2457)
+    - Juniper hardware inventory fix (PR2466)
+    - Fix discovery of Cisco PIX running PixOS 8.0 (PR2480)
+    - Fix bug in Proxmox support if only one VM was detected (PR2490, PR2547)
+  - Alerting:
+    - Strip && and || from query for device-groups (PR2476)
+    - Fix transports being triggered when empty keys set (PR2491)
+  Misc:
+    - Updated device_traffic_descr config to stop graphs failing (PR2386)
+
+#### Improvements
+  - WebUI:
+    - Status column now sortable for /devices/ (PR2397)
+    - Update Gridster library to be responsive (PR2414)
+    - Improved rrdtool 1.4/1.5 compatibility (PR2430)
+    - Use event_id in query for Eventlog (PR2437)
+    - Add graph selector to devices overview (PR2438)
+    - Improved Navbar for varying screen sizes (PR2450)
+    - Added RIPE NCC API support for lookups (PR2455, PR2474)
+    - Improved ports page for device with large number of neighbours (PR2460)
+    - Merged all CPU graphs into one on overview page (PR2470)
+    - Added support for sortting by traffic on device port page (PR2508)
+    - Added support for dynamic graph sizes based on browser size (PR2510)
+    - Made device location clickable in device header (PR2515)
+    - Visual improvements to bills page (PR2519)
+  - Discovery / Polling:
+    - Updated Cisco SB discovery (PR2396)
+    - Added Ceph support via Applications (PR2412)
+    - Added support for per device unix-agent port (PR2439)
+    - Added ability to select up/down devices on worldmap (PR2441)
+    - Allow powerdns app to be set for Unix Agent (PR2489)
+    - Added SLES detection to distro script (PR2502)
+  - Added detection for:
+    - Added CPU + Memory usage for Ubiquiti UniFi (PR2421)
+    - Added support for LigoWave Infinity AP's (PR2456)
+  - Alerting:
+    - Added ability to globally disable sending alerts (PR2385)
+    - Added support for Clickatell and PlaySMS (PR24104, PR2443)
+  - Documnetation:
+    - Improved CentOS install docs (PR2462)
+    - Improved Proxmox setup docs (PR2483)
+  - Misc:
+    - Provide InnoDB config for buffer size issues (PR2401)
+    - Added AD Authentication support (PR2411, PR2425, PR2432, PR2434)
+    - Added Features document (PR2436, PR2511, PR2513)
+    - Centralised innodb buffer check and added to validate (PR2482)
+    - Updated and improved daily.sh (PR2487)
+
+
 ### October 2015
 
 #### Bug fixes

--- a/doc/Installation/Installation-(Debian-Ubuntu).md
+++ b/doc/Installation/Installation-(Debian-Ubuntu).md
@@ -57,7 +57,7 @@ This host is where the web server and SNMP poller run.  It could be the same mac
 
 Install the required software:
 
-    apt-get install libapache2-mod-php5 php5-cli php5-mysql php5-gd php5-snmp php-pear php5-curl snmp graphviz php5-mcrypt php5-json apache2 fping imagemagick whois mtr-tiny nmap python-mysqldb snmpd mysql-client php-net-ipv4 php-net-ipv6 rrdtool git
+    apt-get install libapache2-mod-php5 php5-cli php5-mysql php5-gd php5-snmp php-pear php5-curl snmp graphviz php5-mcrypt php5-json apache2 fping imagemagick whois mtr-tiny nmap python-mysqldb snmpd php-net-ipv4 php-net-ipv6 rrdtool git
 
 The packages listed above are an all-inclusive list of packages that were necessary on a clean install of Ubuntu 12.04/14.04.
 

--- a/doc/Installation/Installation-(RHEL-CentOS).md
+++ b/doc/Installation/Installation-(RHEL-CentOS).md
@@ -186,6 +186,7 @@ server {
   try_files $uri $uri/ @librenms;
  }
  location ~ \.php {
+  fastcgi_param PATH_INFO $fastcgi_path_info;
   include fastcgi.conf;
   fastcgi_split_path_info ^(.+\.php)(/.+)$;
   fastcgi_pass unix:/var/run/php5-fpm.sock;

--- a/html/ajax_setresolution.php
+++ b/html/ajax_setresolution.php
@@ -4,6 +4,3 @@ if(isset($_REQUEST['width']) AND isset($_REQUEST['height'])) {
     $_SESSION['screen_width'] = $_REQUEST['width'];
     $_SESSION['screen_height'] = $_REQUEST['height'];
 }
-
-echo $_SESSION['screen_width'];
-?>

--- a/html/ajax_setresolution.php
+++ b/html/ajax_setresolution.php
@@ -1,0 +1,9 @@
+<?php
+session_start();
+if(isset($_REQUEST['width']) AND isset($_REQUEST['height'])) {
+    $_SESSION['screen_width'] = $_REQUEST['width'];
+    $_SESSION['screen_height'] = $_REQUEST['height'];
+}
+
+echo $_SESSION['screen_width'];
+?>

--- a/html/ajax_setresolution.php
+++ b/html/ajax_setresolution.php
@@ -4,3 +4,5 @@ if(isset($_REQUEST['width']) AND isset($_REQUEST['height'])) {
     $_SESSION['screen_width'] = $_REQUEST['width'];
     $_SESSION['screen_height'] = $_REQUEST['height'];
 }
+echo $_SESSION['screen_width'];
+echo $_SESSION['screen_height'];

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1776,14 +1776,30 @@ label {
         max-width: 45px;
         max-height: 50px;
     }
+    .device-header-table .device_icon img {
+       max-width: 20px;
+       max-height: 20px;
+    }
+    .device-header-table img {
+       max-width: 115px;
+       max-height: 40px;
+    }
+    .device-header-table {font-size : 8px;}
+    .device-header-table a {font-size : 11px;}
 }
 
-@media only screen and (max-width: 720px) and (min-width: 481px) {
+@media only screen and (max-width: 768px) and (min-width: 481px) {
     .thumbnail_graph_table b { font-size : 8px;}
     .thumbnail_graph_table img {
         max-width: 60px;
         max-height: 55px;
     }
+    .device-header-table img {
+       max-width: 150px;
+       max-height: 50px;
+    }
+    .device-header-table {font-size : 10px;}
+    .device-header-table a {font-size : 17px;}
 }
 
 

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1765,6 +1765,43 @@ tr.search:nth-child(odd) {
 label {
     font-weight: normal;
 }
+
 .nav>li>a.dropdown-toggle {
     padding: 15px 6px;
+}
+
+@media only screen and (max-width: 480px) {
+    .thumbnail_graph_table b { font-size : 6px;}
+    .thumbnail_graph_table img {
+        max-width: 45px;
+        max-height: 50px;
+    }
+}
+
+@media only screen and (max-width: 720px) and (min-width: 481px) {
+    .thumbnail_graph_table b { font-size : 8px;}
+    .thumbnail_graph_table img {
+        max-width: 60px;
+        max-height: 55px;
+    }
+}
+
+
+@media only screen and (max-width: 800px) and (min-width: 721px) {
+    .thumbnail_graph_table b { font-size : 8px;}
+    .thumbnail_graph_table img {
+        max-width: 75px;
+        max-height: 60px;
+    }
+}
+
+@media only screen and (max-width: 1024px) and (min-width: 801px) {
+    .thumbnail_graph_table b { font-size : 9px;}
+    .thumbnail_graph_table img {
+        max-width: 105px;
+        max-height: 70px;
+    }
+}
+
+@media only screen and (min-width: 1024px) {
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1776,30 +1776,14 @@ label {
         max-width: 45px;
         max-height: 50px;
     }
-    .device-header-table .device_icon img {
-       max-width: 20px;
-       max-height: 20px;
-    }
-    .device-header-table img {
-       max-width: 115px;
-       max-height: 40px;
-    }
-    .device-header-table {font-size : 8px;}
-    .device-header-table a {font-size : 11px;}
 }
 
-@media only screen and (max-width: 768px) and (min-width: 481px) {
+@media only screen and (max-width: 720px) and (min-width: 481px) {
     .thumbnail_graph_table b { font-size : 8px;}
     .thumbnail_graph_table img {
         max-width: 60px;
         max-height: 55px;
     }
-    .device-header-table img {
-       max-width: 150px;
-       max-height: 50px;
-    }
-    .device-header-table {font-size : 10px;}
-    .device-header-table a {font-size : 17px;}
 }
 
 

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -890,12 +890,14 @@ function get_inventory() {
 
 
 function list_oxidized() {
-    // return details of a single device
+    global $config;
     $app = \Slim\Slim::getInstance();
     $app->response->headers->set('Content-Type', 'application/json');
 
     $devices = array();
-    foreach (dbFetchRows("SELECT hostname,os FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `status`='1' AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL)") as $device) {
+    $device_types = "'".implode("','", $config['oxidized']['ignore_types'])."'";
+    $device_os    = "'".implode("','", $config['oxidized']['ignore_os'])."'";
+    foreach (dbFetchRows("SELECT hostname,os FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `status`='1' AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
         $devices[] = $device;
     }
 

--- a/html/includes/device-header.inc.php
+++ b/html/includes/device-header.inc.php
@@ -24,7 +24,7 @@ $image = getImage($device);
 
 echo '
             <tr bgcolor="'.$device_colour.'" class="alert '.$class.'">
-             <td width="40" align=center valign=middle style="padding: 21px;">'.$image.'</td>
+             <td width="40" align=center valign=middle style="padding: 21px;"><span class="device_icon">'.$image.'</span></td>
              <td valign=middle style="padding: 0 15px;"><span style="font-size: 20px;">'.generate_device_link($device).'</span>
              <br />'.generate_link($device['location'], array('page' => 'devices', 'location' => $device['location'])).'</td>
              <td>';

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -476,7 +476,7 @@ function generate_lazy_graph_tag($args) {
         $urlargs[] = $key."=".urlencode($arg);
     }
 
-    return '<img class="lazy" width="'.$w.'" height="'.$h.'" data-original="graph.php?' . implode('&amp;',$urlargs).'" border="0" />';
+    return '<img class="lazy graphs" width="'.$w.'" height="'.$h.'" data-original="graph.php?' . implode('&amp;',$urlargs).'" border="0" />';
 
 }//end generate_lazy_graph_tag()
 

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1189,7 +1189,7 @@ function generate_dynamic_config_panel($title,$end_panel=true,$config_groups,$it
 <div class="panel panel-default">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a data-toggle="collapse" data-parent="#accordion" href="#'.$anchor.'">'.$title.'</a>
+            <a data-toggle="collapse" data-parent="#accordion" href="#'.$anchor.'"><i class="fa fa-caret-down"></i> '.$title.'</a>
     ';
     if (!empty($transport)) {
         $output .= '<button name="test-alert" id="test-alert" type="button" data-transport="'.$transport.'" class="btn btn-primary btn-xs pull-right">Test transport</button>';

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,22 +39,31 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 430 )/count($periods)+1;
+	   $graph_array['width'] = round(($_SESSION['screen_width'] - 430 )/count($periods)+1,0);
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }
 
+echo $graph_array['width'];
+
+if( $graph_array['width'] < 215) {
+    $graph_array['width'] = 215;
+}
+
 if($_SESSION['screen_height']) {
     if($_SESSION['screen_width'] > 960) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/5;
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/5,0);
     }
     else {
-        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/2;
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/2,0);
     }
 }
 
+if($graph_array['height'] < 100 ) {
+    $graph_array['height'] = 100;
+}
 
 $graph_array['to'] = $config['time']['now'];
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,6 +37,17 @@ else {
     );
 }//end if
 
+if($_SESSION['screen_width'])
+{
+   $graph_array['width'] = $_SESSION['screen_width']/5.5;
+}
+
+if($_SESSION['screen_height'])
+{
+  $graph_array['height'] = $_SESSION['screen_height']/6;
+}
+
+
 $graph_array['to'] = $config['time']['now'];
 
 $graph_data = array();

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,8 +39,9 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }else {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
+   }
+   else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -38,8 +38,8 @@ else {
 }//end if
 
 if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
+   if($_SESSION['screen_width'] > 800) {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
@@ -47,7 +47,12 @@ if($_SESSION['screen_width']) {
 }
 
 if($_SESSION['screen_height']) {
-  $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
+    if($_SESSION['screen_width'] > 960) {
+        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
+    }
+    else {
+        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/2;
+    }
 }
 
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,7 +39,7 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 430 )/count($periods)+1;
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
@@ -48,7 +48,7 @@ if($_SESSION['screen_width']) {
 
 if($_SESSION['screen_height']) {
     if($_SESSION['screen_width'] > 960) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
+        $graph_array['height'] = ($_SESSION['screen_height'] - 250)/5;
     }
     else {
         $graph_array['height'] = ($_SESSION['screen_height'] - 250)/2;

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,10 +39,10 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = round(($_SESSION['screen_width'] - 430 )/count($periods)+1,0);
+	   $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/count($periods)+1,0);
    }
    else {
-	$graph_array['width'] = $_SESSION['screen_width'] - 155;
+	$graph_array['width'] = $_SESSION['screen_width'] - 70;
    }
 }
 
@@ -51,11 +51,11 @@ if( $graph_array['width'] < 215) {
 }
 
 if($_SESSION['screen_height']) {
-    if($_SESSION['screen_width'] > 960) {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/5,0);
+    if($_SESSION['screen_height'] > 960) {
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/4,0);
     }
     else {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/2,0);
+        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/3,0);
     }
 }
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,19 +37,15 @@ else {
     );
 }//end if
 
-if($_SESSION['screen_width'])
-{
-   if($_SESSION['screen_width'] >= 800)
-   {
+if($_SESSION['screen_width']) {
+   if($_SESSION['screen_width'] >= 800) {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }else
-   {
+   }else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }
 
-if($_SESSION['screen_height'])
-{
+if($_SESSION['screen_height']) {
   $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
 }
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -46,8 +46,6 @@ if($_SESSION['screen_width']) {
    }
 }
 
-echo $graph_array['width'];
-
 if( $graph_array['width'] < 215) {
     $graph_array['width'] = 215;
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,7 +39,7 @@ else {
 
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
    }else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -38,30 +38,20 @@ else {
 }//end if
 
 if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] > 800) {
-	   $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/count($periods)+1,0);
-   }
-   else {
-	$graph_array['width'] = $_SESSION['screen_width'] - 70;
-   }
-}
-
-if( $graph_array['width'] < 215) {
-    $graph_array['width'] = 215;
-}
-
-if($_SESSION['screen_height']) {
-    if($_SESSION['screen_height'] > 960) {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/4,0);
+    if($_SESSION['screen_width'] < 1024 && $_SESSION['screen_width'] > 700) {
+        $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/2,0);
     }
     else {
-        $graph_array['height'] = round(($_SESSION['screen_height'] - 250)/3,0);
+        if($_SESSION['screen_width'] > 1024) {
+            $graph_array['width'] = round(($_SESSION['screen_width'] - 90 )/count($periods)+1,0);
+        }
+        else {
+            $graph_array['width'] = $_SESSION['screen_width'] - 70;
+        }
     }
 }
 
-if($graph_array['height'] < 100 ) {
-    $graph_array['height'] = 100;
-}
+$graph_array['height'] = round($graph_array['width'] /2.15);
 
 $graph_array['to'] = $config['time']['now'];
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,11 +37,13 @@ else {
     );
 }//end if
 
-if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] > 800) {
+if($_SESSION['screen_width'])
+{
+   if($_SESSION['screen_width'] >= 800)
+   {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }
-   else {
+   }else
+   {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -40,7 +40,8 @@ else {
 if($_SESSION['screen_width']) {
    if($_SESSION['screen_width'] >= 800) {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
-   }else {
+   }
+   else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -38,8 +38,8 @@ else {
 }//end if
 
 if($_SESSION['screen_width']) {
-   if($_SESSION['screen_width'] >= 800) {
-	   $graph_array['width'] = ($_SESSION['screen_width'] - 420 )/count($periods)+1;
+   if($_SESSION['screen_width'] > 800) {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
    }
    else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -39,12 +39,18 @@ else {
 
 if($_SESSION['screen_width'])
 {
-   $graph_array['width'] = $_SESSION['screen_width']/5.5;
+   if($_SESSION['screen_width'] >= 800)
+   {
+	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
+   }else
+   {
+	$graph_array['width'] = $_SESSION['screen_width'] - 155;
+   }
 }
 
 if($_SESSION['screen_height'])
 {
-  $graph_array['height'] = $_SESSION['screen_height']/6;
+  $graph_array['height'] = ($_SESSION['screen_height'] - 250)/4;
 }
 
 

--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -37,13 +37,10 @@ else {
     );
 }//end if
 
-if($_SESSION['screen_width'])
-{
-   if($_SESSION['screen_width'] >= 800)
-   {
+if($_SESSION['screen_width']) {
+   if($_SESSION['screen_width'] >= 800) {
 	   $graph_array['width'] = ($_SESSION['screen_width'] - 400 )/count($periods)+1;
-   }else
-   {
+   }else {
 	$graph_array['width'] = $_SESSION['screen_width'] - 155;
    }
 }

--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -132,10 +132,10 @@ foreach ($list as $items) {
     if (!in_array($items['local_device_id'],$tmp_ids)) {
         $tmp_devices[] = array('id'=>$items['local_device_id'],'label'=>$items['local_hostname'],'title'=>generate_device_link($local_device,'',array(),'','','',0),'shape'=>'box');
     }
+    array_push($tmp_ids,$items['local_device_id']);
     if (!in_array($items['remote_device_id'],$tmp_ids)) {
         $tmp_devices[] = array('id'=>$items['remote_device_id'],'label'=>$items['remote_hostname'],'title'=>generate_device_link($remote_device,'',array(),'','','',0),'shape'=>'box');
     }
-    array_push($tmp_ids,$items['local_device_id']);
     array_push($tmp_ids,$items['remote_device_id']);
     $speed = $items['local_ifspeed']/1000/1000;
     if ($speed == 100) {

--- a/html/includes/table/sensors.inc.php
+++ b/html/includes/table/sensors.inc.php
@@ -99,8 +99,8 @@ foreach (dbFetchRows($sql, $param) as $sensor) {
 
     $response[] = array(
         'hostname'       => generate_device_link($sensor),
-        'sensor_descr'   => overlib_link($link, $sensor['sensor_descr'], $overlib_content),
-        'graph'          => overlib_link($link_graph, $sensor_minigraph, $overlib_content),
+        'sensor_descr'   => overlib_link($link, $sensor['sensor_descr'], $overlib_content, null),
+        'graph'          => overlib_link($link_graph, $sensor_minigraph, $overlib_content, null),
         'alert'          => $alert,
         'sensor_current' => $sensor['sensor_current'].$unit,
         'sensor_range'   => round($sensor['sensor_limit_low'], 2).$unit.' - '.round($sensor['sensor_limit'], 2).$unit,

--- a/html/includes/table/sensors.inc.php
+++ b/html/includes/table/sensors.inc.php
@@ -1,0 +1,144 @@
+<?php
+
+$graph_type = mres($_POST['graph_type']);
+$unit       = mres($_POST['unit']);
+$class      = mres($_POST['class']);
+
+$sql = ' FROM `sensors` AS S, `devices` AS D';
+
+if (is_admin() === false && is_read() === false) {
+    $sql .= ', devices_perms as P';
+}
+
+$sql .= " WHERE S.sensor_class=? AND S.device_id = D.device_id ";
+$param[] = mres($_POST['class']);
+
+if (is_admin() === false && is_read() === false) {
+    $sql .= " AND D.device_id = P.device_id AND P.user_id = ?";
+    $param[] = $_SESSION['user_id'];
+}
+
+if (isset($searchPhrase) && !empty($searchPhrase)) {
+    $sql .= " AND (`D`.`hostname` LIKE '%$searchPhrase%' OR `sensor_descr` LIKE '%$searchPhrase%' OR `sensor_current` LIKE '%searchPhrase')";
+}
+
+$count_sql = "SELECT COUNT(`sensor_id`) $sql";
+
+$count = dbFetchCell($count_sql, $param);
+if (empty($count)) {
+    $count = 0;
+}
+
+if (!isset($sort) || empty($sort)) {
+    $sort = '`D`.`hostname`, `S`.`sensor_descr`';
+}
+
+$sql .= " ORDER BY $sort";
+
+if (isset($current)) {
+    $limit_low  = (($current * $rowCount) - ($rowCount));
+    $limit_high = $rowCount;
+}
+
+if ($rowCount != -1) {
+    $sql .= " LIMIT $limit_low,$limit_high";
+}
+
+$sql = "SELECT * $sql";
+
+foreach (dbFetchRows($sql, $param) as $sensor) {
+    if (empty($sensor['sensor_current'])) {
+        $sensor['sensor_current'] = 'NaN';
+    }
+    else {
+        if ($sensor['sensor_current'] >= $sensor['sensor_limit']) {
+            $alert = '<img src="images/16/flag_red.png" alt="alert" />';
+        }
+        else {
+            $alert = '';
+        }
+    }
+
+    // FIXME - make this "four graphs in popup" a function/include and "small graph" a function.
+    // FIXME - So now we need to clean this up and move it into a function. Isn't it just "print-graphrow"?
+    // FIXME - DUPLICATED IN device/overview/sensors
+    $graph_colour = str_replace('#', '', $row_colour);
+
+    $graph_array           = array();
+    $graph_array['height'] = '100';
+    $graph_array['width']  = '210';
+    $graph_array['to']     = $config['time']['now'];
+    $graph_array['id']     = $sensor['sensor_id'];
+    $graph_array['type']   = $graph_type;
+    $graph_array['from']   = $config['time']['day'];
+    $graph_array['legend'] = 'no';
+
+    $link_array         = $graph_array;
+    $link_array['page'] = 'graphs';
+    unset($link_array['height'], $link_array['width'], $link_array['legend']);
+    $link_graph = generate_url($link_array);
+
+    $link = generate_url(array('page' => 'device', 'device' => $sensor['device_id'], 'tab' => 'health', 'metric' => $sensor['sensor_class']));
+
+    $overlib_content = '<div style="width: 580px;"><h2>'.$device['hostname'].' - '.$sensor['sensor_descr'].'</h1>';
+    foreach (array('day', 'week', 'month', 'year') as $period) {
+        $graph_array['from'] = $config['time'][$period];
+        $overlib_content    .= str_replace('"', "\'", generate_graph_tag($graph_array));
+    }
+
+    $overlib_content .= '</div>';
+
+    $graph_array['width']  = 80;
+    $graph_array['height'] = 20;
+    $graph_array['bg']     = 'ffffff00';
+    // the 00 at the end makes the area transparent.
+    $graph_array['from'] = $config['time']['day'];
+    $sensor_minigraph =  generate_lazy_graph_tag($graph_array);
+
+    $sensor['sensor_descr'] = truncate($sensor['sensor_descr'], 48, '');
+
+    $response[] = array(
+        'hostname'       => generate_device_link($sensor),
+        'sensor_descr'   => overlib_link($link, $sensor['sensor_descr'], $overlib_content),
+        'graph'          => overlib_link($link_graph, $sensor_minigraph, $overlib_content),
+        'alert'          => $alert,
+        'sensor_current' => $sensor['sensor_current'].$unit,
+        'sensor_range'   => round($sensor['sensor_limit_low'], 2).$unit.' - '.round($sensor['sensor_limit'], 2).$unit,
+    );
+
+    if ($_POST['view'] == 'graphs') {
+
+        $daily_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['day'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
+        $daily_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['day'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
+
+        $weekly_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['week'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
+        $weekly_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['week'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
+
+        $monthly_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['month'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
+        $monthly_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['month'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
+
+        $yearly_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['year'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
+        $yearly_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['year'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
+
+        $response[] = array(
+            'hostname'       => "<a onmouseover=\"return overlib('<img src=\'$daily_url\'>', LEFT);\" onmouseout=\"return nd();\">
+            <img src='$daily_graph' border=0></a> ",
+            'sensor_descr'   => "<a onmouseover=\"return overlib('<img src=\'$weekly_url\'>', LEFT);\" onmouseout=\"return nd();\">
+            <img src='$weekly_graph' border=0></a> ",
+            'graph'          => "<a onmouseover=\"return overlib('<img src=\'$monthly_url\'>', LEFT);\" onmouseout=\"return nd();\">
+            <img src='$monthly_graph' border=0></a>",
+            'alert'          => '',
+            'sensor_current' => "<a onmouseover=\"return overlib('<img src=\'$yearly_url\'>', LEFT);\" onmouseout=\"return nd();\">
+            <img src='$yearly_graph' border=0></a>",
+            'sensor_range'   => '',
+        );
+    } //end if
+}//end foreach
+
+$output = array(
+    'current'  => $current,
+    'rowCount' => $rowCount,
+    'rows'     => $response,
+    'total'    => $count,
+);
+echo _json_encode($output);

--- a/html/index.php
+++ b/html/index.php
@@ -184,6 +184,10 @@ else {
 
 <?php
 
+if(empty($_SESSION['screen_width']) && empty($_SESSION['screen_height'])) {
+    echo "<script>updateResolution();</script>";
+}
+
 if ((isset($vars['bare']) && $vars['bare'] != "yes") || !isset($vars['bare'])) {
     if ($_SESSION['authenticated']) {
         require 'includes/print-menubar.php';

--- a/html/index.php
+++ b/html/index.php
@@ -12,11 +12,13 @@
  *
  */
 
-if( strstr($_SERVER['SERVER_SOFTWARE'],"nginx") ) {
-    $_SERVER['PATH_INFO'] = str_replace($_SERVER['PATH_TRANSLATED'].$_SERVER['PHP_SELF'],"",$_SERVER['ORIG_SCRIPT_FILENAME']);
-}
-else {
-    $_SERVER['PATH_INFO'] = !empty($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : (!empty($_SERVER['ORIG_PATH_INFO']) ? $_SERVER['ORIG_PATH_INFO'] : '');
+if (empty($_SERVER['PATH_INFO'])) {
+    if( strstr($_SERVER['SERVER_SOFTWARE'],"nginx") ) {
+        $_SERVER['PATH_INFO'] = str_replace($_SERVER['PATH_TRANSLATED'].$_SERVER['PHP_SELF'],"",$_SERVER['ORIG_SCRIPT_FILENAME']);
+    }
+    else {
+        $_SERVER['PATH_INFO'] = !empty($_SERVER['ORIG_PATH_INFO']) ? $_SERVER['ORIG_PATH_INFO'] : '';
+    }
 }
 
 function logErrors($errno, $errstr, $errfile, $errline) {

--- a/html/js/lazyload.js
+++ b/html/js/lazyload.js
@@ -32,5 +32,5 @@ $(document).ready(function(){
 function lazyload_done() {
     //Since RRD takes the width and height params for only the canvas, we must unset them 
     //from the final (larger) image to prevent the browser from resizing them.
-    $(this).removeAttr('width').removeAttr('height').removeClass('lazy');
+    $(this).removeAttr('height').removeClass('lazy');
 }

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -140,7 +140,7 @@ function submitCustomRange(frmdata) {
     return true;
 }
 
-function updateResolution()
+function updateResolution(refresh)
 {
     $.post('ajax_setresolution.php', 
         {
@@ -148,6 +148,9 @@ function updateResolution()
             height:$(window).height()
         },
         function(data) {
+            if(refresh == true) {
+                location.reload();
+            }
         },'json'
     );
 }
@@ -155,6 +158,8 @@ function updateResolution()
 var rtime;
 var timeout = false;
 var delta = 500;
+var newH;
+var newW;
 
 $(window).on('resize', function(){
     rtime = new Date();
@@ -169,16 +174,22 @@ function resizeend() {
         setTimeout(resizeend, delta);
     } 
     else {
+        newH=$(window).height();
+        newW=$(window).width();
         timeout = false;
-        updateResolution();
-        resizeGraphs();
+        if(Math.abs(oldW - newW) >= 200)
+        {
+            refresh = true;
+        }
+        else {
+            refresh = false;
+            resizeGraphs();
+        }
+        updateResolution(refresh);
     }  
 };
 
 function resizeGraphs() {
-    newH=$(window).height();
-    newW=$(window).width();
-
     ratioW=newW/oldW;
     ratioH=newH/oldH;
 

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -137,6 +137,18 @@ function submitCustomRange(frmdata) {
     return true;
 }
 
+function updateResolution()
+{
+    $.post(
+        'ajax_setresolution.php', 
+        {width: $(window).width(),height:$(window).height()},
+        function(json) {},
+        'json'
+    );
+}
+
+$(window).on('resize', function(){ updateResolution();});
+
 $(document).on("click", '.collapse-neighbors', function(event)
 {
     var caller = $(this);
@@ -144,24 +156,14 @@ $(document).on("click", '.collapse-neighbors', function(event)
     var list = caller.find('.neighbors-interface-list');
     var continued = caller.find('.neighbors-list-continued');
 
-    if(button.hasClass("glyphicon-plus"))
-    {
+    if(button.hasClass("glyphicon-plus")) {
         button.addClass('glyphicon-minus').removeClass('glyphicon-plus');
-    }else
-    {
+    }else {
         button.addClass('glyphicon-plus').removeClass('glyphicon-minus');
     }
    
     list.toggle();
     continued.toggle();
 });
-
-function updateResolution()
-{
-     $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
-    },'json');
-}
-
-$(window).on('resize', function(){ updateResolution();});
 
 

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -157,7 +157,8 @@ $(document).on("click", '.collapse-neighbors', function(event)
 
     if(button.hasClass("glyphicon-plus")) {
         button.addClass('glyphicon-minus').removeClass('glyphicon-plus');
-    }else {
+    }
+    else {
         button.addClass('glyphicon-plus').removeClass('glyphicon-minus');
     }
    

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -1,3 +1,5 @@
+var oldH;
+var oldW;
 $(document).ready(function() {
     // Device override ajax calls
     $("[name='override_config']").bootstrapSwitch('offColor','danger');
@@ -123,6 +125,8 @@ $(document).ready(function() {
         });
     });
 
+    oldW=$(window).width();
+    oldH=$(window).height();
 });
 
 function submitCustomRange(frmdata) {
@@ -144,14 +148,13 @@ function updateResolution()
             height:$(window).height()
         },
         function(data) {
-            location.reload();
         },'json'
     );
 }
 
 var rtime;
 var timeout = false;
-var delta = 300;
+var delta = 500;
 
 $(window).on('resize', function(){
     rtime = new Date();
@@ -168,8 +171,25 @@ function resizeend() {
     else {
         timeout = false;
         updateResolution();
+        resizeGraphs();
     }  
 };
+
+function resizeGraphs() {
+    newH=$(window).height();
+    newW=$(window).width();
+
+    ratioW=newW/oldW;
+    ratioH=newH/oldH;
+
+    $('.graphs').each(function (){
+        var img = jQuery(this);
+        img.attr('width',img.width() * ratioW);
+    });
+    oldH=newH;
+    oldW=newW;
+}
+
 
 $(document).on("click", '.collapse-neighbors', function(event)
 {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -155,3 +155,7 @@ $(document).on("click", '.collapse-neighbors', function(event)
     continued.toggle();
 });
 
+$(function() {
+    $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
+    },'json');
+});

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,6 +123,7 @@ $(document).ready(function() {
         });
     });
 
+    updateResolution();
 });
 
 function submitCustomRange(frmdata) {
@@ -165,5 +166,3 @@ $(document).on("click", '.collapse-neighbors', function(event)
     list.toggle();
     continued.toggle();
 });
-
-

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,7 +123,6 @@ $(document).ready(function() {
         });
     });
 
-    updateResolution();
 });
 
 function submitCustomRange(frmdata) {
@@ -165,7 +164,8 @@ $(window).on('resize', function(){
 function resizeend() {
     if (new Date() - rtime < delta) {
         setTimeout(resizeend, delta);
-    } else {
+    } 
+    else {
         timeout = false;
         updateResolution();
     }  

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -139,15 +139,37 @@ function submitCustomRange(frmdata) {
 
 function updateResolution()
 {
-    $.post(
-        'ajax_setresolution.php', 
-        {width: $(window).width(),height:$(window).height()},
-        function(json) {},
-        'json'
+    $.post('ajax_setresolution.php', 
+        {
+            width: $(window).width(),
+            height:$(window).height()
+        },
+        function(data) {
+            location.reload();
+        },'json'
     );
 }
 
-$(window).on('resize', function(){ updateResolution();});
+var rtime;
+var timeout = false;
+var delta = 300;
+
+$(window).on('resize', function(){
+    rtime = new Date();
+    if (timeout === false) {
+        timeout = true;
+        setTimeout(resizeend, delta);
+    }
+});
+
+function resizeend() {
+    if (new Date() - rtime < delta) {
+        setTimeout(resizeend, delta);
+    } else {
+        timeout = false;
+        updateResolution();
+    }  
+};
 
 $(document).on("click", '.collapse-neighbors', function(event)
 {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,6 +123,7 @@ $(document).ready(function() {
         });
     });
 
+    updateResolution();
 });
 
 function submitCustomRange(frmdata) {
@@ -155,7 +156,12 @@ $(document).on("click", '.collapse-neighbors', function(event)
     continued.toggle();
 });
 
-$(function() {
-    $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
+function updateResolution()
+{
+     $.post('ajax_setresolution.php', { width: $(window).width() , height:$(window).height() }, function(json) {
     },'json');
-});
+}
+
+$(window).on('resize', function(){ updateResolution();});
+
+

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -123,7 +123,6 @@ $(document).ready(function() {
         });
     });
 
-    updateResolution();
 });
 
 function submitCustomRange(frmdata) {

--- a/html/pages/bill/delete.inc.php
+++ b/html/pages/bill/delete.inc.php
@@ -1,6 +1,4 @@
-
 <form name="form1" action="" method="post" class="form-horizontal">
-  <link rel="stylesheet" href="<?php echo $config['base_url']; ?>/css/bootstrap.min.css">
   <script type="text/javascript">
     function showWarning(checked) {
       $('#warning').toggle();
@@ -12,22 +10,24 @@
     }
   </script>
   <input type="hidden" name="action" value="delete_bill">
-  <fieldset>
-    <legend>Delete Bill</legend>
-    <div class="control-group">
-      <label class="control-label" for="confirm"><strong>Confirm</strong></label>
-      <div class="controls">
-        <label class="checkbox">
-          <input type="checkbox" name="confirm" value="confirm" onchange="javascript: showWarning(this.checked);">
-          Yes, please delete this bill!
+  <h3>Delete Bill</h3>
+  <hr>
+  <div class="control-group">
+    <label class="control-label" for="confirm"><strong>Confirm</strong></label>
+    <div class="controls">
+      <div class="checkbox">
+        <label>
+        <input type="checkbox" name="confirm" value="confirm" onchange="javascript: showWarning(this.checked);">
+        Yes, please delete this bill!
         </label>
       </div>
     </div>
-    <div class="alert alert-message" id="warning" style="display: none;">
-      <h4 class="alert-heading"><i class="icon-warning-sign"></i> Warning!</h4>
-      Are you sure you want to delete his bill?
-    </div>
-  </fieldset>
+  </div>
+  <br>
+  <div class="alert alert-danger" id="warning" style="display: none;">
+    <h4 class="alert-heading"><i class="fa fa-exclamation-triangle"></i> Warning</h4>
+    You are about to delete this bill.
+  </div>
   <div class="form-actions">
     <button id="deleteBtn" type="submit" class="btn btn-danger" disabled="disabled"><i class="icon-trash icon-white"></i> <strong>Delete Bill</strong></button>
   </div>

--- a/html/pages/bill/reset.inc.php
+++ b/html/pages/bill/reset.inc.php
@@ -1,5 +1,4 @@
 <form name="form1" action="" method="post" class="form-horizontal">
-  <link rel="stylesheet" href="<?php echo $config['base_url']; ?>/css/bootstrap.min.css">
   <script type="text/javascript">
     function showWarning() {
       var checked = $('input:checked').length;
@@ -13,26 +12,30 @@
     }
   </script>
   <input type="hidden" name="action" value="reset_bill">
-  <fieldset>
-    <legend>Reset Bill</legend>
-    <div class="control-group">
-      <label class="control-label" for="confirm"><strong>Confirm</strong></label>
-      <div class="controls">
-        <label class="checkbox">
-          <input type="checkbox" name="confirm" value="mysql" onchange="javascript: showWarning();">
-          Yes, please reset MySQL data for all interfaces on this bill!
+  <h3>Reset Bill</h3>
+  <hr>
+  <div class="control-group">
+    <label class="control-label" for="confirm"><strong>Confirm</strong></label>
+    <div class="controls">
+      <div class="checkbox">
+        <label>
+        <input type="checkbox" name="confirm" value="mysql" onchange="javascript: showWarning();">
+        Yes, please reset MySQL data for all interfaces on this bill!
         </label>
-        <label class="checkbox">
-          <input disabled type="checkbox" name="confirm" value="rrd" onchange="javascript: showWarning();">
-          Yes, please reset RRD data for all interfaces on this bill!
+      </div>
+      <div class="checkbox">
+        <label>
+        <input disabled type="checkbox" name="confirm" value="rrd" onchange="javascript: showWarning();">
+        Yes, please reset RRD data for all interfaces on this bill!
         </label>
       </div>
     </div>
-    <div class="alert alert-message" id="warning" style="display: none;">
-      <h4 class="alert-heading"><i class="icon-warning-sign"></i> Warning!</h4>
-      Are you sure you want to reset all <strong>MySQL</strong> and/or <strong>RRD</strong> data for all interface on this bill?
-    </div>
-  </fieldset>
+  </div>
+  <br>
+  <div class="alert alert-danger" id="warning" style="display: none;">
+    <h4 class="alert-heading"><i class="fa fa-exclamation-triangle"></i> Warning</h4>
+    Are you sure you want to reset all <strong>MySQL</strong> and/or <strong>RRD</strong> data for all interface on this bill?
+  </div>
   <div class="form-actions">
     <button id="resetBtn" type="submit" class="btn btn-danger" disabled="disabled"><i class="icon-refresh icon-white"></i> <strong>Reset Bill</strong></button>
   </div>

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -33,7 +33,7 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
     }
 
     echo '<div class="panel panel-default">';
-        echo '<table style="margin: 0px 7px 7px 7px;" cellspacing="0" class="devicetable" width="99%">';
+        echo '<table class="device-header-table" style="margin: 0px 7px 7px 7px;" cellspacing="0" class="devicetable" width="99%">';
         require 'includes/device-header.inc.php';
     echo '</table>';
     echo '</div>';

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -112,21 +112,11 @@ else {
     $graph_array['width']  = $graph_width;
 
     if($_SESSION['screen_width']) {
-        if($_SESSION['screen_width'] > 800) {
-            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/10));
-        }
-        else {
-            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/4));
-        }
+        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
     }
 
     if($_SESSION['screen_height']) {
-        if($_SESSION['screen_height'] > 960 ) { 
-            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
-        }
-        else {
-            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/1.5));
-        }
+        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
     }
 
     echo("<hr />");

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -111,6 +111,14 @@ else {
     $graph_array['height'] = "300";
     $graph_array['width']  = $graph_width;
 
+    if($_SESSION['screen_width']) {
+        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
+    }
+
+    if($_SESSION['screen_height']) {
+        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+    }
+
     echo("<hr />");
 
     include_once 'includes/print-date-selector.inc.php';

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -85,7 +85,7 @@ else {
     $thumb_array = array('sixhour' => '6 Hours', 'day' => '24 Hours', 'twoday' => '48 Hours', 'week' => 'One Week', 'twoweek' => 'Two Weeks',
         'month' => 'One Month', 'twomonth' => 'Two Months','year' => 'One Year', 'twoyear' => 'Two Years');
 
-    echo('<table width=100%><tr>');
+     echo('<table width=100% class="thumbnail_graph_table"><tr>');
 
     foreach ($thumb_array as $period => $text) {
         $graph_array['from']   = $config['time'][$period];
@@ -112,11 +112,21 @@ else {
     $graph_array['width']  = $graph_width;
 
     if($_SESSION['screen_width']) {
-        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
+        if($_SESSION['screen_width'] > 800) {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/10));
+        }
+        else {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/4));
+        }
     }
 
     if($_SESSION['screen_height']) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        if($_SESSION['screen_height'] > 960 ) { 
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        }
+        else {
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/1.5));
+        }
     }
 
     echo("<hr />");

--- a/html/pages/graphs.inc.php
+++ b/html/pages/graphs.inc.php
@@ -112,11 +112,21 @@ else {
     $graph_array['width']  = $graph_width;
 
     if($_SESSION['screen_width']) {
-        $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/12));
+        if($_SESSION['screen_width'] > 800) {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/10));
+        }
+        else {
+            $graph_array['width'] = ($_SESSION['screen_width'] - ($_SESSION['screen_width']/4));
+        }
     }
 
     if($_SESSION['screen_height']) {
-        $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        if($_SESSION['screen_height'] > 960 ) { 
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/2));
+        }
+        else {
+            $graph_array['height'] = ($_SESSION['screen_height'] - ($_SESSION['screen_height']/1.5));
+        }
     }
 
     echo("<hr />");

--- a/html/pages/health/sensors.inc.php
+++ b/html/pages/health/sensors.inc.php
@@ -1,114 +1,32 @@
-<?php
+<div class="table-responsive">
+    <table id="sensors" class="table table-hover table-condensed storage">
+        <thead>
+            <tr>
+                <th data-column-id="hostname">Device</th>
+                <th data-column-id="sensor_descr">Sensor</th>
+                <th data-column-id="graph" data-sortable="false" data-searchable="false"></th>
+                <th data-column-id="alert" data-sortable="false" data-searchable="false"></th>
+                <th data-column-id="sensor_current">Current</th>
+                <th data-column-id="sensor_range" data-sortable="false" data-searchable="false">Range limit</th>
+            </tr>
+        </thead>
+    </table>
+</div>
 
-// FIXME - a little ugly...
-if ($_SESSION['userlevel'] >= '5') {
-    $sql   = "SELECT * FROM `sensors` AS S, `devices` AS D WHERE S.sensor_class='".$class."' AND S.device_id = D.device_id ORDER BY D.hostname, S.sensor_descr";
-    $param = array();
-}
-else {
-    $sql   = "SELECT * FROM `sensors` AS S, `devices` AS D, devices_perms as P WHERE S.sensor_class='".$class."' AND S.device_id = D.device_id AND D.device_id = P.device_id AND P.user_id = ? ORDER BY D.hostname, S.sensor_descr";
-    $param = array($_SESSION['user_id']);
-}
-echo '<div class="table-responsive">';
-echo '<table class="table table-condensed">';
-echo '<tr class="tablehead">
-        <th >Device</th>
-        <th>Sensor</th>
-        <th></th>
-        <th></th>
-        <th class="text-center">Current</th>
-        <th class="text-center">Range limit</th>
-        <th>Notes</th>
-      </tr>';
-
-foreach (dbFetchRows($sql, $param) as $sensor) {
-    if (empty($sensor['sensor_current'])) {
-        $sensor['sensor_current'] = 'NaN';
-    }
-    else {
-        if ($sensor['sensor_current'] >= $sensor['sensor_limit']) {
-            $alert = '<img src="images/16/flag_red.png" alt="alert" />';
-        }
-        else {
-            $alert = '';
-        }
-    }
-
-    // FIXME - make this "four graphs in popup" a function/include and "small graph" a function.
-    // FIXME - So now we need to clean this up and move it into a function. Isn't it just "print-graphrow"?
-    // FIXME - DUPLICATED IN device/overview/sensors
-    $graph_colour = str_replace('#', '', $row_colour);
-
-    $graph_array           = array();
-    $graph_array['height'] = '100';
-    $graph_array['width']  = '210';
-    $graph_array['to']     = $config['time']['now'];
-    $graph_array['id']     = $sensor['sensor_id'];
-    $graph_array['type']   = $graph_type;
-    $graph_array['from']   = $config['time']['day'];
-    $graph_array['legend'] = 'no';
-
-    $link_array         = $graph_array;
-    $link_array['page'] = 'graphs';
-    unset($link_array['height'], $link_array['width'], $link_array['legend']);
-    $link_graph = generate_url($link_array);
-
-    $link = generate_url(array('page' => 'device', 'device' => $sensor['device_id'], 'tab' => 'health', 'metric' => $sensor['sensor_class']));
-
-    $overlib_content = '<div style="width: 580px;"><h2>'.$device['hostname'].' - '.$sensor['sensor_descr'].'</h1>';
-    foreach (array('day', 'week', 'month', 'year') as $period) {
-        $graph_array['from'] = $config['time'][$period];
-        $overlib_content    .= str_replace('"', "\'", generate_graph_tag($graph_array));
-    }
-
-    $overlib_content .= '</div>';
-
-    $graph_array['width']  = 80;
-    $graph_array['height'] = 20;
-    $graph_array['bg']     = 'ffffff00';
-    // the 00 at the end makes the area transparent.
-    $graph_array['from'] = $config['time']['day'];
-    $sensor_minigraph =  generate_lazy_graph_tag($graph_array);
-
-    $sensor['sensor_descr'] = truncate($sensor['sensor_descr'], 48, '');
-
-    echo '<tr class="health">
-          <td class=list-bold>'.generate_device_link($sensor).'</td>
-          <td>'.overlib_link($link, $sensor['sensor_descr'], $overlib_content).'</td>
-          <td >'.overlib_link($link_graph, $sensor_minigraph, $overlib_content).'</td>
-          <td >'.$alert.'</td>
-          <td class="text-center"><strong>'.$sensor['sensor_current'].$unit.'</strong></td>
-          <td class="text-center">'.round($sensor['sensor_limit_low'], 2).$unit.' - '.round($sensor['sensor_limit'], 2).$unit.'</td>
-          <td>'.(isset($sensor['sensor_notes']) ? $sensor['sensor_notes'] : '').'</td>
-        </tr>
-     ';
-
-    if ($vars['view'] == 'graphs') {
-        echo "<tr></tr><tr class='health'><td colspan=7>";
-
-        $daily_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['day'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
-        $daily_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['day'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
-
-        $weekly_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['week'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
-        $weekly_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['week'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
-
-        $monthly_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['month'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
-        $monthly_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['month'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
-
-        $yearly_graph = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['year'].'&amp;to='.$config['time']['now'].'&amp;width=211&amp;height=100';
-        $yearly_url   = 'graph.php?id='.$sensor['sensor_id'].'&amp;type='.$graph_type.'&amp;from='.$config['time']['year'].'&amp;to='.$config['time']['now'].'&amp;width=400&amp;height=150';
-
-        echo "<a onmouseover=\"return overlib('<img src=\'$daily_url\'>', LEFT);\" onmouseout=\"return nd();\">
-        <img src='$daily_graph' border=0></a> ";
-        echo "<a onmouseover=\"return overlib('<img src=\'$weekly_url\'>', LEFT);\" onmouseout=\"return nd();\">
-        <img src='$weekly_graph' border=0></a> ";
-        echo "<a onmouseover=\"return overlib('<img src=\'$monthly_url\'>', LEFT);\" onmouseout=\"return nd();\">
-        <img src='$monthly_graph' border=0></a> ";
-        echo "<a onmouseover=\"return overlib('<img src=\'$yearly_url\'>', LEFT);\" onmouseout=\"return nd();\">
-        <img src='$yearly_graph' border=0></a>";
-        echo '</td></tr>';
-    } //end if
-}//end foreach
-
-echo '</table>';
-echo '</div>';
+<script>
+    var grid = $("#sensors").bootgrid({
+        ajax: true,
+        rowCount: [25,50,100,250,-1],
+        post: function ()
+        {
+            return {
+                id:         'sensors',
+                view:       '<?php echo $vars['view']; ?>',
+                graph_type: '<?php echo $graph_type; ?>',
+                unit:       '<?php echo $unit; ?>',
+                class:      '<?php echo $class; ?>',
+            };
+        },
+        url: "ajax_table.php"
+    });
+</script>

--- a/html/pages/notifications.inc.php
+++ b/html/pages/notifications.inc.php
@@ -103,7 +103,7 @@ $notifications = new ObjCache('notifications');
     <div class="row">
       <div class="col-md-12">
         <blockquote>
-          <p><?php echo $notif['body']; ?></p>
+          <p><?php echo preg_replace('/\\\n/','<br />', $notif['body']); ?></p>
           <footer>Source: <code><?php echo $notif['source']; ?></code></footer>
         </blockquote>
       </div>
@@ -133,7 +133,7 @@ $notifications = new ObjCache('notifications');
     <div class="row">
       <div class="col-md-12">
         <blockquote>
-          <p><?php echo $notif['body']; ?></p>
+          <p><?php echo preg_replace('/\\\n/','<br />', $notif['body']); ?></p>
           <footer>Source: <code><?php echo $notif['source']; ?></code></footer>
         </blockquote>
       </div>

--- a/html/pages/settings/alerting.inc.php
+++ b/html/pages/settings/alerting.inc.php
@@ -291,7 +291,7 @@ echo '
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#api_transport_expand">API transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="api" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#api_transport_expand"><i class="fa fa-caret-down"></i> API transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="api" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="api_transport_expand" class="panel-collapse collapse">
@@ -333,7 +333,7 @@ foreach ($api_urls as $api_url) {
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#pagerduty_transport_expand">Pagerduty transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="pagerduty" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#pagerduty_transport_expand"><i class="fa fa-caret-down"></i> Pagerduty transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="pagerduty" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="pagerduty_transport_expand" class="panel-collapse collapse">
@@ -358,7 +358,7 @@ else {
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#nagios_transport_expand">Nagios compatible transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="nagios" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#nagios_transport_expand"><i class="fa fa-caret-down"></i> Nagios compatible transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="nagios" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="nagios_transport_expand" class="panel-collapse collapse">
@@ -377,7 +377,7 @@ else {
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#irc_transport_expand">IRC transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="irc" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#irc_transport_expand"><i class="fa fa-caret-down"></i> IRC transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="irc" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="irc_transport_expand" class="panel-collapse collapse">
@@ -395,7 +395,7 @@ else {
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#slack_transport_expand">Slack transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="slack" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#slack_transport_expand"><i class="fa fa-caret-down"></i> Slack transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="slack" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="slack_transport_expand" class="panel-collapse collapse">
@@ -461,7 +461,7 @@ foreach ($slack_urls as $slack_url) {
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#hipchat_transport_expand">Hipchat transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="hipchat" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#hipchat_transport_expand"><i class="fa fa-caret-down"></i> Hipchat transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="hipchat" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="hipchat_transport_expand" class="panel-collapse collapse">
@@ -557,7 +557,7 @@ foreach ($hipchat_urls as $hipchat_url) {
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#pushover_transport_expand">Pushover transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="pushover" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#pushover_transport_expand"><i class="fa fa-caret-down"></i> Pushover transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="pushover" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="pushover_transport_expand" class="panel-collapse collapse">
@@ -638,7 +638,7 @@ echo '<div id="pushover_appkey_template" class="hide">
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#boxcar_transport_expand">Boxcar transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="boxcar" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#boxcar_transport_expand"><i class="fa fa-caret-down"></i> Boxcar transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="boxcar" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="boxcar_transport_expand" class="panel-collapse collapse">
@@ -704,7 +704,7 @@ echo '<div id="boxcar_appkey_template" class="hide">
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#pushbullet_transport_expand">Pushbullet</a> <button name="test-alert" id="test-alert" type="button" data-transport="pushbullet" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#pushbullet_transport_expand"><i class="fa fa-caret-down"></i> Pushbullet</a> <button name="test-alert" id="test-alert" type="button" data-transport="pushbullet" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="pushbullet_transport_expand" class="panel-collapse collapse">
@@ -723,7 +723,7 @@ echo '<div id="boxcar_appkey_template" class="hide">
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#victorops_transport_expand">VictorOps</a> <button name="test-alert" id="test-alert" type="button" data-transport="victorops" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#victorops_transport_expand"><i class="fa fa-caret-down"></i> VictorOps</a> <button name="test-alert" id="test-alert" type="button" data-transport="victorops" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="victorops_transport_expand" class="panel-collapse collapse">
@@ -752,7 +752,7 @@ echo '
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#clickatell_transport_expand">Clickatell transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="clickatell" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#clickatell_transport_expand"><i class="fa fa-caret-down"></i> Clickatell transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="clickatell" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="clickatell_transport_expand" class="panel-collapse collapse">
@@ -788,7 +788,7 @@ echo '
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#playsms_transport_expand">PlaySMS transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="playsms" class="btn btn-primary btn-xs pull-right">Test transport</button>
+                    <a data-toggle="collapse" data-parent="#accordion" href="#playsms_transport_expand"><i class="fa fa-caret-down"></i> PlaySMS transport</a> <button name="test-alert" id="test-alert" type="button" data-transport="playsms" class="btn btn-primary btn-xs pull-right">Test transport</button>
                 </h4>
             </div>
             <div id="playsms_transport_expand" class="panel-collapse collapse">

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -123,8 +123,11 @@ function ResolveGlues($tables,$target,$x=0,$hist=array(),$last=array()) {
             $glues = dbFetchRows('SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_NAME = ? && COLUMN_NAME LIKE "%\_id"',array($table));
             if( sizeof($glues) == 1 && $glues[0]['COLUMN_NAME'] != $target ) {
                 //Search for new candidates to expand
-                $tmp = dbFetchRows('SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE "'.substr($table,0,-1).'_%" && TABLE_NAME != "'.$table.'"');
                 $ntables = array();
+                list($tmp) = explode('_',$glues[0]['COLUMN_NAME'],2);
+                $ntables[] = $tmp;
+                $ntables[] = $tmp.'s';
+                $tmp = dbFetchRows('SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME LIKE "'.substr($table,0,-1).'_%" && TABLE_NAME != "'.$table.'"');
                 foreach( $tmp as $expand ) {
                     $ntables[] = $expand['TABLE_NAME'];
                 }

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -59,35 +59,28 @@ function GenSQL($rule) {
     $join = "";
     while( $i < $x ) {
         if( isset($tables[$i+1]) ) {
-            if( dbFetchCell('SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_NAME = ? && COLUMN_NAME = ?',array($tables[$i+1],'device_id')) == 1 ) {
-                //Found valid glue in definition.
-                $join .= $tables[$i].".device_id = ".$tables[$i+1].".device_id && ";
+            $gtmp = ResolveGlues(array($tables[$i+1]),'device_id');
+            if( $gtmp === false ) {
+                //Cannot resolve glue-chain. Rule is invalid.
+                return false;
             }
-            else {
-                //No valid glue, Resolve a glue-chain.
-                $gtmp = ResolveGlues(array($tables[$i+1]),'device_id');
-                if( $gtmp === false ) {
-                    //Cannot resolve glue-chain. Rule is invalid.
-                    return false;
+            $last = "";
+            $qry = "";
+            foreach( $gtmp as $glue ) {
+                if( empty($last) ) {
+                    list($tmp,$last) = explode('.',$glue);
+                    $qry .= $glue.' = ';
                 }
-                $last = "";
-                $qry = "";
-                foreach( $gtmp as $glue ) {
-                    if( empty($last) ) {
-                        list($tmp,$last) = explode('.',$glue);
-                        $qry .= $glue.' = ';
-                    }
-                    else {
-                        list($tmp,$new) = explode('.',$glue);
-                        $qry .= $tmp.'.'.$last.' && '.$tmp.'.'.$new.' = ';
-                        $last = $new;
-                    }
-                    if( !in_array($tmp, $tables) ) {
-                        $tables[] = $tmp;
-                    }
+                else {
+                    list($tmp,$new) = explode('.',$glue);
+                    $qry .= $tmp.'.'.$last.' && '.$tmp.'.'.$new.' = ';
+                    $last = $new;
                 }
-                $join .= "( ".$qry.$tables[0].".device_id ) && ";
+                if( !in_array($tmp, $tables) ) {
+                    $tables[] = $tmp;
+                }
             }
+            $join .= "( ".$qry.$tables[0].".device_id ) && ";
         }
         $i++;
     }

--- a/includes/common.php
+++ b/includes/common.php
@@ -802,7 +802,7 @@ function ceph_rrd($gtype) {
  * @return array Containing the lat and lng coords
 **/
 function parse_location($location) {
-    preg_match('/(\[)([0-9\. ]+),[ ]*([0-9\. ]+)(\])/', $location, $tmp_loc);
+    preg_match('/(\[)(-?[0-9\. ]+),[ ]*(-?[0-9\. ]+)(\])/', $location, $tmp_loc);
     if (!empty($tmp_loc[2]) && !empty($tmp_loc[3])) {
         return array('lat' => $tmp_loc[2], 'lng' => $tmp_loc[3]);
     }

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -830,3 +830,6 @@ $config['availability-map-width']                       = 25;
 
 // Default notifications Feed
 $config['notifications']['LibreNMS']                    = 'http://www.librenms.org/notifications.rss';
+
+// Update channel (Can be 'master' or 'release')
+$config['update_channel']                               = 'master';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -141,7 +141,7 @@ $config['os'][$os]['over'][1]['graph'] = 'device_processor';
 
 $os = 'airos-af';
 $config['os'][$os]['text']             = 'Ubiquiti AirFiber';
-$config['os'][$os]['type']             = 'network';
+$config['os'][$os]['type']             = 'wireless';
 $config['os'][$os]['icon']             = 'ubiquiti';
 $config['os'][$os]['nobulk']           = 1;
 $config['os'][$os]['over'][0]['graph'] = 'device_bits';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1248,6 +1248,8 @@ $os = 'canopy';
 $config['os'][$os]['text'] = 'Cambium';
 $config['os'][$os]['type'] = 'wireless';
 $config['os'][$os]['icon'] = 'cambium';
+$config['os'][$os]['over'][0]['graph'] = 'device_bits';
+$config['os'][$os]['over'][0]['text']  = 'Device Traffic';
 
 $os = 'datacom';
 $config['os'][$os]['text'] = 'Datacom';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -141,7 +141,7 @@ $config['os'][$os]['over'][1]['graph'] = 'device_processor';
 
 $os = 'airos-af';
 $config['os'][$os]['text']             = 'Ubiquiti AirFiber';
-$config['os'][$os]['type']             = 'wireless';
+$config['os'][$os]['type']             = 'network';
 $config['os'][$os]['icon']             = 'ubiquiti';
 $config['os'][$os]['nobulk']           = 1;
 $config['os'][$os]['over'][0]['graph'] = 'device_bits';

--- a/includes/discovery/mempools/vrp.inc.php
+++ b/includes/discovery/mempools/vrp.inc.php
@@ -3,9 +3,9 @@
 // Huawei VRP  mempools
 if ($device['os'] == 'vrp') {
     echo 'VRP : ';
-    $mempools_array = snmpwalk_cache_multi_oid($device, 'hwEntityMemUsage', $mempools_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['install_dir'].'/mibs');
-    $mempools_array = snmpwalk_cache_multi_oid($device, 'hwEntityMemSize', $mempools_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['install_dir'].'/mibs');
-    $mempools_array = snmpwalk_cache_multi_oid($device, 'hwEntityBomEnDesc', $mempools_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['install_dir'].'/mibs');
+    $mempools_array = snmpwalk_cache_multi_oid($device, 'hwEntityMemUsage', $mempools_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
+    $mempools_array = snmpwalk_cache_multi_oid($device, 'hwEntityMemSize', $mempools_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
+    $mempools_array = snmpwalk_cache_multi_oid($device, 'hwEntityBomEnDesc', $mempools_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
     d_echo($mempools_array);
 
     if (is_array($mempools_array)) {

--- a/includes/discovery/os/netonix.inc.php
+++ b/includes/discovery/os/netonix.inc.php
@@ -1,7 +1,6 @@
 <?php
-
-$version = snmp_get($device, 'firmwareVersion.0', '-Osqnv', 'NETONIX-SWITCH-MIB', 'mibs:mibs/netonix/');
-list(,$version) = explode(': ', $version);
-if (is_numeric($version)) {
-    $os = 'netonix';
+if (!$os) {
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.46242')) {
+        $os = 'netonix';
+    }
 }

--- a/includes/discovery/processors/vrp.inc.php
+++ b/includes/discovery/processors/vrp.inc.php
@@ -3,9 +3,9 @@
 // Huawei VRP Processors
 if ($device['os'] == 'vrp') {
     echo 'Huawei VRP ';
-    $processors_array = snmpwalk_cache_multi_oid($device, 'hwEntityCpuUsage', $processors_array, 'HUAWEI-ENTITY-EXTENT-MIB', '+'.$config['install_dir'].'/mibs');
-    $processors_array = snmpwalk_cache_multi_oid($device, 'hwEntityMemSize', $processors_array, 'HUAWEI-ENTITY-EXTENT-MIB', '+'.$config['install_dir'].'/mibs');
-    $processors_array = snmpwalk_cache_multi_oid($device, 'hwEntityBomEnDesc', $processors_array, 'HUAWEI-ENTITY-EXTENT-MIB', '+'.$config['install_dir'].'/mibs');
+    $processors_array = snmpwalk_cache_multi_oid($device, 'hwEntityCpuUsage', $processors_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
+    $processors_array = snmpwalk_cache_multi_oid($device, 'hwEntityMemSize', $processors_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
+    $processors_array = snmpwalk_cache_multi_oid($device, 'hwEntityBomEnDesc', $processors_array, 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
     d_echo($processors_array);
 
     if (is_array($processors_array)) {

--- a/includes/polling/applications/proxmox.inc.php
+++ b/includes/polling/applications/proxmox.inc.php
@@ -68,7 +68,9 @@ if (count($pmxlines) > 0) {
                 DS:OUTOCTETS:DERIVE:600:0:12500000000 '.$config['rrd_rra']);
         }
 
-        rrdtool_update($rrd_filename, 'N:'.$vmpin.':'.$vmpout);
+        rrdtool_update($rrd_filename, array("INOCTETS" => $vmpin, "OUTOCTETS" => $vmpout));
+        print "Proxmox ($pmxcluster): $vmdesc: $vmpin/$vmpout/$vmport\n";
+
         if (proxmox_vm_exists($vmid, $pmxcluster, $pmxcache) === true) {
             dbUpdate(array('device_id' => $device['device_id'], 'last_seen' => array('NOW()'), 'description' => $vmdesc), 'proxmox', '`vmid` = ? AND `cluster` = ?', array($vmid, $pmxcluster));
         }
@@ -84,10 +86,11 @@ if (count($pmxlines) > 0) {
         }
 
     }
-
-    unset($pmxlines);
-    unset($pmxcluster);
-    unset($pmxcdir);
-    unset($proxmox);
-    unset($pmxcache);
 }
+
+
+unset($pmxlines);
+unset($pmxcluster);
+unset($pmxcdir);
+unset($proxmox);
+unset($pmxcache);

--- a/includes/polling/mempools/vrp.inc.php
+++ b/includes/polling/mempools/vrp.inc.php
@@ -8,8 +8,8 @@ if (!is_array($mempool_cache['vrp'])) {
     d_echo('caching');
 
     $mempool_cache['vrp'] = array();
-    $mempool_cache['vrp'] = snmpwalk_cache_multi_oid($device, 'hwEntityMemSize', $mempool_cache['vrp'], 'HUAWEI-ENTITY-EXTENT-MIB', $config['install_dir'].'/mibs');
-    $mempool_cache['vrp'] = snmpwalk_cache_multi_oid($device, 'hwEntityMemUsage', $mempool_cache['vrp'], 'HUAWEI-ENTITY-EXTENT-MIB', $config['install_dir'].'/mibs');
+    $mempool_cache['vrp'] = snmpwalk_cache_multi_oid($device, 'hwEntityMemSize', $mempool_cache['vrp'], 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
+    $mempool_cache['vrp'] = snmpwalk_cache_multi_oid($device, 'hwEntityMemUsage', $mempool_cache['vrp'], 'HUAWEI-ENTITY-EXTENT-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/huawei');
     d_echo($mempool_cache);
 }
 

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -262,6 +262,30 @@ foreach ($ports as $port) {
             $this_port['ifOutOctets'] = $this_port['ifHCOutOctets'];
         }
 
+        if ($device['os'] === 'airos-af' && $port['ifAlias'] === 'eth0') {
+            $airos_stats = snmpwalk_cache_oid($device, '.1.3.6.1.4.1.41112.1.3.3.1', $airos_stats, 'UBNT-AirFIBER-MIB');
+            $this_port['ifInOctets'] = $airos_stats[1]['rxOctetsOK'];
+            $this_port['ifOutOctets'] = $airos_stats[1]['txOctetsOK'];
+            $this_port['ifInErrors'] = $airos_stats[1]['rxErroredFrames'];
+            $this_port['ifOutErrors'] = $airos_stats[1]['txErroredFrames'];
+            $this_port['ifInBroadcastPkts'] = $airos_stats[1]['rxValidBroadcastFrames'];
+            $this_port['ifOutBroadcastPkts'] = $airos_stats[1]['txValidBroadcastFrames'];
+            $this_port['ifInMulticastPkts'] = $airos_stats[1]['rxValidMulticastFrames'];
+            $this_port['ifOutMulticastPkts'] = $airos_stats[1]['txValidMulticastFrames'];
+            $this_port['ifInUcastPkts'] = $airos_stats[1]['rxValidUnicastFrames'];
+            $this_port['ifOutUcastPkts'] = $airos_stats[1]['txValidUnicastFrames'];
+            $ports['update']['ifInOctets'] = $airos_stats[1]['rxOctetsOK'];
+            $ports['update']['ifOutOctets'] = $airos_stats[1]['txOctetsOK'];
+            $ports['update']['ifInErrors'] = $airos_stats[1]['rxErroredFrames'];
+            $ports['update']['ifOutErrors'] = $airos_stats[1]['txErroredFrames'];
+            $ports['update']['ifInBroadcastPkts'] = $airos_stats[1]['rxValidBroadcastFrames'];
+            $ports['update']['ifOutBroadcastPkts'] = $airos_stats[1]['txValidBroadcastFrames'];
+            $ports['update']['ifInMulticastPkts'] = $airos_stats[1]['rxValidMulticastFrames'];
+            $ports['update']['ifOutMulticastPkts'] = $airos_stats[1]['txValidMulticastFrames'];
+            $ports['update']['ifInUcastPkts'] = $airos_stats[1]['rxValidUnicastFrames'];
+            $ports['update']['ifOutUcastPkts'] = $airos_stats[1]['txValidUnicastFrames'];
+        }
+
         // rewrite the ifPhysAddress
         if (strpos($this_port['ifPhysAddress'], ':')) {
             list($a_a, $a_b, $a_c, $a_d, $a_e, $a_f) = explode(':', $this_port['ifPhysAddress']);

--- a/mibs/CISCO-BRIDGE-DOMAIN-MIB
+++ b/mibs/CISCO-BRIDGE-DOMAIN-MIB
@@ -1,0 +1,450 @@
+-- *****************************************************************
+-- CISCO-BRIDGE-DOMAIN-MIB.my : Cisco Bridge Domain MIB
+--   
+-- Oct 2007, Madhavi Dokku
+--   
+-- Copyright (c) 2007 by Cisco Systems, Inc.
+--   
+-- All rights reserved.
+-- *****************************************************************
+
+CISCO-BRIDGE-DOMAIN-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE,
+    Unsigned32
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP
+        FROM SNMPv2-CONF
+    TEXTUAL-CONVENTION,
+    TruthValue,
+    RowStatus,
+    StorageType
+        FROM SNMPv2-TC
+    ifIndex
+        FROM IF-MIB
+    ciscoMgmt
+        FROM CISCO-SMI;
+
+
+ciscoBridgeDomainMIB MODULE-IDENTITY
+    LAST-UPDATED    "200712290000Z"
+    ORGANIZATION    "Cisco Systems, Inc."
+    CONTACT-INFO
+            "Cisco Systems
+            Customer Service
+
+            Postal: 170 W Tasman Drive
+            San Jose, CA  95134
+            USA
+            Tel: +1 800 553-NETS
+
+            E-mail: cs-ethermibs@cisco.com"
+    DESCRIPTION
+        "A bridge domain is one of the means by which it is possible
+        to define a broadcast domain on a bridging device. It is an 
+            alternative to 802.1D bridge-groups and to 802.1Q VLAN 
+        bridging.
+
+        Bridge domain is the service specification, and specifies the 
+        broadcast domain number on which this frame of this particular
+        service instance must be made available on. The physical and 
+        virtual interfaces that can comprise a bridge domain are 
+        heterogeneous in nature comprising Ethernet service instances,
+        WAN Virtual Circuit for ATM or Frame Relay and VFIs. However,
+        the frame encapsulations for all interface types are
+        essentially Ethernet. 
+
+        Without bridge-domains, VLANs would have to be globally unique
+        per device and one would only be restricted to the theoretical  
+             maximum of 4095 VLANs for single tagged traffic. However
+        with        the introduction of bridge-domains, one can
+        associate a service        instance with a bridge-domain and all
+        service instances in the        same bridge-domain form a
+        broadcast domain. Bridge-domain ID        determines the
+        broadcast domain and the VLAN id is merely used        to match
+        and map traffic. With bridge domain feature configured       
+        VLAN IDs would be unique per interface only and not globally.   
+            Thus bridge domains make VLAN ids have only local
+        significance        per port
+
+
+        Differences between Bridge Domains and 802.1AD Bridges:
+        =======================================================
+        1. Scope of the VLAN technology which uses 802.1 AD is global to
+        the box.
+        But in case of Bridge domain, the scope of vlan is local to
+        interface
+
+        2. Switchport 802.1AD restricts the number of broadcast domain  
+            on a box to 4095.
+        However, with Bridge domains, we can have up to 16k broadcast   
+               domain.
+
+        3. Under a single Bridge domain service instance, there can be  
+                flexible service mapping criterion.(i.e match based on
+        outer vlan, outer cos, inner vlan, inner cos and payload
+        ethertype).
+        Whereas in case of switch port 802.1AD/dot1q this is not
+        supported.
+
+        Similarities between Bridge Domains and 802.1AD Bridges:
+        =======================================================
+
+        1. Both use the same MAC address lookup for forwarding.
+
+        2. Both work with protocols like STP, DTP etc.
+
+        3. Both of them classify 'ports' in a system into Bridges/Bridge
+                  Domains.
+
+        Ethernet service instance is the instantiation of an Ethernet 
+        virtual circuit on a given port on a given router. In other 
+        words, an Ethernet service instance is an object that holds 
+        information about the layer 2 service that is being offered
+        on a given port of a given router as part of a given Ethernet
+        virtual circuit. Bridge domains feature is currently supported
+        on ethernet service instances only and can be later extented
+        to other interfaces like ATM and Frame Relay.
+
+        This MIB helps the network management personnel to find out the 
+        details of various broadcast domains configured in the network.
+
+        Definition of terms and acronyms:
+
+        ATM: Asynchronous Transfer mode
+
+        BD: Bridge Domain
+
+        C-mac: Customer MAC
+
+        EVC: Ethernet Virtual Circuit
+
+        FR: Frame Relay
+
+        SH: Split Horizon
+
+        VFI: Virtual Forwarding Instance 
+
+        VLAN: Virtual Local Area Network
+
+        WAN: Wide Area Network"
+    REVISION        "200712290000Z"
+    DESCRIPTION
+        "Modified the MIB description with details on similarities and
+        differences between Bridge Domains and 802.1AD Bridges."
+    REVISION        "200712040000Z"
+    DESCRIPTION
+        "Initial version of this MIB module."
+    ::= { ciscoMgmt 642 }
+
+
+ciscoBdMIBNotifications  OBJECT IDENTIFIER
+    ::= { ciscoBridgeDomainMIB 0 }
+
+ciscoBdMIBObjects  OBJECT IDENTIFIER
+    ::= { ciscoBridgeDomainMIB 1 }
+
+ciscoBdMIBConformance  OBJECT IDENTIFIER
+    ::= { ciscoBridgeDomainMIB 2 }
+
+cbdSystemInfo  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBObjects 1 }
+
+cbdMemberInfo  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBObjects 2 }
+
+
+-- Textual Conventions
+
+CbdType ::= TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "Defines the different types of bridge domain members:
+
+        'other': none of the following
+
+            'ether': Ethernet Service Instance
+
+        'atmVc': ATM Virtual connection
+
+        'frVc': Frame Relay Virtual Connection"
+    SYNTAX          INTEGER  {
+                        other(1),
+                        ether(2),
+                        atmVc(3),
+                        frVc(4)
+                    }
+
+cbdMembersConfigured OBJECT-TYPE
+    SYNTAX          Unsigned32
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the number of bridge domain
+        members configured on this bridge domain." 
+    ::= { cbdSystemInfo 1 }
+-- Member Info Table
+
+cbdMemberInfoTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CbdMemberInfoEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table provides the bridge domain member attributes
+        of the members currently configured for each bridge
+        domain."
+    ::= { cbdMemberInfo 1 }
+
+cbdMemberInfoEntry OBJECT-TYPE
+    SYNTAX          CbdMemberInfoEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "A conceptual row in cbdMemberInfoTable. This is indexed
+        by ifIndex and cbdSIIndex. Each row is created when a bridge
+        domain member is configured under a service instance."
+    INDEX           {
+                        ifIndex,
+                        cbdSIIndex
+                    } 
+    ::= { cbdMemberInfoTable 1 }
+
+CbdMemberInfoEntry ::= SEQUENCE {
+        cbdSIIndex               Unsigned32,
+        cbdMemberType            CbdType,
+        cbdMemberOperState       INTEGER ,
+        cbdMemberAdminState      INTEGER ,
+        cbdMemberSplitHorizon    TruthValue,
+        cbdMemberSplitHorizonNum Unsigned32,
+        cbdMemberStorageType     StorageType,
+        cbdMemberStatus          RowStatus,
+        cbdMembercMac            TruthValue
+}
+
+cbdSIIndex OBJECT-TYPE
+    SYNTAX          Unsigned32 (1..4294967295 )
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This object indicates an arbitary index that uniquely
+        identifies the Service Instance to which this bridge domain
+        member belongs to." 
+    ::= { cbdMemberInfoEntry 1 }
+
+cbdMemberType OBJECT-TYPE
+    SYNTAX          CbdType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object identifies the type of the bridge domain member
+        like ATM VC, Frame Relay VC, or Ethernet service."
+    DEFVAL          { other } 
+    ::= { cbdMemberInfoEntry 2 }
+
+cbdMemberOperState OBJECT-TYPE
+    SYNTAX          INTEGER  {
+                        unknown(1),
+                        up(2),
+                        down(3)
+                    }
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the operational state of the bridge
+        domain Member. Operational state of the Bridge domain member
+        is same as the operational state of the underlying service
+        instance. Bridge domain members are configured under service
+        instances and multiple service instances can be attached to a  
+        single physical interface defining various kinds of services.
+        Bridge domain members have many to one relationship with
+        interface
+        Indexes. When ifOperStatus of the underlying interface is down,
+        the state of cbdMemberOperState should be down. When
+        ifOperStatus
+        of the underlying interface is up, cbdMemberOperState can be
+        either up or down based on the state of underlying service
+        instance.
+
+        'unknown': the bridge domain member is an unknown state.
+
+        'up': the bridge domain member is fully operational and 
+        able to bridge the traffic. This means that both the  
+        physical interface and the underlying service instance
+        are administratively up. 
+
+        'down': the Bridge Domain member is down and not
+        capable of bridging. This state means either the underlying 
+        service instance is down or the interface is down." 
+    ::= { cbdMemberInfoEntry 3 }
+
+cbdMemberAdminState OBJECT-TYPE
+    SYNTAX          INTEGER  {
+                        unknown(1),
+                        up(2),
+                        down(3)
+                    }
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the administrative state of the
+        bridge domain Member.  Admin state of the Bridge domain member
+        is same as the admin state of the underlying service instance.
+        Bridge domain members are configured under service instances 
+        and multiple service instances can be attached to a single
+        physical interface defining various kinds of services. Bridge
+        Domain members have many to one relationship with interface
+        Indexes. When ifAdminStatus of the unerlying interface is down
+        the state of cbdMemberAdminState should be down. When ifOperStatus
+        of the underlying interface is up cbdMemberAdminState can be 
+        either up or down based on the state of underlying service
+        instance.
+
+        'unknown': the bridge domain member is in unknown 
+        administrative state.
+
+        'up': the Bridge Domain member is administratively up. This 
+        means that both the physical interface and the underlying service
+        instance are administratively up. 
+
+        'admindown': the Bridge Domain member is down as it is 
+        administratively configured to be down and is not 
+        capable of bridging. This means that either the underlying 
+        service instance is configured as administratively down or
+        the physical interface is configured as administratively
+        down." 
+    ::= { cbdMemberInfoEntry 4 }
+
+cbdMemberSplitHorizon OBJECT-TYPE
+    SYNTAX          TruthValue
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates whether split horizon is
+        configured on this bridge domain member." 
+    ::= { cbdMemberInfoEntry 5 }
+
+cbdMemberSplitHorizonNum OBJECT-TYPE
+    SYNTAX          Unsigned32 (0..65535 )
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the split horizon number if
+        configured on the bridge domain member. Split horizon
+        is used to avoid sending traffic between interfaces. 
+        Frames are not forwarded to the members belonging to the
+        same split horizon group."
+    DEFVAL          { 0 } 
+    ::= { cbdMemberInfoEntry 6 }
+
+cbdMemberStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the storage type of this conceptual
+        row.  This object can only have a value 'nonVolatile'.  Other 
+        values are not applicable for this conceptual row and are 
+        not supported."
+    DEFVAL          { nonVolatile } 
+    ::= { cbdMemberInfoEntry 7 }
+
+cbdMemberStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object enables the SNMP agent to create, modify,
+        and delete rows in the cbdMemberInfoTable."
+    DEFVAL          { active } 
+    ::= { cbdMemberInfoEntry 8 }
+
+cbdMembercMac OBJECT-TYPE
+    SYNTAX          TruthValue
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object indicates if cmac is configured on this
+        bridge domain member. Cmac denotes if this bridge domain is
+        configured as a customer domain." 
+    ::= { cbdMemberInfoEntry 9 }
+ 
+
+-- Notifications
+
+ciscoBdNotificationPrefix  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBNotifications 0 }
+
+-- Conformance
+
+ciscoBdMIBCompliances  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBConformance 1 }
+
+ciscoBdMIBGroups  OBJECT IDENTIFIER
+    ::= { ciscoBdMIBConformance 2 }
+
+
+ciscoBdMIBComplianceRev1 MODULE-COMPLIANCE
+    STATUS          current
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-BRIDGE-DOMAIN-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cbdSystemInfoGroup,
+                        cbdMemberInfoGroup
+                    }
+    ::= { ciscoBdMIBCompliances 1 }
+
+-- Units of Conformance
+
+cbdSystemInfoGroup OBJECT-GROUP
+    OBJECTS         { cbdMembersConfigured }
+    STATUS          current
+    DESCRIPTION
+        "This group contain information about bridge domain."
+    ::= { ciscoBdMIBGroups 1 }
+
+cbdMemberInfoGroup OBJECT-GROUP
+    OBJECTS         {
+                        cbdMemberType,
+                        cbdMemberOperState,
+                        cbdMemberAdminState,
+                        cbdMemberSplitHorizon,
+                        cbdMemberSplitHorizonNum,
+                        cbdMemberStorageType,
+                        cbdMemberStatus,
+                        cbdMembercMac
+                    }
+    STATUS          current
+    DESCRIPTION
+        "This group contain information related to bridge domain
+        members."
+    ::= { ciscoBdMIBGroups 2 }
+
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/mibs/CISCO-CONTEXT-MAPPING-MIB
+++ b/mibs/CISCO-CONTEXT-MAPPING-MIB
@@ -1,0 +1,853 @@
+-- *****************************************************************
+-- CISCO-CONTEXT-MAPPING-MIB.my:  Cisco Context Mapping MIB
+--   
+-- January 2005, Chinna Pellacuru.
+--   
+-- May 2008, Sheethal Gunjal.
+--   
+-- Copyright (c) 2004-2005, 2008 by cisco Systems Inc.
+-- All rights reserved.
+--   
+-- ****************************************************************
+
+CISCO-CONTEXT-MAPPING-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB
+    RowStatus,
+    StorageType
+        FROM SNMPv2-TC
+    CiscoBridgeDomain
+        FROM CISCO-TC
+    ciscoMgmt
+        FROM CISCO-SMI;
+
+
+ciscoContextMappingMIB MODULE-IDENTITY
+    LAST-UPDATED    "200811220000Z"
+    ORGANIZATION    "Cisco Systems, Inc."
+    CONTACT-INFO
+            "Cisco Systems
+            Customer Service
+
+            Postal: 170 W Tasman Drive
+            San Jose, CA  95134
+            USA
+
+            Tel: +1 800 553-NETS
+
+            E-mail: cs-snmp@cisco.com"
+    DESCRIPTION
+        "A single SNMP agent sometimes needs to support multiple
+        instances of the same MIB module, and does so through the
+        use of multiple SNMP contexts.  This typically occurs because
+        the technology has evolved to have extra dimension(s), i.e.,
+        one or more extra data and/or identifier values which are
+        different in the different contexts, but were not defined in
+        INDEX clause(s) of the original MIB module.  In such cases,
+        network management applications need to know the specific
+        data/identifier values in each context, and this MIB module
+        provides mapping tables which contain that information.
+
+        Within a network there can be multiple Virtual Private
+        Networks (VPNs) configured using Virtual Routing and
+        Forwarding Instances (VRFs). Within a VPN there can be
+        multiple topologies when Multi-topology Routing (MTR) is
+        used. Also, Interior Gateway Protocols (IGPs) can have
+        multiple protocol instances running on the device.
+        A network can have multiple broadcast domains configured
+        using Bridge Domain Identifiers.
+
+        With MTR routing, VRFs, and Bridge domains, a router now 
+        needs to support multiple instances of several existing 
+        MIB modules, and this can be achieved if the router's SNMP 
+        agent provides access to each instance of the same MIB module 
+        via a different SNMP context (see Section 3.1.1 of RFC 3411).
+        For MTR routing, VRFs, and Bridge domains, a different SNMP 
+        context is needed depending on one or more of the following: 
+        the VRF, the topology-identifier, the routing protocol instance,
+        and the bridge domain identifier.
+        In other words, the router's management information can be
+        accessed through multiple SNMP contexts where each such
+        context represents a specific VRF, a specific
+        topology-identifier, a specific routing protocol instance 
+        and/or a bridge domain identifier. This MIB module provides 
+        a mapping of each such SNMP context to the corresponding VRF,
+        the corresponding topology, the corresponding routing protocol 
+        instance, and the corresponding bridge domain identifier.
+        Some SNMP contexts are independent of VRFs, independent of
+        a topology, independent of a routing protocol instance, or 
+        independent of a bridge domain and in such a case, the mapping
+        is to the zero length string.
+
+        With the Cisco package licensing strategy, the features 
+        available in the image are grouped into multiple packages 
+        and each packages can be managed to operate at different 
+        feature levels based on the available license. This MIB 
+        module provides option to associate an SNMP context to a 
+        feature package group. This will allow manageability of 
+        license MIB objects specific to a feature package group.
+
+        As technology evolves more we may need additional
+        identifiers to identify the context. Then we would need
+        to add those additional identifiers into the mapping."
+    REVISION        "200811220000Z"
+    DESCRIPTION
+        "Added New Table cContextMappingLicenseGroupTable
+        to provide SNMP Context support for license package groups.
+
+        Added cContextMappingLicenseGroupDataGroup in OBJECT-GROUP
+        Added cContextMappingMIBComplianceRev2 in MODULE-COMPLIANCE
+
+        Updated the MIB description to indicate the use of
+        the above additions"
+    REVISION        "200805300000Z"
+    DESCRIPTION
+        "Add cContextMappingBridgeInstanceTable.
+
+        Added cContextMappingBridgeInstanceDataGroup.
+        Deprecated cContextMappingMIBComplianceRev1 and added
+        cContextMappingMIBComplianceRev2 compliance statement."
+    REVISION        "200802010000Z"
+    DESCRIPTION
+        "Added New Table cContextMappingBridgeDomainTable
+        to provide SNMP context support to the Bridge Domain.
+
+        Added cContextMappingBridgeDomainDataGroup in OBJECT-GROUP
+        Added cContextMappingMIBComplianceRev1 in MODULE-COMPLIANCE"
+    REVISION        "200503170000Z"
+    DESCRIPTION
+        "Initial version of the MIB module."
+    ::= { ciscoMgmt 468 }
+
+
+cContextMappingMIBObjects  OBJECT IDENTIFIER
+    ::= { ciscoContextMappingMIB 1 }
+
+cContextMappingMIBConformance  OBJECT IDENTIFIER
+    ::= { ciscoContextMappingMIB 2 }
+
+
+cContextMappingTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on which
+        cContextMappingVacmContextName is mapped to
+        which VRF, topology, and routing protocol instance.
+
+        This table is indexed by SNMP VACM context.
+
+        Configuring a row in this table for an SNMP context
+        does not require that the context be already defined,
+        i.e., a row can be created in this table for a context
+        before the corresponding row is created in RFC 3415's
+        vacmContextTable.
+
+        To create a row in this table, a manager must set
+        cContextMappingRowStatus to either 'createAndGo' or
+        'createAndWait'.
+
+        To delete a row in this table, a manager must set
+        cContextMappingRowStatus to 'destroy'."
+    ::= { cContextMappingMIBObjects 1 }
+
+cContextMappingEntry OBJECT-TYPE
+    SYNTAX          CContextMappingEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        cContextMappingVacmContextName to the corresponding VRF,
+        the corresponding topology, and the corresponding routing
+        protocol instance."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingTable 1 }
+
+CContextMappingEntry ::= SEQUENCE {
+        cContextMappingVacmContextName SnmpAdminString,
+        cContextMappingVrfName         SnmpAdminString,
+        cContextMappingTopologyName    SnmpAdminString,
+        cContextMappingProtoInstName   SnmpAdminString,
+        cContextMappingStorageType     StorageType,
+        cContextMappingRowStatus       RowStatus
+}
+
+cContextMappingVacmContextName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "The vacmContextName given to the SNMP context.
+
+        This is a human readable name identifying a particular
+        SNMP VACM context at a particular SNMP entity.
+        The empty contextName (zero length) represents the
+        default context." 
+    ::= { cContextMappingEntry 1 }
+
+cContextMappingVrfName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the VRF to which the SNMP context
+        is mapped to.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this VRF.
+
+        When the value of this object is the zero length
+        string it indicates that the SNMP context is independent
+        of any VRF."
+    DEFVAL          { ''H } 
+    ::= { cContextMappingEntry 2 }
+
+cContextMappingTopologyName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the topology to which the SNMP
+        context is mapped to.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this topology.
+
+        When the value of this object is the zero length
+        string it indicates that the SNMP context is independent
+        of any topology."
+    DEFVAL          { ''H } 
+    ::= { cContextMappingEntry 3 }
+
+cContextMappingProtoInstName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the protocol instance to which the
+        SNMP context is mapped to.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this protocol instance.
+
+        When the value of this object is the zero length
+        string it indicates that the SNMP context is independent
+        of any protocol instance."
+    DEFVAL          { ''H } 
+    ::= { cContextMappingEntry 4 }
+
+cContextMappingStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingEntry 5 }
+
+cContextMappingRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingEntry 6 }
+ 
+
+
+cContextMappingBridgeDomainTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingBridgeDomainEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on which
+        cContextMappingVacmContextName is mapped to
+        which bridge domain.
+
+        A Bridge Domain is one of the means by which it is possible 
+        to define an Ethernet broadcast domain on a bridging device. 
+        A network can have multiple broadcast domains configured.
+        This table helps the network management personnel to find 
+        out the  details of various broadcast domains configured 
+        in the network.
+
+        An entry need to exist in cContextMappingTable, to create 
+        an entry in this table."
+    ::= { cContextMappingMIBObjects 2 }
+
+cContextMappingBridgeDomainEntry OBJECT-TYPE
+    SYNTAX          CContextMappingBridgeDomainEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        cContextMappingVacmContextName to the 
+        corresponding bridge domain.
+
+        To create a row in this table, a manager must set
+        cContextMappingBridgeDomainRowStatus to either 
+        'createAndGo' or 'createAndWait'.
+
+        To delete a row in this table, a manager must set
+        cContextMappingBridgeDomainRowStatus to 'destroy'."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingBridgeDomainTable 1 }
+
+CContextMappingBridgeDomainEntry ::= SEQUENCE {
+        cContextMappingBridgeDomainIdentifier  CiscoBridgeDomain,
+        cContextMappingBridgeDomainStorageType StorageType,
+        cContextMappingBridgeDomainRowStatus   RowStatus
+}
+
+cContextMappingBridgeDomainIdentifier OBJECT-TYPE
+    SYNTAX          CiscoBridgeDomain
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the bridge domain to which the SNMP context is 
+        mapped to."
+    REFERENCE       "CISCO-BRIDGE-DOMAIN-MIB" 
+    ::= { cContextMappingBridgeDomainEntry 1 }
+
+cContextMappingBridgeDomainStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingBridgeDomainEntry 2 }
+
+cContextMappingBridgeDomainRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingBridgeDomainEntry 3 }
+ 
+
+
+cContextMappingBridgeInstanceTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingBridgeInstanceEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on mapping between
+        cContextMappingVacmContextName and bridge instance.
+
+        Bridge instance is an instance of a physical or logical 
+        bridge which has unique bridge-id.
+
+        If an entry is deleted from cContextMappingTable, the
+        corresponding entry in this table will also get deleted.
+
+        If an entry needs to be created in this table, the
+        corresponding entry must exist in cContextMappingTable."
+    REFERENCE       "BRIDGE-MIB"
+    ::= { cContextMappingMIBObjects 3 }
+
+cContextMappingBridgeInstanceEntry OBJECT-TYPE
+    SYNTAX          CContextMappingBridgeInstanceEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        cContextMappingVacmContextName to the 
+        corresponding bridge instance.
+
+        To create a row in this table, a manager must set
+        cContextMappingBridgeInstRowStatus to either 
+        'createAndGo' or 'createAndWait'.
+
+        To delete a row in this table, a manager must set
+        cContextMappingBridgeInstRowStatus to 'destroy'."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingBridgeInstanceTable 1 }
+
+CContextMappingBridgeInstanceEntry ::= SEQUENCE {
+        cContextMappingBridgeInstName        SnmpAdminString,
+        cContextMappingBridgeInstStorageType StorageType,
+        cContextMappingBridgeInstRowStatus   RowStatus
+}
+
+cContextMappingBridgeInstName OBJECT-TYPE
+    SYNTAX          SnmpAdminString
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The object identifies the name given to bridge
+        instance to which the SNMP context is mapped to.
+
+        Value of this object cannot be changed when the 
+        RowStatus object in the same row is 'active'.
+
+        This is typically a human-readable string. This is
+        the same ASCII string used in the router's console
+        interface to refer to this bridge instance.
+
+        When the value of this object is a zero length
+        string, it indicates that the SNMP context is
+        independent of any bridge instances." 
+    ::= { cContextMappingBridgeInstanceEntry 1 }
+
+cContextMappingBridgeInstStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Value of this object cannot be changed when the 
+        RowStatus object in the same row is 'active'.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingBridgeInstanceEntry 2 }
+
+cContextMappingBridgeInstRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingBridgeInstanceEntry 3 }
+ 
+
+
+cContextMappingLicenseGroupTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CContextMappingLicenseGroupEntry 
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table contains information on which
+        cContextMappingVacmContextName is mapped to
+        which License Group.
+        Group level licensing is used where each
+        Technology Package is enabled via a License."
+    ::= { cContextMappingMIBObjects 4 }
+
+cContextMappingLicenseGroupEntry OBJECT-TYPE
+    SYNTAX          CContextMappingLicenseGroupEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "Information relating to a single mapping of
+        CContextMappingVacmContextName to the
+        corresponding License Group."
+    INDEX           { cContextMappingVacmContextName } 
+    ::= { cContextMappingLicenseGroupTable 1 }
+
+CContextMappingLicenseGroupEntry ::= SEQUENCE {
+        cContextMappingLicenseGroupName        SnmpAdminString,
+        cContextMappingLicenseGroupStorageType StorageType,
+        cContextMappingLicenseGroupRowStatus   RowStatus
+}
+
+cContextMappingLicenseGroupName OBJECT-TYPE
+    SYNTAX          SnmpAdminString (SIZE  (0..32))
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The value of an instance of this object identifies
+        the name given to the Group to which the SNMP context
+        is mapped.
+
+        Feature sets from all groups will be combined to form 
+        universal image. User can configure multiple groups as needed.
+
+        For example: In Next generation ISRs will use
+        the universal image package level licensing model
+        for its licensing need. Each group has
+        the feature set needed for that specific technology.
+        Feature sets from different groups are combined to 
+        form universal image and each feature set for a group 
+        can be enabled using a valid license key. There will 
+        be a base level ipbase package in which the router 
+        boots with out any license key.
+
+        The following are the different Technology Groups.
+        1.crypto
+        2.data
+        3.ip
+        4.legacy
+        5.novpn-security
+        6.security
+        7.uc" 
+    ::= { cContextMappingLicenseGroupEntry 1 }
+
+cContextMappingLicenseGroupStorageType OBJECT-TYPE
+    SYNTAX          StorageType
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "The storage type for this conceptual row.
+
+        Conceptual rows having the value 'permanent' need not
+        allow write-access to any columnar objects in the row."
+    DEFVAL          { nonVolatile } 
+    ::= { cContextMappingLicenseGroupEntry 2 }
+
+cContextMappingLicenseGroupRowStatus OBJECT-TYPE
+    SYNTAX          RowStatus
+    MAX-ACCESS      read-create
+    STATUS          current
+    DESCRIPTION
+        "This object facilitates the creation, modification, or
+        deletion of a conceptual row in this table." 
+    ::= { cContextMappingLicenseGroupEntry 3 }
+ 
+
+-- Conformance
+
+cContextMappingMIBCompliances  OBJECT IDENTIFIER
+    ::= { cContextMappingMIBConformance 1 }
+
+cContextMappingMIBGroups  OBJECT IDENTIFIER
+    ::= { cContextMappingMIBConformance 2 }
+
+
+-- Compliance
+
+cContextMappingMIBCompliance MODULE-COMPLIANCE
+    STATUS          deprecated
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS { cContextMappingDataGroup }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+    ::= { cContextMappingMIBCompliances 1 }
+
+cContextMappingMIBComplianceRev1 MODULE-COMPLIANCE
+    STATUS          deprecated
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB. This compliance statement 
+        is superceded by cContextMappingMIBComplianceRev2."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cContextMappingDataGroup,
+                        cContextMappingBridgeDomainDataGroup
+                    }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+
+    OBJECT          cContextMappingBridgeDomainIdentifier
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+    ::= { cContextMappingMIBCompliances 2 }
+
+cContextMappingMIBComplianceRev2 MODULE-COMPLIANCE
+    STATUS          deprecated
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cContextMappingDataGroup,
+                        cContextMappingBridgeDomainDataGroup,
+                        cContextMappingBridgeInstanceDataGroup
+                    }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+
+    OBJECT          cContextMappingBridgeDomainIdentifier
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeDomainTable is not required."
+
+    OBJECT          cContextMappingBridgeInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeInstanceTable is not required."
+    ::= { cContextMappingMIBCompliances 3 }
+
+cContextMappingMIBComplianceRev3 MODULE-COMPLIANCE
+    STATUS          current
+    DESCRIPTION
+        "The compliance statement for entities which implement
+        the CISCO-CONTEXT-MAPPING-MIB."
+    MODULE          -- this module
+    MANDATORY-GROUPS {
+                        cContextMappingDataGroup,
+                        cContextMappingBridgeDomainDataGroup,
+                        cContextMappingBridgeInstanceDataGroup,
+                        cContextMappingLicenseGroupDataGroup
+                    }
+
+    OBJECT          cContextMappingVrfName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingTopologyName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingProtoInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+
+    OBJECT          cContextMappingBridgeDomainIdentifier
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeDomainRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeDomainTable is not required."
+
+    OBJECT          cContextMappingBridgeInstName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingBridgeInstRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingBridgeInstanceTable is not required."
+
+    OBJECT          cContextMappingLicenseGroupName
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingLicenseGroupStorageType
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT          cContextMappingLicenseGroupRowStatus
+    MIN-ACCESS      read-only
+    DESCRIPTION
+        "Create/delete/modify access to the
+        cContextMappingTable is not required."
+    ::= { cContextMappingMIBCompliances 4 }
+
+-- Units of Conformance
+
+cContextMappingDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingVrfName,
+                        cContextMappingTopologyName,
+                        cContextMappingProtoInstName,
+                        cContextMappingStorageType,
+                        cContextMappingRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding VRF, the corresponding topology,
+        and the corresponding routing protocol instance."
+    ::= { cContextMappingMIBGroups 1 }
+
+cContextMappingBridgeDomainDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingBridgeDomainIdentifier,
+                        cContextMappingBridgeDomainStorageType,
+                        cContextMappingBridgeDomainRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding bridge domain."
+    ::= { cContextMappingMIBGroups 2 }
+
+cContextMappingBridgeInstanceDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingBridgeInstName,
+                        cContextMappingBridgeInstStorageType,
+                        cContextMappingBridgeInstRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding bridge instance."
+    ::= { cContextMappingMIBGroups 3 }
+
+cContextMappingLicenseGroupDataGroup OBJECT-GROUP
+    OBJECTS         {
+                        cContextMappingLicenseGroupName,
+                        cContextMappingLicenseGroupStorageType,
+                        cContextMappingLicenseGroupStorageType,
+                        cContextMappingLicenseGroupRowStatus
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects providing the context
+        mapping data between the SNMP context to the
+        corresponding LicenseGroupName."
+    ::= { cContextMappingMIBGroups 4 }
+
+END
+
+
+
+
+
+
+
+

--- a/mibs/FORTINET-CORE-MIB.mib
+++ b/mibs/FORTINET-CORE-MIB.mib
@@ -29,7 +29,7 @@ IMPORTS
         FROM SNMPv2-TC;
 
 fortinet MODULE-IDENTITY
-    LAST-UPDATED "200905200000Z"
+    LAST-UPDATED "201404100000Z"
     ORGANIZATION 
         "Fortinet Technologies, Inc."
     CONTACT-INFO 
@@ -37,7 +37,28 @@ fortinet MODULE-IDENTITY
          email: support@fortinet.com
          http://www.fortinet.com
         "
-    DESCRIPTION 
+    DESCRIPTION
+        "Registered FortiVoiceMib OID"
+    REVISION    "201404100000Z"
+    DESCRIPTION
+        "Registered FortiADCMib OID"
+    REVISION    "201403220000Z"
+    DESCRIPTION
+        "Added fan failure and AMC bypass traps"
+    REVISION    "201205090000Z"
+    DESCRIPTION
+        "Registered FortiDDoSMib OID"
+    REVISION    "201204230000Z"
+    DESCRIPTION
+        "Registered FortiDNSMib OID"
+    REVISION    "201112230000Z"
+    DESCRIPTION
+        "Registered FortiCacheMib OID"
+    REVISION    "201104250000Z"
+    DESCRIPTION
+        "Supporting portuguese language"
+    REVISION    "201005140000Z"
+    DESCRIPTION
         "Registered FortiScanMib OID"
     REVISION    "200905200000Z"
     DESCRIPTION 
@@ -85,6 +106,7 @@ FnLanguage ::= TEXTUAL-CONVENTION
         spanish (5),
         traditionalChinese (6),
         french (7),
+        portuguese (8),
         undefined (255)
     }
 
@@ -137,6 +159,11 @@ fnCoreMib OBJECT IDENTIFIER ::= { fortinet 100 }
 -- fnFortiSwitchMib   OBJECT IDENTIFIER ::= { fortinet 106 }
 -- fnFortiWebMib      OBJECT IDENTIFIER ::= { fortinet 107 }
 -- fnFortiScanMib     OBJECT IDENTIFIER ::= { fortinet 108 }
+-- fnFortiCacheMib    OBJECT IDENTIFIER ::= { fortinet 109 }
+-- fnFortiDNSMib      OBJECT IDENTIFIER ::= { fortinet 110 }
+-- fnFortiDDoSMib     OBJECT IDENTIFIER ::= { fortinet 111 }
+-- fnFortiADCMib      OBJECT IDENTIFIER ::= { fortinet 112 }
+-- fnFortiVoiceMib    OBJECT IDENTIFIER ::= { fortinet 113 }
 --
 
 --
@@ -315,6 +342,22 @@ fnTrapPowerSupplyFailure NOTIFICATION-TYPE
         for specifications."
     ::= { fnTrapsPrefix 106 }
 
+fnTrapAmcIfBypassMode NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName }
+    STATUS      current
+    DESCRIPTION 
+        "An AMC interface entered bypass mode. Available on models with an AMC
+        expansion slot. Used with the ASM-CX4 and ASM-FX2 cards."
+    ::= { fnTrapsPrefix 107 }
+
+fnTrapFanFailure NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName }
+    STATUS      current
+    DESCRIPTION 
+        "A fan failure has been detected. Not all devices have fan sensors.
+        See manual for specifications."
+    ::= { fnTrapsPrefix 108 }
+
 fnTrapIpChange NOTIFICATION-TYPE
     OBJECTS     { fnSysSerial, sysName, ifIndex }
     STATUS      current
@@ -360,6 +403,7 @@ fnTrapsComplianceGroup NOTIFICATION-GROUP
     NOTIFICATIONS { fnTrapCpuThreshold, fnTrapMemThreshold, 
                   fnTrapLogDiskThreshold, fnTrapTempHigh, 
                   fnTrapVoltageOutOfRange, fnTrapPowerSupplyFailure, 
+                  fnTrapAmcIfBypassMode, fnTrapFanFailure,
                   fnTrapIpChange, fnTrapTest }
     STATUS      current
     DESCRIPTION 

--- a/mibs/FORTINET-FORTIGATE-MIB.mib
+++ b/mibs/FORTINET-FORTIGATE-MIB.mib
@@ -13,7 +13,7 @@ FORTINET-FORTIGATE-MIB DEFINITIONS ::= BEGIN
 IMPORTS
     FnBoolState, FnIndex, fnAdminEntry, fnSysSerial, fortinet
         FROM FORTINET-CORE-MIB
-    ifEntry, ifName
+    ifEntry, ifName, ifIndex
         FROM IF-MIB
     InetAddress, InetAddressPrefixLength, InetAddressType, InetPortNumber
         FROM INET-ADDRESS-MIB
@@ -24,13 +24,15 @@ IMPORTS
     Counter32, Counter64, Gauge32, Unsigned32, Integer32, IpAddress,
     MODULE-IDENTITY, NOTIFICATION-TYPE, OBJECT-TYPE, TimeTicks, OBJECT-IDENTITY
         FROM SNMPv2-SMI
+    Ipv6Address
+        FROM IPV6-TC
     CounterBasedGauge64
         FROM HCNUM-TC
-    DisplayString, TEXTUAL-CONVENTION, AutonomousType, DateAndTime
+    DisplayString, TEXTUAL-CONVENTION, AutonomousType, DateAndTime, PhysAddress
         FROM SNMPv2-TC;
 
 fnFortiGateMib MODULE-IDENTITY
-    LAST-UPDATED "201211290000Z"
+    LAST-UPDATED "201504230000Z"
     ORGANIZATION 
         "Fortinet Technologies, Inc."
     CONTACT-INFO 
@@ -39,7 +41,31 @@ fnFortiGateMib MODULE-IDENTITY
          email: support@fortinet.com
          http://www.fortinet.com"
     DESCRIPTION 
-	 "Added fgVpnTrapPhase1Name OID in VPN traps"
+        "Added fgProcessorFnNP6 in fgProcessorTypes."
+    REVISION    "201504230000Z"
+    DESCRIPTION 
+	 "Modify name of enumerations for LTE Modem"
+    REVISION    "201407140000Z"
+    DESCRIPTION 
+	 "Added fgUsbModemInfoObjects OIDs for LTE Modem"
+    REVISION    "201406040000Z"
+    DESCRIPTION 
+	 "Added fgUsbports OIDs for external USB ports"
+    REVISION    "201402130000Z"
+    DESCRIPTION 
+	 "Added fgIntfVrrps OIDs for VRRP"
+    REVISION    "201308120000Z"
+    DESCRIPTION 
+	 "Added fgServerLoadBalance OIDs."
+    REVISION    "201307260000Z"
+    DESCRIPTION 
+	 "Added fgTrapIpsFailOpen OID in fgTraps"
+    REVISION    "201304120000Z"
+    DESCRIPTION 
+        "Added fgWc wireless controller OIDs"
+    REVISION    "201304060000Z"
+    DESCRIPTION 
+        "Added fgVpnTrapPhase1Name OID in VPN traps"
     REVISION    "201211290000Z"
     DESCRIPTION 
         "Added OID for 64-bit sysUpTime"
@@ -175,7 +201,157 @@ FgHaStatsSyncStatusType ::= TEXTUAL-CONVENTION
     STATUS      current
     DESCRIPTION 
         "Current HA Sync status types"
-    SYNTAX      INTEGER { Not-Synchronized(0), Synchronized(1) }
+    SYNTAX      INTEGER { unsynchronized(0), synchronized(1) }
+
+FgWcWlanSecurityType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "enumerated type for WLAN security methods"
+    SYNTAX      INTEGER {
+                  other(0),
+                  open(1),
+                  captivePortal(2),
+                  wep64(3),
+                  wep128(4),
+                  wpaOnlyPersonal(5),
+                  wpaOnlyEnterprise(6),
+                  wpa2OnlyPersonal(7),
+                  wpa2OnlyEnterprise(8),
+                  wpaPersonal(9),
+                  wpaEnterprise(10),
+                  wpaOnlyPersonalCaptivePortal(11),
+                  wpa2OnlyPersonalCaptivePortal(12),
+                  wpaPersonalCaptivePortal(13) }
+
+FgWcWlanAuthenticationType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "enumerated type for WLAN authentication methods"
+    SYNTAX      INTEGER {
+                  other(0),
+                  psk(1),
+                  radiusServer(2),
+                  userGroup(3) }
+
+FgWcWlanEncryptionType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "enumerated type for WLAN encryption methods"
+    SYNTAX      INTEGER {
+                  other(0),
+                  none(1),
+                  tkip(2),
+                  aes(3),
+                  tkipAes(4) }
+
+FgWcWtpRadioId ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "unique identifier of a radio on a WTP"
+    SYNTAX      Unsigned32 (1..31)
+
+FgWcWtpRadioType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "Enumerated types for WTP radio.
+         The following enumerated values are supported:
+           other(0)             - radio type is unknown
+           dot11a(1)            - 802.11a radio
+           dot11b(2)            - 802.11b radio
+           dot11g(3)            - 802.11g/b radio
+           dot11n5g(4)          - 802.11n/a radio at 5GHz band
+           dot11n2g(5)          - 802.11n/g/b radio at 2.4GHz band
+           dot11ac(6)           - 802.11ac/n/a radio
+           dot11ngOnly(7)       - 802.11n/g radio at 2.4GHz band
+           dot11gOnly(8)        - 802.11g radio
+           dot11n2GHzOnly(9)    - 802.11n radio at 2.4GHz band
+           dot11n5GHzOnly(10)   - 802.11n radio at 5GHz band
+           dot11acnOnly(11)     - 802.11ac/n radio
+           dot11acOnly(12)      - 802.11ac radio"
+    SYNTAX      INTEGER {
+                  other(0),
+                  dot11a(1),
+                  dot11b(2),
+                  dot11g(3),
+                  dot11n5g(4),
+                  dot11n2g(5),
+                  dot11ac(6),
+                  dot11ngOnly(7),
+                  dot11gOnly(8),
+                  dot11n2GHzOnly(9),
+                  dot11n5GHzOnly(10),
+                  dot11acnOnly(11),
+                  dot11acOnly(12) }
+
+FgWcWtpChannelWidthType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "enumerated type for WTP radio channel width"
+    SYNTAX      INTEGER {
+                  other(0),
+                  width20MHz(1),
+                  width40MHz(2),
+                  width80MHz(3) }
+
+FgWcWtpRadioBandType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "enumerated type for WTP radio band"
+    SYNTAX      INTEGER {
+                  other(0),
+                  band2GHz(1),
+                  band5GHz(2) }
+
+FgWcWtpRadioChannelNumber ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS      current
+    DESCRIPTION
+        "channel number of a WTP radio"
+    SYNTAX      Integer32 (0..200)
+
+FgWcWtpRadioMode ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION
+        "Represents the operating mode of the WTP radio.
+         The following enumerated values are supported:
+           other(0)        - The radio mode is unknown.
+           notExist(1)     - The radio does not physically exist.
+           disabled(2)     - The radio is administratively disabled.
+           ap(3)           - The radio is configured as an access point.
+           monitor(4)      - The radio is configured as a dedicated rogue AP scanner.
+           sniffer(5)      - The radio is configured as a wireless sniffer."
+    SYNTAX      INTEGER {
+                  other(0),
+                  notExist(1),
+                  disabled(2),
+                  ap(3),
+                  monitor(4),
+                  sniffer(5) }
+
+FgWcCountryString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "3a"
+    STATUS      current
+    DESCRIPTION
+        "This attribute identifies the country or non-country
+         entity in which the station is operating. If it is a
+         country, the first two octets of this
+         string is the two character country code as described
+         in document ISO/IEC 3166-1. The third octet shall
+         be one of the following:
+         1. an ASCII space character, if the regulations under
+         which the station is operating encompass all
+         environments in the country,
+         2. an ASCII 'O' character, if the regulations under
+         which the station is operating are for an Outdoor
+         environment only, or
+         3. an ASCII 'I' character, if the regulations under
+         which the station is operating are for an Indoor
+         environment only.
+         4. an ASCII 'X' character, if the station is operating
+         under a non-country entity. The first two octets of the
+         non-country entity shall be two ASCII 'XX' characters."
+    SYNTAX      OCTET STRING (SIZE(3))
 
 --
 -- fortinet.fnFortiGateMib.fgModel
@@ -186,23 +362,36 @@ fgModel OBJECT IDENTIFIER ::= { fnFortiGateMib 1 }
 -- fgModel start
 
 fg20CA           OBJECT IDENTIFIER ::= { fgModel 214 }
+fg60dc           OBJECT IDENTIFIER ::= { fgModel 641 }
+fgr60D           OBJECT IDENTIFIER ::= { fgModel 643 }
 fgt100           OBJECT IDENTIFIER ::= { fgModel 1000 }
 fgt1000          OBJECT IDENTIFIER ::= { fgModel 10000 }
 fgt1000A         OBJECT IDENTIFIER ::= { fgModel 10001 }
 fgt1000AFA2      OBJECT IDENTIFIER ::= { fgModel 10002 }
 fgt1000ALENC     OBJECT IDENTIFIER ::= { fgModel 10003 }
 fgt1000C         OBJECT IDENTIFIER ::= { fgModel 10004 }
+fgt1000D         OBJECT IDENTIFIER ::= { fgModel 10005 }
 fgt100A          OBJECT IDENTIFIER ::= { fgModel 1001 }
 fgt100D          OBJECT IDENTIFIER ::= { fgModel 1004 }
 fgt110C          OBJECT IDENTIFIER ::= { fgModel 1002 }
 fgt111C          OBJECT IDENTIFIER ::= { fgModel 1003 }
+fgt1200D         OBJECT IDENTIFIER ::= { fgModel 12000 }
 fgt1240B         OBJECT IDENTIFIER ::= { fgModel 12400 }
+fgt140D          OBJECT IDENTIFIER ::= { fgModel 1401 }
+fgt140P          OBJECT IDENTIFIER ::= { fgModel 1402 }
+fgt140T          OBJECT IDENTIFIER ::= { fgModel 1403 }
+fgt1500D         OBJECT IDENTIFIER ::= { fgModel 15000 }
 fgt200           OBJECT IDENTIFIER ::= { fgModel 2000 }
 fgt200A          OBJECT IDENTIFIER ::= { fgModel 2001 }
 fgt200B          OBJECT IDENTIFIER ::= { fgModel 2003 }
 fgt200BPOE       OBJECT IDENTIFIER ::= { fgModel 2004 }
+fgt200D          OBJECT IDENTIFIER ::= { fgModel 2005 }
+fgt200DP         OBJECT IDENTIFIER ::= { fgModel 2007 }
 fgt20C           OBJECT IDENTIFIER ::= { fgModel 212 }
 fgt224B          OBJECT IDENTIFIER ::= { fgModel 2002 }
+fgt240D          OBJECT IDENTIFIER ::= { fgModel 2006 }
+fgt240DP         OBJECT IDENTIFIER ::= { fgModel 2008 }
+fgt280D          OBJECT IDENTIFIER ::= { fgModel 2013 }
 fgt300           OBJECT IDENTIFIER ::= { fgModel 3000 }
 fgt3000          OBJECT IDENTIFIER ::= { fgModel 30000 }
 fgt300A          OBJECT IDENTIFIER ::= { fgModel 3001 }
@@ -211,15 +400,22 @@ fgt300D          OBJECT IDENTIFIER ::= { fgModel 3003 }
 fgt3016B         OBJECT IDENTIFIER ::= { fgModel 30160 }
 fgt3040B         OBJECT IDENTIFIER ::= { fgModel 30400 }
 fgt30B           OBJECT IDENTIFIER ::= { fgModel 302 }
+fgt30D           OBJECT IDENTIFIER ::= { fgModel 304 }
+fgt30DPOE        OBJECT IDENTIFIER ::= { fgModel 305 }
 fgt310B          OBJECT IDENTIFIER ::= { fgModel 3002 }
 fgt311B          OBJECT IDENTIFIER ::= { fgModel 3004 }
 fgt3140B         OBJECT IDENTIFIER ::= { fgModel 30401 }
 fgt3240C         OBJECT IDENTIFIER ::= { fgModel 32401 }
 fgt3600          OBJECT IDENTIFIER ::= { fgModel 36000 }
 fgt3600A         OBJECT IDENTIFIER ::= { fgModel 36003 }
+fgt3600C         OBJECT IDENTIFIER ::= { fgModel 36004 }
+fgt3700D         OBJECT IDENTIFIER ::= { fgModel 37000 }
+fgt3700DX        OBJECT IDENTIFIER ::= { fgModel 37000 }
 fgt3810A         OBJECT IDENTIFIER ::= { fgModel 38100 }
+fgt3810D         OBJECT IDENTIFIER ::= { fgModel 38100 }
 fgt3950B         OBJECT IDENTIFIER ::= { fgModel 39500 }
 fgt3951B         OBJECT IDENTIFIER ::= { fgModel 39501 }
+fgt3HD           OBJECT IDENTIFIER ::= { fgModel 3006 }
 fgt400           OBJECT IDENTIFIER ::= { fgModel 4000 }
 fgt400A          OBJECT IDENTIFIER ::= { fgModel 4001 }
 fgt40C           OBJECT IDENTIFIER ::= { fgModel 410 }
@@ -228,10 +424,12 @@ fgt5001          OBJECT IDENTIFIER ::= { fgModel 50010 }
 fgt5001A         OBJECT IDENTIFIER ::= { fgModel 50011 }
 fgt5001B         OBJECT IDENTIFIER ::= { fgModel 50013 }
 fgt5001C         OBJECT IDENTIFIER ::= { fgModel 50014 }
+fgt5001D         OBJECT IDENTIFIER ::= { fgModel 50015 }
 fgt5001FA2       OBJECT IDENTIFIER ::= { fgModel 50012 }
 fgt5002FB2       OBJECT IDENTIFIER ::= { fgModel 50001 }
 fgt5005FA2       OBJECT IDENTIFIER ::= { fgModel 50051 }
 fgt500A          OBJECT IDENTIFIER ::= { fgModel 5001 }
+fgt500D          OBJECT IDENTIFIER ::= { fgModel 5004 }
 fgt50A           OBJECT IDENTIFIER ::= { fgModel 500 }
 fgt50B           OBJECT IDENTIFIER ::= { fgModel 502 }
 fgt5101C         OBJECT IDENTIFIER ::= { fgModel 51010 }
@@ -243,30 +441,43 @@ fgt60ADSL        OBJECT IDENTIFIER ::= { fgModel 602 }
 fgt60B           OBJECT IDENTIFIER ::= { fgModel 603 }
 fgt60C           OBJECT IDENTIFIER ::= { fgModel 615 }
 fgt60CP          OBJECT IDENTIFIER ::= { fgModel 621 }
+fgt60CSFP        OBJECT IDENTIFIER ::= { fgModel 622 }
+fgt60D           OBJECT IDENTIFIER ::= { fgModel 624 }
+fgt60DPOE        OBJECT IDENTIFIER ::= { fgModel 625 }
 fgt60M           OBJECT IDENTIFIER ::= { fgModel 601 }
 fgt620B          OBJECT IDENTIFIER ::= { fgModel 6200 }
 fgt621B          OBJECT IDENTIFIER ::= { fgModel 6210 }
+fgt70D           OBJECT IDENTIFIER ::= { fgModel 700 }
 fgt800           OBJECT IDENTIFIER ::= { fgModel 8000 }
 fgt800C          OBJECT IDENTIFIER ::= { fgModel 8003 }
 fgt800F          OBJECT IDENTIFIER ::= { fgModel 8001 }
 fgt80C           OBJECT IDENTIFIER ::= { fgModel 800 }
 fgt80CM          OBJECT IDENTIFIER ::= { fgModel 801 }
+fgt80D           OBJECT IDENTIFIER ::= { fgModel 803 }
 fgt82C           OBJECT IDENTIFIER ::= { fgModel 802 }
+fgt90D           OBJECT IDENTIFIER ::= { fgModel 630 }
+fgt90DPOE        OBJECT IDENTIFIER ::= { fgModel 631 }
+fgt92D           OBJECT IDENTIFIER ::= { fgModel 636 }
+fgt94DPOE        OBJECT IDENTIFIER ::= { fgModel 634 }
+fgt98DPOE        OBJECT IDENTIFIER ::= { fgModel 635 }
 fgtONE           OBJECT IDENTIFIER ::= { fgModel 10 }
 fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
-fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
-fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
-fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
-fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
 fgtVM64          OBJECT IDENTIFIER ::= { fgModel 30 }
-fgtVM64          OBJECT IDENTIFIER ::= { fgModel 30 }
+fgtVM64HV        OBJECT IDENTIFIER ::= { fgModel 70 }
+fgtVM64KVm       OBJECT IDENTIFIER ::= { fgModel 60 }
+fgtVM64XEN       OBJECT IDENTIFIER ::= { fgModel 40 }
+fr100C           OBJECT IDENTIFIER ::= { fgModel 1005 }
 fsw5203B         OBJECT IDENTIFIER ::= { fgModel 50023 }
 fw20CA           OBJECT IDENTIFIER ::= { fgModel 213 }
 fw60CA           OBJECT IDENTIFIER ::= { fgModel 618 }
 fw60CM           OBJECT IDENTIFIER ::= { fgModel 617 }
+fw60DP           OBJECT IDENTIFIER ::= { fgModel 627 }
+fw60dc           OBJECT IDENTIFIER ::= { fgModel 642 }
 fw6XMB           OBJECT IDENTIFIER ::= { fgModel 619 }
 fwf20C           OBJECT IDENTIFIER ::= { fgModel 210 }
 fwf30B           OBJECT IDENTIFIER ::= { fgModel 310 }
+fwf30D           OBJECT IDENTIFIER ::= { fgModel 314 }
+fwf30DPOE        OBJECT IDENTIFIER ::= { fgModel 315 }
 fwf40C           OBJECT IDENTIFIER ::= { fgModel 411 }
 fwf50B           OBJECT IDENTIFIER ::= { fgModel 510 }
 fwf60            OBJECT IDENTIFIER ::= { fgModel 610 }
@@ -274,8 +485,12 @@ fwf60A           OBJECT IDENTIFIER ::= { fgModel 611 }
 fwf60AM          OBJECT IDENTIFIER ::= { fgModel 612 }
 fwf60B           OBJECT IDENTIFIER ::= { fgModel 613 }
 fwf60C           OBJECT IDENTIFIER ::= { fgModel 616 }
+fwf60D           OBJECT IDENTIFIER ::= { fgModel 626 }
 fwf80CM          OBJECT IDENTIFIER ::= { fgModel 810 }
 fwf81CM          OBJECT IDENTIFIER ::= { fgModel 811 }
+fwf90D           OBJECT IDENTIFIER ::= { fgModel 632 }
+fwf90DPOE        OBJECT IDENTIFIER ::= { fgModel 633 }
+fwf92D           OBJECT IDENTIFIER ::= { fgModel 637 }
 
 -- fgModel end
 
@@ -360,7 +575,11 @@ FgVdEntry ::= SEQUENCE {
     fgVdEntIndex    FgVdIndex,
     fgVdEntName     DisplayString,
     fgVdEntOpMode   FgOpMode,
-    fgVdEntHaState  FgHaState
+    fgVdEntHaState  FgHaState,
+    fgVdEntCpuUsage Gauge32,
+    fgVdEntMemUsage Gauge32,
+    fgVdEntSesCount Gauge32,
+    fgVdEntSesRate  Gauge32
 }
 
 fgVdEntIndex OBJECT-TYPE
@@ -395,6 +614,39 @@ fgVdEntHaState OBJECT-TYPE
         "HA cluster member state of the virtual domain on this device
          (master, backup or standalone)"
     ::= { fgVdEntry 4 }
+
+fgVdEntCpuUsage OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "CPU usage of the virtual domain (percentage)."
+    ::= { fgVdEntry 5 }
+
+fgVdEntMemUsage OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Memory usage of the virtual domain (percentage)."
+    ::= { fgVdEntry 6 }
+
+fgVdEntSesCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Number of active sessions on the virtual domain."
+    ::= { fgVdEntry 7 }
+
+fgVdEntSesRate OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "Sessions Per Second"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The session setup rate on the virtual domain."
+    ::= { fgVdEntry 8 }
 
 --
 -- fortinet.fnFortiGateMib.fgVirtualDomain.fgVdTables.fgVdTpTable
@@ -921,6 +1173,12 @@ fgProcessorFnNP4 OBJECT-IDENTITY
         "The processor type identifier used for Fortinet NP4 security processor."
     ::= { fgProcessorTypes 7 }
 
+fgProcessorFnNP6 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor type identifier used for Fortinet NP6 security processor."
+    ::= { fgProcessorTypes 8 }
+
 --
 -- fortinet.fnFortiGateMib.fgSystem.fgProcessorModules
 --
@@ -1041,7 +1299,7 @@ fgProcessorModuleCount OBJECT-TYPE
     ::= { fgProcessorModules 2 }
 
 fgProcessorModuleTable OBJECT-TYPE
-    SYNTAX      SEQUENCE OF FgProcModEntry
+    SYNTAX      SEQUENCE OF FgProcessorModuleEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION 
@@ -1049,7 +1307,7 @@ fgProcessorModuleTable OBJECT-TYPE
     ::= { fgProcessorModules 3 }
 
 fgProcessorModuleEntry OBJECT-TYPE
-    SYNTAX      FgProcModEntry
+    SYNTAX      FgProcessorModuleEntry
     MAX-ACCESS  not-accessible
     STATUS      current
     DESCRIPTION 
@@ -1058,7 +1316,7 @@ fgProcessorModuleEntry OBJECT-TYPE
     ::= { fgProcessorModuleTable 1 }
 
 
-FgProcModEntry ::= SEQUENCE {
+FgProcessorModuleEntry ::= SEQUENCE {
     fgProcModIndex          FnIndex,
     fgProcModType           AutonomousType,
     fgProcModName           DisplayString,
@@ -1303,6 +1561,134 @@ fgSIAdvSesNoListenerCount OBJECT-TYPE
     ::= { fgSysInfoAdvSessions 7 }
 
 --
+-- fortinet.fnFortiGateMib.fgSystem.fgUsbports
+--
+
+fgUsbports OBJECT IDENTIFIER
+    ::= { fgSystem 7 }
+
+fgUsbportCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of entries in fgUsbportTable."
+    ::= { fgUsbports 1 }
+
+fgUsbportTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgUsbportEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "A table that lists information for each external USB port."
+    ::= { fgUsbports 2 }
+
+fgUsbportEntry OBJECT-TYPE
+    SYNTAX      FgUsbportEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "An entry containing information for a particular USB port."
+    INDEX       { fgUsbportEntIndex }
+    ::= { fgUsbportTable 1 }
+
+FgUsbportEntry ::= SEQUENCE {
+    fgUsbportEntIndex      FnIndex,
+    fgUsbportPlugged       INTEGER,
+    fgUsbportVersion       DisplayString,
+    fgUsbportClass         INTEGER,
+    fgUsbportVendId        OCTET STRING,
+    fgUsbportProdId        OCTET STRING,
+    fgUsbportRevision      DisplayString,
+    fgUsbportManufacturer  DisplayString,
+    fgUsbportProduct       DisplayString,
+    fgUsbportSerial        DisplayString
+}
+
+fgUsbportEntIndex OBJECT-TYPE
+    SYNTAX      FnIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "A unique identifier within the fgUsbportTable."
+    ::= { fgUsbportEntry 1 }
+
+fgUsbportPlugged OBJECT-TYPE
+    SYNTAX      INTEGER { unplugged(0), plugged(1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The USB port's plugged status."
+    ::= { fgUsbportEntry 2 }
+
+fgUsbportVersion OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The USB port's version."
+    ::= { fgUsbportEntry 3 }
+
+fgUsbportClass OBJECT-TYPE
+    SYNTAX      INTEGER { ifc(0), audio(1), comm(2), hid(3), physical(5),
+                  image(6), printer(7), storage(8), hub(9), cdcData(10),
+                  chipSmartCard(11), contentSecurity(13), appSpec(254), vendorSpec(255)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The device class."
+    ::= { fgUsbportEntry 4 }
+
+fgUsbportVendId OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The Vendor ID of the device."
+    ::= { fgUsbportEntry 5 }
+
+fgUsbportProdId OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The Product ID of the device."
+    ::= { fgUsbportEntry 6 }
+
+fgUsbportRevision OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The release number of the device."
+    ::= { fgUsbportEntry 7 }
+
+fgUsbportManufacturer OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The manufacturer of the device."
+    ::= { fgUsbportEntry 8 }
+
+fgUsbportProduct OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The product of the device."
+    ::= { fgUsbportEntry 9 }
+
+fgUsbportSerial OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The serial number of the device."
+    ::= { fgUsbportEntry 10 }
+
+--
 -- fortinet.fnFortiGateMib.fgFirewall
 --
 
@@ -1347,7 +1733,8 @@ fgFwPolStatsEntry OBJECT-TYPE
 FgFwPolStatsEntry ::= SEQUENCE {
     fgFwPolID               FnIndex,
     fgFwPolPktCount         Counter32,
-    fgFwPolByteCount        Counter32
+    fgFwPolByteCount        Counter32,
+    fgFwPolLastUsed         DisplayString
 }
 
 fgFwPolID OBJECT-TYPE
@@ -1373,6 +1760,14 @@ fgFwPolByteCount OBJECT-TYPE
     DESCRIPTION 
         "Number of bytes in packets matching the policy. See fgFwPolPktCount."
     ::= { fgFwPolStatsEntry 3 }
+
+fgFwPolLastUsed OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "How many minutes since last used."
+    ::= { fgFwPolStatsEntry 4 }
 
 --
 -- fortinet.fnFortiGateMib.fgFirewall.fgFwPolicies.fgFwPolTables.fgFwPol6StatsTable
@@ -1400,7 +1795,8 @@ fgFwPol6StatsEntry OBJECT-TYPE
 FgFwPol6StatsEntry ::= SEQUENCE {
     fgFwPol6ID         FnIndex,
     fgFwPol6PktCount   Counter64,
-    fgFwPol6ByteCount  Counter64
+    fgFwPol6ByteCount  Counter64,
+    fgFwPol6LastUsed   DisplayString
 }
 
 fgFwPol6ID OBJECT-TYPE
@@ -1428,6 +1824,14 @@ fgFwPol6ByteCount OBJECT-TYPE
     DESCRIPTION 
         "Number of bytes in packets matching the policy. See fgFwPol6PktCount."
     ::= { fgFwPol6StatsEntry 3 }
+
+fgFwPol6LastUsed OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "How many minutes since last used."
+    ::= { fgFwPol6StatsEntry 4 }
 
 --
 -- fortinet.fnFortiGateMib.fgFirewall.fgFwUsers
@@ -1623,6 +2027,14 @@ fgManIfMask OBJECT-TYPE
         "Mask of subnet the interface belongs to"
     ::= { fgMgmtTrapObjects 2 }
 
+fgManIfIp6 OBJECT-TYPE
+    SYNTAX      Ipv6Address
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "IPv6 address of the interface listed in the trap"
+    ::= { fgMgmtTrapObjects 3 }
+
 --
 -- fortinet.fnFortiGateMib.fgIntf
 --
@@ -1664,6 +2076,91 @@ fgIntfEntVdom OBJECT-TYPE
     DESCRIPTION 
         "The virtual domain the interface belongs to. This index corresponds to the index used by fgVdTable."
     ::= { fgIntfEntry 1 }
+
+fgIntfVrrps OBJECT IDENTIFIER
+    ::= { fgIntf 3 }
+
+fgIntfVrrpCount OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of entries in fgIntfVrrpTable"
+    ::= { fgIntfVrrps 1 }
+
+fgIntfVrrpTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgIntfVrrpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "A list of VRRPs and values."
+    ::= { fgIntfVrrps 2 }
+
+fgIntfVrrpEntry OBJECT-TYPE
+    SYNTAX      FgIntfVrrpEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "An entry containing the ID, group ID, interface name, state and IP address of a given virtual router."
+    INDEX       { fgIntfVrrpEntIndex }
+    ::= { fgIntfVrrpTable 1 }
+
+FgIntfVrrpEntry ::= SEQUENCE {
+    fgIntfVrrpEntIndex   FnIndex,
+    fgIntfVrrpEntVrId    FnIndex,
+    fgIntfVrrpEntGrpId   FnIndex,
+    fgIntfVrrpEntIfName  DisplayString,
+    fgIntfVrrpEntState   INTEGER,
+    fgIntfVrrpEntVrIp    IpAddress
+}
+
+fgIntfVrrpEntIndex OBJECT-TYPE
+    SYNTAX      FnIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "A unique identifier within the fgIntfVrrpTable"
+    ::= { fgIntfVrrpEntry 1 }
+
+fgIntfVrrpEntVrId OBJECT-TYPE
+    SYNTAX      FnIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "ID of a virtual router."
+    ::= { fgIntfVrrpEntry 2 }
+
+fgIntfVrrpEntGrpId OBJECT-TYPE
+    SYNTAX      FnIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The group ID of a virtual router."
+    ::= { fgIntfVrrpEntry 3 }
+
+fgIntfVrrpEntIfName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The interface name of a virtual router."
+    ::= { fgIntfVrrpEntry 4 }
+
+fgIntfVrrpEntState OBJECT-TYPE
+    SYNTAX      INTEGER { backup(1), master(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "State of a virtual router."
+    ::= { fgIntfVrrpEntry 5 }
+
+fgIntfVrrpEntVrIp OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "IP address of a virtual router."
+    ::= { fgIntfVrrpEntry 6 }
 
 --
 -- fortinet.fnFortiGateMib.fgAntivirus
@@ -4962,6 +5459,1295 @@ fgWcApName OBJECT-TYPE
     ::= { fgWcTrapObjects 3 }
 
 --
+-- fortinet.fnFortiGateMib.fgWc.fgWcInfo
+--
+
+fgWcInfo OBJECT IDENTIFIER
+    ::= { fgWc 2 }
+
+fgWcInfoName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the name of an AC"
+    ::= { fgWcInfo 1 }
+
+fgWcInfoLocation OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the location of an AC"
+    ::= { fgWcInfo 2 }
+
+fgWcInfoWtpCapacity  OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the maximum number of WTPs that can be managed on the AC."
+    ::= { fgWcInfo 3 }
+
+fgWcInfoWtpManaged  OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of WTPs being managed on the AC."
+    ::= { fgWcInfo 4 }
+
+fgWcInfoWtpSessions OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of WTPs that are connecting to the AC."
+    ::= { fgWcInfo 5 }
+
+fgWcInfoStationCapacity  OBJECT-TYPE
+    SYNTAX      Unsigned32 
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the maximum number of stations that can be supported on the AC."
+    ::= { fgWcInfo 6 }
+
+fgWcInfoStationCount  OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of stations that are accessing the wireless service
+         provided by the AC."
+    ::= { fgWcInfo 7 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWlanTable
+--
+
+fgWcWlanTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that allows the operator to display WLAN profiles."
+    ::= { fgWc 3 }
+
+fgWcWlanEntry  OBJECT-TYPE
+    SYNTAX      FgWcWlanEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that stores the settings of a WLAN profile."
+    INDEX       { fgVdEntIndex, ifIndex }
+    ::= { fgWcWlanTable 1 }
+
+FgWcWlanEntry ::= SEQUENCE {
+      fgWcWlanSsid                   OCTET STRING,
+      fgWcWlanBroadcastSsid          FnBoolState,
+      fgWcWlanSecurity               FgWcWlanSecurityType,
+      fgWcWlanEncryption             FgWcWlanEncryptionType,
+      fgWcWlanAuthentication         FgWcWlanAuthenticationType,
+      fgWcWlanRadiusServer           DisplayString,
+      fgWcWlanUserGroup              DisplayString,
+      fgWcWlanLocalBridging          FnBoolState,
+      fgWcWlanVlanId                 Integer32,
+      fgWcWlanMeshBackhaul           FnBoolState,
+      fgWcWlanStationCapacity        Unsigned32,
+      fgWcWlanStationCount           Gauge32
+    }
+
+fgWcWlanSsid OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Service set ID of this WLAN profile."
+    ::= { fgWcWlanEntry 1 }
+
+fgWcWlanBroadcastSsid OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Whether SSID broadcast is enabled on this WLAN profile."
+    ::= { fgWcWlanEntry 2 }
+
+fgWcWlanSecurity  OBJECT-TYPE
+    SYNTAX      FgWcWlanSecurityType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the security type of the WLAN profile."
+    ::= { fgWcWlanEntry 3 }
+
+fgWcWlanEncryption OBJECT-TYPE
+    SYNTAX      FgWcWlanEncryptionType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the encryption method of the WLAN profile."
+    ::= { fgWcWlanEntry 4 }
+
+fgWcWlanAuthentication OBJECT-TYPE
+    SYNTAX      FgWcWlanAuthenticationType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the authentication method of the WLAN profile."
+    ::= { fgWcWlanEntry 5 }
+
+fgWcWlanRadiusServer OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the specified RADIUS server of the WLAN profile."
+    ::= { fgWcWlanEntry 6 }
+
+fgWcWlanUserGroup OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the specified user group of the WLAN profile."
+    ::= { fgWcWlanEntry 7 }
+
+fgWcWlanLocalBridging OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Whether local bridging is enabled on this WLAN profile."
+    ::= { fgWcWlanEntry 8 }
+
+fgWcWlanVlanId OBJECT-TYPE
+    SYNTAX      Integer32 (0 | 1..4094 | 4095)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the VLAN ID of the WLAN profile."
+    ::= { fgWcWlanEntry 9 }
+
+fgWcWlanMeshBackhaul OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Whether mesh backhaul is enabled on this WLAN profile."
+    ::= { fgWcWlanEntry 10 }
+
+fgWcWlanStationCapacity OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the maximum number of clients allowed on this WLAN profile."
+    ::= { fgWcWlanEntry 11 }
+
+fgWcWlanStationCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of clients currently connected to this WLAN profile."
+    ::= { fgWcWlanEntry 12 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables
+--
+
+fgWcWtpTables OBJECT IDENTIFIER
+    ::= { fgWc 4 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables.fgWcWtpProfileTable
+--
+
+fgWcWtpProfileTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWtpProfileEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of objects that display WTP profiles for WTPs to be managed before they connect
+         to the AC. A WTP could get the new configuration through the CAPWAP control channel."
+    ::= { fgWcWtpTables 1 }
+
+fgWcWtpProfileEntry OBJECT-TYPE
+    SYNTAX      FgWcWtpProfileEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that display a WTP profile."
+    INDEX { fgVdEntIndex, fgWcWtpProfileName }
+    ::= { fgWcWtpProfileTable 1 }
+
+FgWcWtpProfileEntry ::= SEQUENCE {
+      fgWcWtpProfileName                    DisplayString,
+      fgWcWtpProfilePlatform                DisplayString,
+      fgWcWtpProfileDataChannelDtlsPolicy   BITS,
+      fgWcWtpProfileCountryString           FgWcCountryString
+    }
+
+fgWcWtpProfileName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..36))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the name of a WTP profile."
+    ::= { fgWcWtpProfileEntry 1 }
+
+fgWcWtpProfilePlatform OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the hardware platform of a WTP profile."
+    ::= { fgWcWtpProfileEntry 2 }
+
+fgWcWtpProfileDataChannelDtlsPolicy OBJECT-TYPE
+    SYNTAX      BITS { other(0), clear(1), dtls(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The AC communicates its policy on the use of DTLS for the CAPWAP data channel.
+         The AC MAY support more than one option, represented by the bit field below:
+           other(0) - Other method, for example, vendor specific
+           clear(1) - Clear text
+           dtls(2)  - DTLS"
+    ::= { fgWcWtpProfileEntry 3 }
+
+fgWcWtpProfileCountryString OBJECT-TYPE
+    SYNTAX      FgWcCountryString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the country setting of a WTP profile, in ISO string format."
+    ::= { fgWcWtpProfileEntry 4 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables.fgWcWtpProfileRadioTable
+--
+
+fgWcWtpProfileRadioTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWtpProfileRadioEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of objects that display WTP radio profiles for WTP radios to be managed
+         before the WTPs connect to the AC. A WTP radio could get the new configuration
+         through the CAPWAP control channel."
+    ::= { fgWcWtpTables 2 }
+
+fgWcWtpProfileRadioEntry  OBJECT-TYPE
+    SYNTAX      FgWcWtpProfileRadioEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that display a WTP radio profile."
+    INDEX { fgVdEntIndex, fgWcWtpProfileRadioProfileName, fgWcWtpProfileRadioRadioId }
+    ::= { fgWcWtpProfileRadioTable 1 }
+
+FgWcWtpProfileRadioEntry ::= SEQUENCE {
+      fgWcWtpProfileRadioProfileName        DisplayString,
+      fgWcWtpProfileRadioRadioId            FgWcWtpRadioId,
+      fgWcWtpProfileRadioMode               FgWcWtpRadioMode,
+      fgWcWtpProfileRadioApScan             FnBoolState,
+      fgWcWtpProfileRadioWidsProfile        DisplayString,
+      fgWcWtpProfileRadioDarrp              FnBoolState,
+      fgWcWtpProfileRadioFrequencyHandoff   FnBoolState,
+      fgWcWtpProfileRadioApHandoff          FnBoolState,
+      fgWcWtpProfileRadioBeaconInterval     Integer32,
+      fgWcWtpProfileRadioDtimPeriod         Integer32,
+      fgWcWtpProfileRadioBand               FgWcWtpRadioType,
+      fgWcWtpProfileRadioChannelBonding     FnBoolState,
+      fgWcWtpProfileRadioChannel            DisplayString,
+      fgWcWtpProfileRadioAutoTxPowerControl FnBoolState,
+      fgWcWtpProfileRadioAutoTxPowerLow     Integer32,
+      fgWcWtpProfileRadioAutoTxPowerHigh    Integer32,
+      fgWcWtpProfileRadioTxPowerLevel       Gauge32,
+      fgWcWtpProfileRadioVaps               DisplayString,
+      fgWcWtpProfileRadioStationCapacity    Unsigned32,
+      fgWcWtpProfileRadioChannelWidth       FgWcWtpChannelWidthType
+    }
+
+fgWcWtpProfileRadioProfileName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..36))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the name of a WTP profile."
+    ::= { fgWcWtpProfileRadioEntry 1 }
+
+fgWcWtpProfileRadioRadioId OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioId
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio Id of a WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 2 }
+
+fgWcWtpProfileRadioMode OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioMode
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the operating mode of a WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 3 }
+
+fgWcWtpProfileRadioApScan OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether background scan is enabled on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 4 }
+
+fgWcWtpProfileRadioWidsProfile OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the WIDS profile configured for this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 5 }
+
+fgWcWtpProfileRadioDarrp OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether DARRP is enabled on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 6 }
+
+fgWcWtpProfileRadioFrequencyHandoff OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether frequency handoff is enabled on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 7 }
+
+fgWcWtpProfileRadioApHandoff OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether AP handoff is enabled on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 8 }
+
+fgWcWtpProfileRadioBeaconInterval OBJECT-TYPE
+    SYNTAX      Integer32 (1..65535)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This attribute shall specify the number of TUs that a station shall use for scheduling
+         Beacon transmissions. This value is transmitted in Beacon and Probe Response frames."
+    ::= { fgWcWtpProfileRadioEntry 9 }
+
+fgWcWtpProfileRadioDtimPeriod OBJECT-TYPE
+    SYNTAX      Integer32 (1..255)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "This attribute shall specify the number of beacon intervals that shall elapse between
+         transmission of Beacon frames containing a TIM element whose DTIM Count field is 0.
+         This value is transmitted in the DTIM Period field of Beacon frames."
+    ::= { fgWcWtpProfileRadioEntry 10 }
+
+fgWcWtpProfileRadioBand OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioType
+    MAX-ACCESS  read-only
+    STATUS current
+    DESCRIPTION
+        "Represents the radio band setting configured for this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 11 }
+
+fgWcWtpProfileRadioChannelBonding OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether channel bonding is enabled on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 12 }
+
+fgWcWtpProfileRadioChannel OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents a list of channels configured for this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 13 }
+
+fgWcWtpProfileRadioAutoTxPowerControl OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether automatic TX power control is enabled on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 14 }
+
+fgWcWtpProfileRadioAutoTxPowerLow OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the low limit of the power level configured for this WTP radio, in dBm.
+         Applicable only when auto power leveling is enabled."
+    ::= { fgWcWtpProfileRadioEntry 15 }
+
+fgWcWtpProfileRadioAutoTxPowerHigh OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the high limit of the power level configured for this WTP radio, in dBm.
+         Applicable only when auto power leveling is enabled."
+    ::= { fgWcWtpProfileRadioEntry 16 }
+
+fgWcWtpProfileRadioTxPowerLevel OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio TX power setting configured for this WTP radio, in percentage.
+         Application only when auto power leveling is disabled."
+    ::= { fgWcWtpProfileRadioEntry 17 }
+
+fgWcWtpProfileRadioVaps OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents a list of WLANs configured for this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 18 }
+
+fgWcWtpProfileRadioStationCapacity OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the maximum number of clients allowed on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 19 }
+
+fgWcWtpProfileRadioChannelWidth OBJECT-TYPE
+    SYNTAX      FgWcWtpChannelWidthType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the channel width on this WTP radio."
+    ::= { fgWcWtpProfileRadioEntry 20 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables.fgWcWtpConfigTable
+--
+
+fgWcWtpConfigTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWtpConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of objects that display the configuration of WTPs."
+    ::= { fgWcWtpTables 3 }
+
+fgWcWtpConfigEntry  OBJECT-TYPE
+    SYNTAX      FgWcWtpConfigEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that display the configuration of a WTP."
+    INDEX { fgVdEntIndex, fgWcWtpConfigWtpId }
+    ::= { fgWcWtpConfigTable 1 }
+
+FgWcWtpConfigEntry ::= SEQUENCE {
+      fgWcWtpConfigWtpId                    DisplayString,
+      fgWcWtpConfigWtpAdmin                 INTEGER,
+      fgWcWtpConfigWtpName                  DisplayString,
+      fgWcWtpConfigWtpLocation              DisplayString,
+      fgWcWtpConfigWtpProfile               DisplayString,
+      fgWcWtpConfigRadioEnable              FnBoolState,
+      fgWcWtpConfigRadioAutoTxPowerControl  FnBoolState,
+      fgWcWtpConfigRadioAutoTxPowerLow      Integer32,
+      fgWcWtpConfigRadioAutoTxPowerHigh     Integer32,
+      fgWcWtpConfigRadioTxPowerLevel        Gauge32,
+      fgWcWtpConfigRadioBand                FgWcWtpRadioBandType,
+      fgWcWtpConfigRadioApScan              FnBoolState,
+      fgWcWtpConfigVapAll                   FnBoolState,
+      fgWcWtpConfigVaps                     DisplayString
+    }
+
+fgWcWtpConfigWtpId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..36))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the unique identifier of a WTP."
+    ::= { fgWcWtpConfigEntry 1 }
+
+fgWcWtpConfigWtpAdmin OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  other(0),
+                  discovered(1),
+                  disable(2),
+                  enable(3)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the administrative status of this WTP.
+         The following enumerated values are supported:
+           discovered(1)   - This WTP was discovered though discovery or join request messages.
+           disable(2)      - Controller is configured to not provide service to this WTP.
+           enable(3),      - Controller is configured to provide service to this WTP.
+           other(0)        - The administration state of the WTP is unknown."
+    ::= { fgWcWtpConfigEntry 2 }
+
+fgWcWtpConfigWtpName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the name configured for this WTP."
+    ::= { fgWcWtpConfigEntry 3 }
+
+fgWcWtpConfigWtpLocation OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the location of this WTP."
+    ::= { fgWcWtpConfigEntry 4 }
+
+fgWcWtpConfigWtpProfile OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the WTP profile configured for this WTP."
+    ::= { fgWcWtpConfigEntry 5 }
+
+fgWcWtpConfigRadioEnable OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether radio is enabled for this WTP."
+    ::= { fgWcWtpConfigEntry 6 }
+
+fgWcWtpConfigRadioAutoTxPowerControl OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether radio automatic TX power control is enabled on this WTP."
+    ::= { fgWcWtpConfigEntry 7 }
+
+fgWcWtpConfigRadioAutoTxPowerLow OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the low limit of radio automatic TX power control configured for this WTP, in dBm."
+    ::= { fgWcWtpConfigEntry 8 }
+
+fgWcWtpConfigRadioAutoTxPowerHigh OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the high limit of radio automatic TX power control configured for this WTP, in dBm."
+    ::= { fgWcWtpConfigEntry 9 }
+
+fgWcWtpConfigRadioTxPowerLevel OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio TX power setting configured for this WTP, in percentage."
+    ::= { fgWcWtpConfigEntry 10 }
+
+fgWcWtpConfigRadioBand OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioBandType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio band configured for this WTP."
+    ::= { fgWcWtpConfigEntry 11 }
+
+fgWcWtpConfigRadioApScan OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether background scan is enabled on this WTP."
+    ::= { fgWcWtpConfigEntry 12 }
+
+fgWcWtpConfigVapAll OBJECT-TYPE
+    SYNTAX      FnBoolState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Whether all VAPs are selected for this WTP."
+    ::= { fgWcWtpConfigEntry 13 }
+
+fgWcWtpConfigVaps OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents a list of VAPs configured for this WTP."
+    ::= { fgWcWtpConfigEntry 14 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables.fgWcWtpSessionTable
+--
+
+fgWcWtpSessionTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWtpSessionEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of objects that indicate the AC's CAPWAP FSM state for each WTP,
+         and helps the operator to query a WTP's current status."
+    ::= { fgWcWtpTables 4 }
+
+fgWcWtpSessionEntry  OBJECT-TYPE
+    SYNTAX      FgWcWtpSessionEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that displays the AC's CAPWAP FSM state for each WTP.
+         Also, the operator could query the current status of a WTP by using
+         the identifier of the corresponding WTP."
+    INDEX { fgVdEntIndex, fgWcWtpSessionWtpId }
+    ::= { fgWcWtpSessionTable 1 }
+
+FgWcWtpSessionEntry ::= SEQUENCE {
+      fgWcWtpSessionWtpId                   DisplayString,
+      fgWcWtpSessionWtpIpAddressType        InetAddressType,
+      fgWcWtpSessionWtpIpAddress            InetAddress,
+      fgWcWtpSessionWtpLocalIpAddressType   InetAddressType,
+      fgWcWtpSessionWtpLocalIpAddress       InetAddress,
+      fgWcWtpSessionWtpBaseMacAddress       PhysAddress,
+      fgWcWtpSessionConnectionState         INTEGER,
+      fgWcWtpSessionWtpUpTime               TimeTicks,
+      fgWcWtpSessionWtpDaemonUpTime         TimeTicks,
+      fgWcWtpSessionWtpSessionUpTime        TimeTicks,
+      fgWcWtpSessionWtpProfileName          DisplayString,
+      fgWcWtpSessionWtpModelNumber          DisplayString,
+      fgWcWtpSessionWtpHwVersion            DisplayString,
+      fgWcWtpSessionWtpSwVersion            DisplayString,
+      fgWcWtpSessionWtpBootVersion          DisplayString,
+      fgWcWtpSessionWtpRegionCode           DisplayString,
+      fgWcWtpSessionWtpStationCount         Gauge32,
+      fgWcWtpSessionWtpByteRxCount          Counter64,
+      fgWcWtpSessionWtpByteTxCount          Counter64,
+      fgWcWtpSessionWtpCpuUsage             Gauge32,
+      fgWcWtpSessionWtpMemoryUsage          Gauge32,
+      fgWcWtpSessionWtpMemoryCapacity       Unsigned32
+    }
+
+fgWcWtpSessionWtpId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..36))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the unique identifier of a WTP."
+    ::= { fgWcWtpSessionEntry 1 }
+
+fgWcWtpSessionWtpIpAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the IP address type of a WTP.
+         Only ipv4(1) and ipv6(2) are supported by the object."
+    ::= { fgWcWtpSessionEntry 2 }
+
+fgWcWtpSessionWtpIpAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the IP address of a WTP that corresponds to the IP address in
+         the IP packet header.
+         The format of this IP address is determined by the corresponding instance of
+         object fgWcWtpWtpIpAddressType."
+    ::= { fgWcWtpSessionEntry 3 }
+
+fgWcWtpSessionWtpLocalIpAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the local IP address type of a WTP.
+         Only ipv4(1) and ipv6(2) are supported by the object."
+    ::= { fgWcWtpSessionEntry 4 }
+
+fgWcWtpSessionWtpLocalIpAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the local IP address of a WTP and models the CAPWAP Local IPv4 Address
+         or CAPWAP Local IPv6 Address fields [RFC5415].
+         If a Network Address Translation (NAT) device is present between WTP and AC, the value of
+         fgWcWtpWtpLocalIpAddress will be different from the value of fgWcWtpWtpIpAddress.
+         The format of this IP address is determined by the corresponding instance of object
+         fgWcWtpSessionWtpLocalIpAddressType."
+    ::= { fgWcWtpSessionEntry 5 }
+
+fgWcWtpSessionWtpBaseMacAddress OBJECT-TYPE
+    SYNTAX      PhysAddress (SIZE(6|8))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the WTP's Base MAC Address, which MAY be assigned to the primary
+         Ethernet interface.
+         The instance of the object corresponds to the Base MAC Address sub-element
+         in the CAPWAP protocol [RFC5415]."
+    ::= { fgWcWtpSessionEntry 6 }
+
+fgWcWtpSessionConnectionState OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  other(0),
+                  offLine(1),
+                  onLine(2),
+                  downloadingImage(3),
+                  connectedImage(4)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the connection state of a WTP to AC.
+         The following enumerated values are supported:
+           offLine(1)           - The WTP is not connected.
+           onLine(2)            - The WTP is connected.
+           downloadingImage(3)  - The WTP is downloading software image from the AC on joining.
+           connectedImage(4)    - The AC is pushing software image to the connected WTP.
+           other(0)             - The WTP connection state is unknown."
+    ::= { fgWcWtpSessionEntry 7 }
+
+fgWcWtpSessionWtpUpTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the time (in hundredths of a second) since the WTP boots."
+    ::= { fgWcWtpSessionEntry 8 }
+
+fgWcWtpSessionWtpDaemonUpTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the time (in hundredths of a second) since the WTP daemon has been started."
+    ::= { fgWcWtpSessionEntry 9 }
+
+fgWcWtpSessionWtpSessionUpTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the time (in hundredths of a second) since the WTP connects to the AC."
+    ::= { fgWcWtpSessionEntry 10 }
+
+fgWcWtpSessionWtpProfileName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the profile configured for this WTP."
+    ::= { fgWcWtpSessionEntry 11 }
+
+fgWcWtpSessionWtpModelNumber OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the model number of a WTP."
+    ::= { fgWcWtpSessionEntry 12 }
+
+fgWcWtpSessionWtpHwVersion OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the hardware version of a WTP."
+    ::= { fgWcWtpSessionEntry 13 }
+
+fgWcWtpSessionWtpSwVersion OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the software version of a WTP."
+    ::= { fgWcWtpSessionEntry 14 }
+
+fgWcWtpSessionWtpBootVersion OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the boot loader version of a WTP."
+    ::= { fgWcWtpSessionEntry 15 }
+
+fgWcWtpSessionWtpRegionCode OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the region code programmed for this WTP."
+    ::= { fgWcWtpSessionEntry 16 }
+
+fgWcWtpSessionWtpStationCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of clients currently connected to this WTP."
+    ::= { fgWcWtpSessionEntry 17 }
+
+fgWcWtpSessionWtpByteRxCount OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of bytes received by this WTP."
+    ::= { fgWcWtpSessionEntry 18 }
+
+fgWcWtpSessionWtpByteTxCount OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of bytes transmitted by this WTP."
+    ::= { fgWcWtpSessionEntry 19 }
+
+fgWcWtpSessionWtpCpuUsage OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the current CPU usage of a WTP (percentage)."
+    ::= { fgWcWtpSessionEntry 20 }
+
+fgWcWtpSessionWtpMemoryUsage OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the current memory usage of a WTP (percentage)."
+    ::= { fgWcWtpSessionEntry 21 }
+
+fgWcWtpSessionWtpMemoryCapacity OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the total physical memory (RAM) installed (KB)."
+    ::= { fgWcWtpSessionEntry 22 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables.fgWcWtpSessionRadioTable
+--
+
+fgWcWtpSessionRadioTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWtpSessionRadioEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of objects that display the status of radios in WTP sessions."
+    ::= { fgWcWtpTables 5 }
+
+fgWcWtpSessionRadioEntry  OBJECT-TYPE
+    SYNTAX      FgWcWtpSessionRadioEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that display the status of a radio in a WTP session."
+    INDEX { fgVdEntIndex, fgWcWtpSessionRadioWtpId, fgWcWtpSessionRadioRadioId}
+    ::= { fgWcWtpSessionRadioTable 1 }
+
+FgWcWtpSessionRadioEntry ::= SEQUENCE {
+      fgWcWtpSessionRadioWtpId              DisplayString,
+      fgWcWtpSessionRadioRadioId            FgWcWtpRadioId,
+      fgWcWtpSessionRadioMode               FgWcWtpRadioMode,
+      fgWcWtpSessionRadioBaseBssid          PhysAddress,
+      fgWcWtpSessionRadioCountryString      FgWcCountryString,
+      fgWcWtpSessionRadioCountryCode        Integer32,
+      fgWcWtpSessionRadioOperatingChannel   FgWcWtpRadioChannelNumber,
+      fgWcWtpSessionRadioOperatingPower     Integer32,
+      fgWcWtpSessionRadioStationCount       Gauge32
+    }
+
+fgWcWtpSessionRadioWtpId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..36))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the unique identifier of a WTP."
+    ::= { fgWcWtpSessionRadioEntry 1 }
+
+fgWcWtpSessionRadioRadioId OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioId
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio Id of a radio."
+    ::= { fgWcWtpSessionRadioEntry 2 }
+
+fgWcWtpSessionRadioMode  OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioMode
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the operating mode of this radio."
+    ::= { fgWcWtpSessionRadioEntry 3 }
+
+fgWcWtpSessionRadioBaseBssid  OBJECT-TYPE
+    SYNTAX      PhysAddress (SIZE(6|8))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents base bssid of this radio."
+    ::= { fgWcWtpSessionRadioEntry 4 }
+
+fgWcWtpSessionRadioCountryString OBJECT-TYPE
+    SYNTAX      FgWcCountryString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the current operating country string, in ISO string format."
+    ::= { fgWcWtpSessionRadioEntry 5 }
+
+fgWcWtpSessionRadioCountryCode OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the current operating country code."
+    ::= { fgWcWtpSessionRadioEntry 6 }
+
+fgWcWtpSessionRadioOperatingChannel OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioChannelNumber
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the current operating channel of this radio."
+    ::= { fgWcWtpSessionRadioEntry 7 }
+
+fgWcWtpSessionRadioOperatingPower OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the current operating power of this radio, in dBm."
+    ::= { fgWcWtpSessionRadioEntry 8 }
+
+fgWcWtpSessionRadioStationCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of clients currently connected to this radio."
+    ::= { fgWcWtpSessionRadioEntry 9 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcWtpTables.fgWcWtpSessionVapTable
+--
+
+fgWcWtpSessionVapTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcWtpSessionVapEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table of objects that display the status of VAPs in WTP sessions.
+         A VAP represents an SSID that is assigned on a WTP radio."
+    ::= { fgWcWtpTables 6 }
+
+fgWcWtpSessionVapEntry  OBJECT-TYPE
+    SYNTAX      FgWcWtpSessionVapEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that display the status of a VAP in a WTP session."
+    INDEX { fgVdEntIndex, fgWcWtpSessionVapWtpId, fgWcWtpSessionVapRadioId, ifIndex }
+    ::= { fgWcWtpSessionVapTable 1 }
+
+FgWcWtpSessionVapEntry ::= SEQUENCE {
+      fgWcWtpSessionVapWtpId                DisplayString,
+      fgWcWtpSessionVapRadioId              FgWcWtpRadioId,
+      fgWcWtpSessionVapSsid                 OCTET STRING,
+      fgWcWtpSessionVapStationCount         Gauge32,
+      fgWcWtpSessionVapByteRxCount          Counter64,
+      fgWcWtpSessionVapByteTxCount          Counter64
+    }
+
+fgWcWtpSessionVapWtpId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..36))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the unique identifier of a WTP."
+    ::= { fgWcWtpSessionVapEntry 1 }
+
+fgWcWtpSessionVapRadioId OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioId
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio Id of a VAP."
+    ::= { fgWcWtpSessionVapEntry 2 }
+
+fgWcWtpSessionVapSsid OBJECT-TYPE
+    SYNTAX      OCTET STRING (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Service set ID of this VAP interface."
+    ::= { fgWcWtpSessionVapEntry 3 }
+
+fgWcWtpSessionVapStationCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of clients currently connected to this VAP."
+    ::= { fgWcWtpSessionVapEntry 4 }
+
+fgWcWtpSessionVapByteRxCount OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of bytes received by this VAP."
+    ::= { fgWcWtpSessionVapEntry 5 }
+
+fgWcWtpSessionVapByteTxCount OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the number of bytes transmitted by this VAP."
+    ::= { fgWcWtpSessionVapEntry 6 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcStaTable
+--
+
+fgWcStaTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgWcStaEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A table that provides information of all the wireless stations that are accessing
+         the wireless service provided by the AC."
+    ::= { fgWc 5 }
+
+fgWcStaEntry OBJECT-TYPE
+    SYNTAX      FgWcStaEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A set of objects that display information of a wireless station."
+    INDEX       { fgVdEntIndex, ifIndex, fgWcStaMacAddress }
+    ::= { fgWcStaTable 1 }
+
+FgWcStaEntry ::= SEQUENCE {
+      fgWcStaMacAddress             PhysAddress,
+      fgWcStaWlan                   DisplayString,
+      fgWcStaWtpId                  DisplayString,
+      fgWcStaRadioId                FgWcWtpRadioId,
+      fgWcStaVlanId                 Integer32,
+      fgWcStaIpAddressType          InetAddressType,
+      fgWcStaIpAddress              InetAddress,
+      fgWcStaVci                    DisplayString,
+      fgWcStaHost                   DisplayString,
+      fgWcStaUser                   DisplayString,
+      fgWcStaGroup                  DisplayString,
+      fgWcStaSignal                 Integer32,
+      fgWcStaNoise                  Integer32,
+      fgWcStaIdle                   Gauge32,
+      fgWcStaBandwidthTx            Gauge32,
+      fgWcStaBandwidthRx            Gauge32,
+      fgWcStaChannel                FgWcWtpRadioChannelNumber,
+      fgWcStaRadioType              FgWcWtpRadioType,
+      fgWcStaSecurity               FgWcWlanSecurityType,
+      fgWcStaEncrypt                FgWcWlanEncryptionType,
+      fgWcStaOnline                 INTEGER
+    }
+
+fgWcStaMacAddress OBJECT-TYPE
+    SYNTAX      PhysAddress (SIZE(6|8))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Represents the MAC address of a wireless station."
+    ::= { fgWcStaEntry 1 }
+
+fgWcStaWlan OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "WLAN interface that a wireless station is connected to."
+    ::= { fgWcStaEntry 2 }
+
+fgWcStaWtpId OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Unique identifier of the WTP that a wireless station is connected to."
+    ::= { fgWcStaEntry 3 }
+
+fgWcStaRadioId OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioId
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio of the WTP that a wireless station is connected to."
+    ::= { fgWcStaEntry 4 }
+
+fgWcStaVlanId OBJECT-TYPE
+    SYNTAX      Integer32 (0 | 1..4094 | 4095)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the VLAN ID that is assigned to a wireless station."
+    ::= { fgWcStaEntry 5 }
+
+fgWcStaIpAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the IP address type of a wireless station.
+         Only ipv4(1) and ipv6(2) are supported by the object."
+    ::= { fgWcStaEntry 6 }
+
+fgWcStaIpAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the IP address of a wireless station."
+    ::= { fgWcStaEntry 7 }
+
+fgWcStaVci OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the vendor class identifier of a wireless station."
+    ::= { fgWcStaEntry 8 }
+
+fgWcStaHost OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the host name of a wireless station."
+    ::= { fgWcStaEntry 9 }
+
+fgWcStaUser OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the user name of a wireless station."
+    ::= { fgWcStaEntry 10 }
+
+fgWcStaGroup OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the user group of a wireless station."
+    ::= { fgWcStaEntry 11 }
+
+fgWcStaSignal OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the signal strengh of a wireless station, in dBm."
+    ::= { fgWcStaEntry 12 }
+
+fgWcStaNoise OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the noise level of a wireless station, in dBm."
+    ::= { fgWcStaEntry 13 }
+
+fgWcStaIdle OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates how long a wireless station in inactive, in seconds."
+    ::= { fgWcStaEntry 14 }
+
+fgWcStaBandwidthTx OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the TX bandwidth of a wireless station, in kbps."
+    ::= { fgWcStaEntry 15 }
+
+fgWcStaBandwidthRx OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the RX bandwidth of a wireless station, in kbps."
+    ::= { fgWcStaEntry 16 }
+
+fgWcStaChannel OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioChannelNumber
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the frequency channel that a wireless station is using."
+    ::= { fgWcStaEntry 17 }
+
+fgWcStaRadioType OBJECT-TYPE
+    SYNTAX      FgWcWtpRadioType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the radio physical type of a wireless station."
+    ::= { fgWcStaEntry 18 }
+
+fgWcStaSecurity OBJECT-TYPE
+    SYNTAX      FgWcWlanSecurityType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the security type of a wireless station."
+    ::= { fgWcStaEntry 19 }
+
+fgWcStaEncrypt OBJECT-TYPE
+    SYNTAX      FgWcWlanEncryptionType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents the encryption method of a wireless station."
+    ::= { fgWcStaEntry 20 }
+
+fgWcStaOnline OBJECT-TYPE
+    SYNTAX      INTEGER { yes(1), no(2) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represent online status of a wireless station."
+    ::= { fgWcStaEntry 21 }
+
+--
 -- fortinet.fnFortiGateMib.fgFc
 --
 
@@ -4999,6 +6785,114 @@ fgFcSwName OBJECT-TYPE
         "Name of the switch"
     ::= { fgFcTrapObjects 3 }
     
+--
+-- fortinet.fnFortiGateMib.fgServerLoadBalance
+--
+
+fgServerLoadBalance OBJECT IDENTIFIER
+    ::= { fnFortiGateMib 16 }
+
+--
+-- fortinet.fnFortiGateMib.fgServerLoadBalance.fgServerLoadBalanceTrapObjects
+--
+
+fgServerLoadBalanceTrapObjects OBJECT IDENTIFIER
+    ::= { fgServerLoadBalance 1 }
+
+fgServerLoadBalanceRealServerAddress OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "IP of the real server."
+    ::= { fgServerLoadBalanceTrapObjects 1 }
+
+fgServerLoadBalanceVirtualServerName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Name of the virual server."
+    ::= { fgServerLoadBalanceTrapObjects 2 }
+
+--
+-- fortinet.fnFortiGateMib.fgUsbModemInfo
+--
+
+fgUsbModemInfo OBJECT IDENTIFIER
+    ::= { fnFortiGateMib 17 }
+
+--
+-- fortinet.fnFortiGateMib.fgUsbModemInfo.fgUsbModemInfoObjects
+--
+
+fgUsbModemInfoObjects OBJECT IDENTIFIER
+    ::= { fgUsbModemInfo 1 }
+
+fgUsbModemSignalStrength OBJECT-TYPE
+    SYNTAX      INTEGER { sig0(0), sig1(1), sig2(2), sig3(3), sig4(4) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem signal Strength."
+    ::= { fgUsbModemInfoObjects 1 }
+
+fgUsbModemStatus OBJECT-TYPE
+    SYNTAX      INTEGER { disconnected(0), connected(1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        " 3G/4G USB Modem status."
+    ::= { fgUsbModemInfoObjects 2 }
+
+fgUsbModemSimState OBJECT-TYPE
+    SYNTAX      INTEGER { invalid(0), valid(1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem sim card status."
+    ::= { fgUsbModemInfoObjects 3 }
+
+fgUsbModemVendor OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem vendor name."
+    ::= { fgUsbModemInfoObjects 4 }
+
+fgUsbModemProduct OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem product name."
+    ::= { fgUsbModemInfoObjects 5 }
+
+fgUsbModemNetwork OBJECT-TYPE
+    SYNTAX      INTEGER { net3G(0), netLTE(1) }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem network type."
+    ::= { fgUsbModemInfoObjects 6 }
+
+fgUsbModemId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem identifier."
+    ::= { fgUsbModemInfoObjects 7 }
+
+fgUsbModemSimId OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "3G/4G USB Modem sim card identifier."
+    ::= { fgUsbModemInfoObjects 8 }
+
 --
 -- fortinet.fnFortiGateMib.fgMibConformance
 --
@@ -5082,6 +6976,13 @@ fgTrapIpsPkgUpdate NOTIFICATION-TYPE
     DESCRIPTION 
         "The IPS signature database has been updated"
     ::= { fgTrapPrefix 505 }
+
+fgTrapIpsFailOpen NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName }
+    STATUS      current
+    DESCRIPTION
+        "The IPS network buffer is full"
+    ::= { fgTrapPrefix 506 }
 
 fgTrapAvVirus NOTIFICATION-TYPE
     OBJECTS     { fnSysSerial, sysName, fgAvTrapVirName }
@@ -5198,11 +7099,18 @@ fgFmTrapConfChange NOTIFICATION-TYPE
     ::= { fgFmTrapPrefix 1003 }
 
 fgFmTrapIfChange NOTIFICATION-TYPE
-    OBJECTS     { fnSysSerial, ifName, fgManIfIp, fgManIfMask }
+    OBJECTS     { fnSysSerial, ifName, fgManIfIp, fgManIfMask, fgManIfIp6 }
     STATUS      current
     DESCRIPTION 
         "Trap is sent to the managing FortiManager if an interface IP is changed"
     ::= { fgFmTrapPrefix 1004 }
+
+fgTrapServerLoadBalanceRealServerDown NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName, fgServerLoadBalanceRealServerAddress, fgServerLoadBalanceVirtualServerName }
+    STATUS      current
+    DESCRIPTION 
+        "One of servers in a Server Load Balance group goes down."
+    ::= { fgTrapPrefix 1101 }
 
 --
 -- fortinet.fnFortiGateMib.fgMibConformance
@@ -5217,7 +7125,7 @@ fgFmTrapGroup NOTIFICATION-GROUP
     ::= { fgMibConformance 1 }
 
 fgFmTrapObjectGroup OBJECT-GROUP
-    OBJECTS     { fgManIfIp, fgManIfMask }
+    OBJECTS     { fgManIfIp, fgManIfMask,fgManIfIp6 }
     STATUS      current
     DESCRIPTION 
         "These objects support the traps in the fgFmTrapGroup."
@@ -5302,7 +7210,7 @@ fgVpnObjectGroup OBJECT-GROUP
                   fgVpnSslTunnelSrcIp, fgVpnSslTunnelIp, 
                   fgVpnSslTunnelUpTime, fgVpnSslTunnelBytesIn, 
                   fgVpnSslTunnelBytesOut, fgVpnTrapLocalGateway, 
-                  fgVpnTrapRemoteGateway, fgVpnTunnelUpCount }
+                  fgVpnTrapRemoteGateway, fgVpnTrapPhase1Name, fgVpnTunnelUpCount }
     STATUS      current
     DESCRIPTION 
         "Objects pertaining to Virtual Priavet Networking on FortiGate devices."
@@ -5315,7 +7223,7 @@ fgFirewallObjectGroup OBJECT-GROUP
                   fgIpSessFromAddr, fgIpSessFromPort, fgIpSessToAddr, 
                   fgIpSessToPort, fgIpSessExp, fgIpSessVdom, 
                   fgIpSessNumber, fgIp6SessNumber, fgFwPol6PktCount,
-                  fgFwPol6ByteCount }
+                  fgFwPol6ByteCount, fgFwPolLastUsed, fgFwPol6LastUsed }
     STATUS      current
     DESCRIPTION 
         "Objects pertaining to Firewall functionality on FortiGate devices."
@@ -5391,6 +7299,7 @@ fgWebFilterObjectGroup OBJECT-GROUP
 fgVirtualDomainObjectGroup OBJECT-GROUP
     OBJECTS     { fgVdNumber, fgVdMaxVdoms, fgVdEnabled, fgVdEntName, 
                   fgVdEntOpMode, fgVdTpMgmtAddrType, fgVdTpMgmtAddr,
+                  fgVdEntCpuUsage, fgVdEntMemUsage, fgVdEntSesCount, fgVdEntSesRate,
                   fgVdTpMgmtMask, fgVdEntHaState }
     STATUS      current
     DESCRIPTION 
@@ -5405,7 +7314,7 @@ fgAdministrationObjectGroup OBJECT-GROUP
     ::= { fgMibConformance 15 }
 
 fgIntfObjectGroup OBJECT-GROUP
-    OBJECTS     { fgIntfEntVdom }
+    OBJECTS     { fgIntfEntVdom, fgIntfVrrpCount, fgIntfVrrpEntVrId, fgIntfVrrpEntGrpId, fgIntfVrrpEntIfName, fgIntfVrrpEntState, fgIntfVrrpEntVrIp }
     STATUS      current
     DESCRIPTION 
         "Objects pertaining to the interface table of FortiGate device."
@@ -5429,12 +7338,13 @@ fgNotificationGroup NOTIFICATION-GROUP
     NOTIFICATIONS { fgTrapVpnTunUp, fgTrapVpnTunDown, fgTrapHaSwitch, 
                   fgTrapHaHBFail, fgTrapHaMemberDown, fgTrapHaMemberUp, 
                   fgTrapIpsSignature, fgTrapIpsAnomaly, 
-                  fgTrapIpsPkgUpdate, fgTrapAvVirus, fgTrapAvOversize, 
+                  fgTrapIpsPkgUpdate, fgTrapIpsFailOpen,
+                  fgTrapAvVirus, fgTrapAvOversize,
                   fgTrapAvPattern, fgTrapAvFragmented, 
                   fgTrapAvEnterConserve, fgTrapAvBypass, 
                   fgTrapAvOversizePass, fgTrapAvOversizeBlock, 
                   fgTrapFazDisconnect, fgTrapWcApUp, fgTrapWcApDown,
-                  fgTrapFcSwUp, fgTrapFcSwDown }
+                  fgTrapFcSwUp, fgTrapFcSwDown, fgTrapServerLoadBalanceRealServerDown }
     STATUS      current
     DESCRIPTION 
         "Notifications that can be generated from a FortiGate device."
@@ -5518,7 +7428,49 @@ fgSystemAdvancedObjectGroup OBJECT-GROUP
     ::= { fgMibConformance 24 }
 
 fgWcObjectGroup OBJECT-GROUP
-    OBJECTS     { fgWcApVdom, fgWcApSerial, fgWcApName }
+    OBJECTS     { fgWcApVdom, fgWcApSerial, fgWcApName,
+                  fgWcInfoName, fgWcInfoLocation, fgWcInfoWtpCapacity, fgWcInfoWtpManaged,
+                  fgWcInfoWtpSessions, fgWcInfoStationCapacity, fgWcInfoStationCount,
+                  fgWcWlanSsid, fgWcWlanBroadcastSsid, fgWcWlanSecurity, fgWcWlanEncryption,
+                  fgWcWlanAuthentication, fgWcWlanRadiusServer, fgWcWlanUserGroup,
+                  fgWcWlanLocalBridging, fgWcWlanVlanId, fgWcWlanMeshBackhaul,
+                  fgWcWlanStationCapacity, fgWcWlanStationCount,
+                  fgWcWtpProfilePlatform, fgWcWtpProfileDataChannelDtlsPolicy,
+                  fgWcWtpProfileCountryString,
+                  fgWcWtpProfileRadioMode, fgWcWtpProfileRadioApScan, fgWcWtpProfileRadioWidsProfile,
+                  fgWcWtpProfileRadioDarrp, fgWcWtpProfileRadioFrequencyHandoff,
+                  fgWcWtpProfileRadioApHandoff, fgWcWtpProfileRadioBeaconInterval,
+                  fgWcWtpProfileRadioDtimPeriod, fgWcWtpProfileRadioBand,
+                  fgWcWtpProfileRadioChannelBonding, fgWcWtpProfileRadioChannel,
+                  fgWcWtpProfileRadioAutoTxPowerControl, fgWcWtpProfileRadioAutoTxPowerLow,
+                  fgWcWtpProfileRadioAutoTxPowerHigh, fgWcWtpProfileRadioTxPowerLevel,
+                  fgWcWtpProfileRadioVaps, fgWcWtpProfileRadioStationCapacity, fgWcWtpProfileRadioChannelWidth,
+                  fgWcWtpConfigWtpAdmin, fgWcWtpConfigWtpName, fgWcWtpConfigWtpLocation,
+                  fgWcWtpConfigWtpProfile, fgWcWtpConfigRadioEnable, fgWcWtpConfigRadioAutoTxPowerControl,
+                  fgWcWtpConfigRadioAutoTxPowerLow, fgWcWtpConfigRadioAutoTxPowerHigh,
+                  fgWcWtpConfigRadioTxPowerLevel, fgWcWtpConfigRadioBand, fgWcWtpConfigRadioApScan,
+                  fgWcWtpConfigVapAll, fgWcWtpConfigVaps,
+                  fgWcWtpSessionWtpIpAddressType, fgWcWtpSessionWtpIpAddress, fgWcWtpSessionWtpLocalIpAddressType,
+                  fgWcWtpSessionWtpLocalIpAddress, fgWcWtpSessionWtpBaseMacAddress,
+                  fgWcWtpSessionConnectionState, fgWcWtpSessionWtpUpTime,
+                  fgWcWtpSessionWtpDaemonUpTime, fgWcWtpSessionWtpSessionUpTime,
+                  fgWcWtpSessionWtpProfileName, fgWcWtpSessionWtpModelNumber,
+                  fgWcWtpSessionWtpHwVersion, fgWcWtpSessionWtpSwVersion,
+                  fgWcWtpSessionWtpBootVersion, fgWcWtpSessionWtpRegionCode,
+                  fgWcWtpSessionWtpStationCount, fgWcWtpSessionWtpByteRxCount,
+                  fgWcWtpSessionWtpByteTxCount, fgWcWtpSessionWtpCpuUsage,
+                  fgWcWtpSessionWtpMemoryUsage, fgWcWtpSessionWtpMemoryCapacity,
+                  fgWcWtpSessionRadioMode, fgWcWtpSessionRadioBaseBssid,
+                  fgWcWtpSessionRadioCountryString, fgWcWtpSessionRadioCountryCode,
+                  fgWcWtpSessionRadioOperatingChannel, fgWcWtpSessionRadioOperatingPower,
+                  fgWcWtpSessionRadioStationCount,
+                  fgWcWtpSessionVapSsid, fgWcWtpSessionVapStationCount,
+                  fgWcWtpSessionVapByteRxCount, fgWcWtpSessionVapByteTxCount,
+                  fgWcStaWlan, fgWcStaWtpId, fgWcStaRadioId, fgWcStaVlanId, fgWcStaIpAddressType, fgWcStaIpAddress,
+                  fgWcStaVci, fgWcStaHost, fgWcStaUser, fgWcStaGroup, fgWcStaSignal, fgWcStaNoise,
+                  fgWcStaIdle, fgWcStaBandwidthTx, fgWcStaBandwidthRx, fgWcStaChannel,
+                  fgWcStaRadioType, fgWcStaSecurity, fgWcStaEncrypt, fgWcStaOnline
+                }
     STATUS      current
     DESCRIPTION 
         "Objects pertaining to wireless controller."
@@ -5530,7 +7482,33 @@ fgFcObjectGroup OBJECT-GROUP
     DESCRIPTION 
         "Objects pertaining to switch controller."
     ::= { fgMibConformance 26 }
-    
+
+fgServerLoadBalanceObjectGroup OBJECT-GROUP
+    OBJECTS     { fgServerLoadBalanceRealServerAddress, fgServerLoadBalanceVirtualServerName }
+    STATUS      current
+    DESCRIPTION 
+        "Objects pertaining to Server Load Balance group."
+    ::= { fgMibConformance 27 }
+
+fgUsbportsObjectGroup OBJECT-GROUP
+    OBJECTS     { fgUsbportCount, fgUsbportPlugged, fgUsbportVersion,
+                  fgUsbportClass, fgUsbportVendId, fgUsbportProdId, fgUsbportRevision,
+                  fgUsbportManufacturer, fgUsbportProduct, fgUsbportSerial
+                }
+    STATUS      current
+    DESCRIPTION 
+        "Objects pertaining to USB device group."
+    ::= { fgMibConformance 28 }
+
+fgUsbModemInfoGroup OBJECT-GROUP
+    OBJECTS     { fgUsbModemSignalStrength, fgUsbModemStatus, fgUsbModemSimState,
+               fgUsbModemVendor, fgUsbModemProduct, fgUsbModemNetwork, fgUsbModemId, fgUsbModemSimId }
+    STATUS      current
+    DESCRIPTION 
+        "Objects pertaining to USB Modem Info group."
+    ::= { fgMibConformance 29 }
+
+
 fgMIBCompliance MODULE-COMPLIANCE
     STATUS      current
     DESCRIPTION 
@@ -5634,6 +7612,19 @@ fgMIBCompliance MODULE-COMPLIANCE
         GROUP   fgFcObjectGroup
         DESCRIPTION
               "Model and feature specific."
+
+        GROUP   fgServerLoadBalanceObjectGroup
+        DESCRIPTION
+              "Model and feature specific."
+
+        GROUP   fgUsbportsObjectGroup
+        DESCRIPTION
+              "Model and feature specific."
+
+        GROUP   fgUsbModemInfoGroup
+        DESCRIPTION
+              "Model and feature specific."
+
 
     ::= { fgMibConformance 100 }
 

--- a/mibs/FORTINET-FORTIGATE-MIB.mib
+++ b/mibs/FORTINET-FORTIGATE-MIB.mib
@@ -26,11 +26,11 @@ IMPORTS
         FROM SNMPv2-SMI
     CounterBasedGauge64
         FROM HCNUM-TC
-    DisplayString, TEXTUAL-CONVENTION, AutonomousType
+    DisplayString, TEXTUAL-CONVENTION, AutonomousType, DateAndTime
         FROM SNMPv2-TC;
 
 fnFortiGateMib MODULE-IDENTITY
-    LAST-UPDATED "201101100000Z"
+    LAST-UPDATED "201211290000Z"
     ORGANIZATION 
         "Fortinet Technologies, Inc."
     CONTACT-INFO 
@@ -38,6 +38,21 @@ fnFortiGateMib MODULE-IDENTITY
          Technical Support
          email: support@fortinet.com
          http://www.fortinet.com"
+    DESCRIPTION 
+	 "Added fgVpnTrapPhase1Name OID in VPN traps"
+    REVISION    "201211290000Z"
+    DESCRIPTION 
+        "Added OID for 64-bit sysUpTime"
+    REVISION    "201207100000Z"
+    DESCRIPTION 
+        "Added OID for a virtual domain's HA cluster member state."
+    REVISION    "201205160000Z"
+    DESCRIPTION 
+        "Added OIDs for advanced system info and NP4/NP2 processors."
+    REVISION    "201202060000Z"
+    DESCRIPTION 
+        "Added OIDs for IPv6 statistics."
+    REVISION    "201109120000Z"
     DESCRIPTION 
         "MIB module for Fortinet FortiGate devices."
     REVISION    "201101100000Z"
@@ -91,6 +106,12 @@ FgHaMode ::= TEXTUAL-CONVENTION
         "enumerated type for HA cluster modes"
     SYNTAX      INTEGER { standalone(1), activeActive(2), 
                     activePassive(3) }
+
+FgHaState ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION 
+        "enumerated type for HA cluster member state"
+    SYNTAX      INTEGER { master(1), backup(2), standalone(3) }
 
 FgHaLBSchedule ::= TEXTUAL-CONVENTION
     STATUS      current
@@ -150,97 +171,113 @@ FgWanOptHistPeriods ::= TEXTUAL-CONVENTION
     SYNTAX      INTEGER { last10Min(1), lastHour(2), lastDay(3), 
                     lastMonth(4) }
 
+FgHaStatsSyncStatusType ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION 
+        "Current HA Sync status types"
+    SYNTAX      INTEGER { Not-Synchronized(0), Synchronized(1) }
+
 --
 -- fortinet.fnFortiGateMib.fgModel
 --
 
 fgModel OBJECT IDENTIFIER ::= { fnFortiGateMib 1 }
 
-fwf20C         OBJECT IDENTIFIER ::= { fgModel 210 }
-fgt20C         OBJECT IDENTIFIER ::= { fgModel 212 }
-fgt30B         OBJECT IDENTIFIER ::= { fgModel 302 }
-fwf30B         OBJECT IDENTIFIER ::= { fgModel 310 }
-fgt40C         OBJECT IDENTIFIER ::= { fgModel 410 }
-fwf40C         OBJECT IDENTIFIER ::= { fgModel 411 }
-fgt50A         OBJECT IDENTIFIER ::= { fgModel 500 }
-fgt50AM        OBJECT IDENTIFIER ::= { fgModel 501 }
-fgt50B         OBJECT IDENTIFIER ::= { fgModel 502 }
-fgt51B         OBJECT IDENTIFIER ::= { fgModel 504 }
-fwf50B         OBJECT IDENTIFIER ::= { fgModel 510 }
-fgt60          OBJECT IDENTIFIER ::= { fgModel 600 }
-fgt60M         OBJECT IDENTIFIER ::= { fgModel 601 }
-fgt60ADSL      OBJECT IDENTIFIER ::= { fgModel 602 }
-fgt60B         OBJECT IDENTIFIER ::= { fgModel 603 }
-fgt60C         OBJECT IDENTIFIER ::= { fgModel 605 }
-fwf60          OBJECT IDENTIFIER ::= { fgModel 610 }
-fwf60A         OBJECT IDENTIFIER ::= { fgModel 611 }
-fwf60AM        OBJECT IDENTIFIER ::= { fgModel 612 }
-fwf60B         OBJECT IDENTIFIER ::= { fgModel 613 }
-fwf60C         OBJECT IDENTIFIER ::= { fgModel 615 }
-fw60CM         OBJECT IDENTIFIER ::= { fgModel 616 }
-fw60CA         OBJECT IDENTIFIER ::= { fgModel 618 }
-fw60CB         OBJECT IDENTIFIER ::= { fgModel 617 }
-fw6XMB         OBJECT IDENTIFIER ::= { fgModel 619 }
-fgt80C         OBJECT IDENTIFIER ::= { fgModel 800 }
-fgt80CM        OBJECT IDENTIFIER ::= { fgModel 801 }
-fgt82C         OBJECT IDENTIFIER ::= { fgModel 802 }
-fwf80CM        OBJECT IDENTIFIER ::= { fgModel 810 }
-fwf81CM        OBJECT IDENTIFIER ::= { fgModel 811 }
-fgt100         OBJECT IDENTIFIER ::= { fgModel 1000 }
-fgt100A        OBJECT IDENTIFIER ::= { fgModel 1001 }
-fgt110C        OBJECT IDENTIFIER ::= { fgModel 1002 }
-fgt111C        OBJECT IDENTIFIER ::= { fgModel 1003 }
-fgt200         OBJECT IDENTIFIER ::= { fgModel 2000 }
-fgt200A        OBJECT IDENTIFIER ::= { fgModel 2001 }
-fgt224B        OBJECT IDENTIFIER ::= { fgModel 2002 }
-fgt200B        OBJECT IDENTIFIER ::= { fgModel 2003 }
-fgt200BPOE     OBJECT IDENTIFIER ::= { fgModel 2004 }
-fgt300         OBJECT IDENTIFIER ::= { fgModel 3000 }
-fgt300A        OBJECT IDENTIFIER ::= { fgModel 3001 }
-fgt310B        OBJECT IDENTIFIER ::= { fgModel 3002 }
-fgt300D        OBJECT IDENTIFIER ::= { fgModel 3003 }
-fgt311B        OBJECT IDENTIFIER ::= { fgModel 3004 }
-fgt300C        OBJECT IDENTIFIER ::= { fgModel 3005 }
-fgt400         OBJECT IDENTIFIER ::= { fgModel 4000 }
-fgt400A        OBJECT IDENTIFIER ::= { fgModel 4001 }
-fgt500         OBJECT IDENTIFIER ::= { fgModel 5000 }
-fgt500A        OBJECT IDENTIFIER ::= { fgModel 5001 }
-fgt620B        OBJECT IDENTIFIER ::= { fgModel 6200 }
-fgt621B        OBJECT IDENTIFIER ::= { fgModel 6210 }
-fgt600D        OBJECT IDENTIFIER ::= { fgModel 6201 }
-fgt600C        OBJECT IDENTIFIER ::= { fgModel 6003 }
-fgt800         OBJECT IDENTIFIER ::= { fgModel 8000 }
-fgt800F        OBJECT IDENTIFIER ::= { fgModel 8001 }
-fgt1000        OBJECT IDENTIFIER ::= { fgModel 10000 }
-fgt1000A       OBJECT IDENTIFIER ::= { fgModel 10001 }
-fgt1000AFA2    OBJECT IDENTIFIER ::= { fgModel 10002 }
-fgt1000ALENC   OBJECT IDENTIFIER ::= { fgModel 10003 }
-fgt1000C       OBJECT IDENTIFIER ::= { fgModel 10004 }
-fgt1240B       OBJECT IDENTIFIER ::= { fgModel 12400 }
-fgt2000        OBJECT IDENTIFIER ::= { fgModel 20000 }
-fgt3000        OBJECT IDENTIFIER ::= { fgModel 30000 }
-fgt3016B       OBJECT IDENTIFIER ::= { fgModel 30160 }
-fgtONE         OBJECT IDENTIFIER ::= { fgModel 10    }
-fgtVM          OBJECT IDENTIFIER ::= { fgModel 20    }
-fgtVM64        OBJECT IDENTIFIER ::= { fgModel 30    }
-fgt3040B       OBJECT IDENTIFIER ::= { fgModel 30400 }
-fgt3140B       OBJECT IDENTIFIER ::= { fgModel 30401 }
-fgt3600        OBJECT IDENTIFIER ::= { fgModel 36000 }
-fgt3600A       OBJECT IDENTIFIER ::= { fgModel 36003 }
-fgt3810A       OBJECT IDENTIFIER ::= { fgModel 38100 }
-fgt3950B       OBJECT IDENTIFIER ::= { fgModel 39500 }
-fgt3951B       OBJECT IDENTIFIER ::= { fgModel 39501 }
-fgt4000        OBJECT IDENTIFIER ::= { fgModel 40000 }
-fgt5000        OBJECT IDENTIFIER ::= { fgModel 50000 }
-fgt5001        OBJECT IDENTIFIER ::= { fgModel 50010 }
-fgt5001A       OBJECT IDENTIFIER ::= { fgModel 50011 }
-fgt5001FA2     OBJECT IDENTIFIER ::= { fgModel 50012 }
-fgt5001B       OBJECT IDENTIFIER ::= { fgModel 50013 }
-fgt5002A       OBJECT IDENTIFIER ::= { fgModel 50021 }
-fgt5002FB2     OBJECT IDENTIFIER ::= { fgModel 50001 }
-fgt5004        OBJECT IDENTIFIER ::= { fgModel 50040 }
-fgt5005        OBJECT IDENTIFIER ::= { fgModel 50050 }
-fgt5005FA2     OBJECT IDENTIFIER ::= { fgModel 50051 }
+-- fgModel start
+
+fg20CA           OBJECT IDENTIFIER ::= { fgModel 214 }
+fgt100           OBJECT IDENTIFIER ::= { fgModel 1000 }
+fgt1000          OBJECT IDENTIFIER ::= { fgModel 10000 }
+fgt1000A         OBJECT IDENTIFIER ::= { fgModel 10001 }
+fgt1000AFA2      OBJECT IDENTIFIER ::= { fgModel 10002 }
+fgt1000ALENC     OBJECT IDENTIFIER ::= { fgModel 10003 }
+fgt1000C         OBJECT IDENTIFIER ::= { fgModel 10004 }
+fgt100A          OBJECT IDENTIFIER ::= { fgModel 1001 }
+fgt100D          OBJECT IDENTIFIER ::= { fgModel 1004 }
+fgt110C          OBJECT IDENTIFIER ::= { fgModel 1002 }
+fgt111C          OBJECT IDENTIFIER ::= { fgModel 1003 }
+fgt1240B         OBJECT IDENTIFIER ::= { fgModel 12400 }
+fgt200           OBJECT IDENTIFIER ::= { fgModel 2000 }
+fgt200A          OBJECT IDENTIFIER ::= { fgModel 2001 }
+fgt200B          OBJECT IDENTIFIER ::= { fgModel 2003 }
+fgt200BPOE       OBJECT IDENTIFIER ::= { fgModel 2004 }
+fgt20C           OBJECT IDENTIFIER ::= { fgModel 212 }
+fgt224B          OBJECT IDENTIFIER ::= { fgModel 2002 }
+fgt300           OBJECT IDENTIFIER ::= { fgModel 3000 }
+fgt3000          OBJECT IDENTIFIER ::= { fgModel 30000 }
+fgt300A          OBJECT IDENTIFIER ::= { fgModel 3001 }
+fgt300C          OBJECT IDENTIFIER ::= { fgModel 3005 }
+fgt300D          OBJECT IDENTIFIER ::= { fgModel 3003 }
+fgt3016B         OBJECT IDENTIFIER ::= { fgModel 30160 }
+fgt3040B         OBJECT IDENTIFIER ::= { fgModel 30400 }
+fgt30B           OBJECT IDENTIFIER ::= { fgModel 302 }
+fgt310B          OBJECT IDENTIFIER ::= { fgModel 3002 }
+fgt311B          OBJECT IDENTIFIER ::= { fgModel 3004 }
+fgt3140B         OBJECT IDENTIFIER ::= { fgModel 30401 }
+fgt3240C         OBJECT IDENTIFIER ::= { fgModel 32401 }
+fgt3600          OBJECT IDENTIFIER ::= { fgModel 36000 }
+fgt3600A         OBJECT IDENTIFIER ::= { fgModel 36003 }
+fgt3810A         OBJECT IDENTIFIER ::= { fgModel 38100 }
+fgt3950B         OBJECT IDENTIFIER ::= { fgModel 39500 }
+fgt3951B         OBJECT IDENTIFIER ::= { fgModel 39501 }
+fgt400           OBJECT IDENTIFIER ::= { fgModel 4000 }
+fgt400A          OBJECT IDENTIFIER ::= { fgModel 4001 }
+fgt40C           OBJECT IDENTIFIER ::= { fgModel 410 }
+fgt500           OBJECT IDENTIFIER ::= { fgModel 5000 }
+fgt5001          OBJECT IDENTIFIER ::= { fgModel 50010 }
+fgt5001A         OBJECT IDENTIFIER ::= { fgModel 50011 }
+fgt5001B         OBJECT IDENTIFIER ::= { fgModel 50013 }
+fgt5001C         OBJECT IDENTIFIER ::= { fgModel 50014 }
+fgt5001FA2       OBJECT IDENTIFIER ::= { fgModel 50012 }
+fgt5002FB2       OBJECT IDENTIFIER ::= { fgModel 50001 }
+fgt5005FA2       OBJECT IDENTIFIER ::= { fgModel 50051 }
+fgt500A          OBJECT IDENTIFIER ::= { fgModel 5001 }
+fgt50A           OBJECT IDENTIFIER ::= { fgModel 500 }
+fgt50B           OBJECT IDENTIFIER ::= { fgModel 502 }
+fgt5101C         OBJECT IDENTIFIER ::= { fgModel 51010 }
+fgt51B           OBJECT IDENTIFIER ::= { fgModel 504 }
+fgt60            OBJECT IDENTIFIER ::= { fgModel 600 }
+fgt600C          OBJECT IDENTIFIER ::= { fgModel 6003 }
+fgt600D          OBJECT IDENTIFIER ::= { fgModel 6201 }
+fgt60ADSL        OBJECT IDENTIFIER ::= { fgModel 602 }
+fgt60B           OBJECT IDENTIFIER ::= { fgModel 603 }
+fgt60C           OBJECT IDENTIFIER ::= { fgModel 615 }
+fgt60CP          OBJECT IDENTIFIER ::= { fgModel 621 }
+fgt60M           OBJECT IDENTIFIER ::= { fgModel 601 }
+fgt620B          OBJECT IDENTIFIER ::= { fgModel 6200 }
+fgt621B          OBJECT IDENTIFIER ::= { fgModel 6210 }
+fgt800           OBJECT IDENTIFIER ::= { fgModel 8000 }
+fgt800C          OBJECT IDENTIFIER ::= { fgModel 8003 }
+fgt800F          OBJECT IDENTIFIER ::= { fgModel 8001 }
+fgt80C           OBJECT IDENTIFIER ::= { fgModel 800 }
+fgt80CM          OBJECT IDENTIFIER ::= { fgModel 801 }
+fgt82C           OBJECT IDENTIFIER ::= { fgModel 802 }
+fgtONE           OBJECT IDENTIFIER ::= { fgModel 10 }
+fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
+fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
+fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
+fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
+fgtVM            OBJECT IDENTIFIER ::= { fgModel 20 }
+fgtVM64          OBJECT IDENTIFIER ::= { fgModel 30 }
+fgtVM64          OBJECT IDENTIFIER ::= { fgModel 30 }
+fsw5203B         OBJECT IDENTIFIER ::= { fgModel 50023 }
+fw20CA           OBJECT IDENTIFIER ::= { fgModel 213 }
+fw60CA           OBJECT IDENTIFIER ::= { fgModel 618 }
+fw60CM           OBJECT IDENTIFIER ::= { fgModel 617 }
+fw6XMB           OBJECT IDENTIFIER ::= { fgModel 619 }
+fwf20C           OBJECT IDENTIFIER ::= { fgModel 210 }
+fwf30B           OBJECT IDENTIFIER ::= { fgModel 310 }
+fwf40C           OBJECT IDENTIFIER ::= { fgModel 411 }
+fwf50B           OBJECT IDENTIFIER ::= { fgModel 510 }
+fwf60            OBJECT IDENTIFIER ::= { fgModel 610 }
+fwf60A           OBJECT IDENTIFIER ::= { fgModel 611 }
+fwf60AM          OBJECT IDENTIFIER ::= { fgModel 612 }
+fwf60B           OBJECT IDENTIFIER ::= { fgModel 613 }
+fwf60C           OBJECT IDENTIFIER ::= { fgModel 616 }
+fwf80CM          OBJECT IDENTIFIER ::= { fgModel 810 }
+fwf81CM          OBJECT IDENTIFIER ::= { fgModel 811 }
+
+-- fgModel end
 
 --
 -- fortinet.fnFortiGateMib.fgTraps
@@ -322,7 +359,8 @@ fgVdEntry OBJECT-TYPE
 FgVdEntry ::= SEQUENCE {
     fgVdEntIndex    FgVdIndex,
     fgVdEntName     DisplayString,
-    fgVdEntOpMode   FgOpMode
+    fgVdEntOpMode   FgOpMode,
+    fgVdEntHaState  FgHaState
 }
 
 fgVdEntIndex OBJECT-TYPE
@@ -348,6 +386,15 @@ fgVdEntOpMode OBJECT-TYPE
     DESCRIPTION 
         "Operation mode of the virtual domain (NAT or Transparent)"
     ::= { fgVdEntry 3 }
+
+fgVdEntHaState OBJECT-TYPE
+    SYNTAX      FgHaState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "HA cluster member state of the virtual domain on this device
+         (master, backup or standalone)"
+    ::= { fgVdEntry 4 }
 
 --
 -- fortinet.fnFortiGateMib.fgVirtualDomain.fgVdTables.fgVdTpTable
@@ -536,6 +583,59 @@ fgSysSesRate60 OBJECT-TYPE
         "The average session setup rate over the past 60 minutes."
     ::= { fgSystemInfo 14 }
 
+fgSysSes6Count OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Number of active ipv6 sessions on the device"
+    ::= { fgSystemInfo 15 }
+
+fgSysSes6Rate1 OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "Sessions Per Second"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The average ipv6 session setup rate over the past minute."
+    ::= { fgSystemInfo 16 }
+
+fgSysSes6Rate10 OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "Sessions Per Second"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The average ipv6 session setup rate over the past 10 minutes."
+    ::= { fgSystemInfo 17 }
+
+fgSysSes6Rate30 OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "Sessions Per Second"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The average ipv6 session setup rate over the past 30 minutes."
+    ::= { fgSystemInfo 18 }
+
+fgSysSes6Rate60 OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "Sessions Per Second"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The average ipv6 session setup rate over the past 60 minutes."
+    ::= { fgSystemInfo 19 }
+
+fgSysUpTime OBJECT-TYPE
+    SYNTAX      Counter64
+    UNITS       "hundredths of a second"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The 64bit time (in hundredths of a second) since the network management portion of the system was last re-initialized."
+    ::= { fgSystemInfo 20 }
+
 --
 -- fortinet.fnFortiGateMib.fgSystem.fgSoftware
 --
@@ -670,7 +770,9 @@ FgProcessorEntry ::= SEQUENCE {
     fgProcessorContainedIn FnIndex,
     fgProcessorPktRxCount  Counter64,
     fgProcessorPktTxCount  Counter64,
-    fgProcessorPktDroppedCount Counter64
+    fgProcessorPktDroppedCount Counter64,
+    fgProcessorUserUsage   Gauge32,
+    fgProcessorSysUsage    Gauge32
 }
 
 fgProcessorEntIndex OBJECT-TYPE
@@ -682,21 +784,25 @@ fgProcessorEntIndex OBJECT-TYPE
     ::= { fgProcessorEntry 1 }
 
 fgProcessorUsage OBJECT-TYPE
-    SYNTAX      Gauge32
+    SYNTAX      Gauge32 (0..100)
+    UNITS       "%"
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION 
         "The processor's CPU usage (percentage), which is an average
-        calculated over the last minute."
+        calculated over the last minute.
+        (only valid for processors types that support this statistic)."
     ::= { fgProcessorEntry 2 }
 
 fgProcessorUsage5sec OBJECT-TYPE
-    SYNTAX      Gauge32
+    SYNTAX      Gauge32 (0..100)
+    UNITS       "%"
     MAX-ACCESS  read-only
     STATUS      current
     DESCRIPTION 
         "The processor's CPU usage (percentage), which is an average
-        calculated over the last 5 sec."
+        calculated over the last 5 sec.
+        (only valid for processors types that support this statistic)."
     ::= { fgProcessorEntry 3 }
 
 fgProcessorType OBJECT-TYPE
@@ -744,6 +850,28 @@ fgProcessorPktDroppedCount OBJECT-TYPE
          (only valid for processors types that support this statistic)."
     ::= { fgProcessorEntry 8 }
 
+fgProcessorUserUsage OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    UNITS       "%"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The processor's CPU user space usage, which is an average 
+         calculated over the last minute.
+         (only valid for processors types that support this statistic)."
+    ::= { fgProcessorEntry 9 }
+
+fgProcessorSysUsage OBJECT-TYPE
+    SYNTAX      Gauge32 (0..100)
+    UNITS       "%"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The processor's CPU system space usage, which is an average 
+         calculated over the last minute.
+         (only valid for processors types that support this statistic)."
+    ::= { fgProcessorEntry 10 }
+
 --
 -- Registrations for processor types, for use with fgProcessorType
 --
@@ -781,6 +909,17 @@ fgProcessorFnSoc OBJECT-IDENTITY
         "The processor type identifier used for Fortinet FortiSoc processor."
     ::= { fgProcessorTypes 5 }
 
+fgProcessorFnNP2 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor type identifier used for Fortinet NP2 security processor."
+    ::= { fgProcessorTypes 6 }
+
+fgProcessorFnNP4 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor type identifier used for Fortinet NP4 security processor."
+    ::= { fgProcessorTypes 7 }
 
 --
 -- fortinet.fnFortiGateMib.fgSystem.fgProcessorModules
@@ -837,6 +976,61 @@ fgProcModFnXG2 OBJECT-IDENTITY
         Fortinet FMC module FMC-XG2."
     ::= { fgProcessorModuleTypes 6 }
 
+fgProcModIntegratedNPU OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for the NPU(s)
+        built in the device."
+    ::= { fgProcessorModuleTypes 7 }
+
+fgProcModFnXD2 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet FMC module FMC-XD2."
+    ::= { fgProcessorModuleTypes 8 }
+
+fgProcModFnF20 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet FMC module FMC-F20."
+    ::= { fgProcessorModuleTypes 9 }
+
+fgProcModFnC20 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet FMC module FMC-C20."
+    ::= { fgProcessorModuleTypes 10 }
+
+fgProcModFnXD4 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet AMC module ADM-XD4."
+    ::= { fgProcessorModuleTypes 11 }
+
+fgProcModFnFB4 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet AMC module ASM-FB4."
+    ::= { fgProcessorModuleTypes 12 }
+
+fgProcModFnFB8 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet AMC module ADM-FB8."
+    ::= { fgProcessorModuleTypes 13 }
+
+fgProcModFnXB2 OBJECT-IDENTITY
+    STATUS current
+    DESCRIPTION
+        "The processor module type identifier used for
+        Fortinet AMC module ADM-XB2."
+    ::= { fgProcessorModuleTypes 14 }
 
 fgProcessorModuleCount OBJECT-TYPE
     SYNTAX      Integer32
@@ -952,6 +1146,163 @@ fgProcModSACount OBJECT-TYPE
     ::= { fgProcessorModuleEntry 9}
 
 --
+-- fortinet.fnFortiGateMib.fgSystem.fgSystemInfoAdvanced
+--
+
+fgSystemInfoAdvanced OBJECT IDENTIFIER
+    ::= { fgSystem 6 }
+
+--
+-- fortinet.fnFortiGateMib.fgSystem.fgSystemInfoAdvanced.fgSysInfoAdvMem
+--
+
+fgSysInfoAdvMem OBJECT IDENTIFIER
+    ::= { fgSystemInfoAdvanced 1 }
+
+fgSIAdvMemPageCache OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The amount of physical RAM used as cache memory for files read from
+         the disk (the page cache)."
+    ::= { fgSysInfoAdvMem 1 }
+
+fgSIAdvMemCacheActive OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The toal amount of buffer or page cache memory that are active.
+         This part of the memory is used recently and usually not reclaimed
+         unless absolutely necessary."
+    ::= { fgSysInfoAdvMem 2 }
+
+fgSIAdvMemCacheInactive OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The total amount of buffer or page cache memory that are free and
+         available. This is memory that has not been recently used and can be 
+         reclaimed for other purposes by the paging algorithm."
+    ::= { fgSysInfoAdvMem 3 }
+
+fgSIAdvMemBuffer OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The amount of physical RAM used for filesystem buffers."
+    ::= { fgSysInfoAdvMem 4 }
+
+fgSIAdvMemEnterKerConsThrsh OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current memory threshold level to enter kernel conserve mode."
+    ::= { fgSysInfoAdvMem 5 }
+
+fgSIAdvMemLeaveKerConsThrsh OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current memory threshold level to leave kernel conserve mode."
+    ::= { fgSysInfoAdvMem 6 }
+
+fgSIAdvMemEnterProxyConsThrsh OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current memory threshold level to enter proxy conserve mode."
+    ::= { fgSysInfoAdvMem 7 }
+
+fgSIAdvMemLeaveProxyConsThrsh OBJECT-TYPE
+    SYNTAX      Gauge32
+    UNITS       "KB"
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current memory threshold level to leave proxy conserve mode."
+    ::= { fgSysInfoAdvMem 8 }
+
+--
+-- fortinet.fnFortiGateMib.fgSystem.fgSystemInfoAdvanced.fgSysInfoAdvSessions
+--
+
+fgSysInfoAdvSessions OBJECT IDENTIFIER
+    ::= { fgSystemInfoAdvanced 2 }
+
+fgSIAdvSesEphemeralCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The current number of ephemeral sessions on the device."
+    ::= { fgSysInfoAdvSessions 1 }
+
+fgSIAdvSesEphemeralLimit OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The limit number of allowed ephemeral sessions on the device."
+    ::= { fgSysInfoAdvSessions 2 }
+
+fgSIAdvSesClashCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of new sessions which have collision with existing sessions.
+         This generally highlights a shortage of ports or IP in ip-pool during
+         source natting (PNAT)."
+    ::= { fgSysInfoAdvSessions 3 }
+
+fgSIAdvSesExpCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of current expectation sessions."
+    ::= { fgSysInfoAdvSessions 4 }
+
+fgSIAdvSesSyncQFCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The sync queue full counter, reflecting bursts on the sync queue."
+    ::= { fgSysInfoAdvSessions 5 }
+
+fgSIAdvSesAcceptQFCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The accept queue full counter, reflecting bursts on the accept queue."
+    ::= { fgSysInfoAdvSessions 6 }
+
+fgSIAdvSesNoListenerCount OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "The number of direct requests to Fortigate local stack from external,
+         reflecting DOS attack towards the Fortigate."
+    ::= { fgSysInfoAdvSessions 7 }
+
+--
 -- fortinet.fnFortiGateMib.fgFirewall
 --
 
@@ -970,6 +1321,10 @@ fgFwPolInfo OBJECT IDENTIFIER
 
 fgFwPolTables OBJECT IDENTIFIER
     ::= { fgFwPolicies 2 }
+
+--
+-- fortinet.fnFortiGateMib.fgFirewall.fgFwPolicies.fgFwPolTables.fgFwPolStatsTable
+--
 
 fgFwPolStatsTable OBJECT-TYPE
     SYNTAX      SEQUENCE OF FgFwPolStatsEntry
@@ -1018,6 +1373,61 @@ fgFwPolByteCount OBJECT-TYPE
     DESCRIPTION 
         "Number of bytes in packets matching the policy. See fgFwPolPktCount."
     ::= { fgFwPolStatsEntry 3 }
+
+--
+-- fortinet.fnFortiGateMib.fgFirewall.fgFwPolicies.fgFwPolTables.fgFwPol6StatsTable
+--
+
+fgFwPol6StatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgFwPol6StatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "Firewall policy6 statistics table.  This table has a dependent
+         expansion relationship with fgVdTable.
+         Only virtual domains with enabled policies are present in this table."
+    ::= { fgFwPolTables 2 }
+
+fgFwPol6StatsEntry OBJECT-TYPE
+    SYNTAX      FgFwPol6StatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "Firewall policy6 statistics on a virtual domain"
+    INDEX       { fgVdEntIndex, fgFwPol6ID }
+    ::= { fgFwPol6StatsTable 1 }
+
+FgFwPol6StatsEntry ::= SEQUENCE {
+    fgFwPol6ID         FnIndex,
+    fgFwPol6PktCount   Counter64,
+    fgFwPol6ByteCount  Counter64
+}
+
+fgFwPol6ID OBJECT-TYPE
+    SYNTAX      FnIndex
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "Firewall policy6 ID. Only enabled policies are present in this table.
+         Policy IDs are only unique within a virtual domain."
+    ::= { fgFwPol6StatsEntry 1 }
+
+fgFwPol6PktCount OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Number of packets matched to policy (passed or blocked, depending
+         on policy action). Count is from the time the policy became active."
+    ::= { fgFwPol6StatsEntry 2 }
+
+fgFwPol6ByteCount OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Number of bytes in packets matching the policy. See fgFwPol6PktCount."
+    ::= { fgFwPol6StatsEntry 3 }
 
 --
 -- fortinet.fnFortiGateMib.fgFirewall.fgFwUsers
@@ -3643,6 +4053,40 @@ fgIpSessNumber OBJECT-TYPE
     ::= { fgIpSessStatsEntry 1 }
 
 --
+-- fortinet.fnFortiGateMib.fgInetProto.fgInetProtoTables.fgIp6SessStatsTable
+--
+
+fgIp6SessStatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FgIp6SessStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "IP session statistics table"
+    ::= { fgInetProtoTables 3 }
+
+fgIp6SessStatsEntry OBJECT-TYPE
+    SYNTAX      FgIp6SessStatsEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION 
+        "IP session statistics on a virtual domain"
+    AUGMENTS    { fgVdEntry }
+    ::= { fgIp6SessStatsTable 1 }
+
+FgIp6SessStatsEntry ::= SEQUENCE {
+    fgIp6SessNumber  Counter32
+}
+
+fgIp6SessNumber OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current number of sessions on the virtual domain"
+    ::= { fgIp6SessStatsEntry 1 }
+
+
+--
 -- fortinet.fnFortiGateMib.fgVpn
 --
 
@@ -4212,6 +4656,15 @@ fgVpnTrapRemoteGateway OBJECT-TYPE
         "Remote gateway IP address. Used in VPN related traps."
     ::= { fgVpnTrapObjects 3 }
 
+fgVpnTrapPhase1Name OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Name of the phase 1. Used in VPN related traps."
+    ::= { fgVpnTrapObjects 4 }
+
+
 --
 -- fortinet.fnFortiGateMib.fgHighAvailability
 --
@@ -4318,7 +4771,12 @@ FgHaStatsEntry ::= SEQUENCE {
     fgHaStatsByteCount  Counter32,
     fgHaStatsIdsCount   Counter32,
     fgHaStatsAvCount    Counter32,
-    fgHaStatsHostname   DisplayString
+    fgHaStatsHostname   DisplayString,
+    fgHaStatsSyncStatus         FgHaStatsSyncStatusType,
+    fgHaStatsSyncDatimeSucc     DateAndTime,
+    fgHaStatsSyncDatimeUnsucc   DateAndTime,
+    fgHaStatsGlobalChecksum     DisplayString,
+    fgHaStatsMasterSerial       DisplayString
 }
 
 fgHaStatsIndex OBJECT-TYPE
@@ -4410,6 +4868,46 @@ fgHaStatsHostname OBJECT-TYPE
         "Host name of the specified cluster member"
     ::= { fgHaStatsEntry 11 }
 
+fgHaStatsSyncStatus OBJECT-TYPE
+    SYNTAX      FgHaStatsSyncStatusType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current HA Sync status"
+    ::= { fgHaStatsEntry 12 }
+
+fgHaStatsSyncDatimeSucc OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Date and time of last successful sync"
+    ::= { fgHaStatsEntry 13 }
+
+fgHaStatsSyncDatimeUnsucc OBJECT-TYPE
+    SYNTAX      DateAndTime
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Date and time of last unsuccessful sync"
+    ::= { fgHaStatsEntry 14 }
+
+fgHaStatsGlobalChecksum OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Current HA global checksum value"
+    ::= { fgHaStatsEntry 15 }
+
+fgHaStatsMasterSerial OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION 
+        "Serial number of master during the last synch attempt (successful of not)"
+    ::= { fgHaStatsEntry 16 }
+
 --
 -- fortinet.fnFortiGateMib.fgHighAvailability.fgHaTrapObjects
 --
@@ -4426,6 +4924,82 @@ fgHaTrapMemberSerial OBJECT-TYPE
     ::= { fgHaTrapObjects 1 }
 
 --
+-- fortinet.fnFortiGateMib.fgWc
+--
+
+fgWc OBJECT IDENTIFIER
+    ::= { fnFortiGateMib 14 }
+
+--
+-- fortinet.fnFortiGateMib.fgWc.fgWcTrapObjects
+--
+
+fgWcTrapObjects OBJECT IDENTIFIER
+    ::= { fgWc 1 }
+
+fgWcApVdom OBJECT-TYPE
+    SYNTAX      FgVdIndex
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Virtual domain the wtp is part of"
+    ::= { fgWcTrapObjects 1 }
+
+fgWcApSerial OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Serial number of the wtp"
+    ::= { fgWcTrapObjects 2 }
+
+fgWcApName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Name of the wtp"
+    ::= { fgWcTrapObjects 3 }
+
+--
+-- fortinet.fnFortiGateMib.fgFc
+--
+
+fgFc OBJECT IDENTIFIER
+    ::= { fnFortiGateMib 15 }
+
+--
+-- fortinet.fnFortiGateMib.fgFc.fgFcTrapObjects
+--
+
+fgFcTrapObjects OBJECT IDENTIFIER
+    ::= { fgFc 1 }
+
+fgFcSwVdom OBJECT-TYPE
+    SYNTAX      FgVdIndex
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Virtual domain the switch is part of"
+    ::= { fgFcTrapObjects 1 }
+
+fgFcSwSerial OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Serial number of the switch"
+    ::= { fgFcTrapObjects 2 }
+
+fgFcSwName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  accessible-for-notify
+    STATUS      current
+    DESCRIPTION 
+        "Name of the switch"
+    ::= { fgFcTrapObjects 3 }
+    
+--
 -- fortinet.fnFortiGateMib.fgMibConformance
 --
 
@@ -4438,7 +5012,7 @@ fgMibConformance OBJECT IDENTIFIER
 
 fgTrapVpnTunUp NOTIFICATION-TYPE
     OBJECTS     { fnSysSerial, sysName, fgVpnTrapLocalGateway, 
-                  fgVpnTrapRemoteGateway }
+                  fgVpnTrapRemoteGateway, fgVpnTrapPhase1Name }
     STATUS      current
     DESCRIPTION 
         "Indicates that the specified VPN tunnel has been brought up."
@@ -4446,7 +5020,7 @@ fgTrapVpnTunUp NOTIFICATION-TYPE
 
 fgTrapVpnTunDown NOTIFICATION-TYPE
     OBJECTS     { fnSysSerial, sysName, fgVpnTrapLocalGateway, 
-                  fgVpnTrapRemoteGateway }
+                  fgVpnTrapRemoteGateway, fgVpnTrapPhase1Name }
     STATUS      current
     DESCRIPTION 
         "The specified VPN tunnel has been brought down."
@@ -4573,6 +5147,34 @@ fgTrapFazDisconnect NOTIFICATION-TYPE
     DESCRIPTION 
         "The device has been disconnected from the FortiAnalyzer."
     ::= { fgTrapPrefix 701 }
+    
+fgTrapWcApUp NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName, fgWcApVdom, fgWcApSerial, fgWcApName }
+    STATUS      current
+    DESCRIPTION 
+        "Indicates that the specified AP is up."
+    ::= { fgTrapPrefix 801 }
+    
+fgTrapWcApDown NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName, fgWcApVdom, fgWcApSerial, fgWcApName }
+    STATUS      current
+    DESCRIPTION 
+        "Indicates that the specified AP is down."
+    ::= { fgTrapPrefix 802 }
+
+fgTrapFcSwUp NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName, fgFcSwVdom, fgFcSwSerial, fgFcSwName }
+    STATUS      current
+    DESCRIPTION 
+        "Indicates that the specified switch controller session is up."
+    ::= { fgTrapPrefix 901 }
+    
+fgTrapFcSwDown NOTIFICATION-TYPE
+    OBJECTS     { fnSysSerial, sysName, fgFcSwVdom, fgFcSwSerial, fgFcSwName }
+    STATUS      current
+    DESCRIPTION 
+        "Indicates that the specified switch controller session is down."
+    ::= { fgTrapPrefix 902 }
 
 fgFmTrapDeployComplete NOTIFICATION-TYPE
     OBJECTS     { fnSysSerial }
@@ -4635,7 +5237,10 @@ fgSystemObjectGroup OBJECT-GROUP
                   fgSysSesCount, fgSysLowMemUsage,
                   fgSysLowMemCapacity, fgSysSesRate1,
                   fgSysSesRate10, fgSysSesRate30,
-                  fgSysSesRate60 }
+                  fgSysSesRate60,
+                  fgSysSes6Count, fgSysSes6Rate1,
+                  fgSysSes6Rate10, fgSysSes6Rate30,
+                  fgSysSes6Rate60, fgSysUpTime }
     STATUS      current
     DESCRIPTION
         "Objects pertaining to the system status of the device."
@@ -4663,6 +5268,8 @@ fgHighAvailabilityObjectGroup OBJECT-GROUP
                   fgHaStatsNetUsage, fgHaStatsSesCount, 
                   fgHaStatsPktCount, fgHaStatsByteCount, 
                   fgHaStatsIdsCount, fgHaStatsAvCount, fgHaStatsHostname, 
+                  fgHaStatsSyncStatus, fgHaStatsSyncDatimeSucc, fgHaStatsSyncDatimeUnsucc, 
+                  fgHaStatsGlobalChecksum, fgHaStatsMasterSerial, 
                   fgHaTrapMemberSerial }
     STATUS      current
     DESCRIPTION 
@@ -4707,7 +5314,8 @@ fgFirewallObjectGroup OBJECT-GROUP
                   fgFwUserState, fgFwUserVdom, fgIpSessProto, 
                   fgIpSessFromAddr, fgIpSessFromPort, fgIpSessToAddr, 
                   fgIpSessToPort, fgIpSessExp, fgIpSessVdom, 
-                  fgIpSessNumber }
+                  fgIpSessNumber, fgIp6SessNumber, fgFwPol6PktCount,
+                  fgFwPol6ByteCount }
     STATUS      current
     DESCRIPTION 
         "Objects pertaining to Firewall functionality on FortiGate devices."
@@ -4783,7 +5391,7 @@ fgWebFilterObjectGroup OBJECT-GROUP
 fgVirtualDomainObjectGroup OBJECT-GROUP
     OBJECTS     { fgVdNumber, fgVdMaxVdoms, fgVdEnabled, fgVdEntName, 
                   fgVdEntOpMode, fgVdTpMgmtAddrType, fgVdTpMgmtAddr,
-                  fgVdTpMgmtMask }
+                  fgVdTpMgmtMask, fgVdEntHaState }
     STATUS      current
     DESCRIPTION 
         "Objects pertaining to Virtual Firewall Domain services on FortiGate devices."
@@ -4807,6 +5415,7 @@ fgProcessorsObjectGroup OBJECT-GROUP
     OBJECTS     { fgProcessorCount, fgProcessorUsage, fgProcessorUsage5sec,
                 fgProcessorType, fgProcessorContainedIn, fgProcessorPktRxCount,
                 fgProcessorPktTxCount, fgProcessorPktDroppedCount,
+                fgProcessorUserUsage, fgProcessorSysUsage,
                 fgProcessorModuleCount, fgProcModType,
                 fgProcModName, fgProcModDescr, fgProcModProcessorCount,
                 fgProcModMemCapacity, fgProcModMemUsage,
@@ -4824,7 +5433,8 @@ fgNotificationGroup NOTIFICATION-GROUP
                   fgTrapAvPattern, fgTrapAvFragmented, 
                   fgTrapAvEnterConserve, fgTrapAvBypass, 
                   fgTrapAvOversizePass, fgTrapAvOversizeBlock, 
-                  fgTrapFazDisconnect }
+                  fgTrapFazDisconnect, fgTrapWcApUp, fgTrapWcApDown,
+                  fgTrapFcSwUp, fgTrapFcSwDown }
     STATUS      current
     DESCRIPTION 
         "Notifications that can be generated from a FortiGate device."
@@ -4891,6 +5501,36 @@ fgObsoleteAppServicesObjectGroup OBJECT-GROUP
         "Objects that have been deprecated, but may still be generated by older models."
     ::= { fgMibConformance 23 }
 
+fgSystemAdvancedObjectGroup OBJECT-GROUP
+    OBJECTS     { fgSIAdvMemPageCache, fgSIAdvMemCacheActive,
+                  fgSIAdvMemCacheInactive, fgSIAdvMemBuffer,
+                  fgSIAdvMemEnterKerConsThrsh, 
+                  fgSIAdvMemLeaveKerConsThrsh,
+                  fgSIAdvMemEnterProxyConsThrsh,
+                  fgSIAdvMemLeaveProxyConsThrsh,
+                  fgSIAdvSesEphemeralCount, fgSIAdvSesEphemeralLimit,
+                  fgSIAdvSesClashCount, fgSIAdvSesExpCount,
+                  fgSIAdvSesSyncQFCount, fgSIAdvSesAcceptQFCount,
+                  fgSIAdvSesNoListenerCount }
+    STATUS      current
+    DESCRIPTION
+        "Objects pertaining to the system advanced status of the device."
+    ::= { fgMibConformance 24 }
+
+fgWcObjectGroup OBJECT-GROUP
+    OBJECTS     { fgWcApVdom, fgWcApSerial, fgWcApName }
+    STATUS      current
+    DESCRIPTION 
+        "Objects pertaining to wireless controller."
+    ::= { fgMibConformance 25 }
+
+fgFcObjectGroup OBJECT-GROUP
+    OBJECTS     { fgFcSwVdom, fgFcSwSerial, fgFcSwName }
+    STATUS      current
+    DESCRIPTION 
+        "Objects pertaining to switch controller."
+    ::= { fgMibConformance 26 }
+    
 fgMIBCompliance MODULE-COMPLIANCE
     STATUS      current
     DESCRIPTION 
@@ -4980,6 +5620,18 @@ fgMIBCompliance MODULE-COMPLIANCE
               "Model and feature specific."
 
         GROUP   fgWanOptObjectGroup
+        DESCRIPTION
+              "Model and feature specific."
+
+        GROUP   fgSystemAdvancedObjectGroup
+        DESCRIPTION
+              "Model and feature specific."
+
+        GROUP   fgWcObjectGroup
+        DESCRIPTION
+              "Model and feature specific."
+
+        GROUP   fgFcObjectGroup
         DESCRIPTION
               "Model and feature specific."
 

--- a/mibs/netonix/NETONIX-SWITCH-MIB
+++ b/mibs/netonix/NETONIX-SWITCH-MIB
@@ -13,7 +13,7 @@ netonixSwitch MODULE-IDENTITY
      DESCRIPTION "The MIB Module for Netonix Switches."
      REVISION "9803231700Z"
      DESCRIPTION "The MIB Module for Netonix Switches."
-    ::= { enterprises 99999 }
+    ::= { enterprises 46242 }
 
 netonixSwitchGroup OBJECT-GROUP
     OBJECTS { firmwareVersion,
@@ -21,7 +21,8 @@ netonixSwitchGroup OBJECT-GROUP
 	tempDescription,
 	temp,
 	voltageDescription,
-	voltage
+	voltage,
+	poeStatus
     }
     STATUS  current
     DESCRIPTION "A collection of objects providing basic instrumentation and control of an SNMPv2 entity."
@@ -83,6 +84,40 @@ fanSpeed OBJECT-TYPE
     STATUS	current
     DESCRIPTION "Integer reference number (row number) for the fan mib."
     ::= { fanEntry 2 }
+
+poeStatusTable OBJECT-TYPE
+    SYNTAX	SEQUENCE OF PoEStatus
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION "PoE Status per port."
+    ::= { netonixSwitch 5 }
+
+poeStatusEntry OBJECT-TYPE
+    SYNTAX     PoeStatusEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION "An entry containing poe status."
+    INDEX      { poeStatusIndex }
+    ::= { poeStatusTable  1 }
+
+PoEStatusEntry ::= SEQUENCE {
+    poeStatusIndex		Integer32,
+    poeStatus		DisplayString
+}
+
+poeStatusIndex OBJECT-TYPE
+    SYNTAX	Integer32 (0..65535)
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION "Integer reference number (row number) for the poe status."
+    ::= { poeStatusEntry 1 }
+
+poeStatus OBJECT-TYPE
+    SYNTAX	DisplayString (SIZE (0..255))
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION "poe status."
+    ::= { poeStatusEntry 2 }
 
 tempTable OBJECT-TYPE
     SYNTAX	SEQUENCE OF TempEntry

--- a/sql-schema/079.sql
+++ b/sql-schema/079.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS `vrf_lite_cisco` ( `vrf_lite_cisco_id` int(11) NOT NULL AUTO_INCREMENT, `device_id` int(11) NOT NULL, `context_name` varchar(128) CHARACTER SET utf8 collate utf8_general_ci not null  ,`intance_name` varchar(128)  DEFAULT '', `vrf_name` varchar(128) DEFAULT 'Default', PRIMARY KEY (`vrf_lite_cisco_id`)  ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+ALTER TABLE `vrf_lite_cisco` ADD INDEX `vrf` (`vrf_name` ASC), ADD INDEX `context` (`context_name` ASC), ADD INDEX `device` (`device_id` ASC), ADD INDEX `mix` (`device_id` ASC, `context_name` ASC, `vrf_name` ASC);
+ALTER TABLE ipv4_addresses  ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv4_networks   ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv4_mac        ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv6_addresses  ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ipv6_networks   ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE bgpPeers        ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE bgpPeers_cbgp   ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_areas      ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_areas      DROP INDEX device_area, ADD UNIQUE KEY `device_area` (`device_id`,`ospfAreaId`,`context_name`);
+ALTER TABLE ospf_instances  ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_instances  DROP INDEX device_id, ADD UNIQUE KEY `device_id` (`device_id`,`ospf_instance_id`,`context_name`);
+ALTER TABLE ospf_nbrs       ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_nbrs       DROP INDEX device_id, ADD UNIQUE KEY `device_id` (`device_id`,`ospf_nbr_id`,`context_name`);
+ALTER TABLE ospf_ports      ADD `context_name` varchar(128)  CHARACTER SET utf8 collate utf8_general_ci ;
+ALTER TABLE ospf_ports DROP INDEX device_id, ADD UNIQUE KEY `device_id` (`device_id`,`ospf_port_id`,`context_name`);
+ALTER TABLE `vlans` CHANGE COLUMN `vlan_name` `vlan_name` VARCHAR(64) DEFAULT NULL;


### PR DESCRIPTION
With the blessing of @nicearma, i commit his code on VRF-lite. 
[NiceArma commit](https://github.com/nicearma/librenms/commit/97ba47cfa679513c91bef93673da9e71f2ce2a9f) : 

Add VRF-Lite logic and adapt all VRF-Lite discovery and polling modules that depend of context like:
* Discovery: arp-table
* Diccovery: bgp-peers
* Discovery: ipv4-add..
* Discovery: ipv6-add

Fix logic in : 
* Poller: bgp-peer
* Poller: ospf

Add two Mibs (CISCO-BRIDGE-DOMAIN-MIB, CISCO-CONTEXT-MAPPING-MIB)

And other little change