### PR TITLE
Detect Cisco ASA-X Firewall Hardware

### DIFF
--- a/includes/polling/os/asa.inc.php
+++ b/includes/polling/os/asa.inc.php
@@ -32,3 +32,7 @@ else if (isset($data[4]['entPhysicalSoftwareRev']) && $data[4]['entPhysicalSoftw
 if (isset($data[1]['entPhysicalSerialNum']) && $data[1]['entPhysicalSerialNum'] != '') {
     $serial = $data[1]['entPhysicalSerialNum'];
 }
+
+if (empty($hardware)) {
+    $hardware = snmp_get($device, 'sysObjectID.0', '-Osqv', 'SNMPv2-MIB:CISCO-PRODUCTS-MIB');
+}

--- a/mibs/CISCO-PRODUCTS-MIB
+++ b/mibs/CISCO-PRODUCTS-MIB
@@ -3,7 +3,7 @@
 --
 -- January 1995, Jeffrey T. Johnson
 --
--- Copyright (c) 1995-2015 by cisco Systems, Inc.
+-- Copyright (c) 1995-2016 by cisco Systems, Inc.
 -- All rights reserved.
 -- 
 -- *****************************************************************
@@ -18,7 +18,7 @@ IMPORTS
 		FROM CISCO-SMI;
 
 ciscoProductsMIB MODULE-IDENTITY
-	LAST-UPDATED	"201503260000Z"
+	LAST-UPDATED	"201607080000Z"
 	ORGANIZATION	"Cisco Systems, Inc."
 	CONTACT-INFO
 		"       Cisco Systems
@@ -35,7 +35,7 @@ ciscoProductsMIB MODULE-IDENTITY
 		"This module defines the object identifiers that are
 		assigned to various hardware platforms, and hence are
 		returned as values for sysObjectID"
-        REVISION "201503250000Z"
+        REVISION "201305280000Z"
         DESCRIPTION
                  "Added following OIDs:
                  ciscoMPX, ciscoNMCUEEC, ciscoWLSE1132, 
@@ -1450,12 +1450,12 @@ cat3750x24s                     OBJECT IDENTIFIER ::= { ciscoProducts 1404 } -- 
 cat3750x12s                     OBJECT IDENTIFIER ::= { ciscoProducts 1405 } -- Catalyst 3750X 12 SFP Gigabit Ethernet Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
 ciscoNME                        OBJECT IDENTIFIER ::= { ciscoProducts 1406 } -- Cisco Network Module Enhanced (NME) for ISR routers x800 series
 ciscoASA5512                    OBJECT IDENTIFIER ::= { ciscoProducts 1407 } -- ASA 5512 Adaptive Security Appliance
-ciscoASA5525                    OBJECT IDENTIFIER ::= { ciscoProducts 1408 } -- ASA 5515 Adaptive Security Appliance
-ciscoASA5545                    OBJECT IDENTIFIER ::= { ciscoProducts 1409 } -- ASA 5525 Adaptive Security Appliance
+ciscoASA5525                    OBJECT IDENTIFIER ::= { ciscoProducts 1408 } -- ASA 5525 Adaptive Security Appliance
+ciscoASA5545                    OBJECT IDENTIFIER ::= { ciscoProducts 1409 } -- ASA 5545 Adaptive Security Appliance
 ciscoASA5555                    OBJECT IDENTIFIER ::= { ciscoProducts 1410 } -- ASA 5555 Adaptive Security Appliance
 ciscoASA5512sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1411 } -- ASA 5512 Adaptive Security Appliance Security Context
-ciscoASA5525sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1412 } -- ASA 5515 Adaptive Security Appliance Security Context
-ciscoASA5545sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1413 } -- ASA 5525 Adaptive Security Appliance Security Context
+ciscoASA5525sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1412 } -- ASA 5525 Adaptive Security Appliance Security Context
+ciscoASA5545sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1413 } -- ASA 5545 Adaptive Security Appliance Security Context
 ciscoASA5555sc                  OBJECT IDENTIFIER ::= { ciscoProducts 1414 } -- ASA 5555 Adaptive Security Appliance Security Context
 ciscoASA5512sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1415 } -- ASA 5512 Adaptive Security Appliance System Context
 ciscoASA5515sy                  OBJECT IDENTIFIER ::= { ciscoProducts 1416 } -- ASA 5515 Adaptive Security Appliance System Context
@@ -1613,7 +1613,12 @@ cisco8500WLC                    OBJECT IDENTIFIER ::= { ciscoProducts 1615 } -- 
 ciscoASA5585Nm8x10GE            OBJECT IDENTIFIER ::= { ciscoProducts 1617 } -- Cisco Adaptive Security Appliance 5585-X Half Width 8 TenGigabit Ethernet Network Module
 ciscoASA5585Nm4x10GE            OBJECT IDENTIFIER ::= { ciscoProducts 1618 } -- Cisco Adaptive Security Appliance 5585-X Half Width 4 TenGigabit Ethernet Network Module
 ciscoISR4400                    OBJECT IDENTIFIER ::= { ciscoProducts 1619 } -- Cisco ISR 4400 Series Router
+cisco892FspK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1620 } -- C892FSP-K9 router with 2 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 8 Giga Ethernet LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM
 cisco897VaMK9                   OBJECT IDENTIFIER ::= { ciscoProducts 1622 } -- C897VA-M-K9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex M Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM 
+cisco897VawEK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1624 } -- C897VAW-E-K9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex A Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 Dual 2.4/5GHz with EU or ETSI compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM
+cisco897VawAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 1625 } -- C897VAW-A-K9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex A Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 Dual 2.4/5GHz with FCC compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM
+cisco897VaK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1626 } -- C897VA-K9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex A Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 ISDN BRI S/T interface, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM
+cisco896VaK9                    OBJECT IDENTIFIER ::= { ciscoProducts 1627 } -- C896VA-K9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL/ADSL2+ Annex B Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 ISDN BRI S/T interface, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM
 ciscoVirtualWlc                 OBJECT IDENTIFIER ::= { ciscoProducts 1631 } -- Cisco Virtual Wireless LAN Controller
 ciscoAIRAP802agn                OBJECT IDENTIFIER ::= { ciscoProducts 1632 } -- Cisco AP802 Smart Access Point with dual IEEE 802.11a/g/n radio ports
 ciscoAp802Hagn                  OBJECT IDENTIFIER ::= { ciscoProducts 1633 } -- Cisco AP802 Hardened Access Point with dual IEEE 802.11a/g/n radio ports for M2M environments
@@ -1633,6 +1638,7 @@ ciscoVSGateway                  OBJECT IDENTIFIER ::= { ciscoProducts 1646 } -- 
 ciscoIbiza                      OBJECT IDENTIFIER ::= { ciscoProducts 1647 } -- Ibiza Cisco AP
 ciscoSkyros                     OBJECT IDENTIFIER ::= { ciscoProducts 1648 } -- Skyros Cisco AP
 ciscoAIRAP1601                  OBJECT IDENTIFIER ::= { ciscoProducts 1656 } -- Cisco Aironet 1600 series WLAN Access Point
