### PR TITLE
Always log why discovery fails

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -28,13 +28,16 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
         // $ip isn't a valid IP so it must be a name.
         if ($ip == $dst_host) {
             d_echo("name lookup of $dst_host failed\n");
-
+            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check name lookup", $device['device_id'], 'discovery');
+ 
             return false;
         }
     } elseif (filter_var($dst_host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === true || filter_var($dst_host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === true) {
         // gethostbyname returned a valid $ip, was $dst_host an IP?
         if ($config['discovery_by_ip'] === false) {
             d_echo('Discovery by IP disabled, skipping ' . $dst_host);
+            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Discovery by IP disabled", $device['device_id'], 'discovery');
+ 
             return false;
         }
     }
@@ -65,10 +68,12 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
 
                 log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery');
             } else {
-                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check ping and SNMP access", $device['device_id'], 'discovery');
+                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check SNMP access", $device['device_id'], 'discovery');
             }
 
             return $remote_device_id;
+        } else {
+            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check SNMP access", $device['device_id'], 'discovery');
         }
     } else {
         d_echo("$ip not in a matched network - skipping\n");

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -68,13 +68,13 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
 
                 log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery');
             } else {
-                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check SNMP access", $device['device_id'], 'discovery');
+                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check ping and SNMP access", $device['device_id'], 'discovery');
             }
 
             return $remote_device_id;
         } 
         else {
-            log_event("$method discovery of " . $dst_host . " ($ip) failed - Check SNMP access", $device['device_id'], 'discovery');
+            log_event("$method discovery of " . $dst_host . " ($ip) failed - Check ping and SNMP access", $device['device_id'], 'discovery');
         }
     } else {
         d_echo("$ip not in a matched network - skipping\n");

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -28,7 +28,7 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
         // $ip isn't a valid IP so it must be a name.
         if ($ip == $dst_host) {
             d_echo("name lookup of $dst_host failed\n");
-            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check name lookup", $device['device_id'], 'discovery');
+            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check name lookup", $device['device_id'], 'discovery');
  
             return false;
         }
@@ -68,12 +68,13 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
 
                 log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery');
             } else {
-                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check SNMP access", $device['device_id'], 'discovery');
+                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check SNMP access", $device['device_id'], 'discovery');
             }
 
             return $remote_device_id;
-        } else {
-            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - check SNMP access", $device['device_id'], 'discovery');
+        } 
+        else {
+            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check SNMP access", $device['device_id'], 'discovery');
         }
     } else {
         d_echo("$ip not in a matched network - skipping\n");

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -28,7 +28,7 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
         // $ip isn't a valid IP so it must be a name.
         if ($ip == $dst_host) {
             d_echo("name lookup of $dst_host failed\n");
-            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check name lookup", $device['device_id'], 'discovery');
+            log_event("$method discovery of " . $dst_host  . " failed - Check name lookup", $device['device_id'], 'discovery');
  
             return false;
         }
@@ -36,7 +36,7 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
         // gethostbyname returned a valid $ip, was $dst_host an IP?
         if ($config['discovery_by_ip'] === false) {
             d_echo('Discovery by IP disabled, skipping ' . $dst_host);
-            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Discovery by IP disabled", $device['device_id'], 'discovery');
+            log_event("$method discovery of " . $dst_host . " failed - Discovery by IP disabled", $device['device_id'], 'discovery');
  
             return false;
         }
@@ -74,7 +74,7 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
             return $remote_device_id;
         } 
         else {
-            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check SNMP access", $device['device_id'], 'discovery');
+            log_event("$method discovery of " . $dst_host . " ($ip) failed - Check SNMP access", $device['device_id'], 'discovery');
         }
     } else {
         d_echo("$ip not in a matched network - skipping\n");


### PR DESCRIPTION
Modified discover_new_device() function to always log why discovery of a new host fails

Searching for discover in the event log after this change will show hosts where discovery failed and snmp or otherwise needs to be fixed.

Tested the third logging function on my machine, just added the other two, think I got the logic right.