### PR TITLE
Ability to use ifIndex,ifName and ifDescr to create and update port rrd files

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -49,3 +49,6 @@ $config['poller-wrapper']['alerter'] = FALSE;
 
 # Uncomment to submit callback stats via proxy
 #$config['callback_proxy'] = "hostname:port";
+
+# Set default port association mode for new devices (default: ifIndex)
+#$config['default_port_association_mode'] = 'ifIndex';

--- a/html/includes/graphs/bill/bits.inc.php
+++ b/html/includes/graphs/bill/bits.inc.php
@@ -4,8 +4,9 @@
 $i = 0;
 
 foreach ($ports as $port) {
-    if (is_file($config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd'))) {
-        $rrd_list[$i]['filename'] = $config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_file = get_port_rrdfile_path ($port['hostname'], $port['port_id']);
+    if (is_file($rrd_file)) {
+        $rrd_list[$i]['filename'] = $rrd_file;
         $rrd_list[$i]['descr']    = $port['ifDescr'];
         $i++;
     }

--- a/html/includes/graphs/customer/bits.inc.php
+++ b/html/includes/graphs/customer/bits.inc.php
@@ -10,8 +10,8 @@ if (!is_array($config['customers_descr'])) {
 $descr_type = "'".implode("', '", $config['customers_descr'])."'";
 
 foreach (dbFetchRows('SELECT * FROM `ports` AS I, `devices` AS D WHERE `port_descr_type` IN (?) AND `port_descr_descr` = ? AND D.device_id = I.device_id', array(array($descr_type), $vars['id'])) as $port) {
-    if (is_file($config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd'))) {
-        $rrd_filename              = $config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_filename = get_port_rrdfile_path ($port['hostname'], $port['port_id']); // FIXME: Unification OK?
+    if (is_file($rrd_filename)) {
         $rrd_list[$i]['filename']  = $rrd_filename;
         $rrd_list[$i]['descr']     = $port['hostname'].'-'.$port['ifDescr'];
         $rrd_list[$i]['descr_in']  = shorthost($port['hostname']);
@@ -20,7 +20,6 @@ foreach (dbFetchRows('SELECT * FROM `ports` AS I, `devices` AS D WHERE `port_des
     }
 }
 
-// echo($config['rrd_dir'] . "/" . $port['hostname'] . "/port-" . safename($port['ifIndex'] . ".rrd"));
 $units       = 'bps';
 $total_units = 'B';
 $colours_in  = 'greens';

--- a/html/includes/graphs/device/bits.inc.php
+++ b/html/includes/graphs/device/bits.inc.php
@@ -22,7 +22,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ?', array($devic
         }
     }
 
-    $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id']);
     if ($ignore != 1 && is_file($rrd_filename)) {
         $port = ifLabel($port);
         // Fix Labels! ARGH. This needs to be in the bloody database!

--- a/html/includes/graphs/global/bits.inc.php
+++ b/html/includes/graphs/global/bits.inc.php
@@ -21,7 +21,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` AS P, `devices` AS D WHERE D.device_
         }
     }
 
-    $rrd_filename = $config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_filename = get_port_rrdfile_path ($port['hostname'], $port['port_id']);
     if (!$ignore && $i < 1100 && is_file($rrd_filename)) {
         $rrd_filenames[]          = $rrd_filename;
         $rrd_list[$i]['filename'] = $rrd_filename;

--- a/html/includes/graphs/location/bits.inc.php
+++ b/html/includes/graphs/location/bits.inc.php
@@ -24,8 +24,9 @@ foreach ($devices as $device) {
             }
         }
 
-        if (is_file($config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($int['ifIndex'].'.rrd')) && $ignore != 1) {
-            $rrd_filename              = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($int['ifIndex'].'.rrd');
+        $rrd_file = get_port_rrdfile_path ($device['hostname'], $int['port_id']);
+        if (is_file($rrd_file) && $ignore != 1) {
+            $rrd_filename              = $rrd_file; // FIXME: Can this be unified without side-effects?
             $rrd_list[$i]['filename']  = $rrd_filename;
             $rrd_list[$i]['descr']     = $port['label'];
             $rrd_list[$i]['descr_in']  = $device['hostname'];

--- a/html/includes/graphs/multiport/bits.inc.php
+++ b/html/includes/graphs/multiport/bits.inc.php
@@ -8,9 +8,10 @@ foreach (explode(',', $vars['id']) as $ifid) {
         $ifid             = str_replace('!', '', $ifid);
     }
 
-    $int = dbFetchRow('SELECT `ifIndex`, `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$int['hostname'].'/port-'.safename($int['ifIndex'].'.rrd'))) {
-        $rrd_filenames[$i] = $config['rrd_dir'].'/'.$int['hostname'].'/port-'.safename($int['ifIndex'].'.rrd');
+    $int = dbFetchRow('SELECT `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
+    $rrd_file = get_port_rrdfile_path ($int['hostname'], $ifid);
+    if (is_file($rrd_file)) {
+        $rrd_filenames[$i] = $rrd_file;
         $i++;
     }
 }

--- a/html/includes/graphs/multiport/bits_duo.inc.php
+++ b/html/includes/graphs/multiport/bits_duo.inc.php
@@ -13,10 +13,11 @@ if ($height < '99') {
 $i = 1;
 
 foreach (explode(',', $_GET['id']) as $ifid) {
-    $int = dbFetchRow('SELECT `ifIndex`, `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd')) {
-        $rrd_options .= ' DEF:inoctets'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:INOCTETS:AVERAGE';
-        $rrd_options .= ' DEF:outoctets'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:OUTOCTETS:AVERAGE';
+    $int = dbFetchRow('SELECT `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
+    $rrd_file = get_port_rrdfile_path ($int['hostname'], $ifid);
+    if (is_file($rrd_file)) {
+        $rrd_options .= ' DEF:inoctets'.$i.'='.$rrd_file.':INOCTETS:AVERAGE';
+        $rrd_options .= ' DEF:outoctets'.$i.'='.$rrd_file.':OUTOCTETS:AVERAGE';
         $in_thing    .= $seperator.'inoctets'.$i.',UN,0,'.'inoctets'.$i.',IF';
         $out_thing   .= $seperator.'outoctets'.$i.',UN,0,'.'outoctets'.$i.',IF';
         $pluses      .= $plus;
@@ -30,10 +31,11 @@ unset($seperator);
 unset($plus);
 
 foreach (explode(',', $_GET['idb']) as $ifid) {
-    $int = dbFetchRow('SELECT `ifIndex`, `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd')) {
-        $rrd_options .= ' DEF:inoctetsb'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:INOCTETS:AVERAGE';
-        $rrd_options .= ' DEF:outoctetsb'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:OUTOCTETS:AVERAGE';
+    $int = dbFetchRow('SELECT `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
+    $rrd_file = get_port_rrdfile_path ($int['hostname'], $ifid);
+    if (is_file($rrd_file)) {
+        $rrd_options .= ' DEF:inoctetsb'.$i.'='.$rrd_file.':INOCTETS:AVERAGE';
+        $rrd_options .= ' DEF:outoctetsb'.$i.'='.$rrd_file.':OUTOCTETS:AVERAGE';
         $in_thingb   .= $seperator.'inoctetsb'.$i.',UN,0,'.'inoctetsb'.$i.',IF';
         $out_thingb  .= $seperator.'outoctetsb'.$i.',UN,0,'.'outoctetsb'.$i.',IF';
         $plusesb     .= $plus;

--- a/html/includes/graphs/multiport/bits_separate.inc.php
+++ b/html/includes/graphs/multiport/bits_separate.inc.php
@@ -4,9 +4,10 @@ $i = 0;
 
 foreach (explode(',', $vars['id']) as $ifid) {
     $port = dbFetchRow('SELECT * FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd'))) {
+    $rrd_file = get_port_rrdfile_path ($port['hostname'], $ifid);
+    if (is_file($rrd_file)) {
         $port = ifLabel($port);
-        $rrd_list[$i]['filename']  = $config['rrd_dir'].'/'.$port['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+        $rrd_list[$i]['filename']  = $rrd_file;
         $rrd_list[$i]['descr']     = $port['hostname'].' '.$port['ifDescr'];
         $rrd_list[$i]['descr_in']  = $port['hostname'];
         $rrd_list[$i]['descr_out'] = makeshortif($port['label']);

--- a/html/includes/graphs/multiport/bits_trio.inc.php
+++ b/html/includes/graphs/multiport/bits_trio.inc.php
@@ -14,8 +14,9 @@ if ($height < '99') {
 $i = 1;
 
 foreach (explode(',', $_GET['id']) as $ifid) {
-    $int = dbFetchRow('SELECT `ifIndex`, `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd')) {
+    $int = dbFetchRow('SELECT `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
+    $rrd_file = get_port_rrdfile_path ($int['hostname'], $ifid);
+    if (is_file($rrd_file)) {
         if (strstr($inverse, 'a')) {
             $in  = 'OUT';
             $out = 'IN';
@@ -25,8 +26,8 @@ foreach (explode(',', $_GET['id']) as $ifid) {
             $out = 'OUT';
         }
 
-        $rrd_options .= ' DEF:inoctets'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:'.$in.'OCTETS:AVERAGE';
-        $rrd_options .= ' DEF:outoctets'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:'.$out.'OCTETS:AVERAGE';
+        $rrd_options .= ' DEF:inoctets'.$i.'='.$rrd_file.':'.$in.'OCTETS:AVERAGE';
+        $rrd_options .= ' DEF:outoctets'.$i.'='.$rrd_file.':'.$out.'OCTETS:AVERAGE';
         $in_thing    .= $seperator.'inoctets'.$i.',UN,0,'.'inoctets'.$i.',IF';
         $out_thing   .= $seperator.'outoctets'.$i.',UN,0,'.'outoctets'.$i.',IF';
         $pluses      .= $plus;
@@ -40,8 +41,9 @@ unset($seperator);
 unset($plus);
 
 foreach (explode(',', $_GET['idb']) as $ifid) {
-    $int = dbFetchRow('SELECT `ifIndex`, `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd')) {
+    $int = dbFetchRow('SELECT `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
+    $rrd_file = get_port_rrdfile_path ($int['hostname'], $ifid);
+    if (is_file($rrd_file)) {
         if (strstr($inverse, 'b')) {
             $in  = 'OUT';
             $out = 'IN';
@@ -51,8 +53,8 @@ foreach (explode(',', $_GET['idb']) as $ifid) {
             $out = 'OUT';
         }
 
-        $rrd_options .= ' DEF:inoctetsb'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:'.$in.'OCTETS:AVERAGE';
-        $rrd_options .= ' DEF:outoctetsb'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:'.$out.'OCTETS:AVERAGE';
+        $rrd_options .= ' DEF:inoctetsb'.$i.'='.$rrd_file.':'.$in.'OCTETS:AVERAGE';
+        $rrd_options .= ' DEF:outoctetsb'.$i.'='.$rrd_file.':'.$out.'OCTETS:AVERAGE';
         $in_thingb   .= $seperator.'inoctetsb'.$i.',UN,0,'.'inoctetsb'.$i.',IF';
         $out_thingb  .= $seperator.'outoctetsb'.$i.',UN,0,'.'outoctetsb'.$i.',IF';
         $plusesb     .= $plus;
@@ -66,8 +68,9 @@ unset($seperator);
 unset($plus);
 
 foreach (explode(',', $_GET['idc']) as $ifid) {
-    $int = dbFetchRow('SELECT `ifIndex`, `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
-    if (is_file($config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd')) {
+    $int = dbFetchRow('SELECT `hostname` FROM `ports` AS I, devices as D WHERE I.port_id = ? AND I.device_id = D.device_id', array($ifid));
+    $rrd_file = get_port_rrdfile_path ($int['hostname'], $ifid);
+    if (is_file($rrd_file)) {
         if (strstr($inverse, 'c')) {
             $in  = 'OUT';
             $out = 'IN';
@@ -77,8 +80,8 @@ foreach (explode(',', $_GET['idc']) as $ifid) {
             $out = 'OUT';
         }
 
-        $rrd_options .= ' DEF:inoctetsc'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:'.$in.'OCTETS:AVERAGE';
-        $rrd_options .= ' DEF:outoctetsc'.$i.'='.$config['rrd_dir'].'/'.$int['hostname'].'/port-'.$int['ifIndex'].'.rrd:'.$out.'OCTETS:AVERAGE';
+        $rrd_options .= ' DEF:inoctetsc'.$i.'='.$rrd_file.':'.$in.'OCTETS:AVERAGE';
+        $rrd_options .= ' DEF:outoctetsc'.$i.'='.$rrd_file.':'.$out.'OCTETS:AVERAGE';
         $in_thingc   .= $seperator.'inoctetsc'.$i.',UN,0,'.'inoctetsc'.$i.',IF';
         $out_thingc  .= $seperator.'outoctetsc'.$i.',UN,0,'.'outoctetsc'.$i.',IF';
         $plusesc     .= $plus;

--- a/html/includes/graphs/port/adsl_attainable.inc.php
+++ b/html/includes/graphs/port/adsl_attainable.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'-adsl.rrd');
+$rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr']    = 'Downstream';

--- a/html/includes/graphs/port/adsl_attenuation.inc.php
+++ b/html/includes/graphs/port/adsl_attenuation.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'-adsl.rrd');
+$rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr']    = 'Downstream';

--- a/html/includes/graphs/port/adsl_power.inc.php
+++ b/html/includes/graphs/port/adsl_power.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'-adsl.rrd');
+$rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr']    = 'Downstream';

--- a/html/includes/graphs/port/adsl_snr.inc.php
+++ b/html/includes/graphs/port/adsl_snr.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'-adsl.rrd');
+$rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr']    = 'Downstream';

--- a/html/includes/graphs/port/adsl_speed.inc.php
+++ b/html/includes/graphs/port/adsl_speed.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'-adsl.rrd');
+$rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'adsl');
 
 $rrd_list[0]['filename'] = $rrd_filename;
 $rrd_list[0]['descr']    = 'Downstream';

--- a/html/includes/graphs/port/auth.inc.php
+++ b/html/includes/graphs/port/auth.inc.php
@@ -13,5 +13,5 @@ if (is_numeric($vars['id']) && ($auth || port_permitted($vars['id']))) {
 
     $auth = true;
 
-    $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id']);
 }

--- a/html/includes/graphs/port/etherlike.inc.php
+++ b/html/includes/graphs/port/etherlike.inc.php
@@ -18,7 +18,7 @@ $oids = array(
         );
 
 $i            = 0;
-$rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('port-'.$port['ifIndex'].'-dot3.rrd');
+$rrd_filename = get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'dot3');
 
 if (is_file($rrd_filename)) {
     foreach ($oids as $oid) {

--- a/html/includes/graphs/port/nupkts.inc.php
+++ b/html/includes/graphs/port/nupkts.inc.php
@@ -1,15 +1,17 @@
 <?php
 
+$rrd_file = get_port_rrdfile_path ($device['hostname'], $port['port_id']);
+
 // FIXME uhh..
 if (1) {
-    // $rrd_list[1]['filename'] = $config['rrd_dir'] . "/" . $device['hostname'] . "/port-" . safename($port['ifIndex'] . ".rrd");
+    // $rrd_list[1]['filename'] = $rrd_file;
     // $rrd_list[1]['descr'] = $int['ifDescr'];
     // $rrd_list[1]['ds_in'] = "INNUCASTPKTS";
     // $rrd_list[1]['ds_out'] = "OUTNUCASTPKTS";
     // $rrd_list[1]['descr']   = "NonUnicast";
     // $rrd_list[1]['colour_area_in'] = "BB77BB";
     // $rrd_list[1]['colour_area_out'] = "FFDD88";
-    $rrd_list[2]['filename']        = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_list[2]['filename']        = $rrd_file;
     $rrd_list[2]['descr']           = $int['ifDescr'];
     $rrd_list[2]['ds_in']           = 'INBROADCASTPKTS';
     $rrd_list[2]['ds_out']          = 'OUTBROADCASTPKTS';
@@ -17,7 +19,7 @@ if (1) {
     $rrd_list[2]['colour_area_in']  = 'aa37BB';
     $rrd_list[2]['colour_area_out'] = 'ee9D88';
 
-    $rrd_list[4]['filename']        = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex'].'.rrd');
+    $rrd_list[4]['filename']        = $rrd_file;
     $rrd_list[4]['descr']           = $int['ifDescr'];
     $rrd_list[4]['ds_in']           = 'INMULTICASTPKTS';
     $rrd_list[4]['ds_out']          = 'OUTMULTICASTPKTS';
@@ -36,8 +38,8 @@ if (1) {
 
     include 'includes/graphs/generic_multi_seperated.inc.php';
 }
-else if (is_file($config['rrd_dir'].'/'.$device['hostname'].'/'.safename($port['ifIndex'].'.rrd'))) {
-    $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename($port['ifIndex'].'.rrd');
+else if (is_file($rrd_file)) {
+    $rrd_filename = $rrd_file;
 
     $ds_in  = 'INNUCASTPKTS';
     $ds_out = 'OUTNUCASTPKTS';

--- a/html/includes/graphs/port/pagp_bits.inc.php
+++ b/html/includes/graphs/port/pagp_bits.inc.php
@@ -3,8 +3,9 @@
 // Generate a list of ports and then call the multi_bits grapher to generate from the list
 $i = 0;
 foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `pagpGroupIfIndex` = ?', array($port['device_id'], $port['ifIndex'])) as $int) {
-    if (is_file($config['rrd_dir'].'/'.$hostname.'/port-'.safename($int['ifIndex'].'.rrd'))) {
-        $rrd_list[$i]['filename'] = $config['rrd_dir'].'/'.$hostname.'/port-'.safename($int['ifIndex'].'.rrd');
+    $rrd_file = get_port_rrdfile_path ($hostname, int['port_id']);
+    if (is_file($rrd_file)) {
+        $rrd_list[$i]['filename'] = $rrd_file;
         $rrd_list[$i]['descr']    = $int['ifDescr'];
         $i++;
     }

--- a/html/includes/print-interface.inc.php
+++ b/html/includes/print-interface.inc.php
@@ -338,10 +338,10 @@ echo '</td></tr>';
 
 // If we're showing graphs, generate the graph and print the img tags
 if ($graph_type == 'etherlike') {
-    $graph_file = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex']).'-dot3.rrd';
+    $graph_file = get_port_rrdfile_path ($device['hostname'], $if_id, 'dot3');
 }
 else {
-    $graph_file = $config['rrd_dir'].'/'.$device['hostname'].'/port-'.safename($port['ifIndex']).'.rrd';
+    $graph_file = get_port_rrdfile_path ($device['hostname'], $if_id);
 }
 
 if ($graph_type && is_file($graph_file)) {

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -65,7 +65,8 @@ if ($_POST['hostname']) {
             $force_add = 0;
         }
 
-        $result = addHost($hostname, $snmpver, $port, $transport, 0, $poller_group, $force_add);
+        $port_assoc_mode = $_POST['port_assoc_mode'];
+        $result = addHost($hostname, $snmpver, $port, $transport, 0, $poller_group, $force_add, $port_assoc_mode);
         if ($result) {
             print_message("Device added ($result)");
         }
@@ -119,6 +120,24 @@ foreach ($config['snmp']['transports'] as $transport) {
     }
 
     echo '>'.$transport.'</option>';
+}
+?>
+        </select>
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="port_association_mode" class="col-sm-3 control-label">Port Association Mode</label>
+      <div class="col-sm-3">
+        <select name="port_assoc_mode" id="port_assoc_mode" class="form-control input-sm">
+<?php
+
+
+foreach (get_port_assoc_modes() as $mode) {
+    $selected = "";
+    if ($mode == $config['default_port_association_mode'])
+        $selected = "selected";
+
+    echo "          <option value=\"$mode\" $selected>$mode</option>\n";
 }
 ?>
         </select>

--- a/html/pages/device/edit/snmp.inc.php
+++ b/html/pages/device/edit/snmp.inc.php
@@ -9,6 +9,7 @@ if ($_POST['editing']) {
         $timeout      = mres($_POST['timeout']);
         $retries      = mres($_POST['retries']);
         $poller_group = mres($_POST['poller_group']);
+        $port_assoc_mode = mres($_POST['port_assoc_mode']);
         $v3           = array(
             'authlevel'  => mres($_POST['authlevel']),
             'authname'   => mres($_POST['authname']),
@@ -25,6 +26,7 @@ if ($_POST['editing']) {
             'port'         => $port,
             'transport'    => $transport,
             'poller_group' => $poller_group,
+            'port_association_mode' => $port_assoc_mode,
         );
 
         if ($_POST['timeout']) {
@@ -43,7 +45,7 @@ if ($_POST['editing']) {
 
         $update = array_merge($update, $v3);
 
-        $device_tmp = deviceArray($device['hostname'], $community, $snmpver, $port, $transport, $v3);
+        $device_tmp = deviceArray($device['hostname'], $community, $snmpver, $port, $transport, $v3, $port_assoc_mode);
         if (isSNMPable($device_tmp)) {
             $rows_updated = dbUpdate($update, 'devices', '`device_id` = ?', array($device['device_id']));
 
@@ -115,6 +117,25 @@ echo "      </select>
     <div class='col-sm-1'>
     <input id='retries' name='retries' class='form-control input-sm' value='".($device['timeout'] ? $device['retries'] : '')."' placeholder='retries' />
     </div>
+    </div>
+    <div class='form-group'>
+      <label for='port_assoc_mode' class='col-sm-2 control-label'>Port Association Mode</label>
+      <div class='col-sm-1'>
+        <select name='port_assoc_mode' id='port_assoc_mode' class='form-control input-sm'>
+";
+
+foreach (get_port_assoc_modes() as $pam) {
+    $pam_id = get_port_assoc_mode_id ($pam);
+    echo "           <option value='$pam_id'";
+
+    if ($pam_id == $device['port_association_mode'])
+        echo " selected='selected'";
+
+    echo ">$pam</option>\n";
+}
+
+echo "        </select>
+      </div>
     </div>
     <div id='snmpv1_2'>
     <div class='form-group'>

--- a/html/pages/device/port/adsl.inc.php
+++ b/html/pages/device/port/adsl.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if (file_exists($config['rrd_dir'].'/'.$device['hostname'].'/port-'.$port['ifIndex'].'-adsl.rrd')) {
+if (file_exists(get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'adsl'))) {
     $iid = $id;
     echo '<div class=graphhead>ADSL Line Speed</div>';
     $graph_type = 'port_adsl_speed';

--- a/html/pages/device/port/graphs.inc.php
+++ b/html/pages/device/port/graphs.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if (file_exists($config['rrd_dir'].'/'.$device['hostname'].'/port-'.$port['ifIndex'].'.rrd')) {
+if (file_exists(get_port_rrdfile_path ($device['hostname'], $port['port_id']))) {
     $iid = $id;
     echo '<div class="panel panel-default">
             <div class="panel-heading">
@@ -41,7 +41,7 @@ if (file_exists($config['rrd_dir'].'/'.$device['hostname'].'/port-'.$port['ifInd
         include 'includes/print-interface-graphs.inc.php';
     echo '</div></div>';
 
-    if (is_file($config['rrd_dir'].'/'.$device['hostname'].'/port-'.$port['ifIndex'].'-dot3.rrd')) {
+    if (is_file(get_port_rrdfile_path ($device['hostname'], $port['port_id'], 'dot3'))) {
         echo '<div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title">Ethernet Errors</h3>

--- a/html/pages/iftype.inc.php
+++ b/html/pages/iftype.inc.php
@@ -94,7 +94,7 @@ if ($if_list) {
 
         echo '<br />';
 
-        if (file_exists($config['rrd_dir'].'/'.$port['hostname'].'/port-'.$port['ifIndex'].'.rrd')) {
+        if (file_exists(get_port_rrdfile_path ($port['hostname'], $port['port_id']))) {
             $graph_type = 'port_bits';
 
             include 'includes/print-interface-graphs.inc.php';

--- a/includes/common.php
+++ b/includes/common.php
@@ -114,7 +114,7 @@ function delete_port($int_id) {
     dbDelete('links', "`remote_port_id` =  ?", array($int_id));
     dbDelete('bill_ports', "`port_id` =  ?", array($int_id));
 
-    unlink(trim($config['rrd_dir'])."/".trim($interface['hostname'])."/port-".$interface['ifIndex'].".rrd");
+    unlink(get_port_rrdfile_path ($interface['hostname'], $interface['port_id']));
 }
 
 function sgn($int) {
@@ -141,6 +141,15 @@ function get_sensor_rrd($device, $sensor) {
     }
 
     return($rrd_file);
+}
+
+function get_port_rrdfile_path ($hostname, $port_id, $suffix = '') {
+    global $config;
+
+    if (! empty ($suffix))
+        $suffix = '-' . $suffix;
+
+    return trim ($config['rrd_dir']) . '/' . safename ($hostname) . '/' . 'port-id' . safename($port_id) . safename ($suffix) . '.rrd';
 }
 
 function get_port_by_index_cache($device_id, $ifIndex) {
@@ -1093,3 +1102,155 @@ function ip_to_sysname($device,$ip) {
     }
     return $ip;
 }//end ip_to_sysname
+
+/**
+ * Return valid port association modes
+ * @param bool $no_cache No-Cache flag (optional, default false)
+ * @return array
+ */
+function get_port_assoc_modes ($no_cache = false) {
+    global $config;
+
+    if ($config['memcached']['enable'] && $no_cache === false) {
+        $assoc_modes = $config['memcached']['resource']->get (hash ('sha512', "port_assoc_modes"));
+        if (! empty ($assoc_modes))
+            return $assoc_modes;
+    }
+
+    $assoc_modes = Null;
+        foreach (dbFetchRows ("SELECT `name` FROM `port_association_mode` ORDER BY pom_id") as $row)
+        $assoc_modes[] = $row['name'];
+
+    if ($config['memcached']['enable'] && $no_cache === false)
+        $config['memcached']['resource']->set (hash ('sha512', "port_assoc_modes"), $assoc_modes, $config['memcached']['ttl']);
+
+    return $assoc_modes;
+}
+
+/**
+ * Validate port_association_mode
+ * @param string $port_assoc_mode
+ * @return bool
+ */
+function is_valid_port_assoc_mode ($port_assoc_mode) {
+    return in_array ($port_assoc_mode, get_port_assoc_modes ());
+}
+
+/**
+ * Get DB id of given port association mode name
+ * @param string $port_assoc_mode
+ * @param bool $no_cache No-Cache flag (optional, default false)
+ */
+function get_port_assoc_mode_id ($port_assoc_mode, $no_cache = false) {
+    global $config;
+
+    if ($config['memcached']['enable'] && $no_cache === false) {
+        $id = $config['memcached']['resource']->get (hash ('sha512', "port_assoc_mode_id|$port_assoc_mode"));
+        if (! empty ($id))
+            return $id;
+    }
+
+    $id = Null;
+    $row = dbFetchRow ("SELECT `pom_id` FROM `port_association_mode` WHERE name = ?", array ($port_assoc_mode));
+    if ($row) {
+        $id = $row['pom_id'];
+        if ($config['memcached']['enable'] && $no_cache === false)
+            $config['memcached']['resource']->set (hash ('sha512', "port_assoc_mode_id|$port_assoc_mode"), $id, $config['memcached']['ttl']);
+    }
+
+    return $id;
+}
+
+/**
+ * Get name of given port association_mode ID
+ * @param int $port_assoc_mode_id Port association mode ID
+ * @param bool $no_cache No-Cache flag (optional, default false)
+ * @return bool
+ */
+function get_port_assoc_mode_name ($port_assoc_mode_id, $no_cache = false) {
+    global $config;
+
+    if ($config['memcached']['enable'] && $no_cache === false) {
+        $name = $config['memcached']['resource']->get (hash ('sha512', "port_assoc_mode_name|$port_assoc_mode_id"));
+        if (! empty ($name))
+            return $name;
+    }
+
+    $name = Null;
+    $row = dbFetchRow ("SELECT `name` FROM `port_association_mode` WHERE pom_id = ?", array ($port_assoc_mode_id));
+    if ($row) {
+        $name = $row['name'];
+        if ($config['memcached']['enable'] && $no_cache === false)
+            $config['memcached']['resource']->set (hash ('sha512', "port_assoc_mode_name|$port_assoc_mode_id"), $name, $config['memcached']['ttl']);
+    }
+
+    return $name;
+}
+
+/**
+ * Query all ports of the given device (by ID) and build port array and
+ * port association maps for ifIndex, ifName, ifDescr. Query port stats
+ * if told to do so, too.
+ * @param int $device_id ID of device to query ports for
+ * @param bool $with_statistics Query port statistics, too. (optional, default false)
+ * @return array
+ */
+function get_ports_mapped ($device_id, $with_statistics = false) {
+    $ports = [];
+    $maps = [
+        'ifIndex' => [],
+        'ifName'  => [],
+        'ifDescr' => [],
+    ];
+
+    /* Query all information available for ports for this device ... */
+    $query = 'SELECT * FROM `ports` WHERE `device_id` = ? ORDER BY port_id';
+    if ($with_statistics) {
+        /* ... including any related ports_statistics if requested */
+        $query = 'SELECT *, `ports_statistics`.`port_id` AS `ports_statistics_port_id`, `ports`.`port_id` AS `port_id` FROM `ports` LEFT OUTER JOIN `ports_statistics` ON `ports`.`port_id` = `ports_statistics`.`port_id` WHERE `ports`.`device_id` = ? ORDER BY ports.port_id';
+    }
+
+    // Query known ports in order of discovery to make sure the latest
+    // discoverd/polled port is in the mapping tables.
+    foreach (dbFetchRows ($query, array ($device_id)) as $port) {
+        // Store port information by ports port_id from DB
+        $ports[$port['port_id']] = $port;
+
+        // Build maps from ifIndex, ifName, ifDescr to port_id
+        $maps['ifIndex'][$port['ifIndex']] = $port['port_id'];
+        $maps['ifName'][$port['ifName']]   = $port['port_id'];
+        $maps['ifDescr'][$port['ifDescr']] = $port['port_id'];
+    }
+
+    return [
+        'ports' => $ports,
+        'maps'  => $maps,
+    ];
+}
+
+/**
+ * Calculate port_id of given port using given devices port information and port association mode
+ * @param array $ports_mapped Port information of device queried by get_ports_mapped()
+ * @param array $port Port information as fetched from DB
+ * @param string $port_association_mode Port association mode to use for mapping
+ * @return int port_id (or Null)
+ */
+function get_port_id ($ports_mapped, $port, $port_association_mode) {
+    // Get port_id according to port_association_mode used for this device
+    $port_id = Null;
+
+    /*
+     * Information an all ports is available through $ports_mapped['ports']
+     * This might come in handy sometime in the future to add you nifty new
+     * port mapping schema:
+     *
+     * $ports = $ports_mapped['ports'];
+    */
+    $maps  = $ports_mapped['maps'];
+
+    if (in_array ($port_association_mode, array ('ifIndex', 'ifName', 'ifDescr'))) {
+        $port_id = $maps[$port_association_mode][$port[$port_association_mode]];
+    }
+
+    return $port_id;
+}

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -853,3 +853,6 @@ $config['notifications']['local']                       = 'misc/notifications.rs
 
 // Update channel (Can be 'master' or 'release')
 $config['update_channel']                               = 'master';
+
+// Default port association mode
+$config['default_port_association_mode'] = 'ifIndex';

--- a/includes/polling/port-adsl.inc.php
+++ b/includes/polling/port-adsl.inc.php
@@ -39,11 +39,11 @@
 // adslAturPerfESs.1 = 0 seconds
 // adslAturPerfValidIntervals.1 = 0
 // adslAturPerfInvalidIntervals.1 = 0
-if (isset($port_stats[$port['ifIndex']]['adslLineCoding'])) {
+if (isset($port_stats[$port_id]['adslLineCoding'])) {
     // Check to make sure Port data is cached.
-    $this_port = &$port_stats[$port['ifIndex']];
+    $this_port = &$port_stats[$port_id];
 
-    $rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('port-'.$port['ifIndex'].'-adsl.rrd');
+    $rrdfile = get_port_rrdfile_path ($device['hostname'], $port_id, 'adsl');
 
     $rrd_create  = ' --step 300';
     $rrd_create .= ' DS:AtucCurrSnrMgn:GAUGE:600:0:635';
@@ -130,8 +130,8 @@ if (isset($port_stats[$port['ifIndex']]['adslLineCoding'])) {
         $this_port[$oid] = ($this_port[$oid] / 10);
     }
 
-    if (dbFetchCell('SELECT COUNT(*) FROM `ports_adsl` WHERE `port_id` = ?', array($port['port_id'])) == '0') {
-        dbInsert(array('port_id' => $port['port_id']), 'ports_adsl');
+    if (dbFetchCell('SELECT COUNT(*) FROM `ports_adsl` WHERE `port_id` = ?', array($port_id)) == '0') {
+        dbInsert(array('port_id' => $port_id), 'ports_adsl');
     }
 
     $port['adsl_update'] = array('port_adsl_updated' => array('NOW()'));
@@ -141,7 +141,7 @@ if (isset($port_stats[$port['ifIndex']]['adslLineCoding'])) {
         $port['adsl_update'][$oid] = $data;
     }
 
-    dbUpdate($port['adsl_update'], 'ports_adsl', '`port_id` = ?', array($port['port_id']));
+    dbUpdate($port['adsl_update'], 'ports_adsl', '`port_id` = ?', array($port_id));
 
     if ($this_port['adslAtucCurrSnrMgn'] > '1280') {
         $this_port['adslAtucCurrSnrMgn'] = 'U';

--- a/includes/polling/port-etherlike.inc.php
+++ b/includes/polling/port-etherlike.inc.php
@@ -1,13 +1,14 @@
 <?php
 
-if ($port_stats[$port['ifIndex']] &&
+if ($port_stats[$port_id] &&
     $port['ifType'] == 'ethernetCsmacd' &&
-    isset($port_stats[$port['ifIndex']]['dot3StatsIndex'])) {
+    isset($port_stats[$port_id]['dot3StatsIndex'])) {
     // Check to make sure Port data is cached.
-    $this_port = &$port_stats[$port[ifIndex]];
+    $this_port = &$port_stats[$port_id];
 
+    // TODO: remove legacy check?
     $old_rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('etherlike-'.$port['ifIndex'].'.rrd');
-    $rrdfile     = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('port-'.$port['ifIndex'].'-dot3.rrd');
+    $rrd_file    = get_port_rrdfile_path ($device['hostname'], $port_id, 'dot3');
 
     $rrd_create = $config['rrd_rra'];
 

--- a/includes/polling/port-poe.inc.php
+++ b/includes/polling/port-poe.inc.php
@@ -35,14 +35,13 @@ $peth_oids = array(
     'pethMainPseConsumptionPower',
 );
 
-if ($port_stats[$port['ifIndex']]
+if ($port_stats[$port_id]
     && $port['ifType'] == 'ethernetCsmacd'
-    && isset($port_stats[$port['ifIndex']]['dot3StatsIndex'])) {
+    && isset($port_stats[$port_id]['dot3StatsIndex'])) {
     // Check to make sure Port data is cached.
-    $this_port = &$port_stats[$port['ifIndex']];
+    $this_port = &$port_stats[$port_id];
 
-    $rrdfile = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename('port-'.$port['ifIndex'].'-poe.rrd');
-
+    $rrdfile = get_port_rrdfile_path ($device['hostname'], $port_id, 'poe');
     if (!file_exists($rrdfile)) {
         $rrd_create .= $config['rrd_rra'];
 

--- a/scripts/tune_port.php
+++ b/scripts/tune_port.php
@@ -24,8 +24,7 @@ foreach (dbFetchRows("SELECT `device_id`,`hostname` FROM `devices` WHERE `hostna
     echo "Found hostname " . $device['hostname'].".......\n";
     foreach (dbFetchRows("SELECT `ifIndex`,`ifName`,`ifSpeed` FROM `ports` WHERE `ifName` LIKE ? AND `device_id` = ?", array('%'.$ports.'%',$device['device_id'])) as $port) {
         echo "Tuning port " . $port['ifName'].".......\n";
-        $host_rrd = $config['rrd_dir'].'/'.$device['hostname'];
-        $rrdfile = $host_rrd.'/port-'.safename($port['ifIndex'].'.rrd');
+        $rrdfile = get_port_rrdfile_path ($device['hostname'], $port['port_id']);
         rrdtool_tune('port',$rrdfile,$port['ifSpeed']);
     }
 }

--- a/sql-schema/096.sql
+++ b/sql-schema/096.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `port_association_mode` (pom_id  int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY, name varchar(12) NOT NULL);
+INSERT INTO port_association_mode (pom_id, name) values (1, 'ifIndex');
+INSERT INTO port_association_mode (name) values ('ifName');
+INSERT INTO port_association_mode (name) values ('ifDescr');
+ALTER TABLE devices ADD port_association_mode int(11) NOT NULL DEFAULT 1;


### PR DESCRIPTION
By default libreNMS used the ifIndex to associate ports just found via SNMP
with ports discoverd/polled before and stored in the database. On Linux boxes
this is a problem as ifIndexes are rather likely to be unstable between reboots
or (re)configuration of tunnel interfaces (think: GRE/OpenVPN/Tinc/...), bridges,
Vlan interfaces, Bonding interfaces, etc.

This patch set adds a »port association mode« configuration option per device which
allows to map discovered and known ports by their ifIndex, ifName, ifDescr, or
maybe other means in the future.
The default port association mode still is ifIndex for compatibility reasons.

As port RRD files were stored by their ifIndex before, they are now identified
by their unique and stable port_id to ensure a stable and unique mapping and
allow future port association modes to be added without requireing any further
internal changes. Existing RRD files are renamend accordingly in discovery and
poller tools to ensure stability of port associations in both modules as we
don't know which might run first after an update.

The graphs are updated to read port data from the new path using a generic function.
The CLI and WebUI interface for adding and editing a host are updated to reflect the new option as well.