### PR TITLE
Add severity on list alerts API method

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -128,6 +128,7 @@ LibreNMS contributors:
 - Piotr Jurga <deutor1361@gmail.com> (deutor)
 - Jonathon Koyle <jonathon.koyle@gmail.com> (jonathon-k)
 - Tamas Szabo <jobs@szatam.com> (szatam)
+- Dennis Væversted <dv@zitcom.dk> (dvaeversted)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -764,7 +764,7 @@ function list_alerts()
         array_push($param, $alert_id);
     }
 
-    $alerts       = dbFetchRows("SELECT `D`.`hostname`, `A`.* FROM `alerts` AS `A`, `devices` AS `D` WHERE `D`.`device_id` = `A`.`device_id` AND `A`.`state` IN (?) $sql", $param);
+    $alerts       = dbFetchRows("SELECT `D`.`hostname`, `A`.*, `R`.`severity` FROM `alerts` AS `A`, `devices` AS `D`, `alert_rules` AS `R` WHERE `D`.`device_id` = `A`.`device_id` AND `A`.`rule_id` = `R`.`id` AND `A`.`state` IN (?) $sql", $param);
     $total_alerts = count($alerts);
     $output       = array(
         'status'  => 'ok',


### PR DESCRIPTION
In our API consumption it makes sense to include the severity of the raised alert, instead of having to make seperate calls on the rules.
