### PR TITLE
Cisco CBQOS

### DIFF
--- a/html/includes/graphs/port/cbqos_bufferdrops.inc.php
+++ b/html/includes/graphs/port/cbqos_bufferdrops.inc.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * LibreNMS module to display Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options['filter']['type'] = array('=','Cisco-CBQOS');
+$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+// We only care about our device id.
+$COMPONENTS = $COMPONENTS[$device['device_id']];
+
+// Determine a policy to show.
+if (!isset($vars['policy'])) {
+    foreach ($COMPONENTS as $ID => $ARRAY) {
+        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+            // Found the first policy
+            $vars['policy'] = $ID;
+            continue;
+        }
+    }
+}
+
+include "includes/graphs/common.inc.php";
+$rrd_options .= " -l 0 -E ";
+$rrd_options .= " COMMENT:'Class-Map              Now      Avg      Max\\n'";
+$rrd_additions = "";
+
+$COUNT = 0;
+foreach ($COMPONENTS as $ID => $ARRAY) {
+    if ( ($ARRAY['qos-type'] == 2) && ($ARRAY['parent'] == $COMPONENTS[$vars['policy']]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$vars['policy']]['sp-id'])) {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd");
+
+        if (file_exists($rrd_filename)) {
+            // Stack the area on the second and subsequent DS's
+            $STACK = "";
+            if ($COUNT != 0) {
+                $STACK = ":STACK ";
+            }
+
+            // Grab a color from the array.
+            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
+                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            }
+            else {
+                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+            }
+
+            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":bufferdrops:AVERAGE ";
+            $rrd_additions .= " CDEF:MOD" . $COUNT . "=DS" . $COUNT . ",8,* ";
+            $rrd_additions .= " AREA:MOD" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":LAST:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":AVERAGE:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":MAX:%6.2lf%s\\\l ";
+
+            $COUNT++;
+        }
+    }
+}
+
+if ($rrd_additions == "") {
+    // We didn't add any data points.
+}
+else {
+    $rrd_options .= $rrd_additions;
+}

--- a/html/includes/graphs/port/cbqos_bufferdrops.inc.php
+++ b/html/includes/graphs/port/cbqos_bufferdrops.inc.php
@@ -12,19 +12,19 @@
  */
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options['filter']['type'] = array('=','Cisco-CBQOS');
-$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+$components = $component->getComponents($device['device_id'],$options);
 
 // We only care about our device id.
-$COMPONENTS = $COMPONENTS[$device['device_id']];
+$components = $components[$device['device_id']];
 
 // Determine a policy to show.
 if (!isset($vars['policy'])) {
-    foreach ($COMPONENTS as $ID => $ARRAY) {
-        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+    foreach ($components as $id => $array) {
+        if ( ($array['qos-type'] == 1) && ($array['ifindex'] == $port['ifIndex'])  && ($array['parent'] == 0) ) {
             // Found the first policy
-            $vars['policy'] = $ID;
+            $vars['policy'] = $id;
             continue;
         }
     }
@@ -35,34 +35,34 @@ $rrd_options .= " -l 0 -E ";
 $rrd_options .= " COMMENT:'Class-Map              Now      Avg      Max\\n'";
 $rrd_additions = "";
 
-$COUNT = 0;
-foreach ($COMPONENTS as $ID => $ARRAY) {
-    if ( ($ARRAY['qos-type'] == 2) && ($ARRAY['parent'] == $COMPONENTS[$vars['policy']]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$vars['policy']]['sp-id'])) {
-        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd");
+$count = 0;
+foreach ($components as $id => $array) {
+    if ( ($array['qos-type'] == 2) && ($array['parent'] == $components[$vars['policy']]['sp-obj']) && ($array['sp-id'] == $components[$vars['policy']]['sp-id'])) {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$array['ifindex']."-cbqos-".$array['sp-id']."-".$array['sp-obj'].".rrd");
 
         if (file_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
-            $STACK = "";
-            if ($COUNT != 0) {
-                $STACK = ":STACK ";
+            $stack = "";
+            if ($count != 0) {
+                $stack = ":STACK ";
             }
 
             // Grab a color from the array.
-            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
-                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            if ( isset($config['graph_colours']['mixed'][$count]) ) {
+                $color = $config['graph_colours']['mixed'][$count];
             }
             else {
-                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+                $color = $config['graph_colours']['oranges'][$count-7];
             }
 
-            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":bufferdrops:AVERAGE ";
-            $rrd_additions .= " CDEF:MOD" . $COUNT . "=DS" . $COUNT . ",8,* ";
-            $rrd_additions .= " AREA:MOD" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":LAST:%6.2lf%s ";
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":AVERAGE:%6.2lf%s ";
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":MAX:%6.2lf%s\\\l ";
+            $rrd_additions .= " DEF:DS" . $count . "=" . $rrd_filename . ":bufferdrops:AVERAGE ";
+            $rrd_additions .= " CDEF:MOD" . $count . "=DS" . $count . ",8,* ";
+            $rrd_additions .= " AREA:MOD" . $count . "#" . $color . ":'" . str_pad(substr($components[$id]['label'],0,15),15) . "'" . $stack;
+            $rrd_additions .= " GPRINT:MOD" . $count . ":LAST:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $count . ":AVERAGE:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $count . ":MAX:%6.2lf%s\\\l ";
 
-            $COUNT++;
+            $count++;
         }
     }
 }

--- a/html/includes/graphs/port/cbqos_qosdrops.inc.php
+++ b/html/includes/graphs/port/cbqos_qosdrops.inc.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * LibreNMS module to display Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options['filter']['type'] = array('=','Cisco-CBQOS');
+$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+// We only care about our device id.
+$COMPONENTS = $COMPONENTS[$device['device_id']];
+
+// Determine a policy to show.
+if (!isset($vars['policy'])) {
+    foreach ($COMPONENTS as $ID => $ARRAY) {
+        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+            // Found the first policy
+            $vars['policy'] = $ID;
+            continue;
+        }
+    }
+}
+
+include "includes/graphs/common.inc.php";
+$rrd_options .= " -l 0 -E ";
+$rrd_options .= " COMMENT:'Class-Map              Now      Avg      Max\\n'";
+$rrd_additions = "";
+
+$COUNT = 0;
+foreach ($COMPONENTS as $ID => $ARRAY) {
+    if ( ($ARRAY['qos-type'] == 2) && ($ARRAY['parent'] == $COMPONENTS[$vars['policy']]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$vars['policy']]['sp-id'])) {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd");
+
+        if (file_exists($rrd_filename)) {
+            // Stack the area on the second and subsequent DS's
+            $STACK = "";
+            if ($COUNT != 0) {
+                $STACK = ":STACK ";
+            }
+
+            // Grab a color from the array.
+            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
+                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            }
+            else {
+                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+            }
+
+            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":qosdrops:AVERAGE ";
+            $rrd_additions .= " CDEF:MOD" . $COUNT . "=DS" . $COUNT . ",8,* ";
+            $rrd_additions .= " AREA:MOD" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":LAST:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":AVERAGE:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":MAX:%6.2lf%s\\\l ";
+
+            $COUNT++;
+        }
+    }
+}
+
+if ($rrd_additions == "") {
+    // We didn't add any data points.
+}
+else {
+    $rrd_options .= $rrd_additions;
+}

