### PR TITLE
Add the ability to include an LDAP filter for users/groups in AD

### DIFF
--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -170,6 +170,19 @@ You can set two Active Directory servers by editing the `$config['auth_ad_url']`
 $config['auth_ad_url'] = "ldaps://dc1.example.com ldaps://dc2.example.com";
 ```
 
+##### Active Directory LDAP filters
+
+You can add an LDAP filter to be ANDed with the builtin user filter (`(sAMAccountName=$username)`).
+
+The defaults are:
+
+```
+$config['auth_ad_user_filter'] = "(objectclass=user)";
+$config['auth_ad_group_filter'] = "(objectclass=group)";
+```
+
+This yields `(&(objectclass=user)(sAMAccountName=$username))` for the user filter and `s/user/group/g` for the group filter.
+
 #### Radius Authentication
 
 Please note that a mysql user is created for each user the logs in successfully. User level 1 is assigned to those accounts so you will then need to assign the relevant permissions unless you set `$config['radius']['userlevel']` to be something other than 1.

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -181,7 +181,7 @@ $config['auth_ad_user_filter'] = "(objectclass=user)";
 $config['auth_ad_group_filter'] = "(objectclass=group)";
 ```
 
-This yields `(&(objectclass=user)(sAMAccountName=$username))` for the user filter and `s/user/group/g` for the group filter.
+This yields `(&(objectclass=user)(sAMAccountName=$username))` for the user filter and `(&(objectclass=group)(sAMAccountName=$group))` for the group filter.
 
 #### Radius Authentication
 

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -219,7 +219,6 @@ function get_userlist()
     $ldap_groups = get_group_list();
 
     foreach ($ldap_groups as $ldap_group) {
-        $group_cn = get_cn($ldap_group);
         $search_filter = "(memberOf=$ldap_group)";
         if ($config['auth_ad_user_filter']) {
             $search_filter = "(&{$config['auth_ad_user_filter']}$search_filter)";

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -32,7 +32,7 @@ function authenticate($username, $password)
                 $search = ldap_search(
                     $ldap_connection,
                     $config['auth_ad_base_dn'],
-                    "(samaccountname={$username})",
+                    get_auth_ad_user_filter($username),
                     array('memberOf')
                 );
                 $entries = ldap_get_entries($ldap_connection, $search);
@@ -135,7 +135,7 @@ function user_exists($username)
     $search = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         array('samaccountname')
     );
     $entries = ldap_get_entries($ldap_connection, $search);
@@ -159,7 +159,7 @@ function get_userlevel($username)
     $search = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         array('memberOf')
     );
     $entries = ldap_get_entries($ldap_connection, $search);
@@ -186,7 +186,7 @@ function get_userid($username)
     $search = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         $attributes
     );
     $entries = ldap_get_entries($ldap_connection, $search);
@@ -292,7 +292,7 @@ function get_fullname($username)
     $result = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         $attributes
     );
     $entries = ldap_get_entries($ldap_connection, $result);
@@ -341,7 +341,7 @@ function get_dn($samaccountname)
     $result = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$samaccountname})",
+        get_auth_ad_group_filter($samaccountname),
         $attributes
     );
     $entries = ldap_get_entries($ldap_connection, $result);

--- a/html/includes/authentication/ad-authorization.inc.php
+++ b/html/includes/authentication/ad-authorization.inc.php
@@ -218,33 +218,27 @@ function get_userlist()
 
     foreach ($ldap_groups as $ldap_group) {
         $group_cn = get_cn($ldap_group);
-        $search = ldap_search($ldap_connection, $config['auth_ad_base_dn'], "(cn={$group_cn})", array('member'));
-        $entries = ldap_get_entries($ldap_connection, $search);
+        $search_filter = "(memberOf=$ldap_group)";
+        if ($config['auth_ad_user_filter']) {
+            $search_filter = "(&{$config['auth_ad_user_filter']}$search_filter)";
+        }
+        $search = ldap_search($ldap_connection, $config['auth_ad_base_dn'], $search_filter, array('samaccountname','displayname','objectsid','mail'));
+        $results = ldap_get_entries($ldap_connection, $search);
 
-        foreach ($entries[0]['member'] as $member) {
-            $member_cn = get_cn($member);
-            $search = ldap_search(
-                $ldap_connection,
-                $config['auth_ad_base_dn'],
-                "(cn={$member_cn})",
-                array('sAMAccountname', 'displayName', 'objectSID', 'mail')
-            );
-            $results = ldap_get_entries($ldap_connection, $search);
-            foreach ($results as $result) {
-                if (isset($result['samaccountname'][0])) {
-                    $userid = preg_replace(
-                        '/.*-(\d+)$/',
-                        '$1',
-                        sid_from_ldap($result['objectsid'][0])
-                    );
+        foreach ($results as $result) {
+            if (isset($result['samaccountname'][0])) {
+                $userid = preg_replace(
+                    '/.*-(\d+)$/',
+                    '$1',
+                    sid_from_ldap($result['objectsid'][0])
+                );
 
-                    // don't make duplicates, user may be member of more than one group
-                    $userhash[$result['samaccountname'][0]] = array(
-                            'realname' => $result['displayName'][0],
-                            'user_id'  => $userid,
-                            'email'    => $result['mail'][0]
-                            );
-                }
+                // don't make duplicates, user may be member of more than one group
+                $userhash[$result['samaccountname'][0]] = array(
+                    'realname' => $result['displayName'][0],
+                    'user_id'  => $userid,
+                    'email'    => $result['mail'][0]
+                );
             }
         }
     }

--- a/html/includes/authentication/ad-authorization.inc.php
+++ b/html/includes/authentication/ad-authorization.inc.php
@@ -217,7 +217,6 @@ function get_userlist()
     $ldap_groups = get_group_list();
 
     foreach ($ldap_groups as $ldap_group) {
-        $group_cn = get_cn($ldap_group);
         $search_filter = "(memberOf=$ldap_group)";
         if ($config['auth_ad_user_filter']) {
             $search_filter = "(&{$config['auth_ad_user_filter']}$search_filter)";

--- a/html/includes/authentication/ad-authorization.inc.php
+++ b/html/includes/authentication/ad-authorization.inc.php
@@ -117,7 +117,7 @@ function user_exists($username)
     $search = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname=${username})",
+        get_auth_ad_user_filter($username),
         array('samaccountname')
     );
     $entries = ldap_get_entries($ldap_connection, $search);
@@ -150,7 +150,7 @@ function get_userlevel($username)
     $search = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         array('memberOf')
     );
     $entries = ldap_get_entries($ldap_connection, $search);
@@ -183,7 +183,7 @@ function get_userid($username)
     $search = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         $attributes
     );
     $entries = ldap_get_entries($ldap_connection, $search);
