### PR TITLE
Added ifOperStatus and ifAdminStatus _prev values to db.

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -410,6 +410,9 @@ foreach ($ports as $port) {
                     }
                 }
                 $port['update'][$oid] = $this_port[$oid];
+                if ($oid == 'ifOperStatus' || $oid == 'ifAdminStatus') {
+                    $port['update'][$oid.'_prev'] = $port[$oid];
+                }
                 log_event($oid.': '.$port[$oid].' -> '.$this_port[$oid], $device, 'interface', $port['port_id']);
                 if ($debug) {
                     d_echo($oid.': '.$port[$oid].' -> '.$this_port[$oid].' ');

--- a/sql-schema/099.sql
+++ b/sql-schema/099.sql
@@ -1,0 +1,2 @@
+ALTER TABLE  `ports` ADD  `ifOperStatus_prev` VARCHAR( 16 ) NULL AFTER  `ifOperStatus` ;
+ALTER TABLE  `ports` ADD  `ifAdminStatus_prev` VARCHAR( 16 ) NULL AFTER  `ifAdminStatus` ;


### PR DESCRIPTION
The new columns are NULL until a status change is detected in ifOperStatus or ifAdminStatus. At which point the old status is recorded.

This should allow people to create alerts where a port is normally down and then something is plugged in as we know it's previous state.