### PR TITLE
Influxdb incorrect storage types

### DIFF
--- a/includes/influxdb.inc.php
+++ b/includes/influxdb.inc.php
@@ -58,7 +58,8 @@ function influx_update($device,$measurement,$tags=array(),$fields) {
             $tmp_tags[$k] = $v;
         }
         foreach ($fields as $k => $v) {
-            $tmp_fields[$k] = force_influx_data('f',$v);
+            $tmp_fields[$k] = $v;
+            //$tmp_fields[$k] = force_influx_data('f',$v);
         }
         
         d_echo("\nInfluxDB data:\n");

--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -57,7 +57,7 @@ if (is_numeric($uptime)) {
     $tags = array(
         'rrd_def' => 'DS:uptime:GAUGE:600:0:U',
     );
-    data_update($device, 'uptime', $tags, $uptime);
+    data_update($device, 'uptime', $tags, intval($uptime));
 
     $graphs['uptime'] = true;
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -293,7 +293,7 @@ function poll_device($device, $options) {
 
         $device_end  = microtime(true);
         $device_run  = ($device_end - $device_start);
-        $device_time = substr($device_run, 0, 5);
+        $device_time = floatval(substr($device_run, 0, 5));
 
         // Poller performance
         if (!empty($device_time)) {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -112,7 +112,7 @@ function poll_sensor($device, $class, $unit) {
         echo "$sensor_value $unit\n";
 
         $fields = array(
-            'sensor' => $sensor_value,
+            'sensor' => floatval($sensor_value),
         );
 
         rrdtool_update($rrd_file, $fields);

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -313,7 +313,7 @@ function poll_device($device, $options) {
                 'rrd_def' => 'DS:ping:GAUGE:600:0:65535',
             );
             $fields = array(
-                'ping' => $ping_time,
+                'ping' => floatval($ping_time),
             );
 
             $update_array['last_ping']             = array('NOW()');

--- a/includes/polling/hr-mib.inc.php
+++ b/includes/polling/hr-mib.inc.php
@@ -41,7 +41,7 @@ if (is_numeric($hrSystem[0]['hrSystemNumUsers'])) {
     }
 
     $fields = array(
-        'users' => $hrSystem[0]['hrSystemNumUsers'],
+        'users' => intval($hrSystem[0]['hrSystemNumUsers']),
     );
 
     rrdtool_update($rrd_file, $fields);

--- a/includes/polling/ipSystemStats.inc.php
+++ b/includes/polling/ipSystemStats.inc.php
@@ -106,9 +106,12 @@ if ($ipSystemStats) {
             $oid_ds      = truncate($oid_ds, 19, '');
             $rrd_create .= " DS:$oid_ds:COUNTER:600:U:100000000000";
             if (strstr($stats[$oid], 'No') || strstr($stats[$oid], 'd') || strstr($stats[$oid], 's')) {
-                $stats[$oid] = '0';
+                $stats[$oid] = 0;
             }
-            $fields[$oid] = $stats[$oid];
+            if (is_null($stats[$oid])) {
+                $stats[$oid] = 0;
+            }
+            $fields[$oid] = intval($stats[$oid]);
         }
 
         if (!file_exists($rrdfile)) {

--- a/includes/polling/mempools.inc.php
+++ b/includes/polling/mempools.inc.php
@@ -27,8 +27,8 @@ foreach (dbFetchRows('SELECT * FROM mempools WHERE device_id = ?', array($device
     }
 
     $fields = array(
-        'used' => $mempool['used'],
-        'free' => $mempool['free'],
+        'used' => intval($mempool['used']),
+        'free' => intval($mempool['free']),
     );
     rrdtool_update($mempool_rrd, $fields);
 

--- a/includes/polling/os/panos.inc.php
+++ b/includes/polling/os/panos.inc.php
@@ -14,7 +14,7 @@ if (is_numeric($sessions)) {
     }
 
     $fields = array(
-        'sessions' => $sessions,
+        'sessions' => intval($sessions),
     );
 
     rrdtool_update($sessrrd, $fields);

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -601,21 +601,21 @@ foreach ($ports as $port) {
         }//end if
 
         $fields = array(
-            'INOCTETS'         => $this_port['ifInOctets'],
-            'OUTOCTETS'        => $this_port['ifOutOctets'],
-            'INERRORS'         => $this_port['ifInErrors'],
-            'OUTERRORS'        => $this_port['ifOutErrors'],
-            'INUCASTPKTS'      => $this_port['ifInUcastPkts'],
-            'OUTUCASTPKTS'     => $this_port['ifOutUcastPkts'],
-            'INNUCASTPKTS'     => $this_port['ifInNUcastPkts'],
-            'OUTNUCASTPKTS'    => $this_port['ifOutNUcastPkts'],
-            'INDISCARDS'       => $this_port['ifInDiscards'],
-            'OUTDISCARDS'      => $this_port['ifOutDiscards'],
-            'INUNKNOWNPROTOS'  => $this_port['ifInUnknownProtos'],
-            'INBROADCASTPKTS'  => $this_port['ifInBroadcastPkts'],
-            'OUTBROADCASTPKTS' => $this_port['ifOutBroadcastPkts'],
-            'INMULTICASTPKTS'  => $this_port['ifInMulticastPkts'],
-            'OUTMULTICASTPKTS' => $this_port['ifOutMulticastPkts'],
+            'INOCTETS'         => intval($this_port['ifInOctets']),
+            'OUTOCTETS'        => intval($this_port['ifOutOctets']),
+            'INERRORS'         => intval($this_port['ifInErrors']),
+            'OUTERRORS'        => intval($this_port['ifOutErrors']),
+            'INUCASTPKTS'      => intval($this_port['ifInUcastPkts']),
+            'OUTUCASTPKTS'     => intval($this_port['ifOutUcastPkts']),
+            'INNUCASTPKTS'     => intval($this_port['ifInNUcastPkts']),
+            'OUTNUCASTPKTS'    => intval($this_port['ifOutNUcastPkts']),
+            'INDISCARDS'       => intval($this_port['ifInDiscards']),
+            'OUTDISCARDS'      => intval($this_port['ifOutDiscards']),
+            'INUNKNOWNPROTOS'  => intval($this_port['ifInUnknownProtos']),
+            'INBROADCASTPKTS'  => intval($this_port['ifInBroadcastPkts']),
+            'OUTBROADCASTPKTS' => intval($this_port['ifOutBroadcastPkts']),
+            'INMULTICASTPKTS'  => intval($this_port['ifInMulticastPkts']),
+            'OUTMULTICASTPKTS' => intval($this_port['ifOutMulticastPkts']),
         );
 
         if ($tune_port === true) {
@@ -623,13 +623,12 @@ foreach ($ports as $port) {
         }
         rrdtool_update("$rrdfile", $fields);
 
-        $fields['ifInUcastPkts_rate'] = $port['ifInUcastPkts_rate'];
-        $fields['ifOutUcastPkts_rate'] = $port['ifOutUcastPkts_rate'];
-        $fields['ifInErrors_rate'] = $port['ifInErrors_rate'];
-        $fields['ifOutErrors_rate'] = $port['ifOutErrors_rate'];
-        $fields['ifInOctets_rate'] = $port['ifInOctets_rate'];
-        $fields['ifOutOctets_rate'] = $port['ifOutOctets_rate'];
-
+        $fields['ifInUcastPkts_rate'] = intval($port['ifInUcastPkts_rate']);
+        $fields['ifOutUcastPkts_rate'] = intval($port['ifOutUcastPkts_rate']);
+        $fields['ifInErrors_rate'] = intval($port['ifInErrors_rate']);
+        $fields['ifOutErrors_rate'] = intval($port['ifOutErrors_rate']);
+        $fields['ifInOctets_rate'] = intval($port['ifInOctets_rate']);
+        $fields['ifOutOctets_rate'] = intval($port['ifOutOctets_rate']);
         $tags = array('ifName' => $port['ifName'], 'port_descr_type' => $port['port_descr_type']);
         influx_update($device,'ports',$tags,$fields);
 


### PR DESCRIPTION
The current code inserts all data into influxdb as strings.

This is pretty hard to spot. The best method I've found is by doing a query using curl.

```
root@mars:/home/dave# curl -G 'http://127.0.0.1:8086/query?pretty=true' -u librenms:librenms --data-urlencode 'db=librenms' --data-urlencode "q=select INOCTETS FROM ports where hostn
ame='localhost'" 
{
    "results": [
        {
            "series": [
                {
                    "name": "ports",
                    "columns": [
                        "time",
                        "INOCTETS"
                    ],
                    "values": [
                        [
                            "2016-03-29T21:55:04.374916409Z",
                            "254380308.0"
                        ],
                        [
                            "2016-03-29T21:55:04.382699772Z",
                            "0.0"
                        ],
```

Note the "'s around the INOCTETS value.

This makes any kind of data manipulation impossible.

```> select 8*INOCTETS from ports where hostname='localhost'
ERR: error constructing iterator for field '8.000 * INOCTETS': type mismatch on RHS, unable to use *influxql.stringChanIterator as a FloatIterator```

Presumably it is like this for compatibility with 0.9.0. This will probably break backwards compatibility.

There are probably a lot more type issues other than these few I've fixed.