### PR TITLE
Fix daily.php not deleting device_perf entries

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -10,7 +10,12 @@ require 'config.php';
 require_once 'includes/definitions.inc.php';
 require 'includes/functions.php';
 
-$options = getopt('f:');
+$options = getopt('f:d');
+
+if (isset($options['d'])) {
+    echo "DEBUG\n";
+    $debug = true;
+}
 
 if ($options['f'] === 'update') {
     $innodb_buffer = innodb_buffer_check();
@@ -101,7 +106,7 @@ if ($options['f'] === 'callback') {
 
 if ($options['f'] === 'device_perf') {
     if (is_numeric($config['device_perf_purge'])) {
-        if (dbDelete('device_perf', 'timestamp < UNIX_TIMESTAMP(DATE_SUB(NOW(),INTERVAL ? DAY))', array($config['device_perf_purge']))) {
+        if (dbDelete('device_perf', 'timestamp < DATE_SUB(NOW(),INTERVAL ? DAY)', array($config['device_perf_purge']))) {
             echo 'Device performance times cleared for entries over '.$config['device_perf_purge']." days\n";
         }
     }


### PR DESCRIPTION
Add -d option to daily.php to show SQL and fix bug where daily.php does
not delete device_perf entries because a unix timestamp (integer) can't
be cast to a datetime.

MariaDB [librenms]> select * from device_perf where timestamp < UNIX_TIMESTAMP(DATE_SUB(NOW(),INTERVAL '7' DAY));
Empty set, 1 warning (1.20 sec)

MariaDB [librenms]> show warnings;
+---------+------+----------------------------------------+
| Level   | Code | Message                                |
+---------+------+----------------------------------------+
| Warning | 1292 | Incorrect datetime value: '1451944875' |
+---------+------+----------------------------------------+
1 row in set (0.00 sec)

MariaDB [librenms]>