### PR TITLE
Ignore devices that do not provide an uptime statistic.

### DIFF
--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -53,7 +53,7 @@ else {
     foreach(dbFetchRows($sql, $param) as $device) {
         if ($device['status'] == '1') {
             $btn_type = 'btn-success';
-            if ($device['uptime'] < $config['uptime_warning']) {
+            if (($device['uptime'] < $config['uptime_warning']) && ($device['uptime'] != '0')) {
                 $btn_type = 'btn-warning';
                 $c++;
             }


### PR DESCRIPTION
Hundreds of my devices do not supply an uptime in their data.  This causes lots of useless warnings in my availability map.  This tweak corrects that.