### PR TITLE
Stop double escaping port notes

### DIFF
--- a/html/includes/forms/update-port-notes.inc.php
+++ b/html/includes/forms/update-port-notes.inc.php
@@ -15,7 +15,7 @@ $message   = 'unknown error';
 
 $device_id = mres($_POST['device_id']);
 $port_id_notes = mres($_POST['port_id_notes']);
-$attrib_value = mres($_POST['notes']);
+$attrib_value = $_POST['notes'];
 
 if (isset($attrib_value) && set_dev_attrib(array('device_id' => $device_id), $port_id_notes, $attrib_value)) {
     $status  = 'ok';


### PR DESCRIPTION
Similar to #3149, this one covers port notes.