### PR TITLE
Syslog trim whitespace

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -115,6 +115,7 @@ function process_syslog($entry, $update) {
         }
 
         $entry['program'] = strtoupper($entry['program']);
+        $entry = array_map('trim', $entry);
 
         if ($update) {
             dbInsert(

--- a/tests/SyslogTest.php
+++ b/tests/SyslogTest.php
@@ -137,7 +137,7 @@ class SyslogTest extends \PHPUnit_Framework_TestCase
         );
         $testdata[] = $this->createData(
             "1.1.1.1||authpriv||notice||notice||55||2016-02-28 00:23:34||    root : TTY=pts/1 ; PWD=/opt/librenms ; USER=librenms ; COMMAND=/usr/bin/git status||sudo",
-            array('device_id'=>1, 'program'=>'SUDO', 'msg'=>'    root : TTY=pts/1 ; PWD=/opt/librenms ; USER=librenms ; COMMAND=/usr/bin/git status')
+            array('device_id'=>1, 'program'=>'SUDO', 'msg'=>'root : TTY=pts/1 ; PWD=/opt/librenms ; USER=librenms ; COMMAND=/usr/bin/git status')
         );
 
 


### PR DESCRIPTION
When checking the syslog entries after the merge of #3036, I noticed that whitespace is not being trimmed (and never has been, I checked some old entries). This should fix it.

Note that the syslog-ng daemon should be restarted after changes to includes/syslog.php.