### PR TITLE
Fix a bug in syslog

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -13,7 +13,7 @@ function get_cache($host, $value) {
         case 'device_id':
             // Try by hostname
             $ip = inet_pton($host);
-            if (var_export(inet_ntop($ip),1) == 'false') {
+            if (inet_ntop($ip) === false) {
                 $dev_cache[$host]['device_id'] = dbFetchCell('SELECT `device_id` FROM devices WHERE `hostname` = ? OR `sysName` = ?', array($host, $host));
             }
             else {

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -13,7 +13,12 @@ function get_cache($host, $value) {
         case 'device_id':
             // Try by hostname
             $ip = inet_pton($host);
-            $dev_cache[$host]['device_id'] = dbFetchCell('SELECT `device_id` FROM devices WHERE `hostname` = ? OR `sysName` = ? OR `ip` = ?', array($host, $host, $ip));
+            if (var_export(inet_ntop($ip),1) == 'false') {
+                $dev_cache[$host]['device_id'] = dbFetchCell('SELECT `device_id` FROM devices WHERE `hostname` = ? OR `sysName` = ?', array($host, $host));
+            }
+            else {
+                $dev_cache[$host]['device_id'] = dbFetchCell('SELECT `device_id` FROM devices WHERE `hostname` = ? OR `sysName` = ? OR `ip` = ?', array($host, $host, $ip));
+            }
             // If failed, try by IP
             if (!is_numeric($dev_cache[$host]['device_id'])) {
                 $dev_cache[$host]['device_id'] = dbFetchCell('SELECT `device_id` FROM `ipv4_addresses` AS A, `ports` AS I WHERE A.ipv4_address = ? AND I.port_id = A.port_id', array($host));


### PR DESCRIPTION
since PR #3812 syslog writes to wrong device id in syslog table.
this happens on all devices where inet_pton() returns false.