### PR TITLE
Enlarge device purpose (description) field

### DIFF
--- a/html/pages/device/edit/device.inc.php
+++ b/html/pages/device/edit/device.inc.php
@@ -86,7 +86,7 @@ elseif ($update_message) {
     <div class="form-group">
         <label for="descr" class="col-sm-2 control-label">Description:</label>
         <div class="col-sm-6">
-            <input id="descr" name="descr" value="<?php echo($device['purpose']); ?>" class="form-control">
+            <textarea id="descr" name="descr" class="form-control"><?php echo($device['purpose']); ?></textarea>
         </div>
     </div>
     <div class="form-group">

--- a/sql-schema/104.sql
+++ b/sql-schema/104.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `devices` CHANGE `purpose` `purpose` text CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;


### PR DESCRIPTION
We're using the device's purpose (description) field for some double bookkeeping and would've liked the field to be a bit longer. That's simply what this PR does.