### PR TITLE
Added support for Juniper optic sensors

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -892,14 +892,6 @@ function generate_ap_url($ap, $vars=array()) {
 
 }//end generate_ap_url()
 
-
-function report_this($message) {
-    global $config;
-    return '<h2>'.$message.' Please <a href="'.$config['project_issues'].'">report this</a> to the '.$config['project_name'].' developers.</h2>';
-
-}//end report_this()
-
-
 function report_this_text($message) {
     global $config;
     return $message.'\nPlease report this to the '.$config['project_name'].' developers at '.$config['project_issues'].'\n';

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -5,7 +5,6 @@ $valid['sensor'] = array();
 // Pre-cache data for later use
 require 'includes/discovery/sensors/pre-cache.inc.php';
 
-
 require 'includes/discovery/sensors/cisco-entity-sensor.inc.php';
 require 'includes/discovery/sensors/entity-sensor.inc.php';
 require 'includes/discovery/sensors/ipmi.inc.php';

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -2,6 +2,10 @@
 
 $valid['sensor'] = array();
 
+// Pre-cache data for later use
+require 'includes/discovery/sensors/pre-cache.inc.php';
+
+
 require 'includes/discovery/sensors/cisco-entity-sensor.inc.php';
 require 'includes/discovery/sensors/entity-sensor.inc.php';
 require 'includes/discovery/sensors/ipmi.inc.php';

--- a/includes/discovery/sensors/current/junos.inc.php
+++ b/includes/discovery/sensors/current/junos.inc.php
@@ -1,0 +1,24 @@
+<?php
+
+if ($device['os'] == 'junos' || $device['os_group'] == 'junos') {
+    echo 'JunOS ';
+
+    $multiplier = 1;
+    $divisor    = 1000000;
+    foreach ($junos_oids as $index => $entry) {
+        if (is_numeric($entry['jnxDomCurrentTxLaserBiasCurrent'])) {
+            $oid = '.1.3.6.1.4.1.2636.3.60.1.1.1.1.6.'.$index;
+            $descr = dbFetchCell('SELECT `ifDescr` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ?', array($index, $device['device_id'])) . ' Rx Current';
+            $limit_low = $entry['jnxDomCurrentTxLaserBiasCurrentLowAlarmThreshold']/$divisor;
+            $warn_limit_low = $entry['jnxDomCurrentTxLaserBiasCurrentLowWarningThreshold']/$divisor;
+            $limit = $entry['jnxDomCurrentTxLaserBiasCurrentHighAlarmThreshold']/$divisor;
+            $warn_limit = $entry['jnxDomCurrentTxLaserBiasCurrentHighWarningThreshold']/$divisor;
+            $current = $entry['jnxDomCurrentTxLaserBiasCurrent'];
+            $entPhysicalIndex = $index;
+            $entPhysicalIndex_measured = 'ports';
+            discover_sensor($valid['sensor'], 'current', $device, $oid, 'rx-'.$index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        }
+
+    }
+
+}

--- a/includes/discovery/sensors/current/junos.inc.php
+++ b/includes/discovery/sensors/current/junos.inc.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2016 Neil Lathwood <neil@lathwood.co.uk>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
 
 if ($device['os'] == 'junos' || $device['os_group'] == 'junos') {
     echo 'JunOS ';

--- a/includes/discovery/sensors/dbm/junos.inc.php
+++ b/includes/discovery/sensors/dbm/junos.inc.php
@@ -1,0 +1,37 @@
+<?php
+
+if ($device['os'] == 'junos' || $device['os_group'] == 'junos') {
+    echo 'JunOS ';
+
+    $multiplier = 1;
+    $divisor    = 100;
+    foreach ($junos_oids as $index => $entry) {
+        if (is_numeric($entry['jnxDomCurrentRxLaserPower'])) {
+            $oid = '.1.3.6.1.4.1.2636.3.60.1.1.1.1.5.'.$index;
+            $descr = dbFetchCell('SELECT `ifDescr` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ?', array($index, $device['device_id'])) . ' Rx Power';
+            $limit_low = $entry['jnxDomCurrentRxLaserPowerLowAlarmThreshold']/$divisor;
+            $warn_limit_low = $entry['jnxDomCurrentRxLaserPowerLowWarningThreshold']/$divisor;
+            $limit = $entry['jnxDomCurrentRxLaserPowerHighAlarmThreshold']/$divisor;
+            $warn_limit = $entry['jnxDomCurrentRxLaserPowerHighWarningThreshold']/$divisor;
+            $current = $entry['jnxDomCurrentRxLaserPower'];
+            $entPhysicalIndex = $index;
+            $entPhysicalIndex_measured = 'ports';
+            discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-'.$index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        }
+
+        if (is_numeric($entry['jnxDomCurrentTxLaserOutputPower'])) {
+            $oid = '.1.3.6.1.4.1.2636.3.60.1.1.1.1.7.'.$index;
+            $descr = dbFetchCell('SELECT `ifDescr` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ?', array($index, $device['device_id'])) . ' Tx Power';
+            $limit_low = $entry['jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold']/$divisor;
+            $warn_limit_low = $entry['jnxDomCurrentTxLaserOutputPowerLowWarningThreshold']/$divisor;
+            $limit = $entry['jnxDomCurrentModuleTemperatureHighAlarmThreshold']/$divisor;
+            $warn_limit = $entry['jnxDomCurrentModuleTemperatureHighWarningThreshold']/$divisor;
+            $current = $entry['jnxDomCurrentTxLaserOutputPower'];
+            $entPhysicalIndex = $index;
+            $entPhysicalIndex_measured = 'ports';
+            discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-'.$index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        }
+
+    }
+
+}

--- a/includes/discovery/sensors/dbm/junos.inc.php
+++ b/includes/discovery/sensors/dbm/junos.inc.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2016 Neil Lathwood <neil@lathwood.co.uk>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
 
 if ($device['os'] == 'junos' || $device['os_group'] == 'junos') {
     echo 'JunOS ';

--- a/includes/discovery/sensors/pre-cache.inc.php
+++ b/includes/discovery/sensors/pre-cache.inc.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2016 Neil Lathwood <neil@lathwood.co.uk>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
 
 echo 'Pre-cache: ';
 

--- a/includes/discovery/sensors/pre-cache.inc.php
+++ b/includes/discovery/sensors/pre-cache.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+echo 'Pre-cache: ';
+
+// Include all discovery modules
+$include_dir = 'includes/discovery/sensors/pre-cache';
+require 'includes/include-dir.inc.php';
+
+echo "\n";

--- a/includes/discovery/sensors/pre-cache/junos.inc.php
+++ b/includes/discovery/sensors/pre-cache/junos.inc.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2016 Neil Lathwood <neil@lathwood.co.uk>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
 
 if ($device['os'] == 'junos') {
 

--- a/includes/discovery/sensors/pre-cache/junos.inc.php
+++ b/includes/discovery/sensors/pre-cache/junos.inc.php
@@ -1,0 +1,12 @@
+<?php
+
+if ($device['os'] == 'junos') {
+
+    echo 'Pre-cache JunOS: ';
+
+    $junos_oids = array();
+    echo 'Caching OIDs:';
+
+    $junos_oids = snmpwalk_cache_multi_oid($device, 'JnxDomCurrentEntry', $oids, 'JUNIPER-DOM-MIB', $config['mib_dir'].':'.$config['mib_dir'].'/junos');
+
+}

--- a/includes/discovery/sensors/temperatures/junos.inc.php
+++ b/includes/discovery/sensors/temperatures/junos.inc.php
@@ -26,4 +26,21 @@ if ($device['os'] == 'junos' || $device['os_group'] == 'junos') {
             }
         }
     }
+
+    $multiplier = 1;
+    $divisor    = 1;
+    foreach ($junos_oids as $index => $entry) {
+        if (is_numeric($entry['jnxDomCurrentModuleTemperature'])) {
+            $oid = '.1.3.6.1.4.1.2636.3.60.1.1.1.1.8.'.$index;
+            $descr = dbFetchCell('SELECT `ifDescr` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ?', array($index, $device['device_id'])) . ' Temperature';
+            $limit_low = $entry['jnxDomCurrentModuleTemperatureLowAlarmThreshold']/$divisor;
+            $warn_limit_low = $entry['jnxDomCurrentModuleTemperatureLowWarningThreshold']/$divisor;
+            $limit = $entry['jnxDomCurrentModuleTemperatureHighAlarmThreshold']/$divisor;
+            $warn_limit = $entry['jnxDomCurrentModuleTemperatureHighWarningThreshold']/$divisor;
+            $current = $entry['jnxDomCurrentModuleTemperature'];
+            $entPhysicalIndex = $index;
+            $entPhysicalIndex_measured = 'ports';
+            discover_sensor($valid['sensor'], 'temperature', $device, $oid, 'rx-'.$index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+        }
+    }
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1535,3 +1535,9 @@ function create_sensor_to_state_index($device, $state_name, $index)
         dbInsert($insert, 'sensors_to_state_indexes');
     }
 }
+
+function report_this($message) {
+    global $config;
+    return '<h2>'.$message.' Please <a href="'.$config['project_issues'].'">report this</a> to the '.$config['project_name'].' developers.</h2>';
+
+}//end report_this()


### PR DESCRIPTION
This adds support for optic sensors in junos kit where supported.

I've learnt in the sensors table we have entPhysicalIndex and entPhysicalIndex_measured which for cisco kit points to the entPhysical information. For Juniper I can't see the same but it made sense to map these to the ifIndex and ports so you can tie alert rules into ports as well and then not alert on optic sensors where the port is down.

report_this() was moved as it's called from snmp.inc.php which doesn't have access to html/includes/functions.inc.php

The pre-cache in sensors is so we only bulkwalk the table once at the start and make it available to all included files.

Tested against a live device.