### PR TITLE
Removed unused code in port poller for non-cisco devices

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -1,65 +1,115 @@
 <?php
 
-
 function poll_sensor($device, $class, $unit) {
     global $config, $memcache, $agent_sensors;
 
+    $x = 0;
+    $y = 0;
     foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ?', array($class, $device['device_id'])) as $sensor) {
+        if ($sensor['poller_type'] == 'snmp') {
+            if($x == 32) {
+                $y++;
+                $x = 0;
+            }
+            $snmp_sensors[] = $sensor;
+            $sensor_oids[$y][] = $sensor['sensor_oid'];
+            $x++;
+        }
+        else {
+            $other_sensors[] = $sensor;
+        }
+    }
+
+    $snmp_cache = array();
+    foreach ($snmp_sensors as $sensor) {
+        if ($device['os'] == 'siklu') {
+            $mib = ':RADIO-BRIDGE-MIB';
+        }
+        else {
+            $mib = '';
+        }
+
+        $new_sensor_oid = ltrim($sensor['sensor_oid'],".");
+        if (!$snmp_cache[$new_sensor_oid]['']) {
+            foreach ($sensor_oids as $sensor_oid) {
+                $snmp_cache = snmp_get_multi($device, implode(' ', $sensor_oid), '-OaQn', "SNMPv2-MIB:PowerNet-MIB$mib", '', $snmp_cache);
+            }
+        }
+        $sensor_value = trim(str_replace('"', '', $snmp_cache[$new_sensor_oid]['']));
+
+        if ($class == 'temperature') {
+            if ($device['os'] == 'netapp') {
+                include 'includes/polling/temperatures/netapp.inc.php';
+            }
+            else {
+                // Try 5 times to get a valid temp reading
+                for ($i = 0; $i < 5; $i++) {
+                    d_echo("Attempt $i ");
+                    preg_match('/[\d\.]+/', $sensor_value, $temp_response);
+                    if (!empty($temp_response[0])) {
+                        $sensor_value = $temp_response[0];
+                    }
+
+                    if (is_numeric($sensor_value) && $sensor_value != 9999) {
+                        break;
+                        // TME sometimes sends 999.9 when it is right in the middle of an update;
+                    }
+                    else {
+                        $sensor_value = trim(str_replace('"', '', snmp_get($device, $sensor['sensor_oid'], '-OUqnv', "SNMPv2-MIB$mib")));
+                    }
+                    // end if
+                }
+            }//end if
+        }
+        else if ($class == 'state') {
+        }
+        else if ($class == 'dbm') {
+            //iosxr does not expose dbm values through SNMP so we convert Watts to dbm to have a nice graph to show
+            if ($device['os'] == "iosxr") {
+                $sensor_value = round(10*log10($sensor_value/1000),3);
+            }
+        }
+        unset($mib);
+        $rrd_file = get_sensor_rrd($device, $sensor);
+
+        if (!is_file($rrd_file)) {
+            rrdtool_create(
+                $rrd_file,
+                '--step 300
+                DS:sensor:GAUGE:600:-20000:20000 '.$config['rrd_rra']
+            );
+        }
+
+        if ($sensor_value == -32768) {
+            echo 'Invalid (-32768) ';
+            $sensor_value = 0;
+        }
+
+        if ($sensor['sensor_divisor']) {
+            $sensor_value = ($sensor_value / $sensor['sensor_divisor']);
+        }
+
+        if ($sensor['sensor_multiplier']) {
+            $sensor_value = ($sensor_value * $sensor['sensor_multiplier']);
+        }
+
+        echo "$sensor_value $unit\n";
+
+        $fields = array(
+            'sensor' => $sensor_value,
+        );
+
+        rrdtool_update($rrd_file, $fields);
+
+        dbUpdate(array('sensor_current' => $sensor_value), 'sensors', '`sensor_class` = ? AND `sensor_id` = ?', array($class, $sensor['sensor_id']));
+
+    }
+
+    foreach ($other_sensor as $sensor) {
         echo 'Checking ('.$sensor['poller_type'].") $class ".$sensor['sensor_descr'].'... ';
         $sensor_value = '';
 
-        if ($sensor['poller_type'] == 'snmp') {
-            if ($device['os'] == 'siklu') {
-                $mib = ':RADIO-BRIDGE-MIB';
-            }
-            else {
-                $mib = '';
-            }
-
-            if ($class == 'temperature') {
-                if ($device['os'] == 'netapp') {
-                    include 'includes/polling/temperatures/netapp.inc.php';
-                }
-                else {
-                    // Try 5 times to get a valid temp reading
-                    for ($i = 0; $i < 5; $i++) {
-                        d_echo("Attempt $i ");
-
-                        $sensor_value = trim(str_replace('"', '', snmp_get($device, $sensor['sensor_oid'], '-OUqnv', "SNMPv2-MIB$mib")));
-                        preg_match('/[\d\.]+/', $sensor_value, $temp_response);
-                        if (!empty($temp_response[0])) {
-                            $sensor_value = $temp_response[0];
-                        }
-
-                        if (is_numeric($sensor_value) && $sensor_value != 9999) {
-                            break;
-                            // TME sometimes sends 999.9 when it is right in the middle of an update;
-                        }              sleep(1);
-                        // end if
-                    }
-                }//end if
-            }
-            else if ($class == 'state') {
-                $sensor_value = trim(str_replace('"', '', snmp_walk($device, $sensor['sensor_oid'], '-Oevq', 'SNMPv2-MIB')));
-            }
-            else if ($class == 'dbm') {
-                $sensor_value = trim(str_replace('"', '', snmp_get($device, $sensor['sensor_oid'], '-OUqnv', "SNMPv2-MIB$mib")));
-                //iosxr does not expose dbm values through SNMP so we convert Watts to dbm to have a nice graph to show
-                if ($device['os'] == "iosxr") {
-                    $sensor_value = round(10*log10($sensor_value/1000),3);
-                }
-            }
-            else {
-                if ($sensor['sensor_type'] == 'apc') {
-                    $sensor_value = trim(str_replace('"', '', snmp_walk($device, $sensor['sensor_oid'], '-OUqnv', "SNMPv2-MIB:PowerNet-MIB$mib")));
-                }
-                else {
-                    $sensor_value = trim(str_replace('"', '', snmp_get($device, $sensor['sensor_oid'], '-OUqnv', "SNMPv2-MIB$mib")));
-                }
-            }//end if
-            unset($mib);
-        }
-        else if ($sensor['poller_type'] == 'agent') {
+        if ($sensor['poller_type'] == 'agent') {
             if (isset($agent_sensors)) {
                 $sensor_value = $agent_sensors[$class][$sensor['sensor_type']][$sensor['sensor_index']]['current'];
             }
@@ -96,7 +146,7 @@ function poll_sensor($device, $class, $unit) {
         if (!is_file($rrd_file)) {
             rrdtool_create(
                 $rrd_file,
-                '--step 300 
+                '--step 300
                 DS:sensor:GAUGE:600:-20000:20000 '.$config['rrd_rra']
             );
         }
@@ -126,7 +176,7 @@ function poll_sensor($device, $class, $unit) {
     }//end foreach
 
 }//end poll_sensor()
-
+ 
 
 function poll_device($device, $options) {
     global $config, $device, $polled_devices, $db_stats, $memcache;

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -184,27 +184,6 @@ if ($device['os_group'] == 'cisco') {
 }
 else {
     $port_stats = snmpwalk_cache_oid($device, 'dot1qPortVlanTable', $port_stats, 'Q-BRIDGE-MIB');
-
-    $vlan_ports       = snmpwalk_cache_twopart_oid($device, 'dot1qVlanCurrentEgressPorts', $vlan_stats, 'Q-BRIDGE-MIB');
-    $vlan_ifindex_map = snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', $vlan_stats, 'Q-BRIDGE-MIB');
-
-    foreach ($vlan_ports as $instance) {
-        foreach (array_keys($instance) as $vlan_id) {
-            $parts  = explode(' ', $instance[$vlan_id]['dot1qVlanCurrentEgressPorts']);
-            $binary = '';
-            foreach ($parts as $part) {
-                $binary .= zeropad(decbin($part), 8);
-            }
-
-            for ($i = 0; $i < strlen($binary); $i++) {
-                if ($binary[$i]) {
-                    $ifindex = $i;
-                    // FIXME $vlan_ifindex_map[$i]
-                    $q_bridge_mib[$ifindex][] = $vlan_id;
-                }
-            }
-        }
-    }
 }//end if
 
 $polled = time();

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -46,7 +46,7 @@ function mibdir($mibdir) {
 }//end mibdir()
 
 
-function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=null) {
+function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=null, $array=array()) {
     global $debug,$config,$runtime_stats,$mibs_loaded;
 
     // populate timeout & retries values from configuration
@@ -82,7 +82,6 @@ function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=nul
 
     $data = trim(external_exec($cmd));
     $runtime_stats['snmpget']++;
-    $array = array();
     foreach (explode("\n", $data) as $entry) {
         list($oid,$value)  = explode('=', $entry, 2);
         $oid               = trim($oid);
@@ -96,7 +95,6 @@ function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=nul
     return $array;
 
 }//end snmp_get_multi()
-
 
 function snmp_get($device, $oid, $options=null, $mib=null, $mibdir=null) {
     global $debug,$config,$runtime_stats,$mibs_loaded;


### PR DESCRIPTION
Fix #2772 

This removes a bit of code which does nothing more than waste cpu cycles both in polling and on the devices.