### PR TITLE
Added link back to hardware node for VMs

### DIFF
--- a/html/includes/device-header.inc.php
+++ b/html/includes/device-header.inc.php
@@ -21,11 +21,20 @@ if ($device['disabled'] == '1') {
 $type = strtolower($device['os']);
 
 $image = getImage($device);
+$host_id = dbFetchCell("SELECT `device_id` FROM `vminfo` WHERE `vmwVmDisplayName` = ? OR `vmwVmDisplayName` = ?", array($device['hostname'],$device['hostname'].'.'.$config['mydomain']));
 
 echo '
             <tr bgcolor="'.$device_colour.'" class="alert '.$class.'">
-             <td width="40" align=center valign=middle style="padding: 21px;"><span class="device_icon">'.$image.'</span></td>
-             <td valign=middle style="padding: 0 15px;"><span style="font-size: 20px;">'.generate_device_link($device).'</span>
+             <td><span class="device_icon">'.$image.'</span></td>
+             <td>';
+if ($host_id > 0) {
+    echo '
+             <a href="'.generate_url(array('page'=>'device','device'=>$host_id)).'"><i class="fa fa-server fa-fw fa-lg"></i></a>
+         ';
+}
+             
+echo '
+             <span style="font-size: 20px;">'.generate_device_link($device).'</span>
              <br />'.generate_link($device['location'], array('page' => 'devices', 'location' => $device['location'])).'</td>
              <td>';
 


### PR DESCRIPTION
Added a font awesome server icon before the hostname for a VM if we can work out the device_id it's linked to. Looks like this:

![image](https://cloud.githubusercontent.com/assets/3941142/12566080/bbf7cc52-c3af-11e5-8df5-d8a3b8313ab7.png)

Hopefully fix #2843 