### PR TITLE
Fixed issue with new bills not grabbing data

### DIFF
--- a/poll-billing.php
+++ b/poll-billing.php
@@ -125,7 +125,7 @@ function CollectData($bill_id) {
         $out_delta = $prev_out_delta;
     }
 
-    if ($period < '0') {
+    if (!empty($period) && $period < '0') {
         logfile("BILLING: negative period! id:$bill_id period:$period delta:$delta in_delta:$in_delta out_delta:$out_delta");
     }
     else {


### PR DESCRIPTION
@richardlawley would you have a quick check on this pls.

We had a user saying new bills weren't collecting data, this patch fixed it for them (existing bills were ok as data was returned from the query and used).
