### PR TITLE
Populate device icon in the database

### DIFF
--- a/includes/discovery/os.inc.php
+++ b/includes/discovery/os.inc.php
@@ -5,10 +5,15 @@ echo 'OS: ';
 // MYSQL Check - FIXME
 // 1 UPDATE
 $os = getHostOS($device);
+if ($os != $device['os'] || empty($device['icon'])) {
+    $device['os'] = $os;
 
-if ($os != $device['os']) {
-    $sql = dbUpdate(array('os' => $os), 'devices', 'device_id=?', array($device['device_id']));
+    // update icon
+    $icon = getImageName($device, false);
+    $device['icon'] = $icon;
+
+
+    $sql = dbUpdate(array('os' => $os, 'icon' => $icon), 'devices', 'device_id=?', array($device['device_id']));
     echo "Changed OS! : $os\n";
     log_event('Device OS changed '.$device['os']." => $os", $device, 'system');
-    $device['os'] = $os;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -153,33 +153,41 @@ function getImage($device) {
 }
 
 function getImageSrc($device) {
+    // is base_url needed?
+    return '/images/os/' . getImageName($device) . '.png';
+}
+
+function getImageName($device, $use_database=true) {
     global $config;
 
     $device['os'] = strtolower($device['os']);
 
-    if (!empty($device['icon']) && file_exists($config['html_dir'] . "/images/os/" . $device['icon'] . ".png")) {
-        $image = $config['base_url'] . '/images/os/' . $device['icon'] . '.png';
+    // fetch from the database
+    if ($use_database && !empty($device['icon']) && file_exists($config['html_dir'] . "/images/os/" . $device['icon'] . ".png")) {
+        return $device['icon'];
     }
-    elseif (!empty($config['os'][$device['os']]['icon']) && file_exists($config['html_dir'] . "/images/os/" . $config['os'][$device['os']]['icon'] . ".png")) {
-        $image = $config['base_url'] . '/images/os/' . $config['os'][$device['os']]['icon'] . '.png';
-    }
-    else {
-        if (file_exists($config['html_dir'] . '/images/os/' . $device['os'] . '.png')) {
-            $image = $config['base_url'] . '/images/os/' . $device['os'] . '.png';
-        }
-        if ($device['os'] == "linux") {
-            $features = strtolower(trim($device['features']));
-            list($distro) = explode(" ", $features);
-            if (file_exists($config['html_dir'] . "/images/os/$distro" . ".png")) {
-                $image = $config['base_url'] . '/images/os/' . $distro . '.png';
-            }
-        }
-        if (empty($image)) {
-            $image = $config['base_url'] . '/images/os/generic.png';
+
+    // linux specific handling, distro icons
+    if ($device['os'] == "linux") {
+        $features = strtolower(trim($device['features']));
+        list($distro) = explode(" ", $features);
+        if (file_exists($config['html_dir'] . "/images/os/$distro" . ".png")) {
+            return $distro;
         }
     }
 
-    return $image;
+    // use the icon from os config
+    if (!empty($config['os'][$device['os']]['icon']) && file_exists($config['html_dir'] . "/images/os/" . $config['os'][$device['os']]['icon'] . ".png")) {
+        return $config['os'][$device['os']]['icon'];
+    }
+
+    // guess the icon has the same name as the os
+    if (file_exists($config['html_dir'] . '/images/os/' . $device['os'] . '.png')) {
+        return $device['os'];
+    }
+
+    // fallback to the generic icon
+    return 'generic';
 }
 
 function renamehost($id, $new, $source = 'console') {


### PR DESCRIPTION
The icon field was originally set up as an override for the display option but the only way to set it currently is directly in the DB afaik.
Populate the icon field during discovery, this should move a little execution from page display time to discovery time.
v2