### PR TITLE
fix: Remove Cisco remote access stats graph transparency

### DIFF
--- a/html/includes/graphs/device/cras_sessions.inc.php
+++ b/html/includes/graphs/device/cras_sessions.inc.php
@@ -15,32 +15,32 @@ $rrd_options .= " DEF:webvpn=$rrd_filename:webvpn:AVERAGE";
 
 $rrd_options .= " COMMENT:'Sessions         Current    Average   Maximum\\n'";
 
-$rrd_options .= " AREA:svc#aa000080:'SSLVPN Tunnels'";
+$rrd_options .= " AREA:svc#aa0000:'SSLVPN Tunnels'";
 $rrd_options .= " GPRINT:svc:LAST:'%6.2lf%s'";
 $rrd_options .= " GPRINT:svc:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:svc:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:webvpn#99999980:'Clientless VPN'";
+$rrd_options .= " AREA:webvpn#999999:'Clientless VPN'";
 $rrd_options .= " GPRINT:webvpn:LAST:'%6.2lf%s'";
 $rrd_options .= " GPRINT:webvpn:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:webvpn:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:ipsec#00aa0080:'IPSEC         '";
+$rrd_options .= " AREA:ipsec#00aa00:'IPSEC         '";
 $rrd_options .= " GPRINT:ipsec:LAST:'%6.2lf%s'";
 $rrd_options .= " GPRINT:ipsec:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:ipsec:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:l2l#aaaa0080:'Lan-to-Lan    '";
+$rrd_options .= " AREA:l2l#aaaa00:'Lan-to-Lan    '";
 $rrd_options .= ' GPRINT:l2l:LAST:%6.2lf%s';
 $rrd_options .= " GPRINT:l2l:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:l2l:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:email#0000aa80:'Email         '";
+$rrd_options .= " AREA:email#0000aa:'Email         '";
 $rrd_options .= ' GPRINT:email:LAST:%6.2lf%s';
 $rrd_options .= " GPRINT:email:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:email:MAX:' %6.2lf%s\\\\n'";
 
-$rrd_options .= " AREA:lb#aa00aa80:'Load Balancer '";
+$rrd_options .= " AREA:lb#aa00aa:'Load Balancer '";
 $rrd_options .= ' GPRINT:lb:LAST:%6.2lf%s';
 $rrd_options .= " GPRINT:lb:AVERAGE:' %6.2lf%s'";
 $rrd_options .= " GPRINT:lb:MAX:' %6.2lf%s\\\\n'";


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
Transparency made it harder to distinguish between the different values, revert this.
