### PR TITLE
Removed duplicate log_file config check and declaration fix

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1771,10 +1771,6 @@ if (isset($config['rrdgraph_def_text'])) {
     $config['rrd_opts_array']    = explode(' ', trim($config['rrdgraph_def_text']));
 }
 
-if (!isset($config['log_file'])) {
-    $config['log_file'] = $config['log_dir'].'/'.$config['project_id'].'.log';
-}
-
 if (isset($config['cdp_autocreate'])) {
     $config['dp_autocreate'] = $config['cdp_autocreate'];
 }
@@ -1843,7 +1839,7 @@ if (!isset($config['log_dir'])) {
 }
 
 if (!isset($config['log_file'])) {
-    $config['log_dir'].'/'.$config['project_id'].'.log';
+    $config['log_file'] = $config['log_dir'].'/'.$config['project_id'].'.log';
 }
 
 if (!isset($config['plugin_dir'])) {


### PR DESCRIPTION
The check for $config['log_file'] was being done twice but the second time it didn't then correctly set the variable.