### PR TITLE
Clear $graph_array after graph is printed

### DIFF
--- a/html/includes/print-graphrow.inc.php
+++ b/html/includes/print-graphrow.inc.php
@@ -76,3 +76,4 @@ foreach ($periods as $period) {
         echo "</div>";
     }
 }
+unset($graph_array);


### PR DESCRIPTION
This fixes #2710 and probably some other issues we haven't noticed as well; print-graphrow is a prime candidate for changing to a function to eliminate silly bugs like this...