### PR TITLE
Add PoE state to Netonix devices

### DIFF
--- a/html/pages/device/overview/generic/sensor.inc.php
+++ b/html/pages/device/overview/generic/sensor.inc.php
@@ -1,9 +1,11 @@
 <?php
 
-$sensors = dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND device_id = ? ORDER BY `poller_type`, `sensor_oid`, `sensor_index`', array($sensor_class, $device['device_id']));
 
 if ($sensor_class == 'state') {
-    $sensors = dbFetchRows('SELECT * FROM `sensors` LEFT JOIN `sensors_to_state_indexes` ON sensors_to_state_indexes.sensor_id = sensors.sensor_id LEFT JOIN state_indexes ON state_indexes.state_index_id = sensors_to_state_indexes.state_index_id WHERE `sensor_class` = ? AND device_id = ? ORDER BY `poller_type`, `sensor_oid`, `sensor_index`', array($sensor_class, $device['device_id']));
+    $sensors = dbFetchRows('SELECT * FROM `sensors` LEFT JOIN `sensors_to_state_indexes` ON sensors_to_state_indexes.sensor_id = sensors.sensor_id LEFT JOIN state_indexes ON state_indexes.state_index_id = sensors_to_state_indexes.state_index_id WHERE `sensor_class` = ? AND device_id = ? ORDER BY `poller_type`, `sensor_index`+0, `sensor_oid`', array($sensor_class, $device['device_id']));
+}
+else {
+    $sensors = dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND device_id = ? ORDER BY `poller_type`, `sensor_oid`, `sensor_index`', array($sensor_class, $device['device_id']));
 }
 
 if (count($sensors)) {

--- a/includes/discovery/sensors/states/netonix.inc.php
+++ b/includes/discovery/sensors/states/netonix.inc.php
@@ -12,7 +12,7 @@
 
 if ($device['os'] == 'netonix') {
 
-    $temp = snmpwalk_cache_multi_oid($device, '.1.3.6.1.4.1.46242.5.1.2');
+    $temp = snmpwalk_cache_multi_oid($device, '.1.3.6.1.4.1.46242.5.1.2', array());
     $cur_oid = '.1.3.6.1.4.1.';
 
     if (is_array($temp)) {

--- a/includes/discovery/sensors/states/netonix.inc.php
+++ b/includes/discovery/sensors/states/netonix.inc.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2016 Tony Murray <murrayton@gmail.com> 
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+if ($device['os'] == 'netonix') {
+
+    $temp = snmpwalk_cache_multi_oid($device, '.1.3.6.1.4.1.46242.5.1.2');
+    $cur_oid = '.1.3.6.1.4.1.';
+
+    if (is_array($temp)) {
+        //Create State Index
+        $state_name = 'netonixPoeStatus';
+        $state_index_id = create_state_index($state_name);
+
+        $states_ids = array(
+            'Off' => 1,
+            '24V' => 2,
+            '48V' => 3
+        );
+
+        //Create State Translation
+        if ($state_index_id !== null) {
+            $states = array(
+                array($state_index_id,'Off',0,1,-1) ,
+                array($state_index_id,'24V',0,2,0) ,
+                array($state_index_id,'48V',0,3,1) ,
+             );
+            foreach($states as $value){ 
+                $insert = array(
+                    'state_index_id' => $value[0],
+                    'state_descr' => $value[1],
+                    'state_draw_graph' => $value[2],
+                    'state_value' => $value[3],
+                    'state_generic_value' => $value[4]
+                );
+                dbInsert($insert, 'state_translations');
+            }
+        }
+
+        foreach ($temp as $index => $entry) {
+            $id = substr($index, strrpos($index, '.')+1);
+            $descr = 'Port ' . $id . ' PoE';
+            $current = $states_ids[$entry['enterprises']];
+            //Discover Sensors
+            discover_sensor($valid['sensor'], 'state', $device, $cur_oid.$index, $id, $state_name, $descr, '1', '1', null, null, null, null, $current);
+
+            //Create Sensor To State Index
+            create_sensor_to_state_index($device, $state_name, $id);
+        }
+    }
+}

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -44,6 +44,13 @@ function poll_sensor($device, $class, $unit) {
             }
             else if ($class == 'state') {
                 $sensor_value = trim(str_replace('"', '', snmp_walk($device, $sensor['sensor_oid'], '-Oevq', 'SNMPv2-MIB')));
+                if (!is_numeric($sensor_value)) {
+                    $state_value = dbFetchCell('SELECT `state_value` FROM `state_translations` LEFT JOIN `sensors_to_state_indexes` ON `state_translations`.`state_index_id` = `sensors_to_state_indexes`.`state_index_id` WHERE `sensors_to_state_indexes`.`sensor_id` = ? AND `state_translations`.`state_descr` LIKE ?', array($sensor['sensor_id'], $sensor_value));
+                    d_echo('State value of ' . $sensor_value . ' is ' . $state_value . "\n");
+                    if (is_numeric($state_value)) {
+                        $sensor_value = $state_value;
+                    }
+                }
             }
             else if ($class == 'signal') {
                $currentOS = $device['os'];


### PR DESCRIPTION
Allow for non-numeric states.  state_descr must match what is returned by the device.
Change the ordering of state sensors on the overview page (and save an sql query)