### PR TITLE
Removed gc_maxlifetime setting

### DIFF
--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-@ini_set('session.gc_maxlifetime', '0');
 @ini_set('session.use_only_cookies', 1);
 @ini_set('session.cookie_httponly', 1);
 require 'includes/PasswordHash.php';


### PR DESCRIPTION
Fix #3372 

Not sure about merging this 100% but it doesn't cause an issue for me. Removing it does make sense though as this is how long before sessions are cleared up. I can't see anything to suggest 0 is unlimited.