### PR TITLE
fix: Missing include file for ajax_listports.php causing 500

### DIFF
--- a/html/ajax_listports.php
+++ b/html/ajax_listports.php
@@ -13,6 +13,7 @@
 require_once '../includes/defaults.inc.php';
 require_once '../config.php';
 require_once '../includes/definitions.inc.php';
+require_once '../includes/functions.php';
 require_once 'includes/functions.inc.php';
 require_once '../includes/dbFacile.php';
 require_once '../includes/common.php';


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

