### PR TITLE
fix: This removes stale entries in the mac_ipv4 table

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -41,7 +41,7 @@ foreach ($vrfs_lite_cisco as $vrf) {
             $clean_mac = $m_a.$m_b.$m_c.$m_d.$m_e.$m_f;
             $mac_table[$if][$mac]['cleanmac'] = $clean_mac;
             $port_id = $interface['port_id'];
-            $mac_table[$port_id][$clean_mac] = 1;
+            $mac_table[$port_id][$clean_mac][$ip] = 1;
 
             if (dbFetchCell('SELECT COUNT(*) from ipv4_mac WHERE port_id = ? AND ipv4_address = ?', array($interface['port_id'], $ip))) {
                 // Commented below, no longer needed but leaving for reference.
@@ -74,8 +74,9 @@ foreach ($vrfs_lite_cisco as $vrf) {
     foreach (dbFetchRows($sql) as $entry) {
         $entry_mac = $entry['mac_address'];
         $entry_if  = $entry['port_id'];
-        if (!$mac_table[$entry_if][$entry_mac]) {
-            dbDelete('ipv4_mac', '`port_id` = ? AND `mac_address` = ?', array($entry_if, $entry_mac));
+        $entry_ip  = $entry['ipv4_address'];
+        if (!$mac_table[$entry_if][$entry_mac][$entry_ip]) {
+            dbDelete('ipv4_mac', '`port_id` = ? AND `mac_address` = ? AND `ipv4_address` = ? ', array($entry_if, $entry_mac, $entry_ip));
             d_echo("Removing MAC $entry_mac from interface ".$interface['ifName']);
 
             echo '-';


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

The issue before was that an entry in mac_ipv4 is only unique with port_id, mac_address and ipv4_address. Both port_id and mac_address can be in the table multiple times but Ip should only be in it once.

Before this change, arp entries that no longer exist on a device would remain in the mac_ipv4 table.