### PR TITLE
Update availability map options -- show disabled and ignored

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -315,6 +315,7 @@ A.purple:visited, a.purple, .purple { color: #740074; }
 .bluebg  { background-color: #aaaaff; }
 .greenbg { background-color: #aaffaa; }
 .greybg  { background-color: #DEEFEF; }
+.blackbg { background-color: #000000; }
 
 .selector {
   width:275px;
@@ -1924,6 +1925,14 @@ label {
 
 .device-availability.warn, .service-availability.warn {
   border:1px solid #FFB733;
+}
+
+.device-availability.ignored, .service-availability.ignored {
+  border:1px solid #36393D;
+}
+
+.device-availability.disabled, .service-availability.disabled {
+  border:1px solid #000000;
 }
 
 .availability-label {

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -55,17 +55,13 @@ if (defined('SHOW_SETTINGS')) {
         </div>';
     }
 
-    if (isset($widget_settings['show_disabled_and_ignored'])) {
-        $showDisabledAndIgnored = 1;
-    } else {
-        $showDisabledAndIgnored = 0;
-    }
+    $showDisabledAndIgnored =  isset($widget_settings['show_disabled_and_ignored']) && $widget_settings['show_disabled_and_ignored'];
 
     $common_output[] = '
     <div class="form-group">
         <label for="show_disabled_and_ignored" class="col-sm-4 control-label">Disabled and ignored</label>
         <div class="col-sm-6">
-            <input type="checkbox" class="form-control" name="show_disabled_and_ignored" value="1" ' .($showDisabledAndIgnored == 1 ? 'checked' : ''). '>
+            <input type="checkbox" class="form-control" name="show_disabled_and_ignored" value="1" ' .($showDisabledAndIgnored ? 'checked' : ''). '>
         </div>
     </div>
 

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -330,7 +330,7 @@ if (defined('SHOW_SETTINGS')) {
 
     if ($directpage == "yes") {
         $deviceClass = 'page-availability-report-host';
-        $serviceClass = 'page-availability-report-service';
+        $serviceClass = 'page-availability-report-host';
     } else {
         $deviceClass = 'widget-availability-host';
         $serviceClass = 'widget-availability-service';


### PR DESCRIPTION
Add an option to display disabled and ignored devices in the availability-map widget

The change at html/includes/common/availability-map.inc.php:311 is because I suspected a copy paste error -- if anyone can confirm that it was not, I will remove this change.