### PR TITLE
Dell Powerconnect 3548P uses 3019 as the last bit

### DIFF
--- a/includes/discovery/sensors/temperatures/powerconnect.inc.php
+++ b/includes/discovery/sensors/temperatures/powerconnect.inc.php
@@ -18,6 +18,14 @@ if ($device['os'] == 'powerconnect') {
         $temperature = trim(snmp_get($device, ".1.3.6.1.4.1.89.53.15.1.9.1", "-Ovq"));
         discover_sensor($valid['sensor'], 'temperature', $device, '.1.3.6.1.4.1.89.53.15.1.9.1', 0, 'powerconnect', 'Internal Temperature', '1', '1', '0', null, null, '45', $temperature);
         break;
+        /**
+        * Dell Powerconnect 3548P
+        * Operating Temperature: 0º C to 45º C
+        */
+        case '.1.3.6.1.4.1.674.10895.3019':
+        $temperature = trim(snmp_get($device, ".1.3.6.1.4.1.89.53.15.1.9.1", "-Ovq"));
+        discover_sensor($valid['sensor'], 'temperature', $device, '.1.3.6.1.4.1.89.53.15.1.9.1', 0, 'powerconnect', 'Internal Temperature', '1', '1', '0', null, null, '45', $temperature);
+        break;		
         default :
         /**
         * Default Temperature Discovery


### PR DESCRIPTION
Dell Powerconnect 3548P's temperature sensor wasn't working, but the 3548 was, I looked into it, and the 3548 was using 3017, while the PoE version was 3019, so I copied the bit and changed.  It's working with that change.