### PR TITLE
Added missing column to perf_times table

### DIFF
--- a/sql-schema/089.sql
+++ b/sql-schema/089.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `perf_times` ADD  `poller` VARCHAR( 255 ) NOT NULL ;


### PR DESCRIPTION
This column is used to insert poller times. Currently it fails without this.