### PR TITLE
Moved memory graphs for vmware to mempool polling

### DIFF
--- a/includes/discovery/mempools/hrstorage.inc.php
+++ b/includes/discovery/mempools/hrstorage.inc.php
@@ -31,6 +31,10 @@ if (is_array($storage_array)) {
             break;
         }
 
+        if ($device['os'] == 'vmware' && $descr == 'Real Memory') {
+            $deny = 0;
+        }
+
         if ($device['os'] == 'routeros' && $descr == 'main memory') {
             $deny = 0;
         }

--- a/includes/discovery/storage/hrstorage.inc.php
+++ b/includes/discovery/storage/hrstorage.inc.php
@@ -33,6 +33,13 @@ if (is_array($hrstorage_array)) {
                 break;
         }
 
+        if ($device['os'] == 'vmware' && $descr == 'Real Memory') {
+            $old_rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('storage-hrstorage-'.safename($descr).'.rrd');
+            $new_rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('mempool-hrstorage-'.$storage['hrStorageIndex'].'.rrd');
+            rename($old_rrdfile, $new_rrdfile);
+            $deny = 1;
+        }
+
         foreach ($config['ignore_mount'] as $bi) {
             if ($bi == $descr) {
                 $deny = 1;


### PR DESCRIPTION
Fix #2569 

Real Memory is currently picked up by storage discovery, this should now stop that and add it to mempool. We also move old storage rrd file to the mempool rrd so people retain data.