### PR TITLE
Removed unecessary db lookups

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -458,12 +458,12 @@ foreach ($ports as $port) {
         foreach ($data_oids as $oid) {
 
             if ($oid == 'ifAlias') {
-                if (get_dev_attrib($device, 'ifName:'.$port['ifName'], 1)) {
+                if ($attribs['ifName:'.$port['ifName']]) {
                     $this_port['ifAlias'] = $port['ifAlias'];
                 }
             }
             if ($oid == 'ifSpeed' || $oid == 'ifHighSpeed') {
-                if (get_dev_attrib($device, 'ifSpeed:'.$port['ifName'], 1)) {
+                if ($attribs['ifSpeed:'.$port['ifName']]) {
                     $this_port[$oid] = $port[$oid];
                 }
             }


### PR DESCRIPTION
We do a lookup at the start for all of the devices attributes so no point in calling for that info again.

This will save us two db lookups per port.