### PR TITLE
Overlib Style Tweak

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1855,3 +1855,12 @@ label {
     color: black;
     border-color:transparent;
 }
+
+#overDiv {
+    z-index: 1200 !important;
+    border: solid 1px #ccc;
+    background-color: white;
+    padding: 5px;
+    border-radius: 4px;
+    box-shadow: 0 5px 15px rgba(0,0,0,.5);
+}


### PR DESCRIPTION
This minor tweak adds a visible border and drop-shadow to overlib floating panels, and bumps the z-index allowing it to be used from a bootstrap modal.  Without a border, the edges are difficult to distinguish from the rest of the page.  Some pages have tried to style this manually to avoid the problem.

![image](https://cloud.githubusercontent.com/assets/1608083/13583970/21ce3fc6-e4ac-11e5-81cd-b62ab0067d97.png)
