### PR TITLE
Added config.php to be excluded in psr2 pre-commit check

### DIFF
--- a/scripts/pre-commit.php
+++ b/scripts/pre-commit.php
@@ -121,6 +121,7 @@ function check_style($passthru = false, $command_only = false)
         '/vendor/',
         '/lib/',
         '/html/plugins/',
+        '/config.php',
     );
 
     $cs_exclude = build_excludes('--ignore=', $cs_excludes);


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Simple change, excludes config.php from psr2 check as we have no control over that.