### PR TITLE
Fix sensors icon bug

### DIFF
--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -207,7 +207,7 @@ foreach (dbFetchRows($sql, $param) as $device) {
         $hostname .= '<br />'.$device['sysName'];
         if (empty($port_count)) {
             $port_count = 0;
-	    $col_port = '';
+            $col_port = '';
         }
         if ($port_count) {
             $col_port = ' <img src="images/icons/port.png" align=absmiddle /> '.$port_count.'<br />';

--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -207,6 +207,7 @@ foreach (dbFetchRows($sql, $param) as $device) {
         $hostname .= '<br />'.$device['sysName'];
         if (empty($port_count)) {
             $port_count = 0;
+	    $col_port = '';
         }
         if ($port_count) {
             $col_port = ' <img src="images/icons/port.png" align=absmiddle /> '.$port_count.'<br />';


### PR DESCRIPTION
Fixes a javascript bug where the sensors icon html string will continually append to every device if it loops through a device with no ports and the preceding device has ports AND sensors.

A image of the bug:

<img width="1876" alt="screen shot 2016-04-11 at 1 40 47 pm" src="https://cloud.githubusercontent.com/assets/6710758/14441946/24d8e508-ffec-11e5-9927-877bdeafe4b1.png">

What it should look like:

<img width="1875" alt="screen shot 2016-04-11 at 1 41 16 pm" src="https://cloud.githubusercontent.com/assets/6710758/14441902/f6f3eade-ffeb-11e5-94eb-b35c3debc75e.png">
