### PR TITLE
Added alert log purge setting - defaults to 365

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -114,6 +114,14 @@ if ($options['f'] === 'bill_data') {
     }
 }
 
+if ($options['f'] === 'alert_log') {
+    if (is_numeric($config['alert_log_purge']) && $config['alert_log_purge'] > 0) {
+        if (dbDelete('alert_log', 'time_logged < DATE_SUB(NOW(),INTERVAL ? DAY)', array($config['alert_log_purge']))) {
+            echo 'Alert log data cleared for entries over '.$config['alert_log_purge']." days\n";
+        }
+    }
+}
+
 if ($options['f'] === 'purgeusers') {
     $purge = 0;
     if (is_numeric($config['radius']['users_purge']) && $config['auth_mechanism'] === 'radius') {

--- a/daily.sh
+++ b/daily.sh
@@ -75,6 +75,7 @@ else
             php daily.php -f device_perf
             php daily.php -f purgeusers
             php daily.php -f bill_data
+            php daily.php -f alert_log
         ;;
         submodules)
             # Init+Update our submodules

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -775,6 +775,8 @@ $config['perf_times_purge'] = 30;
 // Number in days of how long to keep performace polling stats  entries for.
 $config['device_perf_purge'] = 7;
 // Number in days of how long to keep device performance data for.
+$config['alert_log_purge'] = 365;
+// Number in days of how long to keep alert log data for.
 
 // Date format for PHP date()s
 $config['dateformat']['long'] = 'r';

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -4,8 +4,8 @@
  <title>LibreNMS Notifications</title>
  <description>RSS feed for notifications to LibreNMS users</description>
  <link>http://www.librenms.org/</link>
- <lastBuildDate>Mon, 07 Mar 2016 12:00:00 +0000</lastBuildDate>
- <pubDate>Mon, 07 Mar 2016 12:00:00 +0000</pubDate>
+ <lastBuildDate>Mon, 02 May 2016 20:00:00 +0000</lastBuildDate>
+ <pubDate>Mon, 02 Mar 2016 20:00:00 +0000</pubDate>
  <ttl>1800</ttl>
  <item>
   <title>Hello World!</title>
@@ -23,6 +23,12 @@
    the database which was not used.  Please check that your billing data is updating as expected, and 
    if you notice any problems open an issue on GitHub.</description>
    <pubDate>Mon, 07 Mar 2016 12:00:00 +0000</pubDate>
+ </item>
+ <item>
+   <title>Introduction of default purge interval or alert history</title>
+   <description>We have introduced a purge setting for alert history which is set to 365 days as default. If you would like to update this then please 
+   set $config['alert_log_purge'] to a custom value (set in days).</description>
+   <pubDate>Mon, 02 May 2016 20:00:00 +0000</pubDate>
  </item>
 </channel>
 </rss>


### PR DESCRIPTION
Added rss entry to warn people.

Set to 1 year as I expect people will want to keep alert history for longer than things like eventlog data.

Fix #3357 