### PR TITLE
Added forced refresh for generic images widget

### DIFF
--- a/html/includes/common/generic-image.inc.php
+++ b/html/includes/common/generic-image.inc.php
@@ -58,5 +58,11 @@ if( defined('show_settings') || empty($widget_settings) ) {
 }
 else {
     $widget_settings['title'] = $widget_settings['image_title'];
+    if (strstr($widget_settings['image_url'], '?')) {
+        $widget_settings['image_url'] .= "&".mt_rand();
+    }
+    else {
+        $widget_settings['image_url'] .= "?".mt_rand();
+    }
     $common_output[]          = '<a target="_blank" href="'.$widget_settings['target_url'].'"><img class="minigraph-image" style="max-width: '.$widget_dimensions['x'].'px; max-height:'.$widget_dimensions['y'].'px;" src="'.$widget_settings['image_url'].'"/></a>';
 }


### PR DESCRIPTION
Confirmed this.

Because the image hasn't changed it doesn't actually refresh the widget, so we force a random value at the end of the image called which then forces the browser to think it's a different image.

Now works for me.

Fix #3738 