### PR TITLE
fix: Removed suggestion in install.php on installing php modules

### DIFF
--- a/html/install.php
+++ b/html/install.php
@@ -205,7 +205,7 @@ foreach ($modules as $extension) {
             <td>$extension</td>
             <td>$ext_loaded</td>");
     if ($ext_loaded == 'no') {
-        echo("<td>apt-get install php5-$extension / yum install php-$extension</td>");
+        echo("<td></td>");
     } else {
         echo("<td></td>");
     }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes #3503

We can't suggest all the different phpX-Y methods so removing instead.