+ciscoAIRAP2600                  OBJECT IDENTIFIER ::= { ciscoProducts 1657 } -- Cisco Aironet 2600 series WLAN Access Point
 ciscoCRS8SB                     OBJECT IDENTIFIER ::= { ciscoProducts 1658 } -- Enhanced 8 Slots Carrier Routing system   
 ciscoAIRAP2602                  OBJECT IDENTIFIER ::= { ciscoProducts 1659 } -- Cisco Aironet 2600 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
 ciscoAIRAP1602                  OBJECT IDENTIFIER ::= { ciscoProducts 1660 } -- Cisco Aironet 1600 series WLAN Access Point with one 10/100/1000TX port and dual IEEE 802.11n radio ports
@@ -1680,6 +1686,10 @@ ciscoISR4442                    OBJECT IDENTIFIER ::= { ciscoProducts 1706 } -- 
 ciscoISR4451                    OBJECT IDENTIFIER ::= { ciscoProducts 1707 } -- Cisco ISR 4451 Router
 ciscoISR4452                    OBJECT IDENTIFIER ::= { ciscoProducts 1708 } -- Cisco ISR 4452 Router
 ciscoASR9912                    OBJECT IDENTIFIER ::= { ciscoProducts 1709 } -- Cisco Aggregation Services Router (ASR) 9912 Chassis
+cat3560x48U                     OBJECT IDENTIFIER ::= { ciscoProducts 1710 } -- Catalyst 3560X 48 10/100/1000 UPoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
+cat3560x24U                     OBJECT IDENTIFIER ::= { ciscoProducts 1711 } -- Catalyst 3560X 24 10/100/1000 UPoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Switch
+cat3750x48U                     OBJECT IDENTIFIER ::= { ciscoProducts 1712 } -- Catalyst 3750X 48 10/100/1000 UPoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
+cat3750x24U                     OBJECT IDENTIFIER ::= { ciscoProducts 1713 } -- Catalyst 3750X 24 10/100/1000 UPoE Ports + 4 SFP Ports + 2 SFP+ Ports Layer 2/Layer 3 Ethernet Stackable Switch
 ciscoIE20008TCGN                OBJECT IDENTIFIER ::= { ciscoProducts 1714 } -- 8+2 combo Gig uplink port, Base SW with 1588 & NAT
 ciscoIE200016TCGN               OBJECT IDENTIFIER ::= { ciscoProducts 1715 } -- 16+2 SFP FE port+2 combo Gig uplink port, Base SW with 1588 & NAT
 ciscoIem30004SM                 OBJECT IDENTIFIER ::= { ciscoProducts 1720 } -- Cisco Industrial Ethernet Switch Expansion Module IE3000, 4 10/100 SFP
@@ -1726,6 +1736,7 @@ cat385024U                      OBJECT IDENTIFIER ::= { ciscoProducts 1767 } -- 
 cat385048U                      OBJECT IDENTIFIER ::= { ciscoProducts 1768 } -- Catalyst 3850 48 10/100/1000 UPoE Ports Layer 2/Layer 3 Ethernet Stackable Switch
 ciscoVG310                      OBJECT IDENTIFIER ::= { ciscoProducts 1769 } -- VG310 Medium Density Voice  Gateway (2 GE, 1 24 onboard  analog FXS, 1  EHWIC, 1 PVDM3, 1 CF, 1GB DRAM)
 ciscoVG320                      OBJECT IDENTIFIER ::= { ciscoProducts 1770 } -- VG320 Medium Density Voice  Gateway (2 GE, 1 24 onboard  analog FXS, 1  EHWIC, 1 PVDM3, 1 CF, 1GB DRAM)
+ciscoC6880xle                   OBJECT IDENTIFIER ::= { ciscoProducts 1784 } -- Catalyst 6880 BP chassis 
 cat45Sup8e                      OBJECT IDENTIFIER ::= { ciscoProducts 1796 } -- Catalyst 4500 Sup 8-E Wired Wireless Convergence, 928 Gbps Wired, 8x10Gbps SFP+ uplink ports
 ciscoWsC2960XR48FpdI            OBJECT IDENTIFIER ::= { ciscoProducts 1797 } -- Catalyst 2960XR 48 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable with POE support for 740W 
 ciscoWsC2960XR48LpdI            OBJECT IDENTIFIER ::= { ciscoProducts 1798 } -- Catalyst 2960XR 48 Gig Downlinks and 2 SFP+ uplinks IP Lite Stackable with POE support for 370W 
@@ -1743,7 +1754,16 @@ ciscoA901S3SGFD                 OBJECT IDENTIFIER ::= { ciscoProducts 1819 } -- 
 ciscoA901S2SGFD                 OBJECT IDENTIFIER ::= { ciscoProducts 1820 } -- Agora platform - 3 external Ports (2 SFP+2Cu) + 1 Gland Interface, DC PSU 
 ciscoA901S3SGFAH                OBJECT IDENTIFIER ::= { ciscoProducts 1821 } -- Agora platform - AC, 3 External Ports (3SFP) + 1 Gland Interface, AC PSU, 1sec holdover for 1 PoE+ 
 ciscoA901S2SGFAH                OBJECT IDENTIFIER ::= { ciscoProducts 1822 } -- Agora platform - AC, 3 External Ports (2 SFP+1 Cu) + 1 Gland Interface, AC PSU, 1sec holdover for 1 PoE+ 
+ciscoC365024TS                  OBJECT IDENTIFIER ::= { ciscoProducts 1823 } -- Cisco  Catalyst 3650 24 Port Data 4x1G Uplink
+ciscoC365048TS                  OBJECT IDENTIFIER ::= { ciscoProducts 1824 } -- Cisco  Catalyst 3650 48 Port Data 4x1G Uplink
+ciscoC365024PS                  OBJECT IDENTIFIER ::= { ciscoProducts 1825 } -- Cisco  Catalyst 3650 24 Port POE 4x1G Uplink
+ciscoC365048PS                  OBJECT IDENTIFIER ::= { ciscoProducts 1826 } -- Cisco  Catalyst 3650 48 Port POE 4x1G Uplink
+ciscoC365024TD                  OBJECT IDENTIFIER ::= { ciscoProducts 1827 } -- Cisco  Catalyst 3650 24 Port Data 2x10G Uplink
+ciscoC365048TD                  OBJECT IDENTIFIER ::= { ciscoProducts 1828 } -- Cisco  Catalyst 3650 48 Port Data 2x10G Uplink
+ciscoC365024PD                  OBJECT IDENTIFIER ::= { ciscoProducts 1829 } -- Cisco  Catalyst 3650 24 Port POE 2x10G Uplink
+ciscoC365048PD                  OBJECT IDENTIFIER ::= { ciscoProducts 1830 } -- Cisco  Catalyst 3650 48 Port POE 2x10G Uplink
 ciscoIE2000U4STSG               OBJECT IDENTIFIER ::= { ciscoProducts 1839 } -- Cisco Industrial Ethernet 2000U Switch, 4 10/100 SFP + 2 1000 SFP 
