### PR TITLE
Added location_map_regex

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -83,6 +83,7 @@ LibreNMS contributors:
 - Maximilian Wilhelm <max@rfc2324.org> (BarbarossaTM)
 - Jameson Finney <jameson.finney@gmail.com> (JamesonFinney)
 - John Wells <john.wells@greatworx.com> (jbwiv)
+- Paul Blasquez <pblasquez@gmail.com> (pblasquez)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -379,10 +379,15 @@ NFSen integration support.
 
 #### Location mapping
 
+Exact Matching:
 ```php
 $config['location_map']['Under the Sink'] = "Under The Sink, The Office, London, UK";
 ```
-The above is an example, this will rewrite basic snmp locations so you don't need to configure full location within snmp.
+Regex Matching:
+```php
+$config['location_map']['/Sink/'] = "Under The Sink, The Office, London, UK";
+```
+The above are examples, these will rewrite device snmp locations so you don't need to configure full location within snmp.
 
 #### Interfaces to be ignored
 

--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -85,7 +85,7 @@ $poll_device['sysLocation'] = str_replace('"', '', $poll_device['sysLocation']);
 $poll_device['sysLocation'] = trim($poll_device['sysLocation'], '\\');
 
 // Rewrite sysLocation if there is a mapping array (database too?)
-if (!empty($poll_device['sysLocation']) && is_array($config['location_map'])) {
+if (!empty($poll_device['sysLocation']) && (is_array($config['location_map']) || is_array($config['location_map_regex']))) {
     $poll_device['sysLocation'] = rewrite_location($poll_device['sysLocation']);
 }
 

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -9,6 +9,7 @@ function rewrite_location($location) {
         foreach ($config['location_map_regex'] as $reg => $val) {
             if (preg_match($reg, $location)) {
                 $location = $val;
+                continue;
             }
         }
     }

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -5,6 +5,14 @@ function rewrite_location($location) {
     // FIXME -- also check the database for rewrites?
     global $config, $debug;
 
+    if (is_array($config['location_map_regex'])) {
+        foreach ($config['location_map_regex'] as $reg => $val) {
+            if (preg_match($reg, $location)) {
+                $location = $val;
+            }
+        }
+    }
+    
     if (isset($config['location_map'][$location])) {
         $location = $config['location_map'][$location];
     }


### PR DESCRIPTION
Allows location mapping based on case-sensitive regex. Example:

$config['location_map_regex']['/ASH1/'] = 'Ashburn, Virginia - ASH1';
$config['location_map_regex']['/PHX2/'] = 'Chandler, Arizona - PHX2';