### PR TITLE
Update of ifSpeed checking in ports poller

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -410,12 +410,12 @@ foreach ($ports as $port) {
         }
 
         if (isset($this_port['ifHighSpeed']) && is_numeric($this_port['ifHighSpeed'])) {
-            d_echo 'HighSpeed ';
+            d_echo('HighSpeed ');
             $this_port['ifSpeed'] = ($this_port['ifHighSpeed'] * 1000000);
-        } elseif (isset($this_port['ifSpeed'] && is_numeric($this_port['ifSpeed'])) {
-            d_echo 'ifSpeed ';
+        } elseif (isset($this_port['ifSpeed']) && is_numeric($this_port['ifSpeed'])) {
+            d_echo('ifSpeed ');
         } else {
-            d_echo 'No ifSpeed ';
+            d_echo('No ifSpeed ');
             $this_port['ifSpeed'] = 0;
         }
 

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -409,10 +409,14 @@ foreach ($ports as $port) {
             $this_port['ifOutMulticastPkts'] = $this_port['ifHCOutMulticastPkts'];
         }
 
-        // Overwrite ifSpeed with ifHighSpeed if it's over 1G
-        if (is_numeric($this_port['ifHighSpeed']) && ($this_port['ifSpeed'] > '1000000000' || $this_port['ifSpeed'] == 0)) {
-            echo 'HighSpeed ';
+        if (isset($this_port['ifHighSpeed']) && is_numeric($this_port['ifHighSpeed'])) {
+            d_echo 'HighSpeed ';
             $this_port['ifSpeed'] = ($this_port['ifHighSpeed'] * 1000000);
+        } elseif (isset($this_port['ifSpeed'] && is_numeric($this_port['ifSpeed'])) {
+            d_echo 'ifSpeed ';
+        } else {
+            d_echo 'No ifSpeed ';
+            $this_port['ifSpeed'] = 0;
         }
 
         // Overwrite ifDuplex with dot3StatsDuplexStatus if it exists


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Tagging #4090 

This may not fix that issue but the ifSpeed checking needed to be updated - I've not seen any eventlogs in my install saying this is causing it to change so it should be good.

The biggest thing from the performance improvements in ports polling is that we don't call for ifSpeed unless ifXEntry doesn't work for us so it doesn't actually contain any data for the previous check.

The only way I could see this would be an issue is if a device returns bad ifHighSpeed values but good ifSpeed.