### PR TITLE
Historical Billing Graphs use correct values for 95th line

### DIFF
--- a/html/bandwidth-graph.php
+++ b/html/bandwidth-graph.php
@@ -68,8 +68,20 @@ else {
     exit;
 }
 
-$start = $_GET['from'];
-$end   = $_GET['to'];
+if (is_numeric($_GET['bill_id']) && is_numeric($_GET[bill_hist_id])) {
+    $histrow = dbFetchRow('SELECT UNIX_TIMESTAMP(bill_datefrom) as `from`, UNIX_TIMESTAMP(bill_dateto) AS `to` FROM bill_history WHERE bill_id = ? AND bill_hist_id = ?', array($_GET['bill_id'], $_GET['bill_hist_id']));
+    if (is_null($histrow)) {
+        header("HTTP/1.0 404 Not Found");
+        exit();
+    }
+    $start        = $histrow['from'];
+    $end          = $histrow['to'];
+} 
+else {
+    $start        = $_GET[from];
+    $end          = $_GET[to];
+}
+
 $xsize = (is_numeric($_GET['x']) ? $_GET['x'] : '800' );
 $ysize = (is_numeric($_GET['y']) ? $_GET['y'] : '250' );
 // $count        = (is_numeric($_GET['count']) ? $_GET['count'] : "0" );

--- a/html/billing-graph.php
+++ b/html/billing-graph.php
@@ -67,8 +67,27 @@ else {
     exit;
 }
 
-$start = $_GET[from];
-$end   = $_GET[to];
+$rate_data    = dbFetchRow('SELECT * from `bills` WHERE `bill_id`= ? LIMIT 1', array($bill_id));
+$bill_name = $rate_data['bill_name'];
+
+if (is_numeric($_GET['bill_id']) && is_numeric($_GET[bill_hist_id])) {
+    $histrow = dbFetchRow('SELECT UNIX_TIMESTAMP(bill_datefrom) as `from`, UNIX_TIMESTAMP(bill_dateto) AS `to`, rate_95th, rate_average FROM bill_history WHERE bill_id = ? AND bill_hist_id = ?', array($_GET['bill_id'], $_GET['bill_hist_id']));
+    if (is_null($histrow)) {
+        header("HTTP/1.0 404 Not Found");
+        exit();
+    }
+    $start        = $histrow['from'];
+    $end          = $histrow['to'];
+    $rate_95th    = $histrow['rate_95th'];
+    $rate_average = $histrow['rate_average'];
+} 
+else {
+    $start        = $_GET[from];
+    $end          = $_GET[to];
+    $rate_95th    = $rate_data['rate_95th'];
+    $rate_average = $rate_data['rate_average'];
+}
+
 $xsize = $_GET[x];
 $ysize = $_GET[y];
 $count = $_GET[count];
@@ -86,15 +105,6 @@ $dur = ($end - $start);
 
 $datefrom = date('Ymthis', $start);
 $dateto   = date('Ymthis', $end);
-
-// $rate_data = getRates($bill_id,$datefrom,$dateto);
-$rate_data    = dbFetchRow('SELECT * from `bills` WHERE `bill_id`= ? LIMIT 1', array($bill_id));
-$rate_95th    = $rate_data['rate_95th'];
-$rate_average = $rate_data['rate_average'];
-
-// $bi_a = dbFetchRow("SELECT * FROM bills WHERE bill_id = ?", array($bill_id));
-// $bill_name = $bi_a['bill_name'];
-$bill_name = $rate_data['bill_name'];
 
 $dur = ($end - $start);
 

--- a/html/pages/bill/history.inc.php
+++ b/html/pages/bill/history.inc.php
@@ -13,7 +13,7 @@ $img['his'] .= '" style="margin: 15px 5px 25px 5px;" />';
 echo $img['his'];
 
 
-function showDetails($bill_id, $imgtype, $from, $to, $bittype='Quota') {
+function showDetails($bill_id, $imgtype, $bill_hist_id, $bittype='Quota') {
     if ($imgtype == 'bitrate') {
         $res = '<img src="billing-graph.php?bill_id='.$bill_id;
         if ($bittype == 'Quota') {
@@ -30,7 +30,7 @@ function showDetails($bill_id, $imgtype, $from, $to, $bittype='Quota') {
     // $res .= "&amp;type=".$type;
     $res .= '&amp;type='.$imgtype;
     $res .= '&amp;x=1190&amp;y=250';
-    $res .= '&amp;from='.$from.'&amp;to='.$to;
+    $res .= '&amp;bill_hist_id='.$bill_hist_id;
     $res .= '" style="margin: 15px 5px 25px 5px;" />';
     return $res;
 
@@ -108,9 +108,9 @@ foreach (dbFetchRows('SELECT * FROM `bill_history` WHERE `bill_id` = ? ORDER BY 
             </tr>';
 
         if ($vars['detail'] == $history['bill_hist_id'] || $vars['detail'] == 'all') {
-            $img['bitrate'] = showDetails($bill_id, 'bitrate', strtotime($datefrom), strtotime($dateto), $type);
-            $img['bw_day']  = showDetails($bill_id, 'day', strtotime($datefrom), strtotime($dateto));
-            $img['bw_hour'] = showDetails($bill_id, 'hour', strtotime($datefrom), strtotime($dateto));
+            $img['bitrate'] = showDetails($bill_id, 'bitrate', $history['bill_hist_id'], $type);
+            $img['bw_day']  = showDetails($bill_id, 'day', $history['bill_hist_id']);
+            $img['bw_hour'] = showDetails($bill_id, 'hour', $history['bill_hist_id']);
             echo '
                 <tr style="background: #fff; border-top: 1px solid '.$row_colour.'; border-bottom: 1px solid #ccc;">
                     <td colspan="11">


### PR DESCRIPTION
This PR changes the historical view of billing so that the graphs are called with a bill_hist_id param instead of from and to.  This is used to look up the 95th percentile line and draw this on the graph.  This means that when viewing the billing graph for previous months, the relevant 95th percentile line will be drawn on instead of the current value.

This may conflict with #3194 - I'll update whichever one of those gets done second if so!