### PR TITLE
Keep aspect ratio for external images on dashboard

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -105,6 +105,7 @@ LibreNMS contributors:
 - Peter Tkatchenko <peter@flytrace.com> (Peter2121)
 - Marc Runkel <marc@runkel.org> (mrunkel)
 - Josh Driver <keeperofdakeys@gmail.com> (keeperofdakeys)
+- Felix Eckhofer <felix@eckhofer.com> (tribut)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/html/includes/common/generic-image.inc.php
+++ b/html/includes/common/generic-image.inc.php
@@ -58,5 +58,5 @@ if( defined('show_settings') || empty($widget_settings) ) {
 }
 else {
     $widget_settings['title'] = $widget_settings['image_title'];
-    $common_output[]          = '<a target="_blank" href="'.$widget_settings['target_url'].'"><img class="minigraph-image" width="'.$widget_dimensions['x'].'" height="'.$widget_dimensions['y'].'" src="'.$widget_settings['image_url'].'"/></a>';
+    $common_output[]          = '<a target="_blank" href="'.$widget_settings['target_url'].'"><img class="minigraph-image" style="max-width: '.$widget_dimensions['x'].'px; max-height:'.$widget_dimensions['y'].'px;" src="'.$widget_settings['image_url'].'"/></a>';
 }


### PR DESCRIPTION
Not sure if anybody really wants their images stretched to full size. If so, we could make this a checkbox ("keep aspect ratio").