### PR TITLE
Fix lldp remote port

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -157,7 +157,8 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                         $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
                     }
                     // normalize MAC address if present
-                    if ($lldp['lldpRemChassisIdSubtype'] == 'macAddress') {
+		    $remote_port_mac_address = ''
+                    if ($lldp['lldpRemPortIdSubtype'] == 'macAddress') {
                         $remote_port_mac_address = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemPortId']));
                     }
                     // get remote device hostname from db by MAC address and replace lldpRemSysName if absent

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -157,7 +157,7 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                         $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
                     }
                     // normalize MAC address if present
-                    $remote_port_mac_address = ''
+                    $remote_port_mac_address = '';
                     if ($lldp['lldpRemPortIdSubtype'] == 'macAddress') {
                         $remote_port_mac_address = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemPortId']));
                     }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -157,7 +157,7 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                         $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
                     }
                     // normalize MAC address if present
-		    $remote_port_mac_address = ''
+                    $remote_port_mac_address = ''
                     if ($lldp['lldpRemPortIdSubtype'] == 'macAddress') {
                         $remote_port_mac_address = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemPortId']));
                     }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -158,11 +158,11 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                     }
                     // normalize MAC address if present
                     if ($lldp['lldpRemChassisIdSubtype'] == 'macAddress') {
-                        $remote_mac_address = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemChassisId']));
+                        $remote_port_mac_address = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemPortId']));
                     }
                     // get remote device hostname from db by MAC address and replace lldpRemSysName if absent
-                    if (!$remote_device_id && $remote_mac_address) {
-                        $remote_device_id = dbFetchCell('SELECT `device_id` FROM `ports` WHERE ifPhysAddress = ? AND `deleted` = ?', array($remote_mac_address, '0'));
+                    if (!$remote_device_id && $remote_port_mac_address) {
+                        $remote_device_id = dbFetchCell('SELECT `device_id` FROM `ports` WHERE ifPhysAddress = ? AND `deleted` = ?', array($remote_port_mac_address, '0'));
                         if ($remote_device_id) {
                             $remote_device_hostname = dbFetchRow('SELECT `hostname` FROM `devices` WHERE `device_id` = ?', array($remote_device_id));
                         }    
@@ -173,7 +173,7 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                     if ($remote_device_id) {
                         $if             = $lldp['lldpRemPortDesc'];
                         $id             = $lldp['lldpRemPortId'];
-                        $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_mac_address, $remote_device_id));
+                        $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));
                     }
                     else {
                         $remote_port_id = '0';


### PR DESCRIPTION
Code was improperly using chassis id instead of port id for port matching.

Fixes #4069 .