--- a/html/includes/graphs/port/cbqos_qosdrops.inc.php
+++ b/html/includes/graphs/port/cbqos_qosdrops.inc.php
@@ -12,19 +12,19 @@
  */
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options['filter']['type'] = array('=','Cisco-CBQOS');
-$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+$components = $component->getComponents($device['device_id'],$options);
 
 // We only care about our device id.
-$COMPONENTS = $COMPONENTS[$device['device_id']];
+$components = $components[$device['device_id']];
 
 // Determine a policy to show.
 if (!isset($vars['policy'])) {
-    foreach ($COMPONENTS as $ID => $ARRAY) {
-        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+    foreach ($components as $id => $array) {
+        if ( ($array['qos-type'] == 1) && ($array['ifindex'] == $port['ifIndex'])  && ($array['parent'] == 0) ) {
             // Found the first policy
-            $vars['policy'] = $ID;
+            $vars['policy'] = $id;
             continue;
         }
     }
@@ -35,34 +35,34 @@ $rrd_options .= " -l 0 -E ";
 $rrd_options .= " COMMENT:'Class-Map              Now      Avg      Max\\n'";
 $rrd_additions = "";
 
-$COUNT = 0;
-foreach ($COMPONENTS as $ID => $ARRAY) {
-    if ( ($ARRAY['qos-type'] == 2) && ($ARRAY['parent'] == $COMPONENTS[$vars['policy']]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$vars['policy']]['sp-id'])) {
-        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd");
+$count = 0;
+foreach ($components as $id => $array) {
+    if ( ($array['qos-type'] == 2) && ($array['parent'] == $components[$vars['policy']]['sp-obj']) && ($array['sp-id'] == $components[$vars['policy']]['sp-id'])) {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$array['ifindex']."-cbqos-".$array['sp-id']."-".$array['sp-obj'].".rrd");
 
         if (file_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
-            $STACK = "";
-            if ($COUNT != 0) {
-                $STACK = ":STACK ";
+            $stack = "";
+            if ($count != 0) {
+                $stack = ":STACK ";
             }
 
             // Grab a color from the array.
-            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
-                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            if ( isset($config['graph_colours']['mixed'][$count]) ) {
+                $color = $config['graph_colours']['mixed'][$count];
             }
             else {
-                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+                $color = $config['graph_colours']['oranges'][$count-7];
             }
 
-            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":qosdrops:AVERAGE ";
-            $rrd_additions .= " CDEF:MOD" . $COUNT . "=DS" . $COUNT . ",8,* ";
-            $rrd_additions .= " AREA:MOD" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":LAST:%6.2lf%s ";
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":AVERAGE:%6.2lf%s ";
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":MAX:%6.2lf%s\\\l ";
+            $rrd_additions .= " DEF:DS" . $count . "=" . $rrd_filename . ":qosdrops:AVERAGE ";
+            $rrd_additions .= " CDEF:MOD" . $count . "=DS" . $count . ",8,* ";
+            $rrd_additions .= " AREA:MOD" . $count . "#" . $color . ":'" . str_pad(substr($components[$id]['label'],0,15),15) . "'" . $stack;
+            $rrd_additions .= " GPRINT:MOD" . $count . ":LAST:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $count . ":AVERAGE:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $count . ":MAX:%6.2lf%s\\\l ";
 
-            $COUNT++;
+            $count++;
         }
     }
 }

--- a/html/includes/graphs/port/cbqos_traffic.inc.php
+++ b/html/includes/graphs/port/cbqos_traffic.inc.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * LibreNMS module to display Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options['filter']['type'] = array('=','Cisco-CBQOS');
+$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+// We only care about our device id.
+$COMPONENTS = $COMPONENTS[$device['device_id']];
+
+// Determine a policy to show.
+if (!isset($vars['policy'])) {
+    foreach ($COMPONENTS as $ID => $ARRAY) {
+        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+            // Found the first policy
+            $vars['policy'] = $ID;
+            continue;
+        }
+    }
+}
+
+include "includes/graphs/common.inc.php";
+$rrd_options .= " -l 0 -E ";
+$rrd_options .= " COMMENT:'Class-Map              Now      Avg      Max\\n'";
+$rrd_additions = "";
+
+$COUNT = 0;
+foreach ($COMPONENTS as $ID => $ARRAY) {
+    if ( ($ARRAY['qos-type'] == 2) && ($ARRAY['parent'] == $COMPONENTS[$vars['policy']]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$vars['policy']]['sp-id'])) {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd");
+
+        if (file_exists($rrd_filename)) {
+            // Stack the area on the second and subsequent DS's
+            $STACK = "";
+            if ($COUNT != 0) {
+                $STACK = ":STACK ";
+            }
+
+            // Grab a color from the array.
+            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
+                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            }
+            else {
+                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+            }
+
+            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":postbits:AVERAGE ";
+            $rrd_additions .= " CDEF:MOD" . $COUNT . "=DS" . $COUNT . ",8,* ";
+            $rrd_additions .= " AREA:MOD" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":LAST:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":AVERAGE:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":MAX:%6.2lf%s\\\l ";
+
+            $COUNT++;
+        }
+    }
+}
+
+if ($rrd_additions == "") {
+    // We didn't add any data points.
+}
+else {
+    $rrd_options .= $rrd_additions;
+}

