### PR TITLE
Quote snmp v2c community

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -776,8 +776,8 @@ function snmp_gen_auth(&$device) {
         }
     }
     else if ($device['snmpver'] === 'v2c' or $device['snmpver'] === 'v1') {
-        $cmd  = ' -'.$device['snmpver'];
-        $cmd .= ' -c '.$device['community'];
+        $cmd  = " -".$device['snmpver'];
+        $cmd .= " -c '".$device['community']."'";
     }
     else {
         if ($debug) {


### PR DESCRIPTION
- Quote the SNMP v2c community, v3 is already quoted.
- Change the snmpver to double quotes for consistency.

Fixes #2448