### PR TITLE
walk cbgpPeer2RemoteAs only once

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -1,6 +1,10 @@
 <?php
 
 if ($config['enable_bgp']) {
+    if ($device['os'] != 'junos') {    
+        $peer_data_check = snmpwalk_cache_oid($device, 'cbgpPeer2RemoteAs', array(), 'CISCO-BGP4-MIB', $config['mibdir']);
+    }
+    
     foreach (dbFetchRows('SELECT * FROM bgpPeers WHERE device_id = ?', array($device['device_id'])) as $peer) {
         // Poll BGP Peer
         $peer2 = false;
@@ -10,7 +14,6 @@ if ($config['enable_bgp']) {
             if (!strstr($peer['bgpPeerIdentifier'], ':') || $device['os'] != 'junos') {
                 // v4 BGP4 MIB
                 // FIXME - needs moved to function
-                $peer_data_check = snmpwalk_cache_oid($device, 'cbgpPeer2RemoteAs', array(), 'CISCO-BGP4-MIB', $config['mibdir']);
                 if (count($peer_data_check) > 0) {
                     $peer2 = true;
                 }


### PR DESCRIPTION
snmpwalk of cbgpPeer2RemoteAs has been done for each peer, which results in a long runtime of routers with many BGP peers (about 18 minutes for >1000 peers), calling it just once outside the for loop reduces the runtime to about 3 minutes