### PR TITLE
Update Alerting.md

### DIFF
--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -627,7 +627,9 @@ Entity: `%macros.port_usage_perc`
 
 Description: Return port-usage in percent.
 
-Source: `((%ports.ifInOctets_rate*8)/%ports.ifSpeed)*100`
+Source: `((%ports.ifInOctets_rate*8) / %ports.ifSpeed)*100`
+
+**Warning:** When using division operator, you have to include a space after the '/' operator. The space before the operator is just to add visibility.
 
 ## <a name="macros-time">Time</a>
 

--- a/sql-schema/115.sql
+++ b/sql-schema/115.sql
@@ -1,0 +1,2 @@
+update config set config_value='((%ports.ifInOctets_rate*8) / %ports.ifSpeed)*100' where config_id=460;
+update config set config_default='((%ports.ifInOctets_rate*8) / %ports.ifSpeed)*100' where config_id=460;


### PR DESCRIPTION
Add a warning when using '/' operator in a custom macro.
Add a new sql file to correct built-in port_usage_perc macro regarding spaces problem.
Related to [this issue](https://github.com/librenms/librenms/issues/3546)