### PR TITLE
Added ability to force devices to use ifEntry instead of ifXEntry

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -432,6 +432,7 @@ $config['os'][$os]['over'][1]['text']  = 'CPU Usage';
 $config['os'][$os]['over'][2]['graph'] = 'device_mempool';
 $config['os'][$os]['over'][2]['text']  = 'Memory Usage';
 $config['os'][$os]['icon']             = 'cisco';
+$config['os'][$os]['bad_ifXEntry'][]   = 'cisco1941';
 
 $os = 'acsw';
 // $config['os'][$os]['group']            = "cisco";

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -122,7 +122,10 @@ $ifmib_oids = array(
 );
 
 echo 'Caching Oids: ';
-$port_stats = snmpwalk_cache_oid($device, 'ifXEntry', $port_stats, 'IF-MIB');
+
+if (!in_array($device['hardware'], $config['os'][$device['os']]['bad_ifXEntry'])) {
+    $port_stats = snmpwalk_cache_oid($device, 'ifXEntry', $port_stats, 'IF-MIB');
+}
 
 $hc_test = array_slice($port_stats, 0, 1);
 if (!isset($hc_test[0]['ifHCInOctets']) && !is_numeric($hc_test[0]['ifHCInOctets'])) {


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fix #4025 

Not sure if this is the best approach to take here but basically some devices don't always output the info we need in ifXEntry for various interfaces so it's difficult for us to check we have complete data. Falling back to ifEntry seems the best approach for those devices.

The alternative would be to poll both ifXEntry and ifEntry as we did before but that would slow polling down for these devices.