### PR TITLE
IRC Bot - detect lost communication

### DIFF
--- a/irc.php
+++ b/irc.php
@@ -28,6 +28,7 @@ require_once 'includes/discovery/functions.inc.php';
 error_reporting(E_ERROR);
 
 class ircbot {
+    
     private $last_activity = '';
     
     private $data = '';

--- a/irc.php
+++ b/irc.php
@@ -178,7 +178,6 @@ class ircbot {
             if($this->config['irc_conn_timeout']) {
                 $inactive_seconds = time() - $this->last_activity;
                 $max_inactive = $this->config['irc_conn_timeout'];
-
                 if( $inactive_seconds > $max_inactive) {
                     $this->log("No data from server since " . $max_inactive . " seconds. Restarting.");
                     break;

--- a/irc.php
+++ b/irc.php
@@ -175,10 +175,10 @@ class ircbot {
                 $this->alertData();
             }
             
-            if($this->config['irc_conn_timeout']) {
+            if ($this->config['irc_conn_timeout']) {
                 $inactive_seconds = time() - $this->last_activity;
                 $max_inactive = $this->config['irc_conn_timeout'];
-                if( $inactive_seconds > $max_inactive) {
+                if ($inactive_seconds > $max_inactive) {
                     $this->log("No data from server since " . $max_inactive . " seconds. Restarting.");
                     break;
                 }

--- a/irc.php
+++ b/irc.php
@@ -28,7 +28,8 @@ require_once 'includes/discovery/functions.inc.php';
 error_reporting(E_ERROR);
 
 class ircbot {
-
+    private $last_activity = '';
+    
     private $data = '';
 
     private $authd = array();
@@ -149,6 +150,8 @@ class ircbot {
             $this->connect_alert();
         }
 
+        $this->last_activity = time();
+
         $this->j = 2;
 
         $this->connect();
@@ -170,6 +173,17 @@ class ircbot {
             if ($this->config['irc_alert']) {
                 $this->alertData();
             }
+            
+            if($this->config['irc_conn_timeout']) {
+                $inactive_seconds = time() - $this->last_activity;
+                $max_inactive = $this->config['irc_conn_timeout'];
+
+                if( $inactive_seconds > $max_inactive) {
+                    $this->log("No data from server since " . $max_inactive . " seconds. Restarting.");
+                    break;
+                }
+            }
+
 
             usleep($this->tick);
         }
@@ -267,6 +281,7 @@ class ircbot {
 
     private function getData() {
         if (($data = $this->read('irc')) !== false) {
+            $this->last_activity = time();
             $this->data = $data;
             $ex         = explode(' ', $this->data);
             if ($ex[0] == 'PING') {

--- a/irc.php
+++ b/irc.php
@@ -28,9 +28,9 @@ require_once 'includes/discovery/functions.inc.php';
 error_reporting(E_ERROR);
 
 class ircbot {
-    
+
     private $last_activity = '';
-    
+
     private $data = '';
 
     private $authd = array();


### PR DESCRIPTION
Force reconnect if no data received from server for config['irc_conn_timeout'] seconds (that may happen when network/VPN goes down - in such case IRC bot won't get immediately notification that connection was lost, at least till it tries to send anything).
#### Please note

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
