### PR TITLE
Config option for global default dashboard

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -143,6 +143,16 @@ A number of home pages are provided within the install and can be found in html/
 setting `front_page`. The other options are used to alter the look of those pages that support it (default.php supports these options).
 
 ```php
+// This option exists in the web UI, edit it under Global Settings -> webui
+$config['webui']['default_dashboard_id'] = 0;
+```
+Allows the specification of a global default dashboard page for any user who
+has not set one in their user preferences.  Should be set to dashboard_id of an
+existing dashboard that is shared or shared(read).  Otherwise, the system will
+automatically create each user an empty dashboard called `Default` on their
+first login.
+
+```php
 $config['login_message']    = "Unauthorised access or use shall render the user liable to criminal and/or civil prosecution.";
 ```
 This is the default message on the login page displayed to users.

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1219,11 +1219,19 @@ function generate_dynamic_config_panel($title, $config_groups, $items = array(),
                 ';
                 if (!empty($item['options'])) {
                     foreach ($item['options'] as $option) {
-                        $output .= '<option value="'.$option.'"';
-                        if ($option == $config_groups[$item['name']]['config_value']) {
+                        if (gettype($option) == 'string') {
+                            /* for backwards-compatibility */
+                            $tmp_opt = $option;
+                            $option = array(
+                                'value' => $tmp_opt,
+                                'description' => $tmp_opt,
+                            );
+                        }
+                        $output .= '<option value="'.$option['value'].'"';
+                        if ($option['value'] == $config_groups[$item['name']]['config_value']) {
                             $output .= ' selected';
                         }
-                        $output .= '>'.$option.'</option>';
+                        $output .= '>'.$option['description'].'</option>';
                     }
                 }
                 $output .='

--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -32,9 +32,9 @@ if ($default_dash == 0 && dbFetchCell(
     'SELECT dashboard_id FROM dashboards WHERE user_id=?',
     array($_SESSION['user_id'])
 ) == 0) {
-    $vars['dashboard'] = dbInsert(array('dashboard_name'=>'Default','user_id'=>$_SESSION['user_id']),'dashboards');
-    if (dbFetchCell('select 1 from users_widgets where user_id = ? && dashboard_id = ?',array($_SESSION['user_id'],0)) == 1) {
-        dbUpdate(array('dashboard_id'=>$vars['dashboard']),'users_widgets','user_id = ? && dashboard_id = ?',array($_SESSION['user_id'],0));
+    $vars['dashboard'] = dbInsert(array('dashboard_name'=>'Default', 'user_id'=>$_SESSION['user_id']), 'dashboards');
+    if (dbFetchCell('select 1 from users_widgets where user_id = ? && dashboard_id = ?', array($_SESSION['user_id'],0)) == 1) {
+        dbUpdate(array('dashboard_id'=>$vars['dashboard']), 'users_widgets', 'user_id = ? && dashboard_id = ?', array($_SESSION['user_id'], 0));
     }
 }
 if (!empty($vars['dashboard'])) {

--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -18,12 +18,23 @@
 
 $no_refresh   = true;
 $default_dash = 0;
-if (($tmp = dbFetchCell('SELECT dashboard FROM users WHERE user_id=?', array($_SESSION['user_id']))) != 0) {
+$tmp = dbFetchCell(
+    'SELECT dashboard FROM users WHERE user_id=?',
+    array($_SESSION['user_id'])
+);
+if ($tmp != 0) {
     $default_dash = $tmp;
-} elseif (dbFetchCell('SELECT dashboard_id FROM dashboards WHERE user_id=?', array($_SESSION['user_id'])) == 0) {
-    $vars['dashboard'] = dbInsert(array('dashboard_name'=>'Default','user_id'=>$_SESSION['user_id']), 'dashboards');
-    if (dbFetchCell('select 1 from users_widgets where user_id = ? && dashboard_id = ?', array($_SESSION['user_id'],0)) == 1) {
-        dbUpdate(array('dashboard_id'=>$vars['dashboard']), 'users_widgets', 'user_id = ? && dashboard_id = ?', array($_SESSION['user_id'],0));
+} elseif ((int)$config['webui']['default_dashboard_id']) {
+    // if the user hasn't set their default page, and there is a global default set
+    $default_dash = (int)$config['webui']['default_dashboard_id'];
+}
+if ($default_dash == 0 && dbFetchCell(
+    'SELECT dashboard_id FROM dashboards WHERE user_id=?',
+    array($_SESSION['user_id'])
+) == 0) {
+    $vars['dashboard'] = dbInsert(array('dashboard_name'=>'Default','user_id'=>$_SESSION['user_id']),'dashboards');
+    if (dbFetchCell('select 1 from users_widgets where user_id = ? && dashboard_id = ?',array($_SESSION['user_id'],0)) == 1) {
+        dbUpdate(array('dashboard_id'=>$vars['dashboard']),'users_widgets','user_id = ? && dashboard_id = ?',array($_SESSION['user_id'],0));
     }
 }
 if (!empty($vars['dashboard'])) {

--- a/html/pages/settings/webui.inc.php
+++ b/html/pages/settings/webui.inc.php
@@ -28,7 +28,21 @@ $availability_map_conf = array(
 $dashboard_conf = array(
     array('name'               => 'webui.default_dashboard_id',
           'descr'              => 'Set global default dashboard id',
-          'type'               => 'text',
+          'type'               => 'select',
+          'options'            => dbFetchRows(
+              "SELECT 0 as `value`, 'no default dashboard' as `description`
+               UNION ALL
+               SELECT `dashboards`.`dashboard_id` as `value`,
+                 CONCAT( `users`.`username`, ':', `dashboards`.`dashboard_name`,
+                   CASE
+                     WHEN `dashboards`.`access` = 1 THEN ' (shared, read-only)'
+                     WHEN `dashboards`.`access` = 2 THEN ' (shared, read-write)'
+                     ELSE ''
+                   END
+                 ) as `description`
+               FROM `dashboards` JOIN `users` ON `users`.`user_id` = `dashboards`.`user_id`
+               WHERE `dashboards`.`access` > 0;"
+          ),
     ),
 );
 

--- a/html/pages/settings/webui.inc.php
+++ b/html/pages/settings/webui.inc.php
@@ -25,6 +25,13 @@ $availability_map_conf = array(
     ),
 );
 
+$dashboard_conf = array(
+    array('name'               => 'webui.default_dashboard_id',
+          'descr'              => 'Set global default dashboard id',
+          'type'               => 'text',
+    ),
+);
+
 echo '
 <div class="panel-group" id="accordion">
     <form class="form-horizontal" role="form" action="" method="post">
@@ -33,6 +40,7 @@ echo '
 echo generate_dynamic_config_panel('Graph settings', $config_groups, $graph_conf);
 echo generate_dynamic_config_panel('Search settings', $config_groups, $search_conf);
 echo generate_dynamic_config_panel('Availability map settings', $config_groups, $availability_map_conf);
+echo generate_dynamic_config_panel('Dashboard settings', $config_groups, $dashboard_conf);
 
 echo '
     </form>

--- a/sql-schema/130.sql
+++ b/sql-schema/130.sql
@@ -1,0 +1,1 @@
+INSERT INTO `config` (`config_name`,`config_value`,`config_default`,`config_descr`,`config_group`,`config_group_order`,`config_sub_group`,`config_sub_group_order`,`config_hidden`,`config_disabled`) VALUES ('webui.default_dashboard_id','0','0','Global default dashboard_id for all users who do not have their own default set','webui',0,'dashboard',0,'0','0');


### PR DESCRIPTION
Add config option to set a shared dashboard as the global default dashbord.  If set, this will be used unless a user has changed their default dashboard in their user settings.