### PR TITLE
Update avaya-vsp.inc.php  change oid to be the 5 minute  average 

### DIFF
--- a/includes/polling/os/avaya-vsp.inc.php
+++ b/includes/polling/os/avaya-vsp.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS
  *
- * Copyright (c) 2016 Neil Lathwood <neil@lathwood.co.uk>
+ * Copyright (c) 2016 Daniel Cox <danielcoxman@gmail.com>
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation, either version 3 of the License, or (at your
@@ -10,7 +10,20 @@
  * the source code distribution for details.
  */
 
-$temp     = explode(' ', $poll_device['sysDescr']);
-$hardware = $temp[0];
-$serial   = snmp_get($device, 'rcChasSerialNumber', '-Osqv', 'RAPID-CITY');
-$version  = snmp_get($device, 'rcSysVersion', '-Osqv', 'RAPID-CITY');
+// rcSysVersion
+$version = snmp_get($device, '.1.3.6.1.4.1.2272.1.1.7.0', '-Oqvn');
+$version = explode(' ', $version);
+$version = $version[0];
+$version = str_replace('"', '', $version);
+
+// rcChasSerialNumber
+$serial = snmp_get($device, '.1.3.6.1.4.1.2272.1.4.2.0', '-Oqvn');
+$serial = str_replace('"', '', $serial);
+
+// rcChasHardwareRevision
+$sysDescr = $poll_device['sysDescr'];
+$sysDescr = explode(' ', $sysDescr);
+$sysDescr = $sysDescr[0];
+$hwrevision = snmp_get($device, '.1.3.6.1.4.1.2272.1.4.3.0', '-Oqvn');
+$hardware = $sysDescr . " HW: $hwrevision";
+$hardware = str_replace('"', '', $hardware);


### PR DESCRIPTION
#### Please note

> Please read this information carefully.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

more updates for the avaya-vsp to make it more descriptive when looking at the device.  I have also documented the OID names used.  I felt it was more efficient to use the decimal notation and not use the RAPID-CITY min.