### PR TITLE
MIB-based-polling: Fix short name generation

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1189,8 +1189,10 @@ function load_mibdefs($module, $name)
 
     // add shortname to each element
     $prefix = longest_matching_prefix($name, $object_types);
-    foreach ($result as $mib => $m) {
-        $result[$mib]['shortname'] = str_replace($prefix, '', $m['object_type']);
+    if (strlen($prefix) > 2) {
+        foreach ($result as $mib => $m) {
+            $result[$mib]['shortname'] = preg_replace("/^$prefix/", '', $m['object_type'], 1);
+        }
     }
 
     d_print_r($result);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1189,9 +1189,12 @@ function load_mibdefs($module, $name)
 
     // add shortname to each element
     $prefix = longest_matching_prefix($name, $object_types);
-    if (strlen($prefix) > 2) {
-        foreach ($result as $mib => $m) {
+    foreach ($result as $mib => $m) {
+        if (strlen($prefix) > 2) {
             $result[$mib]['shortname'] = preg_replace("/^$prefix/", '', $m['object_type'], 1);
+        }
+        else {
+            $result[$mib]['shortname'] = $m['object_type'];
         }
     }
 


### PR DESCRIPTION
Should only replace first occurrence of prefix in the string.
Also only strips the prefix if it saves more than 2 characters.

This fixes a bug where, e.g., 'casnDisconnect' would be shortened to 'asnDisonnet'.