### PR TITLE
Billing Module reports constant traffic if Interface Counters don't change

### DIFF
--- a/poll-billing.php
+++ b/poll-billing.php
@@ -59,7 +59,7 @@ function CollectData($bill_id) {
         if ($last_data['state'] == 'ok') {
             $port_data['last_in_measurement'] = $last_data[counter];
             $port_data['last_in_delta']       = $last_data[delta];
-            if ($port_data['in_measurement'] > $port_data['last_in_measurement']) {
+            if ($port_data['in_measurement'] >= $port_data['last_in_measurement']) {
                 $port_data['in_delta'] = ($port_data['in_measurement'] - $port_data['last_in_measurement']);
             }
             else {
@@ -76,7 +76,7 @@ function CollectData($bill_id) {
         if ($last_data[state] == 'ok') {
             $port_data['last_out_measurement'] = $last_data[counter];
             $port_data['last_out_delta']       = $last_data[delta];
-            if ($port_data['out_measurement'] > $port_data['last_out_measurement']) {
+            if ($port_data['out_measurement'] >= $port_data['last_out_measurement']) {
                 $port_data['out_delta'] = ($port_data['out_measurement'] - $port_data['last_out_measurement']);
             }
             else {


### PR DESCRIPTION
We've noticed that if the port counters on a billed port don't change over a polling interval, the delta for that port is reported as the last recorded delta, rather than 0.  This was spotted in a live environment because a down port was reporting high constant traffic in the billing module, even though the RRD port graphs were fine.

Using a test install and running the poller by hand in order to generate test data, this is the value of port_in_measurements (the delta value goes into bill_data).

```
+---------+---------------------+------------+-------+
| port_id | timestamp           | counter    | delta |
+---------+---------------------+------------+-------+
|    1175 | 2016-03-01 12:37:08 | 3788125760 |  1173 |
|    1175 | 2016-03-01 12:37:54 | 3788126799 |  1039 |  Counter Increments, Delta correct
|    1175 | 2016-03-01 12:37:59 | 3788126799 |  1039 |  Counter stays same, Delta wrong!
+---------+---------------------+------------+-------+
```

This looks like a problem in the code for detecting a counter reset, and is a simple < vs <= error.  I'm not 100% sure what the intention behind reusing the last value in the event of a counter rollover is, but I'm pretty sure it's not meant to be used if the counter doesn't change.

With this fix in place:

```
+---------+---------------------+------------+-------+
| port_id | timestamp           | counter    | delta |
+---------+---------------------+------------+-------+
|    1175 | 2016-03-01 12:40:42 | 3788132407 |  2347 |
|    1175 | 2016-03-01 12:41:03 | 3788132541 |   134 |
|    1175 | 2016-03-01 12:41:04 | 3788132541 |     0 |  Same counter, delta now correct = 0
+---------+---------------------+------------+-------+
```