### PR TITLE
For SQL debug, if we see an insert into alert_log with details column then we mask the output

### DIFF
--- a/includes/dbFacile.mysql.php
+++ b/includes/dbFacile.mysql.php
@@ -28,7 +28,12 @@ function dbQuery($sql, $parameters=array()) {
     $fullSql = dbMakeQuery($sql, $parameters);
     if ($debug) {
         if (php_sapi_name() == 'cli' && empty($_SERVER['REMOTE_ADDR'])) {
-            print $console_color->convert("\nSQL[%y".$fullSql.'%n] ');
+            if (preg_match('/(INSERT INTO `alert_log`).*(details)/i',$fullSql)) {
+                echo "\nINSERT INTO `alert_log` entry masked due to binary data\n";
+            }
+            else {
+                print $console_color->convert("\nSQL[%y".$fullSql.'%n] ');
+            }
         }
         else {
             $sql_debug[] = $fullSql;

--- a/includes/dbFacile.mysqli.php
+++ b/includes/dbFacile.mysqli.php
@@ -28,7 +28,12 @@ function dbQuery($sql, $parameters=array()) {
     $fullSql = dbMakeQuery($sql, $parameters);
     if ($debug) {
         if (php_sapi_name() == 'cli' && empty($_SERVER['REMOTE_ADDR'])) {
-            print $console_color->convert("\nSQL[%y".$fullSql.'%n] ');
+            if (preg_match('/(INSERT INTO `alert_log`).*(details)/i',$fullSql)) {
+                echo "\nINSERT INTO `alert_log` entry masked due to binary data\n";
+            }
+            else {
+                print $console_color->convert("\nSQL[%y".$fullSql.'%n] ');
+            }
         }
         else {
             $sql_debug[] = $fullSql;


### PR DESCRIPTION
Fix #2584 

This will stop consoles crashing due to binary output. Seeing this debug info is pretty much next to useless anyway so shouldn't be a loss.