### PR TITLE
Use unique id for bootgrid table in alert widget

### DIFF
--- a/html/includes/common/alerts.inc.php
+++ b/html/includes/common/alerts.inc.php
@@ -148,7 +148,6 @@ else {
     $widget_settings['title'] = $title;
 
     $group        = $widget_settings['group'];
-    $widget_id    = (int)$_POST['id'];
 
     $common_output[] = '
 <div class="row">
@@ -157,7 +156,7 @@ else {
     </div>
 </div>
 <div class="table-responsive">
-    <table id="alerts_'.$widget_id.'" class="table table-hover table-condensed alerts">
+    <table id="alerts_'.$unique_id.'" class="table table-hover table-condensed alerts">
         <thead>
             <tr>
                 <th data-column-id="status" data-formatter="status" data-sortable="false">Status</th>
@@ -172,7 +171,7 @@ else {
     </table>
 </div>
 <script>
-var alerts_grid = $("#alerts_'.$widget_id.'").bootgrid({
+var alerts_grid = $("#alerts_'.$unique_id.'").bootgrid({
     ajax: true,
     post: function ()
     {

--- a/html/includes/common/alerts.inc.php
+++ b/html/includes/common/alerts.inc.php
@@ -148,6 +148,7 @@ else {
     $widget_settings['title'] = $title;
 
     $group        = $widget_settings['group'];
+    $widget_id    = (int)$_POST['id'];
 
     $common_output[] = '
 <div class="row">
@@ -156,7 +157,7 @@ else {
     </div>
 </div>
 <div class="table-responsive">
-    <table id="alerts" class="table table-hover table-condensed alerts">
+    <table id="alerts_'.$widget_id.'" class="table table-hover table-condensed alerts">
         <thead>
             <tr>
                 <th data-column-id="status" data-formatter="status" data-sortable="false">Status</th>
@@ -171,7 +172,7 @@ else {
     </table>
 </div>
 <script>
-var alerts_grid = $("#alerts").bootgrid({
+var alerts_grid = $("#alerts_'.$widget_id.'").bootgrid({
     ajax: true,
     post: function ()
     {


### PR DESCRIPTION
Use unique id for bootgrid table in alerts widget to allow more than one widget on the same dashboard to function properly.