### PR TITLE
Added support for Juniper EX2500

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -639,6 +639,13 @@ $config['os'][$os]['over'][1]['text']  = 'CPU Usage';
 $config['os'][$os]['over'][2]['graph'] = 'device_mempool';
 $config['os'][$os]['over'][2]['text']  = 'Memory Usage';
 
+$os = 'juniperex2500os';
+$config['os'][$os]['text']             = 'Juniper EX2500';
+$config['os'][$os]['type']             = 'network';
+$config['os'][$os]['icon']             = 'junos';
+$config['os'][$os]['over'][0]['graph'] = 'device_bits';
+$config['os'][$os]['over'][0]['text']  = 'Device Traffic';
+
 // Pulse Secure OS definition
 $os = 'pulse';
 $config['os'][$os]['text']             = 'Pulse Secure';

--- a/includes/discovery/os/juniperex2500os.inc.php
+++ b/includes/discovery/os/juniperex2500os.inc.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!$os) {
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.1411.102')) {
+        $os = 'juniperex2500os';
+    }
+}


### PR DESCRIPTION
This adds support for the Juniper EX2500. 
The reason it is a new 'OS' is because the Juniper EX2500 runs an unverified OS and therefore I decided to name it juniperex2500os.