### PR TITLE
API transport update to transmit JSON datas

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -125,7 +125,7 @@ require 'includes/sql-schema/update.php';
 
 $discovered_devices = 0;
 
-if ($config['distributed_poller'] === true) {
+if (!empty($config['distributed_poller_group'])) {
     $where .= ' AND poller_group IN('.$config['distributed_poller_group'].')';
 }
 

--- a/includes/alerts/transport.api.php
+++ b/includes/alerts/transport.api.php
@@ -26,15 +26,22 @@ foreach( $opts as $method=>$apis ) {
     foreach( $apis as $api ) {
         //		var_dump($api); //FIXME: propper debuging
         list($host, $api) = explode("?",$api,2);
+        $datas=array();
+        foreach (explode ("&",$api) as $fields) {
+            $field = explode ("=",$fields);
+            $datas[$field[0]] = $field[1];
+        }
+        $json_datas = json_encode($datas);
         foreach( $obj as $k=>$v ) {
-            $api = str_replace("%".$k,$method == "get" ? urlencode($v) : $v, $api);
+            $json_datas = str_replace("%".$k, $v, $json_datas);
         }
         //		var_dump($api); //FIXME: propper debuging
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, ($method == "get" ? $host."?".$api : $host) );
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, strtoupper($method));
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $api);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $json_datas);
         $ret = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         if( $code != 200 ) {


### PR DESCRIPTION
Hi,

We would like to make librenms send notifications to a tool like [canopsis ](http://www.canopsis.org/)through API transport. The [canopsis API](http://www.canopsis.org/wp-content/themes/canopsis/doc/sakura/developer-guide/REST/rest-api.html) use JSON datas. This pull request propose you to send JSON datas. It should be completed with an option in the WebUI to propose both sending method. This is just a proposal.

With the transport configured like this...

> http://my.api.server/api/test?severity=%severity&msg=%msg

..., here is an example of datas that could be received by a JSON API (with a `var_dump ((object)json_decode($data_received));`) :

```
object(stdClass)#2 (2) {
  ["severity"]=>
  string(8) "critical"
  ["msg"]=>
  string(331) "Alert for device 172.16.0.247 - Test_Device_Down
Severity: critical
Timestamp: 2016-03-02 16:10:02
Unique-ID: 31
Rule: Test_Device_Down
Faults:
  #1: sysObjectID => enterprises.25506.11.1.23; sysDescr => HP Comware Platform Software, Software Version 5.20.105, Release 1809P06;
Alert sent to: librenms <librenms@localhost> "
}
```

What's your opinion ?