### PR TITLE
Change slack format to attachment style

### DIFF
--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -268,7 +268,7 @@ $config['alert']['transports']['irc'] = true;
 
 > You can configure these options within the WebUI now, please avoid setting these options within config.php
 
-The Slack transport will POST the alert message to your Slack Incoming WebHook, you are able to specify multiple webhooks along with the relevant options to go with it. All options are optional, the only required value is for url, without this then no call to Slack will be made. Below is an example of how to send alerts to two channels with different customised options:
+The Slack transport will POST the alert message to your Slack Incoming WebHook using the [attachments](https://api.slack.com/docs/message-attachments) option, you are able to specify multiple webhooks along with the relevant options to go with it. Simple html tags are stripped from the message. All options are optional, the only required value is for url, without this then no call to Slack will be made. Below is an example of how to send alerts to two channels with different customised options:
 
 ~~
 ```php

--- a/includes/alerts/transport.slack.php
+++ b/includes/alerts/transport.slack.php
@@ -24,8 +24,17 @@
 foreach( $opts as $tmp_api ) {
     $host = $tmp_api['url'];
     $curl = curl_init();
+    $slack_msg = strip_tags($obj['msg']);
+    $color = ($obj['state'] == 0 ? '#00FF00' : '#FF0000');
     $data = array(
-        'text' => $obj['msg'],
+        'attachments' => array(
+                0 => array(
+                'fallback' => $slack_msg,
+                'color' => $color,
+                'title' => $obj['title'],
+                'text' => $slack_msg,
+            )
+        ),
         'channel' => $tmp_api['channel'],
         'username' => $tmp_api['username'],
         'icon_url' => $tmp_api['icon_url'],

--- a/includes/alerts/transport.slack.php
+++ b/includes/alerts/transport.slack.php
@@ -28,7 +28,7 @@ foreach( $opts as $tmp_api ) {
     $color = ($obj['state'] == 0 ? '#00FF00' : '#FF0000');
     $data = array(
         'attachments' => array(
-                0 => array(
+            0 => array(
                 'fallback' => $slack_msg,
                 'color' => $color,
                 'title' => $obj['title'],


### PR DESCRIPTION
As documented here: https://api.slack.com/docs/message-attachments

This change also makes things compatible with simple HTML templates by using strip_tags() on the template output.