### PR TITLE
Cisco OTV

### DIFF
--- a/doc/Extensions/Component.md
+++ b/doc/Extensions/Component.md
@@ -307,11 +307,11 @@ To see an example of how the component module can used, please see the following
 
 - Cisco CBQoS
     - includes/discovery/cisco-cbqos.inc.php
-    - includes/poller/cisco-cbqos.inc.php
+    - includes/polling/cisco-cbqos.inc.php
     - html/includes/graphs/device/cbqos_traffic.inc.php
 - Cisco OTV
     - includes/discovery/cisco-otv.inc.php
-    - includes/poller/applications/cisco-otv.inc.php
+    - includes/polling/cisco-otv.inc.php
     - html/includes/graphs/device/cisco-otv-mac.inc.php
-    - html/pages/device/apps/cisco-otv.inc.php
+    - html/pages/routing/cisco-otv.inc.php
 

--- a/html/includes/graphs/device/cisco-otv-mac.inc.php
+++ b/html/includes/graphs/device/cisco-otv-mac.inc.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * LibreNMS module to display Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options['filter']['type'] = array('=','Cisco-OTV');
+$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+// We only care about our device id.
+$COMPONENTS = $COMPONENTS[$device['device_id']];
+
+include "includes/graphs/common.inc.php";
+$rrd_options .= " -l 0 -E ";
+$rrd_options .= " COMMENT:'MAC Addresses       Now    Min     Max\\n'";
+$rrd_additions = "";
+
+$COUNT = 0;
+foreach ($COMPONENTS as $ID => $ARRAY) {
+    if ($ARRAY['otvtype'] == 'endpoint') {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("cisco-otv-".$ARRAY['endpoint']."-mac.rrd");
+
+        if (file_exists($rrd_filename)) {
+            // Stack the area on the second and subsequent DS's
+            $STACK = "";
+            if ($COUNT != 0) {
+                $STACK = ":STACK ";
+            }
+
+            // Grab a color from the array.
+            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
+                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            }
+            else {
+                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+            }
+
+            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":count:AVERAGE ";
+            $rrd_additions .= " AREA:DS" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['endpoint'],0,15),15) . "'" . $STACK;
+            $rrd_additions .= " GPRINT:DS" . $COUNT . ":LAST:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $COUNT .    ":MIN:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $COUNT . ":MAX:%4.0lf%s\\\l ";
+            $COUNT++;
+        }
+    }
+}
+
+if ($rrd_additions == "") {
+    // We didn't add any data points.
+}
+else {
+    $rrd_options .= $rrd_additions;
+}

--- a/html/includes/graphs/device/cisco-otv-mac.inc.php
+++ b/html/includes/graphs/device/cisco-otv-mac.inc.php
@@ -12,44 +12,44 @@
  */
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options['filter']['type'] = array('=','Cisco-OTV');
-$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+$components = $component->getComponents($device['device_id'],$options);
 
 // We only care about our device id.
-$COMPONENTS = $COMPONENTS[$device['device_id']];
+$components = $components[$device['device_id']];
 
 include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
 $rrd_options .= " COMMENT:'MAC Addresses       Now    Min     Max\\n'";
 $rrd_additions = "";
 
-$COUNT = 0;
-foreach ($COMPONENTS as $ID => $ARRAY) {
-    if ($ARRAY['otvtype'] == 'endpoint') {
-        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("cisco-otv-".$ARRAY['endpoint']."-mac.rrd");
+$count = 0;
+foreach ($components as $id => $array) {
+    if ($array['otvtype'] == 'endpoint') {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("cisco-otv-".$array['endpoint']."-mac.rrd");
 
         if (file_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
-            $STACK = "";
-            if ($COUNT != 0) {
-                $STACK = ":STACK ";
+            $stack = "";
+            if ($count != 0) {
+                $stack = ":STACK ";
             }
 
             // Grab a color from the array.
-            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
-                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            if ( isset($config['graph_colours']['mixed'][$count]) ) {
+                $color = $config['graph_colours']['mixed'][$count];
             }
             else {
-                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+                $color = $config['graph_colours']['oranges'][$count-7];
             }
 
-            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":count:AVERAGE ";
-            $rrd_additions .= " AREA:DS" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['endpoint'],0,15),15) . "'" . $STACK;
-            $rrd_additions .= " GPRINT:DS" . $COUNT . ":LAST:%4.0lf%s ";
-            $rrd_additions .= " GPRINT:DS" . $COUNT .    ":MIN:%4.0lf%s ";
-            $rrd_additions .= " GPRINT:DS" . $COUNT . ":MAX:%4.0lf%s\\\l ";
-            $COUNT++;
+            $rrd_additions .= " DEF:DS" . $count . "=" . $rrd_filename . ":count:AVERAGE ";
+            $rrd_additions .= " AREA:DS" . $count . "#" . $color . ":'" . str_pad(substr($components[$id]['endpoint'],0,15),15) . "'" . $stack;
+            $rrd_additions .= " GPRINT:DS" . $count . ":LAST:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $count .    ":MIN:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $count . ":MAX:%4.0lf%s\\\l ";
+            $count++;
         }
     }
 }

--- a/html/includes/graphs/device/cisco-otv-vlan.inc.php
+++ b/html/includes/graphs/device/cisco-otv-vlan.inc.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * LibreNMS module to display Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options['filter']['type'] = array('=','Cisco-OTV');
+$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+// We only care about our device id.
+$COMPONENTS = $COMPONENTS[$device['device_id']];
+
+include "includes/graphs/common.inc.php";
+$rrd_options .= " -l 0 -E ";
+$rrd_options .= " COMMENT:'VLANs               Now     Min    Max\\n'";
+$rrd_additions = "";
+
+$COUNT = 0;
+foreach ($COMPONENTS as $ID => $ARRAY) {
+    if ($ARRAY['otvtype'] == 'overlay') {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("cisco-otv-".$ARRAY['label']."-vlan.rrd");
+
+        if (file_exists($rrd_filename)) {
+            // Stack the area on the second and subsequent DS's
+            $STACK = "";
+            if ($COUNT != 0) {
+                $STACK = ":STACK ";
+            }
+
+            // Grab a color from the array.
+            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
+                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            }
+            else {
+                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+            }
+
+            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":count:AVERAGE ";
+            $rrd_additions .= " AREA:DS" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
+            $rrd_additions .= " GPRINT:DS" . $COUNT . ":LAST:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $COUNT . ":MIN:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $COUNT . ":MAX:%4.0lf%s\\\l ";
+            $COUNT++;
+        }
+    }
+}
+
+if ($rrd_additions == "") {
+    // We didn't add any data points.
+}
+else {
+    $rrd_options .= $rrd_additions;
+}

--- a/html/includes/graphs/device/cisco-otv-vlan.inc.php
+++ b/html/includes/graphs/device/cisco-otv-vlan.inc.php
@@ -12,44 +12,44 @@
  */
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options['filter']['type'] = array('=','Cisco-OTV');
-$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+$components = $component->getComponents($device['device_id'],$options);
 
 // We only care about our device id.
-$COMPONENTS = $COMPONENTS[$device['device_id']];
+$components = $components[$device['device_id']];
 
 include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
 $rrd_options .= " COMMENT:'VLANs               Now     Min    Max\\n'";
 $rrd_additions = "";
 
