### PR TITLE
Missing SystemExit

### DIFF
--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -163,6 +163,8 @@ if ('distributed_poller' in config and
             print "Could not connect to memcached, disabling distributed poller."
             distpoll = False
             IsNode = False
+    except SystemExit:
+        raise
     except ImportError:
         print "ERROR: missing memcache python module:"
         print "On deb systems: apt-get install python-memcache"


### PR DESCRIPTION
When there is a sysexit() in a try block, it must be matched by an except SystemExit: or the script will not actually exit.