### PR TITLE
The rotating box between Top 10 devices, and Top 10 ports is not wide…

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -488,7 +488,7 @@ a.list-device-disabled, a.list-device-disabled:visited {
 }
 
 .box {
-  width: 350px;
+  width: 500px;
   height: 300px;
   padding: 0px;
   vertical-align: center;


### PR DESCRIPTION
The rotating box between Top 10 devices, and Top 10 ports is not wide enough when it is on the Top 10 ports. This causes the box to extend down over the Summary box below.

![image](https://cloud.githubusercontent.com/assets/1226821/13466617/9d64883e-e092-11e5-8654-cfd242ce6cf6.png)

I've grep'd the source for class=box and class="box, and cannot find anywhere else this CSS is used, so should be safe to change.

If you need me to sign a contributes agreement, point me in the right direction.