### PR TITLE
Added device_id to eventlog table

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -719,6 +719,7 @@ function log_event($text, $device = NULL, $type = NULL, $reference = NULL) {
     }
 
     $insert = array('host' => ($device['device_id'] ? $device['device_id'] : 0),
+        'device_id' => ($device['device_id'] ? $device['device_id'] : 0),
         'reference' => ($reference ? $reference : "NULL"),
         'type' => ($type ? $type : "NULL"),
         'datetime' => array("NOW()"),

--- a/sql-schema/118.sql
+++ b/sql-schema/118.sql
@@ -1,0 +1,4 @@
+UPDATE dbSchema SET version = 118;
+ALTER TABLE `eventlog` ADD `device_id` INT NOT NULL AFTER `host` ;
+ALTER TABLE `eventlog` ADD INDEX ( `device_id` ) ;
+UPDATE eventlog SET device_id=host WHERE device_id=0;


### PR DESCRIPTION
This is so you can use eventlog items in alerting to match up with a device.

On a large install 4m+ eventlog entries it takes a while to run hence we set the schema version on the first line so now duplicate schema updates are ran. We also go back and update all old entries to have a correct device_id based on host field. This isn't necessary but has been done for completeness.

mysql> ALTER TABLE `eventlog` ADD `device_id` INT NOT NULL AFTER `host` ;
Query OK, 4057885 rows affected (8 min 39.57 sec)
Records: 4057885  Duplicates: 0  Warnings: 0

mysql> ALTER TABLE `eventlog` ADD INDEX ( `device_id` ) ;
Query OK, 0 rows affected (33.89 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> UPDATE eventlog SET device_id=host WHERE device_id=0;
Query OK, 4057904 rows affected (6 min 25.35 sec)
Rows matched: 4058103  Changed: 4057904  Warnings: 0