@@ -290,7 +290,7 @@ function get_fullname($username)
     $result = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$username})",
+        get_auth_ad_user_filter($username),
         $attributes
     );
     $entries = ldap_get_entries($ldap_connection, $result);
@@ -339,7 +339,7 @@ function get_dn($samaccountname)
     $result = ldap_search(
         $ldap_connection,
         $config['auth_ad_base_dn'],
-        "(samaccountname={$samaccountname})",
+        get_auth_ad_group_filter($samaccountname),
         $attributes
     );
     $entries = ldap_get_entries($ldap_connection, $result);

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1339,13 +1339,19 @@ function ipmiSensorName($hardwareId, $sensorIpmi, $rewriteArray)
 function get_auth_ad_user_filter($username)
 {
     global $config;
-    $user_filter = str_replace('%user%', $username, $config['auth_ad_user_filter']);
+    $user_filter = "(samaccountname=$username)";
+    if ($config['auth_ad_user_filter']) {
+        $user_filter = "(&{$config['auth_ad_user_filter']}$user_filter)";
+    }
     return $user_filter;
 }
 
 function get_auth_ad_group_filter($groupname)
 {
     global $config;
-    $group_filter = str_replace('%group%', $groupname, $config['auth_ad_group_filter']);
+    $group_filter = "(samaccountname=$groupname)";
+    if ($config['auth_ad_group_filter']) {
+        $group_filter = "(&{$config['auth_ad_group_filter']}$group_filter)";
+    }
     return $group_filter;
 }

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1338,12 +1338,14 @@ function ipmiSensorName($hardwareId, $sensorIpmi, $rewriteArray)
 
 function get_auth_ad_user_filter($username)
 {
+    global $config;
     $user_filter = str_replace('%user%', $username, $config['auth_ad_user_filter']);
     return $user_filter;
 }
 
 function get_auth_ad_group_filter($groupname)
 {
+    global $config;
     $group_filter = str_replace('%group%', $groupname, $config['auth_ad_group_filter']);
     return $group_filter;
 }

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1335,3 +1335,15 @@ function ipmiSensorName($hardwareId, $sensorIpmi, $rewriteArray)
         return $sensorIpmi;
     }
 }
+
+function get_auth_ad_user_filter($username)
+{
+    $user_filter = str_replace('%user%', $username, $config['auth_ad_user_filter']);
+    return $user_filter;
+}
+
+function get_auth_ad_group_filter($groupname)
+{
+    $group_filter = str_replace('%group%', $groupname, $config['auth_ad_group_filter']);
+    return $group_filter;
+}

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -590,6 +590,10 @@ $config['auth_ldap_emailattr']                  = 'mail';
 $config['auth_ldap_cache_ttl'] = 300;
 // How long in seconds should ldap* module cache user information in $_SESSION
 
+// Active Directory Authentication
+$config['auth_ad_user_filter'] = "(sAMAccountName=%user%)";
+$config['auth_ad_group_filter'] = "(sAMAccountName=%group%)";
+
 // Sensors
 $config['allow_entity_sensor']['amperes']     = 1;
 $config['allow_entity_sensor']['celsius']     = 1;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -591,8 +591,8 @@ $config['auth_ldap_cache_ttl'] = 300;
 // How long in seconds should ldap* module cache user information in $_SESSION
 
 // Active Directory Authentication
-$config['auth_ad_user_filter'] = "(sAMAccountName=%user%)";
-$config['auth_ad_group_filter'] = "(sAMAccountName=%group%)";
+$config['auth_ad_user_filter'] = "(objectclass=user)";
+$config['auth_ad_group_filter'] = "(objectclass=group)";
 
 // Sensors
 $config['allow_entity_sensor']['amperes']     = 1;


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Allow users to set a filter to be ANDed with existing filters for AD authentication/authorization.

I have not tested the ad-authorization, since I'm not entirely sure how it works (I wonder if the two should be merged and add a config option like `auth_ad_authorization_only` to make the subtle changes to what it does?).