### PR TITLE
Add https transport for influxDB

### DIFF
--- a/doc/Extensions/InfluxDB.md
+++ b/doc/Extensions/InfluxDB.md
@@ -21,15 +21,17 @@ RRD will continue to function as normal so LibreNMS itself should continue to fu
 ### Configuration
 ```php
 $config['influxdb']['enable'] = true;
-$config['influxdb']['transport'] = 'http';
+$config['influxdb']['transport'] = 'http'; # Default, other options: https, udp
 $config['influxdb']['host'] = '127.0.0.1';
 $config['influxdb']['port'] = '8086';
 $config['influxdb']['db'] = 'librenms';
 $config['influxdb']['username'] = 'admin';
 $config['influxdb']['password'] = 'admin';
+$config['influxdb']['timeout'] = 0; # Optional
+$config['influxdb']['verifySSL'] = false; # Optional
 ```
 
-UDP is a supported transport and no credentials are needed if you don't use InfluxDB authentication.
+No credentials are needed if you don't use InfluxDB authentication.
 
 The same data then stored within rrd will be sent to InfluxDB and recorded. You can then create graphs within Grafana
 to display the information you need.

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -866,3 +866,7 @@ $config['default_port_association_mode'] = 'ifIndex';
 // Ignore ports which can't be mapped using a devices port_association_mode
 // See include/polling/ports.inc.php for a lenghty explanation.
 $config['ignore_unmapable_port'] = False;
+
+// InfluxDB default configuration
+$config['influxdb']['timeout']      = 0;
+$config['influxdb']['verifySSL']    = false;

--- a/includes/influxdb.inc.php
+++ b/includes/influxdb.inc.php
@@ -29,6 +29,9 @@ function influxdb_connect() {
     if ($config['influxdb']['transport'] == 'http') {
         $influxdb_conn = 'influxdb';
     }
+    elseif ($config['influxdb']['transport'] == 'https') {
+        $influxdb_conn = 'https+influxdb';
+    }
     elseif ($config['influxdb']['transport'] == 'udp') {
         $influxdb_conn = 'udp+influxdb';
     }
@@ -37,7 +40,7 @@ function influxdb_connect() {
         return false;
     }
 
-    $db = \InfluxDB\Client::fromDSN($influxdb_conn.'://'.$influxdb_url);
+    $db = \InfluxDB\Client::fromDSN($influxdb_conn.'://'.$influxdb_url, $config['influxdb']['timeout'], $config['influxdb']['verifySSL']);
     return($db);
 
 }// end influxdb_connect


### PR DESCRIPTION
Add support for influxDB instances configured to use https, and configurable timeout and ability to verify SSL certificate.