### PR TITLE
Force explicit full path to mib files.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -111,6 +111,7 @@ LibreNMS contributors:
 - Benjamin Busche <benjamin.busche@gmail.com> (optic00)
 - Brandon Boudrias <bt.boudrias@gmail.com> (brandune)
 - Andy Noyland <andrew@noyland.co.uk> (Zappatron) 
+- Mark Steckel <mjs@fix.net> (mjsteckel)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -45,6 +45,12 @@ function mibdir($mibdir) {
 
 }//end mibdir()
 
+function mibpath($mib, $mibdir) {
+    global $config;
+    return ' -m '.($mibdir ? $mibdir : $config['mibdir']) .'/'.$mib;
+
+}//end mibpath()
+
 
 function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=null) {
     global $debug,$config,$runtime_stats,$mibs_loaded;
@@ -65,10 +71,8 @@ function snmp_get_multi($device, $oids, $options='-OQUs', $mib=null, $mibdir=nul
     }
 
     if ($mib) {
-        $cmd .= ' -m '.$mib;
+        $cmd .= mibpath($mib, $mibdir);
     }
-
-    $cmd .= mibdir($mibdir);
 
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
@@ -120,10 +124,8 @@ function snmp_get($device, $oid, $options=null, $mib=null, $mibdir=null) {
     }
 
     if ($mib) {
-        $cmd .= ' -m '.$mib;
+        $cmd .= mibpath($mib, $mibdir);
     }
-
-    $cmd .= mibdir($mibdir);
 
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
     $cmd .= isset($retries) ? ' -r '.$retries : '';
@@ -178,7 +180,7 @@ function snmp_walk($device, $oid, $options=null, $mib=null, $mibdir=null) {
     }
 
     if ($mib) {
-        $cmd .= " -m $mib";
+        $cmd .= mibpath($mib, $mibdir);
     }
 
     $cmd .= mibdir($mibdir);
@@ -237,7 +239,7 @@ function snmpwalk_cache_cip($device, $oid, $array=array(), $mib=0) {
 
     $cmd .= ' -O snQ';
     if ($mib) {
-        $cmd .= " -m $mib";
+        $cmd .= mibpath($mib, $mibdir);
     }
 
     $cmd .= mibdir(null);
@@ -470,7 +472,7 @@ function snmpwalk_cache_twopart_oid($device, $oid, $array, $mib=0) {
     $cmd .= mibdir(null);
 
     if ($mib) {
-        $cmd .= " -m $mib";
+        $cmd .= mibpath($mib, $mibdir);
     }
 
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
@@ -523,7 +525,7 @@ function snmpwalk_cache_threepart_oid($device, $oid, $array, $mib=0) {
     $cmd .= ' -O QUs';
     $cmd .= mibdir(null);
     if ($mib) {
-        $cmd .= " -m $mib";
+        $cmd .= mibpath($mib, $mibdir);
     }
 
     $cmd .= isset($timeout) ? ' -t '.$timeout : '';
@@ -580,7 +582,7 @@ function snmp_cache_slotport_oid($oid, $device, $array, $mib=0) {
 
     $cmd .= ' -O QUs';
     if ($mib) {
-        $cmd .= " -m $mib";
+        $cmd .= mibpath($mib, $mibdir);
     }
 
     $cmd .= mibdir(null);
@@ -643,7 +645,7 @@ function snmp_cache_port_oids($oids, $port, $device, $array, $mib=0) {
 
     $cmd .= mibdir(null);
     if ($mib) {
-        $cmd .= " -m $mib";
+        $cmd .= mibpath($mib, $mibdir);
     }
 
     $cmd .= ' -t '.$timeout.' -r '.$retries;

--- a/mibs/UBNT-AirFIBER-MIB
+++ b/mibs/UBNT-AirFIBER-MIB
@@ -1,20 +1,114 @@
-UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
+UBNT-MIB DEFINITIONS ::= BEGIN
     IMPORTS
-        MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter64, 
-        IpAddress FROM SNMPv2-SMI
+        MODULE-IDENTITY, OBJECT-TYPE, Integer32, Gauge32, Counter64, 
+        IpAddress, TimeTicks, enterprises  FROM SNMPv2-SMI
         DisplayString, TruthValue, MacAddress FROM SNMPv2-TC
-        OBJECT-GROUP FROM SNMPv2-CONF
-        ubntMIB FROM UBNT-MIB;
+        OBJECT-GROUP, MODULE-COMPLIANCE FROM SNMPv2-CONF;
+        -- ubntAirosGroups, ubntMIB FROM UBNT-MIB;
 
 
-    ubntAirFIBER MODULE-IDENTITY
-    LAST-UPDATED "201405270000Z"
+    ubntMIB MODULE-IDENTITY
+    LAST-UPDATED "201408150000Z"
     ORGANIZATION "Ubiquiti Networks, Inc."
     CONTACT-INFO "support@ubnt.com"
-    DESCRIPTION  "The AirFIBER MIB module for Ubiquiti Networks, Inc. entities"
-    REVISION "201405090000Z"
-    DESCRIPTION "ubntAirFIBER revision"
-    ::= { ubntMIB 3 }
+    DESCRIPTION  "The MIB module for Ubiquiti Networks, Inc. entities"
+    REVISION "201408150000Z"
+    DESCRIPTION "AF.v2.2 revision"
+    ::= { ubnt 1 }
+
+    -- --------------------------------------------------------------------------------
+    --                         Ubiquiti Networks Root
+    -- --------------------------------------------------------------------------------
+
+    ubnt OBJECT IDENTIFIER ::= { enterprises 41112 }
+
+    -- --------------------------------------------------------------------------------
+    --                         Ubiquiti Networks SNMP Information
+    -- --------------------------------------------------------------------------------
+
+    ubntSnmpInfo OBJECT IDENTIFIER ::= { ubntMIB 2 }
+    ubntSnmpGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 1}
+    ubntAirosGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 2}
+    ubntAirFiberGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 3}
+    ubntEdgeMaxGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 4}
+    ubntUniFiGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 5}
+    ubntAirVisionGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 6}
+    ubntMFiGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 7}
+    ubntUniTelGroups OBJECT IDENTIFIER ::= { ubntSnmpInfo 8}
+
+    -- --------------------------------------------------------------------------------
+    --                         Ubiquiti Networks Products
+    -- --------------------------------------------------------------------------------
+    
+    ubntAirFIBER OBJECT IDENTIFIER ::= { ubntMIB 3 }
+    ubntAirMAX OBJECT IDENTIFIER ::= { ubntMIB 4 }
+    ubntEdgeMax OBJECT IDENTIFIER ::= { ubntMIB 5 }
+    ubntUniFi OBJECT IDENTIFIER ::= { ubntMIB 6 }
+    ubntAirVision OBJECT IDENTIFIER ::= { ubntMIB 7 }
+    ubntMFi OBJECT IDENTIFIER ::= { ubntMIB 8 }
+    ubntUniTel OBJECT IDENTIFIER ::= { ubntMIB 9 }
+
+    -- --------------------------------------------------------------------------------
+    --                         Ubiquiti Networks OR table
+    -- --------------------------------------------------------------------------------
+
+
+    ubntORTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntOREntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Capabilities"
+        ::= { ubntMIB 1 }
+
+
+    ubntOREntry OBJECT-TYPE
+       SYNTAX     UbntOREntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntORTable"
+       INDEX      { ubntORIndex }
+       ::= { ubntORTable 1 }
+
+
+    UbntOREntry ::= SEQUENCE {
+        ubntORIndex     Integer32,
+        ubntORID        OBJECT IDENTIFIER,
+        ubntORDescr     DisplayString
+    }
+
+
+    ubntORIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Index for the ubntORTable"
+        ::= { ubntOREntry 1 }
+
+
+    ubntORID OBJECT-TYPE
+        SYNTAX     OBJECT IDENTIFIER
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "OR ID"
+        ::= { ubntOREntry 2 }
+
+
+    ubntORDescr OBJECT-TYPE
+        SYNTAX     DisplayString
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Description of idenfifier"
+        ::= { ubntOREntry 3 }
+
+
+    ubntORInfoGroup OBJECT-GROUP OBJECTS {
+        ubntORID, ubntORDescr
+    }
+    STATUS current
+    DESCRIPTION "Collection of related objects"
+    ::= { ubntSnmpGroups 1 }
+
+ubntAirFIBER OBJECT IDENTIFIER ::= { ubntMIB 3 }
 
     -- --------------------------------------------------------------------------------
     --                           AirFiber Config Table
