### PR TITLE
Added option to cache DNS for SNMP queries

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -234,6 +234,7 @@ $config['snmp']['retries'] = 5;            # how many times to retry the query
 $config['snmp']['transports'] = array('udp', 'udp6', 'tcp', 'tcp6');
 $config['snmp']['version'] = "v2c";         # Default version to use
 $config['snmp']['port'] = 161;
+$config['snmp']['use_ip'] = false;         # Option to cache DNS resolution at beginning of poll
 ```
 Default SNMP options including retry and timeout settings and also default version and port.
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -181,6 +181,8 @@ $config['snmp']['community'][0] = 'public';
 // Communities to try during adding hosts and discovery
 $config['snmp']['port'] = 161;
 // Port Client SNMP is running on
+$config['snmp']['use_ip'] = false;
+// Use cached DNS resolution for SNMP polls
 // SNMPv3 default settings
 // The array can be expanded to give another set of parameters
 // NOTE: If you change these, also change the equivalents in includes/defaults.inc.php - not sure why they are separate

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -159,6 +159,14 @@ function poll_device($device, $options) {
     echo $device['hostname'].' '.$device['device_id'].' '.$device['os'].' ';
     $ip = dnslookup($device);
 
+    if (!filter_var($ip, FILTER_VALIDATE_IP) === false  &&  $config['snmp']['use_ip'] === true) {
+        d_echo("Valid IP address.\n");
+        $device['poll_host'] = $ip;
+    }
+    else {
+        $device['poll_host'] = $device['hostname'];
+    }
+
     if (!empty($ip) && $ip != inet6_ntop($device['ip'])) {
         log_event('Device IP changed to '.$ip, $device, 'system');
         $db_ip = inet_pton($ip);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -73,7 +73,7 @@ function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=nul
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'];
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'];
     $cmd .= ' '.$oids;
 
     if (!$debug) {
@@ -128,7 +128,7 @@ function snmp_get($device, $oid, $options=null, $mib=null, $mibdir=null) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'];
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'];
     $cmd .= ' '.$oid;
 
     if (!$debug) {
@@ -186,7 +186,7 @@ function snmp_walk($device, $oid, $options=null, $mib=null, $mibdir=null) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' '.$oid;
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' '.$oid;
 
     if (!$debug) {
         $cmd .= ' 2>/dev/null';
@@ -244,7 +244,7 @@ function snmpwalk_cache_cip($device, $oid, $array=array(), $mib=0) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' '.$oid;
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' '.$oid;
 
     if (!$debug) {
         $cmd .= ' 2>/dev/null';
@@ -475,7 +475,7 @@ function snmpwalk_cache_twopart_oid($device, $oid, $array, $mib=0) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' '.$oid;
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' '.$oid;
 
     if (!$debug) {
         $cmd .= ' 2>/dev/null';
@@ -528,7 +528,7 @@ function snmpwalk_cache_threepart_oid($device, $oid, $array, $mib=0) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' '.$oid;
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' '.$oid;
 
     if (!$debug) {
         $cmd .= ' 2>/dev/null';
@@ -587,7 +587,7 @@ function snmp_cache_slotport_oid($oid, $device, $array, $mib=0) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' '.$oid;
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' '.$oid;
 
     if (!$debug) {
         $cmd .= ' 2>/dev/null';
@@ -646,7 +646,7 @@ function snmp_cache_port_oids($oids, $port, $device, $array, $mib=0) {
     }
 
     $cmd .= ' -t '.$timeout.' -r '.$retries;
-    $cmd .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' '.$string;
+    $cmd .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' '.$string;
 
     if (!$debug) {
         $cmd .= ' 2>/dev/null';
@@ -688,7 +688,7 @@ function snmp_cache_portIfIndex($device, $array) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd      .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' portIfIndex';
+    $cmd      .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' portIfIndex';
     $output    = trim(external_exec($cmd));
 
     foreach (explode("\n", $output) as $entry) {
@@ -724,7 +724,7 @@ function snmp_cache_portName($device, $array) {
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
 
-    $cmd      .= ' '.$device['transport'].':'.$device['hostname'].':'.$device['port'].' portName';
+    $cmd      .= ' '.$device['transport'].':'.$device['poll_host'].':'.$device['port'].' portName';
     $output    = trim(external_exec($cmd));
     // echo("Caching: portName\n");
     foreach (explode("\n", $output) as $entry) {


### PR DESCRIPTION
Option to set is $config['snmp']['use_ip']

This has had a massive impact to my query times in my test install:

http://geordish.org/graph.png