### PR TITLE
Allow start-of-string (^) and end-of-string ($) in LIKE statements for device groups

### DIFF
--- a/html/includes/forms/parse-device-group.inc.php
+++ b/html/includes/forms/parse-device-group.inc.php
@@ -20,7 +20,7 @@ $group_id = $_POST['group_id'];
 
 if (is_numeric($group_id) && $group_id > 0) {
     $group       = dbFetchRow('SELECT * FROM `device_groups` WHERE `id` = ? LIMIT 1', array($group_id));
-    $group_split = preg_split('/([a-zA-Z0-9_\-\.\=\%\<\>\ \"\'\!\~\(\)\*\/\@\[\]]+[&&\|\|]+)/', $group['pattern'], -1, (PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY));
+    $group_split = preg_split('/([a-zA-Z0-9_\-\.\=\%\<\>\ \"\'\!\~\(\)\*\/\@\[\]\^\$]+[&&\|\|]+)/', $group['pattern'], -1, (PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY));
     $count       = (count($group_split) - 1);
     if (preg_match('/\&\&$/', $group_split[$count]) == 1 || preg_match('/\|\|$/', $group_split[$count]) == 1) {
         $group_split[$count] = $group_split[$count];


### PR DESCRIPTION

Fixes issue librenms/librenms#3349