### PR TITLE
include common.php in definitions.inc.php

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once $config['install_dir'].'/includes/common.php';
 require_once $config['install_dir'].'/includes/dbFacile.php';
 require_once $config['install_dir'].'/includes/mergecnf.inc.php';
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

definitions.inc.php makes a call to dbFetchRow, which uses c_echo()
It is safe to include common.php here as it only has function definitions.