### PR TITLE
add config option for typeahead limit

### DIFF
--- a/html/ajax_dash.php
+++ b/html/ajax_dash.php
@@ -35,6 +35,7 @@ if ($type == 'placeholder') {
 elseif (is_file('includes/common/'.$type.'.inc.php')) {
 
     $results_limit     = 10;
+    $typeahead_limit   = $config['webui']['global_search_result_limit'];
     $no_form           = true;
     $title             = ucfirst($type);
     $unique_id         = str_replace(array("-","."),"_",uniqid($type,true));

--- a/html/includes/common/generic-graph.inc.php
+++ b/html/includes/common/generic-graph.inc.php
@@ -204,6 +204,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_device.ttAdapter(),
+    limit: '.$config['typeahead_limit'].',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Devices</strong></h5>",
@@ -240,6 +241,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_port.ttAdapter(),
+    limit: '.$config['typeahead_limit'].',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Ports</strong></h5>",
@@ -275,6 +277,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_application.ttAdapter(),
+    limit: '.$config['typeahead_limit'].',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Applications</strong></h5>",
@@ -312,6 +315,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_munin.ttAdapter(),
+    limit: '.$config['typeahead_limit'].',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Munin</strong></h5>",
@@ -346,6 +350,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_bill.ttAdapter(),
+    limit: '.$config['typeahead_limit'].',
     async: false,
     templates: {
       header: "<h5><strong><i class=\'fa fa-money\'></i>&nbsp;Bill</strong></h5>",

--- a/html/includes/common/generic-graph.inc.php
+++ b/html/includes/common/generic-graph.inc.php
@@ -204,7 +204,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_device.ttAdapter(),
-    limit: '.$config['typeahead_limit'].',
+    limit: '.$typeahead_limit.',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Devices</strong></h5>",
@@ -241,7 +241,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_port.ttAdapter(),
-    limit: '.$config['typeahead_limit'].',
+    limit: '.$typeahead_limit.',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Ports</strong></h5>",
@@ -277,7 +277,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_application.ttAdapter(),
-    limit: '.$config['typeahead_limit'].',
+    limit: '.$typeahead_limit.',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Applications</strong></h5>",
@@ -315,7 +315,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_munin.ttAdapter(),
-    limit: '.$config['typeahead_limit'].',
+    limit: '.$typeahead_limit.',
     async: false,
     templates: {
       header: "<h5><strong>&nbsp;Munin</strong></h5>",
@@ -350,7 +350,7 @@ function '.$unique_id.'() {
   },
   {
     source: '.$unique_id.'_bill.ttAdapter(),
-    limit: '.$config['typeahead_limit'].',
+    limit: '.$typeahead_limit.',
     async: false,
     templates: {
       header: "<h5><strong><i class=\'fa fa-money\'></i>&nbsp;Bill</strong></h5>",
@@ -437,3 +437,4 @@ else {
     $common_output[]                   = '<a href="graphs/'.$param.'/type='.$widget_settings['graph_type'].'/from='.$config['time'][$widget_settings['graph_range']].'"><img class="minigraph-image" width="'.$widget_dimensions['x'].'" height="'.$widget_dimensions['y'].'" src="graph.php?'.$param.'&from='.$config['time'][$widget_settings['graph_range']].'&to='.$config['time']['now'].'&width='.$widget_dimensions['x'].'&height='.$widget_dimensions['y'].'&type='.$widget_settings['graph_type'].'&legend='.($widget_settings['graph_legend'] == 1 ? 'yes' : 'no').'&absolute=1"/></a>';
 
 }
+

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -717,6 +717,7 @@ $('#gsearch').typeahead({
 },
 {
   source: devices.ttAdapter(),
+  limit: '<?php echo($config['typeahead_limit']); ?>',
   async: true,
   display: 'name',
   valueKey: 'name',
@@ -727,6 +728,7 @@ $('#gsearch').typeahead({
 },
 {
   source: ports.ttAdapter(),
+  limit: '<?php echo($config['typeahead_limit']); ?>',
   async: true,
   display: 'name',
   valueKey: 'name',
@@ -737,6 +739,7 @@ $('#gsearch').typeahead({
 },
 {
   source: bgp.ttAdapter(),
+  limit: '<?php echo($config['typeahead_limit']); ?>',
   async: true,
   display: 'name',
   valueKey: 'name',

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -3,8 +3,9 @@ require $config['install_dir'].'/includes/object-cache.inc.php';
 
 // FIXME - this could do with some performance improvements, i think. possible rearranging some tables and setting flags at poller time (nothing changes outside of then anyways)
 
-$service_status = get_service_status();
-$if_alerts      = dbFetchCell("SELECT COUNT(port_id) FROM `ports` WHERE `ifOperStatus` = 'down' AND `ifAdminStatus` = 'up' AND `ignore` = '0'");
+$service_status   = get_service_status();
+$typeahead_limit  = $config['webui']['global_search_result_limit'];
+$if_alerts        = dbFetchCell("SELECT COUNT(port_id) FROM `ports` WHERE `ifOperStatus` = 'down' AND `ifAdminStatus` = 'up' AND `ignore` = '0'");
 
 if ($_SESSION['userlevel'] >= 5) {
     $links['count']        = dbFetchCell("SELECT COUNT(*) FROM `links`");
@@ -717,7 +718,7 @@ $('#gsearch').typeahead({
 },
 {
   source: devices.ttAdapter(),
-  limit: '<?php echo($config['typeahead_limit']); ?>',
+  limit: '<?php echo($typeahead_limit); ?>',
   async: true,
   display: 'name',
   valueKey: 'name',
@@ -728,7 +729,7 @@ $('#gsearch').typeahead({
 },
 {
   source: ports.ttAdapter(),
-  limit: '<?php echo($config['typeahead_limit']); ?>',
+  limit: '<?php echo($typeahead_limit); ?>',
   async: true,
   display: 'name',
   valueKey: 'name',
@@ -739,7 +740,7 @@ $('#gsearch').typeahead({
 },
 {
   source: bgp.ttAdapter(),
-  limit: '<?php echo($config['typeahead_limit']); ?>',
+  limit: '<?php echo($typeahead_limit); ?>',
   async: true,
   display: 'name',
   valueKey: 'name',
@@ -752,3 +753,4 @@ $('#gsearch').bind('typeahead:open', function(ev, suggestion) {
     $('#gsearch').addClass('search-box');
 });
 </script>
+

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -871,3 +871,6 @@ $config['ignore_unmapable_port'] = False;
 // InfluxDB default configuration
 $config['influxdb']['timeout']      = 0;
 $config['influxdb']['verifySSL']    = false;
+
+// Typeahead default configuration
+$config['typeahead_limit']    = 5;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -871,6 +871,3 @@ $config['ignore_unmapable_port'] = False;
 // InfluxDB default configuration
 $config['influxdb']['timeout']      = 0;
 $config['influxdb']['verifySSL']    = false;
-
-// Typeahead default configuration
-$config['typeahead_limit']    = 5;


### PR DESCRIPTION
Added config option:
$config['typeahead_limit'] 

to set limit for typeahead results. Default is set to 5 (as default was before).

Fixes librenms/librenms#3362