@@ -40,23 +134,23 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
 
     AirFiberConfigEntry ::= SEQUENCE {
     airFiberConfigIndex Integer32,
-    radioEnable         Integer32,
-    radioLinkMode       Integer32,
-    radioDuplex         Integer32,
+    radioEnable         INTEGER,
+    radioLinkMode       INTEGER,
+    radioDuplex         INTEGER,
     txFrequency         Integer32,
     rxFrequency         Integer32,
-    regDomain           Integer32,
-    gpsSync             Integer32,
+    regDomain           DisplayString,
+    gpsSync             INTEGER,
     txPower             Integer32,
-    rxGain              Integer32,
-    maxTxModRate        Integer32,
-    modRateControl      Integer32,
-    ethDPortLinkSpeed   Integer32,
+    rxGain              INTEGER,
+    maxTxModRate        INTEGER,
+    modRateControl      INTEGER,
+    ethDPortLinkSpeed   INTEGER,
     linkName            DisplayString,
     encryptKey          DisplayString,
-    ethFlowControl      Integer32,
-    ethMcastFilter      Integer32,
-    ethTrackRFLink      Integer32,
+    ethFlowControl      INTEGER,
+    ethMcastFilter      INTEGER,
+    ethTrackRFLink      INTEGER,
     ethLinkOffDuration  Integer32,
     ethLinkOffSpacing   Integer32,
     txFrequency1        Integer32,
@@ -79,9 +173,9 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 1 }
 
     radioEnable OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 enabled   (1),