+ciscoIE2000U16TCGP              OBJECT IDENTIFIER ::= { ciscoProducts 1840 } -- Cisco Industrial Ethernet 2000U Switch, 16 10/100 T (4 PoE) + 2 1000 T/SFP until Jun 2013, contact kavenkat
 ciscoIE20008T67B                OBJECT IDENTIFIER ::= { ciscoProducts 1841 } -- Cisco IE2000 IP67 Variant Switch with  8 port 10/100 downlink, LAN Base Image  
 ciscoIE200016T67B               OBJECT IDENTIFIER ::= { ciscoProducts 1842 } -- Cisco IE2000 IP67 Variant Switch with  16 port 10/100 downlink, LAN Base Image
 ciscoIE200024T67B               OBJECT IDENTIFIER ::= { ciscoProducts 1843 } -- Cisco IE2000 IP67 Variant Switch with  24 port 10/100 downlink, LAN Base Image
@@ -1803,6 +1823,7 @@ ciscoC68xxVirtualSwitch         OBJECT IDENTIFIER ::= { ciscoProducts 1934 } -- 
 ciscoISR4431                    OBJECT IDENTIFIER ::= { ciscoProducts 1935 } -- Cisco ISR 4431 Router Chassis
 ciscoC6880x                     OBJECT IDENTIFIER ::= { ciscoProducts 1936 } -- Catalyst 6880 chassis 
 ciscoCPT50                      OBJECT IDENTIFIER ::= { ciscoProducts 1937 } -- Cisco Carrier Packet Transport (CPT) 50 
+ciscoAIRAP2702                  OBJECT IDENTIFIER ::= { ciscoProducts 1938 } -- Cisco Aironet 2700 Series (IEEE 802.11ac) Access Point
 ciscoCSE340WG32K9               OBJECT IDENTIFIER ::= { ciscoProducts 1940 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G
 ciscoCSE340WG32AK9              OBJECT IDENTIFIER ::= { ciscoProducts 1941 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For American)
 ciscoCSE340WG32CK9              OBJECT IDENTIFIER ::= { ciscoProducts 1942 } -- Cisco Edge 340 Digital Media Player general model,equipped with 32G SSD, WiFi chip, support 2.4G, 5G(For China)
@@ -1843,7 +1864,10 @@ ciscoWRP500                             OBJECT IDENTIFIER ::= { ciscoProducts 20
 cisco897VABK9                           OBJECT IDENTIFIER ::= { ciscoProducts 2008 } -- C897VAB-K9 router with 1 VDSL2 withbonding/ADSL2+ WAN , 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet Primary WAN, 8 Giga Ethernet LAN,4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM
 cisco819HWDCK9                          OBJECT IDENTIFIER ::= { ciscoProducts 2023 } -- C819HWD-C-K9 Hardened Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 Serial, CCC Mark compliant Wireless LAN, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
 catAIRCT57006                      OBJECT IDENTIFIER ::= { ciscoProducts 2026 } -- AIR-CT5760-6 Catalyst 5700 Series Wireless Controller with 6 TenGE Interfaces
+cisco897VAMGLTEGAK9                OBJECT IDENTIFIER ::= { ciscoProducts 2045 } -- 4G LTE  Global(Europe & Australia) router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex M Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 ISDN BRI S/T interface, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM
 cisco897VAGLTEGAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2053 } -- 4G LTE  Global(Europe & Australia) router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex A Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 ISDN BRI S/T interface, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM 
+cisco887VAG4GGAK9                 OBJECT IDENTIFIER ::= { ciscoProducts 2058 } -- router with 1 WAN multimode VDSL2/ADSL2+ over POTS, 4 switch ports 2 ports POE, 1 embedded multimode Global(Europe and Australia) 4G LTE/ HSPA+ modem with GPS and SMS 1GB DRAM
+cisco819G4GGAK9                   OBJECT IDENTIFIER ::= { ciscoProducts 2059 } -- router with 1 WAN multimode VDSL2/ADSL2+ over POTS, 4 switch ports 2 ports POE, 1 embedded multimode Global(Europe and Australia) 4G LTE/ HSPA+ modem with GPS and SMS 1GB DRAM
 ciscoIOG910WK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2063 } -- Programmable IoT Sensor Gateway, 1 Combo (GE/SFP), 1 open slot for 802.15.4 module, 1 slot for external storage. 802.11 b/g/n Wi-Fi
 ciscoIOG910GK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2064 } -- Programmable IoT Sensor Gateway, 1 Combo (GE/SFP), 1 open slot for 802.15.4 module, 1 slot for external storage. 3G HSPA and CDMA EV-DO selective
 ciscoIOG910K9                       OBJECT IDENTIFIER ::= { ciscoProducts 2065 } -- Programmable IoT Sensor Gateway, 1 Combo (GE/SFP), 1 open slot for 802.15.4 module, 1 slot for external storage
@@ -1889,9 +1913,18 @@ ciscoWallander2x1GESKU              OBJECT IDENTIFIER ::= { ciscoProducts 2113 }
 ciscoASA5506                        OBJECT IDENTIFIER ::= { ciscoProducts 2114 } -- ASA 5506 Adaptive Security Appliance
 ciscoASA5506sc                      OBJECT IDENTIFIER ::= { ciscoProducts 2115 } -- ASA 5506 Adaptive Security Appliance Security Context
 ciscoASA5506sy                      OBJECT IDENTIFIER ::= { ciscoProducts 2116 } -- ASA 5506 Adaptive Security Appliance System Context
+ciscoASA5506W                       OBJECT IDENTIFIER ::= { ciscoProducts 2117 } -- ASA 5506W Adaptive Security Appliance
+ciscoASA5506Wsc                     OBJECT IDENTIFIER ::= { ciscoProducts 2118 } -- ASA 5506W Adaptive Security Appliance Security Context
+ciscoASA5506Wsy                     OBJECT IDENTIFIER ::= { ciscoProducts 2119 } -- ASA 5506W Adaptive Security Appliance System Context
+ciscoASA5508                        OBJECT IDENTIFIER ::= { ciscoProducts 2120 } -- ASA 5508 Adaptive Security Appliance
+ciscoASA5508sc                      OBJECT IDENTIFIER ::= { ciscoProducts 2121 } -- ASA 5508 Adaptive Security Appliance Security Context
+ciscoASA5508sy                      OBJECT IDENTIFIER ::= { ciscoProducts 2122 } -- ASA 5508 Adaptive Security Appliance System Context
 ciscoASA5506K7                      OBJECT IDENTIFIER ::= { ciscoProducts 2123 } -- ASA 5506 Adaptive Security Appliance with No Payload Encryption
 ciscoASA5506K7sc                    OBJECT IDENTIFIER ::= { ciscoProducts 2124 } -- ASA 5506 Adaptive Security Appliance Security Context with No Payload Encryption
 ciscoASA5506K7sy                    OBJECT IDENTIFIER ::= { ciscoProducts 2125 } -- ASA 5506 Adaptive Security Appliance System Context with No Payload Encryption
