### PR TITLE
Added support for multiple emails

### DIFF
--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -192,6 +192,11 @@ $config['alert']['admins']  = true; //Include Administrators into alert-contacts
 
 > You can configure these options within the WebUI now, please avoid setting these options within config.php
 
+For all but the default contact, we support setting multiple email addresses separated by a comma. So you can 
+set the devices sysContact, override the sysContact or have your users emails set like:
+
+`email@domain.com, alerting@domain.com`
+
 E-Mail transport is enabled with adding the following to your `config.php`:
 ~
 ```php

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -281,5 +281,18 @@ function GetContacts($results) {
             $contacts[$user['email']] = $user['realname'];
         }
     }
-    return $contacts;
+
+    $tmp_contacts = array();
+    foreach ($contacts as $email => $name) {
+        if (strstr($email, ',')) {
+            $split_contacts = preg_split("/[,\s]+/", $email);
+            foreach ($split_contacts as $split_email) {
+                $tmp_contacts[$split_email] = $name;
+            }
+        } else {
+            $tmp_contacts[$email] = $name;
+        }
+    }
+
+    return $tmp_contacts;
 }

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -287,7 +287,9 @@ function GetContacts($results) {
         if (strstr($email, ',')) {
             $split_contacts = preg_split("/[,\s]+/", $email);
             foreach ($split_contacts as $split_email) {
-                $tmp_contacts[$split_email] = $name;
+                if(!empty($split_email)) {
+                    $tmp_contacts[$split_email] = $name;
+                }
             }
         } else {
             $tmp_contacts[$email] = $name;


### PR DESCRIPTION
Fix #3860 

Doesn't work with default contact - you should set an alias to be used on your email server here.

But users, sysContact and sysContact override can all have comma separated emails.