### PR TITLE
Polling group check should not require distributed polling

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -125,7 +125,7 @@ require 'includes/sql-schema/update.php';
 
 $discovered_devices = 0;
 
-if ($config['distributed_poller'] === true) {
+if (!empty($config['distributed_poller_group'])) {
     $where .= ' AND poller_group IN('.$config['distributed_poller_group'].')';
 }
 


### PR DESCRIPTION
distributed_polling_group and distributed_polling will be standalone configurations with this change.