### PR TITLE
Only push the toc down, not the content

### DIFF
--- a/doc/librenms.css
+++ b/doc/librenms.css
@@ -8,10 +8,9 @@ body {
     overflow-x: hidden !important;
 }
 
-/* pushdown the content when the header flows to two lines */
-.navbar-fixed-top {
-    top: -70px;
-    position: relative;
+/* push down the content when the header flows to two lines */
+.bs-sidebar {
+    margin-top: 45px;
 }
 
 /* hide the menu called hidden, used to generate unlinked docs */


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

the toc is on top when the header switches to two lines, so we only need to push that down.