### PR TITLE
fix: Restore previous snmp debug/vdebug logic so -v can be specified by itself

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -70,26 +70,23 @@ function format_number_short($number, $sf)
 function external_exec($command)
 {
     global $debug,$vdebug;
-    if ($debug) {
-        if ($vdebug) {
-            c_echo('SNMP[%c'.$command."%n]\n");
-        } else {
-            $debug_command = preg_replace('/-c [\S]+/', '-c COMMUNITY', $command);
-            $debug_command = preg_replace('/(udp|udp6|tcp|tcp6):([^:]+):([\d]+)/', '\1:HOSTNAME:\3', $debug_command);
-            c_echo('SNMP[%c'.$debug_command."%n]\n");
-        }
+
+    if ($debug && !$vdebug) {
+        $debug_command = preg_replace('/-c [\S]+/', '-c COMMUNITY', $command);
+        $debug_command = preg_replace('/(udp|udp6|tcp|tcp6):([^:]+):([\d]+)/', '\1:HOSTNAME:\3', $debug_command);
+        c_echo('SNMP[%c' . $debug_command . "%n]\n");
+    } elseif ($vdebug) {
+        c_echo('SNMP[%c'.$command."%n]\n");
     }
 
     $output = shell_exec($command);
 
-    if ($debug) {
-        if ($vdebug) {
-            d_echo($output.PHP_EOL);
-        } else {
-            $ip_regex = '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/';
-            $debug_output = preg_replace($ip_regex, '*', $output);
-            d_echo($debug_output.PHP_EOL);
-        }
+    if ($debug && !$vdebug) {
+        $ip_regex = '/(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/';
+        $debug_output = preg_replace($ip_regex, '*', $output);
+        d_echo($debug_output . PHP_EOL);
+    } elseif ($vdebug) {
+        d_echo($output . PHP_EOL);
     }
 
     return $output;


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

