### PR TITLE
Add snmp polling capability for Memcached

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -106,14 +106,15 @@ LibreNMS contributors:
 - Marc Runkel <marc@runkel.org> (mrunkel)
 - Josh Driver <keeperofdakeys@gmail.com> (keeperofdakeys)
 - Felix Eckhofer <felix@eckhofer.com> (tribut)
-- Vikram Adukia <adukia@dropbox.com> (justmedude) 
+- Vikram Adukia <adukia@dropbox.com> (justmedude)
 - Tijmen de Mes <tijmen@ag-projects.com> (tijmenNL)
 - Benjamin Busche <benjamin.busche@gmail.com> (optic00)
 - Brandon Boudrias <bt.boudrias@gmail.com> (brandune)
-- Andy Noyland <andrew@noyland.co.uk> (Zappatron) 
+- Andy Noyland <andrew@noyland.co.uk> (Zappatron)
 - Cercel Valentin <crc@nuamchefazi.ro> (crcro)
 - Ahmed Sajid <ahmed4343@hotmail.com> (ahmedsajid)
 - Karsten Schmidt <git@guggemand.dk> (guggemand)
+- Florian Beer <fb@42dev.eu> (florianbeer)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -12,6 +12,8 @@ Different applications support a variety of ways collect data: by direct connect
 6. [TinyDNS/djbdns](#tinydns-aka-djbdns) - Agent
 7. [OS Updates](#os-updates) - extend SNMP
 8. [DHCP Stats](#dhcp-stats) - extend SNMP
+9. [Memcached](#memcached) - extend SNMP
+
 
 * [Agent Setup](#agent-setup)
 
@@ -156,6 +158,15 @@ extend dhcpstats /opt/dhcp-status.sh
 4. Restart snmpd on your host
 5. On the device page in Librenms, edit your host and check the `DHCP Stats` under the Applications tab.
 
+### Memcached
+1. Copy the [memcached script](https://github.com/librenms/librenms-agent/blob/master/agent-local/memcached) to `/usr/local/bin` (or any other suitable location) on your remote server.
+2. Make the script executable: `chmod +x /usr/local/memcached`
+3. Edit your snmpd.conf file (usually `/etc/snmp/snmpd.conf`) and add:
+```
+extend memcached /usr/local/bin/memcached
+```
+4. Restart snmpd on your host
+5. On the device page in Librenms, edit your host and check `Memcached` under the Applications tab.
 
 Agent Setup
 -----------

--- a/includes/polling/applications/memcached.inc.php
+++ b/includes/polling/applications/memcached.inc.php
@@ -4,49 +4,9 @@ if (!empty($agent_data['app']['memcached'])) {
     $data = $agent_data['app']['memcached'][$app['app_instance']];
 } else {
     $options = '-O qv';
-    $oid     = 'nsExtendOutputFull.9.109.101.109.99.97.99.104.101.100';
-    $res     = explode(';' , snmp_get($device, $oid, $options));
-    $values  = [
-        'uptime',
-        'threads',
-        'rusage_user_microseconds',
-        'rusage_system_microseconds',
-        'curr_items',
-        'total_items',
-        'limit_maxbytes',
-        'curr_connections',
-        'total_connections',
-        'connection_structures',
-        'bytes',
-        'cmd_get',
-        'cmd_set',
-        'get_hits',
-        'get_misses',
-        'evictions',
-        'bytes_read',
-        'bytes_written',
-    ];
-
-    $data = array_map(function ($key) use ($res) {
-        return substr($res[$key+1], 2);
-    },
-    array_combine(
-        $values,
-        array_values(
-            array_flip(
-                array_filter(
-                    $res,
-                    function ($item) use ($values) {
-                        foreach ($values as $value) {
-                            if (strpos($item, $value)) {
-                                return true;
-                            }
-                        }
-                    }
-                )
-            )
-        )
-    ));
+    $oid     = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.109.101.109.99.97.99.104.101.100';
+    $result  = snmp_get($device, $oid, $options);
+    $data    = reset(unserialize(str_replace("<<<app-memcached>>>\n", '', $result)));
 }
 
 $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/app-memcached-'.$app['app_id'].'.rrd';

--- a/includes/polling/applications/memcached.inc.php
+++ b/includes/polling/applications/memcached.inc.php
@@ -6,7 +6,8 @@ if (!empty($agent_data['app']['memcached'])) {
     $options = '-O qv';
     $oid     = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.109.101.109.99.97.99.104.101.100';
     $result  = snmp_get($device, $oid, $options);
-    $data    = reset(unserialize(str_replace("<<<app-memcached>>>\n", '', $result)));
+    $result  = unserialize(str_replace("<<<app-memcached>>>\n", '', $result));
+    $data    = $result[0];
 }
 
 $rrd_filename = $config['rrd_dir'].'/'.$device['hostname'].'/app-memcached-'.$app['app_id'].'.rrd';


### PR DESCRIPTION
This is a sort of proof of concept of snmp's extend feature. It is here to show, that no check_mk is needed to run local scripts on remote servers, it's all available within snmp.  
The apache, nginx and mysql scripts in `/opt/librenms/includes/polling/application` already have snmp polling included, I just ported it to the memcache poller script.

The slightly daunting nested code beginning on line 30 is just a transformation to get memcached's strange status output into the required php array. It is basically a map/reduce for all of the available values using native php functions.

To activate memcache over snmp take the following steps:

- Deploy the memcache status script (https://github.com/librenms/librenms-agent/blob/master/agent-local/memcached) on your remote server for example in `/usr/local/bin`
- On your remote server edit the snmp daemon config (most probably in `/etc/snmp/snmpd.conf`) and add the following line at the bottom `extend memcached /usr/local/memcached`
- Restart snmpd
- On your LibreNMS webfrontend, find the device you just deployed the script to, click on edit and activate "Memcached" on the "Applications" tab.