### PR TITLE
WIP: Attempt to speed up SNMP port polling

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -112,7 +112,6 @@ $ifmib_oids = array_merge($data_oids, $stat_oids);
 
 $ifmib_oids = array(
     'ifDescr',
-    'ifXEntry',
     'ifAdminStatus',
     'ifOperStatus',
     'ifInErrors',
@@ -122,13 +121,17 @@ $ifmib_oids = array(
 );
 
 echo 'Caching Oids: ';
-foreach ($ifmib_oids as $oid) {
-    echo "$oid ";
-    $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'IF-MIB');
-}
+$port_stats = snmpwalk_cache_oid($device, 'ifXEntry', $port_stats, 'IF-MIB');
+
 
 if (!isset($port_stats[1]['ifHCInOctets']) && !is_numeric($port_stats[1]['ifHCInOctets'])) {
     $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB');
+}
+else {
+    foreach ($ifmib_oids as $oid) {
+        echo "$oid ";
+        $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'IF-MIB');
+    }
 }
 
 if ($config['enable_ports_etherlike']) {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -111,7 +111,6 @@ $pagp_oids = array(
 $ifmib_oids = array_merge($data_oids, $stat_oids);
 
 $ifmib_oids = array(
-    //'ifEntry',
     'ifDescr',
     'ifXEntry',
     'ifAdminStatus',
@@ -366,6 +365,10 @@ foreach ($ports as $port) {
             echo 'HC ';
             $this_port['ifInOctets']  = $this_port['ifHCInOctets'];
             $this_port['ifOutOctets'] = $this_port['ifHCOutOctets'];
+        }
+        if (is_numeric($this_port['ifHCInUcastPkts']) && $this_port['ifHCInUcastPkts'] > 0 && is_numeric($this_port['ifHCOutUcastPkts']) && $this_port['ifHCOutUcastPkts'] > 0) {
+            $this_port['ifInUcastPkts']  = $this_port['ifHCInUcastPkts'];
+            $this_port['ifOutUcastPkts'] = $this_port['ifHCOutUcastPkts'];
         }
 
         if ($device['os'] === 'airos-af' && $port['ifAlias'] === 'eth0') {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -111,7 +111,8 @@ $pagp_oids = array(
 $ifmib_oids = array_merge($data_oids, $stat_oids);
 
 $ifmib_oids = array(
-    'ifEntry',
+    //'ifEntry',
+    'ifDescr',
     'ifXEntry',
 );
 
@@ -119,6 +120,10 @@ echo 'Caching Oids: ';
 foreach ($ifmib_oids as $oid) {
     echo "$oid ";
     $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'IF-MIB');
+}
+
+if (!isset($port_stats[1]['ifHCInOctets']) && !is_numeric($port_stats[1]['ifHCInOctets'])) {
+    $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB');
 }
 
 if ($config['enable_ports_etherlike']) {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -116,6 +116,8 @@ $ifmib_oids = array(
     'ifXEntry',
     'ifAdminStatus',
     'ifOperStatus',
+    'ifInErrors',
+    'ifOutErrors',
 );
 
 echo 'Caching Oids: ';

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -108,8 +108,6 @@ $pagp_oids = array(
     'pagpGroupIfIndex',
 );
 
-$ifmib_oids = array_merge($data_oids, $stat_oids);
-
 $ifmib_oids = array(
     'ifDescr',
     'ifAdminStatus',
@@ -123,8 +121,8 @@ $ifmib_oids = array(
 echo 'Caching Oids: ';
 $port_stats = snmpwalk_cache_oid($device, 'ifXEntry', $port_stats, 'IF-MIB');
 
-
-if (!isset($port_stats[1]['ifHCInOctets']) && !is_numeric($port_stats[1]['ifHCInOctets'])) {
+$hc_test = array_slice($port_stats, 0, 1);
+if (!isset($hc_test[0]['ifHCInOctets']) && !is_numeric($hc_test[0]['ifHCInOctets'])) {
     $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB');
 }
 else {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -114,6 +114,8 @@ $ifmib_oids = array(
     //'ifEntry',
     'ifDescr',
     'ifXEntry',
+    'ifAdminStatus',
+    'ifOperStatus',
 );
 
 echo 'Caching Oids: ';

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -117,6 +117,8 @@ $ifmib_oids = array(
     'ifOperStatus',
     'ifInErrors',
     'ifOutErrors',
+    'ifInDiscards',
+    'ifOutDiscards',
 );
 
 echo 'Caching Oids: ';


### PR DESCRIPTION
I've been playing around with trying to speed up the SNMP port polling.

I noticed that the code is always pulling both ifEntry and ifXEntry, regardless if all the stats are needed or not. Worst case this is doubling the amount of SNMP polls that need to be made per device for each poll.

This change attempts to only poll for ifXEntry (Also need ifDescr from ifEntry too). It then checks to see if there is valid data in it, and only then if there isn't polls regular ifEntry.

On my test install it looks like this has reduced port polling time by 50%.

I doubt this is ready to commit. I'm not particularly pleased with the way I'm checking to see if there is data in ifXEntry, and I've not got any devices that don't support ifXEntry to test against. I have dropped polling down to v1 though which should be broadly equivalent (and works).

Feedback welcome!