### PR TITLE
Validate.php fixes

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1039,10 +1039,6 @@ function version_info($remote=true) {
     $output['local_sha']    = rtrim(`git rev-parse HEAD`);
     $output['local_branch'] = rtrim(`git rev-parse --abbrev-ref HEAD`);
 
-    exec('git diff --name-only --exit-code', $cmdoutput, $code);
-    $output['git_modified'] = ($code !== 0);
-    $output['git_modified_files'] = $cmdoutput;
-
     $output['db_schema']   = dbFetchCell('SELECT version FROM dbSchema');
     $output['php_ver']     = phpversion();
     $output['mysql_ver']   = dbFetchCell('SELECT version()');

--- a/validate.php
+++ b/validate.php
@@ -85,11 +85,13 @@ if($versions['local_branch'] != 'master') {
     print_warn("Your local git branch is not master, this will prevent automatic updates.");
 }
 
+// check for modified files
 $modifiedcmd = 'git diff --name-only --exit-code';
 if($username === 'root') {
     $modifiedcmd = 'su '.$config['user'].' -c "'.$modifiedcmd.'"';
 }
-if(exec($modifiedcmd, $cmdoutput, $code) !== 0) {
+exec($modifiedcmd, $cmdoutput, $code);
+if($code !== 0) {
     print_warn("Your local git contains modified files, this could prevent automatic updates.\nModified files:");
     echo(implode("\n", $cmdoutput) . "\n");
 }

--- a/validate.php
+++ b/validate.php
@@ -36,7 +36,7 @@ if (isset($options['h'])) {
 if (strstr(`php -ln config.php`, 'No syntax errors detected')) {
     $first_line = `head -n1 config.php`;
     $last_lines = explode(PHP_EOL, `tail -n2 config.php`);
-    if (strstr($first_line, '\<\?php')) {
+    if (substr($first_line, 0, 5) !== '<?php') {
         print_fail("config.php doesn't start with a <?php - please fix this ($first_line)");
     }
     else if ($last_lines[0] == '?>' && $last_lines[1] == '') {
@@ -84,9 +84,14 @@ else {
 if($versions['local_branch'] != 'master') {
     print_warn("Your local git branch is not master, this will prevent automatic updates.");
 }
-if($versions['git_modified'] === true) {
+
+$modifiedcmd = 'git diff --name-only --exit-code';
+if($username === 'root') {
+    $modifiedcmd = 'su '.$config['user'].' -c "'.$modifiedcmd.'"';
+}
+if(exec($modifiedcmd, $cmdoutput, $code) !== 0) {
     print_warn("Your local git contains modified files, this could prevent automatic updates.\nModified files:");
-    echo(implode("\n", $versions['git_modified_files']) . "\n");
+    echo(implode("\n", $cmdoutput) . "\n");
 }
 
 echo "DB Schema: ".$versions['db_schema']."\n";


### PR DESCRIPTION
Run git as the configured user when ./validate.php is run as root
Move the modified files check out of the get_version function
Actually checks if the file starts with '<?php', not just that the first line contains it.

Fix for issue found in #3672, alternate PR #3725 