### PR TITLE
Alert Failure Detail

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -345,13 +345,17 @@ function ExtTransports($obj) {
             $prefix = array( 0=>"recovery", 1=>$obj['severity']." alert", 2=>"acknowledgment" );
             $prefix[3] = &$prefix[0];
             $prefix[4] = &$prefix[0];
-            if ($tmp) {
+            if ($tmp === true) {
                 echo 'OK';
                 log_event('Issued '.$prefix[$obj['state']]." for rule '".$obj['name']."' to transport '".$transport."'", $obj['device_id']);
             }
-            else {
+            elseif ($tmp === false) {
                 echo 'ERROR';
                 log_event('Could not issue '.$prefix[$obj['state']]." for rule '".$obj['name']."' to transport '".$transport."'", $obj['device_id']);
+            }
+            else {
+                echo 'ERROR: '.$tmp."\r\n";
+                log_event('Could not issue '.$prefix[$obj['state']]." for rule '".$obj['name']."' to transport '".$transport."' Error: ".$tmp, $obj['device_id']);
             }
         }
 

--- a/includes/alerts/transport.api.php
+++ b/includes/alerts/transport.api.php
@@ -41,7 +41,7 @@ foreach( $opts as $method=>$apis ) {
             var_dump("API '$host' returned Error"); //FIXME: propper debuging
             var_dump("Params: ".$api); //FIXME: propper debuging
             var_dump("Return: ".$ret); //FIXME: propper debuging
-            return false;
+            return 'HTTP Status code '.$code;
         }
     }
 }

--- a/includes/alerts/transport.hipchat.php
+++ b/includes/alerts/transport.hipchat.php
@@ -28,6 +28,10 @@ foreach($opts as $option) {
     }
     $curl = curl_init();
 
+    if (empty($obj["msg"])) {
+        return "Empty Message";
+    }
+
     if (empty($option["message_format"])) {
         $option["message_format"] = 'text';
     }
@@ -60,7 +64,7 @@ foreach($opts as $option) {
         var_dump("API '$url' returned Error");
         var_dump("Params: " . $message);
         var_dump("Return: " . $ret);
-        return false;
+        return 'HTTP Status code '.$code;
     }
 }
 return true;

--- a/includes/alerts/transport.pagerduty.php
+++ b/includes/alerts/transport.pagerduty.php
@@ -48,6 +48,6 @@ $ret = curl_exec($curl);
 $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 if( $code != 200 ) {
     var_dump("PagerDuty returned Error, retry later"); //FIXME: propper debuging
-    return false;
+    return 'HTTP Status code '.$code;
 }
 return true;

--- a/includes/alerts/transport.pushbullet.php
+++ b/includes/alerts/transport.pushbullet.php
@@ -42,6 +42,6 @@ if( $code > 201 ) {
     if( $debug ) {
         var_dump($ret);
     }
-    return false;
+    return 'HTTP Status code '.$code;
 }
 return true;

--- a/includes/alerts/transport.pushover.php
+++ b/includes/alerts/transport.pushover.php
@@ -86,7 +86,7 @@ foreach( $opts as $api ) {
     $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
     if( $code != 200 ) {
         var_dump("Pushover returned error"); //FIXME: proper debugging
-        return false;
+        return 'HTTP Status code '.$code;
     }
 }
 return true;

--- a/includes/alerts/transport.slack.php
+++ b/includes/alerts/transport.slack.php
@@ -45,7 +45,7 @@ foreach( $opts as $tmp_api ) {
         var_dump("API '$host' returned Error"); //FIXME: propper debuging
         var_dump("Params: ".$alert_message); //FIXME: propper debuging
         var_dump("Return: ".$ret); //FIXME: propper debuging
-        return false;
+        return 'HTTP Status code '.$code;
     }
 }
 return true;


### PR DESCRIPTION
A little more verbosity to allow debugging failed transports, or faulty templates.
Fixes the mail transport errors, not being caught as errors.

Looks like:
http://i.imgur.com/4cEWZ2v.png