### PR TITLE
Added fallback icon for syslog table

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -27,6 +27,7 @@ function generate_priority_icon($priority)
         "notice"    => "application_edit",
         "info"      => "application",
         "debug"     => "bug",
+        ""          => "application",
     );
 
     return '<img src="images/16/' . $map[$priority] .'.png" title="' . $priority . '">';


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

When the priority was unknown we didn't provide an image, now just falls back to using application.png - we should update to FA icons though.

Fixes #4216 