### PR TITLE
Increase rule suggestions to 20

### DIFF
--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -255,9 +255,10 @@ $('#suggest').typeahead({
   async: true,
   displayKey: 'name',
   valueKey: name,
-    templates: {
-        suggestion: Handlebars.compile('<p>&nbsp;{{name}}</p>')
-    }
+  templates: {
+      suggestion: Handlebars.compile('<p>&nbsp;{{name}}</p>')
+  },
+  limit: 20
 });
 
 var map_devices = new Bloodhound({


### PR DESCRIPTION
On the new alerts page, this increases the number of rule suggestions from 5 to 20.