### PR TITLE
Fix create_state_index function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1447,7 +1447,7 @@ function rrdtest($path, &$stdOutput, &$stdError) {
 }
 
 function create_state_index($state_name) {
-    if (dbFetchRow('SELECT * FROM state_indexes WHERE state_name = ?', array($state_name)) == null) {
+    if (dbFetchRow('SELECT * FROM state_indexes WHERE state_name = ?', array($state_name)) !== true) {
         $insert = array('state_name' => $state_name);
         return dbInsert($insert, 'state_indexes');
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1447,7 +1447,7 @@ function rrdtest($path, &$stdOutput, &$stdError) {
 }
 
 function create_state_index($state_name) {
-    if (dbFetchRow('SELECT * FROM state_indexes WHERE state_name = ?', array($state_name)) === false) {
+    if (dbFetchRow('SELECT * FROM state_indexes WHERE state_name = ?', array($state_name)) == null) {
         $insert = array('state_name' => $state_name);
         return dbInsert($insert, 'state_indexes');
     }


### PR DESCRIPTION
Shouldn’t be compared to false, but null instead.
Wasn't working for some users and clean installs.
Tested, :+1: 