### PR TITLE
Scripts tune_port is calling rrdtool_pipe_open() instead of rrdtool_initialize();

### DIFF
--- a/scripts/tune_port.php
+++ b/scripts/tune_port.php
@@ -5,7 +5,7 @@ require 'includes/defaults.inc.php';
 require 'config.php';
 require 'includes/definitions.inc.php';
 require 'includes/functions.php';
-rrdtool_pipe_open($rrd_process, $rrd_pipes);
+rrdtool_initialize();
 
 $options = getopt('h:p:');
 


### PR DESCRIPTION
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Resolves #4314 