### PR TITLE
Remove some detection logic from Brocade NOS foo

### DIFF
--- a/includes/discovery/os/nos.inc.php
+++ b/includes/discovery/os/nos.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!$os) {
-    if (strstr($sysDescr, "Brocade VDX") || strstr($sysObjectId, '.1.3.6.1.4.1.1588.2.2.1.1.1.5') || stristr($sysDescr, 'Brocade Communications Systems')) { 
+    if (strstr($sysDescr, "Brocade VDX")) {
         $os = "nos"; 
     }
 }


### PR DESCRIPTION
Remove one overly-broad and one overly-narrow detection check for Brocade VDX devices.

I think @vizay had it right.  .1.3.6.1.4.1.1588.2.2.1.1.1.5 appears to match only a single Brocade model (VDX6710P54), and there are a lot of non-NOS devices that say Brocade Communication Systems (ironware, fibre channel, etc.).

After a couple of comments in  #2712 , I think it is best to remove these unless someone knows of a VDX device that the new test doesn't match.