### PR TITLE
fix: Don’t add Cisco VSS sensors if VSS is not running #4111

### DIFF
--- a/includes/discovery/sensors/states/cisco.inc.php
+++ b/includes/discovery/sensors/states/cisco.inc.php
@@ -26,6 +26,10 @@ if ($device['os_group'] == 'cisco') {
         $cur_oid = $tablevalue[1];
 
         if (is_array($temp)) {
+            if ($temp[0][$tablevalue[2]] == 'nonRedundant') {
+                break;
+            }
+
             //Create State Index
             $state_name = $tablevalue[2];
             $state_index_id = create_state_index($state_name);


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
Fix #4111 
Tested on 4500X which are participating in VSS and others who don't, works as expected.
