### PR TITLE
Fix applications snmp-extend

### DIFF
--- a/includes/polling/applications/apache.inc.php
+++ b/includes/polling/applications/apache.inc.php
@@ -1,18 +1,19 @@
 <?php
 
-// Polls Apache statistics from script via SNMP
+
 $name = 'apache';
 $app_id = $app['app_id'];
+
+echo " $name";
+
 if (!empty($agent_data['app'][$name])) {
     $apache = $agent_data['app'][$name];
 }
 else {
-    $options = '-O qv';
-    $oid     = 'nsExtendOutputFull.6.97.112.97.99.104.101';
-    $apache  = snmp_get($device, $oid, $options);
+    // NET-SNMP-EXTEND-MIB::nsExtendOutputFull."apache"
+    $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.6.97.112.97.99.104.101';
+    $apache = snmp_get($device, $oid, '-Oqv');
 }
-
-echo ' apache';
 
 list ($total_access, $total_kbyte, $cpuload, $uptime, $reqpersec, $bytespersec,
     $bytesperreq, $busyworkers, $idleworkers, $score_wait, $score_start,

--- a/includes/polling/applications/dhcp-stats.inc.php
+++ b/includes/polling/applications/dhcp-stats.inc.php
@@ -1,11 +1,13 @@
 <?php
 $name = 'dhcp-stats';
 $app_id = $app['app_id'];
-$options      = '-O qv';
-$mib          = 'NET-SNMP-EXTEND-MIB';
-$oid          = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.9.100.104.99.112.115.116.97.116.115';
 
-$dhcpstats = snmp_walk($device, $oid, $options, $mib);
+echo " $name";
+
+// NET-SNMP-EXTEND-MIB::nsExtendOutLine."dhcpstats"
+$oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.9.100.104.99.112.115.116.97.116.115';
+$dhcpstats = snmp_walk($device, $oid, '-Oqv');
+
 list($dhcp_total,$dhcp_active,$dhcp_expired,$dhcp_released,$dhcp_abandoned,$dhcp_reset,$dhcp_bootp,$dhcp_backup,$dhcp_free) = explode("\n",$dhcpstats);
 
 $rrd_name = array('app', $name, $app_id);

--- a/includes/polling/applications/mailscanner.inc.php
+++ b/includes/polling/applications/mailscanner.inc.php
@@ -1,11 +1,8 @@
 <?php
 
-// Polls MailScanner statistics from script via SNMP
-
-$options      = '-O qv';
-$oid          = 'nsExtendOutputFull.11.109.97.105.108.115.99.97.110.110.101.114';
-
-$mailscanner = snmp_get($device, $oid, $options);
+// NET-SNMP-EXTEND-MIB::nsExtendOutputFull."mailscanner"
+$oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.11.109.97.105.108.115.99.97.110.110.101.114';
+$mailscanner = snmp_get($device, $oid, '-Oqv');
 
 echo ' mailscanner';
 

--- a/includes/polling/applications/memcached.inc.php
+++ b/includes/polling/applications/memcached.inc.php
@@ -5,6 +5,7 @@ $app_id = $app['app_id'];
 if (!empty($agent_data['app']['memcached'])) {
     $data = $agent_data['app']['memcached'][$app['app_instance']];
 } else {
+    // NET-SNMP-EXTEND-MIB::nsExtendOutputFull."memcached"
     $oid     = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.109.101.109.99.97.99.104.101.100';
     $result  = snmp_get($device, $oid, '-Oqv');
     $result  = unserialize(str_replace("<<<app-memcached>>>\n", '', $result));

--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -3,17 +3,17 @@
 // FIXME - this is lame
 $name = 'mysql';
 $app_id = $app['app_id'];
+
+echo " $name";
+
 if (!empty($agent_data['app'][$name])) {
     $mysql = $agent_data['app'][$name];
 }
 else {
-    // Polls MySQL  statistics from script via SNMP
-    $mysql_cmd  = $config['snmpget'].' -m NET-SNMP-EXTEND-MIB -O qv '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'];
-    $mysql_cmd .= ' nsExtendOutputFull.5.109.121.115.113.108';
-    $mysql      = shell_exec($mysql_cmd);
+    // NET-SNMP-EXTEND-MIB::nsExtendOutputFull."mysql"
+    $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.5.109.121.115.113.108';
+    $mysql = snmp_get($device, $oid, '-Oqv');
 }
-
-echo ' mysql';
 
 // General Stats
 $mapping = array(

--- a/includes/polling/applications/nfs-stats.inc.php
+++ b/includes/polling/applications/nfs-stats.inc.php
@@ -1,11 +1,12 @@
 <?php
 $name = 'nfsstat';
 $app_id = $app['app_id'];
-$oid = '.1.3.6.1.4.1.8072.1.3.2.4';
 
 echo ' ' . $name;
 
-$nfsstats = snmp_walk($device, $oid, '-Oqv', 'NET-SNMP-EXTEND-MIB');
+// NET-SNMP-EXTEND-MIB::nsExtendOutputFull."nfs-stats"
+$oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.110.102.115.45.115.116.97.116.115';
+$nfsstats = snmp_get($device, $oid, '-Oqv');
 
 $rrd_name = array('app', $name, $app_id);
 $rrd_def = array(

--- a/includes/polling/applications/nfs-v3-stats.inc.php
+++ b/includes/polling/applications/nfs-v3-stats.inc.php
@@ -1,11 +1,12 @@
 <?php
 $name = 'nfs-v3-stats';
 $app_id = $app['app_id'];
-$oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.7.110.102.115.115.116.97.116';
 
 echo ' ' . $name;
 
-$nfsstats = snmp_walk($device, $oid, '-Oqv', 'NET-SNMP-EXTEND-MIB');
+// NET-SNMP-EXTEND-MIB::nsExtendOutLine."nfsstat"
+$oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.7.110.102.115.115.116.97.116';
+$nfsstats = snmp_get($device, $oid, '-Oqv');
 
 $rrd_name = array('app', 'nfs-stats', $app_id);
 $rrd_def = array(

--- a/includes/polling/applications/nginx.inc.php
+++ b/includes/polling/applications/nginx.inc.php
@@ -6,8 +6,9 @@ if (!empty($agent_data['app'][$name])) {
     $nginx = $agent_data['app'][$name];
 }
 else {
-    // Polls nginx statistics from script via SNMP
-    $nginx = snmp_get($device, 'nsExtendOutputFull.5.110.103.105.110.120', '-Ovq', 'NET-SNMP-EXTEND-MIB');
+    // NET-SNMP-EXTEND-MIB::nsExtendOutputFull."nginx"
+    $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.5.110.103.105.110.120';
+    $nginx = snmp_get($device, $oid, '-Ovq');
 }
 
 echo ' nginx';

--- a/includes/polling/applications/ntp-client.inc.php
+++ b/includes/polling/applications/ntp-client.inc.php
@@ -1,9 +1,8 @@
 <?php
 
-// Polls ntp-client statistics from script via SNMP
-$options      = '-O qv';
-$oid          = 'nsExtendOutputFull.9.110.116.112.99.108.105.101.110.116';
-$ntpclient = snmp_get($device, $oid, $options);
+// NET-SNMP-EXTEND-MIB::nsExtendOutputFull."ntpclient"
+$oid          = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.110.116.112.99.108.105.101.110.116';
+$ntpclient = snmp_get($device, $oid, '-Oqv');
 
 $name = 'ntpclient';
 $app_id = $app['app_id'];

--- a/includes/polling/applications/os-updates.inc.php
+++ b/includes/polling/applications/os-updates.inc.php
@@ -1,16 +1,15 @@
 <?php
 $name = 'os-updates';
 $app_id = $app['app_id'];
-$options = '-O qv';
-$mib = 'NET-SNMP-EXTEND-MIB';
+
+// NET-SNMP-EXTEND-MIB::nsExtendOutLine."osupdate".1
 $oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.8.111.115.117.112.100.97.116.101.1';
+$osupdates = snmp_get($device, $oid, $options, $mib);
 
 $rrd_name = array('app', $name, $app_id);
 $rrd_def = array(
     'DS:packages:GAUGE:600:0:U',
 );
-
-$osupdates = snmp_get($device, $oid, $options, $mib);
 
 $fields = array('packages' => $osupdates,);
 

--- a/includes/polling/applications/powerdns.inc.php
+++ b/includes/polling/applications/powerdns.inc.php
@@ -1,20 +1,18 @@
 <?php
 
-// Polls powerdns statistics from script via SNMP
-$options      = '-O qv';
-$mib          = 'NET-SNMP-EXTEND-MIB';
-$oid          = 'nsExtendOutputFull.8.112.111.119.101.114.100.110.115';
-
 $name = 'powerdns';
 $app_id = $app['app_id'];
+
+echo " $name";
+
 if ($agent_data['app'][$name]) {
     $powerdns = $agent_data['app'][$name];
 }
 else {
-    $powerdns = snmp_get($device, $oid, $options, $mib);
+    // NET-SNMP-EXTEND-MIB::nsExtendOutputFull."powerdns"
+    $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.8.112.111.119.101.114.100.110.115';
+    $powerdns = snmp_get($device, $oid, '-Oqv');
 }
-
-echo ' powerdns';
 
 list ($corrupt, $def_cacheInserts, $def_cacheLookup, $latency, $pc_hit,
     $pc_miss, $pc_size, $qsize, $qc_hit, $qc_miss, $rec_answers,

--- a/includes/polling/applications/rrdcached.inc.php
+++ b/includes/polling/applications/rrdcached.inc.php
@@ -70,14 +70,14 @@ if ($agent_data['app'][$name]) {
 $rrd_name = array('app', $name, $app_id);
 $rrd_def = array(
     'DS:queue_length:GAUGE:600:0:U',
-    'DS:updates_received:COUNTER:600:0:U',
-    'DS:flushes_received:COUNTER:600:0:U',
-    'DS:updates_written:COUNTER:600:0:U',
-    'DS:data_sets_written:COUNTER:600:0:U',
+    'DS:updates_received:DERIVE:600:0:U',
+    'DS:flushes_received:DERIVE:600:0:U',
+    'DS:updates_written:DERIVE:600:0:U',
+    'DS:data_sets_written:DERIVE:600:0:U',
     'DS:tree_nodes_number:GAUGE:600:0:U',
     'DS:tree_depth:GAUGE:600:0:U',
-    'DS:journal_bytes:COUNTER:600:0:U',
-    'DS:journal_rotate:COUNTER:600:0:U'
+    'DS:journal_bytes:DERIVE:600:0:U',
+    'DS:journal_rotate:DERIVE:600:0:U'
 );
 
 $fields = array();

--- a/includes/polling/applications/shoutcast.inc.php
+++ b/includes/polling/applications/shoutcast.inc.php
@@ -4,11 +4,11 @@
 $name = 'shoutcast';
 $app_id = $app['app_id'];
 
-$options = '-O qv';
-$oid     = 'nsExtendOutputFull.9.115.104.111.117.116.99.97.115.116';
-$shoutcast = snmp_get($device, $oid, $options);
+echo " $name";
 
-echo ' shoutcast';
+// NET-SNMP-EXTEND-MIB::nsExtendOutputFull."shoutcast"
+$oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.115.104.111.117.116.99.97.115.116';
+$shoutcast = snmp_get($device, $oid, '-Oqv');
 
 $servers = explode("\n", $shoutcast);
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Most were broken as they used nsExtendOutputFull without the MIB.
Use just numbers, but leave the name in a comment for ease of discovery
The nfs-stats used some wierd snmpwalk, so they could be broken (or fixed).