### PR TITLE
Preliminary HP Virtual Connect support

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1577,6 +1577,14 @@ $config['os'][$os]['icon']             = 'hp';
 $config['os'][$os]['over'][0]['graph'] = 'device_bits';
 $config['os'][$os]['over'][0]['text']  = 'Traffic';
 
+// HP Virtual Connect
+$os = 'hpvc';
+$config['os'][$os]['text']             = 'HP Virtual Connect';
+$config['os'][$os]['type']             = 'network';
+$config['os'][$os]['icon']             = 'hp';
+$config['os'][$os]['over'][0]['graph'] = 'device_bits';
+$config['os'][$os]['over'][0]['text']  = 'Traffic';
+
 // Riverbed
 $os = 'riverbed';
 $config['os'][$os]['text']             = 'Riverbed';

--- a/includes/discovery/os/hpvc.inc.php
+++ b/includes/discovery/os/hpvc.inc.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!$os) {
+    if (strstr($sysObjectId, '.1.3.6.1.4.1.11.5.7.5.1')) {
+        $os = 'hpvc';
+    }
+}

--- a/includes/polling/os/hpvc.inc.php
+++ b/includes/polling/os/hpvc.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+// Format of sysDescr is hardware model followed by version followed by build date
+$tempstr = substr($poll_device['sysDescr'], 0, strrpos($poll_device['sysDescr'], ' '));
+$version = trim(substr($tempstr, strrpos($tempstr, ' ')));
+$hardware = trim(substr($tempstr, 0, strrpos($tempstr, ' ')));
+
+// Serial number is in sysName after string "VCEX"
+$serial = substr(snmp_get($device, 'sysName.0', '-OvQ', 'SNMPv2-MIB:HOST-RESOURCES-MIB:SNMP-FRAMEWORK-MIB'), 4);


### PR DESCRIPTION
Barebones support to discovering HP Virtual Connect (Ethernet) modules including their model, serial and version.

SNMP support in Virtual Connect is quite limited, information like CPU and MEM usage etc. is not available.