### PR TITLE
Stop double escaping the notes post variable.

### DIFF
--- a/html/includes/forms/update-notes.inc.php
+++ b/html/includes/forms/update-notes.inc.php
@@ -14,7 +14,7 @@ $status    = 'error';
 $message   = 'unknown error';
 
 $device_id = mres($_POST['device_id']);
-$notes = mres($_POST['notes']);
+$notes = $_POST['notes'];
 
 if (isset($notes) && (dbUpdate(array('notes' => $notes), 'devices', 'device_id = ?', array($device_id)))) {
     $status  = 'ok';


### PR DESCRIPTION
Patch the symptom not the problem!

Looks like we are using 'mres' to escape variables on user input, but also escaping them down in dbFacile.  This means certain characters will be double escaped and will be converted to plain text.

This was tested with dbFacile.mysqli, not db.Facile.mysql.

We should probably go through the code base and tidy up other instances of double escaping, but it will usually only be apparent when allowing users to input text into free text areas.