### PR TITLE
Updated gitignore and added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[**.css]
+indent_style = space
+indent_size = 2
+
+[**.php]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ nbproject
 .ircbot.alert
 .metadata_never_index
 *.swp
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+Thumbs.db


### PR DESCRIPTION
Updated the gitignore file to ignore temporary os files (.DS_Store, Thumbs.db etc) and added an .editorconfig file with the indentation and tab/spaces settings described in the documentation. See http://editorconfig.org for details about editorconfig.