### PR TITLE
Add support for stopping devices being added with duplicate sysNames

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -204,9 +204,13 @@ if (!empty($argv[1])) {
         echo 'Added device '.$device['hostname'].' ('.$device_id.")\n";
         exit;
     }
-}//end if
+    else {
+        print $console_color->convert("%rWe couldn't add this device, please check the snmp details%n\n");
+    }
+}
+else {
 
-print $console_color->convert(
+    print $console_color->convert(
     "\n".$config['project_name_version'].' Add Host Tool
 
     Usage (SNMPv1/2c): ./addhost.php [-g <poller group>] [-f] [-p <port assoc mode>] <%Whostname%n> [community] [v1|v2c] [port] ['.implode('|', $config['snmp']['transports']).']
@@ -224,4 +228,5 @@ print $console_color->convert(
 
     %rRemember to run discovery for the host afterwards.%n
 '
-);
+    );
+}

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -220,6 +220,12 @@ $config['addhost_alwayscheckip']   = FALSE; #TRUE - check for duplicate ips even
                                             #FALSE- only check when adding host by ip.
 ```
 
+By default we allow hosts to be added with duplicate sysName's, you can disable this with the following config:
+
+```php
+$config['allow_duplicate_sysName'] = false;
+```
+
 #### SNMP Settings
 
 ```php

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -793,6 +793,10 @@ $config['dateformat']['mysql']['time']    = '%H:%i:%s';
 $config['enable_clear_discovery'] = 1;
 // Set this to 0 if you want to disable the web option to rediscover devices
 $config['force_ip_to_sysname']    = false;// Set to true if you want to use sysName in place of IPs
+
+// Allow duplicate devices by sysName
+$config['allow_duplicate_sysName'] = true;// Set to false if you want to only allow unique sysName's
+
 $config['enable_port_relationship'] = true;
 // Set this to false to not display neighbour relationships for ports
 $config['enable_footer'] = 1;


### PR DESCRIPTION
I've left this enabled for now but we should consider changing this to false so that duplicate devices based on sysName aren't added.

I've also updated the addhost output so that an error is printed and not the help details as it's confusing. This could do with expanding further but it's a quick fix.

Fix #3012