### PR TITLE
Fix mempool reporting for Brocade IronWare NetIron devices 

### DIFF
--- a/includes/discovery/mempools/ironware-dyn.inc.php
+++ b/includes/discovery/mempools/ironware-dyn.inc.php
@@ -1,11 +1,45 @@
 <?php
 
 if ($device['os'] == 'ironware' || $device['os_type'] == 'ironware') {
-    echo 'Ironware Dynamic: ';
 
-    $percent = snmp_get($device, 'snAgGblDynMemUtil.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+    $is_netiron = snmp_get($device, 'sysObjectID.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
 
-    if (is_numeric($percent)) {
-        discover_mempool($valid_mempool, $device, 0, 'ironware-dyn', 'Dynamic Memory', '1', null, null);
-    }
-}
+    if (strpos($is_netiron, 'NI') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'Cer') === false) {
+
+        echo 'Ironware Dynamic: ';
+
+        $percent = snmp_get($device, 'snAgGblDynMemUtil.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+
+        if (is_numeric($percent)) {
+            discover_mempool($valid_mempool, $device, 0, 'ironware-dyn', 'Dynamic Memory', '1', null, null);
+        } //end_if
+    } //end_if
+    else {
+
+        echo 'NetIron: ';
+
+        d_echo('caching');
+        $ni_mempools_array = snmpwalk_cache_multi_oid($device, 'snAgentBrdMainBrdDescription', $ni_mempools_array, 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+        $ni_mempools_array = snmpwalk_cache_multi_oid($device, 'snAgentBrdMemoryUtil100thPercent', $ni_mempools_array, 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+        $ni_mempools_array = snmpwalk_cache_multi_oid($device, 'snAgentBrdMemoryAvailable', $ni_mempools_array, 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+        $ni_mempools_array = snmpwalk_cache_multi_oid($device, 'snAgentBrdMemoryTotal', $ni_mempools_array, 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+        d_echo($ni_mempool_array);
+
+       if (is_array($ni_mempools_array)) {
+           foreach ($ni_mempools_array as $index => $entry) {
+
+               d_echo($index.' '.$entry['snAgentBrdMainBrdDescription'].' -> '.$entry['snAgentBrdMemoryUtil100thPercent']."\n");
+
+               $usage_oid = '.1.3.6.1.4.1.1991.1.1.2.2.1.1.28.'.$index;
+               $descr     = $entry['snAgentBrdMainBrdDescription'];
+               $usage     = ($entry['snAgentBrdMemoryUtil100thPercent'] / 100);
+               if (!strstr($descr, 'No') && !strstr($usage, 'No') && $descr != '') {
+                   discover_mempool($valid_mempool, $device, $index, 'ironware-dyn', $descr, '1', null, null);
+             } //end_if
+           } //end_foreach
+        } //end_if
+   } //end_else
+} //end_if
+
+
+

--- a/includes/polling/mempools/ironware-dyn.inc.php
+++ b/includes/polling/mempools/ironware-dyn.inc.php
@@ -1,7 +1,36 @@
 <?php
 
-// Simple hard-coded poller for Brocade Ironware Dynamic Memory (old style)
-// Yes, it really can be this simple.
-$mempool['total'] = snmp_get($device, 'snAgGblDynMemTotal.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
-$mempool['free']  = snmp_get($device, 'snAgGblDynMemFree.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
-$mempool['used']  = ($mempool['total'] - $mempool['free']);
+$oid = $mempool['mempool_index'];
+
+d_echo('Ironware Mempool'."\n");
+
+$is_netiron = snmp_get($device, 'sysObjectID.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+
+if (strpos($is_netiron, 'NI') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'Cer') === false) {
+
+    $mempool['total'] = snmp_get($device, 'snAgGblDynMemTotal.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+    $mempool['free']  = snmp_get($device, 'snAgGblDynMemFree.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+    $mempool['used']  = ($mempool['total'] - $mempool['free']);
+
+} //end_if
+
+else {
+
+    d_echo('caching');
+    $mempool_cache['ironware-dyn'] = array();
+    $mempool_cache['ironware-dyn'] = snmpwalk_cache_multi_oid($device, 'snAgentBrdMemoryUtil100thPercent', $mempool_cache['ironware-dyn'], 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+    $mempool_cache['ironware-dyn'] = snmpwalk_cache_multi_oid($device, 'snAgentBrdMemoryAvailable', $mempool_cache['ironware-dyn'], 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+    $mempool_cache['ironware-dyn'] = snmpwalk_cache_multi_oid($device, 'snAgentBrdMemoryTotal', $mempool_cache['ironware-dyn'], 'FOUNDRY-SN-AGENT-MIB', $config['install_dir'].'/mibs');
+    d_echo($mempool_cache);
+
+    $entry = $mempool_cache['ironware-dyn'][$mempool[mempool_index]];
+
+    $perc = $entry['snAgentBrdMemoryUtil100thPercent'];
+
+    $memory_available = $entry['snAgentBrdMemoryTotal'];
+
+    $mempool['total'] = $memory_available;
+    $mempool['used']  = $memory_available / 10000 * $perc;
+    $mempool['free']  = $memory_available - $mempool['used'];
+
+} //end_else


### PR DESCRIPTION
Modified <code>includes/polling/mempools/ironware-dyn.inc.php</code> and <code>includes/discovery/mempools/ironware-dyn.inc.php</code> to identify NetIron devices and discover/poll the proper OIDs to report module memory usage.