### PR TITLE
Explicitly show units for total in bit graphs

### DIFF
--- a/html/includes/graphs/generic_data.inc.php
+++ b/html/includes/graphs/generic_data.inc.php
@@ -123,9 +123,9 @@ if ($config['rrdgraph_real_95th']) {
     $rrd_options .= " GPRINT:95thhigh:\"%30.2lf%s\\n\"";
 }
 
-$rrd_options .= " GPRINT:tot:'Total %6.2lf%s'";
-$rrd_options .= " GPRINT:totin:'(In %6.2lf%s'";
-$rrd_options .= " GPRINT:totout:'Out %6.2lf%s)\\l'";
+$rrd_options .= " GPRINT:tot:'Total %6.2lf%sB'";
+$rrd_options .= " GPRINT:totin:'(In %6.2lf%sB'";
+$rrd_options .= " GPRINT:totout:'Out %6.2lf%sB)\\l'";
 $rrd_options .= ' LINE1:95thin#aa0000';
 $rrd_options .= ' LINE1:d95thout#aa0000';
 


### PR DESCRIPTION
Previously the rest of the graph was in "bps", as indicated in the legend, however the unit for the totals is "B" (bytes) - as only the prefix (M, G, T) was shown for the totals it was not clear that the unit was different.

Before:
![screenshot from 2016-01-08 11-44-04](https://cloud.githubusercontent.com/assets/747138/12197372/7187f02a-b5fe-11e5-8111-7de521fa3235.png)

After:
![screenshot from 2016-01-08 11-43-26](https://cloud.githubusercontent.com/assets/747138/12197375/75dfb2ca-b5fe-11e5-9407-a48caa830af7.png)
