### PR TITLE
Tabs to spaces

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -449,7 +449,7 @@ function DescribeAlert($alert) {
     }
     if ($alert['state'] >= 1) {
         if (!empty($tpl['title'])) {
-	    $obj['title'] = $tpl['title'];
+            $obj['title'] = $tpl['title'];
         }
         else {
             $obj['title'] = 'Alert for device '.$device['hostname'].' - '.($alert['name'] ? $alert['name'] : $alert['rule']);
@@ -481,10 +481,10 @@ function DescribeAlert($alert) {
         }
 
         $extra          = json_decode(gzuncompress($id['details']), true);
-	if (!empty($tpl['title_rec'])) {
-	    $obj['title'] = $tpl['title_rec'];
-	}
-	else {
+        if (!empty($tpl['title_rec'])) {
+            $obj['title'] = $tpl['title_rec'];
+        }
+        else {
             $obj['title']   = 'Device '.$device['hostname'].' recovered from '.($alert['name'] ? $alert['name'] : $alert['rule']);
         }
         $obj['elapsed'] = TimeFormat(strtotime($alert['time_logged']) - strtotime($id['time_logged']));

--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -54,8 +54,8 @@ if(is_admin() !== false) {
                         <select id='condition' name='condition' placeholder='Condition' class='form-control'>
                                 <option value='='>Equals</option>
                                 <option value='!='>Not Equals</option>
-				<option value='~'>Like</option>
-				<option value='!~'>Not Like</option>
+                                <option value='~'>Like</option>
+                                <option value='!~'>Not Like</option>
                                 <option value='>'>Larger than</option>
                                 <option value='>='>Larger than or Equals</option>
                                 <option value='<'>Smaller than</option>
@@ -156,8 +156,8 @@ $('#create-alert').on('hide.bs.modal', function (event) {
 });
 
 $('#add-map').click('',function (event) {
-	$('#map-tags').data('tagmanager').populate([ $('#map-stub').val() ]);
-	$('#map-stub').val('');
+    $('#map-tags').data('tagmanager').populate([ $('#map-stub').val() ]);
+    $('#map-stub').val('');
 });
 
 $('#create-alert').on('show.bs.modal', function (event) {

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -265,7 +265,7 @@ function RunRules($device) {
                 }
             }
         }
-       else {
+        else {
             if( $chk['state'] === "0" ) {
                 echo " NOCHG ";
             }

--- a/tests/SyslogTest.php
+++ b/tests/SyslogTest.php
@@ -83,7 +83,7 @@ class SyslogTest extends \PHPUnit_Framework_TestCase
         foreach($testdata as $data) {
             $res = process_syslog($data['input'], 0);
             $this->assertEquals($data['result'], $res);
-	}
+        }
     }
 }
 


### PR DESCRIPTION
While debugging I noticed some tabs that don't indent the code properly if tab width is 4. Replaced all tab characters in `*alert*`.
Also replaced one tab in tests/SyslogTest.php, see my latest comment in https://github.com/librenms/librenms/pull/3099 .