### PR TITLE
Updated version_info to output unix timestamp

### DIFF
--- a/html/pages/about.inc.php
+++ b/html/pages/about.inc.php
@@ -237,5 +237,5 @@ echo "
 
     // convert the version date from ISO 8601 to the browser's timezone
     var ver_date = $('#version_date');
-    ver_date.text(new Date(ver_date.text()).toString());
+    ver_date.text(moment.unix(ver_date.text()));
 </script>

--- a/html/pages/about.inc.php
+++ b/html/pages/about.inc.php
@@ -235,7 +235,6 @@ echo "
         });
     });
 
-    // convert the version date from ISO 8601 to the browser's timezone
     var ver_date = $('#version_date');
     ver_date.text(moment.unix(ver_date.text()));
 </script>

--- a/includes/common.php
+++ b/includes/common.php
@@ -1038,7 +1038,7 @@ function version_info($remote=true) {
         curl_setopt($api, CURLOPT_RETURNTRANSFER, 1);
         $output['github'] = json_decode(curl_exec($api),true);
     }
-    list($local_sha, $local_date) = explode('|', rtrim(`git show --pretty='%H|%ci' -s HEAD`));
+    list($local_sha, $local_date) = explode('|', rtrim(`git show --pretty='%H|%ct' -s HEAD`));
     $output['local_sha']    = $local_sha;
     $output['local_date']   = $local_date;
     $output['local_branch'] = rtrim(`git rev-parse --abbrev-ref HEAD`);

--- a/validate.php
+++ b/validate.php
@@ -76,7 +76,7 @@ $versions = version_info();
 echo "Version info:\n";
 $cur_sha = $versions['local_sha'];
 if ($config['update_channel'] == 'master' && $cur_sha != $versions['github']['sha']) {
-    $commit_date = new DateTime($versions['local_date'], new DateTimeZone(date_default_timezone_get()));
+    $commit_date = new DateTime('@'.$versions['local_date'], new DateTimeZone(date_default_timezone_get()));
     print_warn("Your install is out of date: $cur_sha " . $commit_date->format('(r)'));
 }
 else {


### PR DESCRIPTION
Fixes a bug in Safari where it wouldn't show the date of the commit.