### PR TITLE
Change the default error_reporting level to include all fatal errors

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -21,7 +21,7 @@
 //
 // Please don't edit this file -- make changes to the configuration array in config.php
 //
-error_reporting(E_ERROR|E_CORE_ERROR|E_COMPILE_ERROR);
+error_reporting(E_ERROR|E_PARSE|E_CORE_ERROR|E_COMPILE_ERROR);
 
 function set_debug($debug) {
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -21,7 +21,7 @@
 //
 // Please don't edit this file -- make changes to the configuration array in config.php
 //
-error_reporting(E_ERROR);
+error_reporting(E_ERROR|E_CORE_ERROR|E_COMPILE_ERROR);
 
 function set_debug($debug) {
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

This will hopefully save confusion when there are things like syntax errors and missing required files.