### PR TITLE
./daily.sh as librenms user

### DIFF
--- a/doc/General/Updating.md
+++ b/doc/General/Updating.md
@@ -6,7 +6,7 @@ by ensuring:
 	$config['update'] = 0;
 
 is no longer commented out. If you would like to perform a manual update
-then you can do this by running the following command:
+then you can do this by running the following command as the librenms user:
 
 	./daily.sh
 


### PR DESCRIPTION
Add hint to encourage running ./daily.sh as the user librenms user.

We could also add this:
`runuser -l librenms -c ./daily.sh`
or this
`su - librenms -c ./daily.sh`