### PR TITLE
Use python2 in Python script shebang lines

### DIFF
--- a/poller-service.py
+++ b/poller-service.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 """
  poller-service A service to wrap SNMP polling.  It will poll up to $threads devices at a time, and will not re-poll
                 devices that have been polled within the last $poll_frequency seconds. It will prioritize devices based

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 """
  poller-wrapper A small tool which wraps around the poller and tries to
                 guide the polling process with a more modern approach with a

--- a/scripts/agent-local/nginx
+++ b/scripts/agent-local/nginx
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import urllib2
 import re
 

--- a/scripts/mysql-stats
+++ b/scripts/mysql-stats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import warnings
 import re
 warnings.filterwarnings(action="ignore", message='the sets module is deprecated')

--- a/scripts/nginx-stats
+++ b/scripts/nginx-stats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import urllib2
 import re
 


### PR DESCRIPTION
Python scripts should use a specific Python version in their shebang lines, unless they are compatible with both Python 2 and Python 3. See also [PEP 0394](https://www.python.org/dev/peps/pep-0394/):

> […] Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line.

This fixes issue #3336.