### PR TITLE
Use proc_terminate instead of proc_close to protect against zombies

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -102,7 +102,7 @@ function rrdtool_pipe_close($rrd_process, &$rrd_pipes)
 
     // It is important that you close any pipes before calling
     // proc_close in order to avoid a deadlock
-    return proc_close($rrd_process);
+    return proc_terminate($rrd_process);
 }
 
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

