### PR TITLE
Allow lmsensor fanspeeds of 0 to be discovered.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -104,6 +104,7 @@ LibreNMS contributors:
 - Robert Verspuy <robert@exa.nl> (exarv)
 - Peter Tkatchenko <peter@flytrace.com> (Peter2121)
 - Marc Runkel <marc@runkel.org> (mrunkel)
+- Josh Driver <keeperofdakeys@gmail.com> (keeperofdakeys)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/includes/discovery/sensors/fanspeeds/lmsensors.inc.php
+++ b/includes/discovery/sensors/fanspeeds/lmsensors.inc.php
@@ -19,7 +19,7 @@ if ($device['os'] == 'linux' || $device['os'] == 'pktj' ||  $device['os'] == 'cu
             $oid              = '1.3.6.1.4.1.2021.13.16.3.1.3.'.$index;
             $current          = snmp_get($device, $oid, '-Oqv', 'LM-SENSORS-MIB');
             $descr            = trim(str_ireplace('fan-', '', $descr));
-            if ($current > '0') {
+            if ($current !== false && $current >= 0) {
                 discover_sensor($valid['sensor'], 'fanspeed', $device, $oid, $index, 'lmsensors', $descr, '1', '1', null, null, null, null, $current);
             }
         }


### PR DESCRIPTION
Devices that have a fan that spins down are currently undiscovered during discovery. Allow the fanspeed to be 0 to fix this.