### PR TITLE
Updates for Windows 10

### DIFF
--- a/includes/polling/os/windows.inc.php
+++ b/includes/polling/os/windows.inc.php
@@ -28,7 +28,7 @@ if (strstr($poll_device['sysDescr'], 'Intel64')) {
     $hardware = 'Intel x64';
 }
 
-if ($poll_device['sysObjectID'] == '.1.3.6.1.4.1.311.1.1.3.1.1') {
+if ($poll_device['sysObjectID'] == 'enterprises.311.1.1.3.1.1') {
     if (strstr($poll_device['sysDescr'], 'Build Number: 1057')) {
         $version = 'NT 3.51 Workstation';
     }
@@ -79,6 +79,10 @@ if ($poll_device['sysObjectID'] == '.1.3.6.1.4.1.311.1.1.3.1.1') {
 
     if (strstr($poll_device['sysDescr'], 'Build 9600')) {
         $version = '8.1 SP1 (NT 6.2)';
+    }
+
+    if (strstr($poll_device['sysDescr'], 'Version 6.3 (Build 10')) {
+        $version = '10 (NT 6.3)';
     }
 
 }


### PR DESCRIPTION
Hi,

Not sure this is 100% ready yet, but want to flag this - by all means comment!

The changes are (reverse order, for a reason),
2) Recognize Windows 10. Builds are 10xxx (> 10000), so just look for the 10 at the start.
1) I checked the response for sysObjectID, and it seems to be returning 'enterprises' rather than .1.3.6.1.4.1 ... is that just me? In any case, without this change - the Windows version checks were not being run.

Thanks!