### PR TITLE
Remove extra dbInsert from dashborads creation

### DIFF
--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -22,7 +22,6 @@ if (($tmp = dbFetchCell('SELECT dashboard FROM users WHERE user_id=?',array($_SE
     $default_dash = $tmp;
 }
 else if (dbFetchCell('SELECT dashboard_id FROM dashboards WHERE user_id=?',array($_SESSION['user_id'])) == 0) {
-    $tmp = dbInsert(array('dashboard_name'=>'Default','user_id'=>$_SESSION['user_id']),'dashboards');
     $vars['dashboard'] = dbInsert(array('dashboard_name'=>'Default','user_id'=>$_SESSION['user_id']),'dashboards');
     if (dbFetchCell('select 1 from users_widgets where user_id = ? && dashboard_id = ?',array($_SESSION['user_id'],0)) == 1) {
         dbUpdate(array('dashboard_id'=>$vars['dashboard']),'users_widgets','user_id = ? && dashboard_id = ?',array($_SESSION['user_id'],0));


### PR DESCRIPTION
Hi,

Trying to debug an error during dashboard update, I saw that two records were created when a dashboard is newly created. In the code, there is two dbInsert, one to affect a $tmp variable and another to affect $vars variable. $tmp doesn't seem to be used later in the code, so I propose to remoted it to avoid having two dashboards in table :
`mysql> select * from dashboards;
+--------------+---------+----------------+--------+
| dashboard_id | user_id | dashboard_name | access |
+--------------+---------+----------------+--------+

|            1 |       1 | Default        |      0 |
|           11 |   54813 | Default        |      0 |
|           12 |   54813 | Default        |      0 |

+--------------+---------+----------------+--------+
`
 