### PR TITLE
deduping type_where code, adding manual types to graph widgets 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -104,6 +104,7 @@ LibreNMS contributors:
 - Robert Verspuy <robert@exa.nl> (exarv)
 - Peter Tkatchenko <peter@flytrace.com> (Peter2121)
 - Marc Runkel <marc@runkel.org> (mrunkel)
+- Brandon Boudrias <bt.boudrias@gmail.com> (brandune)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -495,19 +495,10 @@ function get_graph_by_portgroup() {
     $vars['width']  = $_GET['width'] ?: 1075;
     $vars['height'] = $_GET['height'] ?: 300;
     $auth           = '1';
-    $type_where     = ' (';
-    $or             = '';
-    $type_param     = array();
-    foreach (explode(',', $group) as $type) {
-        $type_where  .= " $or `port_descr_type` = ?";
-        $or           = 'OR';
-        $type_param[] = $type;
-    }
 
-    $type_where .= ') ';
+    $ports = get_ports_from_type(explode(',', $group));
     $if_list     = '';
     $seperator   = '';
-    $ports       = dbFetchRows("SELECT * FROM `ports` as I, `devices` AS D WHERE $type_where AND I.device_id = D.device_id ORDER BY I.ifAlias", $type_param);
     foreach ($ports as $port) {
         $if_list  .= $seperator.$port['port_id'];
         $seperator = ',';

--- a/html/includes/common/generic-graph.inc.php
+++ b/html/includes/common/generic-graph.inc.php
@@ -393,39 +393,19 @@ else {
     elseif ($type == 'munin') {
         $param                        = 'device='.$widget_settings['graph_'.$type]['device_id'].'&plugin='.$widget_settings['graph_'.$type]['name'];
     }
-    elseif ($type == 'transit' || $type == 'peering' || $type == 'core') {
-        $type_where = ' (';
-        if (is_array($config[$type.'_descr']) === false) {
-            $config[$type.'_descr'] = array($config[$type.'_descr']);
+    elseif ($type == 'transit' || $type == 'peering' || $type == 'core' || $type == 'custom') {
+        if ( $type == 'custom' ) {
+            $type = $widget_settings['graph_custom'];
         }
-        foreach ($config[$type.'_descr'] as $additional_type) {
-            if (!empty($additional_type)) {
-                $type_where  .= " $or `port_descr_type` = ?";
-                $or           = 'OR';
-                $type_param[] = $additional_type;
-            }
-        }
-        $type_where  .= " $or `port_descr_type` = ?";
-        $or           = 'OR';
-        $type_param[] = $type;
-        $type_where  .= ') ';
-        foreach (dbFetchRows("SELECT port_id FROM `ports` WHERE $type_where ORDER BY ifAlias", $type_param) as $port) {
+
+        $ports = get_ports_from_type($type);
+        foreach ($ports as $port) {
             $tmp[] = $port['port_id'];
         }
         $param                         = 'id='.implode(',',$tmp);
         $widget_settings['graph_type'] = 'multiport_bits_separate';
         if (empty($widget_settings['title'])) {
-            $widget_settings['title']  = 'Overall '.ucfirst($type).' Bits ('.$widget_settings['graph_range'].')';
-        }
-    }
-    elseif ($type == 'custom') {
-        foreach (dbFetchRows("SELECT port_id FROM `ports` WHERE `port_descr_type` = ? ORDER BY ifAlias", array($widget_settings['graph_custom'])) as $port) {
-            $tmp[] = $port['port_id'];
-        }
-        $param                         = 'id='.implode(',',$tmp);
-        $widget_settings['graph_type'] = 'multiport_bits_separate';
-        if (empty($widget_settings['title'])) {
-            $widget_settings['title']  = 'Overall '.ucfirst(htmlspecialchars($widget_settings['graph_custom'])).' Bits ('.$widget_settings['graph_range'].')';
+            $widget_settings['title']  = 'Overall '.ucfirst(htmlspecialchars($type)).' Bits ('.$widget_settings['graph_range'].')';
         }
     }
     else {

--- a/html/includes/common/generic-graph.inc.php
+++ b/html/includes/common/generic-graph.inc.php
@@ -74,6 +74,7 @@ if( defined('show_settings') || empty($widget_settings) ) {
         <option value="peering"'.($widget_settings['graph_type'] == 'peering' ? ' selected' : '').'>&nbsp;&nbsp;&nbsp;Peering</option>
         <option value="core"'.($widget_settings['graph_type'] == 'core' ? ' selected' : '').'>&nbsp;&nbsp;&nbsp;Core</option>
         <option value="custom"'.($widget_settings['graph_type'] == 'custom' ? ' selected' : '').'>&nbsp;&nbsp;&nbsp;Custom Descr</option>
+        <option value="manual"'.($widget_settings['graph_type'] == 'manual' ? ' selected' : '').'>&nbsp;&nbsp;&nbsp;Manual Descr</option>
         <option disabled></option>
         <option value="bill_bits"'.($widget_settings['graph_type'] == 'bill_bits' ? ' selected' : '').'>Bill</option>
       </select>
@@ -149,6 +150,14 @@ if( defined('show_settings') || empty($widget_settings) ) {
     }
     $common_output[] = '      </select>
     </div>
+  </div>
+  <div class="form-group input_'.$unique_id.'" id="input_'.$unique_id.'_manual">
+    <div class="col-sm-2">
+      <label for="graph_manual" class="control-label">Manual Port-Desc: </label>
+    </div>
+    <div class="col-sm-10">
+      <input type="text" class="form-control input_'.$unique_id.'_manual" name="graph_manual" placeholder="Descr String" value="'.htmlspecialchars($widget_settings['graph_manual']).'">';
+    $common_output[] = '    </div>
   </div>
   <div class="form-group input_'.$unique_id.'" id="input_'.$unique_id.'_bill">
     <div class="col-sm-2">
@@ -393,9 +402,10 @@ else {
     elseif ($type == 'munin') {
         $param                        = 'device='.$widget_settings['graph_'.$type]['device_id'].'&plugin='.$widget_settings['graph_'.$type]['name'];
     }
-    elseif ($type == 'transit' || $type == 'peering' || $type == 'core' || $type == 'custom') {
-        if ( $type == 'custom' ) {
-            $type = $widget_settings['graph_custom'];
+    elseif ($type == 'transit' || $type == 'peering' || $type == 'core' || $type == 'custom' || $type == 'manual') {
+        if ( $type == 'custom' || $type == 'manual') {
+            $type = $widget_settings['graph_'.$type];
+            $type = explode(',', $type);
         }
 
         $ports = get_ports_from_type($type);

--- a/html/pages/iftype.inc.php
+++ b/html/pages/iftype.inc.php
@@ -16,27 +16,8 @@ else {
     $bg = '#ffffff';
 }
 
-$type_where = ' (';
-foreach (explode(',', $vars['type']) as $type) {
-    if (is_array($config[$type.'_descr']) === false) {
-        $config[$type.'_descr'] = array($config[$type.'_descr']);
-    }
-
-    foreach ($config[$type.'_descr'] as $additional_type) {
-        if (!empty($additional_type)) {
-            $type_where  .= " $or `port_descr_type` = ?";
-            $or           = 'OR';
-            $type_param[] = $additional_type;
-        }
-    }
-
-    $type_where  .= " $or `port_descr_type` = ?";
-    $or           = 'OR';
-    $type_param[] = $type;
-}
-
-$type_where .= ') ';
-$ports       = dbFetchRows("SELECT * FROM `ports` as I, `devices` AS D WHERE $type_where AND I.device_id = D.device_id ORDER BY I.ifAlias", $type_param);
+$types_array = explode(',', $vars['type']);
+$ports = get_ports_from_type($types_array);
 
 foreach ($ports as $port) {
     $if_list  .= $seperator.$port['port_id'];
@@ -45,7 +26,6 @@ foreach ($ports as $port) {
 
 unset($seperator);
 
-$types_array = explode(',', $vars['type']);
 for ($i = 0; $i < count($types_array);
 $i++) {
     $types_array[$i] = ucfirst($types_array[$i]);


### PR DESCRIPTION
Follow-up to https://github.com/librenms/librenms/pull/3564

Several places in the code run queries against the 'ports' table to find ports matching a given 'port_descr_type'. There are ever so slight differences in each of these places, but nothing meaningful as far as I can tell. One commit here dedups that code with a function in functions.inc.php.

The new function adds two new behaviors: It substitutes @ for % in the SQL, allowing for the use of wildcards. It also supports querying for arbitrary strings that aren't represented in $config. This is mostly to support the second commit, but also allows for arbitrary queries on the iftype page and the get_graph_by_portgroup api endpoint as well.

The second commit adds a new dropdown selection to the graph dashboard widget called 'Manual Descr'. It provides a text field to manually specify the string that's used to query the ports table. This adds some flexibility in the dashboards you can create by structuring your interface descriptions and using the wildcard behavior added in the first commit.