### PR TITLE
Improve performance of billing poller

### DIFF
--- a/includes/billing.php
+++ b/includes/billing.php
@@ -82,10 +82,8 @@ function getValue($host, $port, $id, $inout) {
 
 function getLastPortCounter($port_id, $inout) {
     $return = array();
-    $rows   = dbFetchCell('SELECT count(counter) from `port_'.mres($inout)."_measurements` WHERE `port_id`='".mres($port_id)."'");
-
-    if ($rows > 0) {
-        $row             = dbFetchRow('SELECT counter,delta FROM `port_'.mres($inout)."_measurements` WHERE `port_id`='".mres($port_id)."' ORDER BY timestamp DESC");
+    $row    = dbFetchRow('SELECT counter,delta FROM `port_'.mres($inout)."_measurements` WHERE `port_id`='".mres($port_id)."' ORDER BY timestamp DESC LIMIT 1");
+    if (!is_null($row)) {
         $return[counter] = $row['counter'];
         $return[delta]   = $row['delta'];
         $return[state]   = 'ok';
@@ -101,10 +99,8 @@ function getLastPortCounter($port_id, $inout) {
 
 function getLastMeasurement($bill_id) {
     $return = array();
-    $rows   = dbFetchCell("SELECT count(delta) from bill_data WHERE bill_id='".mres($bill_id)."'");
-
-    if ($rows > 0) {
-        $row               = dbFetchRow("SELECT timestamp,delta,in_delta,out_delta FROM bill_data WHERE bill_id='".mres($bill_id)."' ORDER BY timestamp DESC");
+    $row    = dbFetchRow("SELECT timestamp,delta,in_delta,out_delta FROM bill_data WHERE bill_id='".mres($bill_id)."' ORDER BY timestamp DESC LIMIT 1");
+    if (!is_null($row)) {
         $return[delta]     = $row['delta'];
         $return[delta_in]  = $row['delta_in'];
         $return[delta_out] = $row['delta_out'];

--- a/sql-schema/106.sql
+++ b/sql-schema/106.sql
@@ -1,0 +1,3 @@
+ALTER TABLE port_in_measurements ADD INDEX (`port_id`, `timestamp`);
+ALTER TABLE port_out_measurements ADD INDEX (`port_id`, `timestamp`);
+ALTER TABLE bill_data ADD INDEX (`bill_id`, `timestamp`);


### PR DESCRIPTION
This partly addresses #3115 by adding indexes (non-unique because duplicate data is present) and optimises the queries used by the billing module poller.  These changes improved the performance drastically on our installation - the billing poller previously was taking significantly over 5 minutes to run without them, and 40 seconds with these changes.

Please note, adding the indexes can take some time on systems with lots of billing history, so the DB update script might take a few minutes to run.

The unnecessary tables and duplicate data can be dealt with separately.