### PR TITLE
prevent device_by_id_cache from adding unneeded array elements to $device

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -318,14 +318,16 @@ function device_by_id_cache($device_id, $refresh = '0') {
 		
 		//order vrf_lite_cisco with context, this will help to get the vrf_name and instance_name all the time
 		$vrfs_lite_cisco = dbFetchRows("SELECT * FROM `vrf_lite_cisco` WHERE `device_id` = ?", array($device_id));
-		$device['vrf_lite_cisco'] = array();
 		if(!empty($vrfs_lite_cisco)){
+			$device['vrf_lite_cisco'] = array();
 			foreach ($vrfs_lite_cisco as $vrf){
 				$device['vrf_lite_cisco'][$vrf['context_name']] = $vrf;
 			}
 		}
 
-        $device['ip'] = inet6_ntop($device['ip']);
+        if(!empty($device['ip'])) {
+            $device['ip'] = inet6_ntop($device['ip']);
+        }
         $cache['devices']['id'][$device_id] = $device;
     }
     return $device;


### PR DESCRIPTION
I was attempting to use the get_device endpoint to determine whether a device existed in LibreNMS as the endpoint is written to return a 404 if the device doesn't exist. But I found that no matter what hostname you gave it a 200 would be returned along with this:

`{ "status": "ok", "devices": [ { "vrf_lite_cisco": [], "ip": "" } ] }`

get_device depends on device_by_id_cache for a device object, which hits the DB for the device table info and vrf_lite_cisco table info. However, the index 'vrf_lite_cisco' is added to the device object before validating that anything was returned from the DB. 'ip' gets added by processing it with inet6_pton whether or not an IP was returned from the DB.

This commit moves the addition of 'vrf_lite_cisco' in to the block that validates that any vrf rows exist, and adds the same kind of validation to the IP element.