### PR TITLE
Alert template transport

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -121,8 +121,6 @@ function IssueAlert($alert) {
     $obj = DescribeAlert($alert);
     if (is_array($obj)) {
         echo 'Issuing Alert-UID #'.$alert['id'].'/'.$alert['state'].': ';
-        $msg        = FormatAlertTpl($obj);
-        $obj['msg'] = $msg;
         if (!empty($config['alert']['transports'])) {
             ExtTransports($obj);
         }
@@ -336,6 +334,9 @@ function ExtTransports($obj) {
             $opts = array_filter($opts);
         }
         if (($opts === true || !empty($opts)) && $opts != false && file_exists($config['install_dir'].'/includes/alerts/transport.'.$transport.'.php')) {
+            $obj['transport'] = $transport;
+            $msg        = FormatAlertTpl($obj);
+            $obj['msg'] = $msg;
             echo $transport.' => ';
             eval('$tmp = function($obj,$opts) { global $config; '.file_get_contents($config['install_dir'].'/includes/alerts/transport.'.$transport.'.php').' return false; };');
             $tmp = $tmp($obj,$opts);

--- a/alerts.php
+++ b/alerts.php
@@ -360,13 +360,25 @@ function ExtTransports($obj) {
 
 
 /**
+ * Escape certain characters in template string
+ * @param string $tpl Template
+ * @return string
+ */
+function TplEscape($tpl) {
+    // theoretically like addslashes(), but don't escape single quote (') and do escape $
+    // FIXME: is there still a way to break out of the double-quoted string, maybe with a unicode char?
+    return preg_replace('(["\\\\$\\0])','\\0',$tpl);
+}
+
+
+/**
  * Format Alert
  * @param array  $obj Alert-Array
  * @return string
  */
 function FormatAlertTpl($obj) {
     $tpl    = $obj["template"];
-    $msg    = '$ret .= "'.str_replace(array('{else}', '{/if}', '{/foreach}'), array('"; } else { $ret .= "', '"; } $ret .= "', '"; } $ret .= "'), addslashes($tpl)).'";';
+    $msg    = '$ret .= "'.str_replace(array('{else}', '{/if}', '{/foreach}'), array('"; } else { $ret .= "', '"; } $ret .= "', '"; } $ret .= "'), TplEscape($tpl)).'";';
     $parsed = $msg;
     $s      = strlen($msg);
     $x      = $pos = -1;

--- a/alerts.php
+++ b/alerts.php
@@ -360,25 +360,13 @@ function ExtTransports($obj) {
 
 
 /**
- * Escape certain characters in template string
- * @param string $tpl Template
- * @return string
- */
-function TplEscape($tpl) {
-    // theoretically like addslashes(), but don't escape single quote (') and do escape $
-    // FIXME: is there still a way to break out of the double-quoted string, maybe with a unicode char?
-    return preg_replace('(["\\\\$\\0])','\\0',$tpl);
-}
-
-
-/**
  * Format Alert
  * @param array  $obj Alert-Array
  * @return string
  */
 function FormatAlertTpl($obj) {
     $tpl    = $obj["template"];
-    $msg    = '$ret .= "'.str_replace(array('{else}', '{/if}', '{/foreach}'), array('"; } else { $ret .= "', '"; } $ret .= "', '"; } $ret .= "'), TplEscape($tpl)).'";';
+    $msg    = '$ret .= "'.str_replace(array('{else}', '{/if}', '{/foreach}'), array('"; } else { $ret .= "', '"; } $ret .= "', '"; } $ret .= "'), addslashes($tpl)).'";';
     $parsed = $msg;
     $s      = strlen($msg);
     $x      = $pos = -1;

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -99,7 +99,7 @@ The template-parser understands `if` and `foreach` controls and replaces certain
 Controls:
 
 - if-else (Else can be omitted):
-`{if %placeholder == 'value'}Some Text{else}Other Text{/if}`
+`{if %placeholder == value}Some Text{else}Other Text{/if}`
 - foreach-loop:
 `{foreach %placeholder}Key: %key<br/>Value: %value{/foreach}`
 
@@ -139,7 +139,7 @@ Alert sent to: {foreach %contacts}%value <%key> {/foreach}
 
 Conditional formatting example, will display a link to the host in email or just the hostname in any other transport:
 ```text
-{if %transport == 'mail'}<a href='https://my.librenms.install/device/device=%hostname/'>%hostname</a>{else}%hostname{/if}
+{if %transport == mail}<a href='https://my.librenms.install/device/device=%hostname/'>%hostname</a>{else}%hostname{/if}
 ```
 
 # <a name="transports">Transports</a>

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -139,8 +139,11 @@ Alert sent to: {foreach %contacts}%value <%key> {/foreach}
 
 Conditional formatting example, will display a link to the host in email or just the hostname in any other transport:
 ```text
-{if %transport == mail}<a href='https://my.librenms.install/device/device=%hostname/'>%hostname</a>{else}%hostname{/if}
+{if %transport == mail}<a href="https://my.librenms.install/device/device=%hostname/">%hostname</a>{else}%hostname{/if}
 ```
+
+Note the use of double-quotes.  Single quotes (`'`) in templates will be escaped (replaced with `\'`) in the output and should therefore be avoided.
+
 
 # <a name="transports">Transports</a>
 

--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -116,6 +116,7 @@ Placeholders:
 - Rule: `%rule`
 - Rule-Name: `%name`
 - Timestamp: `%timestamp`
+- Transport name: `%transport`
 - Contacts, must be iterated in a foreach, `%key` holds email and `%value` holds name: `%contacts`
 
 The Default Template is a 'one-size-fit-all'. We highly recommend defining own templates for your rules to include more specific information.
@@ -134,6 +135,11 @@ Rule: {if %name}%name{else}%rule{/if}\r\n
 {if %faults}Faults:\r\n
 {foreach %faults}  #%key: %value.string\r\n{/foreach}{/if}
 Alert sent to: {foreach %contacts}%value <%key> {/foreach}
+```
+
+Conditional formatting example, will display a link to the host in email or just the hostname in any other transport:
+```text
+{if %transport == 'mail'}<a href='https://my.librenms.install/device/device=%hostname/'>%hostname</a>{else}%hostname{/if}
 ```
 
 # <a name="transports">Transports</a>


### PR DESCRIPTION
Resolves #3125 in a different way.  Gives access to the transport name within the template to allow things such as:

    {if %transport == mail}something email-specific{/if}