### PR TITLE
Enable discovery of CDP neighbour by IP address

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -55,7 +55,7 @@ if ($config['autodiscovery']['xdp'] === true) {
                     $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']));
 
                     if (!$remote_device_id) {
-                        if(!$config['discovery_by_ip']) {
+                        if($config['discovery_by_ip'] !== true) {
                             $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
                         }
                         else {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -59,7 +59,7 @@ if ($config['autodiscovery']['xdp'] === true) {
                             $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
                         }
                         else {
-                            $ip_arr = explode(" ", $array['cdpCacheAddress']);
+                            $ip_arr = explode(" ", $cdp['cdpCacheAddress']);
 
                             $a = hexdec($ip_arr[0]);
                             $b = hexdec($ip_arr[1]);

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -55,7 +55,21 @@ if ($config['autodiscovery']['xdp'] === true) {
                     $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']));
 
                     if (!$remote_device_id) {
-                        $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
+                        if(!$config['discovery_by_ip']) {
+                            $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
+                        }
+                        else {
+                            $ip_arr = explode(" ", $array['cdpCacheAddress']);
+
+                            $a = hexdec($ip_arr[0]);
+                            $b = hexdec($ip_arr[1]);
+                            $c = hexdec($ip_arr[2]);
+                            $d = hexdec($ip_arr[3]);
+
+                            $cdp_ip = "$a.$b.$c.$d";
+
+                            $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
+                        }
                     }
 
                     if ($remote_device_id) {


### PR DESCRIPTION
Fix for #2715.

Setting $config['discovery_by_ip'] = true allows CDP neighbour to be discovered by IP instead of hostname.