### PR TITLE
API access when using LDAP authentication

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -23,7 +23,12 @@ function authToken(\Slim\Route $route) {
     $app   = \Slim\Slim::getInstance();
     $token = $app->request->headers->get('X-Auth-Token');
     if (isset($token) && !empty($token)) {
-        $username = get_user(dbFetchCell('SELECT `AT`.`user_id` FROM `api_tokens` AS AT WHERE `AT`.`token_hash`=?', array($token)));
+        if (!function_exists('get_user')) {
+            $username = dbFetchCell('SELECT `U`.`username` FROM `api_tokens` AS AT JOIN `users` AS U ON `AT`.`user_id`=`U`.`user_id` WHERE `AT`.`token_hash`=?', array($token));
+        }
+        else {
+            $username = get_user(dbFetchCell('SELECT `AT`.`user_id` FROM `api_tokens` AS AT WHERE `AT`.`token_hash`=?', array($token)));
+        }
         if (!empty($username)) {
             $authenticated = true;
         }

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -15,12 +15,15 @@
 require_once '../includes/functions.php';
 require_once '../includes/component.php';
 require_once '../includes/device-groups.inc.php';
+if (file_exists('../html/includes/authentication/'.$config['auth_mechanism'].'.inc.php')) {
+       include '../html/includes/authentication/'.$config['auth_mechanism'].'.inc.php';
+}
 
 function authToken(\Slim\Route $route) {
     $app   = \Slim\Slim::getInstance();
     $token = $app->request->headers->get('X-Auth-Token');
     if (isset($token) && !empty($token)) {
-        $username = dbFetchCell('SELECT `U`.`username` FROM `api_tokens` AS AT JOIN `users` AS U ON `AT`.`user_id`=`U`.`user_id` WHERE `AT`.`token_hash`=?', array($token));
+        $username = get_user(dbFetchCell('SELECT `AT`.`user_id` FROM `api_tokens` AS AT WHERE `AT`.`token_hash`=?', array($token)));
         if (!empty($username)) {
             $authenticated = true;
         }

--- a/html/includes/authentication/ldap-authorization.inc.php
+++ b/html/includes/authentication/ldap-authorization.inc.php
@@ -242,7 +242,9 @@ function can_update_users () {
 
 
 function get_user ($user_id) {
-    // Not supported
+    foreach (get_userlist() as $users) {
+         if ($users['user_id'] === $user_id) return $users['username'];
+    }
     return 0;
 }
 

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -189,7 +189,9 @@ function can_update_users() {
 
 
 function get_user($user_id) {
-    // not supported
+    foreach (get_userlist() as $users) {
+         if ($users['user_id'] === $user_id) return $users['username'];
+    }
     return 0;
 
 }


### PR DESCRIPTION
Partly fixes #3069, but might break API access for authentication mechanisms that do store username and user_id in the database, but don't have the `get_user` function. Do those exist?

The `get_user` function I added is not pretty, but should do for now.