### PR TITLE
Fixes to actually apply color to the hipchat messages

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -103,11 +103,10 @@ LibreNMS contributors:
 - Jens Langhammer <jens@beryju.org> (BeryJu)
 - Robert Verspuy <robert@exa.nl> (exarv)
 - Peter Tkatchenko <peter@flytrace.com> (Peter2121)
+- Marc Runkel <marc@runkel.org> (mrunkel)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:
 - Adam Armstrong
 - Tom Laermans
 - various others as indicated in the file contents and commit logs
-
-

--- a/includes/alerts/transport.hipchat.php
+++ b/includes/alerts/transport.hipchat.php
@@ -36,20 +36,23 @@ foreach($opts as $option) {
         $option["message_format"] = 'text';
     }
 
+    // Sane default of making the message color green if the message indicates
+    // that the alert recovered.
+    if(stripos($data["message"], "recovered")) {
+        $color = "green";
+    } else {
+	      $color = $option["color"];
+    }
+
     $data[] = "message=".urlencode($obj["msg"]);
     $data[] = "room_id=".urlencode($option["room_id"]);
     $data[] = "from=".urlencode($option["from"]);
-    $data[] = "color=".urlencode($option["color"]);
+    $data[] = "color=".urlencode($color);
     $data[] = "notify=".urlencode($option["notify"]);
     $data[] = "message_format=".urlencode($option["message_format"]);
 
     $data = implode('&', $data);
 
-    // Sane default of making the message color green if the message indicates
-    // that the alert recovered.
-    if(strstr($data["message"], "recovered")) {
-        $data["color"] = "green";
-    }
     curl_setopt($curl, CURLOPT_URL, $url);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_POST, true);

--- a/includes/alerts/transport.hipchat.php
+++ b/includes/alerts/transport.hipchat.php
@@ -21,6 +21,7 @@
  * @subpackage Alerts
  */
 
+// loop through each room
 foreach($opts as $option) {
     $url = $option['url'];
     foreach($obj as $key=>$value) {
@@ -37,9 +38,11 @@ foreach($opts as $option) {
     }
 
     // Sane default of making the message color green if the message indicates
-    // that the alert recovered.
-    if(stripos($data["message"], "recovered")) {
+    // that the alert recovered.   If it rebooted, make it yellow.
+    if(stripos($obj["msg"], "recovered")) {
         $color = "green";
+    } elseif(stripos($obj["msg"], "rebooted")) {
+        $color = "yellow";
     } else {
 	      $color = $option["color"];
     }


### PR DESCRIPTION
All hipchat messages are red today, this patch actually makes recovery messages green and rebooted messages yellow.