### PR TITLE
Added verbose debugging, normal debugging will now try and mask certain information

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -28,6 +28,8 @@
 require_once 'includes/defaults.inc.php';
 require_once 'config.php';
 
+$options = getopt('d::');
+
 $lock = false;
 if (file_exists($config['install_dir'].'/.alerts.lock')) {
     $pids = explode("\n", trim(`ps -e | grep php | awk '{print $1}'`));
@@ -47,6 +49,22 @@ else {
 require_once $config['install_dir'].'/includes/definitions.inc.php';
 require_once $config['install_dir'].'/includes/functions.php';
 require_once $config['install_dir'].'/includes/alerts.inc.php';
+
+if (isset($options['d'])) {
+    echo "DEBUG!\n";
+    $debug = true;
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    ini_set('log_errors', 1);
+    ini_set('error_reporting', 1);
+}
+else {
+    $debug = false;
+    // ini_set('display_errors', 0);
+    ini_set('display_startup_errors', 0);
+    ini_set('log_errors', 0);
+    // ini_set('error_reporting', 0);
+}
 
 if (!defined('TEST') && $config['alert']['disable'] != 'true') {
     echo 'Start: '.date('r')."\r\n";

--- a/discovery.php
+++ b/discovery.php
@@ -23,7 +23,7 @@ require 'includes/discovery/functions.inc.php';
 $start         = microtime(true);
 $runtime_stats = array();
 $sqlparams     = array();
-$options       = getopt('h:m:i:n:d::a::q',array('os:','type:'));
+$options       = getopt('h:m:i:n:d::v::a::q',array('os:','type:'));
 
 if (!isset($options['q'])) {
     echo $config['project_name_version']." Discovery\n";
@@ -82,8 +82,11 @@ if (isset($options['i']) && $options['i'] && isset($options['n'])) {
     $doing = $options['n'].'/'.$options['i'];
 }
 
-if (isset($options['d'])) {
+if (isset($options['d']) || isset($options['v'])) {
     echo "DEBUG!\n";
+    if (isset($options['v'])) {
+        $vdebug = true;
+    }
     $debug = true;
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);
@@ -111,6 +114,7 @@ if (!$where) {
     echo "\n";
     echo "Debugging and testing options:\n";
     echo "-d                                           Enable debugging output\n";
+    echo "-v                                           Enable verbose debugging output\n";
     echo "-m                                           Specify single module to be run\n";
     echo "\n";
     echo "Invalid arguments!\n";

--- a/includes/common.php
+++ b/includes/common.php
@@ -33,9 +33,25 @@ function format_number_short($number, $sf) {
 }
 
 function external_exec($command) {
-    d_echo($command."\n");
+    global $debug,$vdebug;
+    if ($debug && !$vdebug) {
+        $debug_command = preg_replace('/-c [\S]+/','-c COMMUNITY',$command);
+        $debug_command = preg_replace('/(udp|udp6|tcp|tcp6):(.*):([\d]+)/','\1:HOSTNAME:\3',$debug_command);
+        d_echo($debug_command);
+    }
+    elseif ($vdebug) {
+        d_echo($command."\n");
+    }
+
     $output = shell_exec($command);
-    d_echo($output."\n");
+
+    if ($debug && !$vdebug) {
+        $debug_output = preg_replace('/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/', '*', $output);
+        d_echo("$debug_output\n");
+    }
+    elseif ($vdebug) {
+        d_echo($output."\n");
+    }
 
     return $output;
 }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -745,7 +745,7 @@ function snmp_cache_portName($device, $array) {
 
 
 function snmp_gen_auth(&$device) {
-    global $debug;
+    global $debug, $vdebug;
 
     $cmd = '';
 
@@ -781,11 +781,11 @@ function snmp_gen_auth(&$device) {
     }
     else {
         if ($debug) {
-            print 'DEBUG: '.$device['snmpver']." : Unsupported SNMP Version (wtf have you done ?)\n";
+            print 'DEBUG: '.$device['snmpver']." : Unsupported SNMP Version (shouldn't be possible to get here)\n";
         }
     }//end if
 
-    if ($debug) {
+    if ($vdebug) {
         print "DEBUG: SNMP Auth options = $cmd\n";
     }
 

--- a/poller.php
+++ b/poller.php
@@ -33,7 +33,7 @@ echo "MySQL: ".$versions['mysql_ver']."\n";
 echo "RRDTool: ".$versions['rrdtool_ver']."\n";
 echo "SNMP: ".$versions['netsnmp_ver']."\n";
 
-$options = getopt('h:m:i:n:r::d::a::f::');
+$options = getopt('h:m:i:n:r::d::v::a::f::');
 
 if ($options['h'] == 'odd') {
     $options['n'] = '1';
@@ -83,14 +83,18 @@ if (!$where) {
     echo "-r                                           Do not create or update RRDs\n";
     echo "-f                                           Do not insert data into InfluxDB\n";
     echo "-d                                           Enable debugging output\n";
+    echo "-d                                           Enable verbose debugging output\n";
     echo "-m                                           Specify module(s) to be run\n";
     echo "\n";
     echo "No polling type specified!\n";
     exit;
 }
 
-if (isset($options['d'])) {
+if (isset($options['d']) || isset($options['v'])) {
     echo "DEBUG!\n";
+    if (isset($options['v'])) {
+        $vdebug = true;
+    }
     $debug = true;
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);


### PR DESCRIPTION
This may help with #2778. It doesn't do anything with SQL queries but that can follow a similar format.

1. Adds debugging option to alerts.php: `alerts.php -d`

2. Adds a -v flag to poller.php and discovery.php for verbose debugging. With just normal -d snmp queries now mask the community and hostname for v1 and v2c. It will also mask any IPv4 addresses.

Yes more can be added but it gets the initial framework in place allowing others to add to this.