### PR TITLE
Moved the device type discovery to before it is needed

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -97,6 +97,13 @@ function discover_device($device, $options = null) {
         }
     }
 
+    // Set type to a predefined type for the OS if it's not already set
+    if ($device['type'] == 'unknown' || $device['type'] == '') {
+        if ($config['os'][$device['os']]['type']) {
+            $device['type'] = $config['os'][$device['os']]['type'];
+        }
+    }
+
     if ($config['os'][$device['os']]['group']) {
         $device['os_group'] = $config['os'][$device['os']]['group'];
         echo ' (' . $device['os_group'] . ')';
@@ -132,13 +139,6 @@ function discover_device($device, $options = null) {
     if (is_mib_poller_enabled($device)) {
         $devicemib = array($device['sysObjectID'] => 'all');
         register_mibs($device, $devicemib, "includes/discovery/functions.inc.php");
-    }
-
-    // Set type to a predefined type for the OS if it's not already set
-    if ($device['type'] == 'unknown' || $device['type'] == '') {
-        if ($config['os'][$device['os']]['type']) {
-            $device['type'] = $config['os'][$device['os']]['type'];
-        }
     }
 
     $device_end = microtime(true);


### PR DESCRIPTION
Pretty certain this doesn't need to go later on.

```bash
[root@librenms01 librenms]# grep "device\['type" ./includes/discovery/* -R
./includes/discovery/functions.inc.php:    if ($device['type'] == 'unknown' || $device['type'] == '') {
./includes/discovery/functions.inc.php:            $device['type'] = $config['os'][$device['os']]['type'];
./includes/discovery/functions.inc.php:    dbUpdate(array('last_discovered' => array('NOW()'), 'type' => $device['type'], 'last_discovered_timetaken' => $device_time), 'devices', '`device_id` = ?', ar;
./includes/discovery/services.inc.php:    if ($device['type'] == 'server') {
```

It's only used in the discovery function but having it later meant that we had the chance a device could be discovered but the type wouldn't be set until after a full discovery is run.