### PR TITLE
Removed / Updated version info to just be LibreNMS

### DIFF
--- a/html/pages/about.inc.php
+++ b/html/pages/about.inc.php
@@ -145,7 +145,6 @@ echo "
 <?php
 $versions = version_info(false);
 $project_name    = $config['project_name'];
-$project_version = $config['version'];
 $apache_version  = str_replace('Apache/', '', $_SERVER['SERVER_SOFTWARE']);
 $php_version     = $versions['php_ver'];
 $mysql_version   = $versions['mysql_ver'];

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -2561,8 +2561,7 @@ $config['device_types'][$i]['icon'] = 'appliance.png';
 //
 // No changes below this line #
 //
-$config['version']              = '2015.master';
-$config['project_name_version'] = $config['project_name'].' '.$config['version'];
+$config['project_name_version'] = $config['project_name'];
 
 if (isset($config['rrdgraph_def_text'])) {
     $config['rrdgraph_def_text'] = str_replace('  ', ' ', $config['rrdgraph_def_text']);


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

This was largely a waste of space in the code, the version never is or was 2015.master so stripped it back to just be LibreNMS.

We have separate version info now.