### PR TITLE
Bootgrid alignment

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1663,7 +1663,6 @@ tr.search:nth-child(odd) {
 
 .gridster li {
     font-size: 1em;
-    text-align: center;
     line-height: 100%;
 }
 
@@ -1705,6 +1704,7 @@ tr.search:nth-child(odd) {
     padding: 0.8em;
     background-color: #000000;
     color: #ffffff;
+    text-align: center;
     -webkit-border-top-left-radius: 4px;
      -moz-border-top-right-radius: 4px;
           border-top-left-radius: 4px;


### PR DESCRIPTION
The dropdown li inherit text alignment.  This corrects the centering.

![screen shot 2016-08-19 at 20 06 33](https://cloud.githubusercontent.com/assets/1351571/17827342/42845ba0-6649-11e6-8147-00089b060154.png)
to
![screen shot 2016-08-19 at 20 13 08](https://cloud.githubusercontent.com/assets/1351571/17827352/60a97160-6649-11e6-9e0c-1f02b2495766.png)

