### PR TITLE
Corrected CentOS 7/RHEL 7 snmp.conf path

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -121,8 +121,8 @@ Once you have completed the web installer steps. Please add the following to `co
 #### Configure snmpd
 
 ```bash
-cp /opt/librenms/snmpd.conf.example /etc/snmpd/snmpd.conf
-vim /etc/snmpd/snmpd.conf
+cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
+vim /etc/snmp/snmpd.conf
 ```
 
 Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community string.

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -132,8 +132,8 @@ Once you have completed the web installer steps. Please add the following to `co
 #### Configure snmpd
 
 ```bash
-cp /opt/librenms/snmpd.conf.example /etc/snmpd/snmpd.conf
-vim /etc/snmpd/snmpd.conf
+cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
+vim /etc/snmp/snmpd.conf
 ```
 
 Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community string.


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

- Changed the path for snmpd.conf for CentOS 7 and Red Hat 7 installation