### PR TITLE
Update pbn.inc.php

### DIFF
--- a/includes/polling/os/pbn.inc.php
+++ b/includes/polling/os/pbn.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if (preg_match('/^Pacific Broadband Networks .+\n.+ Version ([^,]+), .+\n.+\n.+\nSerial num:([^,]+), .+/', $poll_device['sysDescr'], $regexp_result)) {
+if (preg_match('/^Pacific Broadband Networks .+\n.+ Version ([^,]+), .+\n.+\n.+\nSerial num:([^,]+), .+/', snmp_get($device, 'SNMPv2-MIB::sysDescr.0', '-Ovq'), $regexp_result)) {
     $version = $regexp_result[1];
     $serial  = $regexp_result[2];
 


### PR DESCRIPTION
This was broken since poll_device['sysDescr'] not more return multiline value.

Problem is that in upstream function snmp_get_multi the trim function is used.
But we need here a multiline value as PBN sysDescr contains new lines in it.