### PR TITLE
Add ./validate.php -m rrdcheck

### DIFF
--- a/doc/Support/Install Validation.md
+++ b/doc/Support/Install Validation.md
@@ -17,7 +17,9 @@ So, to try and help with some of the general issues people come across we've put
 
 Optionally you can also pass -m and a module name for that to be tested. Current modules are:
 
- - mail. This will validate your mail transport configuration.
+ - mail - This will validate your mail transport configuration.
+ - dist-poller - This will test your distributed poller configuration.
+ - rrdcheck - This will test your rrd files to see if they are unreadable or corrupted (source of broken graphs).
 
 Output, this is color coded to try and make things a little easier:
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1373,7 +1373,7 @@ function dnslookup($device,$type=false,$return=false) {
  *
 **/
 
-class RRDReursiveFilterIterator extends \RecursiveFilterIterator {
+class RRDRecursiveFilterIterator extends \RecursiveFilterIterator {
     public function accept() {
         $filename = $this->current()->getFilename();
         if ($filename[0] === '.') {
@@ -1402,6 +1402,7 @@ class RRDReursiveFilterIterator extends \RecursiveFilterIterator {
 **/
 
 function rrdtest($path, &$stdOutput, &$stdError) {
+    global $config;
     //rrdtool info <escaped rrd path>
     $command = $config['rrdtool'].' info '.escapeshellarg($path);
     $process = proc_open(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1366,3 +1366,65 @@ function dnslookup($device,$type=false,$return=false) {
     $record = dns_get_record($device['hostname'],$type);
     return $record[0][$return];
 }//end dnslookup
+
+
+/**
+ * Reursive Filter Iterator to iterate directories and locate .rrd files.
+ *
+**/
+
+class RRDReursiveFilterIterator extends \RecursiveFilterIterator {
+    public function accept() {
+        $filename = $this->current()->getFilename();
+        if ($filename[0] === '.') {
+            // Ignore hidden files and directories
+            return false;
+        }
+        if ($this->isDir()) {
+            // We want to search into directories
+            return true;
+        }
+        // Matches files with .rrd in the filename.
+        // We are only searching rrd folder, but there could be other files and we don't want to cause a stink.
+        return strpos($filename, '.rrd') !== false;
+    }
+}
+
+/**
+ * Run rrdtool info on a file path
+ *
+ * @param string $path Path to pass to rrdtool info
+ * @param string $stdOutput Variable to recieve the output of STDOUT
+ * @param string $stdError Variable to recieve the output of STDERR
+ *
+ * @return int exit code
+ *
+**/
+
+function rrdtest($path, &$stdOutput, &$stdError) {
+    //rrdtool info <escaped rrd path>
+    $command = $config['rrdtool'].' info '.escapeshellarg($path);
+    $process = proc_open(
+        $command,
+        array (
+            0 => array('pipe', 'r'),
+            1 => array('pipe', 'w'),
+            2 => array('pipe', 'w'),
+        ),
+        $pipes
+    );
+
+    if (!is_resource($process)) {
+        throw new \RuntimeException('Could not create a valid process');
+    }
+
+    $status = proc_get_status($process);
+    while($status['running']) {
+        $status = proc_get_status($process);
+    }
+
+    $stdOutput = stream_get_contents($pipes[1]);
+    $stdError  = stream_get_contents($pipes[2]);
+    proc_close($process);
+    return $status['exitcode'];
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1424,6 +1424,7 @@ function rrdtest($path, &$stdOutput, &$stdError) {
 
     $status = proc_get_status($process);
     while($status['running']) {
+        usleep(2000); // Sleep 2000 microseconds or 2 milliseconds
         $status = proc_get_status($process);
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1371,9 +1371,12 @@ function dnslookup($device,$type=false,$return=false) {
 /**
  * Reursive Filter Iterator to iterate directories and locate .rrd files.
  *
+ * @method boolean isDir()
+ *
 **/
 
 class RRDRecursiveFilterIterator extends \RecursiveFilterIterator {
+
     public function accept() {
         $filename = $this->current()->getFilename();
         if ($filename[0] === '.') {


### PR DESCRIPTION
This adds a little tool to list unreadable rrd files in your rrd folder.
```
Scanning 9656 rrd files in /opt/librenms/rrd...
[FAIL]    Error parsing "/opt/librenms/rrd/nexus-c/port-5.rrd" RRD ERROR: '/opt/librenms/rrd/nexus-c/port-5.rrd.old' is not an RRD file
[FAIL]    Error parsing "/opt/librenms/rrd/nexus-c/ucd_diskio-dm-1.rrd" RRD ERROR: mmaping file '/opt/librenms/rrd/nexus-c/ucd_diskio-dm-1.rrd': Invalid argument
[FAIL]    Error parsing "/opt/librenms/rrd/nexus-c/ucd_diskio-dm-0.rrd" RRD ERROR: mmaping file '/opt/librenms/rrd/nexus-c/ucd_diskio-dm-0.rrd': Invalid argument
Status: 9656/9656 - Complete
```