### PR TITLE
Sophos Support Redo

### DIFF
--- a/includes/discovery/os/linux.inc.php
+++ b/includes/discovery/os/linux.inc.php
@@ -69,9 +69,9 @@ if (!$os) {
         elseif (stristr($sysObjectId, 'cumulusMib') || strstr($sysObjectId, '.1.3.6.1.4.1.40310')) {
             $os = 'cumulus';
         }
-//        elseif (strstr($sysObjectId, '.1.3.6.1.4.1.8072.3.2.10')) {
-//            $os = 'sophos';
-//        }
+        elseif (strstr($sysDescr, 'g56fa85e') || strstr($sysDescr, 'gc80f187')) {
+            $os = 'sophos';
+        }
         else {
             // Check for Synology DSM
             $hrSystemInitialLoadParameters = trim(snmp_get($device, 'HOST-RESOURCES-MIB::hrSystemInitialLoadParameters.0', '-Osqnv'));


### PR DESCRIPTION
Impossible to find anything on these things, but this seems that this string in the sysDescr is unique to the firmvere or something like that.

Data from: SG105 9.402-7 && #2404 