--- a/html/includes/graphs/port/cbqos_traffic.inc.php
+++ b/html/includes/graphs/port/cbqos_traffic.inc.php
@@ -12,19 +12,19 @@
  */
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options['filter']['type'] = array('=','Cisco-CBQOS');
-$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+$components = $component->getComponents($device['device_id'],$options);
 
 // We only care about our device id.
-$COMPONENTS = $COMPONENTS[$device['device_id']];
+$components = $components[$device['device_id']];
 
 // Determine a policy to show.
 if (!isset($vars['policy'])) {
-    foreach ($COMPONENTS as $ID => $ARRAY) {
-        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+    foreach ($components as $id => $array) {
+        if ( ($array['qos-type'] == 1) && ($array['ifindex'] == $port['ifIndex'])  && ($array['parent'] == 0) ) {
             // Found the first policy
-            $vars['policy'] = $ID;
+            $vars['policy'] = $id;
             continue;
         }
     }
@@ -35,34 +35,34 @@ $rrd_options .= " -l 0 -E ";
 $rrd_options .= " COMMENT:'Class-Map              Now      Avg      Max\\n'";
 $rrd_additions = "";
 
-$COUNT = 0;
-foreach ($COMPONENTS as $ID => $ARRAY) {
-    if ( ($ARRAY['qos-type'] == 2) && ($ARRAY['parent'] == $COMPONENTS[$vars['policy']]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$vars['policy']]['sp-id'])) {
-        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd");
+$count = 0;
+foreach ($components as $id => $array) {
+    if ( ($array['qos-type'] == 2) && ($array['parent'] == $components[$vars['policy']]['sp-obj']) && ($array['sp-id'] == $components[$vars['policy']]['sp-id'])) {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("port-".$array['ifindex']."-cbqos-".$array['sp-id']."-".$array['sp-obj'].".rrd");
 
         if (file_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
-            $STACK = "";
-            if ($COUNT != 0) {
-                $STACK = ":STACK ";
+            $stack = "";
+            if ($count != 0) {
+                $stack = ":STACK ";
             }
 
             // Grab a color from the array.
-            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
-                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            if ( isset($config['graph_colours']['mixed'][$count]) ) {
+                $color = $config['graph_colours']['mixed'][$count];
             }
             else {
-                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+                $color = $config['graph_colours']['oranges'][$count-7];
             }
 
-            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":postbits:AVERAGE ";
-            $rrd_additions .= " CDEF:MOD" . $COUNT . "=DS" . $COUNT . ",8,* ";
-            $rrd_additions .= " AREA:MOD" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":LAST:%6.2lf%s ";
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":AVERAGE:%6.2lf%s ";
-            $rrd_additions .= " GPRINT:MOD" . $COUNT . ":MAX:%6.2lf%s\\\l ";
+            $rrd_additions .= " DEF:DS" . $count . "=" . $rrd_filename . ":postbits:AVERAGE ";
+            $rrd_additions .= " CDEF:MOD" . $count . "=DS" . $count . ",8,* ";
+            $rrd_additions .= " AREA:MOD" . $count . "#" . $color . ":'" . str_pad(substr($components[$id]['label'],0,15),15) . "'" . $stack;
+            $rrd_additions .= " GPRINT:MOD" . $count . ":LAST:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $count . ":AVERAGE:%6.2lf%s ";
+            $rrd_additions .= " GPRINT:MOD" . $count . ":MAX:%6.2lf%s\\\l ";
 
-            $COUNT++;
+            $count++;
         }
     }
 }

--- a/html/pages/device/port.inc.php
+++ b/html/pages/device/port.inc.php
@@ -87,6 +87,12 @@ if (dbFetchCell("SELECT COUNT(*) FROM `ports_vlans` WHERE `port_id` = '".$port['
     $menu_options['vlans'] = 'VLANs';
 }
 
+// Are there any CBQoS rrd's for this ifIndex?
+$cbqos = glob($config['rrd_dir'].'/'.$device['hostname'].'/port-'.$port['ifIndex'].'-cbqos-*.rrd');
+if (!empty($cbqos)) {
+    $menu_options['cbqos'] = 'CBQoS';
+}
+
 $sep = '';
 foreach ($menu_options as $option => $text) {
     echo $sep;

--- a/html/pages/device/port/cbqos.inc.php
+++ b/html/pages/device/port/cbqos.inc.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ * LibreNMS module to display Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+function find_child($COMPONENTS,$parent,$level) {
+    global $vars;
+
+    foreach($COMPONENTS as $ID => $ARRAY) {
+        if ($ARRAY['qos-type'] == 3) {
+            continue;
+        }
+        if (($ARRAY['parent'] == $COMPONENTS[$parent]['sp-obj']) && ($ARRAY['sp-id'] == $COMPONENTS[$parent]['sp-id'])) {
+            echo "<ul>";
+            echo "<li>";
+            if ($ARRAY['qos-type'] == 1) {
+                // Its a policy, we need to make it a link.
+                echo('<a href="' . generate_url($vars, array('policy' => $ID)) . '">' . $ARRAY['label'] . '</a>');
+            }
+            else {
+                // No policy, no link
+                echo $ARRAY['label'];
+            }
+            if (isset($ARRAY['match'])) {
+                echo ' ('.$ARRAY['match'].')';
+            }
+
+            find_child($COMPONENTS,$ID,$level+1);
+
+            echo "</li>";
+            echo "</ul>";
+        }
+    }
+}
+
+$rrdarr = glob($config['rrd_dir'].'/'.$device['hostname'].'/port-'.$port['ifIndex'].'-cbqos-*.rrd');
+if (!empty($rrdarr)) {
+    require_once "../includes/component.php";
+    $COMPONENT = new component();
+    $options['filter']['type'] = array('=','Cisco-CBQOS');
+    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+    // We only care about our device id.
+    $COMPONENTS = $COMPONENTS[$device['device_id']];
+
+    if (isset($vars['policy'])) {
+        // if a policy is set try to use it.
+        $graph_array['policy'] = $vars['policy'];
+    }
+    else {
+        // if not, find the first parent and use it.
+        foreach ($COMPONENTS as $ID => $ARRAY) {
+            if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex'])  && ($ARRAY['parent'] == 0) ) {
+                // Found the first policy
+                $graph_array['policy'] = $ID;
+                continue;
+            }
+        }
+    }
+    echo "\n\n";
+
+    // Display the ingress policy at the top of the page.
+    echo "<div class='col-md-6'><ul class='mktree' id='ingress'>";
+    echo '<div><strong><i class="fa fa-sign-in"></i>&nbsp;Ingress Policy:</strong></div>';
+    $FOUND = false;
+    foreach ($COMPONENTS as $ID => $ARRAY) {
+        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex']) && ($ARRAY['direction'] == 1)  && ($ARRAY['parent'] == 0) ) {
+            echo "<li class='liOpen'>";
+            echo('<a href="' . generate_url($vars, array('policy' => $ID)) . '">' . $ARRAY['label'] . '</a>');
+            find_child($COMPONENTS,$ID,1);
+            echo "</li>";
+            $FOUND = true;
+        }
+    }
+    if (!$FOUND) {
+        // No Ingress policies
+        echo '<div><i>No Policies</i></div>';
+    }
+    echo '</ul></div>';
+
+    // Display the egress policy at the top of the page.
+    echo "<div class='col-md-6'><ul class='mktree' id='egress'>";
+    echo '<div><strong><i class="fa fa-sign-out"></i>&nbsp;Egress Policy:</strong></div>';
+    $FOUND = false;
+    foreach ($COMPONENTS as $ID => $ARRAY) {
+        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex']) && ($ARRAY['direction'] == 2)  && ($ARRAY['parent'] == 0) ) {
+            echo "<li class='liOpen'>";
+            echo('<a href="' . generate_url($vars, array('policy' => $ID)) . '">' . $ARRAY['label'] . '</a>');
+            find_child($COMPONENTS,$ID,1);
+            echo "</li>";
+            $FOUND = true;
+        }
+    }
+    if (!$FOUND) {
+        // No Egress policies
+        echo '<div><i>No Policies</i></div>';
+    }
+    echo "</ul></div>\n\n";
+
+    // Let's make sure the policy we are trying to access actually exists.
+    foreach ($COMPONENTS as $ID => $ARRAY) {
+        if ( ($ARRAY['qos-type'] == 1) && ($ARRAY['ifindex'] == $port['ifIndex']) && ($ID == $graph_array['policy']) ) {
+            // The policy exists.
+
+            echo "<div class='col-md-12'>&nbsp;</div>\n\n";
+
+            // Display each graph row.
+            echo "<div class='col-md-12'>";
+            echo "<div class='graphhead'>Traffic by CBQoS Class - ".$COMPONENTS[$graph_array['policy']]['label']."</div>";
+            $graph_type = 'port_cbqos_traffic';
+            include 'includes/print-interface-graphs.inc.php';
+
+            echo "<div class='graphhead'>QoS Drops by CBQoS Class - ".$COMPONENTS[$graph_array['policy']]['label']."</div>";
+            $graph_type = 'port_cbqos_bufferdrops';
+            include 'includes/print-interface-graphs.inc.php';
+
+            echo "<div class='graphhead'>Buffer Drops by CBQoS Class - ".$COMPONENTS[$graph_array['policy']]['label']."</div>";
+            $graph_type = 'port_cbqos_qosdrops';
+            include 'includes/print-interface-graphs.inc.php';
+            echo "</div>\n\n";
+        }
+    }
+}

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -710,6 +710,7 @@ $config['poller_modules']['applications']                = 1;
 $config['poller_modules']['cisco-asa-firewall']          = 1;
 $config['poller_modules']['mib'] = 0;
 $config['poller_modules']['cisco-voice']                 = 1;
+$config['poller_modules']['cisco-cbqos']                 = 1;
 $config['poller_modules']['stp']                         = 1;
 
 // List of discovery modules. Need to be in this array to be
@@ -742,6 +743,7 @@ $config['discovery_modules']['toner']          = 1;
 $config['discovery_modules']['ucd-diskio']     = 1;
 $config['discovery_modules']['services']       = 1;
 $config['discovery_modules']['charge']         = 1;
+$config['discovery_modules']['cisco-cbqos']    = 0;
 $config['discovery_modules']['stp']            = 1;
 
 $config['modules_compat']['rfc1628']['liebert']    = 1;

--- a/includes/discovery/cisco-cbqos.inc.php
+++ b/includes/discovery/cisco-cbqos.inc.php
@@ -13,15 +13,15 @@
 
 if ($device['os_group'] == 'cisco') {
 
-    $MODULE = 'Cisco-CBQOS';
-    echo $MODULE.': ';
+    $module = 'Cisco-CBQOS';
+    echo $module.': ';
 
     require_once 'includes/component.php';
-    $COMPONENT = new component();
-    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],array('type'=>$MODULE));
+    $component = new component();
+    $components = $component->getComponents($device['device_id'],array('type'=>$module));
 
     // We only care about our device id.
-    $COMPONENTS = $COMPONENTS[$device['device_id']];
+    $components = $components[$device['device_id']];
 
 
     // Begin our master array, all other values will be processed into this array.
@@ -49,68 +49,68 @@ if ($device['os_group'] == 'cisco') {
         foreach ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.2'] as $spid => $array) {
 
             foreach ($array as $spobj => $index) {
-                $RESULT = array();
+                $result = array();
 
                 // Produce a unique reproducible index for this entry.
-                $RESULT['UID'] = hash('crc32', $spid."-".$spobj);
+                $result['UID'] = hash('crc32', $spid."-".$spobj);
 
                 // Now that we have a valid identifiers, lets add some more data
-                $RESULT['sp-id'] = $spid;
-                $RESULT['sp-obj'] = $spobj;
+                $result['sp-id'] = $spid;
+                $result['sp-obj'] = $spobj;
 
                 // Add the Type, Policy-map, Class-map, etc.
                 $type = $tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.3'][$spid][$spobj];
-                $RESULT['qos-type'] = $type;
+                $result['qos-type'] = $type;
 
                 // Add the Parent, this lets us work out our hierarchy for display later.
-                $RESULT['parent'] = $tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.4'][$spid][$spobj];
-                $RESULT['direction'] = $tblcbQosServicePolicy['1.3.6.1.4.1.9.9.166.1.1.1.1.3'][$spid];
-                $RESULT['ifindex'] = $tblcbQosServicePolicy['1.3.6.1.4.1.9.9.166.1.1.1.1.4'][$spid];
+                $result['parent'] = $tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.4'][$spid][$spobj];
+                $result['direction'] = $tblcbQosServicePolicy['1.3.6.1.4.1.9.9.166.1.1.1.1.3'][$spid];
+                $result['ifindex'] = $tblcbQosServicePolicy['1.3.6.1.4.1.9.9.166.1.1.1.1.4'][$spid];
 
                 // Gather different data depending on the type.
                 switch ($type) {
                     case 1:
                         // Policy-map, get data from that table.
                         d_echo("\nIndex: ".$index."\n");
-                        d_echo("    UID: ".$RESULT['UID']."\n");
-                        d_echo("    SPID.SPOBJ: ".$RESULT['sp-id'].".".$RESULT['sp-obj']."\n");
-                        d_echo("    If-Index: ".$RESULT['ifindex']."\n");
+                        d_echo("    UID: ".$result['UID']."\n");
+                        d_echo("    SPID.SPOBJ: ".$result['sp-id'].".".$result['sp-obj']."\n");
+                        d_echo("    If-Index: ".$result['ifindex']."\n");
                         d_echo("    Type: 1 - Policy-Map\n");
-                        $RESULT['label'] = $tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.1'][$index];
+                        $result['label'] = $tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.1'][$index];
                         if ($tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.2'][$index] != "") {
-                            $RESULT['label'] .= " - ".$tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.2'][$index];
+                            $result['label'] .= " - ".$tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.2'][$index];
                         }
-                        d_echo("    Label: ".$RESULT['label']."\n");
+                        d_echo("    Label: ".$result['label']."\n");
                         break;
                     case 2:
                         // Class-map, get data from that table.
                         d_echo("\nIndex: ".$index."\n");
-                        d_echo("    UID: ".$RESULT['UID']."\n");
-                        d_echo("    SPID.SPOBJ: ".$RESULT['sp-id'].".".$RESULT['sp-obj']."\n");
-                        d_echo("    If-Index: ".$RESULT['ifindex']."\n");
+                        d_echo("    UID: ".$result['UID']."\n");
+                        d_echo("    SPID.SPOBJ: ".$result['sp-id'].".".$result['sp-obj']."\n");
+                        d_echo("    If-Index: ".$result['ifindex']."\n");
                         d_echo("    Type: 2 - Class-Map\n");
-                        $RESULT['label'] = $tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.1'][$index];
+                        $result['label'] = $tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.1'][$index];
                         if($tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.2'][$index] != "") {
-                            $RESULT['label'] .= " - ".$tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.2'][$index];
+                            $result['label'] .= " - ".$tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.2'][$index];
                         }
-                        d_echo("    Label: ".$RESULT['label']."\n");
+                        d_echo("    Label: ".$result['label']."\n");
                         if ($tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.3'][$index] == 2) {
-                            $RESULT['map-type'] = 'Match-All';
+                            $result['map-type'] = 'Match-All';
                         }
                         elseif ($tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.3'][$index] == 3) {
-                            $RESULT['map-type'] = 'Match-Any';
+                            $result['map-type'] = 'Match-Any';
                         }
                         else {
-                            $RESULT['map-type'] = 'None';
+                            $result['map-type'] = 'None';
                         }
 
                         // Find a child, this will be a type 3
-                        foreach ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.4'][$spid] as $ID => $VALUE) {
-                            if ($VALUE == $RESULT['sp-obj']) {
+                        foreach ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.4'][$spid] as $id => $value) {
+                            if ($value == $result['sp-obj']) {
                                 // We have our child, import the match
-                                if ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.3'][$spid][$ID] == 3) {
-                                    $RESULT['match'] = $RESULT['map-type'].": ".$tblcbQosMatchStmtCfg['1.3.6.1.4.1.9.9.166.1.8.1.1.1'][$tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.2'][$spid][$ID]];
-                                    d_echo("    Match: ".$RESULT['match']."\n");
+                                if ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.3'][$spid][$id] == 3) {
+                                    $result['match'] = $result['map-type'].": ".$tblcbQosMatchStmtCfg['1.3.6.1.4.1.9.9.166.1.8.1.1.1'][$tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.2'][$spid][$id]];
+                                    d_echo("    Match: ".$result['match']."\n");
                                 }
                             }
                         }
@@ -119,7 +119,7 @@ if ($device['os_group'] == 'cisco') {
                         continue 2;
                 }
 
-                $tblCBQOS[] = $RESULT;
+                $tblCBQOS[] = $result;
             }
         }
 
@@ -130,25 +130,25 @@ if ($device['os_group'] == 'cisco') {
          * Let's loop over the SNMP data to see if we need to ADD or UPDATE any components.
          */
         foreach ($tblCBQOS as $key => $array) {
-            $COMPONENT_KEY = false;
+            $component_key = false;
 
             // Loop over our components to determine if the component exists, or we need to add it.
-            foreach ($COMPONENTS as $COMPID => $CHILD) {
-                if ($CHILD['UID'] === $array['UID']) {
-                    $COMPONENT_KEY = $COMPID;
+        foreach ($components as $compid => $child) {
+                if ($child['UID'] === $array['UID']) {
+                    $component_key = $compid;
                 }
             }
 
-            if (!$COMPONENT_KEY) {
+            if (!$component_key) {
                 // The component doesn't exist, we need to ADD it - ADD.
-                $NEW_COMPONENT = $COMPONENT->createComponent($device['device_id'],$MODULE);
-                $COMPONENT_KEY = key($NEW_COMPONENT);
-                $COMPONENTS[$COMPONENT_KEY] = array_merge($NEW_COMPONENT[$COMPONENT_KEY], $array);
+                $new_component = $component->createComponent($device['device_id'],$module);
+                $component_key = key($new_component);
+                $components[$component_key] = array_merge($new_component[$component_key], $array);
                 echo "+";
             }
             else {
                 // The component does exist, merge the details in - UPDATE.
-                $COMPONENTS[$COMPONENT_KEY] = array_merge($COMPONENTS[$COMPONENT_KEY], $array);
+                $components[$component_key] = array_merge($components[$component_key], $array);
                 echo ".";
             }
 
@@ -157,26 +157,26 @@ if ($device['os_group'] == 'cisco') {
         /*
          * Loop over the Component data to see if we need to DELETE any components.
          */
-        foreach ($COMPONENTS as $key => $array) {
+        foreach ($components as $key => $array) {
             // Guilty until proven innocent
-            $FOUND = false;
+            $found = false;
 
             foreach ($tblCBQOS as $k => $v) {
                 if ($array['UID'] == $v['UID']) {
                     // Yay, we found it...
-                    $FOUND = true;
+                    $found = true;
                 }
             }
 
-            if ($FOUND === false) {
+            if ($found === false) {
                 // The component has not been found. we should delete it.
                 echo "-";
-                $COMPONENT->deleteComponent($key);
+                $component->deleteComponent($key);
             }
         }
 
         // Write the Components back to the DB.
-        $COMPONENT->setComponentPrefs($device['device_id'],$COMPONENTS);
+        $component->setComponentPrefs($device['device_id'],$components);
         echo "\n";
 
     } // End if not error

--- a/includes/discovery/cisco-cbqos.inc.php
+++ b/includes/discovery/cisco-cbqos.inc.php
@@ -1,0 +1,184 @@
+<?php
+/*
+ * LibreNMS module to capture Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+if ($device['os_group'] == 'cisco') {
+
+    $MODULE = 'Cisco-CBQOS';
+    echo $MODULE.': ';
+
+    require_once 'includes/component.php';
+    $COMPONENT = new component();
+    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],array('type'=>$MODULE));
+
+    // We only care about our device id.
+    $COMPONENTS = $COMPONENTS[$device['device_id']];
+
+
+    // Begin our master array, all other values will be processed into this array.
+    $tblCBQOS = array();
+
+    // Let's gather some data..
+    $tblcbQosServicePolicy = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.166.1.1');
+    $tblcbQosObjects = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.166.1.5', 2);
+    $tblcbQosPolicyMapCfg = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.166.1.6');
+    $tblcbQosClassMapCfg = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.166.1.7');
+    $tblcbQosMatchStmtCfg = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.166.1.8');
+
+    /*
+     * False == no object found - this is not an error, there is no QOS configured
+     * null  == timeout or something else that caused an error, there may be QOS configured but we couldn't get it.
+     */
+    if ( is_null($tblcbQosServicePolicy) || is_null($tblcbQosObjects) || is_null($tblcbQosPolicyMapCfg) || is_null($tblcbQosClassMapCfg) || is_null($tblcbQosMatchStmtCfg) ) {
+        // We have to error here or we will end up deleting all our QoS components.
+        echo "Error\n";
+    }
+    else {
+        // No Error, lets process things.
+        d_echo("QoS Objects Found:\n");
+
+        foreach ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.2'] as $spid => $array) {
+
+            foreach ($array as $spobj => $index) {
+                $RESULT = array();
+
+                // Produce a unique reproducible index for this entry.
+                $RESULT['UID'] = hash('crc32', $spid."-".$spobj);
+
+                // Now that we have a valid identifiers, lets add some more data
+                $RESULT['sp-id'] = $spid;
+                $RESULT['sp-obj'] = $spobj;
+
+                // Add the Type, Policy-map, Class-map, etc.
+                $type = $tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.3'][$spid][$spobj];
+                $RESULT['qos-type'] = $type;
+
+                // Add the Parent, this lets us work out our hierarchy for display later.
+                $RESULT['parent'] = $tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.4'][$spid][$spobj];
+                $RESULT['direction'] = $tblcbQosServicePolicy['1.3.6.1.4.1.9.9.166.1.1.1.1.3'][$spid];
+                $RESULT['ifindex'] = $tblcbQosServicePolicy['1.3.6.1.4.1.9.9.166.1.1.1.1.4'][$spid];
+
+                // Gather different data depending on the type.
+                switch ($type) {
+                    case 1:
+                        // Policy-map, get data from that table.
+                        d_echo("\nIndex: ".$index."\n");
+                        d_echo("    UID: ".$RESULT['UID']."\n");
+                        d_echo("    SPID.SPOBJ: ".$RESULT['sp-id'].".".$RESULT['sp-obj']."\n");
+                        d_echo("    If-Index: ".$RESULT['ifindex']."\n");
+                        d_echo("    Type: 1 - Policy-Map\n");
+                        $RESULT['label'] = $tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.1'][$index];
+                        if ($tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.2'][$index] != "") {
+                            $RESULT['label'] .= " - ".$tblcbQosPolicyMapCfg['1.3.6.1.4.1.9.9.166.1.6.1.1.2'][$index];
+                        }
+                        d_echo("    Label: ".$RESULT['label']."\n");
+                        break;
+                    case 2:
+                        // Class-map, get data from that table.
+                        d_echo("\nIndex: ".$index."\n");
+                        d_echo("    UID: ".$RESULT['UID']."\n");
+                        d_echo("    SPID.SPOBJ: ".$RESULT['sp-id'].".".$RESULT['sp-obj']."\n");
+                        d_echo("    If-Index: ".$RESULT['ifindex']."\n");
+                        d_echo("    Type: 2 - Class-Map\n");
+                        $RESULT['label'] = $tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.1'][$index];
+                        if($tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.2'][$index] != "") {
+                            $RESULT['label'] .= " - ".$tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.2'][$index];
+                        }
+                        d_echo("    Label: ".$RESULT['label']."\n");
+                        if ($tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.3'][$index] == 2) {
+                            $RESULT['map-type'] = 'Match-All';
+                        }
+                        elseif ($tblcbQosClassMapCfg['1.3.6.1.4.1.9.9.166.1.7.1.1.3'][$index] == 3) {
+                            $RESULT['map-type'] = 'Match-Any';
+                        }
+                        else {
+                            $RESULT['map-type'] = 'None';
+                        }
+
+                        // Find a child, this will be a type 3
+                        foreach ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.4'][$spid] as $ID => $VALUE) {
+                            if ($VALUE == $RESULT['sp-obj']) {
+                                // We have our child, import the match
+                                if ($tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.3'][$spid][$ID] == 3) {
+                                    $RESULT['match'] = $RESULT['map-type'].": ".$tblcbQosMatchStmtCfg['1.3.6.1.4.1.9.9.166.1.8.1.1.1'][$tblcbQosObjects['1.3.6.1.4.1.9.9.166.1.5.1.1.2'][$spid][$ID]];
+                                    d_echo("    Match: ".$RESULT['match']."\n");
+                                }
+                            }
+                        }
+                        break;
+                    default:
+                        continue 2;
+                }
+
+                $tblCBQOS[] = $RESULT;
+            }
+        }
+
+        /*
+         * Ok, we have our 2 array's (Components and SNMP) now we need
+         * to compare and see what needs to be added/updated.
+         *
+         * Let's loop over the SNMP data to see if we need to ADD or UPDATE any components.
+         */
+        foreach ($tblCBQOS as $key => $array) {
+            $COMPONENT_KEY = false;
+
+            // Loop over our components to determine if the component exists, or we need to add it.
+            foreach ($COMPONENTS as $COMPID => $CHILD) {
+                if ($CHILD['UID'] === $array['UID']) {
+                    $COMPONENT_KEY = $COMPID;
+                }
+            }
+
+            if (!$COMPONENT_KEY) {
+                // The component doesn't exist, we need to ADD it - ADD.
+                $NEW_COMPONENT = $COMPONENT->createComponent($device['device_id'],$MODULE);
+                $COMPONENT_KEY = key($NEW_COMPONENT);
+                $COMPONENTS[$COMPONENT_KEY] = array_merge($NEW_COMPONENT[$COMPONENT_KEY], $array);
+                echo "+";
+            }
+            else {
+                // The component does exist, merge the details in - UPDATE.
+                $COMPONENTS[$COMPONENT_KEY] = array_merge($COMPONENTS[$COMPONENT_KEY], $array);
+                echo ".";
+            }
+
+        }
+
+        /*
+         * Loop over the Component data to see if we need to DELETE any components.
+         */
+        foreach ($COMPONENTS as $key => $array) {
+            // Guilty until proven innocent
+            $FOUND = false;
+
+            foreach ($tblCBQOS as $k => $v) {
+                if ($array['UID'] == $v['UID']) {
+                    // Yay, we found it...
+                    $FOUND = true;
+                }
+            }
+
+            if ($FOUND === false) {
+                // The component has not been found. we should delete it.
+                echo "-";
+                $COMPONENT->deleteComponent($key);
+            }
+        }
+
+        // Write the Components back to the DB.
+        $COMPONENT->setComponentPrefs($device['device_id'],$COMPONENTS);
+        echo "\n";
+
+    } // End if not error
+
+}

--- a/includes/polling/cisco-cbqos.inc.php
+++ b/includes/polling/cisco-cbqos.inc.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * LibreNMS module to capture Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+if ($device['os_group'] == "cisco") {
+
+    $MODULE = 'Cisco-CBQOS';
+
+    require_once 'includes/component.php';
+    $COMPONENT = new component();
+    $options['filter']['type'] = array('=',$MODULE);
+    $options['filter']['disabled'] = array('=',0);
+    $options['filter']['ignore'] = array('=',0);
+    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+    // We only care about our device id.
+    $COMPONENTS = $COMPONENTS[$device['device_id']];
+
+    // Only collect SNMP data if we have enabled components
+    if (count($COMPONENTS > 0)) {
+        // Let's gather the stats..
+        $tblcbQosClassMapStats = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.166.1.15.1.1', 2);
+
+        // Loop through the components and extract the data.
+        foreach ($COMPONENTS as $KEY => $ARRAY) {
+            $TYPE = $ARRAY['qos-type'];
+
+            // Get data from the class table.
+            if ($TYPE == 2) {
+                // Let's make sure the RRD is setup for this class.
+                $filename = "port-".$ARRAY['ifindex']."-cbqos-".$ARRAY['sp-id']."-".$ARRAY['sp-obj'].".rrd";
+                $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);
+
+                if (!file_exists ($rrd_filename)) {
+                    rrdtool_create ($rrd_filename, " DS:postbits:COUNTER:600:0:U DS:bufferdrops:COUNTER:600:0:U DS:qosdrops:COUNTER:600:0:U" . $config['rrd_rra']);
+                }
+
+                // Let's print some debugging info.
+                d_echo("\n\nComponent: ".$KEY."\n");
+                d_echo("    Class-Map: ".$ARRAY['label']."\n");
+                d_echo("    SPID.SPOBJ: ".$ARRAY['sp-id'].".".$ARRAY['sp-obj']."\n");
+                d_echo("    PostBytes:   1.3.6.1.4.1.9.9.166.1.15.1.1.10.".$ARRAY['sp-id'].".".$ARRAY['sp-obj']." = ".$tblcbQosClassMapStats['1.3.6.1.4.1.9.9.166.1.15.1.1.10'][$ARRAY['sp-id']][$ARRAY['sp-obj']]."\n");
+                d_echo("    BufferDrops: 1.3.6.1.4.1.9.9.166.1.15.1.1.21.".$ARRAY['sp-id'].".".$ARRAY['sp-obj']." = ".$tblcbQosClassMapStats['1.3.6.1.4.1.9.9.166.1.15.1.1.21'][$ARRAY['sp-id']][$ARRAY['sp-obj']]."\n");
+                d_echo("    QOSDrops:    1.3.6.1.4.1.9.9.166.1.15.1.1.17.".$ARRAY['sp-id'].".".$ARRAY['sp-obj']." = ".$tblcbQosClassMapStats['1.3.6.1.4.1.9.9.166.1.15.1.1.17'][$ARRAY['sp-id']][$ARRAY['sp-obj']]."\n");
+
+                $RRD['postbytes'] = $tblcbQosClassMapStats['1.3.6.1.4.1.9.9.166.1.15.1.1.10'][$ARRAY['sp-id']][$ARRAY['sp-obj']];
+                $RRD['bufferdrops'] = $tblcbQosClassMapStats['1.3.6.1.4.1.9.9.166.1.15.1.1.21'][$ARRAY['sp-id']][$ARRAY['sp-obj']];
+                $RRD['qosdrops'] = $tblcbQosClassMapStats['1.3.6.1.4.1.9.9.166.1.15.1.1.17'][$ARRAY['sp-id']][$ARRAY['sp-obj']];
+
+                // Update RRD
+                rrdtool_update ($rrd_filename, $RRD);
+
+                // Clean-up after yourself!
+                unset($filename, $rrd_filename);
+            }
+        } // End foreach components
+
+        echo $MODULE." ";
+    } // end if count components
+
+    // Clean-up after yourself!
+    unset($TYPE, $COMPONENTS, $COMPONENT, $options, $MODULE);
+}

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1293,9 +1293,9 @@ function register_mibs($device, $mibs, $included_by)
  * @internal param $string
  * @return array
  */
-function snmpwalk_array_num($device,$OID,$indexes=1) {
+function snmpwalk_array_num($device,$oid,$indexes=1) {
     $array = array();
-    $string = snmp_walk($device, $OID, '-Osqn');
+    $string = snmp_walk($device, $oid, '-Osqn');
 
     if ( $string === false) {
         // False means: No Such Object.


### PR DESCRIPTION
Implements the CISCO-CLASS-BASED-QOS-MIB to retrieve QOS counters from Cisco devices.
Policy and Class-map details are collected and stored in the database.
Details are presented on a new "CBQoS" tab of the interface that the policy is applied to.
Includes a policy selector that allows you to select which policy-map to show graphs for.

Each class-map has its own rrd file, in which 3 metrics are stored: Bytes, QoS Drops, Buffer Drops.
This can produce a LOT of rrd files.
As an example:
A Cisco 4500 series switch, running MQC on 200 ports. Each port has a common 5 class queueing policy applied, this creates 1000 (5 x 200) RRD's.

Because of this I have currently set:
```
$config['discovery_modules']['cisco-cbqos']    = 0;
```
Happy to default on if its preferred.

Includes function snmpwalk_array_num, which performs a numeric SNMPWalk and returns an array containing $count indexes
One Index:
 From: 1.3.6.1.4.1.9.9.166.1.15.1.1.27.18.655360 = 0
 To: $array['1.3.6.1.4.1.9.9.166.1.15.1.1.27.18']['655360'] = 0
Two Indexes:
 From: 1.3.6.1.4.1.9.9.166.1.15.1.1.27.18.655360 = 0
 To: $array['1.3.6.1.4.1.9.9.166.1.15.1.1.27']['18']['655360'] = 0
And so on...

Have a play and let me know what you think.

Thanks,
Aaron