### PR TITLE
Add Interface at bill create screen

### DIFF
--- a/html/pages/bill/addoreditbill.inc.php
+++ b/html/pages/bill/addoreditbill.inc.php
@@ -1,3 +1,4 @@
+<h4>Bill Information</h4>
 <div class="form-group">
   <label for="bill_name" class="col-sm-4 control-label">Description</label>
   <div class="col-sm-8">

--- a/html/pages/bill/edit.inc.php
+++ b/html/pages/bill/edit.inc.php
@@ -150,16 +150,7 @@
                         <?php
                           $devices = dbFetchRows('SELECT * FROM `devices` ORDER BY hostname');
                           foreach ($devices as $device) {
-                              unset($done);
-                              foreach ($access_list as $ac) {
-                                  if ($ac == $device['device_id']) {
-                                      $done = 1;
-                                  }
-                              }
-                          
-                              if (!$done) {
-                                  echo "          <option value='".$device['device_id']."'>".$device['hostname']."</option>\n";
-                              }
+                              echo "<option value='${device['device_id']}'>${device['hostname']}</option>\n";
                           }
                           
                           ?>

--- a/html/pages/bills.inc.php
+++ b/html/pages/bills.inc.php
@@ -75,8 +75,8 @@ if ($_POST['addbill'] == 'yes') {
 
     $bill_id = dbInsert($insert, 'bills');
 
-    if (is_numeric($bill_id) && is_numeric($_POST['port'])) {
-        dbInsert(array('bill_id' => $bill_id, 'port_id' => $_POST['port']), 'bill_ports');
+    if (is_numeric($bill_id) && is_numeric($_POST['port_id'])) {
+        dbInsert(array('bill_id' => $bill_id, 'port_id' => $_POST['port_id']), 'bill_ports');
     }
     
     header('Location: /' . generate_url(array('page' => 'bill', 'bill_id' => $bill_id, 'view' => 'edit')));


### PR DESCRIPTION
Brings the switch/port dropdowns to the create traffic bill page.  Pre-populates them if linked from a port page.

Also removed a redundant check for access lists when populating the device list - $access_list wasn't defined anywhere in bill-related pages.

Closes #1967