### PR TITLE
about page fix

### DIFF
--- a/html/pages/about.inc.php
+++ b/html/pages/about.inc.php
@@ -10,7 +10,7 @@ $git_log = `git log -10`;
         <h4 class="modal-title" id="myModalLabel">Local git log</h4>
       </div>
       <div class="modal-body">
-<pre><?php echo $git_log; ?></pre>
+	<pre><?php htmlspecialchars($git_log, ENT_COMPAT,'ISO-8859-1', true); ?></pre>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
Due to some git log commit message (that included special chars) the about page was showing only the top navbar.