+ciscoASA5508K7                      OBJECT IDENTIFIER ::= { ciscoProducts 2126 } -- ASA 5508 Adaptive Security Appliance with No Payload Encryption
+ciscoASA5508K7sc                    OBJECT IDENTIFIER ::= { ciscoProducts 2127 } -- ASA 5508 Adaptive Security Appliance Security Context with No Payload Encryption
+ciscoASA5508K7sy                    OBJECT IDENTIFIER ::= { ciscoProducts 2128 } -- ASA 5508 Adaptive Security Appliance System Context with No Payload Encryption
 ciscoAIRAP1702                      OBJECT IDENTIFIER ::= { ciscoProducts 2129 } --  Cisco Aironet 1700 Series (IEEE 802.11ac) Access Point
 catwsC3560CX12pdS                   OBJECT IDENTIFIER ::= { ciscoProducts 2132 } -- Smirnoff catalyst 3560CX 12x GE downlink, PoE+, 2x CU + 2x 10G SFP+ uplinks
 catwsC3560CX12tcS                   OBJECT IDENTIFIER ::= { ciscoProducts 2133 } -- Smirnoff catalyst 3560CX 12x GE downlink, 2x Copper + 2x SFP uplinks
@@ -1903,19 +1936,27 @@ cisco2911TK9                        OBJECT IDENTIFIER ::= { ciscoProducts 2138 }
 ciscoSNS3495K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2139 } -- Cisco Secure Network Server platform SNS-3495 appliance
 ciscoSNS3415K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2140 } -- Cisco Secure Network Server platform SNS-3415 appliance
 ciscoAIRAP702w                      OBJECT IDENTIFIER ::= { ciscoProducts 2146 } -- Cisco Aironet 702w (IEEE 802.11n) Series Access Points
+ciscoAIRAP1572                      OBJECT IDENTIFIER ::= { ciscoProducts 2147 } -- Cisco Aironet 1570 (IEEE 802.11ac) Series Outdoor Access Points with two radio's
 cisco891x24XK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2148 } -- C891-24X Router series with 2 Giga Ethernet WAN Xor'ed with SFP (Small Form-factor Pluggable), 24 Giga Ethernet LAN with 8 PoE 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 512MB/1GB DRAM
+ciscoUCSEN120E54                    OBJECT IDENTIFIER ::= { ciscoProducts 2149 } -- UCS E-Series NCE DW-EHWIC,  2C Rangeley, 4GB RAM, 50GB HDD, 1 SD
+ciscoUCSEN120E108                   OBJECT IDENTIFIER ::= { ciscoProducts 2151 } -- UCS E-Series NCE DW-EHWIC,  2C Rangeley, 8GB RAM, 100GB HDD, 1 SD
+ciscoUCSEN120E208                   OBJECT IDENTIFIER ::= { ciscoProducts 2154 } -- UCS E-Series NCE DW-EHWIC,  2C Rangeley, 8GB RAM , 200GB HDD, 1 SD
 ciscoASR9204SZD                     OBJECT IDENTIFIER ::= { ciscoProducts 2155 } -- Cisco ASR920 Series - 2GE and 4-10GE -DC model
 ciscoASR9208SZ0A                    OBJECT IDENTIFIER ::= { ciscoProducts 2156 } -- Cisco ASR920 Series - 8GE and 4-10GE - Outdoor AC model
 ciscoASR92012CZA                    OBJECT IDENTIFIER ::= { ciscoProducts 2157 } -- Cisco ASR920 Series - 12GE and 2-10GE - AC model
 ciscoASR92012CZD                    OBJECT IDENTIFIER ::= { ciscoProducts 2158 } -- Cisco ASR920 Series - 12GE and 2-10GE - DC model
 ciscoASR9204SZA                     OBJECT IDENTIFIER ::= { ciscoProducts 2159 } -- Cisco ASR920 Series - 2GE and 4-10GE -AC model
-ciscoASR9208SZ0D                    OBJECT IDENTIFIER ::= { ciscoProducts 2160 } -- Cisco ASR920 Series - 8GE and 4-10GE - Outdoor DC model
+ciscoASR92010SZ0D                   OBJECT IDENTIFIER ::= { ciscoProducts 2160 } -- Cisco ASR920 Series - 10GE and 2-10GE - Outdoor DC model
 ciscoTSCodecG3                      OBJECT IDENTIFIER ::= { ciscoProducts 2161 } -- Cisco Telepresence Generation 3 Codec
 ciscoC385012XS                      OBJECT IDENTIFIER ::= { ciscoProducts 2162 } -- Cisco Catalyst 3850 12 Port 10G Fiber Switch
 ciscoC385024XS                      OBJECT IDENTIFIER ::= { ciscoProducts 2163 } -- Cisco Catalyst 3850 24 Port 10G Fiber Switch
 ciscoC385048XS                      OBJECT IDENTIFIER ::= { ciscoProducts 2164 } -- Cisco Catalyst 3850 48 Port 10G Fiber Switch
+ciscoC385012X48U                    OBJECT IDENTIFIER ::= { ciscoProducts 2165 } -- Cisco Catalyst 3850 48 UPOE 12 100M/1G/2.5G/5G/10G and 36 1G Ports Layer 2/Layer 3 Ethernet
+ciscoC385024XU                      OBJECT IDENTIFIER ::= { ciscoProducts 2166 } -- Cisco Catalyst 3850 24 UPOE 100M/1G/2.5G/5G/10G Ports Layer2/Layer3 Ethernet
 ciscoRAIE1783ZMS4T4E2TGN            OBJECT IDENTIFIER ::= { ciscoProducts 2168 } -- Cisco IE2000 IP67 Variant with  4 port 10/100 downlink, 4 port POE/POE+ downlink, 2 10/100/1000 uplink, w/FPGA, LAN Base Image, PTP and NAT Support
 ciscoRAIE1783ZMS8T8E2TGN            OBJECT IDENTIFIER ::= { ciscoProducts 2169 } -- Cisco IE2000 IP67 Variant with 8 port 10/100 downlink, 8 port POE/POE+ downlink, 2 10/100/1000 uplink, w/FPGA, LAN Base Image, PTP and NAT Support
