### PR TITLE
Prettify the poller + disco output

### DIFF
--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -237,7 +237,6 @@ function RunGroupMacros($rule,$x=1) {
 function UpdateGroupsForDevice($device_id)
 {
     global $debug;
-    $debug = true;
     $queried_groups = QueryGroupsFromDevice($device_id);
     $db_groups = GetGroupsFromDevice($device_id);
 

--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -236,7 +236,6 @@ function RunGroupMacros($rule,$x=1) {
  */
 function UpdateGroupsForDevice($device_id)
 {
-    global $debug;
     $queried_groups = QueryGroupsFromDevice($device_id);
     $db_groups = GetGroupsFromDevice($device_id);
 

--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -2,8 +2,6 @@
 
 unset($mac_table);
 
-echo 'ARP Table : ';
-
 if( key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco'])!=0) ){
     $vrfs_lite_cisco = $device['vrf_lite_cisco'];
 }

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -1,7 +1,6 @@
 <?php
 if ($config['enable_bgp']) {
     // Discover BGP peers
-    echo 'BGP Sessions : ';
     
     if( key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco'])!=0) ){
         $vrfs_lite_cisco = $device['vrf_lite_cisco'];

--- a/includes/discovery/cisco-cbqos.inc.php
+++ b/includes/discovery/cisco-cbqos.inc.php
@@ -14,7 +14,6 @@
 if ($device['os_group'] == 'cisco') {
 
     $module = 'Cisco-CBQOS';
-    echo $module.': ';
 
     require_once 'includes/component.php';
     $component = new component();

--- a/includes/discovery/cisco-cef.inc.php
+++ b/includes/discovery/cisco-cef.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Cisco CEF Switching Path: ';
-
 $cefs = array();
 $cefs = snmpwalk_cache_threepart_oid($device, 'CISCO-CEF-MIB::cefSwitchingPath', $cefs);
 d_echo($cefs);

--- a/includes/discovery/cisco-mac-accounting.inc.php
+++ b/includes/discovery/cisco-mac-accounting.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($device['os_group'] == 'cisco') {
-    echo 'Cisco MAC Accounting : ';
 
     $datas = shell_exec($config['snmpbulkwalk'].' -M '.$config['mibdir'].' -m CISCO-IP-STAT-MIB -Oqn '.snmp_gen_auth($device).' '.$device['hostname'].' cipMacSwitchedBytes');
     // echo("$datas\n");

--- a/includes/discovery/cisco-otv.inc.php
+++ b/includes/discovery/cisco-otv.inc.php
@@ -58,7 +58,6 @@ if ($device['os_group'] == 'cisco') {
     $error_overlay[6] = "destroy";
 
     $module = 'Cisco-OTV';
-    echo $module.': ';
 
     require_once 'includes/component.php';
     $component = new component();

--- a/includes/discovery/cisco-pw.inc.php
+++ b/includes/discovery/cisco-pw.inc.php
@@ -4,8 +4,6 @@ if ($config['enable_pseudowires'] && $device['os_group'] == 'cisco') {
     unset($cpw_count);
     unset($cpw_exists);
 
-    echo 'Cisco Pseudowires : ';
-
     // Pre-cache the existing state of pseudowires for this device from the database
     $pws_db_raw = dbFetchRows('SELECT * FROM `pseudowires` WHERE `device_id` = ?', array($device['device_id']));
     foreach ($pws_db_raw as $pw_db) {

--- a/includes/discovery/cisco-sla.inc.php
+++ b/includes/discovery/cisco-sla.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($config['enable_sla'] && $device['os_group'] == 'cisco') {
-    echo 'SLAs : ';
 
     $slas = snmp_walk($device, 'ciscoRttMonMIB.ciscoRttMonObjects.rttMonCtrl', '-Osq', '+CISCO-RTTMON-MIB');
 

--- a/includes/discovery/cisco-vrf-lite.inc.php
+++ b/includes/discovery/cisco-vrf-lite.inc.php
@@ -24,7 +24,6 @@ if ($config['enable_vrf_lite_cisco']) {
 
     // For the moment only will be cisco and the version 3
     if ($device['os_group'] == "cisco" && $device['snmpver'] == 'v3') {
-        echo ("VRF lite cisco : \n");
         $mib = "SNMP-COMMUNITY-MIB";
         $mib = "CISCO-CONTEXT-MAPPING-MIB";
         //-Osq because if i put the n the oid from the first command is not the same of this one

--- a/includes/discovery/cisco-vrf.inc.php
+++ b/includes/discovery/cisco-vrf.inc.php
@@ -5,8 +5,6 @@ if ($config['enable_vrfs']) {
     if ($device['os_group'] == 'cisco' || $device['os_group'] == 'junos' || $device['os'] == 'ironware') {
         unset($vrf_count);
 
-        echo 'VRFs : ';
-
         /*
             There are 2 MIBs for VPNs : MPLS-VPN-MIB (oldest) and MPLS-L3VPN-STD-MIB (newest)
             Unfortunately, there is no simple way to find out which one to use, unless we reference

--- a/includes/discovery/discovery-arp.inc.php
+++ b/includes/discovery/discovery-arp.inc.php
@@ -13,8 +13,6 @@
 // License: GPLv3
 //
 
-echo 'ARP Discovery: ';
-
 $hostname = $device['hostname'];
 $deviceid = $device['device_id'];
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Discovery protocols:';
-
 global $link_exists;
 
 $community = $device['community'];

--- a/includes/discovery/entity-physical.inc.php
+++ b/includes/discovery/entity-physical.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($config['enable_inventory']) {
-    echo 'Physical Inventory : ';
 
     echo "\nCaching OIDs:";
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -854,6 +854,7 @@ function load_discovery_module($module, $device, $attribs) {
     echo "#### Load disco module $module ####\n";
     include "includes/discovery/$module.inc.php";
     $module_time = microtime(true) - $module_start;
-    echo "\n>> Runtime for discovery module '$module': $module_time\n";
+    $module_time = substr($module_time, 0, 5)
+    echo "\n>> Runtime for discovery module '$module': $module_time seconds\n";
     echo "#### Unload disco module $module ####\n\n";
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -854,7 +854,7 @@ function load_discovery_module($module, $device, $attribs) {
     echo "#### Load disco module $module ####\n";
     include "includes/discovery/$module.inc.php";
     $module_time = microtime(true) - $module_start;
-    $module_time = substr($module_time, 0, 5)
+    $module_time = substr($module_time, 0, 5);
     echo "\n>> Runtime for discovery module '$module': $module_time seconds\n";
     echo "#### Unload disco module $module ####\n\n";
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -108,20 +108,17 @@ function discover_device($device, $options = null) {
     if ($options['m']) {
         foreach (explode(',', $options['m']) as $module) {
             if (is_file("includes/discovery/$module.inc.php")) {
-                include "includes/discovery/$module.inc.php";
+                load_discovery_module($module, $device, $attribs);
             }
         }
     } else {
         foreach ($config['discovery_modules'] as $module => $module_status) {
             if ($attribs['discover_' . $module] || ( $module_status && !isset($attribs['discover_' . $module]))) {
-                $module_start = microtime(true);
-                include 'includes/discovery/' . $module . '.inc.php';
-                $module_time = microtime(true) - $module_start;
-                echo "Runtime for discovery module '$module': $module_time\n";
+                load_discovery_module($module, $device, $attribs);
             } else if (isset($attribs['discover_' . $module]) && $attribs['discover_' . $module] == '0') {
-                echo "Module [ $module ] disabled on host.\n";
+                echo "Module [ $module ] disabled on host.\n\n";
             } else {
-                echo "Module [ $module ] disabled globally.\n";
+                echo "Module [ $module ] disabled globally.\n\n";
             }
         }
     }
@@ -851,3 +848,12 @@ function avtech_add_sensor($device, $sensor) {
     return true;
 }
 
+function load_discovery_module($module, $device, $attribs) {
+    global $config, $valid;
+    $module_start = microtime(true);
+    echo "#### Load disco module $module ####\n";
+    include "includes/discovery/$module.inc.php";
+    $module_time = microtime(true) - $module_start;
+    echo "\n>> Runtime for discovery module '$module': $module_time\n";
+    echo "#### Unload disco module $module ####\n\n";
+}

--- a/includes/discovery/hr-device.inc.php
+++ b/includes/discovery/hr-device.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'hrDevice : ';
-
 $hrDevice_oids = array(
     'hrDeviceEntry',
     'hrProcessorEntry',

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-echo 'IPv4 Addresses : ';
 if( key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco'])!= 0) ){
     $vrfs_lite_cisco = $device['vrf_lite_cisco'];
 }

--- a/includes/discovery/ipv6-addresses.inc.php
+++ b/includes/discovery/ipv6-addresses.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-echo 'IPv6 Addresses : ';
 if( key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco'])!=0) ){
     $vrfs_lite_cisco = $device['vrf_lite_cisco'];
 } 

--- a/includes/discovery/junose-atm-vp.inc.php
+++ b/includes/discovery/junose-atm-vp.inc.php
@@ -4,7 +4,6 @@
 // snmpwalk -v2c -c <community> <hostname> -M mibs/junose/ -m Juniper-UNI-ATM-MIB juniAtmVpStatsEntry
 // JunOSe ATM vps
 if ($device['os'] == 'junose' && $config['enable_ports_junoseatmvp']) {
-    echo 'JunOSe ATM vps : ';
     $vp_array = snmpwalk_cache_multi_oid($device, 'juniAtmVpStatsInCells', $vp_array, 'Juniper-UNI-ATM-MIB', $config['install_dir'].'/mibs/junose');
     $valid_vp = array();
     d_echo($vp_array);

--- a/includes/discovery/libvirt-vminfo.inc.php
+++ b/includes/discovery/libvirt-vminfo.inc.php
@@ -5,8 +5,6 @@
 if ($config['enable_libvirt'] == '1' && $device['os'] == 'linux') {
     $libvirt_vmlist = array();
 
-    echo 'Libvirt VM: ';
-
     $ssh_ok = 0;
 
     $userHostname = $device['hostname'];

--- a/includes/discovery/mempools.inc.php
+++ b/includes/discovery/mempools.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Memory : ';
-
 // Include all discovery modules
 $include_dir = 'includes/discovery/mempools';
 require 'includes/include-dir.inc.php';

--- a/includes/discovery/os.inc.php
+++ b/includes/discovery/os.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'OS: ';
-
 $os   = getHostOS($device);
 if ($os != $device['os']) {
     log_event('Device OS changed '.$device['os']." => $os", $device, 'system');

--- a/includes/discovery/ports-stack.inc.php
+++ b/includes/discovery/ports-stack.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Port Stack: ';
-
 $sql = "SELECT * FROM `ports_stack` WHERE `device_id` = '".$device['device_id']."'";
 
 foreach (dbFetchRows($sql) as $entry) {

--- a/includes/discovery/processors.inc.php
+++ b/includes/discovery/processors.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Processors : ';
-
 // Include all discovery modules
 $include_dir = 'includes/discovery/processors';
 require 'includes/include-dir.inc.php';

--- a/includes/discovery/route.inc.php
+++ b/includes/discovery/route.inc.php
@@ -25,7 +25,6 @@ $ids = array();
 // For the moment only will be cisco and the version 3
 if ($device['os_group'] == "cisco") {
 
-    echo ("ROUTE : ");
     //RFC1213-MIB
     $mib = "RFC1213-MIB";
     //IpRouteEntry

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -2,8 +2,6 @@
 
 $valid['sensor'] = array();
 
-echo 'Sensors: ';
-
 require 'includes/discovery/sensors/cisco-entity-sensor.inc.php';
 require 'includes/discovery/sensors/entity-sensor.inc.php';
 require 'includes/discovery/sensors/ipmi.inc.php';

--- a/includes/discovery/services.inc.php
+++ b/includes/discovery/services.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($config['discover_services']) {
-    echo 'Services: ';
 
     // FIXME: use /etc/services?
     $known_services = array(

--- a/includes/discovery/storage.inc.php
+++ b/includes/discovery/storage.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Storage : ';
-
 // Include all discovery modules
 $include_dir = 'includes/discovery/storage';
 require 'includes/include-dir.inc.php';

--- a/includes/discovery/stp.inc.php
+++ b/includes/discovery/stp.inc.php
@@ -14,8 +14,6 @@
  * needs RSTP-MIB
  */
 
-echo "Spanning Tree: ";
-
 // Pre-cache existing state of STP for this device from database
 $stp_db = dbFetchRow('SELECT * FROM `stp` WHERE `device_id` = ?', array($device['device_id']));
 //d_echo($stp_db);

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -3,8 +3,6 @@
 if ($config['enable_printers']) {
     $valid_toner = array();
 
-    echo 'Toner : ';
-
     if ($device['os_group'] == 'printer') {
         $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.12.1.1.2.1 ', '-OsqnU'));
         if (!$oids) {

--- a/includes/discovery/ucd-diskio.inc.php
+++ b/includes/discovery/ucd-diskio.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-echo 'UCD Disk IO : ';
 $diskio_array = snmpwalk_cache_oid($device, 'diskIOEntry', array(), 'UCD-DISKIO-MIB', '+'.$config['install_dir'].'/mibs/');
 $valid_diskio = array();
 if (is_array($diskio_array)) {

--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo "VLANs:\n";
-
 // Pre-cache the existing state of VLANs for this device from the database
 $vlans_db_raw = dbFetchRows('SELECT * FROM `vlans` WHERE `device_id` = ?', array($device['device_id']));
 foreach ($vlans_db_raw as $vlan_db) {

--- a/includes/discovery/vmware-vminfo.inc.php
+++ b/includes/discovery/vmware-vminfo.inc.php
@@ -16,8 +16,6 @@ if (($device['os'] == 'vmware') || ($device['os'] == 'linux')) {
      * CONSOLE: Start the VMware discovery process.
      */
 
-    echo 'VMware VM: ';
-
     /*
      * Fetch information about Virtual Machines.
      */

--- a/includes/polling/applications.inc.php
+++ b/includes/polling/applications.inc.php
@@ -6,7 +6,6 @@ d_echo($sql."\n");
 $app_rows = dbFetchRows('SELECT * FROM `applications` WHERE `device_id`  = ?', array($device['device_id']));
 
 if (count($app_rows)) {
-    echo 'Applications:';
     foreach ($app_rows as $app) {
         $app_include = $config['install_dir'].'/includes/polling/applications/'.$app['app_type'].'.inc.php';
         if (is_file($app_include)) {

--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -2,7 +2,6 @@
 if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
     global $config;
 
-    echo 'Aruba Controller: ';
     $polled = time();
 
     // Build SNMP Cache Array

--- a/includes/polling/cisco-cbqos.inc.php
+++ b/includes/polling/cisco-cbqos.inc.php
@@ -64,7 +64,6 @@ if ($device['os_group'] == "cisco") {
             }
         } // End foreach components
 
-        echo $module." ";
     } // end if count components
 
     // Clean-up after yourself!

--- a/includes/polling/cisco-cef.inc.php
+++ b/includes/polling/cisco-cef.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($device['os_group'] == 'cisco') {
-    echo 'Cisco CEF Switching Path: ';
 
     $cefs   = array();
     $cefs   = snmpwalk_cache_threepart_oid($device, 'CISCO-CEF-MIB::cefSwitchingStatsEntry', $cefs, 'CISCO-CEF-MIB');

--- a/includes/polling/cisco-mac-accounting.inc.php
+++ b/includes/polling/cisco-mac-accounting.inc.php
@@ -6,7 +6,6 @@ if ($device['os_group'] == 'cisco') {
         'cipMacHCSwitchedBytes',
         'cipMacHCSwitchedPkts',
     );
-    echo 'Cisco MAC - Caching OID: ';
     $cip_array = array();
 
     foreach ($cip_oids as $oid) {

--- a/includes/polling/cisco-otv.inc.php
+++ b/includes/polling/cisco-otv.inc.php
@@ -198,7 +198,6 @@ if ($device['os_group'] == "cisco") {
         // Write the Components back to the DB.
         $component->setComponentPrefs($device['device_id'],$components);
 
-        echo $module." ";
     } // end if count components
 
     // Clean-up after yourself!

--- a/includes/polling/cisco-remote-access-monitor.inc.php
+++ b/includes/polling/cisco-remote-access-monitor.inc.php
@@ -65,7 +65,6 @@ if ($device['os_group'] == 'cisco') {
         influx_update($device,'cras_sessions',$tags,$fields);
 
         $graphs['cras_sessions'] = true;
-        echo ' CRAS Sessions';
     }
 
     unset($data, $$rrd_filename, $rrd_create, $fields);

--- a/includes/polling/entity-physical.inc.php
+++ b/includes/polling/entity-physical.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Entity Physical: ';
-
 if ($device['os'] == 'ios') {
     echo "Cisco Cat6xxx/76xx Crossbar : \n";
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -237,17 +237,14 @@ function poll_device($device, $options) {
         if ($options['m']) {
             foreach (explode(',', $options['m']) as $module) {
                 if (is_file('includes/polling/'.$module.'.inc.php')) {
-                    include 'includes/polling/'.$module.'.inc.php';
+                    load_poller_module($module, $device, $attribs);
                 }
             }
         }
         else {
             foreach ($config['poller_modules'] as $module => $module_status) {
                 if ($attribs['poll_'.$module] || ( $module_status && !isset($attribs['poll_'.$module]))) {
-                    $module_start = microtime(true);
-                    include 'includes/polling/'.$module.'.inc.php';
-                    $module_time = microtime(true) - $module_start;
-                    echo "Runtime for polling module '$module': $module_time\n";
+                    load_poller_module($module, $device, $attribs);
 
                     // save per-module poller stats
                     $tags = array(
@@ -530,3 +527,13 @@ function location_to_latlng($device) {
         }
     }
 }// end location_to_latlng()
+
+function load_poller_module($module, $device) {
+    global $config, $valid;
+    $module_start = microtime(true);
+    echo "\n#### Load poller module $module ####\n";
+    include "includes/polling/$module.inc.php";
+    $module_time = microtime(true) - $module_start;
+    echo "\n>> Runtime for poller module '$module': $module_time\n";
+    echo "#### Unload poller module $module ####\n\n";
+}

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -244,7 +244,7 @@ function poll_device($device, $options) {
         else {
             foreach ($config['poller_modules'] as $module => $module_status) {
                 if ($attribs['poll_'.$module] || ( $module_status && !isset($attribs['poll_'.$module]))) {
-                    load_poller_module($module, $device, $attribs);
+                    $module_time = load_poller_module($module, $device, $attribs);
 
                     // save per-module poller stats
                     $tags = array(
@@ -528,7 +528,7 @@ function location_to_latlng($device) {
     }
 }// end location_to_latlng()
 
-function load_poller_module($module, $device) {
+function load_poller_module($module, $device, $attribs) {
     global $config, $valid;
     $module_start = microtime(true);
     echo "\n#### Load poller module $module ####\n";
@@ -537,4 +537,5 @@ function load_poller_module($module, $device) {
     $module_time = substr($module_time, 0, 5);
     echo "\n>> Runtime for poller module '$module': $module_time seconds\n";
     echo "#### Unload poller module $module ####\n\n";
+    return $module_time;
 }

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -534,6 +534,7 @@ function load_poller_module($module, $device) {
     echo "\n#### Load poller module $module ####\n";
     include "includes/polling/$module.inc.php";
     $module_time = microtime(true) - $module_start;
-    echo "\n>> Runtime for poller module '$module': $module_time\n";
+    $module_time = substr($module_time, 0, 5);
+    echo "\n>> Runtime for poller module '$module': $module_time seconds\n";
     echo "#### Unload poller module $module ####\n\n";
 }

--- a/includes/polling/hr-mib.inc.php
+++ b/includes/polling/hr-mib.inc.php
@@ -5,8 +5,6 @@
 $oid_list = 'hrSystemProcesses.0 hrSystemNumUsers.0';
 $hrSystem = snmp_get_multi($device, $oid_list, '-OUQs', 'HOST-RESOURCES-MIB');
 
-echo 'HR Stats:';
-
 if (is_numeric($hrSystem[0]['hrSystemProcesses'])) {
     $rrd_file = $config['rrd_dir'].'/'.$device['hostname'].'/hr_processes.rrd';
     if (!is_file($rrd_file)) {

--- a/includes/polling/ipSystemStats.inc.php
+++ b/includes/polling/ipSystemStats.inc.php
@@ -46,7 +46,6 @@
 // IP-MIB::ipSystemStatsDiscontinuityTime.ipv6 = Timeticks: (0) 0:00:00.00
 // IP-MIB::ipSystemStatsRefreshRate.ipv4 = Gauge32: 30000 milli-seconds
 // IP-MIB::ipSystemStatsRefreshRate.ipv6 = Gauge32: 30000 milli-seconds
-echo 'Polling IP-MIB ipSystemStats ';
 
 $ipSystemStats = snmpwalk_cache_oid($device, 'ipSystemStats', null, 'IP-MIB');
 

--- a/includes/polling/junose-atm-vp.inc.php
+++ b/includes/polling/junose-atm-vp.inc.php
@@ -13,8 +13,6 @@ if (count($vp_rows)) {
     $vp_cache = snmpwalk_cache_multi_oid($device, 'juniAtmVpStatsOutPacketOctets', $vp_cache, 'Juniper-UNI-ATM-MIB', $config['install_dir'].'/mibs/junose');
     $vp_cache = snmpwalk_cache_multi_oid($device, 'juniAtmVpStatsOutPacketErrors', $vp_cache, 'Juniper-UNI-ATM-MIB', $config['install_dir'].'/mibs/junose');
 
-    echo 'Checking JunOSe ATM vps: ';
-
     foreach ($vp_rows as $vp) {
         echo '.';
 

--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -31,7 +31,6 @@
 // NS-ROOT-MIB::vsvrTotalClients."observium" = Counter64: 43023
 // NS-ROOT-MIB::vsvrClientConnOpenRate."observium" = STRING: "0"
 if ($device['os'] == 'netscaler') {
-    echo "Netscaler VServers\n";
 
     $oids_gauge = array(
                    'vsvrCurClntConnections',

--- a/includes/polling/netstats.inc.php
+++ b/includes/polling/netstats.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-echo 'Polling Netstats:';
-
 require 'netstats-ip.inc.php';
 require 'netstats-tcp.inc.php';
 require 'netstats-udp.inc.php';

--- a/includes/polling/ospf.inc.php
+++ b/includes/polling/ospf.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-echo 'OSPF: ';
 $ospf_instance_count  = 0;
 $ospf_port_count      = 0;
 $ospf_area_count      = 0;

--- a/includes/polling/stp.inc.php
+++ b/includes/polling/stp.inc.php
@@ -14,8 +14,6 @@
  * needs RSTP-MIB
  */
 
-echo "Spanning Tree: ";
-
 // Pre-cache existing state of STP for this device from database
 $stp_db = dbFetchRow('SELECT * FROM `stp` WHERE `device_id` = ?', array($device['device_id']));
 //d_echo($stp_db);

--- a/includes/polling/ucd-diskio.inc.php
+++ b/includes/polling/ucd-diskio.inc.php
@@ -6,8 +6,6 @@ if (count($diskio_data)) {
     $diskio_cache = array();
     $diskio_cache = snmpwalk_cache_oid($device, 'diskIOEntry', $diskio_cache, 'UCD-DISKIO-MIB');
 
-    echo 'Checking UCD DiskIO MIB: ';
-
     foreach ($diskio_data as $diskio) {
         $index = $diskio['diskio_index'];
 

--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['type'] == 'wireless') {
-    echo "Wireless: MAG\n";
 
     if ($device['os'] == 'airos') {
         echo "It Is Airos\n";


### PR DESCRIPTION
Output now looks like:

```bash
#### Load poller module storage ####
Storage /: 3% [RRD Disabled]
Storage /sys/fs/cgroup: 0% [RRD Disabled]
Storage /sys/fs/cgroup/cgmanager: 0% [RRD Disabled]
Storage /dev/shm: 0% [RRD Disabled]
Storage /run: 9% [RRD Disabled]
Storage /run/user/0: 0% [RRD Disabled]
Storage /run/user/997: 0% [RRD Disabled]

>> Runtime for poller module 'storage': 0.450 seconds
#### Unload poller module storage ####
```

Tidies things up a little.

Also fixed a bug where the device group include was setting debug.