### PR TITLE
Previous Billing Period view links directly to historical usage

### DIFF
--- a/html/pages/bills/pmonth.inc.php
+++ b/html/pages/bills/pmonth.inc.php
@@ -52,7 +52,7 @@ foreach (dbFetchRows('SELECT * FROM `bills` ORDER BY `bill_name`') as $bill) {
 
             echo "
                 <tr style=\"background: $row_colour;\">
-                <td><a href=\"".generate_url(array('page' => 'bill', 'bill_id' => $bill['bill_id'])).'"><span style="font-weight: bold;" class="interface">'.$bill['bill_name'].'</a></span><br />from '.strftime('%x', strtotime($datefrom)).' to '.strftime('%x', strtotime($dateto))."</td>
+                <td><a href=\"".generate_url(array('page' => 'bill', 'bill_id' => $bill['bill_id'], 'view' => 'history', detail => $history['bill_hist_id'])).'"><span style="font-weight: bold;" class="interface">'.$bill['bill_name'].'</a></span><br />from '.strftime('%x', strtotime($datefrom)).' to '.strftime('%x', strtotime($dateto))."</td>
                 <td>$type</td>
                 <td>$allowed</td>
                 <td>$in</td>


### PR DESCRIPTION
Clicking from a bill in the "Previous Billing Period" view of the billing section will now link directly to the historical usage page for that period, rather than to the current usage page.

Fixes #2402.