### PR TITLE
Fix remote rrdtool_check_rrd_exists() calls

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -260,7 +260,8 @@ function rrdtool_check_rrd_exists($filename)
     global $config;
     if ($config['rrdcached'] && version_compare($config['rrdtool_version'], '1.5', '>=')) {
         $chk = rrdtool('last', $filename, '');
-        return strpos(implode($chk), "$filename': No such file or directory") === false;
+        $filename = str_replace(array($config['rrd_dir'].'/', $config['rrd_dir']), '', $filename);
+        return !str_contains(implode($chk), "$filename': No such file or directory");
     } else {
         return is_file($filename);
     }


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

It was comparing with the full name when rrdcached only printed out the relative name.
Thanks to mikmak on irc for lots of work troubleshooting this.