### PR TITLE
fix: Change CiscoSB devices to ifEntry

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -740,6 +740,15 @@ $config['os'][$os]['over'][0]['graph'] = 'device_bits';
 $config['os'][$os]['over'][0]['text']  = 'Device Traffic';
 $config['os'][$os]['over'][1]['graph'] = 'device_processor';
 $config['os'][$os]['over'][1]['text']  = 'CPU Usage';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SF300-24';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SF300-24P';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SF300-48';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SF302-08';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SG300-10';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SG300-10SFP';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SG300-20';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SG300-28';
+$config['os'][$os]['bad_ifXEntry'][]   = 'SG300-28MP';
 
 // Huawei
 $os = 'vrp';


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

The ifXEntry change broke graphs on CiscoSB devices(unicast etc.).
Added exceptions for the devices I know of.

