### PR TITLE
Fix typo in adtran-aos mempools discovery if conditional

### DIFF
--- a/includes/discovery/mempools/adtran-aos.inc.php
+++ b/includes/discovery/mempools/adtran-aos.inc.php
@@ -20,7 +20,7 @@
 */
 
 
-if ($device['os'] == 'adtrana-aos') {
+if ($device['os'] == 'adtran-aos') {
     echo 'Adtran AOS: ';
 
     $used  = snmp_get($device, 'adGenAOSHeapSize.0', '-OvQ', 'ADTRAN-AOSCPU');


### PR DESCRIPTION
Fixed typo in adtran-aos mempools discovery if conditional.