### PR TITLE
Disabling auto-updates doesn't work

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -18,6 +18,10 @@ if (isset($options['d'])) {
 }
 
 if ($options['f'] === 'update') {
+    if (!$config['update']) {
+        exit(0);
+    }
+
     $innodb_buffer = innodb_buffer_check();
     if ($innodb_buffer['used'] > $innodb_buffer['size']) {
         if (!empty($config['alert']['default_mail'])) {
@@ -39,19 +43,14 @@ The ' . $config['project_name'] . ' team.';
         echo warn_innodb_buffer($innodb_buffer);
         exit(2);
     }
-    else {
-        if ($config['update']) {
-            if ($config['update_channel'] == 'master') {
-                exit(1);
-            }
-            elseif ($config['update_channel'] == 'release') {
-                exit(3);
-            }
-        }
-        else {
-            exit(0);
-        }
+
+    if ($config['update_channel'] == 'master') {
+        exit(1);
     }
+    elseif ($config['update_channel'] == 'release') {
+        exit(3);
+    }
+    exit(0);
 }
 
 if ($options['f'] === 'syslog') {

--- a/daily.sh
+++ b/daily.sh
@@ -33,7 +33,11 @@ status_run() {
 
 if [ -z "$arg" ]; then
     up=$(php daily.php -f update >&2; echo $?)
-    if [ "$up" -eq 1 ]; then
+    if [ "$up" -eq 0 ]; then
+        # Updates are disabled.
+        status_run 'Cleaning up DB' "$0 cleanup"
+        exit $?
+    elif [ "$up" -eq 1 ]; then
         # Update to Master-Branch
         status_run 'Updating to latest codebase' 'git pull --quiet'
     elif [ "$up" -eq 3 ]; then

--- a/daily.sh
+++ b/daily.sh
@@ -34,9 +34,8 @@ status_run() {
 if [ -z "$arg" ]; then
     up=$(php daily.php -f update >&2; echo $?)
     if [ "$up" -eq 0 ]; then
-        # Updates are disabled.
-        status_run 'Cleaning up DB' "$0 cleanup"
-        exit $?
+        $0 no-code-update
+        exit
     elif [ "$up" -eq 1 ]; then
         # Update to Master-Branch
         status_run 'Updating to latest codebase' 'git pull --quiet'
@@ -53,6 +52,12 @@ if [ -z "$arg" ]; then
     fi
 else
     case $arg in
+        no-code-update)
+            # Updates of the code are disabled, just check for schema updates
+            # and clean up the db.
+            status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'
+            status_run 'Cleaning up DB' "$0 cleanup"
+        ;;
         post-pull)
             # List all tasks to do after pull in the order of execution
             status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'


### PR DESCRIPTION
Disabling auto-updates doesn't actually disable them.

1) It still does the innodb check (I'm not sure what this is for, if the pools are incorrect, that may affect performance but it won't stop a schema from being upgraded).

2) It still does the post-pull tasks (trying to update the submodules).

Made it do the auto-update check before doing anything else and if it's disabled, then the daily script will check for any schema changes to be applied and a db cleanup.
