### PR TITLE
Eaton UPS - OS Discovery

### DIFF
--- a/includes/discovery/os/eatonups.inc.php
+++ b/includes/discovery/os/eatonups.inc.php
@@ -1,0 +1,7 @@
+<?php
+if (!$os) {
+    // Eaton UPS
+    if (strstr($sysDescr, 'Eaton 5PX')) {
+        $os = 'eatonups';
+    }
+}


### PR DESCRIPTION
I added this file in my local LibreNMS installation to discover my Eaton 5PX UPS. An other file is also needed :
librenms/includes/discovery/sensors/current/eatonups.inc.php