### PR TITLE
Removed -O parameter from rrdtool command line for rrdtool < 1.5

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -153,6 +153,10 @@ function rrdtool($command, $filename, $options, $timeout = 0)
 {
     global $config, $debug, $rrd_pipes, $console_color;
     
+    // do not ovewrite files when creating
+    if ($command == 'create') {
+        $options .= ' -O';
+    }
     // rrdcached commands: >=1.5.5: all, >=1.5 all: except tune, <1.5: all except tune and create
     if ($config['rrdcached'] &&
         (version_compare($config['rrdtool_version'], '1.5.5', '>=') ||
@@ -175,7 +179,10 @@ function rrdtool($command, $filename, $options, $timeout = 0)
     ) {
         print $console_color->convert('[%rRRD Disabled%n]');
         $output = array(null, null);
-    } else if ($command == 'create' && rrdtool_check_rrd_exists($filename)){ // do not ovewrite files when creating
+    } elseif ($command == 'create' &&
+        version_compare($config['rrdtool_version'], '1.5', '<') &&
+        file_exists($filename)
+        ) { // do not ovewrite RRD if already exist and RRDTool ver. < 1.5
         print $console_color->convert('[%yRRD file ' . $filename . ' already exist%n]');
         $output = array(null, null);
     } else {

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -153,10 +153,6 @@ function rrdtool($command, $filename, $options, $timeout = 0)
 {
     global $config, $debug, $rrd_pipes, $console_color;
 
-    // do not ovewrite files when creating
-    if ($command == 'create') {
-        $options .= ' -O';
-    }
     // rrdcached commands: >=1.5.5: all, >=1.5 all: except tune, <1.5: all except tune and create
     if ($config['rrdcached'] &&
         (version_compare($config['rrdtool_version'], '1.5.5', '>=') ||
@@ -178,6 +174,9 @@ function rrdtool($command, $filename, $options, $timeout = 0)
             array('graph', 'graphv', 'dump', 'fetch', 'first', 'last', 'lastupdate', 'info', 'xport'))
     ) {
         print $console_color->convert('[%rRRD Disabled%n]');
+        $output = array(null, null);
+    } else if ($command == 'create' && file_exists($filename)){ // do not ovewrite files when creating
+        print $console_color->convert('[%yRRD file ' . $filename . ' already exist%n]');
         $output = array(null, null);
     } else {
         if ($timeout > 0 && stream_select($r = $rrd_pipes, $w = null, $x = null, 0)) {

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -152,7 +152,7 @@ function rrdtool_graph($graph_file, $options)
 function rrdtool($command, $filename, $options, $timeout = 0)
 {
     global $config, $debug, $rrd_pipes, $console_color;
-
+    
     // rrdcached commands: >=1.5.5: all, >=1.5 all: except tune, <1.5: all except tune and create
     if ($config['rrdcached'] &&
         (version_compare($config['rrdtool_version'], '1.5.5', '>=') ||
@@ -175,7 +175,7 @@ function rrdtool($command, $filename, $options, $timeout = 0)
     ) {
         print $console_color->convert('[%rRRD Disabled%n]');
         $output = array(null, null);
-    } else if ($command == 'create' && file_exists($filename)){ // do not ovewrite files when creating
+    } else if ($command == 'create' && rrdtool_check_rrd_exists($filename)){ // do not ovewrite files when creating
         print $console_color->convert('[%yRRD file ' . $filename . ' already exist%n]');
         $output = array(null, null);
     } else {

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -152,7 +152,7 @@ function rrdtool_graph($graph_file, $options)
 function rrdtool($command, $filename, $options, $timeout = 0)
 {
     global $config, $debug, $rrd_pipes, $console_color;
-    
+
     // do not ovewrite files when creating
     if ($command == 'create') {
         $options .= ' -O';
@@ -181,9 +181,9 @@ function rrdtool($command, $filename, $options, $timeout = 0)
         $output = array(null, null);
     } elseif ($command == 'create' &&
         version_compare($config['rrdtool_version'], '1.5', '<') &&
-        file_exists($filename)
+        is_file($filename)
         ) { // do not ovewrite RRD if already exist and RRDTool ver. < 1.5
-        print $console_color->convert('[%yRRD file ' . $filename . ' already exist%n]');
+        d_echo('[RRD file ' . $filename . ' already exist]');
         $output = array(null, null);
     } else {
         if ($timeout > 0 && stream_select($r = $rrd_pipes, $w = null, $x = null, 0)) {


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)


-O does not exists in RRDTool < 1.4.3 (CentOS 6.x uses 1.3.8 by default).
Maybe better to check RRD file existence with file_exists() instead?
