### PR TITLE
Try to find rancid file based on both fqdn and short host name

### DIFF
--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -16,9 +16,11 @@ if ($_SESSION['userlevel'] >= '7') {
 
             if (is_file($configs.$device['hostname'])) {
                 $file = $configs.$device['hostname'];
-            } elseif (is_file($configs.strtok($device['hostname'], '.'))) { // Strip domain
+            } 
+            elseif (is_file($configs.strtok($device['hostname'], '.'))) { // Strip domain
                 $file = $configs.strtok($device['hostname'], '.');
-            } else {
+            } 
+            else {
                 if (!empty($config['mydomain'])) { // Try with domain name if set
                     if (is_file($configs.$device['hostname'].'.'.$config['mydomain'])) {
                         $file = $configs.$device['hostname'].'.'.$config['mydomain'];

--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -16,7 +16,15 @@ if ($_SESSION['userlevel'] >= '7') {
 
             if (is_file($configs.$device['hostname'])) {
                 $file = $configs.$device['hostname'];
-            }
+            } elseif (is_file($configs.strtok($device['hostname'], '.'))) { // Strip domain
+                $file = $configs.strtok($device['hostname'], '.');
+            } else {
+                if (!empty($config['mydomain'])) { // Try with domain name if set
+                    if (is_file($configs.$device['hostname'].'.'.$config['mydomain'])) {
+                        $file = $configs.$device['hostname'].'.'.$config['mydomain'];
+                    }
+                }
+            } // end if
         }
 
         echo '<div style="clear: both;">';


### PR DESCRIPTION
In our environment hostnames in rancid are set up as short hostnames (i.e no domain) but in our librenms installation we use fqdn. This patch tries to locate the rancid file based on several different device name formats:
- device name as stored in librenms
- device name without domain (i.e. short hostname).
- device name with added domain, if "$config['mydomain']" is set.