### PR TITLE
Added config option to force showing sysName instead of IP

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -209,6 +209,8 @@ function generate_device_link($device, $text=null, $vars=array(), $start=0, $end
         $text = $device['hostname'];
     }
 
+    $text = ip_to_sysname($device,$text);
+
     if (isset($config['os'][$device['os']]['over'])) {
         $graphs = $config['os'][$device['os']]['over'];
     }

--- a/includes/common.php
+++ b/includes/common.php
@@ -1040,3 +1040,19 @@ function version_info($remote=true) {
     return $output;
 
 }//end version_info()
+
+/**
+ * Convert IP to use sysName
+ * @param array device
+ * @param string ip address
+ * @return string
+**/
+function ip_to_sysname($device,$ip) {
+    global $config;
+    if ($config['force_ip_to_sysname'] === true) {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) == true || filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) == true) {
+            $ip = $device['sysName'];
+        }
+    }
+    return $ip;
+}//end ip_to_sysname

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -779,6 +779,7 @@ $config['dateformat']['mysql']['time']    = '%H:%i:%s';
 
 $config['enable_clear_discovery'] = 1;
 // Set this to 0 if you want to disable the web option to rediscover devices
+$config['force_ip_to_sysname']    = false;// Set to true if you want to use sysName in place of IPs
 $config['enable_port_relationship'] = true;
 // Set this to false to not display neighbour relationships for ports
 $config['enable_footer'] = 1;


### PR DESCRIPTION
Fix #2091 

Anywhere we use generate_device_link(), this will now change the 'hostname' if it's an IP to use sysName instead. I'm sure we will still have areas that we need to update to use this properly but it works in the device list + the two widgets requested in that issue.