### PR TITLE
fix: Cisco remote access stats bugfix #4293

### DIFF
--- a/html/includes/graphs/device/cras_sessions.inc.php
+++ b/html/includes/graphs/device/cras_sessions.inc.php
@@ -12,36 +12,35 @@ $rrd_options .= " DEF:l2l=$rrd_filename:l2l:AVERAGE";
 $rrd_options .= " DEF:lb=$rrd_filename:lb:AVERAGE";
 $rrd_options .= " DEF:svc=$rrd_filename:svc:AVERAGE";
 $rrd_options .= " DEF:webvpn=$rrd_filename:webvpn:AVERAGE";
-$rrd_options .= ' CDEF:webvpn_only=webvpn,svc,-';
 
 $rrd_options .= " COMMENT:'Sessions         Current    Average   Maximum\\n'";
 
-$rrd_options .= " AREA:svc#aa0000:'SSLVPN Tunnels':STACK";
+$rrd_options .= " AREA:svc#aa000080:'SSLVPN Tunnels'";
 $rrd_options .= " GPRINT:svc:LAST:'%6.2lf%s'";
 $rrd_options .= " GPRINT:svc:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:svc:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:webvpn_only#999999:'Clientless VPN':STACK";
-$rrd_options .= " GPRINT:webvpn_only:LAST:'%6.2lf%s'";
-$rrd_options .= " GPRINT:webvpn_only:AVERAGE:' %6.2lf%s'";
-$rrd_options .= " GPRINT:webvpn_only:MAX:' %6.2lf%s\\\\n'";
+$rrd_options .= " AREA:webvpn#99999980:'Clientless VPN'";
+$rrd_options .= " GPRINT:webvpn:LAST:'%6.2lf%s'";
+$rrd_options .= " GPRINT:webvpn:AVERAGE:' %6.2lf%s'";
+$rrd_options .= " GPRINT:webvpn:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:ipsec#00aa00:'IPSEC         ':STACK";
+$rrd_options .= " AREA:ipsec#00aa0080:'IPSEC         '";
 $rrd_options .= " GPRINT:ipsec:LAST:'%6.2lf%s'";
 $rrd_options .= " GPRINT:ipsec:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:ipsec:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:l2l#aaaa00:'Lan-to-Lan    ':STACK";
+$rrd_options .= " AREA:l2l#aaaa0080:'Lan-to-Lan    '";
 $rrd_options .= ' GPRINT:l2l:LAST:%6.2lf%s';
 $rrd_options .= " GPRINT:l2l:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:l2l:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:email#0000aa:'Email         ':STACK";
+$rrd_options .= " AREA:email#0000aa80:'Email         '";
 $rrd_options .= ' GPRINT:email:LAST:%6.2lf%s';
 $rrd_options .= " GPRINT:email:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:email:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:lb#aa00aa:'Load Balancer ':STACK";
+$rrd_options .= " AREA:lb#aa00aa80:'Load Balancer '";
 $rrd_options .= ' GPRINT:lb:LAST:%6.2lf%s';
 $rrd_options .= " GPRINT:lb:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:lb:MAX:' %6.2lf%s\\\\n'";

--- a/includes/polling/cisco-remote-access-monitor.inc.php
+++ b/includes/polling/cisco-remote-access-monitor.inc.php
@@ -35,7 +35,7 @@ if ($device['os_group'] == 'cisco') {
     $data     = snmp_get_multi($device, $oid_list, '-OUQs', 'CISCO-REMOTE-ACCESS-MONITOR-MIB');
     $data     = $data[0];
 
-    if ($data['crasEmailNumSessions'] || $data['crasIPSecNumSessions'] || $data['crasL2LNumSessions'] || $data['crasLBNumSessions'] || $data['crasSVCNumSessions'] || $data['crasWebvpnSessions']) {
+    if (is_numeric($data['crasEmailNumSessions']) && is_numeric($data['crasIPSecNumSessions']) && is_numeric($data['crasL2LNumSessions']) && is_numeric($data['crasLBNumSessions']) && is_numeric($data['crasSVCNumSessions']) && is_numeric($data['crasWebvpnNumSessions'])) {
         $rrd_def = array(
             'DS:email:GAUGE:600:0:U',
             'DS:ipsec:GAUGE:600:0:U',


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)   

Fix #4293 
Fixes the following:
- Issue in the polling, typo(crasWebvpnNumSessions).   
- Issue in the polling, the check didn't take into account if all values returned 0(false), also didn't take into account that any of the values could be bogus.
- Issue in the graphing, no reason to use the webvpn_only calculation when the values returned are perfectly fine.

Also a small visual update.