-                eisabled  (2)
+                disabled  (2)
         } 
         MAX-ACCESS read-only
         STATUS current
@@ -89,7 +183,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 2 }
 
    radioLinkMode OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 master (1),
                 slave  (2),
                 spectral (3)
@@ -100,7 +194,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 3 }
 
     radioDuplex OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 halfDuplex (1),
                 fullDuplex (2)
         } 
@@ -131,7 +225,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 7 }
 
     gpsSync OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 off (1),
                 on  (2)
         } 
@@ -148,7 +242,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 9 }
 
     rxGain OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 low  (1),
                 high (2)
         } 
@@ -158,7 +252,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 10 }
 
     maxTxModRate OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
             qPSK-SISO-1-4x (0),
             qPSK-SISO-1x   (1),
             qPSK-MIMO-2x   (2),
@@ -172,7 +266,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 11 }
 
     modRateControl OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 manual    (1),
                 automatic (2)
         }
@@ -182,7 +276,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 12 }
 
     ethDPortLinkSpeed OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
             auto          (1),
             half-10Mbps   (2),
             half-100Mbps  (3),
@@ -210,7 +304,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 15 }
 
     ethFlowControl OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 off (1),
                 on  (2)
         }         
@@ -220,7 +314,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 16 }
    
     ethMcastFilter OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 off (1),
                 on  (2)
         }         
@@ -230,7 +324,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberConfigEntry 17 }
 
     ethTrackRFLink OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 disabled (0),
                 use-Timers (1),
                 enabled  (2)
@@ -341,15 +435,15 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
 
     AirFiberStatusEntry ::= SEQUENCE {
     airFiberStatusIndex     Integer32,
-    curTXModRate            Integer32,
+    curTXModRate            INTEGER,
     radioLinkDistFt         Integer32,
     radioLinkDistM          Integer32,
     rxCapacity              Integer32,
     txCapacity              Integer32,
-    radio0TempC             Integer32,
     radio0TempF             Integer32,
-    radio1TempC             Integer32,
+    radio0TempC             Integer32,
     radio1TempF             Integer32,
+    radio1TempC             Integer32,
     rxPower0                Integer32,
     rxPower0Valid           TruthValue,
     rxOverload0             TruthValue,
@@ -357,7 +451,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
     rxPower1Valid           TruthValue,
     rxOverload1             TruthValue,
     remoteTXPower           Integer32,
-    remoteTXModRate         Integer32,
+    remoteTXModRate         INTEGER,
     remoteRXPower0          Integer32,
     remoteRXPower0Valid     TruthValue,
     remoteRXPower0Overload  TruthValue,
@@ -365,8 +459,8 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
     remoteRXPower1Valid     TruthValue,
     remoteRXPower1Overload  TruthValue,
     countryCode             Integer32,
-    radioLinkState          Integer32,
-    ethDataPortState        Integer32,
+    radioLinkState          INTEGER,
+    ethDataPortState        INTEGER,
     gpsPulse                DisplayString,
     gpsFix                  DisplayString,
     gpsLat                  DisplayString,
@@ -404,7 +498,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberStatusEntry 1 }
 
     curTXModRate OBJECT-TYPE
