### PR TITLE
updated timeSinceTopologyChange to be an int as it can not be used within alerts

### DIFF
--- a/sql-schema/103.sql
+++ b/sql-schema/103.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `stp` CHANGE  `timeSinceTopologyChange`  `timeSinceTopologyChange` INT UNSIGNED NOT NULL


### PR DESCRIPTION
Fix #3023 

I've snuck this in before the other schema pr as that still needs a rebase and this has been confirmed to be working.