### PR TITLE
Updated parsing of alert rules to allow |

### DIFF
--- a/html/includes/forms/parse-alert-rule.inc.php
+++ b/html/includes/forms/parse-alert-rule.inc.php
@@ -20,7 +20,7 @@ $alert_id = $_POST['alert_id'];
 
 if (is_numeric($alert_id) && $alert_id > 0) {
     $rule               = dbFetchRow('SELECT * FROM `alert_rules` WHERE `id` = ? LIMIT 1', array($alert_id));
-    $rule_split         = preg_split('/([a-zA-Z0-9_\-\.\=\%\<\>\ \"\'\!\~\(\)\*\/\@]+[&&\|\|]+)/', $rule['rule'], -1, (PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY));
+    $rule_split         = preg_split('/([a-zA-Z0-9_\-\.\=\%\<\>\ \"\'\!\~\(\)\*\/\@\|]+[&&|\|\|]{2})/', $rule['rule'], -1, (PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY));
     $count              = (count($rule_split) - 1);
     $rule_split[$count] = $rule_split[$count].'  &&';
     $output             = array(


### PR DESCRIPTION
Shouldn't break anything, I have tested against a variety of existing rules with both AND and OR without issues.

Fix #2917