### PR TITLE
fix: Added support for Graylog 2.1 API change

### DIFF
--- a/doc/Extensions/Graylog.md
+++ b/doc/Extensions/Graylog.md
@@ -11,8 +11,17 @@ standalone appliance.
 Config is simple, here's an example:
 
 ```php
-$config['graylog']['server'] = 'http://127.0.0.1';
-$config['graylog']['port'] = 12900;
+$config['graylog']['server']   = 'http://127.0.0.1';
+$config['graylog']['port']     = 12900;
 $config['graylog']['username'] = 'admin';
 $config['graylog']['password'] = 'admin';
+$config['graylog']['version']  = '2.1';
 ```
+
+> Since Graylog 2.1, the default API path is /api/
+
+If you are running a version earlier than Graylog then please set `$config['graylog']['version']` to the version 
+number of your Graylog install.
+
+If you have altered the default uri for your Graylog setup then you can override the default of `/api/` using 
+`$config['graylog']['base_uri'] = '/somepath/';`

--- a/html/includes/table/graylog.inc.php
+++ b/html/includes/table/graylog.inc.php
@@ -42,7 +42,15 @@ if (!empty($filter_hostname)) {
     }
 }
 
-$graylog_url = $config['graylog']['server'] . ':' . $config['graylog']['port'] . '/search/universal/relative?query=' . urlencode($query) . '&range='. $filter_range . $extra_query;
+if (isset($config['graylog']['base_uri'])) {
+    $graylog_base = $config['graylog']['base_uri'];
+} elseif (version_compare($config['graylog']['version'], '2.1', '>=')) {
+    $graylog_base = '/api/search/universal/relative';
+} else {
+    $graylog_base = '/search/universal/relative';
+}
+
+$graylog_url = $config['graylog']['server'] . ':' . $config['graylog']['port'] . $graylog_base . '?query=' . urlencode($query) . '&range='. $filter_range . $extra_query;
 
 $context = stream_context_create(array(
     'http' => array(


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Graylog2 has change the default api uri. Rather than just say to the user, define your endpoint I've done it so they can define the endpoint (as you can customise that in graylog) but if they don't then enter the version number so we can work out which endpoint to use.

Untested as I don't have a graylog install.

Thanks to https://twitter.com/jalogisch for the heads up.