### PR TITLE
Disabling auto-updates doesn't work

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -18,6 +18,10 @@ if (isset($options['d'])) {
 }
 
 if ($options['f'] === 'update') {
+    if (!$config['update']) {
+        exit(0);
+    }
+
     $innodb_buffer = innodb_buffer_check();
     if ($innodb_buffer['used'] > $innodb_buffer['size']) {
         if (!empty($config['alert']['default_mail'])) {
@@ -39,19 +43,14 @@ The ' . $config['project_name'] . ' team.';
         echo warn_innodb_buffer($innodb_buffer);
         exit(2);
     }
-    else {
-        if ($config['update']) {
-            if ($config['update_channel'] == 'master') {
-                exit(1);
-            }
-            elseif ($config['update_channel'] == 'release') {
-                exit(3);
-            }
-        }
-        else {
-            exit(0);
-        }
+
+    if ($config['update_channel'] == 'master') {
+        exit(1);
     }
+    elseif ($config['update_channel'] == 'release') {
+        exit(3);
+    }
+    exit(0);
 }
 
 if ($options['f'] === 'syslog') {

--- a/daily.sh
+++ b/daily.sh
@@ -33,7 +33,11 @@ status_run() {
 
 if [ -z "$arg" ]; then
     up=$(php daily.php -f update >&2; echo $?)
-    if [ "$up" -eq 1 ]; then
+    if [ "$up" -eq 0 ]; then
+        # Updates are disabled.
+        status_run 'Cleaning up DB' "$0 cleanup"
+        exit $?
+    elif [ "$up" -eq 1 ]; then
         # Update to Master-Branch
         status_run 'Updating to latest codebase' 'git pull --quiet'
     elif [ "$up" -eq 3 ]; then


### PR DESCRIPTION
Disabling auto-updates doesn't actually disable them.

1) It still does the innodb check (I'm not sure what this is for, if the pools are incorrect, that may affect performance but it won't stop a schema from being upgraded).

2) It still does the post-pull tasks (trying to update the db schema, update the submodules).

Made it do the auto-update check before doing anything else and if it's disabled, then the daily script will only do the db clean up.
