### PR TITLE
rrdcached hack to bypass is_file checks

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -176,6 +176,7 @@ function rrdtool($command, $filename, $options)
         ($command != "create" && $command != "tune"))
         ) {
         if (isset($config['rrdcached_dir']) && $config['rrdcached_dir'] !== false) {
+            $local_cmd = "$command $filename $options";
             $filename = str_replace($config['rrd_dir'].'/', './'.$config['rrdcached_dir'].'/', $filename);
             $filename = str_replace($config['rrd_dir'], './'.$config['rrdcached_dir'].'/', $filename);
         }
@@ -190,6 +191,7 @@ function rrdtool($command, $filename, $options)
         print $console_color->convert('[%rRRD Disabled%n]');
     }
     else {
+        if (!empty($local_cmd)) { fwrite($rrd_pipes[0], $local_cmd."\n"); }
         fwrite($rrd_pipes[0], $cmd."\n");
     }
 


### PR DESCRIPTION
The codebase has many, many is_file checks as part of the polling process even though rrdcached allows creates over the network now.  This hack writes both locally and to the network in order to satisfy the is_file checks.  Please note that the local files will only be created and never updated as updates happen on the network.