### PR TITLE
Fix rrd graphs

### DIFF
--- a/html/includes/graphs/generic_multi_seperated.inc.php
+++ b/html/includes/graphs/generic_multi_seperated.inc.php
@@ -84,7 +84,7 @@ foreach ($rrd_list as $rrd) {
     }
 
     $rrd_options  .= " COMMENT:'\\n'";
-    $rrd_optionsb .= ' AREA:outbits'.$i.'_neg#'.$colour_out."$stack";
+    $rrd_optionsb .= ' AREA:outbits'.$i.'_neg#'.$colour_out.":$stack";
     $rrd_options  .= ' HRULE:999999999999999#'.$colour_out.":'".str_pad('', 10)."Out'";
     $rrd_options  .= ' GPRINT:outbits'.$i.':LAST:%6.2lf%s';
     $rrd_options  .= ' GPRINT:outbits'.$i.':AVERAGE:%6.2lf%s';


### PR DESCRIPTION
Weird graphs were being produced with spurious STACK items at the end

example
https://demo.librenms.org/graphs/to=1457385300/id=50/type=port_nupkts/from=1457298900/

also see:
https://groups.google.com/forum/#!topic/librenms-project/LG5ipNVRRo4