### PR TITLE
Added example to alerting doc for using variables of similar name

### DIFF
--- a/doc/Extensions/Alerting.md
+++ b/doc/Extensions/Alerting.md
@@ -130,6 +130,18 @@ Placeholders:
 - Transport name: `%transport`
 - Contacts, must be iterated in a foreach, `%key` holds email and `%value` holds name: `%contacts`
 
+> NOTE: Placeholder names which are contained within another need to be ordered correctly. As an example:
+
+```text
+Limit: %value.sensor_limit / %value.sensor_limit_low
+```
+
+Should be done as:
+
+```text
+Limit: %value.sensor_limit_low / %value.sensor_limit
+```
+
 The Default Template is a 'one-size-fit-all'. We highly recommend defining own templates for your rules to include more specific information.
 Templates can be matched against several rules.
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Hopefully goes to show the order of variable names matters.

Fixes #3993 