+cisco5520WLC                        OBJECT IDENTIFIER ::= { ciscoProducts 2170 } -- Cisco 5520 Series Wireless Controller
+cisco8540Wlc                        OBJECT IDENTIFIER ::= { ciscoProducts 2171 } -- Cisco 8540 Series Wireless Controller 
 ciscoRAIE1783HMS8TG4CGR             OBJECT IDENTIFIER ::= { ciscoProducts 2172 } -- CISCO IE4000 with 8 GE Copper DL ports, 4 GE combo UL ports, w/FPGA
 ciscoRAIE1783HMS8SG4CGR             OBJECT IDENTIFIER ::= { ciscoProducts 2173 } -- CISCO IE4000 with 8 GE Fiber DL ports, 4 GE combo UL ports, w/FPGA
 ciscoRAIE1783HMS4EG8CGR             OBJECT IDENTIFIER ::= { ciscoProducts 2174 } -- CISCO IE4000 with 4 GE Combo DL ports + 4 GE Copper DL ports with POE, 4 GE combo UL ports, w/FPGA
@@ -1926,6 +1967,9 @@ ciscoUCSC220M4                      OBJECT IDENTIFIER ::= { ciscoProducts 2178 }
 ciscoUCSC240M4                      OBJECT IDENTIFIER ::= { ciscoProducts 2179 } -- Cisco UCS C240 M4 Rack server
 ciscoUCSC3160                       OBJECT IDENTIFIER ::= { ciscoProducts 2180 } -- Cisco UCS C3160 Rack server
 cisco1941WTK9                       OBJECT IDENTIFIER ::= { ciscoProducts 2181 } -- CISCO1941W-T/K9 with 802.11 a/b/g/ n  Israel Compliant WLAN ISM 
+ciscoUCSC3260                       OBJECT IDENTIFIER ::= { ciscoProducts 2182 } -- Cisco UCS C3260 Rack server
+ciscoUCSE160DM2K9                   OBJECT IDENTIFIER ::= { ciscoProducts 2183 } -- Cisco Integrated Management Controller (CIMC) UCS-E160D-M2/K9
+ciscoUCSE180DM2K9                   OBJECT IDENTIFIER ::= { ciscoProducts 2184 } -- Cisco Integrated Management Controller (CIMC) UCS-E180D-M2/K9
 ciscoCDScde2802s5                   OBJECT IDENTIFIER ::= { ciscoProducts 2185 } -- Cisco Content Delivery System Model CDE-280-2S5
 ciscoCDScde2802s10                  OBJECT IDENTIFIER ::= { ciscoProducts 2186 } -- Cisco Content Delivery System Model CDE-280-2S10
 ciscoCDScde2802s21                  OBJECT IDENTIFIER ::= { ciscoProducts 2187 } -- Cisco Content Delivery System Model CDE-280-2S21
@@ -1971,8 +2015,117 @@ ciscoFp7010K9                       OBJECT IDENTIFIER ::= { ciscoProducts 2227  
 ciscoFp7020K9                       OBJECT IDENTIFIER ::= { ciscoProducts 2228  } -- Cisco FirePOWER 7020 Appliance, 1U 
 cisco841Mx4XK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2229 } -- C841M-4X/K9 router with 4GE LAN, 2GE WAN, 2 WIM slots
 cisco841Mx8XK9                      OBJECT IDENTIFIER ::= { ciscoProducts 2230 } --  C841M-8X/K9 router with 8GE LAN, 2GE WAN, 2 WIM slots
+ciscoC819GWLTEMNAAK9                OBJECT IDENTIFIER ::= { ciscoProducts 2231 } -- C819GW-LTE-MNA-AK9 router with 1 4G LTE interface, 4 Fast Ethernet LAN interfaces, 1GE WAN, 1 Serial(sync/async) interface, 2 terminal lines, 1 Virtual Private Network (VPN) Module, 1 cisco Embedded AP, 1 Console/Aux port, and 1GB FLASH
+ciscoC819GWLTEGAEK9                 OBJECT IDENTIFIER ::= { ciscoProducts 2232 } -- C819GW-LTE-GA-EK9 router with 1 4G LTE interface, 4 Fast Ethernet LAN interfaces, 1GE WAN, 1 Serial(sync/async) interface, 2 terminal lines, 1 Virtual Private Network (VPN) Module, 1 cisco Embedded AP, 1 Console/Aux port, and 1GB FLASH
+ciscoIE500012S12P10G                OBJECT IDENTIFIER ::= { ciscoProducts 2233 } -- Cisco IE5000 ruggedized Ethernet switch with 12x 10/100/1000 BaseT Copper downlinks with POE/POE+, 12x 100/1000BaseX Fiber SFP downlinks, 4x 10G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28NAC			      OBJECT IDENTIFIER ::= { ciscoProducts 2234 } -- Cisco IE5000 for RockWell Automation Lanbase license AC power supply ruggedized Ethernet switch with 12x 10/100/1000 BaseT Copper downlinks with POE/POE+, 12x 100/1000BaseX Fiber SFP downlinks, 4x 10G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28NDC			      OBJECT IDENTIFIER ::= { ciscoProducts 2235 } -- Cisco IE5000 for RockWell Automation Lanbase license DC power supply ruggedized Ethernet switch with 12x 10/100/1000 BaseT Copper downlinks with POE/POE+, 12x 100/1000BaseX Fiber SFP downlinks, 4x 10G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28RAC			      OBJECT IDENTIFIER ::= { ciscoProducts 2236 } -- Cisco IE5000 for RockWell Automation IP Services license AC power supply ruggedized Ethernet switch with 12x 10/100/1000 BaseT Copper downlinks with POE/POE+, 12x 100/1000BaseX Fiber SFP downlinks, 4x 10G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28RDC			      OBJECT IDENTIFIER ::= { ciscoProducts 2237 } -- Cisco IE5000 for RockWell Automation IP Services license DC power supply ruggedized Ethernet switch with 12x 10/100/1000 BaseT Copper downlinks with POE/POE+, 12x 100/1000BaseX Fiber SFP downlinks, 4x 10G Fiber SFP+ uplinks, Timing module 
+ciscoACIController                  OBJECT IDENTIFIER ::= { ciscoProducts 2238 } -- The Cisco Application Policy Infrastructure Controller (Cisco APIC) is the unifying point of automation and management for the Application Centric Infrastructure (ACI) fabric. The Cisco APIC provides centralized access to all fabric information, optimizes the application lifecycle for scale and performance, and supports flexible application provisioning across physical and virtual resources
+ciscoAIRAPIW3702                    OBJECT IDENTIFIER ::= { ciscoProducts 2240 } -- Cisco Aironet 3702 Series (IEEE 802.11ac) Access Point
+ciscoASA5506H                       OBJECT IDENTIFIER ::= { ciscoProducts 2241 } -- ASA 5506H Adaptive Security Appliance 
+ciscoASA5516                        OBJECT IDENTIFIER ::= { ciscoProducts 2242 } -- ASA 5516 Adaptive Security Appliance
+ciscoASA5506Hsc                     OBJECT IDENTIFIER ::= { ciscoProducts 2243 } -- ASA 5506H Adaptive Security Appliance Security Context
+ciscoASA5516sc                      OBJECT IDENTIFIER ::= { ciscoProducts 2244 } -- ASA 5516 Adaptive Security Appliance Security Context
+ciscoASA5506Hsy                     OBJECT IDENTIFIER ::= { ciscoProducts 2245 } -- ASA 5506H Adaptive Security Appliance System Context
+ciscoASA5516sy                      OBJECT IDENTIFIER ::= { ciscoProducts 2246 } -- ASA 5516 Adaptive Security Appliance System Context
 ciscoIR829GWLTEMAAK9                OBJECT IDENTIFIER ::= { ciscoProducts 2248 } -- IR829 Hardened WAN GE 4G LTE secure platform multi-mode Sprint LTE/DoRa  with 802.11n, PoE, FCC compliant
 ciscoPwsX474812X48uE                OBJECT IDENTIFIER ::= { ciscoProducts 2249 } -- Switch 4500E  100/1000/2500/5000/10GBaseT (RJ45)+V E Series with 48 10GbaseT
