### PR TITLE
fix: Use isset for checking poller option

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -277,7 +277,7 @@ function poll_device($device, $options)
         // Update device_groups
         UpdateGroupsForDevice($device['device_id']);
 
-        if (!$options['m']) {
+        if (!isset($options['m'])) {
             // FIXME EVENTLOGGING -- MAKE IT SO WE DO THIS PER-MODULE?
             // This code cycles through the graphs already known in the database and the ones we've defined as being polled here
             // If there any don't match, they're added/deleted from the database.


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

I'm not sure why but this resolved an issue for someone who couldn't see graphs in the webui, confirmed fix in irc:

`10:56 <Azathoth> yay, I have graphs now :)`