### PR TITLE
Make toner overview line up with the rest

### DIFF
--- a/html/pages/device/overview/toner.inc.php
+++ b/html/pages/device/overview/toner.inc.php
@@ -5,7 +5,8 @@ $graph_type = 'toner_usage';
 $toners = dbFetchRows('SELECT * FROM `toner` WHERE device_id = ?', array($device['device_id']));
 
 if (count($toners)) {
-    echo '<div class="row">
+    echo '<div class="container-fluid">
+          <div class="row">
           <div class="col-md-12">
             <div class="panel panel-default panel-condensed">
               <div class="panel-heading">';
@@ -53,6 +54,7 @@ if (count($toners)) {
     }//end foreach
 
     echo '</table>';
+    echo '</div>';
     echo '</div>';
     echo '</div>';
     echo '</div>';


### PR DESCRIPTION
The toner field in the device overview wasn't lining up with the rest.