### PR TITLE
Update per-module poller performance collection

### DIFF
--- a/html/includes/graphs/device/poller_modules_perf.inc.php
+++ b/html/includes/graphs/device/poller_modules_perf.inc.php
@@ -1,8 +1,10 @@
 <?php
 /*
- * LibreNMS
+ * LibreNMS per-module poller performance
  *
  * Copyright (c) 2016 Mike Rostermund <mike@kollegienet.dk>
+ * Copyright (c) 2016 Paul D. Gear <paul@librenms.org>
+ *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation, either version 3 of the License, or (at your
@@ -11,28 +13,28 @@
  */
 
 $scale_min = '0';
-$colour_scheme = 'mixed';
 $attribs = get_dev_attribs($device['device_id']);
 ksort($config['poller_modules']);
 
 require 'includes/graphs/common.inc.php';
 
-$colour_iter = 0;
-$rrd_options .= " 'COMMENT:Seconds               Current  Minimum  Maximum  Average\\n'";
+$count = 0;
 foreach ($config['poller_modules'] as $module => $module_status) {
-    $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/poller-'.$module.'-perf.rrd';
+    $rrd_filename = rrd_name($device['hostname'], array('poller-perf', $module));
     if ($attribs['poll_'.$module] || ( $module_status && !isset($attribs['poll_'.$module]))) {
         if (is_file($rrd_filename)) {
-            if (!$config['graph_colours'][$colour_scheme][$colour_iter]) {
-                $colour_iter = 0;
-            }
-            $colour = $config['graph_colours'][$colour_scheme][$colour_iter];
-            $colour_iter++;
-
-            $rrd_options .= ' DEF:'.$module.'='.$rrd_filename.':'.$module.':AVERAGE';
-            $rrd_options .= ' LINE1.25:'.$module.'#'.$colour.':"'.str_pad($module, 18," ").'"';
-            $rrd_options .= ' GPRINT:'.$module.':LAST:%6.2lf  GPRINT:'.$module.':AVERAGE:%7.2lf';
-            $rrd_options .= " GPRINT:".$module.":MAX:%7.2lf  'GPRINT:".$module.":AVERAGE:%7.2lf\\n'";
+            $ds['ds']       = 'poller';
+            $ds['descr']    = $module;
+            $ds['filename'] = $rrd_filename;
+            $rrd_list[]     = $ds;
+            $count++;
         }
     }
 }
+
+$unit_text = "Seconds";
+$simple_rrd = false;
+$nototal = false;
+$text_orig = true;
+$colours = 'manycolours';
+require "includes/graphs/generic_multi_simplex_seperated.inc.php";


### PR DESCRIPTION
This makes the following changes:
- Record per-module performance data in the same measurement as overall poller-perf
- Add tags to distinguish modules
- Update rrd filenames
- Use stacked graph for poller modules