### PR TITLE
only output the mib if there is a match

### DIFF
--- a/includes/discovery/sensors/power/extreme.inc.php
+++ b/includes/discovery/sensors/power/extreme.inc.php
@@ -1,8 +1,8 @@
 <?php
 
-echo(" EXTREME-BASE-MIB ");
 
 if ($device['os'] == 'xos') {
+    echo(" EXTREME-BASE-MIB ");
     // Power Usage
     $descr   = "Power Usage";
     $oid     = "1.3.6.1.4.1.1916.1.1.1.40.1.0"; // extremeSystemPowerUsage


### PR DESCRIPTION
Currently, when discovering a device, "EXTREME-BASE-MIB" will always show up under the power output, even if there isn't a match. This is inconsistent with other power related oses such as ipoman