### PR TITLE
Remove $config['enable_printers'] option.

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -328,7 +328,6 @@ $config['enable_syslog']                = 0; # Enable Syslog
 $config['enable_inventory']             = 1; # Enable Inventory
 $config['enable_pseudowires']           = 1; # Enable Pseudowires
 $config['enable_vrfs']                  = 1; # Enable VRFs
-$config['enable_printers']              = 0; # Enable Printer support
 $config['enable_sla']                   = 0; # Enable Cisco SLA collection and display
 ```
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -449,8 +449,6 @@ $config['enable_vrfs'] = 1;
 // Enable VRFs
 $config['enable_vrf_lite_cisco'] = 1;
 // Enable routes for VRF lite cisco
-$config['enable_printers'] = 0;
-// Enable Printer support
 $config['enable_sla'] = 0;
 // Enable Cisco SLA collection and display
 // Ports extension modules

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -2546,12 +2546,10 @@ $config['device_types'][$i]['text'] = 'Storage';
 $config['device_types'][$i]['type'] = 'storage';
 $config['device_types'][$i]['icon'] = 'storage.png';
 
-if (isset($config['enable_printers']) && $config['enable_printers']) {
-    $i++;
-    $config['device_types'][$i]['text'] = 'Printers';
-    $config['device_types'][$i]['type'] = 'printer';
-    $config['device_types'][$i]['icon'] = 'printer.png';
-}
+$i++;
+$config['device_types'][$i]['text'] = 'Printers';
+$config['device_types'][$i]['type'] = 'printer';
+$config['device_types'][$i]['icon'] = 'printer.png';
 
 $i++;
 $config['device_types'][$i]['text'] = 'Appliance';

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -1,61 +1,59 @@
 <?php
 
-if ($config['enable_printers']) {
-    $valid_toner = array();
+$valid_toner = array();
 
-    if ($device['os_group'] == 'printer') {
-        $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.12.1.1.2.1 ', '-OsqnU'));
-        if (!$oids) {
-            $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.11.1.1.2.1 ', '-OsqnU'));
-        }
-
-        d_echo($oids."\n");
-
-        if ($oids) {
-            echo 'Jetdirect ';
-        }
-
-        foreach (explode("\n", $oids) as $data) {
-            $data = trim($data);
-            if ($data) {
-                list($oid,$role) = explode(' ', $data);
-                $split_oid       = explode('.', $oid);
-                $index           = $split_oid[(count($split_oid) - 1)];
-                if (is_numeric($role)) {
-                    $toner_oid    = ".1.3.6.1.2.1.43.11.1.1.9.1.$index";
-                    $descr_oid    = ".1.3.6.1.2.1.43.11.1.1.6.1.$index";
-                    $capacity_oid = ".1.3.6.1.2.1.43.11.1.1.8.1.$index";
-                    $descr        = trim(str_replace("\n", '', str_replace('"', '', snmp_get($device, $descr_oid, '-Oqv'))));
-                    if ($descr != '') {
-                        $current  = snmp_get($device, $toner_oid, '-Oqv');
-                        $capacity = snmp_get($device, $capacity_oid, '-Oqv');
-                        $current  = ($current / $capacity * 100);
-                        $type     = 'jetdirect';
-                        if (isHexString($descr)) {
-                            $descr = snmp_hexstring($descr);
-                        }
-
-                        discover_toner($valid_toner, $device, $toner_oid, $index, $type, $descr, $capacity_oid, $capacity, $current);
-                    }
-                }
-            }//end if
-        }//end foreach
-    }//end if
-
-    // Delete removed toners
-    d_echo("\n Checking ... \n");
-    d_echo($valid_toner);
-
-    $sql = "SELECT * FROM toner WHERE device_id = '".$device['device_id']."'";
-    foreach (dbFetchRows($sql) as $test_toner) {
-        $toner_index = $test_toner['toner_index'];
-        $toner_type  = $test_toner['toner_type'];
-        if (!$valid_toner[$toner_type][$toner_index]) {
-            echo '-';
-            dbDelete('toner', '`toner_id` = ?', array($test_toner['toner_id']));
-        }
+if ($device['os_group'] == 'printer') {
+    $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.12.1.1.2.1 ', '-OsqnU'));
+    if (!$oids) {
+        $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.11.1.1.2.1 ', '-OsqnU'));
     }
 
-    unset($valid_toner);
-    echo "\n";
-} //end if
+    d_echo($oids."\n");
+
+    if ($oids) {
+        echo 'Jetdirect ';
+    }
+
+    foreach (explode("\n", $oids) as $data) {
+        $data = trim($data);
+        if ($data) {
+            list($oid,$role) = explode(' ', $data);
+            $split_oid       = explode('.', $oid);
+            $index           = $split_oid[(count($split_oid) - 1)];
+            if (is_numeric($role)) {
+                $toner_oid    = ".1.3.6.1.2.1.43.11.1.1.9.1.$index";
+                $descr_oid    = ".1.3.6.1.2.1.43.11.1.1.6.1.$index";
+                $capacity_oid = ".1.3.6.1.2.1.43.11.1.1.8.1.$index";
+                $descr        = trim(str_replace("\n", '', str_replace('"', '', snmp_get($device, $descr_oid, '-Oqv'))));
+                if ($descr != '') {
+                    $current  = snmp_get($device, $toner_oid, '-Oqv');
+                    $capacity = snmp_get($device, $capacity_oid, '-Oqv');
+                    $current  = ($current / $capacity * 100);
+                    $type     = 'jetdirect';
+                    if (isHexString($descr)) {
+                        $descr = snmp_hexstring($descr);
+                    }
+
+                    discover_toner($valid_toner, $device, $toner_oid, $index, $type, $descr, $capacity_oid, $capacity, $current);
+                }
+            }
+        }//end if
+    }//end foreach
+}//end if
+
+// Delete removed toners
+d_echo("\n Checking ... \n");
+d_echo($valid_toner);
+
+$sql = "SELECT * FROM toner WHERE device_id = '".$device['device_id']."'";
+foreach (dbFetchRows($sql) as $test_toner) {
+    $toner_index = $test_toner['toner_index'];
+    $toner_type  = $test_toner['toner_type'];
+    if (!$valid_toner[$toner_type][$toner_index]) {
+        echo '-';
+        dbDelete('toner', '`toner_id` = ?', array($test_toner['toner_id']));
+    }
+}
+
+unset($valid_toner);
+echo "\n";

--- a/includes/polling/toner.inc.php
+++ b/includes/polling/toner.inc.php
@@ -1,33 +1,31 @@
 <?php
 
-if ($config['enable_printers']) {
-    $toner_data = dbFetchRows('SELECT * FROM toner WHERE device_id = ?', array($device['device_id']));
+$toner_data = dbFetchRows('SELECT * FROM toner WHERE device_id = ?', array($device['device_id']));
 
-    foreach ($toner_data as $toner) {
-        echo 'Checking toner '.$toner['toner_descr'].'... ';
+foreach ($toner_data as $toner) {
+    echo 'Checking toner '.$toner['toner_descr'].'... ';
 
-        if ($toner['toner_capacity_oid']) {
-            // FIXME this if can go on 1-Sep-2012
-            $toner['toner_capacity'] = snmp_get($device, $toner['toner_capacity_oid'], '-OUqnv');
-        }
+    if ($toner['toner_capacity_oid']) {
+        // FIXME this if can go on 1-Sep-2012
+        $toner['toner_capacity'] = snmp_get($device, $toner['toner_capacity_oid'], '-OUqnv');
+    }
 
-        $tonerperc = round((snmp_get($device, $toner['toner_oid'], '-OUqnv') / $toner['toner_capacity'] * 100));
-        echo $tonerperc." %\n";
+    $tonerperc = round((snmp_get($device, $toner['toner_oid'], '-OUqnv') / $toner['toner_capacity'] * 100));
+    echo $tonerperc." %\n";
 
-        $tags = array(
-            'rrd_def'     => 'DS:toner:GAUGE:600:0:20000',
-            'rrd_name'    => array('toner', $toner['toner_index']),
-            'rrd_oldname' => array('toner', $toner['toner_descr']),
-            'index'       => $toner['toner_index'],
-        );
-        data_update($device, 'toner', $tags, $tonerperc);
+    $tags = array(
+        'rrd_def'     => 'DS:toner:GAUGE:600:0:20000',
+        'rrd_name'    => array('toner', $toner['toner_index']),
+        'rrd_oldname' => array('toner', $toner['toner_descr']),
+        'index'       => $toner['toner_index'],
+    );
+    data_update($device, 'toner', $tags, $tonerperc);
 
-        // FIXME should report for toner out... :)
-        // Log toner swap
-        if ($tonerperc > $toner['toner_current']) {
-            log_event('Toner '.$toner['toner_descr'].' was replaced (new level: '.$tonerperc.'%)', $device, 'toner', $toner['toner_id']);
-        }
+    // FIXME should report for toner out... :)
+    // Log toner swap
+    if ($tonerperc > $toner['toner_current']) {
+        log_event('Toner '.$toner['toner_descr'].' was replaced (new level: '.$tonerperc.'%)', $device, 'toner', $toner['toner_id']);
+    }
 
-        dbUpdate(array('toner_current' => $tonerperc, 'toner_capacity' => $toner['toner_capacity']), 'toner', '`toner_id` = ?', array($toner['toner_id']));
-    }//end foreach
-}//end if
+    dbUpdate(array('toner_current' => $tonerperc, 'toner_capacity' => $toner['toner_capacity']), 'toner', '`toner_id` = ?', array($toner['toner_id']));
+}//end foreach


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Not sure the original reason behind this but I don't see why you'd need it, if people don't want toner support then disable it globally in modules or per device.