### PR TITLE
Fixed discovery+poller performance of VMware virtual machines.

### DIFF
--- a/includes/discovery/vmware-vminfo.inc.php
+++ b/includes/discovery/vmware-vminfo.inc.php
@@ -19,80 +19,45 @@ if (($device['os'] == 'vmware') || ($device['os'] == 'linux')) {
     echo 'VMware VM: ';
 
     /*
-     * Fetch the list is Virtual Machines.
-     *
-     *  vmwVmVMID.224 = INTEGER: 224
-     *  vmwVmVMID.416 = INTEGER: 416
-     *  ...
+     * Fetch information about Virtual Machines.
      */
 
-    $oids = snmp_walk($device, 'VMWARE-VMINFO-MIB::vmwVmVMID', '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs');
-    if (empty($oids)) {
-        $oids = trim(snmp_walk($device, 'vmwVmUUID', '-Osq', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs'));
-        $oids = str_replace('vmwVmUUID.', '', $oids);
+    $oids = snmpwalk_cache_multi_oid($device, 'vmwVmTable', $oids, '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['mib_dir'].'/vmware:'.$config['mib_dir']);
+
+    foreach ($oids as $index => $entry) {
+        $vmwVmDisplayName = $entry['vmwVmDisplayName'];
+        $vmwVmGuestOS     = $entry['vmwVmGuestOS'];
+        $vmwVmMemSize     = $entry['vmwVmMemSize'];
+        $vmwVmState       = $entry['vmwVmState'];
+        $vmwVmCpus        = $entry['vmwVmCpus'];
+
+        /*
+         * VMware does not return an INTEGER but a STRING of the vmwVmMemSize. This bug
+         * might be resolved by VMware in the future making this code obsolete.
+         */
+        if (preg_match('/^([0-9]+) .*$/', $vmwVmMemSize, $matches)) {
+            $vmwVmMemSize = $matches[1];
+        }
+
+        /*
+         * Check whether the Virtual Machine is already known for this host.
+         */
+        if (dbFetchCell("SELECT COUNT(id) FROM `vminfo` WHERE `device_id` = ? AND `vmwVmVMID` = ? AND vm_type='vmware'", array($device['device_id'], $index)) == 0) {
+            $vmid = dbInsert(array('device_id' => $device['device_id'], 'vm_type' => 'vmware', 'vmwVmVMID' => $index, 'vmwVmDisplayName' => mres($vmwVmDisplayName), 'vmwVmGuestOS' => mres($vmwVmGuestOS), 'vmwVmMemSize' => mres($vmwVmMemSize), 'vmwVmCpus' => mres($vmwVmCpus), 'vmwVmState' => mres($vmwVmState)), 'vminfo');
+            log_event(mres($vmwVmDisplayName)." ($vmwVmMemSize GB / $vmwVmCpus vCPU) Discovered", $device, 'system', $vmid);
+            echo '+';
+            // FIXME eventlog
+        }
+        else {
+            echo '.';
+        }
+
+        /*
+         * Save the discovered Virtual Machine.
+         */
+
+        $vmw_vmlist[] = $index;
     }
-
-    if ($oids != '') {
-        $oids = explode("\n", $oids);
-
-        foreach ($oids as $data) {
-            $data           = trim($data);
-            list($oid,) = explode(' ', $data);
-            /*
-             * Fetch the Virtual Machine information.
-             *
-             *  vmwVmDisplayName.224 = STRING: My First VM
-             *  vmwVmDisplayName.416 = STRING: My Second VM
-             *  vmwVmGuestOS.224 = STRING: windows7Server64Guest
-             *  vmwVmGuestOS.416 = STRING: winLonghornGuest
-             *  vmwVmMemSize.224 = INTEGER: 8192 megabytes
-             *  vmwVmMemSize.416 = INTEGER: 8192 megabytes
-             *  vmwVmState.224 = STRING: poweredOn
-             *  vmwVmState.416 = STRING: poweredOn
-             *  vmwVmVMID.224 = INTEGER: 224
-             *  vmwVmVMID.416 = INTEGER: 416
-             *  vmwVmCpus.224 = INTEGER: 2
-             *  vmwVmCpus.416 = INTEGER: 2
-             */
-
-
-            $vmwVmDisplayName = snmp_get($device, 'vmwVmDisplayName.'.$oid, '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs');
-            $vmwVmGuestOS     = snmp_get($device, 'vmwVmGuestOS.'.$oid, '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs');
-            $vmwVmMemSize     = snmp_get($device, 'vmwVmMemSize.'.$oid, '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs');
-            $vmwVmState       = snmp_get($device, 'vmwVmState.'.$oid, '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs');
-            $vmwVmCpus        = snmp_get($device, 'vmwVmCpus.'.$oid, '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['install_dir'].'/mibs');
-
-            /*
-             * VMware does not return an INTEGER but a STRING of the vmwVmMemSize. This bug
-             * might be resolved by VMware in the future making this code obsolete.
-             */
-
-            if (preg_match('/^([0-9]+) .*$/', $vmwVmMemSize, $matches)) {
-                $vmwVmMemSize = $matches[1];
-            }
-
-            /*
-             * Check whether the Virtual Machine is already known for this host.
-             */
-
-            if (dbFetchCell("SELECT COUNT(id) FROM `vminfo` WHERE `device_id` = ? AND `vmwVmVMID` = ? AND vm_type='vmware'", array($device['device_id'], $oid)) == 0) {
-                $vmid = dbInsert(array('device_id' => $device['device_id'], 'vm_type' => 'vmware', 'vmwVmVMID' => $oid, 'vmwVmDisplayName' => mres($vmwVmDisplayName), 'vmwVmGuestOS' => mres($vmwVmGuestOS), 'vmwVmMemSize' => mres($vmwVmMemSize), 'vmwVmCpus' => mres($vmwVmCpus), 'vmwVmState' => mres($vmwVmState)), 'vminfo');
-                log_event(mres($vmwVmDisplayName)." ($vmwVmMemSize GB / $vmwVmCpus vCPU) Discovered", $device, 'system', $vmid);
-                echo '+';
-                // FIXME eventlog
-            }
-            else {
-                echo '.';
-            }
-
-            // FIXME update code!
-            /*
-             * Save the discovered Virtual Machine.
-             */
-
-            $vmw_vmlist[] = $oid;
-        }//end foreach
-    }//end if
 
     /*
      * Get a list of all the known Virtual Machines for this host.

--- a/includes/polling/os/vmware.inc.php
+++ b/includes/polling/os/vmware.inc.php
@@ -28,6 +28,7 @@ echo 'VMware VM: ';
  */
 
 $db_info_list = dbFetchRows('SELECT id, vmwVmVMID, vmwVmDisplayName, vmwVmGuestOS, vmwVmMemSize, vmwVmCpus, vmwVmState FROM vminfo WHERE device_id = ?', array($device['device_id']));
+$current_vminfo = snmpwalk_cache_multi_oid($device, 'vmwVmTable', array(), '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['mib_dir'].'/vmware:'.$config['mib_dir']);
 
 foreach ($db_info_list as $db_info) {
     /*
@@ -43,11 +44,11 @@ foreach ($db_info_list as $db_info) {
 
     $vm_info = array();
 
-    $vm_info['vmwVmDisplayName'] = snmp_get($device, 'VMWARE-VMINFO-MIB::vmwVmDisplayName.'.$db_info['vmwVmVMID'], '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['mibdir']);
-    $vm_info['vmwVmGuestOS']     = snmp_get($device, 'VMWARE-VMINFO-MIB::vmwVmGuestOS.'.$db_info['vmwVmVMID'], '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['mibdir']);
-    $vm_info['vmwVmMemSize']     = snmp_get($device, 'VMWARE-VMINFO-MIB::vmwVmMemSize.'.$db_info['vmwVmVMID'], '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['mibdir']);
-    $vm_info['vmwVmState']       = snmp_get($device, 'VMWARE-VMINFO-MIB::vmwVmState.'.$db_info['vmwVmVMID'], '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['mibdir']);
-    $vm_info['vmwVmCpus']        = snmp_get($device, 'VMWARE-VMINFO-MIB::vmwVmCpus.'.$db_info['vmwVmVMID'], '-Osqnv', '+VMWARE-ROOT-MIB:VMWARE-VMINFO-MIB', '+'.$config['install_dir'].'/mibs/vmware:'.$config['mibdir']);
+    $vm_info['vmwVmDisplayName'] = $current_vminfo[$db_info['vmwVmVMID']]['vmwVmDisplayName'];
+    $vm_info['vmwVmGuestOS']     = $current_vminfo[$db_info['vmwVmVMID']]['vmwVmGuestOS'];
+    $vm_info['vmwVmMemSize']     = $current_vminfo[$db_info['vmwVmVMID']]['vmwVmMemSize'];
+    $vm_info['vmwVmState']       = $current_vminfo[$db_info['vmwVmVMID']]['vmwVmState'];
+    $vm_info['vmwVmCpus']        = $current_vminfo[$db_info['vmwVmVMID']]['vmwVmCpus'];
 
     /*
      * VMware does not return an INTEGER but a STRING of the vmwVmMemSize. This bug


### PR DESCRIPTION
BLOCKER: I've only got ESXi 6.0 hosts, so this should be tested on older platforms as well before merging.

Polling graph for an ESXi 6.0 host:
![alt text](https://i.imgur.com/5TVNjWf.png "Polling performance graph")
Polling graph provided by @Lucheni for an ESXi 5.5 host:
![alt text](http://andreas.fr/content/images/2016/01/poller-jpg.png "Polling performance graph")
------
Before:
```bash
librenms@librenms01:~$ time ./discovery.php -h esx.example.dk -d -m vmware-vminfo | grep /usr/bin/snmp | wc -l
157

real    0m10.260s
user    0m6.268s
sys     0m3.422s

librenms@librenms01:~$ time ./poller.php -h esx.example.dk -d -r -m os | grep /usr/bin/snmp | wc -l
159

real    0m12.190s
user    0m6.492s
sys     0m4.830s

```
After:
```bash
librenms@librenms01:~$ git checkout vmware-polling-perf
librenms@librenms01:~$ time ./discovery.php -h esx.example.dk -d -m vmware-vminfo | grep /usr/bin/snmp | wc -l
1

real    0m0.169s
user    0m0.098s
sys     0m0.045s

librenms@librenms01:~$ time ./poller.php -h esx.example.dk -d -r -m os | grep /usr/bin/snmp | wc -l
5

real    0m0.758s
user    0m0.160s
sys     0m0.172s
```