### PR TITLE
Fixed not sending port_descr_type

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -640,6 +640,7 @@ foreach ($ports as $port) {
             rrdtool_tune('port',$rrdfile,$this_port['ifSpeed']);
         }
 
+        $port_descr_type = $port['port_descr_type'];
         $tags = compact('ifName', 'port_descr_type', 'rrd_name', 'rrd_def');
         rrdtool_data_update($device, 'ports', $tags, $fields);
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

This variable was missing so the tag was never sent.