### PR TITLE
Added ability to ignore device sensors from entity mib

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -406,6 +406,17 @@ Entries defined in `rewrite_if` are being replaced completely.
 Entries defined in `rewrite_if_regexp` only replace the match.
 Matches are compared case-insensitive.
 
+#### Entity sensors to be ignored
+
+Some devices register bogus sensors as they are returned via SNMP but either don't exist or just don't return data.
+This allows you to ignore those based on the descr field in the database. You can either ignore globally or on a per 
+os basis.
+
+```php
+$config['bad_entity_sensor_regex'][] = '/Physical id [0-9]+/';
+$config['os']['cisco']['bad_entity_sensor_regex'] = '/Physical id [0-9]+/';
+```
+
 #### Storage configuration
 
 ```php

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -710,3 +710,31 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
     }//end if
 
 }//end discover_process_ipv6()
+
+/*
+ * Check entity sensors to be excluded
+ * 
+ * @param string value to check
+ * @param array device
+ *
+ * @return bool true if sensor is valid
+ *              false if sensor is invalid
+*/
+function check_entity_sensor($string, $device) {
+    global $config;
+    $valid  = true;
+    $string = strtolower($string);
+    if (is_array($config['bad_entity_sensor_regex'])) {
+        $fringe = $config['bad_entity_sensor_regex'];
+        if (is_array($config['os'][$device['os']]['bad_entity_sensor_regex'])) {
+            $fringe = array_merge($config['bad_entity_sensor_regex'],$config['os'][$device['os']]['bad_entity_sensor_regex']);
+        }
+        foreach ($fringe as $bad) {
+            if (preg_match($bad . "i", $string)) {
+                $valid = false;
+                d_echo("Ignored entity sensor: $bad : $string");
+            }
+        }
+    }
+    return $valid;
+}

--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -50,7 +50,7 @@ if (is_array($oids)) {
                 $descr = rewrite_entity_descr($descr);
             }
 
-            $thisisnotbullshit = true;
+            $thisisnotbullshit = check_entity_sensor($descr, $device);
 
             $type = $entitysensor[$entry['entPhySensorType']];
 

--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -50,7 +50,7 @@ if (is_array($oids)) {
                 $descr = rewrite_entity_descr($descr);
             }
 
-            $thisisnotbullshit = check_entity_sensor($descr, $device);
+            $valid = check_entity_sensor($descr, $device);
 
             $type = $entitysensor[$entry['entPhySensorType']];
 
@@ -103,16 +103,16 @@ if (is_array($oids)) {
 
             if ($type == 'temperature') {
                 if ($current > '200') {
-                    $thisisnotbullshit = false;
+                    $valid = false;
                 } $descr = preg_replace('/[T|t]emperature[|s]/', '', $descr);
             }
 
             // echo($descr . "|" . $index . "|" .$current . "|" . $multiplier . "|" . $divisor ."|" . $entry['entPhySensorScale'] . "|" . $entry['entPhySensorPrecision'] . "\n");
             if ($current == '-127') {
-                $thisisnotbullshit = false;
+                $valid = false;
             }
 
-            if ($thisisnotbullshit && dbFetchCell("SELECT COUNT(*) FROM `sensors` WHERE device_id = ? AND `sensor_class` = ? AND `sensor_type` = 'cisco-entity-sensor' AND `sensor_index` = ?", array($device['device_id'], $type, $index)) == '0') {
+            if ($valid && dbFetchCell("SELECT COUNT(*) FROM `sensors` WHERE device_id = ? AND `sensor_class` = ? AND `sensor_type` = 'cisco-entity-sensor' AND `sensor_index` = ?", array($device['device_id'], $type, $index)) == '0') {
                 // Check to make sure we've not already seen this sensor via cisco's entity sensor mib
                 discover_sensor($valid['sensor'], $type, $device, $oid, $index, 'entity-sensor', $descr, $divisor, $multiplier, null, null, null, null, $current);
             }


### PR DESCRIPTION
Fix #2859 

This allows people to set either global or per OS descriptions that can be ignored for Entity sensors.