### PR TITLE
fix: New installs would have multiple entries in dbSchema table

### DIFF
--- a/includes/sql-schema/update.php
+++ b/includes/sql-schema/update.php
@@ -153,6 +153,9 @@ foreach ($filelist as $file) {
         $db_rev = $filename;
         if ($insert) {
             dbInsert(array('version' => $db_rev), 'dbSchema');
+            if ($db_rev >= 6) {
+                $insert = 0;
+            }
         } else {
             dbUpdate(array('version' => $db_rev), 'dbSchema');
         }

--- a/sql-schema/048.sql
+++ b/sql-schema/048.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `alert_schedule` DROP `device_id`;
 ALTER TABLE  `alert_schedule` CHANGE  `id`  `schedule_id` INT( 11 ) NOT NULL AUTO_INCREMENT;
 ALTER TABLE  `alert_schedule` ADD  `title` VARCHAR( 255 ) NOT NULL ,ADD  `notes` TEXT NOT NULL ;
-CREATE TABLE  `librenms`.`alert_schedule_items` (`item_id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,`schedule_id` INT NOT NULL ,`target` VARCHAR( 255 ) NOT NULL ,INDEX (  `schedule_id` )) ENGINE = INNODB;
+CREATE TABLE  `alert_schedule_items` (`item_id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,`schedule_id` INT NOT NULL ,`target` VARCHAR( 255 ) NOT NULL ,INDEX (  `schedule_id` )) ENGINE = INNODB;

--- a/sql-schema/134.sql
+++ b/sql-schema/134.sql
@@ -1,0 +1,2 @@
+DELETE FROM `dbSchema`;
+INSERT INTO `dbSchema` (`version`) VALUES ('134');


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

On new installs, entries in the DB would continuously run inserting new versions from 118 until the current. This fixes that behaviour and fixes existing installs which may be 'stuck'.