### PR TITLE
Ability to set Max repeaters per device

### DIFF
--- a/doc/Support/FAQ.md
+++ b/doc/Support/FAQ.md
@@ -15,6 +15,7 @@
  - [Why do I see traffic spikes in my graphs?](#faq15)
  - [Why do I see gaps in my graphs?](#faq17)
  - [How do I change the IP / hostname of a device?](#faq16)
+ - [My device doesn't finish polling within 300 seconds](#faq19)
  - [Things aren't working correctly?](#faq18)
 
 ### Developing
@@ -119,6 +120,14 @@ Usage:
 ```bash
 ./renamehost.php <old hostname> <new hostname>
 ```
+
+#### <a name="faq19"> My device doesn't finish polling within 300 seconds</a>
+
+We have a few things you can try:
+
+  - Disable unnecessary polling modules under edit device.
+  - Set a max repeater value within the snmp settings for a device.
+    What to set this to is tricky, you really should run an snmpbulkwalk with -Cr10 through -Cr50 to see what works best. 50 is usually a good choice if the device can cope.
 
 #### <a name="faq18"> Things aren't working correctly?</a>
 

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -167,6 +167,10 @@ function snmp_walk($device, $oid, $options=null, $mib=null, $mibdir=null) {
     }
     else {
         $snmpcommand = $config['snmpbulkwalk'];
+        $max_repeaters = get_dev_attrib($device, 'snmp_max_repeaters');
+        if ($max_repeaters > 0) {
+            $snmpcommand .= " -Cr$max_repeaters ";
+        }
     }
 
     $cmd = $snmpcommand;
@@ -230,6 +234,10 @@ function snmpwalk_cache_cip($device, $oid, $array=array(), $mib=0) {
     }
     else {
         $snmpcommand = $config['snmpbulkwalk'];
+        $max_repeaters = get_dev_attrib($device, 'snmp_max_repeaters');
+        if ($max_repeaters > 0) {
+            $snmpcommand .= " -Cr$max_repeaters ";
+        }
     }
 
     $cmd  = $snmpcommand;
@@ -301,6 +309,10 @@ function snmp_cache_ifIndex($device) {
     }
     else {
         $snmpcommand = $config['snmpbulkwalk'];
+        $max_repeaters = get_dev_attrib($device, 'snmp_max_repeaters');
+        if ($max_repeaters > 0) {
+            $snmpcommand .= " -Cr$max_repeaters ";
+        }
     }
 
     $cmd  = $snmpcommand;
@@ -461,6 +473,10 @@ function snmpwalk_cache_twopart_oid($device, $oid, $array, $mib=0) {
     }
     else {
         $snmpcommand = $config['snmpbulkwalk'];
+        $max_repeaters = get_dev_attrib($device, 'snmp_max_repeaters');
+        if ($max_repeaters > 0) {
+            $snmpcommand .= " -Cr$max_repeaters ";
+        }
     }
 
     $cmd  = $snmpcommand;
@@ -515,6 +531,10 @@ function snmpwalk_cache_threepart_oid($device, $oid, $array, $mib=0) {
     }
     else {
         $snmpcommand = $config['snmpbulkwalk'];
+        $max_repeaters = get_dev_attrib($device, 'snmp_max_repeaters');
+        if ($max_repeaters > 0) {
+            $snmpcommand .= " -Cr$max_repeaters ";
+        }
     }
 
     $cmd  = $snmpcommand;
@@ -573,6 +593,10 @@ function snmp_cache_slotport_oid($oid, $device, $array, $mib=0) {
     }
     else {
         $snmpcommand = $config['snmpbulkwalk'];
+        $max_repeaters = get_dev_attrib($device, 'snmp_max_repeaters');
+        if ($max_repeaters > 0) {
+            $snmpcommand .= " -Cr$max_repeaters ";
+        }
     }
 
     $cmd  = $snmpcommand;


### PR DESCRIPTION
This will tag on to the snmpbulk* command -Cr$num

Should be useful to those with large number of ports and / or high latency to devices.

Default is off with no way to turn on globally, it has to be set per device. 