### PR TITLE
skip graph.php authentication if configured

### DIFF
--- a/html/graph.php
+++ b/html/graph.php
@@ -40,8 +40,9 @@ require_once '../includes/dbFacile.php';
 require_once '../includes/rewrites.php';
 require_once 'includes/functions.inc.php';
 require_once '../includes/rrdtool.inc.php';
-require_once 'includes/authenticate.inc.php';
-
+if($config['allow_unauth_graphs'] == 0) {
+  require_once 'includes/authenticate.inc.php';
+}
 require 'includes/graphs/graph.inc.php';
 
 $console_color = new Console_Color2();


### PR DESCRIPTION
Major overhead is saved by skipping graph.php authentication entirely if $config['allow_unauth_graphs'] == 1.