### PR TITLE
Update icons when discovery protocols change os.

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -93,7 +93,8 @@ function discover_device($device, $options = null) {
         $device['os'] = getHostOS($device);
         if ($device['os'] != 'generic') {
             echo "\nDevice os was updated to " . $device['os'] . '!';
-            dbUpdate(array('os' => $device['os']), 'devices', '`device_id` = ?', array($device['device_id']));
+            $device['icon'] = getImageName($device, false);
+            dbUpdate(array('os' => $device['os'], 'icon' => $device['icon']), 'devices', 'device_id=?', array($device['device_id']));
         }
     }
 


### PR DESCRIPTION
Do we need this or should we just wait until a normal discovery sets the correct icon?

issue #3236