-$COUNT = 0;
-foreach ($COMPONENTS as $ID => $ARRAY) {
-    if ($ARRAY['otvtype'] == 'overlay') {
-        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("cisco-otv-".$ARRAY['label']."-vlan.rrd");
+$count = 0;
+foreach ($components as $id => $array) {
+    if ($array['otvtype'] == 'overlay') {
+        $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/'.safename("cisco-otv-".$array['label']."-vlan.rrd");
 
         if (file_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
-            $STACK = "";
-            if ($COUNT != 0) {
-                $STACK = ":STACK ";
+            $stack = "";
+            if ($count != 0) {
+                $stack = ":STACK ";
             }
 
             // Grab a color from the array.
-            if ( isset($config['graph_colours']['mixed'][$COUNT]) ) {
-                $COLOR = $config['graph_colours']['mixed'][$COUNT];
+            if ( isset($config['graph_colours']['mixed'][$count]) ) {
+                $color = $config['graph_colours']['mixed'][$count];
             }
             else {
-                $COLOR = $config['graph_colours']['oranges'][$COUNT-7];
+                $color = $config['graph_colours']['oranges'][$count-7];
             }
 
-            $rrd_additions .= " DEF:DS" . $COUNT . "=" . $rrd_filename . ":count:AVERAGE ";
-            $rrd_additions .= " AREA:DS" . $COUNT . "#" . $COLOR . ":'" . str_pad(substr($COMPONENTS[$ID]['label'],0,15),15) . "'" . $STACK;
-            $rrd_additions .= " GPRINT:DS" . $COUNT . ":LAST:%4.0lf%s ";
-            $rrd_additions .= " GPRINT:DS" . $COUNT . ":MIN:%4.0lf%s ";
-            $rrd_additions .= " GPRINT:DS" . $COUNT . ":MAX:%4.0lf%s\\\l ";
-            $COUNT++;
+            $rrd_additions .= " DEF:DS" . $count . "=" . $rrd_filename . ":count:AVERAGE ";
+            $rrd_additions .= " AREA:DS" . $count . "#" . $color . ":'" . str_pad(substr($components[$id]['label'],0,15),15) . "'" . $stack;
+            $rrd_additions .= " GPRINT:DS" . $count . ":LAST:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $count . ":MIN:%4.0lf%s ";
+            $rrd_additions .= " GPRINT:DS" . $count . ":MAX:%4.0lf%s\\\l ";
+            $count++;
         }
     }
 }

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -420,7 +420,13 @@ $routing_count['ospf'] = dbFetchCell("SELECT COUNT(ospf_instance_id) FROM `ospf_
 $routing_count['cef']  = dbFetchCell("SELECT COUNT(cef_switching_id) from `cef_switching`");
 $routing_count['vrf']  = dbFetchCell("SELECT COUNT(vrf_id) from `vrfs`");
 
-if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf']+$routing_count['cef']+$routing_count['vrf']) > "0") {
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options['type'] = 'Cisco-OTV';
+$OTV = $COMPONENT->getComponents(null,$options);
+$routing_count['cisco-otv'] = count($OTV);
+
+if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf']+$routing_count['cef']+$routing_count['vrf']+$routing_count['cisco-otv']) > "0") {
 
 ?>
         <li class="dropdown">
@@ -440,6 +446,16 @@ if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf
             $separator = 0;
         }
         echo('<li><a href="routing/protocol=ospf/"><i class="fa fa-circle-o-notch fa-rotate-180 fa-fw fa-lg"></i> OSPF Devices </a></li>');
+        $separator++;
+    }
+
+    // Cisco OTV Links
+    if ($_SESSION['userlevel'] >= '5' && $routing_count['cisco-otv']) {
+        if ($separator) {
+            echo('            <li role="presentation" class="divider"></li>');
+            $separator = 0;
+        }
+        echo('<li><a href="routing/protocol=cisco-otv/"><i class="fa fa-exchange fa-fw fa-lg"></i> Cisco OTV </a></li>');
         $separator++;
     }
 

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -421,10 +421,10 @@ $routing_count['cef']  = dbFetchCell("SELECT COUNT(cef_switching_id) from `cef_s
 $routing_count['vrf']  = dbFetchCell("SELECT COUNT(vrf_id) from `vrfs`");
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options['type'] = 'Cisco-OTV';
-$OTV = $COMPONENT->getComponents(null,$options);
-$routing_count['cisco-otv'] = count($OTV);
+$otv = $component->getComponents(null,$options);
+$routing_count['cisco-otv'] = count($otv);
 
 if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf']+$routing_count['cef']+$routing_count['vrf']+$routing_count['cisco-otv']) > "0") {
 

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -210,6 +210,16 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
             $routing_tabs[] = 'vrf';
         }
 
+        require_once "../includes/component.php";
+        $COMPONENT = new component();
+        $options['type'] = 'Cisco-OTV';
+        $options['filter']['device_id'] = array('=',$device['device_id']);
+        $OTV = $COMPONENT->getComponents(null,$options);
+        $device_routing_count['cisco-otv'] = count($OTV);
+        if ($device_routing_count['cisco-otv'] > 0) {
+            $routing_tabs[] = 'cisco-otv';
+        }
+
         if (is_array($routing_tabs)) {
             echo '<li class="'.$select['routing'].'">
                 <a href="'.generate_device_url($device, array('tab' => 'routing')).'">

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -211,11 +211,11 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
         }
 
         require_once "../includes/component.php";
-        $COMPONENT = new component();
+        $component = new component();
         $options['type'] = 'Cisco-OTV';
         $options['filter']['device_id'] = array('=',$device['device_id']);
-        $OTV = $COMPONENT->getComponents(null,$options);
-        $device_routing_count['cisco-otv'] = count($OTV);
+        $otv = $component->getComponents(null,$options);
+        $device_routing_count['cisco-otv'] = count($otv);
         if ($device_routing_count['cisco-otv'] > 0) {
             $routing_tabs[] = 'cisco-otv';
         }

--- a/html/pages/device/routing.inc.php
+++ b/html/pages/device/routing.inc.php
@@ -20,6 +20,7 @@ $type_text['bgp']  = 'BGP';
 $type_text['cef']  = 'CEF';
 $type_text['ospf'] = 'OSPF';
 $type_text['vrf']  = 'VRFs';
+$type_text['cisco-otv']  = 'OTV';
 
 print_optionbar_start();
 

--- a/html/pages/device/routing/cisco-otv.inc.php
+++ b/html/pages/device/routing/cisco-otv.inc.php
@@ -1,0 +1,94 @@
+<?php
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options = array();
+$options['filter']['ignore'] = array('=',0);
+$options['type'] = 'Cisco-OTV';
+$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+$COMPONENTS = $COMPONENTS[$device['device_id']];
+
+global $config;
+?>
+<div class="panel panel-default" id="overlays">
+    <div class="panel-heading">
+        <h3 class="panel-title">Overlay's & Adjacencies</h3>
+    </div>
+    <div class="panel list-group">
+<?php
+// Loop over each component, pulling out the Overlays.
+foreach ($COMPONENTS as $OID => $OVERLAY) {
+    if ($OVERLAY['otvtype'] == 'overlay') {
+        if ($OVERLAY['status'] == 1) {
+            $OVERLAY_STATUS = "<span class='green pull-right'>Normal</span>";
+            $GLI = "";
+        }
+        else {
+            $OVERLAY_STATUS = "<span class='pull-right'>".$OVERLAY['error']." - <span class='red'>Alert</span></span>";
+            $GLI = "list-group-item-danger";
+        }
+?>
+        <a class="list-group-item <?=$GLI?>" data-toggle="collapse" data-target="#<?=$OVERLAY['index']?>" data-parent="#overlays"><?=$OVERLAY['label']?> - <?=$OVERLAY['transport']?> <?=$OVERLAY_STATUS?></a>
+        <div id="<?=$OVERLAY['index']?>" class="sublinks collapse">
+<?php
+        foreach ($COMPONENTS as $AID => $ADJACENCY) {
+            if (($ADJACENCY['otvtype'] == 'adjacency') && ($ADJACENCY['index'] == $OVERLAY['index'])) {
+                if ($ADJACENCY['status'] == 1) {
+                    $ADJ_STATUS = "<span class='green pull-right'>Normal</span>";
+                    $GLI = "";
+                }
+                else {
+                    $ADJ_STATUS = "<span class='pull-right'>".$ADJACENCY['error']." - <span class='red'>Alert</span></span>";
+                    $GLI = "list-group-item-danger";
+                }
+?>
+            <a class="list-group-item <?=$GLI?> small"><span class="glyphicon glyphicon-chevron-right"></span> <?=$ADJACENCY['label']?> - <?=$ADJACENCY['endpoint']?> <?=$ADJ_STATUS?></a>
+<?php
+            }
+        }
+?>
+        </div>
+<?php
+    }
+}
+?>
+    </div>
+</div>
+
+<div class="panel panel-default" id="vlanperoverlay">
+    <div class="panel-heading">
+        <h3 class="panel-title">AED Enabled VLAN's</h3>
+    </div>
+    <div class="panel-body">
+<?php
+
+$graph_array = array();
+$graph_array['device'] = $device['device_id'];
+$graph_array['height'] = '100';
+$graph_array['width']  = '215';
+$graph_array['to']     = $config['time']['now'];
+$graph_array['type']   = 'device_cisco-otv-vlan';
+require 'includes/print-graphrow.inc.php';
+
+?>
+    </div>
+</div>
+
+<div class="panel panel-default" id="macperendpoint">
+    <div class="panel-heading">
+        <h3 class="panel-title">MAC Addresses</h3>
+    </div>
+    <div class="panel-body">
+<?php
+
+$graph_array = array();
+$graph_array['device'] = $device['device_id'];
+$graph_array['height'] = '100';
+$graph_array['width']  = '215';
+$graph_array['to']     = $config['time']['now'];
+$graph_array['type']   = 'device_cisco-otv-mac';
+require 'includes/print-graphrow.inc.php';
+
+        ?>
+    </div>
+</div>

--- a/html/pages/device/routing/cisco-otv.inc.php
+++ b/html/pages/device/routing/cisco-otv.inc.php
@@ -1,12 +1,12 @@
 <?php
 
 require_once "../includes/component.php";
-$COMPONENT = new component();
+$component = new component();
 $options = array();
 $options['filter']['ignore'] = array('=',0);
 $options['type'] = 'Cisco-OTV';
-$COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
-$COMPONENTS = $COMPONENTS[$device['device_id']];
+$components = $component->getComponents($device['device_id'],$options);
+$components = $components[$device['device_id']];
 
 global $config;
 ?>
@@ -17,32 +17,32 @@ global $config;
     <div class="panel list-group">
 <?php
 // Loop over each component, pulling out the Overlays.
-foreach ($COMPONENTS as $OID => $OVERLAY) {
-    if ($OVERLAY['otvtype'] == 'overlay') {
-        if ($OVERLAY['status'] == 1) {
-            $OVERLAY_STATUS = "<span class='green pull-right'>Normal</span>";
-            $GLI = "";
+foreach ($components as $oid => $overlay) {
+    if ($overlay['otvtype'] == 'overlay') {
+        if ($overlay['status'] == 1) {
+            $overlay_status = "<span class='green pull-right'>Normal</span>";
+            $gli = "";
         }
         else {
-            $OVERLAY_STATUS = "<span class='pull-right'>".$OVERLAY['error']." - <span class='red'>Alert</span></span>";
-            $GLI = "list-group-item-danger";
+            $overlay_status = "<span class='pull-right'>".$overlay['error']." - <span class='red'>Alert</span></span>";
+            $gli = "list-group-item-danger";
         }
 ?>
-        <a class="list-group-item <?=$GLI?>" data-toggle="collapse" data-target="#<?=$OVERLAY['index']?>" data-parent="#overlays"><?=$OVERLAY['label']?> - <?=$OVERLAY['transport']?> <?=$OVERLAY_STATUS?></a>
-        <div id="<?=$OVERLAY['index']?>" class="sublinks collapse">
+        <a class="list-group-item <?=$gli?>" data-toggle="collapse" data-target="#<?=$overlay['index']?>" data-parent="#overlays"><?=$overlay['label']?> - <?=$overlay['transport']?> <?=$overlay_status?></a>
+        <div id="<?=$overlay['index']?>" class="sublinks collapse">
 <?php
-        foreach ($COMPONENTS as $AID => $ADJACENCY) {
-            if (($ADJACENCY['otvtype'] == 'adjacency') && ($ADJACENCY['index'] == $OVERLAY['index'])) {
-                if ($ADJACENCY['status'] == 1) {
-                    $ADJ_STATUS = "<span class='green pull-right'>Normal</span>";
-                    $GLI = "";
+        foreach ($components as $aid => $adjacency) {
+            if (($adjacency['otvtype'] == 'adjacency') && ($adjacency['index'] == $overlay['index'])) {
+                if ($adjacency['status'] == 1) {
+                    $adj_status = "<span class='green pull-right'>Normal</span>";
+                    $gli = "";
                 }
                 else {
-                    $ADJ_STATUS = "<span class='pull-right'>".$ADJACENCY['error']." - <span class='red'>Alert</span></span>";
-                    $GLI = "list-group-item-danger";
+                    $adj_status = "<span class='pull-right'>".$adjacency['error']." - <span class='red'>Alert</span></span>";
+                    $gli = "list-group-item-danger";
                 }
 ?>
-            <a class="list-group-item <?=$GLI?> small"><span class="glyphicon glyphicon-chevron-right"></span> <?=$ADJACENCY['label']?> - <?=$ADJACENCY['endpoint']?> <?=$ADJ_STATUS?></a>
+            <a class="list-group-item <?=$gli?> small"><span class="glyphicon glyphicon-chevron-right"></span> <?=$adjacency['label']?> - <?=$adjacency['endpoint']?> <?=$adj_status?></a>
 <?php
             }
         }

--- a/html/pages/routing.inc.php
+++ b/html/pages/routing.inc.php
@@ -16,6 +16,7 @@ $type_text['bgp']  = 'BGP';
 $type_text['cef']  = 'CEF';
 $type_text['ospf'] = 'OSPF';
 $type_text['vrf']  = 'VRFs';
+$type_text['cisco-otv']  = 'OTV';
 
 print_optionbar_start();
 
@@ -53,6 +54,7 @@ switch ($vars['protocol']) {
     case 'vrf':
     case 'cef':
     case 'ospf':
+    case 'cisco-otv':
         include 'pages/routing/'.$vars['protocol'].'.inc.php';
     break;
 

--- a/html/pages/routing/cisco-otv.inc.php
+++ b/html/pages/routing/cisco-otv.inc.php
@@ -1,0 +1,58 @@
+<?php
+
+require_once "../includes/component.php";
+$COMPONENT = new component();
+$options = array();
+$options['filter']['ignore'] = array('=',0);
+$options['type'] = 'Cisco-OTV';
+$COMPONENTS = $COMPONENT->getComponents(null,$options);
+
+foreach ($COMPONENTS as $DEVICE_ID => $COMP) {
+    $LINK = generate_url(array('page' => 'device', 'device' => $DEVICE_ID, 'tab' => 'routing', 'proto' => 'cisco-otv'));
+?>
+<div class="panel panel-default" id="overlays-<?=$DEVICE_ID?>">
+    <div class="panel-heading">
+        <h3 class="panel-title"><a href="<?=$LINK?>"><?=gethostbyid($DEVICE_ID)?> - Overlay's & Adjacencies</a></h3>
+    </div>
+    <div class="panel list-group">
+        <?php
+        // Loop over each component, pulling out the Overlays.
+        foreach ($COMP as $OID => $OVERLAY) {
+            if ($OVERLAY['otvtype'] == 'overlay') {
+                if ($OVERLAY['status'] == 1) {
+                    $OVERLAY_STATUS = "<span class='green pull-right'>Normal</span>";
+                    $GLI = "";
+                }
+                else {
+                    $OVERLAY_STATUS = "<span class='pull-right'>".$OVERLAY['error']." - <span class='red'>Alert</span></span>";
+                    $GLI = "list-group-item-danger";
+                }
+                ?>
+                <a class="list-group-item <?=$GLI?>" data-toggle="collapse" data-target="#<?=$OVERLAY['index']?>" data-parent="#overlays-<?=$DEVICE_ID?>"><?=$OVERLAY['label']?> - <?=$OVERLAY['transport']?> <?=$OVERLAY_STATUS?></a>
+                <div id="<?=$OVERLAY['index']?>" class="sublinks collapse">
+                    <?php
+                    foreach ($COMP as $AID => $ADJACENCY) {
+                        if (($ADJACENCY['otvtype'] == 'adjacency') && ($ADJACENCY['index'] == $OVERLAY['index'])) {
+                            if ($ADJACENCY['status'] == 1) {
+                                $ADJ_STATUS = "<span class='green pull-right'>Normal</span>";
+                                $GLI = "";
+                            }
+                            else {
+                                $ADJ_STATUS = "<span class='pull-right'>".$ADJACENCY['error']." - <span class='red'>Alert</span></span>";
+                                $GLI = "list-group-item-danger";
+                            }
+                            ?>
+                            <a class="list-group-item <?=$GLI?> small"><span class="glyphicon glyphicon-chevron-right"></span> <?=$ADJACENCY['label']?> - <?=$ADJACENCY['endpoint']?> <?=$ADJ_STATUS?></a>
+                        <?php
+                        }
+                    }
+                    ?>
+                </div>
+            <?php
+            }
+        }
+        ?>
+    </div>
+</div>
+<?php
+}

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -711,6 +711,7 @@ $config['poller_modules']['cisco-asa-firewall']          = 1;
 $config['poller_modules']['mib'] = 0;
 $config['poller_modules']['cisco-voice']                 = 1;
 $config['poller_modules']['stp']                         = 1;
+$config['poller_modules']['cisco-otv']                   = 1;
 
 // List of discovery modules. Need to be in this array to be
 // considered for execution.
@@ -743,6 +744,7 @@ $config['discovery_modules']['ucd-diskio']     = 1;
 $config['discovery_modules']['services']       = 1;
 $config['discovery_modules']['charge']         = 1;
 $config['discovery_modules']['stp']            = 1;
+$config['discovery_modules']['cisco-otv']      = 1;
 
 $config['modules_compat']['rfc1628']['liebert']    = 1;
 $config['modules_compat']['rfc1628']['netmanplus'] = 1;

--- a/includes/discovery/cisco-otv.inc.php
+++ b/includes/discovery/cisco-otv.inc.php
@@ -124,6 +124,15 @@ if ($device['os_group'] == 'cisco') {
                 $result['status'] = 1;
             }
 
+            // Let's log some debugging
+            d_echo("\n\nOverlay: ".$result['label']."\n");
+            d_echo("    Index: ".$result['index']."\n");
+            d_echo("    UID: ".$result['UID']."\n");
+            d_echo("    Transport: ".$result['transport']."\n");
+            d_echo("    Type: ".$result['otvtype']."\n");
+            d_echo("    Status: ".$result['status']."\n");
+            d_echo("    Message: ".$result['error']."\n");
+
             // Add the result to the parent array.
             $tblOTV[] = $result;
         }
@@ -162,6 +171,14 @@ if ($device['os_group'] == 'cisco') {
                 }
             }
 
+            // Let's log some debugging
+            d_echo("\n\nAdjacency: ".$result['label']."\n");
+            d_echo("    Endpoint: ".$result['endpoint']."\n");
+            d_echo("    Index: ".$result['index']."\n");
+            d_echo("    UID: ".$result['UID']."\n");
+            d_echo("    Status: ".$result['status']."\n");
+            d_echo("    Message: ".$result['error']."\n");
+
             // Add the result to the parent array.
             $tblOTV[] = $result;
         }
@@ -172,6 +189,11 @@ if ($device['os_group'] == 'cisco') {
             $result['otvtype'] = 'endpoint';
             $result['endpoint'] = $k;
             $result['UID'] = $result['otvtype']."-".$k;
+
+            // Let's log some debugging
+            d_echo("\n\nEndpoint: ".$result['label']."\n");
+            d_echo("    UID: ".$result['UID']."\n");
+            d_echo("    Type: ".$result['otvtype']."\n");
 
             // Add the result to the parent array.
             $tblOTV[] = $result;

--- a/includes/discovery/cisco-otv.inc.php
+++ b/includes/discovery/cisco-otv.inc.php
@@ -14,55 +14,58 @@
 if ($device['os_group'] == 'cisco') {
 
     // Define some error messages
-    $ERROR_VPN[0] = "Other";
-    $ERROR_VPN[1] = "Configuration changed";
-    $ERROR_VPN[2] = "Control Group information is unavailable";
-    $ERROR_VPN[3] = "Data Group range information is unavailable";
-    $ERROR_VPN[4] = "Join or Source interface information is unavailable";
-    $ERROR_VPN[5] = "VPN name is unavailable";
-    $ERROR_VPN[6] = "IP address is missing for Join Interface";
-    $ERROR_VPN[7] = "Join Interface is down";
-    $ERROR_VPN[8] = "Overlay is administratively shutdown";
-    $ERROR_VPN[9] = "Overlay is in delete hold down phase";
-    $ERROR_VPN[10] = "VPN is reinitializing";
-    $ERROR_VPN[11] = "Site ID information is unavailable";
-    $ERROR_VPN[12] = "Site ID mismatch has occurred";
-    $ERROR_VPN[13] = "IP address is missing for Source Interface";
-    $ERROR_VPN[14] = "Source interface is down";
-    $ERROR_VPN[15] = "Changing site identifier";
-    $ERROR_VPN[16] = "Changing control group";
-    $ERROR_VPN[17] = "Device ID information is unavailable";
-    $ERROR_VPN[18] = "Changing device ID";
-    $ERROR_VPN[19] = "Cleanup in progress";
+    $error_vpn = array();
+    $error_vpn[0] = "Other";
+    $error_vpn[1] = "Configuration changed";
+    $error_vpn[2] = "Control Group information is unavailable";
+    $error_vpn[3] = "Data Group range information is unavailable";
+    $error_vpn[4] = "Join or Source interface information is unavailable";
+    $error_vpn[5] = "VPN name is unavailable";
+    $error_vpn[6] = "IP address is missing for Join Interface";
+    $error_vpn[7] = "Join Interface is down";
+    $error_vpn[8] = "Overlay is administratively shutdown";
+    $error_vpn[9] = "Overlay is in delete hold down phase";
+    $error_vpn[10] = "VPN is reinitializing";
+    $error_vpn[11] = "Site ID information is unavailable";
+    $error_vpn[12] = "Site ID mismatch has occurred";
+    $error_vpn[13] = "IP address is missing for Source Interface";
+    $error_vpn[14] = "Source interface is down";
+    $error_vpn[15] = "Changing site identifier";
+    $error_vpn[16] = "Changing control group";
+    $error_vpn[17] = "Device ID information is unavailable";
+    $error_vpn[18] = "Changing device ID";
+    $error_vpn[19] = "Cleanup in progress";
 
-    $ERROR_AED[0] = "Other";
-    $ERROR_AED[1] = "Overlay is Down";
-    $ERROR_AED[2] = "Site ID is not configured";
-    $ERROR_AED[3] = "Site ID mismatch";
-    $ERROR_AED[4] = "Version mismatch";
-    $ERROR_AED[5] = "Site VLAN is Down";
-    $ERROR_AED[6] = "No extended VLAN is operationally up";
-    $ERROR_AED[7] = "No Overlay Adjacency is up";
-    $ERROR_AED[8] = "LSPDB sync incomplete";
-    $ERROR_AED[9] = "Overlay state down event in progress";
-    $ERROR_AED[10] = "ISIS control group sync pending";
+    $error_aed = array();
+    $error_aed[0] = "Other";
+    $error_aed[1] = "Overlay is Down";
+    $error_aed[2] = "Site ID is not configured";
+    $error_aed[3] = "Site ID mismatch";
+    $error_aed[4] = "Version mismatch";
+    $error_aed[5] = "Site VLAN is Down";
+    $error_aed[6] = "No extended VLAN is operationally up";
+    $error_aed[7] = "No Overlay Adjacency is up";
+    $error_aed[8] = "LSPDB sync incomplete";
+    $error_aed[9] = "Overlay state down event in progress";
+    $error_aed[10] = "ISIS control group sync pending";
 
-    $ERROR_OVERLAY[1] = "active";
-    $ERROR_OVERLAY[2] = "notInService";
-    $ERROR_OVERLAY[3] = "notReady";
-    $ERROR_OVERLAY[4] = "createAndGo";
-    $ERROR_OVERLAY[5] = "createAndWait";
-    $ERROR_OVERLAY[6] = "destroy";
+    $error_overlay = array();
+    $error_overlay[1] = "active";
+    $error_overlay[2] = "notInService";
+    $error_overlay[3] = "notReady";
+    $error_overlay[4] = "createAndGo";
+    $error_overlay[5] = "createAndWait";
+    $error_overlay[6] = "destroy";
 
-    $MODULE = 'Cisco-OTV';
-    echo $MODULE.': ';
+    $module = 'Cisco-OTV';
+    echo $module.': ';
 
     require_once 'includes/component.php';
-    $COMPONENT = new component();
-    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],array('type'=>$MODULE));
+    $component = new component();
+    $components = $component->getComponents($device['device_id'],array('type'=>$module));
 
     // We only care about our device id.
-    $COMPONENTS = $COMPONENTS[$device['device_id']];
+    $components = $components[$device['device_id']];
 
     // Begin our master array, all other values will be processed into this array.
     $tblOTV = array();
@@ -86,92 +89,92 @@ if ($device['os_group'] == 'cisco') {
 
         // Add each overlay to the array.
         foreach ($tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.2'] as $index => $name) {
-            $RESULT = array();
+            $result = array();
             $message = false;
-            $RESULT['index'] = $index;
-            $RESULT['label'] = $name;
+            $result['index'] = $index;
+            $result['label'] = $name;
             if ($tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.15'][$index] == 1) {
-                $RESULT['transport'] = 'Multicast';
+                $result['transport'] = 'Multicast';
             }
             else {
-                $RESULT['transport'] = 'Unicast';
+                $result['transport'] = 'Unicast';
             }
-            $RESULT['otvtype'] = 'overlay';
-            $RESULT['UID'] = $RESULT['otvtype']."-".$RESULT['index'];
-            $RESULT['vpn_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$index];
-            if ($RESULT['vpn_state'] != 2) {
-                $message .= "VPN Down: ".$ERROR_VPN[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.4'][$index]]."\n";
+            $result['otvtype'] = 'overlay';
+            $result['UID'] = $result['otvtype']."-".$result['index'];
+            $result['vpn_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$index];
+            if ($result['vpn_state'] != 2) {
+                $message .= "VPN Down: ".$error_vpn[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.4'][$index]]."\n";
             }
-            $RESULT['aed_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.13'][$index];
-            if ($RESULT['aed_state'] == 2) {
-                $message .= "AED Down: ".$ERROR_AED[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.14'][$index]]."\n";
+            $result['aed_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.13'][$index];
+            if ($result['aed_state'] == 2) {
+                $message .= "AED Down: ".$error_aed[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.14'][$index]]."\n";
             }
-            $RESULT['overlay_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.23'][$index];
-            if ($RESULT['overlay_state'] == 2) {
-                $message .= "Overlay Down: ".$ERROR_OVERLAY[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.24'][$index]]."\n";
+            $result['overlay_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.23'][$index];
+            if ($result['overlay_state'] == 2) {
+                $message .= "Overlay Down: ".$error_overlay[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.24'][$index]]."\n";
             }
 
             // If we have set a message, we have an error, activate alert.
             if ($message !== false) {
-                $RESULT['error'] = $message;
-                $RESULT['status'] = 0;
+                $result['error'] = $message;
+                $result['status'] = 0;
             }
             else {
-                $RESULT['error'] = "";
-                $RESULT['status'] = 1;
+                $result['error'] = "";
+                $result['status'] = 1;
             }
 
             // Add the result to the parent array.
-            $tblOTV[] = $RESULT;
+            $tblOTV[] = $result;
         }
 
         // Add each adjacency to the array.
         foreach ($tblAdjacentDevName as $key => $value) {
-            preg_match('/^1.3.6.1.4.1.9.9.810.1.3.1.1.4.(\d+).1.4.(\d+.\d+.\d+.\d+)$/', $key, $MATCHES);
-            $RESULT = array();
-            $RESULT['index'] = $MATCHES[1];
-            $RESULT['endpoint'] = $MATCHES[2];
+            preg_match('/^1.3.6.1.4.1.9.9.810.1.3.1.1.4.(\d+).1.4.(\d+.\d+.\d+.\d+)$/', $key, $matches);
+            $result = array();
+            $result['index'] = $matches[1];
+            $result['endpoint'] = $matches[2];
             $tblEndpoints[$value] = true;
-            $RESULT['otvtype'] = 'adjacency';
-            $RESULT['UID'] = $RESULT['otvtype']."-".$RESULT['index']."-".str_replace(' ', '', $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.3.'.$RESULT['index'].'.1.4.'.$RESULT['endpoint']]);
-            $RESULT['uptime'] = $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$RESULT['index'].'.1.4.'.$RESULT['endpoint']];
+            $result['otvtype'] = 'adjacency';
+            $result['UID'] = $result['otvtype']."-".$result['index']."-".str_replace(' ', '', $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.3.'.$result['index'].'.1.4.'.$result['endpoint']]);
+            $result['uptime'] = $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$result['index'].'.1.4.'.$result['endpoint']];
             $message = false;
-            if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.5.'.$RESULT['index'].'.1.4.'.$RESULT['endpoint']] != 1) {
+            if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.5.'.$result['index'].'.1.4.'.$result['endpoint']] != 1) {
                 $message .= "Adjacency is Down\n";
             }
 
             // If we have set a message, we have an error, activate alert.
             if ($message !== false) {
-                $RESULT['error'] = $message;
-                $RESULT['status'] = 0;
+                $result['error'] = $message;
+                $result['status'] = 0;
             }
             else {
-                $RESULT['error'] = "";
-                $RESULT['status'] = 1;
+                $result['error'] = "";
+                $result['status'] = 1;
             }
 
             // Set a default name, if for some unknown reason we cant find the parent VPN.
-            $RESULT['label'] = "Unknown (".$RESULT['index'].") - ".$value;
+            $result['label'] = "Unknown (".$result['index'].") - ".$value;
             // We need to search the existing array to build the name
-            foreach ($tblOTV as $ITEM) {
-                if (($ITEM['otvtype'] == 'overlay') && ($ITEM['index'] == $RESULT['index'])) {
-                    $RESULT['label'] = $ITEM['label']." - ".$value;
+            foreach ($tblOTV as $item) {
+                if (($item['otvtype'] == 'overlay') && ($item['index'] == $result['index'])) {
+                    $result['label'] = $item['label']." - ".$value;
                 }
             }
 
             // Add the result to the parent array.
-            $tblOTV[] = $RESULT;
+            $tblOTV[] = $result;
         }
 
         // We retain a list of all endpoints to tie the RRD to.
-        foreach ($tblEndpoints as $K => $V) {
-            $RESULT['label'] = "Endpoint: ".$K;
-            $RESULT['otvtype'] = 'endpoint';
-            $RESULT['endpoint'] = $K;
-            $RESULT['UID'] = $RESULT['otvtype']."-".$K;
+        foreach ($tblEndpoints as $k => $v) {
+            $result['label'] = "Endpoint: ".$k;
+            $result['otvtype'] = 'endpoint';
+            $result['endpoint'] = $k;
+            $result['UID'] = $result['otvtype']."-".$k;
 
             // Add the result to the parent array.
-            $tblOTV[] = $RESULT;
+            $tblOTV[] = $result;
         }
 
         /*
@@ -181,25 +184,25 @@ if ($device['os_group'] == 'cisco') {
          * Let's loop over the SNMP data to see if we need to ADD or UPDATE any components.
          */
         foreach ($tblOTV as $key => $array) {
-            $COMPONENT_KEY = false;
+            $component_key = false;
 
             // Loop over our components to determine if the component exists, or we need to add it.
-            foreach ($COMPONENTS as $COMPID => $CHILD) {
-                if ($CHILD['UID'] === $array['UID']) {
-                    $COMPONENT_KEY = $COMPID;
+            foreach ($components as $compid => $child) {
+                if ($child['UID'] === $array['UID']) {
+                    $component_key = $compid;
                 }
             }
 
-            if (!$COMPONENT_KEY) {
+            if (!$component_key) {
                 // The component doesn't exist, we need to ADD it - ADD.
-                $NEW_COMPONENT = $COMPONENT->createComponent($device['device_id'],$MODULE);
-                $COMPONENT_KEY = key($NEW_COMPONENT);
-                $COMPONENTS[$COMPONENT_KEY] = array_merge($NEW_COMPONENT[$COMPONENT_KEY], $array);
+                $new_component = $component->createComponent($device['device_id'],$module);
+                $component_key = key($new_component);
+                $components[$component_key] = array_merge($new_component[$component_key], $array);
                 echo "+";
             }
             else {
                 // The component does exist, merge the details in - UPDATE.
-                $COMPONENTS[$COMPONENT_KEY] = array_merge($COMPONENTS[$COMPONENT_KEY], $array);
+                $components[$component_key] = array_merge($components[$component_key], $array);
                 echo ".";
             }
 
@@ -208,26 +211,26 @@ if ($device['os_group'] == 'cisco') {
         /*
          * Loop over the Component data to see if we need to DELETE any components.
          */
-        foreach ($COMPONENTS as $key => $array) {
+        foreach ($components as $key => $array) {
             // Guilty until proven innocent
-            $FOUND = false;
+            $found = false;
 
             foreach ($tblOTV as $k => $v) {
                 if ($array['UID'] == $v['UID']) {
                     // Yay, we found it...
-                    $FOUND = true;
+                    $found = true;
                 }
             }
 
-            if ($FOUND === false) {
+            if ($found === false) {
                 // The component has not been found. we should delete it.
                 echo "-";
-                $COMPONENT->deleteComponent($key);
+                $component->deleteComponent($key);
             }
         }
 
         // Write the Components back to the DB.
-        $COMPONENT->setComponentPrefs($device['device_id'],$COMPONENTS);
+        $component->setComponentPrefs($device['device_id'],$components);
         echo "\n";
 
     } // End if not error

--- a/includes/discovery/cisco-otv.inc.php
+++ b/includes/discovery/cisco-otv.inc.php
@@ -1,0 +1,235 @@
+<?php
+/*
+ * LibreNMS module to capture Cisco OTV Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+if ($device['os_group'] == 'cisco') {
+
+    // Define some error messages
+    $ERROR_VPN[0] = "Other";
+    $ERROR_VPN[1] = "Configuration changed";
+    $ERROR_VPN[2] = "Control Group information is unavailable";
+    $ERROR_VPN[3] = "Data Group range information is unavailable";
+    $ERROR_VPN[4] = "Join or Source interface information is unavailable";
+    $ERROR_VPN[5] = "VPN name is unavailable";
+    $ERROR_VPN[6] = "IP address is missing for Join Interface";
+    $ERROR_VPN[7] = "Join Interface is down";
+    $ERROR_VPN[8] = "Overlay is administratively shutdown";
+    $ERROR_VPN[9] = "Overlay is in delete hold down phase";
+    $ERROR_VPN[10] = "VPN is reinitializing";
+    $ERROR_VPN[11] = "Site ID information is unavailable";
+    $ERROR_VPN[12] = "Site ID mismatch has occurred";
+    $ERROR_VPN[13] = "IP address is missing for Source Interface";
+    $ERROR_VPN[14] = "Source interface is down";
+    $ERROR_VPN[15] = "Changing site identifier";
+    $ERROR_VPN[16] = "Changing control group";
+    $ERROR_VPN[17] = "Device ID information is unavailable";
+    $ERROR_VPN[18] = "Changing device ID";
+    $ERROR_VPN[19] = "Cleanup in progress";
+
+    $ERROR_AED[0] = "Other";
+    $ERROR_AED[1] = "Overlay is Down";
+    $ERROR_AED[2] = "Site ID is not configured";
+    $ERROR_AED[3] = "Site ID mismatch";
+    $ERROR_AED[4] = "Version mismatch";
+    $ERROR_AED[5] = "Site VLAN is Down";
+    $ERROR_AED[6] = "No extended VLAN is operationally up";
+    $ERROR_AED[7] = "No Overlay Adjacency is up";
+    $ERROR_AED[8] = "LSPDB sync incomplete";
+    $ERROR_AED[9] = "Overlay state down event in progress";
+    $ERROR_AED[10] = "ISIS control group sync pending";
+
+    $ERROR_OVERLAY[1] = "active";
+    $ERROR_OVERLAY[2] = "notInService";
+    $ERROR_OVERLAY[3] = "notReady";
+    $ERROR_OVERLAY[4] = "createAndGo";
+    $ERROR_OVERLAY[5] = "createAndWait";
+    $ERROR_OVERLAY[6] = "destroy";
+
+    $MODULE = 'Cisco-OTV';
+    echo $MODULE.': ';
+
+    require_once 'includes/component.php';
+    $COMPONENT = new component();
+    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],array('type'=>$MODULE));
+
+    // We only care about our device id.
+    $COMPONENTS = $COMPONENTS[$device['device_id']];
+
+    // Begin our master array, all other values will be processed into this array.
+    $tblOTV = array();
+    $tblEndpoints = array();
+
+    // Let's gather some data..
+    $tblOverlayEntry = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.2.1.1');
+    $tblAdjacencyDatabaseEntry = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.3.1.1', 0);
+    $tblAdjacentDevName = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.3.1.1.4', 0);
+
+    /*
+     * False == no object found - this is not an error, there is no QOS configured
+     * null  == timeout or something else that caused an error, there may be QOS configured but we couldn't get it.
+     */
+    if ( is_null($tblOverlayEntry) || is_null($tblAdjacencyDatabaseEntry) || is_null($tblAdjacentDevName) ) {
+        // We have to error here or we will end up deleting all our components.
+        echo "Error\n";
+    }
+    else {
+        // No Error, lets process things.
+
+        // Add each overlay to the array.
+        foreach ($tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.2'] as $index => $name) {
+            $RESULT = array();
+            $message = false;
+            $RESULT['index'] = $index;
+            $RESULT['label'] = $name;
+            if ($tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.15'][$index] == 1) {
+                $RESULT['transport'] = 'Multicast';
+            }
+            else {
+                $RESULT['transport'] = 'Unicast';
+            }
+            $RESULT['otvtype'] = 'overlay';
+            $RESULT['UID'] = $RESULT['otvtype']."-".$RESULT['index'];
+            $RESULT['vpn_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$index];
+            if ($RESULT['vpn_state'] != 2) {
+                $message .= "VPN Down: ".$ERROR_VPN[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.4'][$index]]."\n";
+            }
+            $RESULT['aed_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.13'][$index];
+            if ($RESULT['aed_state'] == 2) {
+                $message .= "AED Down: ".$ERROR_AED[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.14'][$index]]."\n";
+            }
+            $RESULT['overlay_state'] = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.23'][$index];
+            if ($RESULT['overlay_state'] == 2) {
+                $message .= "Overlay Down: ".$ERROR_OVERLAY[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.24'][$index]]."\n";
+            }
+
+            // If we have set a message, we have an error, activate alert.
+            if ($message !== false) {
+                $RESULT['error'] = $message;
+                $RESULT['status'] = 0;
+            }
+            else {
+                $RESULT['error'] = "";
+                $RESULT['status'] = 1;
+            }
+
+            // Add the result to the parent array.
+            $tblOTV[] = $RESULT;
+        }
+
+        // Add each adjacency to the array.
+        foreach ($tblAdjacentDevName as $key => $value) {
+            preg_match('/^1.3.6.1.4.1.9.9.810.1.3.1.1.4.(\d+).1.4.(\d+.\d+.\d+.\d+)$/', $key, $MATCHES);
+            $RESULT = array();
+            $RESULT['index'] = $MATCHES[1];
+            $RESULT['endpoint'] = $MATCHES[2];
+            $tblEndpoints[$value] = true;
+            $RESULT['otvtype'] = 'adjacency';
+            $RESULT['UID'] = $RESULT['otvtype']."-".$RESULT['index']."-".str_replace(' ', '', $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.3.'.$RESULT['index'].'.1.4.'.$RESULT['endpoint']]);
+            $RESULT['uptime'] = $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$RESULT['index'].'.1.4.'.$RESULT['endpoint']];
+            $message = false;
+            if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.5.'.$RESULT['index'].'.1.4.'.$RESULT['endpoint']] != 1) {
+                $message .= "Adjacency is Down\n";
+            }
+
+            // If we have set a message, we have an error, activate alert.
+            if ($message !== false) {
+                $RESULT['error'] = $message;
+                $RESULT['status'] = 0;
+            }
+            else {
+                $RESULT['error'] = "";
+                $RESULT['status'] = 1;
+            }
+
+            // Set a default name, if for some unknown reason we cant find the parent VPN.
+            $RESULT['label'] = "Unknown (".$RESULT['index'].") - ".$value;
+            // We need to search the existing array to build the name
+            foreach ($tblOTV as $ITEM) {
+                if (($ITEM['otvtype'] == 'overlay') && ($ITEM['index'] == $RESULT['index'])) {
+                    $RESULT['label'] = $ITEM['label']." - ".$value;
+                }
+            }
+
+            // Add the result to the parent array.
+            $tblOTV[] = $RESULT;
+        }
+
+        // We retain a list of all endpoints to tie the RRD to.
+        foreach ($tblEndpoints as $K => $V) {
+            $RESULT['label'] = "Endpoint: ".$K;
+            $RESULT['otvtype'] = 'endpoint';
+            $RESULT['endpoint'] = $K;
+            $RESULT['UID'] = $RESULT['otvtype']."-".$K;
+
+            // Add the result to the parent array.
+            $tblOTV[] = $RESULT;
+        }
+
+        /*
+         * Ok, we have our 2 array's (Components and SNMP) now we need
+         * to compare and see what needs to be added/updated.
+         *
+         * Let's loop over the SNMP data to see if we need to ADD or UPDATE any components.
+         */
+        foreach ($tblOTV as $key => $array) {
+            $COMPONENT_KEY = false;
+
+            // Loop over our components to determine if the component exists, or we need to add it.
+            foreach ($COMPONENTS as $COMPID => $CHILD) {
+                if ($CHILD['UID'] === $array['UID']) {
+                    $COMPONENT_KEY = $COMPID;
+                }
+            }
+
+            if (!$COMPONENT_KEY) {
+                // The component doesn't exist, we need to ADD it - ADD.
+                $NEW_COMPONENT = $COMPONENT->createComponent($device['device_id'],$MODULE);
+                $COMPONENT_KEY = key($NEW_COMPONENT);
+                $COMPONENTS[$COMPONENT_KEY] = array_merge($NEW_COMPONENT[$COMPONENT_KEY], $array);
+                echo "+";
+            }
+            else {
+                // The component does exist, merge the details in - UPDATE.
+                $COMPONENTS[$COMPONENT_KEY] = array_merge($COMPONENTS[$COMPONENT_KEY], $array);
+                echo ".";
+            }
+
+        }
+
+        /*
+         * Loop over the Component data to see if we need to DELETE any components.
+         */
+        foreach ($COMPONENTS as $key => $array) {
+            // Guilty until proven innocent
+            $FOUND = false;
+
+            foreach ($tblOTV as $k => $v) {
+                if ($array['UID'] == $v['UID']) {
+                    // Yay, we found it...
+                    $FOUND = true;
+                }
+            }
+
+            if ($FOUND === false) {
+                // The component has not been found. we should delete it.
+                echo "-";
+                $COMPONENT->deleteComponent($key);
+            }
+        }
+
+        // Write the Components back to the DB.
+        $COMPONENT->setComponentPrefs($device['device_id'],$COMPONENTS);
+        echo "\n";
+
+    } // End if not error
+
+}

--- a/includes/polling/cisco-otv.inc.php
+++ b/includes/polling/cisco-otv.inc.php
@@ -1,0 +1,181 @@
+<?php
+/*
+ * LibreNMS module to capture Cisco Class-Based QoS Details
+ *
+ * Copyright (c) 2015 Aaron Daniels <aaron@daniels.id.au>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+if ($device['os_group'] == "cisco") {
+
+    // Define some error messages
+    $ERROR_VPN[0] = "Other";
+    $ERROR_VPN[1] = "Configuration changed";
+    $ERROR_VPN[2] = "Control Group information is unavailable";
+    $ERROR_VPN[3] = "Data Group range information is unavailable";
+    $ERROR_VPN[4] = "Join or Source interface information is unavailable";
+    $ERROR_VPN[5] = "VPN name is unavailable";
+    $ERROR_VPN[6] = "IP address is missing for Join Interface";
+    $ERROR_VPN[7] = "Join Interface is down";
+    $ERROR_VPN[8] = "Overlay is administratively shutdown";
+    $ERROR_VPN[9] = "Overlay is in delete hold down phase";
+    $ERROR_VPN[10] = "VPN is reinitializing";
+    $ERROR_VPN[11] = "Site ID information is unavailable";
+    $ERROR_VPN[12] = "Site ID mismatch has occurred";
+    $ERROR_VPN[13] = "IP address is missing for Source Interface";
+    $ERROR_VPN[14] = "Source interface is down";
+    $ERROR_VPN[15] = "Changing site identifier";
+    $ERROR_VPN[16] = "Changing control group";
+    $ERROR_VPN[17] = "Device ID information is unavailable";
+    $ERROR_VPN[18] = "Changing device ID";
+    $ERROR_VPN[19] = "Cleanup in progress";
+
+    $ERROR_AED[0] = "Other";
+    $ERROR_AED[1] = "Overlay is Down";
+    $ERROR_AED[2] = "Site ID is not configured";
+    $ERROR_AED[3] = "Site ID mismatch";
+    $ERROR_AED[4] = "Version mismatch";
+    $ERROR_AED[5] = "Site VLAN is Down";
+    $ERROR_AED[6] = "No extended VLAN is operationally up";
+    $ERROR_AED[7] = "No Overlay Adjacency is up";
+    $ERROR_AED[8] = "LSPDB sync incomplete";
+    $ERROR_AED[9] = "Overlay state down event in progress";
+    $ERROR_AED[10] = "ISIS control group sync pending";
+
+    $ERROR_OVERLAY[1] = "active";
+    $ERROR_OVERLAY[2] = "notInService";
+    $ERROR_OVERLAY[3] = "notReady";
+    $ERROR_OVERLAY[4] = "createAndGo";
+    $ERROR_OVERLAY[5] = "createAndWait";
+    $ERROR_OVERLAY[6] = "destroy";
+
+    $MODULE = 'Cisco-OTV';
+
+    require_once 'includes/component.php';
+    $COMPONENT = new component();
+    $options['filter']['type'] = array('=',$MODULE);
+    $options['filter']['disabled'] = array('=',0);
+    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+
+    // We only care about our device id.
+    $COMPONENTS = $COMPONENTS[$device['device_id']];
+
+    // Only collect SNMP data if we have enabled components
+    if (count($COMPONENTS > 0)) {
+        // Let's gather the stats..
+        $tblOverlayEntry = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.2.1.1');
+        $tblAdjacencyDatabaseEntry = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.3.1.1', 0);
+        $tblRouteNextHopAddr = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.5.1.1.8', 0);
+        $tblVlanEdgeDevIsAed = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.2.2.1.6', 2);
+
+        // Let's create an array of each remote OTV endpoint and the count of MAC addresses that are reachable via.
+        $COUNT_MAC = array();
+        foreach ($tblRouteNextHopAddr as $k => $v) {
+            $COUNT_MAC[$v]++;
+        }
+
+        // Loop through the components and extract the data.
+        foreach ($COMPONENTS as $KEY => &$ARRAY) {
+
+            if ($ARRAY['otvtype'] == 'overlay') {
+                // Let's check the varius status' of the overlay
+                $message = false;
+                $vpn_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$ARRAY['index']];
+                if ($vpn_state != 2) {
+                    $message .= "VPN Down: ".$ERROR_VPN[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.4'][$ARRAY['index']]];
+                }
+                $aed_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.13'][$ARRAY['index']];
+                if ($aed_state == 2) {
+                    $message .= "AED Down: ".$ERROR_AED[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.14'][$ARRAY['index']]];
+                }
+                $overlay_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.23'][$ARRAY['index']];
+                if ($overlay_state == 2) {
+                    $message .= "Overlay Down: ".$ERROR_OVERLAY[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.24'][$ARRAY['index']]];
+                }
+
+                // If we have set a message, we have an error, activate alert.
+                if ($message !== false) {
+                    $ARRAY['error'] = $message;
+                    $ARRAY['status'] = 0;
+                }
+                else {
+                    $ARRAY['error'] = "";
+                    $ARRAY['status'] = 1;
+                }
+
+                // Time to graph the count of the active VLAN's on this overlay.
+                $COUNT_VLAN = 0;
+                foreach ($tblVlanEdgeDevIsAed['1.3.6.1.4.1.9.9.810.1.2.2.1.6'][$ARRAY['index']] as $v) {
+                    if ($v == 1) {
+                        $COUNT_VLAN++;
+                    }
+                }
+
+                $filename = "cisco-otv-".$ARRAY['label']."-vlan.rrd";
+                $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);
+
+                if (!file_exists ($rrd_filename)) {
+                    rrdtool_create ($rrd_filename, " DS:count:GAUGE:600:0:U" . $config['rrd_rra']);
+                }
+                $RRD['count'] = $COUNT_VLAN;
+
+                // Update RRD
+                rrdtool_update ($rrd_filename, $RRD);
+
+            }
+            elseif ($ARRAY['otvtype'] == 'adjacency') {
+                $ARRAY['uptime'] = $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$ARRAY['index'].'.1.4.'.$ARRAY['endpoint']];
+                $message = false;
+                if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.5.'.$ARRAY['index'].'.1.4.'.$ARRAY['endpoint']] != 1) {
+                    $message .= "Adjacency is Down\n";
+                }
+                if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$ARRAY['index'].'.1.4.'.$ARRAY['endpoint']] < $ARRAY['uptime']) {
+                    $message .= "Adjacency has been reset\n";
+                }
+
+                // If we have set a message, we have an error, activate alert.
+                if ($message !== false) {
+                    $ARRAY['error'] = $message;
+                    $ARRAY['status'] = 0;
+                }
+                else {
+                    $ARRAY['error'] = "";
+                    $ARRAY['status'] = 1;
+                }
+            }
+            elseif ($ARRAY['otvtype'] == 'endpoint') {
+                if (isset($COUNT_MAC[$ARRAY['endpoint']])) {
+                    $RRD['count'] = $COUNT_MAC[$ARRAY['endpoint']];
+                }
+                else {
+                    $RRD['count'] = "0";
+                }
+
+                $filename = "cisco-otv-".$ARRAY['endpoint']."-mac.rrd";
+                $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);
+
+                if (!file_exists ($rrd_filename)) {
+                    rrdtool_create ($rrd_filename, " DS:count:GAUGE:600:0:U" . $config['rrd_rra']);
+                }
+
+                // Update RRD
+                rrdtool_update ($rrd_filename, $RRD);
+
+            } // End If
+
+        } // End foreach components
+
+        // Write the Components back to the DB.
+        $COMPONENT->setComponentPrefs($device['device_id'],$COMPONENTS);
+
+        echo $MODULE." ";
+    } // end if count components
+
+    // Clean-up after yourself!
+    unset($COMPONENTS, $COMPONENT, $MODULE);
+}

--- a/includes/polling/cisco-otv.inc.php
+++ b/includes/polling/cisco-otv.inc.php
@@ -81,12 +81,14 @@ if ($device['os_group'] == "cisco") {
         foreach ($tblRouteNextHopAddr as $k => $v) {
             $count_mac[$v]++;
         }
+        // Let's log some debugging
+        d_echo("\n\nMAC Addresses: ".print_r($count_mac,TRUE));
 
         // Loop through the components and extract the data.
         foreach ($components as $key => &$array) {
 
             if ($array['otvtype'] == 'overlay') {
-                // Let's check the varius status' of the overlay
+                // Let's check the various status' of the overlay
                 $message = false;
                 $vpn_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$array['index']];
                 if ($vpn_state != 2) {
@@ -119,6 +121,14 @@ if ($device['os_group'] == "cisco") {
                     }
                 }
 
+                // Let's log some debugging
+                d_echo("\n\nOverlay Component: ".$key."\n");
+                d_echo("    Label: ".$array['label']."\n");
+                d_echo("    Index: ".$array['index']."\n");
+                d_echo("    Status: ".$array['status']."\n");
+                d_echo("    Message: ".$array['error']."\n");
+                d_echo("    VLAN Count: ".$count_vlan."\n");
+
                 $filename = "cisco-otv-".$array['label']."-vlan.rrd";
                 $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);
 
@@ -150,6 +160,13 @@ if ($device['os_group'] == "cisco") {
                     $array['error'] = "";
                     $array['status'] = 1;
                 }
+
+                // Let's log some debugging
+                d_echo("\n\nAdjacency Component: ".$key."\n");
+                d_echo("    Label: ".$array['label']."\n");
+                d_echo("    Index: ".$array['index']."\n");
+                d_echo("    Status: ".$array['status']."\n");
+                d_echo("    Message: ".$array['error']."\n");
             }
             elseif ($array['otvtype'] == 'endpoint') {
                 if (isset($count_mac[$array['endpoint']])) {
@@ -158,6 +175,11 @@ if ($device['os_group'] == "cisco") {
                 else {
                     $rrd['count'] = "0";
                 }
+
+                // Let's log some debugging
+                d_echo("\n\nEndpoint Component: ".$key."\n");
+                d_echo("    Label: ".$array['label']."\n");
+                d_echo("    MAC Count: ".$rrd['count']."\n");
 
                 $filename = "cisco-otv-".$array['endpoint']."-mac.rrd";
                 $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);

--- a/includes/polling/cisco-otv.inc.php
+++ b/includes/polling/cisco-otv.inc.php
@@ -14,59 +14,62 @@
 if ($device['os_group'] == "cisco") {
 
     // Define some error messages
-    $ERROR_VPN[0] = "Other";
-    $ERROR_VPN[1] = "Configuration changed";
-    $ERROR_VPN[2] = "Control Group information is unavailable";
-    $ERROR_VPN[3] = "Data Group range information is unavailable";
-    $ERROR_VPN[4] = "Join or Source interface information is unavailable";
-    $ERROR_VPN[5] = "VPN name is unavailable";
-    $ERROR_VPN[6] = "IP address is missing for Join Interface";
-    $ERROR_VPN[7] = "Join Interface is down";
-    $ERROR_VPN[8] = "Overlay is administratively shutdown";
-    $ERROR_VPN[9] = "Overlay is in delete hold down phase";
-    $ERROR_VPN[10] = "VPN is reinitializing";
-    $ERROR_VPN[11] = "Site ID information is unavailable";
-    $ERROR_VPN[12] = "Site ID mismatch has occurred";
-    $ERROR_VPN[13] = "IP address is missing for Source Interface";
-    $ERROR_VPN[14] = "Source interface is down";
-    $ERROR_VPN[15] = "Changing site identifier";
-    $ERROR_VPN[16] = "Changing control group";
-    $ERROR_VPN[17] = "Device ID information is unavailable";
-    $ERROR_VPN[18] = "Changing device ID";
-    $ERROR_VPN[19] = "Cleanup in progress";
+    $error_vpn = array();
+    $error_vpn[0] = "Other";
+    $error_vpn[1] = "Configuration changed";
+    $error_vpn[2] = "Control Group information is unavailable";
+    $error_vpn[3] = "Data Group range information is unavailable";
+    $error_vpn[4] = "Join or Source interface information is unavailable";
+    $error_vpn[5] = "VPN name is unavailable";
+    $error_vpn[6] = "IP address is missing for Join Interface";
+    $error_vpn[7] = "Join Interface is down";
+    $error_vpn[8] = "Overlay is administratively shutdown";
+    $error_vpn[9] = "Overlay is in delete hold down phase";
+    $error_vpn[10] = "VPN is reinitializing";
+    $error_vpn[11] = "Site ID information is unavailable";
+    $error_vpn[12] = "Site ID mismatch has occurred";
+    $error_vpn[13] = "IP address is missing for Source Interface";
+    $error_vpn[14] = "Source interface is down";
+    $error_vpn[15] = "Changing site identifier";
+    $error_vpn[16] = "Changing control group";
+    $error_vpn[17] = "Device ID information is unavailable";
+    $error_vpn[18] = "Changing device ID";
+    $error_vpn[19] = "Cleanup in progress";
 
-    $ERROR_AED[0] = "Other";
-    $ERROR_AED[1] = "Overlay is Down";
-    $ERROR_AED[2] = "Site ID is not configured";
-    $ERROR_AED[3] = "Site ID mismatch";
-    $ERROR_AED[4] = "Version mismatch";
-    $ERROR_AED[5] = "Site VLAN is Down";
-    $ERROR_AED[6] = "No extended VLAN is operationally up";
-    $ERROR_AED[7] = "No Overlay Adjacency is up";
-    $ERROR_AED[8] = "LSPDB sync incomplete";
-    $ERROR_AED[9] = "Overlay state down event in progress";
-    $ERROR_AED[10] = "ISIS control group sync pending";
+    $error_aed = array();
+    $error_aed[0] = "Other";
+    $error_aed[1] = "Overlay is Down";
+    $error_aed[2] = "Site ID is not configured";
+    $error_aed[3] = "Site ID mismatch";
+    $error_aed[4] = "Version mismatch";
+    $error_aed[5] = "Site VLAN is Down";
+    $error_aed[6] = "No extended VLAN is operationally up";
+    $error_aed[7] = "No Overlay Adjacency is up";
+    $error_aed[8] = "LSPDB sync incomplete";
+    $error_aed[9] = "Overlay state down event in progress";
+    $error_aed[10] = "ISIS control group sync pending";
 
-    $ERROR_OVERLAY[1] = "active";
-    $ERROR_OVERLAY[2] = "notInService";
-    $ERROR_OVERLAY[3] = "notReady";
-    $ERROR_OVERLAY[4] = "createAndGo";
-    $ERROR_OVERLAY[5] = "createAndWait";
-    $ERROR_OVERLAY[6] = "destroy";
+    $error_overlay = array();
+    $error_overlay[1] = "active";
+    $error_overlay[2] = "notInService";
+    $error_overlay[3] = "notReady";
+    $error_overlay[4] = "createAndGo";
+    $error_overlay[5] = "createAndWait";
+    $error_overlay[6] = "destroy";
 
-    $MODULE = 'Cisco-OTV';
+    $module = 'Cisco-OTV';
 
     require_once 'includes/component.php';
-    $COMPONENT = new component();
-    $options['filter']['type'] = array('=',$MODULE);
+    $component = new component();
+    $options['filter']['type'] = array('=',$module);
     $options['filter']['disabled'] = array('=',0);
-    $COMPONENTS = $COMPONENT->getComponents($device['device_id'],$options);
+    $components = $component->getComponents($device['device_id'],$options);
 
     // We only care about our device id.
-    $COMPONENTS = $COMPONENTS[$device['device_id']];
+    $components = $components[$device['device_id']];
 
     // Only collect SNMP data if we have enabled components
-    if (count($COMPONENTS > 0)) {
+    if (count($components > 0)) {
         // Let's gather the stats..
         $tblOverlayEntry = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.2.1.1');
         $tblAdjacencyDatabaseEntry = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.3.1.1', 0);
@@ -74,89 +77,89 @@ if ($device['os_group'] == "cisco") {
         $tblVlanEdgeDevIsAed = snmpwalk_array_num($device, '.1.3.6.1.4.1.9.9.810.1.2.2.1.6', 2);
 
         // Let's create an array of each remote OTV endpoint and the count of MAC addresses that are reachable via.
-        $COUNT_MAC = array();
+        $count_mac = array();
         foreach ($tblRouteNextHopAddr as $k => $v) {
-            $COUNT_MAC[$v]++;
+            $count_mac[$v]++;
         }
 
         // Loop through the components and extract the data.
-        foreach ($COMPONENTS as $KEY => &$ARRAY) {
+        foreach ($components as $key => &$array) {
 
-            if ($ARRAY['otvtype'] == 'overlay') {
+            if ($array['otvtype'] == 'overlay') {
                 // Let's check the varius status' of the overlay
                 $message = false;
-                $vpn_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$ARRAY['index']];
+                $vpn_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.3'][$array['index']];
                 if ($vpn_state != 2) {
-                    $message .= "VPN Down: ".$ERROR_VPN[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.4'][$ARRAY['index']]];
+                    $message .= "VPN Down: ".$error_vpn[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.4'][$array['index']]];
                 }
-                $aed_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.13'][$ARRAY['index']];
+                $aed_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.13'][$array['index']];
                 if ($aed_state == 2) {
-                    $message .= "AED Down: ".$ERROR_AED[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.14'][$ARRAY['index']]];
+                    $message .= "AED Down: ".$error_aed[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.14'][$array['index']]];
                 }
-                $overlay_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.23'][$ARRAY['index']];
+                $overlay_state = $tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.23'][$array['index']];
                 if ($overlay_state == 2) {
-                    $message .= "Overlay Down: ".$ERROR_OVERLAY[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.24'][$ARRAY['index']]];
+                    $message .= "Overlay Down: ".$error_overlay[$tblOverlayEntry['1.3.6.1.4.1.9.9.810.1.2.1.1.24'][$array['index']]];
                 }
 
                 // If we have set a message, we have an error, activate alert.
                 if ($message !== false) {
-                    $ARRAY['error'] = $message;
-                    $ARRAY['status'] = 0;
+                    $array['error'] = $message;
+                    $array['status'] = 0;
                 }
                 else {
-                    $ARRAY['error'] = "";
-                    $ARRAY['status'] = 1;
+                    $array['error'] = "";
+                    $array['status'] = 1;
                 }
 
                 // Time to graph the count of the active VLAN's on this overlay.
-                $COUNT_VLAN = 0;
-                foreach ($tblVlanEdgeDevIsAed['1.3.6.1.4.1.9.9.810.1.2.2.1.6'][$ARRAY['index']] as $v) {
+                $count_vlan = 0;
+                foreach ($tblVlanEdgeDevIsAed['1.3.6.1.4.1.9.9.810.1.2.2.1.6'][$array['index']] as $v) {
                     if ($v == 1) {
-                        $COUNT_VLAN++;
+                        $count_vlan++;
                     }
                 }
 
-                $filename = "cisco-otv-".$ARRAY['label']."-vlan.rrd";
+                $filename = "cisco-otv-".$array['label']."-vlan.rrd";
                 $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);
 
                 if (!file_exists ($rrd_filename)) {
                     rrdtool_create ($rrd_filename, " DS:count:GAUGE:600:0:U" . $config['rrd_rra']);
                 }
-                $RRD['count'] = $COUNT_VLAN;
+                $rrd['count'] = $count_vlan;
 
                 // Update RRD
-                rrdtool_update ($rrd_filename, $RRD);
+                rrdtool_update ($rrd_filename, $rrd);
 
             }
-            elseif ($ARRAY['otvtype'] == 'adjacency') {
-                $ARRAY['uptime'] = $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$ARRAY['index'].'.1.4.'.$ARRAY['endpoint']];
+            elseif ($array['otvtype'] == 'adjacency') {
+                $array['uptime'] = $tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$array['index'].'.1.4.'.$array['endpoint']];
                 $message = false;
-                if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.5.'.$ARRAY['index'].'.1.4.'.$ARRAY['endpoint']] != 1) {
+                if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.5.'.$array['index'].'.1.4.'.$array['endpoint']] != 1) {
                     $message .= "Adjacency is Down\n";
                 }
-                if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$ARRAY['index'].'.1.4.'.$ARRAY['endpoint']] < $ARRAY['uptime']) {
+                if ($tblAdjacencyDatabaseEntry['1.3.6.1.4.1.9.9.810.1.3.1.1.6.'.$array['index'].'.1.4.'.$array['endpoint']] < $array['uptime']) {
                     $message .= "Adjacency has been reset\n";
                 }
 
                 // If we have set a message, we have an error, activate alert.
                 if ($message !== false) {
-                    $ARRAY['error'] = $message;
-                    $ARRAY['status'] = 0;
+                    $array['error'] = $message;
+                    $array['status'] = 0;
                 }
                 else {
-                    $ARRAY['error'] = "";
-                    $ARRAY['status'] = 1;
+                    $array['error'] = "";
+                    $array['status'] = 1;
                 }
             }
-            elseif ($ARRAY['otvtype'] == 'endpoint') {
-                if (isset($COUNT_MAC[$ARRAY['endpoint']])) {
-                    $RRD['count'] = $COUNT_MAC[$ARRAY['endpoint']];
+            elseif ($array['otvtype'] == 'endpoint') {
+                if (isset($count_mac[$array['endpoint']])) {
+                    $rrd['count'] = $count_mac[$array['endpoint']];
                 }
                 else {
-                    $RRD['count'] = "0";
+                    $rrd['count'] = "0";
                 }
 
-                $filename = "cisco-otv-".$ARRAY['endpoint']."-mac.rrd";
+                $filename = "cisco-otv-".$array['endpoint']."-mac.rrd";
                 $rrd_filename = $config['rrd_dir'] . "/" . $device['hostname'] . "/" . safename ($filename);
 
                 if (!file_exists ($rrd_filename)) {
@@ -164,18 +167,18 @@ if ($device['os_group'] == "cisco") {
                 }
 
                 // Update RRD
-                rrdtool_update ($rrd_filename, $RRD);
+                rrdtool_update ($rrd_filename, $rrd);
 
             } // End If
 
         } // End foreach components
 
         // Write the Components back to the DB.
-        $COMPONENT->setComponentPrefs($device['device_id'],$COMPONENTS);
+        $component->setComponentPrefs($device['device_id'],$components);
 
-        echo $MODULE." ";
+        echo $module." ";
     } // end if count components
 
     // Clean-up after yourself!
-    unset($COMPONENTS, $COMPONENT, $MODULE);
+    unset($components, $component, $module);
 }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1293,9 +1293,9 @@ function register_mibs($device, $mibs, $included_by)
  * @internal param $string
  * @return array
  */
-function snmpwalk_array_num($device,$OID,$indexes=1) {
+function snmpwalk_array_num($device,$oid,$indexes=1) {
     $array = array();
-    $string = snmp_walk($device, $OID, '-Osqn');
+    $string = snmp_walk($device, $oid, '-Osqn');
 
     if ( $string === false) {
         // False means: No Such Object.


### PR DESCRIPTION
Implements the CISCO-OTV-MIB to retrieve OTV counters from Cisco devices.
This collects information on the configured Overlays and Adjacencies

Statistics are collected for the amount of VLAN's on each overlay and the amount of MAC addresses available over each OTV endpoint.
OTV alerts are collected and generated if the appropriate alerting rules exist.

Data is displayed under routing at both the global and device level.

Includes function snmpwalk_array_num, which performs a numeric SNMPWalk and returns an array containing $count indexes
One Index:
 From: 1.3.6.1.4.1.9.9.166.1.15.1.1.27.18.655360 = 0
 To: $array['1.3.6.1.4.1.9.9.166.1.15.1.1.27.18']['655360'] = 0
Two Indexes:
 From: 1.3.6.1.4.1.9.9.166.1.15.1.1.27.18.655360 = 0
 To: $array['1.3.6.1.4.1.9.9.166.1.15.1.1.27']['18']['655360'] = 0
And so on...

Have a play and let me know what you think.

Thanks,
Aaron