### PR TITLE
Bug in SSL Service Check for PHP7

### DIFF
--- a/includes/services/ssl_cert/check.inc
+++ b/includes/services/ssl_cert/check.inc
@@ -9,7 +9,7 @@ if( !empty($service['service_ip']) ) {
 $cmd .= " ".$service['service_param'];
 
 $check = shell_exec($cmd);
-list($check, $time) = split("\|", $check);
+list($check, $time) = explode("\|", $check);
 
 if(strstr($check, "SSL_CERT OK")) {
   $status = '1';


### PR DESCRIPTION
`split()` doesn't exist anymore. Let's use `explode`.