### PR TITLE
Updated Apps layout to use panels

### DIFF
--- a/html/pages/device/apps/drbd.inc.php
+++ b/html/pages/device/apps/drbd.inc.php
@@ -16,11 +16,14 @@ foreach ($graphs as $key => $text) {
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
 
-    echo '<h3>'.$text.'</h3>';
-
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/mailscanner.inc.php
+++ b/html/pages/device/apps/mailscanner.inc.php
@@ -16,10 +16,14 @@ foreach ($graphs as $key => $text) {
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
 
-    echo '<h3>'.$text.'</h3>';
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/memcached.inc.php
+++ b/html/pages/device/apps/memcached.inc.php
@@ -19,11 +19,14 @@ foreach ($graphs as $key => $text) {
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
 
-    echo '<h3>'.$text.'</h3>';
-
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/mysql.inc.php
+++ b/html/pages/device/apps/mysql.inc.php
@@ -70,11 +70,15 @@ foreach ($graphs[$vars['app_section']] as $key => $text) {
     $graph_array['to']     = $config['time']['now'];
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
-    echo '<h3>'.$text.'</h3>';
-
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/nginx.inc.php
+++ b/html/pages/device/apps/nginx.inc.php
@@ -14,11 +14,15 @@ foreach ($graphs as $key => $text) {
     $graph_array['to']     = $config['time']['now'];
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
-    echo '<h3>'.$text.'</h3>';
 
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/ntp-client.inc.php
+++ b/html/pages/device/apps/ntp-client.inc.php
@@ -14,10 +14,15 @@ foreach ($graphs as $key => $text) {
     $graph_array['to']     = $config['time']['now'];
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
-    echo '<h3>'.$text.'</h3>';
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/ntpd-server.inc.php
+++ b/html/pages/device/apps/ntpd-server.inc.php
@@ -19,10 +19,15 @@ foreach ($graphs as $key => $text) {
     $graph_array['to']     = $config['time']['now'];
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
-    echo '<h3>'.$text.'</h3>';
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
 
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/powerdns.inc.php
+++ b/html/pages/device/apps/powerdns.inc.php
@@ -20,11 +20,14 @@ foreach ($graphs as $key => $text) {
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
 
-    echo '<h3>'.$text.'</h3>';
-
-    echo "<tr bgcolor='$row_colour'><td colspan=5>";
-
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }

--- a/html/pages/device/apps/shoutcast.inc.php
+++ b/html/pages/device/apps/shoutcast.inc.php
@@ -30,12 +30,17 @@ if (isset($total) && $total === true) {
         $graph_array['to']     = $config['time']['now'];
         $graph_array['id']     = $app['app_id'];
         $graph_array['type']   = 'application_'.$key;
-        echo '<h3>'.$text.'</h3>';
-        echo "<tr bgcolor='$row_colour'><td colspan=5>";
 
+        echo '<div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">'.$text.'</h3>
+        </div>
+        <div class="panel-body">
+        <div class="row">';
         include 'includes/print-graphrow.inc.php';
-
-        echo '</td></tr>';
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
     }
 }
 

--- a/html/pages/device/apps/tinydns.inc.php
+++ b/html/pages/device/apps/tinydns.inc.php
@@ -39,7 +39,15 @@ foreach ($graphs as $key => $text) {
     $graph_array['to']     = $config['time']['now'];
     $graph_array['id']     = $app['app_id'];
     $graph_array['type']   = 'application_'.$key;
-    echo "<h3>$text</h3><tr bgcolor='$row_colour'><td colspan=5>";
+    
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
     include 'includes/print-graphrow.inc.php';
-    echo '</td></tr>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 }


### PR DESCRIPTION
The App pages were still using a table-based layout (e.g. included TR when there is no open table).  This PR updates them to use the same markup style used on the Graphs pages, using a bootstrap panel.

**BEFORE:** ![before](https://cloud.githubusercontent.com/assets/1608083/13395847/2cb11cb0-dee9-11e5-8dc5-ab5311da6fa3.png)             **AFTER:** ![after](https://cloud.githubusercontent.com/assets/1608083/13395846/2cb0ad0c-dee9-11e5-9634-eaa1b07e0cf5.png)

I've only got memcached and mysql installed locally so unable to test the other apps, but I only replaced markup which looked identical to those on the mysql/memcache pages.
