### PR TITLE
Corrected the rsyslog documentation to be compatible with logrotate

### DIFF
--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -104,9 +104,8 @@ $ModLoad omprog
 
 $template librenms,"%fromhost%||%syslogfacility%||%syslogpriority%||%syslogseverity%||%syslogtag%||%$year%-%$month%-%$day% %timereported:8:25%||%msg%||%programname%\n"
 
-:inputname, isequal, "imudp" action(type="omprog"
-                                    binary="/opt/librenms/syslog.php"
-                                    template="librenms")
+*.* action(type="omprog" binary="/opt/librenms/syslog.php" template="librenms")
+
 & stop
 
 ```


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

- When using rsyslog configuration like this, the forwarder will stop every night when logrotate is running.
- Rsyslog configuration was modified to solve this issue