### PR TITLE
Added eventlog to show when device has been removed

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -236,6 +236,7 @@ function delete_device($id) {
     }
 
     $ret .= "Removed device $host\n";
+    log_event("Device $host has been removed", 0, 'system');
     return $ret;
 }
 
@@ -691,7 +692,7 @@ function log_event($text, $device = NULL, $type = NULL, $reference = NULL) {
         $device = device_by_id_cache($device);
     }
 
-    $insert = array('host' => ($device['device_id'] ? $device['device_id'] : "NULL"),
+    $insert = array('host' => ($device['device_id'] ? $device['device_id'] : 0),
         'reference' => ($reference ? $reference : "NULL"),
         'type' => ($type ? $type : "NULL"),
         'datetime' => array("NOW()"),


### PR DESCRIPTION
Fix #2833 

This will add an eventlog entry logging when a device was removed (currently devices removed vanish without trace).

I've updated the event_log() function to use 0 instead of NULL for 'host' column - this is because NULL isn't valid for an int column when mysql strict mode is on.