### PR TITLE
Fix Brocade VDX detection

### DIFF
--- a/includes/discovery/os/nos.inc.php
+++ b/includes/discovery/os/nos.inc.php
@@ -1,10 +1,7 @@
 <?php
 
 if (!$os) {
-    if (strstr($sysDescr, "Brocade VDX")) {
+    if (strstr($sysDescr, "Brocade VDX")||strstr($sysDescr, "BR-VDX")||strstr($sysDescr, "VDX67")) {
         $os = "nos"; 
-    }
-    elseif (strstr($sysDescr, "BR-VDX")) {
-        $os = "nos";
     }
 }

--- a/includes/discovery/os/nos.inc.php
+++ b/includes/discovery/os/nos.inc.php
@@ -4,4 +4,7 @@ if (!$os) {
     if (strstr($sysDescr, "Brocade VDX")) {
         $os = "nos"; 
     }
+    elseif (strstr($sysDescr, "BR-VDX")) {
+        $os = "nos";
+    }
 }


### PR DESCRIPTION
Seems that brocade has changed some strings again. This trivial patch fix this on VDX6740, BR-VDX6740, Network Operating System Software Version 6.0.2a2