-       SYNTAX     Integer32 {
+       SYNTAX     INTEGER {
             qPSK-SISO-1-4x (0),
             qPSK-SISO-1x   (1),
             qPSK-MIMO-2x   (2),
@@ -523,7 +617,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberStatusEntry 17 }
 
     remoteTXModRate OBJECT-TYPE
-       SYNTAX     Integer32 {
+       SYNTAX     INTEGER {
             qPSK-SISO-1-4x (0),
             qPSK-SISO-1x   (1),
             qPSK-MIMO-2x   (2),
@@ -586,7 +680,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberStatusEntry 25 }
 
     radioLinkState OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 down (0),
                 up   (1)
         }         
@@ -596,7 +690,7 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         ::= { airFiberStatusEntry 26 }
 
     ethDataPortState OBJECT-TYPE
-        SYNTAX     Integer32 {
+        SYNTAX     INTEGER {
                 down (0),
                 up   (1)
         }         
@@ -1357,4 +1451,851 @@ UBNT-AirFIBER-MIB DEFINITIONS ::= BEGIN
         DESCRIPTION "RF Total Packets Received"
         ::= { airFiberStatisticsEntry 67 }
 
- END
+    ubntAirFiberStatusGroup OBJECT-GROUP OBJECTS {
+        radioEnable,
+        radioLinkMode,
+        radioDuplex,
+        txFrequency,
+        rxFrequency,
+        regDomain,
+        gpsSync,
+        txPower,
+        rxGain,
+        maxTxModRate,
+        modRateControl,
+        ethDPortLinkSpeed,
+        linkName,
+        encryptKey,
+        ethFlowControl,
+        ethMcastFilter,
+        ethTrackRFLink,
+        ethLinkOffDuration,
+        ethLinkOffSpacing,
+        txFrequency1,
+        rxFrequency1,
+        txFrequency2,
+        rxFrequency2,
+        txFrequency3,
+        rxFrequency3,
+        channelWidth,
+        txChannelWidth,
+        rxChannelWidth,
+        curTXModRate,
+        radioLinkDistFt,
+        radioLinkDistM,
+        rxCapacity,
+        txCapacity,
+        radio0TempC,
+        radio0TempF,
+        radio1TempC,
+        radio1TempF,
+        rxPower0,
+        rxPower0Valid,
+        rxOverload0,
+        rxPower1,
+        rxPower1Valid,
+        rxOverload1,
+        remoteTXPower,
+        remoteTXModRate,
+        remoteRXPower0,
+        remoteRXPower0Valid,
+        remoteRXPower0Overload,
+        remoteRXPower1,
+        remoteRXPower1Valid,
+        remoteRXPower1Overload,
+        countryCode,
+        radioLinkState,
+        ethDataPortState,
+        gpsPulse,
+        gpsFix,
+        gpsLat,
+        gpsLong,
+        gpsAltMeters,
+        gpsAltFeet,
+        gpsSatsVisible,
+        gpsSatsTracked,
+        gpsHDOP,
+        dfsState,
+        upTime,
+        dateTime,  
+        fwVersion,
+        remoteRXGain,
+        radioLinkInfo,
+        ethDataPortInfo,    
+        linkUpTime,
+        remoteMAC,
+        remoteIP,
+        dfsDetections,
+        dfsDomain,
+        dfsStateTxFreq1,
+        dfsStateTxFreq2,
+        dfsStateTxFreq3,
+        dfsTimerTxFreq1,
+        dfsTimerTxFreq2,
+        dfsTimerTxFreq3,
+        txFramesOK,
+        rxFramesOK,
+        rxFrameCrcErr,
+        rxAlignErr,
+        txOctetsOK,
+        rxOctetsOK,
+        txPauseFrames,
+        rxPauseFrames,
+        rxErroredFrames,
+        txErroredFrames,
+        rxValidUnicastFrames,
+        rxValidMulticastFrames,
+        rxValidBroadcastFrames,
+        txValidUnicastFrames,
+        txValidMulticastFrames,
+        txValidBroadcastFrames,
+        rxDroppedMacErrFrames,
+        rxTotalOctets,
+        rxTotalFrames,
+        rxLess64ByteFrames,
+        rxOverLengthFrames,
+        rx64BytePackets,
+        rx65-127BytePackets,
+        rx128-255BytePackets,
+        rx256-511BytePackets,
+        rx512-1023BytePackets,
+        rx1024-1518BytesPackets,
+        rx1519PlusBytePackets,
+        rxTooLongFrameCrcErr,
+        rxTooShortFrameCrcErr,
+        txqosoct0,
+        txqosoct1,
+        txqosoct2,
+        txqosoct3,
+        txqosoct4,
+        txqosoct5,
+        txqosoct6,
+        txqosoct7,
+        txqospkt0,
+        txqospkt1,
+        txqospkt2,
+        txqospkt3,
+        txqospkt4,
+        txqospkt5,
+        txqospkt6,
+        txqospkt7,
+        rxqosoct0,
+        rxqosoct1,
+        rxqosoct2,
+        rxqosoct3,
+        rxqosoct4,
+        rxqosoct5,
+        rxqosoct6,
+        rxqosoct7,
+        rxqospkt0,
+        rxqospkt1,
+        rxqospkt2,
+        rxqospkt3,
+        rxqospkt4,
+        rxqospkt5,
+        rxqospkt6,
+        rxqospkt7,
+        txoctetsAll,
+        txpktsAll,
+        rxoctetsAll,
+        rxpktsAll }
+        STATUS current
+        DESCRIPTION "Config Status and statistics for AirFiber monitoring"
+        ::= { ubntAirFiberGroups 1 }
+
+    ubntAirFiberStatusCompliance MODULE-COMPLIANCE
+        STATUS current
+        DESCRIPTION "The compliance statement for Ubiquiti AirFiber entities."
+        MODULE
+            GROUP ubntAirFiberStatusGroup
+            DESCRIPTION "This group is for Ubiquiti systems AirFiber Radios."
+        ::= { ubntAirFiberGroups 2 }
+                
+ubntAirMAX OBJECT IDENTIFIER ::= { ubntMIB 4 }
+
+    -- --------------------------------------------------------------------------------
+    --                            radio table
+    -- --------------------------------------------------------------------------------
+
+    ubntRadioTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntRadioEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Radio status & statistics"
+        ::= { ubntAirMAX 1 }
+
+    ubntRadioEntry OBJECT-TYPE
+       SYNTAX     UbntRadioEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntRadioTable"
+       INDEX      { ubntRadioIndex }
+       ::= { ubntRadioTable 1 }
+
+    UbntRadioEntry ::= SEQUENCE {
+        ubntRadioIndex      Integer32,
+        ubntRadioMode       INTEGER,
+        ubntRadioCCode      Integer32,
+        ubntRadioFreq       Integer32,
+        ubntRadioDfsEnabled TruthValue,
+        ubntRadioTxPower    Integer32,
+        ubntRadioDistance   Integer32,
+        ubntRadioChainmask  Integer32,
+        ubntRadioAntenna    DisplayString
+    }
+
+    ubntRadioIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Index for the ubntRadioTable"
+        ::= { ubntRadioEntry 1 }
+
+    ubntRadioMode OBJECT-TYPE
+        SYNTAX     INTEGER {
+        sta(1),
+        ap(2),
+        aprepeater(3),
+        apwds(4)
+    }
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Radio mode"
+        ::= { ubntRadioEntry 2 }
+
+    ubntRadioCCode OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Country code"
+        ::= { ubntRadioEntry 3 }
+
+    ubntRadioFreq OBJECT-TYPE
+        SYNTAX Integer32 (1..65535)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Operating frequency"
+        ::= { ubntRadioEntry 4 }
+
+    ubntRadioDfsEnabled OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "DFS status"
+        ::= { ubntRadioEntry 5 }
+
+    ubntRadioTxPower OBJECT-TYPE
+        SYNTAX Integer32 (1..65535)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Transmit power"
+        ::= { ubntRadioEntry 6 }
+
+    ubntRadioDistance OBJECT-TYPE
+        SYNTAX Integer32 (1..65535)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Distance"
+        ::= { ubntRadioEntry 7 }
+
+    ubntRadioChainmask OBJECT-TYPE
+        SYNTAX Integer32 (1..255)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Chainmask"
+        ::= { ubntRadioEntry 8 }
+
+    ubntRadioAntenna OBJECT-TYPE
+        SYNTAX     DisplayString
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Antenna"
+        ::= { ubntRadioEntry 9 }
+
+    ubntRadioRssiTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntRadioRssiEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Radio RSSI per chain"
+        ::= { ubntAirMAX 2 }
+
+    ubntRadioRssiEntry OBJECT-TYPE
+       SYNTAX     UbntRadioRssiEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntRadioRssiTable"
+       INDEX      { ubntRadioIndex, ubntRadioRssiIndex }
+       ::= { ubntRadioRssiTable 1 }
+
+    UbntRadioRssiEntry ::= SEQUENCE {
+        ubntRadioRssiIndex Integer32,
+        ubntRadioRssi      Integer32,
+        ubntRadioRssiMgmt  Integer32,
+        ubntRadioRssiExt   Integer32
+    }
+
+    ubntRadioRssiIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible 
+        STATUS     current
+        DESCRIPTION "Index for the ubntRadioRssiTable"
+        ::= { ubntRadioRssiEntry 1 }
+
+    ubntRadioRssi OBJECT-TYPE
+        SYNTAX Integer32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Data frames rssi per chain"
+        ::= { ubntRadioRssiEntry 2 }
+
+    ubntRadioRssiMgmt OBJECT-TYPE
+        SYNTAX Integer32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Management frames rssi per chain"
+        ::= { ubntRadioRssiEntry 3 }
+
+    ubntRadioRssiExt OBJECT-TYPE
+        SYNTAX Integer32
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Extension channel rssi per chain"
+        ::= { ubntRadioRssiEntry 4 }
+
+    -- --------------------------------------------------------------------------------
+    --                            airMAX table
+    -- --------------------------------------------------------------------------------
+
+    ubntAirMaxTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntAirMaxEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "airMAX protocol statistics"
+        ::= { ubntAirMAX 6 }
+
+    ubntAirMaxEntry OBJECT-TYPE
+       SYNTAX     UbntAirMaxEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntAirMaxTable"
+       INDEX      { ubntAirMaxIfIndex }
+       ::= { ubntAirMaxTable 1 }
+
+    UbntAirMaxEntry ::= SEQUENCE {
+        ubntAirMaxIfIndex     Integer32,
+        ubntAirMaxEnabled     TruthValue,
+        ubntAirMaxQuality     Integer32,
+        ubntAirMaxCapacity    Integer32,
+        ubntAirMaxPriority    INTEGER,
+        ubntAirMaxNoAck       TruthValue
+    }
+
+    ubntAirMaxIfIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible 
+        STATUS     current
+        DESCRIPTION "Index for the ubntAirMaxTable"
+        ::= { ubntAirMaxEntry 1 }
+
+    ubntAirMaxEnabled OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "airMAX status - on/off"
+        ::= { ubntAirMaxEntry 2 }
+
+    ubntAirMaxQuality OBJECT-TYPE
+        SYNTAX Integer32 (0..100)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "airMAX quality - percentage"
+        ::= { ubntAirMaxEntry 3 }
+
+    ubntAirMaxCapacity OBJECT-TYPE
+        SYNTAX Integer32 (0..100)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "airMAX capacity - percentage"
+        ::= { ubntAirMaxEntry 4 }
+
+    ubntAirMaxPriority OBJECT-TYPE
+        SYNTAX INTEGER {
+        high(0),
+        medium(1),
+        low(2),
+        none(3)
+    }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "airMAX priority - none/high/low/medium"
+        ::= { ubntAirMaxEntry 5 }
+
+    ubntAirMaxNoAck OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "airMAX NoACK mode - on/off"
+        ::= { ubntAirMaxEntry 6 }
+
+    -- --------------------------------------------------------------------------------
+    --                            airSync table
+    -- --------------------------------------------------------------------------------
+
+    ubntAirSyncTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntAirSyncEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "airSync protocol statistics"
+        ::= { ubntAirMAX 3 }
+
+    ubntAirSyncEntry OBJECT-TYPE
+       SYNTAX     UbntAirSyncEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntAirSyncTable"
+       INDEX      { ubntAirSyncIfIndex }
+       ::= { ubntAirSyncTable 1 }
+
+    UbntAirSyncEntry ::= SEQUENCE {
+        ubntAirSyncIfIndex    Integer32,
+        ubntAirSyncMode       INTEGER,
+        ubntAirSyncCount      Integer32,
+        ubntAirSyncDownUtil   Integer32,
+        ubntAirSyncUpUtil     Integer32
+    }
+
+    ubntAirSyncIfIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible 
+        STATUS     current
+        DESCRIPTION "Index for the ubntAirSyncTable"
+        ::= { ubntAirSyncEntry 1 }
+
+    ubntAirSyncMode OBJECT-TYPE
+        SYNTAX     INTEGER {
+        disabled(0),
+        master(1),
+        slave(2)
+    }
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airSync mode - master/slave"
+        ::= { ubntAirSyncEntry 2 }
+
+    ubntAirSyncCount OBJECT-TYPE
+        SYNTAX     Integer32 (0..255)
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airSync client count"
+        ::= { ubntAirSyncEntry 3 }
+
+    ubntAirSyncDownUtil OBJECT-TYPE
+        SYNTAX     Integer32 (0..100)
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airSync down utilization"
+        ::= { ubntAirSyncEntry 4 }
+
+    ubntAirSyncUpUtil OBJECT-TYPE
+        SYNTAX     Integer32 (0..100)
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airSync up utilization"
+        ::= { ubntAirSyncEntry 5 }
+
+    -- --------------------------------------------------------------------------------
+    --                            airSelect table
+    -- --------------------------------------------------------------------------------
+
+    ubntAirSelTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntAirSelEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "airSelect protocol statistics"
+        ::= { ubntAirMAX 4 }
+
+    ubntAirSelEntry OBJECT-TYPE
+       SYNTAX     UbntAirSelEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntAirSelTable"
+       INDEX      { ubntAirSelIfIndex }
+       ::= { ubntAirSelTable 1 }
+
+    UbntAirSelEntry ::= SEQUENCE {
+        ubntAirSelIfIndex    Integer32,
+        ubntAirSelEnabled    TruthValue,
+        ubntAirSelInterval   Integer32
+    }
+
+    ubntAirSelIfIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible 
+        STATUS     current
+        DESCRIPTION "Index for the ubntAirSelTable"
+        ::= { ubntAirSelEntry 1 }
+
+    ubntAirSelEnabled OBJECT-TYPE
+        SYNTAX TruthValue
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "airSelect status - on/off"
+        ::= { ubntAirSelEntry 2 }
+
+    ubntAirSelInterval OBJECT-TYPE
+        SYNTAX     Integer32 (0..65535)
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airSelect hop interval (miliseconds)"
+        ::= { ubntAirSelEntry 3 }
+
+    -- --------------------------------------------------------------------------------
+    --                            wireless statistics table
+    -- --------------------------------------------------------------------------------
+
+    ubntWlStatTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntWlStatEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Wireless statistics"
+        ::= { ubntAirMAX 5 }
+
+    ubntWlStatEntry OBJECT-TYPE
+       SYNTAX     UbntWlStatEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION "An entry in the ubntWlStatTable"
+       INDEX      { ubntWlStatIndex }
+       ::= { ubntWlStatTable 1 }
+
+    UbntWlStatEntry ::= SEQUENCE {
+        ubntWlStatIndex      Integer32,
+        ubntWlStatSsid       DisplayString,
+        ubntWlStatHideSsid   TruthValue,
+        ubntWlStatApMac      MacAddress,
+        ubntWlStatSignal     Integer32,
+        ubntWlStatRssi       Integer32,
+        ubntWlStatCcq        Integer32,
+        ubntWlStatNoiseFloor Integer32,
+        ubntWlStatTxRate     Integer32,
+        ubntWlStatRxRate     Integer32,
+        ubntWlStatSecurity   DisplayString,
+        ubntWlStatWdsEnabled TruthValue,
+        ubntWlStatApRepeater TruthValue,
+        ubntWlStatChanWidth  Integer32,
+        ubntWlStatStaCount   Gauge32
+    }
+
+    ubntWlStatIndex OBJECT-TYPE
+        SYNTAX     Integer32 (1..255)
+        MAX-ACCESS not-accessible 
+        STATUS     current
+        DESCRIPTION "Index for the ubntWlStatTable"
+        ::= { ubntWlStatEntry 1 }
+
+    ubntWlStatSsid OBJECT-TYPE
+        SYNTAX     DisplayString
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "SSID"
+        ::= { ubntWlStatEntry 2 }
+
+    ubntWlStatHideSsid OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Hide SSID - on/off"
+        ::= { ubntWlStatEntry 3 }
+
+    ubntWlStatApMac OBJECT-TYPE
+        SYNTAX     MacAddress
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "AP MAC address"
+        ::= { ubntWlStatEntry 4 }
+
+    ubntWlStatSignal OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Signal strength, dBm"
+        ::= { ubntWlStatEntry 5 }
+
+    ubntWlStatRssi OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "RSSI, dBm"
+        ::= { ubntWlStatEntry 6 }
+
+    ubntWlStatCcq OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "CCQ in %"
+        ::= { ubntWlStatEntry 7 }
+
+    ubntWlStatNoiseFloor OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Noise floor"
+        ::= { ubntWlStatEntry 8 }
+
+    ubntWlStatTxRate OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "TX rate"
+        ::= { ubntWlStatEntry 9 }
+
+    ubntWlStatRxRate OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "RX rate"
+        ::= { ubntWlStatEntry 10 }
+
+    ubntWlStatSecurity OBJECT-TYPE
+        SYNTAX     DisplayString
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Wireless security mode"
+        ::= { ubntWlStatEntry 11 }
+
+    ubntWlStatWdsEnabled OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "WDS - on/off"
+        ::= { ubntWlStatEntry 12 }
+
+    ubntWlStatApRepeater OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "AP repeater - on/off"
+        ::= { ubntWlStatEntry 13 }
+
+    ubntWlStatChanWidth OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Channel Width"
+        ::= { ubntWlStatEntry 14 }
+
+    ubntWlStatStaCount OBJECT-TYPE
+        SYNTAX     Gauge32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Station count"
+        ::= { ubntWlStatEntry 15 }
+
+    -- --------------------------------------------------------------------------------
+    --                            station list table
+    -- --------------------------------------------------------------------------------
+
+    ubntStaTable OBJECT-TYPE
+        SYNTAX     SEQUENCE OF UbntStaEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "Station list"
+        ::= { ubntAirMAX 7 }
+
+    ubntStaEntry OBJECT-TYPE
+        SYNTAX     UbntStaEntry
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION "An entry in the ubntStaEntry"
+        INDEX      { ubntWlStatIndex, ubntStaMac }
+        ::= { ubntStaTable 1 }
+
+    UbntStaEntry ::= SEQUENCE {
+        ubntStaMac        MacAddress,
+        ubntStaName       DisplayString,
+        ubntStaSignal     Integer32,
+        ubntStaNoiseFloor Integer32,
+        ubntStaDistance   Integer32,
+        ubntStaCcq        Integer32,
+        ubntStaAmp        Integer32,
+        ubntStaAmq        Integer32,
+        ubntStaAmc        Integer32,
+        ubntStaLastIp     IpAddress,
+        ubntStaTxRate     Integer32,
+        ubntStaRxRate     Integer32,
+        ubntStaTxBytes    Counter64,
+        ubntStaRxBytes    Counter64,
+        ubntStaConnTime   TimeTicks
+    }
+
+    ubntStaMac OBJECT-TYPE
+        SYNTAX     MacAddress
+        MAX-ACCESS not-accessible 
+        STATUS     current
+        DESCRIPTION "Station MAC address"
+        ::= { ubntStaEntry 1 }
+
+    ubntStaName OBJECT-TYPE
+        SYNTAX     DisplayString
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Station name"
+        ::= { ubntStaEntry 2 }
+
+    ubntStaSignal OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Signal strength, dBm"
+        ::= { ubntStaEntry 3 }
+
+    ubntStaNoiseFloor OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Noise floor"
+        ::= { ubntStaEntry 4 }
+
+    ubntStaDistance OBJECT-TYPE
+        SYNTAX Integer32 (1..65535)
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION "Distance"
+        ::= { ubntStaEntry 5 }
+
+    ubntStaCcq OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "CCQ in %"
+        ::= { ubntStaEntry 6 }
+
+
+    ubntStaAmp OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airMAX priority"
+        ::= { ubntStaEntry 7 }
+
+    ubntStaAmq OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airMAX quality"
+        ::= { ubntStaEntry 8 }
+
+    ubntStaAmc OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "airMAX capacity"
+        ::= { ubntStaEntry 9 }
+
+    ubntStaLastIp OBJECT-TYPE
+        SYNTAX     IpAddress
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Last known IP address"
+        ::= { ubntStaEntry 10 }
+
+    ubntStaTxRate OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "TX rate"
+        ::= { ubntStaEntry 11 }
+
+    ubntStaRxRate OBJECT-TYPE
+        SYNTAX     Integer32
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "RX rate"
+        ::= { ubntStaEntry 12 }
+
+    ubntStaTxBytes OBJECT-TYPE
+        SYNTAX     Counter64
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "TX bytes"
+        ::= { ubntStaEntry 13 }
+
+    ubntStaRxBytes OBJECT-TYPE
+        SYNTAX     Counter64
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "TX rate"
+        ::= { ubntStaEntry 14 }
+
+    ubntStaConnTime OBJECT-TYPE
+        SYNTAX     TimeTicks
+        MAX-ACCESS read-only
+        STATUS     current
+        DESCRIPTION "Connection Time in seconds"
+        ::= { ubntStaEntry 15 }
+
+
+    ubntAirMAXStatusGroup OBJECT-GROUP OBJECTS {
+        ubntStaName,
+        ubntStaSignal,
+        ubntStaNoiseFloor,
+        ubntStaDistance,
+        ubntStaCcq,
+        ubntStaAmp,
+        ubntStaAmq,
+        ubntStaAmc,
+        ubntStaLastIp,
+        ubntStaTxRate,
+        ubntStaRxRate,
+        ubntStaTxBytes,
+        ubntStaRxBytes,
+        ubntStaConnTime,
+        ubntRadioMode,
+        ubntRadioCCode,
+        ubntRadioFreq,
+        ubntRadioDfsEnabled,
+        ubntRadioTxPower,
+        ubntRadioDistance,
+        ubntRadioChainmask,
+        ubntRadioAntenna,
+        ubntRadioRssi,
+        ubntRadioRssiMgmt,
+        ubntRadioRssiExt,
+        ubntAirMaxEnabled,
+        ubntAirMaxQuality,
+        ubntAirMaxCapacity,
+        ubntAirMaxPriority,
+        ubntAirMaxNoAck,
+        ubntAirSyncMode,
+        ubntAirSyncCount,
+        ubntAirSyncDownUtil,
+        ubntAirSyncUpUtil,
+        ubntAirSelEnabled,
+        ubntAirSelInterval,
+        ubntWlStatSsid,
+        ubntWlStatHideSsid,
+        ubntWlStatApMac,
+        ubntWlStatSignal,
+        ubntWlStatRssi,
+        ubntWlStatCcq,
+        ubntWlStatNoiseFloor,
+        ubntWlStatTxRate,
+        ubntWlStatRxRate,
+        ubntWlStatSecurity,
+        ubntWlStatWdsEnabled,
+        ubntWlStatApRepeater,
+        ubntWlStatChanWidth,
+        ubntWlStatStaCount }
+        STATUS current
+        DESCRIPTION "Status and statistics for AirMax monitoring"
+        ::= { ubntAirosGroups 1 }
+
+    ubntAirMAXStatusCompliance MODULE-COMPLIANCE
+        STATUS current
+        DESCRIPTION "The compliance statement for Ubiquiti AirMax entities."
+        MODULE
+            GROUP ubntAirMAXStatusGroup
+            DESCRIPTION "This group is for Ubiquiti systems."
+        ::= { ubntAirosGroups 2 }
+
+END


### PR DESCRIPTION
snmpget and snmpwalk where not finding some mibs even though a) they were in the mibs directory and b) all perms were correct.

This patch provides the full path to each mib to be specified (-m) on the snmp[get|walk| cmd line, which takes precedence over the (-M) mib search path.