### PR TITLE
fix: generic_v3_multiline graph

### DIFF
--- a/html/includes/graphs/generic_v3_multiline.inc.php
+++ b/html/includes/graphs/generic_v3_multiline.inc.php
@@ -96,7 +96,7 @@ foreach ($rrd_list as $rrd) {
     $rrd_options .= ' GPRINT:'.$t_defname.$i.'max:MAX:%8.0lf%s GPRINT:'.$t_defname.$i.":AVERAGE:'%8.0lf%s\\n'";
 
     if ($printtotal === 1) {
-        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.2lf%s'".rrdtool_escape($total_units)."'";
+        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%8.0lf%s'".rrdtool_escape($total_units)."'";
     }
 
     $rrd_options .= " COMMENT:'\\n'";


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

fixes total print of generic_v3_multiline.inc.php to be the same integer value
created in PR #4386 the generic_v3_multiline_float.inc.php with floating values