+ciscoRAISA1783SAD2T2Ssy             OBJECT IDENTIFIER ::= { ciscoProducts 2254 } -- Cisco Rockwell ISA 30002C2F (1783SAD2T2S)Industrial Security Appliance, System Context
+ciscoRAISA1783SAD4T0Ssy             OBJECT IDENTIFIER ::= { ciscoProducts 2255 } -- Cisco Rockwell ISA 30004C (1783SAD4T0S) Industrial Security Appliance, System Context
+ciscoISA30002C2Fsy                  OBJECT IDENTIFIER ::= { ciscoProducts 2256 } -- ISA 30002C2F Industrial Security Appliance, System Context
+ciscoISA30004Csy                    OBJECT IDENTIFIER ::= { ciscoProducts 2257 } -- ISA 30004C Industrial Security Appliance, System Context
+ciscoISA4000sy                      OBJECT IDENTIFIER ::= { ciscoProducts 2258 } -- ISA 4000 Industrial Security Appliance, System Context
+ciscoISA4000sc                      OBJECT IDENTIFIER ::= { ciscoProducts 2259 } -- ISA 4000 Industrial Security Appliance , Security Context
+ciscoRAISA1783SAD2T2Ssc             OBJECT IDENTIFIER ::= { ciscoProducts 2260 } -- Cisco Rockwell ISA 30002C2F (1783SAD2T2S)Industrial Security Appliance, Security Context 
+ciscoRAISA1783SAD4T0Ssc             OBJECT IDENTIFIER ::= { ciscoProducts 2261 } -- Cisco Rockwell ISA 30004C (1783SAD4T0S) Industrial Security Appliance, Security Context 
+ciscoISA30002C2Fsc                  OBJECT IDENTIFIER ::= { ciscoProducts 2262 } -- ISA 30002C2F Industrial Security Appliance, Security Context
+ciscoISA30004Csc                    OBJECT IDENTIFIER ::= { ciscoProducts 2263 } -- ISA 30004C Industrial Security Appliance, Security Context
+ciscoIOSXRv9000                     OBJECT IDENTIFIER ::= { ciscoProducts 2264 } -- Cisco IOS-XR vRouter
+ciscoSNS3515K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2265 } -- Cisco Secure Network Server platform SNS-3515 appliance
+ciscoSNS3595K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2266 } -- Cisco Secure Network Server platform SNS-3595 appliance
+ciscoISA30002C2F                    OBJECT IDENTIFIER ::= { ciscoProducts 2267 } -- ISA 30002C2F Industrial Security Appliance
+ciscoISA30004C                      OBJECT IDENTIFIER ::= { ciscoProducts 2268 } -- ISA 30004C Industrial Security Appliance
+ciscoRAISA1783SAD4T0S               OBJECT IDENTIFIER ::= { ciscoProducts 2269 } -- Cisco Rockwell ISA 30004C (1783SAD4T0S) Industrial Security Appliance
+ciscoRAISA1783SAD2T2S               OBJECT IDENTIFIER ::= { ciscoProducts 2270 } -- Cisco Rockwell ISA 30002C2F (1783SAD2T2SS)Industrial Security Appliance
+ciscoISA4000                        OBJECT IDENTIFIER ::= { ciscoProducts 2271 } -- ISA 4000 Industrial Security Appliance
+ciscoC888EAK9                       OBJECT IDENTIFIER ::= { ciscoProducts 2272 } -- Cisco Multimode 888EA G.SHDSL (EFM/ATM) Router with 802.3 ah EFM
+ciscoC6816xle                       OBJECT IDENTIFIER ::= { ciscoProducts 2273 } -- Catalyst C6816-X-LE with 16x10G ports
+ciscoC6832xle                       OBJECT IDENTIFIER ::= { ciscoProducts 2274 } -- Catalyst C6832-X-LE with 32x10G ports
+ciscoC6824xle                       OBJECT IDENTIFIER ::= { ciscoProducts 2275 } -- Catalyst C6824-X-LE with 24x10GE ports plus 2x40GE uplinks
+ciscoC6840xle                       OBJECT IDENTIFIER ::= { ciscoProducts 2276 } -- Catalyst C6840-X-LE with 40x10GE ports plus 2x40GE uplinks
+cat35xxStack                        OBJECT IDENTIFIER ::= { ciscoProducts 2277 } -- A stack of any catalyst35xx stack-able ethernet switches with unified identity (as a single unified switch), control and management
+ciscoNam2420                        OBJECT IDENTIFIER ::= { ciscoProducts 2282 } -- Cisco NAM Appliance 2420
+ciscoNam2440                        OBJECT IDENTIFIER ::= { ciscoProducts 2283 } -- Cisco NAM Appliance 2440
+ciscoflowAgent3300                  OBJECT IDENTIFIER ::= { ciscoProducts 2284 } -- Cisco Integrated NetFlow Generation Agent Series 3300
+ciscoFpr9300K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2285 } -- Cisco FirePOWER 9300 Security Appliance, 3U
+ciscoFpr9000SM24                    OBJECT IDENTIFIER ::= { ciscoProducts 2286 } -- Cisco FirePOWER 9000 Security Module 24
+ciscoFpr9000SM36                    OBJECT IDENTIFIER ::= { ciscoProducts 2288 } -- Cisco FirePOWER 9000 Security Module 36
+ciscoFpr4140K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2293 } -- Cisco FirePOWER 4140 Security Appliance, 1U with embedded security module 36
+ciscoFpr4120K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2294 } -- Cisco FirePOWER 4120 Security Appliance, 1U with embedded security module 24
+ciscoFpr4110K9                      OBJECT IDENTIFIER ::= { ciscoProducts 2295 } -- Cisco FirePOWER 4110 Security Appliance, 1U with embedded security module 12
+ciscoIE500016S12P                   OBJECT IDENTIFIER ::= { ciscoProducts 2296 } -- Cisco IE5000 ruggedized Ethernet switch with 12x 10/100/1000 BaseT Copper downlinks with POE/POE+, 12x 100/1000BaseX Fiber SFP downlinks, 4x 1G Fiber SFP uplinks, Timing module
+ciscoASA5512td                      OBJECT IDENTIFIER ::= { ciscoProducts 2297 } -- ASA 5512 Adaptive Security Appliance, Threat Defense
+ciscoASA5515td                      OBJECT IDENTIFIER ::= { ciscoProducts 2298 } -- ASA 5515 Adaptive Security Appliance, Threat Defense
+ciscoASA5525td                      OBJECT IDENTIFIER ::= { ciscoProducts 2299 } -- ASA 5525 Adaptive Security Appliance, Threat Defense
+ciscoASA5545td                      OBJECT IDENTIFIER ::= { ciscoProducts 2300 } -- ASA 5545 Adaptive Security Appliance, Threat Defense
+ciscoASA5555td                      OBJECT IDENTIFIER ::= { ciscoProducts 2301 } -- ASA 5555 Adaptive Security Appliance, Threat Defense
+ciscoASA5506td                      OBJECT IDENTIFIER ::= { ciscoProducts 2302 } -- ASA 5506 Adaptive Security Appliance, Threat Defense
+ciscoASA5506Wtd                     OBJECT IDENTIFIER ::= { ciscoProducts 2303 } -- ASA 5506W Adaptive Security Appliance, Threat Defense
+ciscoASA5506Htd                     OBJECT IDENTIFIER ::= { ciscoProducts 2304 } -- ASA 5506H Adaptive Security Appliance, Threat Defense
+ciscoASA5508td                      OBJECT IDENTIFIER ::= { ciscoProducts 2305 } -- ASA 5508 Adaptive Security Appliance, Threat Defense
+ciscoASA5516td                      OBJECT IDENTIFIER ::= { ciscoProducts 2306 } -- ASA 5516 Adaptive Security Appliance, Threat Defense
+ciscoPIUCSAPLK9                     OBJECT IDENTIFIER ::= { ciscoProducts 2307 } -- Cisco Prime Infrastructure Appliance
+cisco899GLTEJPK9                    OBJECT IDENTIFIER ::= { ciscoProducts 2308 } -- 4G LTE Japan router with 2 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 8 Giga Ethernet LAN, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM 
+cisco819GLTEMNAK9                   OBJECT IDENTIFIER ::= { ciscoProducts 2309 } -- router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 4G LTE Multi-carrier North America HSPA+ Release 7, 1 Serial, 1 Console/Aux ports, 1GB flash memory and 1GB DRAM
+ciscoFpr4110SM12                    OBJECT IDENTIFIER ::= { ciscoProducts 2313 } -- Cisco FirePOWER 4110 Security Module 12
+ciscoFpr4120SM24                    OBJECT IDENTIFIER ::= { ciscoProducts 2314 } -- Cisco FirePOWER 4120 Security Module 24
+ciscoFpr4140SM36                    OBJECT IDENTIFIER ::= { ciscoProducts 2315 } -- Cisco FirePOWER 4140 Security Module 36
+ciscoNCS5001                        OBJECT IDENTIFIER ::= { ciscoProducts 2317 } -- Cisco NCS 5001 Series Router
+ciscoNCS5002                        OBJECT IDENTIFIER ::= { ciscoProducts 2318 } -- Cisco NCS 5002 Series Router
+ciscoFpvK9                          OBJECT IDENTIFIER ::= { ciscoProducts 2319 } -- Cisco FirePOWER Virtual Appliance
+ciscoASR901CC                       OBJECT IDENTIFIER ::= { ciscoProducts 2320 } -- ASR901 platform with Conformal Coating
+ciscoASR901ECC                      OBJECT IDENTIFIER ::= { ciscoProducts 2321 } -- ASR901-E platform with Conformal Coating
+ciscoASR901DC10GCC                  OBJECT IDENTIFIER ::= { ciscoProducts 2322 } -- ASR901 10G DC platform with Conformal Coating
+ciscoASR901EDC10GCC                 OBJECT IDENTIFIER ::= { ciscoProducts 2323 } -- ASR901E 10G DC platform with Conformal Coating
+ciscoASR901DC10GSCC                 OBJECT IDENTIFIER ::= { ciscoProducts 2324 } -- ASR901 10GS DC platform with Conformal Coating
+ciscoASR92012SZIMCC                 OBJECT IDENTIFIER ::= { ciscoProducts 2325 } -- ASR920 Series - 12GE and 4-10GE - Modular PSU,IM and conformal coating
+ciscoNcs4201                        OBJECT IDENTIFIER ::= { ciscoProducts 2326 } -- NCS 4201 System (1RU,24GE and 4-10GE)   
+ciscoNcs4202                        OBJECT IDENTIFIER ::= { ciscoProducts 2327 } -- NCS 4202 System (1RU,12GE,4-10GE and 1 SLOT)
+ciscoNcs4206                        OBJECT IDENTIFIER ::= { ciscoProducts 2328 } -- NCS 4206 System (3RU and 6 SLOT)
+ciscoNcs4216                        OBJECT IDENTIFIER ::= { ciscoProducts 2329 } -- NCS 4216 System (7RU and 16 SLOT)
+ciscoVFTD                           OBJECT IDENTIFIER ::= { ciscoProducts 2334 } -- Cisco Virtual Firepower Threat Defense
+ciscoRAIE1783IMS28GNAC              OBJECT IDENTIFIER ::= { ciscoProducts 2340 } -- Cisco IE5000 for Rockwell Automation ruggedized Ethernet switch supports Lanbase license and AC power supply with 12x10/100/1000 BaseT Copper downlinks with POE/POE+, 12x100/1000BaseX Fiber SFP downlinks, 4x1G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28GNDC              OBJECT IDENTIFIER ::= { ciscoProducts 2341 } -- Cisco IE5000 for Rockwell Automation ruggedized Ethernet switch supports Lanbase license and DC power supply with 12x10/100/1000 BaseT Copper downlinks with POE/POE+, 12x100/1000BaseX Fiber SFP downlinks, 4x1G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28GRAC              OBJECT IDENTIFIER ::= { ciscoProducts 2342 } -- Cisco IE5000 for Rockwell Automation ruggedized Ethernet switch supports IP Service license and AC power supply with 12x10/100/1000 BaseT Copper downlinks with POE/POE+, 12x100/1000BaseX Fiber SFP downlinks, 4x1G Fiber SFP+ uplinks, Timing module
+ciscoRAIE1783IMS28GRDC              OBJECT IDENTIFIER ::= { ciscoProducts 2343 } -- Cisco IE5000 for Rockwell Automation ruggedized Ethernet switch supports IP Service license and DC power supply with 12x10/100/1000 BaseT Copper downlinks with POE/POE+, 12x100/1000BaseX Fiber SFP downlinks, 4x1G Fiber SFP+ uplinks, Timing module
+ciscoQSFP100GCWDM4S                 OBJECT IDENTIFIER ::= { ciscoProducts 2344 } -- 100GE-CWDM4-S QSFP Module
+cisco897VAGWLTEGAEK9                OBJECT IDENTIFIER ::= { ciscoProducts 2345 } -- C897VAGW-LTE-GAEK9 router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 multi-mode VDSL2/ADSL2+ over POTS, 1 4G LTE secure platform multi-mode Global (Europe) LTE/HSPA+, 8 Giga Ethernet LAN, 4 PoE Optional, 1 Dual 2.4/5GHz with FCC compliant Wireless LAN, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM
+cisco886VAGLTEGAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2346 } -- C886VAG-LTE-GA-K9 router with 1 WAN VDSL2/ADSL2+ over ISDN, 1 4G LTE secure platform multi-mode Global (Europe) LTE/HSPA+, 4 Fast Ethernet LAN, 1 USB 2.0 port, 1 Console/Aux port, 256MB flash memory and 1GB DRAM
+ciscoNcs1002                        OBJECT IDENTIFIER ::= { ciscoProducts 2347 } -- NCS 1002 System (1RP, 3 FANs, 2 Powers)
+ciscoNCS5508                        OBJECT IDENTIFIER ::= { ciscoProducts 2349 } -- Network Convergence Services NCS5500 8 Slot Single Chassis
+ciscoUnifiedSipProxy                OBJECT IDENTIFIER ::= { ciscoProducts 2352 } -- SIP-based stateless call routing engine
+cisco898EAGLTELAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2355 } -- 4G LTE Latin America router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 EFM over G.SH DSL WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM
+cisco897VAGLTELAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2356 } -- 4G LTE  Latin America router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 VDSL2/ADSL2+ Annex A Data Backup WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 ISDN BRI S/T interface, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM
+cisco819GWLTELACK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2357 } -- C819GW-LTE-LA-CK9 Latin America router with 1 4G LTE interface, 4 Fast Ethernet LAN interfaces, 1GE WAN, 1 Serial(sync/async) interface, 2 terminal lines, 1 Virtual Private Network (VPN) Module, 1 cisco Embedded AP, 1 Console/Aux port, and 1GB FLASH
+cisco819GWLTELAQK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2358 } -- C819GW-LTE-LA-QK9 Latin America router with 1 4G LTE interface, 4 Fast Ethernet LAN interfaces, 1GE WAN, 1 Serial(sync/async) interface, 2 terminal lines, 1 Virtual Private Network (VPN) Module, 1 cisco Embedded AP, 1 Console/Aux port, and 1GB FLASH
+cisco819GWLTELANK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2359 } -- C819GW-LTE-LA-NK9 Latin America router with 1 4G LTE interface, 4 Fast Ethernet LAN interfaces, 1GE WAN, 1 Serial(sync/async) interface, 2 terminal lines, 1 Virtual Private Network (VPN) Module, 1 cisco Embedded AP, 1 Console/Aux port, and 1GB FLASH
+cisco899GLTELAK9                    OBJECT IDENTIFIER ::= { ciscoProducts 2381 } -- C899G-LTE-LA-K9 4G router with 1 Giga Ethernet WAN, 1 SFP (Small Form-factor Pluggable) Giga Ethernet WAN, 1 EFM over G.SH DSL WAN, 8 Giga Ethernet LAN, 4 PoE Optional, 1 USB 2.0 port, 1 Console/Aux port, 1GB flash memory and 1GB DRAM
+cisco819GLTELAK9                    OBJECT IDENTIFIER ::= { ciscoProducts 2382 } -- C819G-LTE-LA-K9 Router with 1 Gigabit Ethernet WAN, 4 Fast Ethernet LAN, 1 AT&T LTE modem, 1 Serial, 1 Console/Aux ports,256MB flash memory, 512MB DRAM
+ciscoStealthWatch2404               OBJECT IDENTIFIER ::= { ciscoProducts 2385 } -- Cisco StealthWatch Packet Analyzer 2404
+ciscoStealthWatch2420               OBJECT IDENTIFIER ::= { ciscoProducts 2386 } -- Cisco StealthWatch Packet Analyzer 2420
+ciscoNamApp2404                     OBJECT IDENTIFIER ::= { ciscoProducts 2387 } -- Cisco Prime NAM Appliance 2404
+ciscoASR9910                        OBJECT IDENTIFIER ::= { ciscoProducts 2390 } -- Cisco Aggregation Services Router (ASR) 9910 Chassis
+cisco819HGLTEMNAK9                  OBJECT IDENTIFIER ::= { ciscoProducts 2392 } -- C819HG-LTE-MNA-K9 Hardened Fixed router with multi-carrier North America SKU LTE Modem
+ciscoIR829GWLTEGASK9                OBJECT IDENTIFIER ::= { ciscoProducts 2393 } -- IR829 Hardened WAN GE 4G LTE secure platform multi-mode Global (Singapore) LTE/HSPA+ with 802.11n, PoE, Australia Compliant
+ciscoIR829GWLTEGACK9                OBJECT IDENTIFIER ::= { ciscoProducts 2394 } -- IR829 Hardened WAN GE 4G LTE secure platform multi-mode Global (Malaysia) LTE/HSPA+ with 802.11n, PoE, Australia Compliant
+ciscoCSP2100                        OBJECT IDENTIFIER ::= { ciscoProducts 2397 } -- Cloud Services Platform Model CSP-2100
+ciscoNCS4216F2BSA                   OBJECT IDENTIFIER ::= { ciscoProducts 2402 } -- NCS 4216 Front to Back Shelf Assembly (16 slots - 14 RU) - Includes Air Deflector Plenum and Brackets/Guides
+ciscoFpr2110td                      OBJECT IDENTIFIER ::= { ciscoProducts 2404 } -- Cisco FirePOWER 2110 Security Appliance, 1U with embedded security module 
+ciscoFpr2120td                      OBJECT IDENTIFIER ::= { ciscoProducts 2405 } -- Cisco FirePOWER 2120 Security Appliance, 1U with embedded security module  
+ciscoFpr2130td                      OBJECT IDENTIFIER ::= { ciscoProducts 2406 } -- Cisco FirePOWER 2130 Security Appliance, 1U with embedded security module
+ciscoFpr2140td                      OBJECT IDENTIFIER ::= { ciscoProducts 2407 } -- Cisco FirePOWER 2140 Security Appliance, 1U with embedded security module 
 END
 
 


### PR DESCRIPTION
For newer ASA's we need to use this way to be able to detect the hw in the boxes (5516X, FirePower 4110 Etc).