### PR TITLE
Rework edituser page to allow user selection of a default dashboard

### DIFF
--- a/html/pages/edituser.inc.php
+++ b/html/pages/edituser.inc.php
@@ -262,9 +262,18 @@ if ($_SESSION['userlevel'] != '10') {
                 }
             }
 
-            if (can_update_users() == '1') {
-                $users_details = get_user($vars['user_id']);
-                if (!empty($users_details)) {
+            $users_details = get_user($vars['user_id']);
+            if (!empty($users_details)) {
+                    if (!empty($vars['dashboard']) && $vars['dashboard'] != $users_details['dashboard']) {
+                        dbUpdate(array('dashboard'=>$vars['dashboard']), 'users', 'user_id = ?', array($vars['user_id']));
+                        print_message("User default dashboard updated");
+                    }
+                    echo "<form class='form-horizontal' role='form' method='post' action=''>
+  <input type='hidden' name='user_id' value='".$vars['user_id']."'>
+  <input type='hidden' name='cur_username' value='" . $users_details['username'] . "'>
+  <input type='hidden' name='edit' value='yes'>
+";
+                if (can_update_users() == '1') {
                     if (empty($vars['new_realname'])) {
                         $vars['new_realname'] = $users_details['realname'];
                     }
@@ -283,35 +292,7 @@ if ($_SESSION['userlevel'] != '10') {
                         $vars['new_email'] = $users_details['email'];
                     }
 
-                    if ($config['twofactor']) {
-                        if ($vars['twofactorremove']) {
-                            if (dbUpdate(array('twofactor' => ''), users, 'user_id = ?', array($vars['user_id']))) {
-                                echo "<div class='alert alert-success'>TwoFactor credentials removed.</div>";
-                            } else {
-                                echo "<div class='alert alert-danger'>Couldnt remove user's TwoFactor credentials.</div>";
-                            }
-                        }
-
-                        if ($vars['twofactorunlock']) {
-                            $twofactor          = dbFetchRow('SELECT twofactor FROM users WHERE user_id = ?', array($vars['user_id']));
-                            $twofactor          = json_decode($twofactor['twofactor'], true);
-                            $twofactor['fails'] = 0;
-                            if (dbUpdate(array('twofactor' => json_encode($twofactor)), users, 'user_id = ?', array($vars['user_id']))) {
-                                echo "<div class='alert alert-success'>User unlocked.</div>";
-                            } else {
-                                echo "<div class='alert alert-danger'>Couldnt reset user's TwoFactor failures.</div>";
-                            }
-                        }
-                    }
-
-                    if (!empty($vars['dashboard'])) {
-                        dbUpdate(array('dashboard'=>$vars['dashboard']), 'users', 'user_id = ?', array($vars['user_id']));
-                    }
-
-                    echo "<form class='form-horizontal' role='form' method='post' action=''>
-  <input type='hidden' name='user_id' value='".$vars['user_id']."'>
-  <input type='hidden' name='cur_username' value='" . $users_details['username'] . "'>
-  <input type='hidden' name='edit' value='yes'>
+                    echo "
   <div class='form-group'>
     <label for='new_realname' class='col-sm-2 control-label'>Realname</label>
     <div class='col-sm-4'>
@@ -370,18 +351,6 @@ if ($_SESSION['userlevel'] != '10') {
         </div>
         ";
                     }
-                    echo "
-       <div class='form-group'>
-           <label for='dashboard' class='col-sm-2 control-label'>Dashboard</label>
-           <div class='col-sm-4'><select class='form-control' name='dashboard'>";
-                    $defdash = dbFetchCell("SELECT dashboard FROM users WHERE user_id = ?", array($vars['user_id']));
-                    foreach (dbFetchRows("SELECT dashboards.*,users.username FROM `dashboards` INNER JOIN `users` ON users.user_id = dashboards.user_id WHERE (dashboards.access > 0 && dashboards.user_id != ?) || dashboards.user_id = ?", array($vars['user_id'],$vars['user_id'])) as $dash) {
-                        echo "<option value='".$dash['dashboard_id']."'".($defdash == $dash['dashboard_id'] ? ' selected' : '').">".$dash['username'].':'.$dash['dashboard_name']."</option>";
-                    }
-                    echo "</select>
-           </div>
-       </div>
-       ";
 
                     echo "<div class='form-group'>
     <div class='col-sm-6'>
@@ -397,14 +366,46 @@ if ($_SESSION['userlevel'] != '10') {
     <div class='col-sm-6'>
     </div>
   </div>
+";
+                }
+                echo "
+       <div class='form-group'>
+           <label for='dashboard' class='col-sm-2 control-label'>Dashboard</label>
+           <div class='col-sm-4'><select class='form-control' name='dashboard'>";
+                $defdash = dbFetchCell("SELECT dashboard FROM users WHERE user_id = ?", array($vars['user_id']));
+                foreach (dbFetchRows("SELECT dashboards.*,users.username FROM `dashboards` INNER JOIN `users` ON users.user_id = dashboards.user_id WHERE (dashboards.access > 0 && dashboards.user_id != ?) || dashboards.user_id = ?", array($vars['user_id'],$vars['user_id'])) as $dash) {
+                    echo "<option value='".$dash['dashboard_id']."'".($defdash == $dash['dashboard_id'] ? ' selected' : '').">".$dash['username'].':'.$dash['dashboard_name']."</option>";
+                }
+                echo "</select>
+           </div>
+       </div>
   <button type='submit' class='btn btn-default'>Update User</button>
   </form>";
-                    if ($config['twofactor']) {
-                        echo "<br/><div class='well'><h3>Two-Factor Authentication</h3>";
-                        $twofactor = dbFetchRow('SELECT twofactor FROM users WHERE user_id = ?', array($vars['user_id']));
-                        $twofactor = json_decode($twofactor['twofactor'], true);
-                        if ($twofactor['fails'] >= 3 && (!$config['twofactor_lock'] || (time() - $twofactor['last']) < $config['twofactor_lock'])) {
-                            echo "<form class='form-horizontal' role='form' method='post' action=''>
+
+                if ($config['twofactor']) {
+                    if ($vars['twofactorremove']) {
+                        if (dbUpdate(array('twofactor' => ''), users, 'user_id = ?', array($vars['user_id']))) {
+                            echo "<div class='alert alert-success'>TwoFactor credentials removed.</div>";
+                        } else {
+                            echo "<div class='alert alert-danger'>Couldnt remove user's TwoFactor credentials.</div>";
+                        }
+                    }
+
+                    if ($vars['twofactorunlock']) {
+                        $twofactor          = dbFetchRow('SELECT twofactor FROM users WHERE user_id = ?', array($vars['user_id']));
+                        $twofactor          = json_decode($twofactor['twofactor'], true);
+                        $twofactor['fails'] = 0;
+                        if (dbUpdate(array('twofactor' => json_encode($twofactor)), users, 'user_id = ?', array($vars['user_id']))) {
+                            echo "<div class='alert alert-success'>User unlocked.</div>";
+                        } else {
+                            echo "<div class='alert alert-danger'>Couldnt reset user's TwoFactor failures.</div>";
+                        }
+                    }
+                    echo "<br/><div class='well'><h3>Two-Factor Authentication</h3>";
+                    $twofactor = dbFetchRow('SELECT twofactor FROM users WHERE user_id = ?', array($vars['user_id']));
+                    $twofactor = json_decode($twofactor['twofactor'], true);
+                    if ($twofactor['fails'] >= 3 && (!$config['twofactor_lock'] || (time() - $twofactor['last']) < $config['twofactor_lock'])) {
+                        echo "<form class='form-horizontal' role='form' method='post' action=''>
   <input type='hidden' name='user_id' value='".$vars['user_id']."'>
   <input type='hidden' name='edit' value='yes'>
   <div class='form-group'>
@@ -413,26 +414,23 @@ if ($_SESSION['userlevel'] != '10') {
     <button type='submit' class='btn btn-default'>Unlock</button>
   </div>
 </form>";
-                        }
+                    }
 
-                        if ($twofactor['key']) {
-                            echo "<form class='form-horizontal' role='form' method='post' action=''>
+                    if ($twofactor['key']) {
+                        echo "<form class='form-horizontal' role='form' method='post' action=''>
   <input type='hidden' name='user_id' value='".$vars['user_id']."'>
   <input type='hidden' name='edit' value='yes'>
   <input type='hidden' name='twofactorremove' value='1'>
   <button type='submit' class='btn btn-danger'>Disable TwoFactor</button>
 </form>
 </div>";
-                        } else {
-                            echo '<p>No TwoFactor key generated for this user, Nothing to do.</p>';
-                        }
-                    }//end if
-                } else {
-                    print_error('Error getting user details');
+                    } else {
+                        echo '<p>No TwoFactor key generated for this user, Nothing to do.</p>';
+                    }
                 }//end if
             } else {
-                print_error("Authentication method doesn't support updating users");
-            }//end if
+                print_error('Error getting user details');
+            }//end if !empty($users_details)
         }//end if
     } else {
         $user_list = get_userlist();

--- a/html/pages/edituser.inc.php
+++ b/html/pages/edituser.inc.php
@@ -264,11 +264,11 @@ if ($_SESSION['userlevel'] != '10') {
 
             $users_details = get_user($vars['user_id']);
             if (!empty($users_details)) {
-                    if (!empty($vars['dashboard']) && $vars['dashboard'] != $users_details['dashboard']) {
-                        dbUpdate(array('dashboard'=>$vars['dashboard']), 'users', 'user_id = ?', array($vars['user_id']));
-                        print_message("User default dashboard updated");
-                    }
-                    echo "<form class='form-horizontal' role='form' method='post' action=''>
+                if (!empty($vars['dashboard']) && $vars['dashboard'] != $users_details['dashboard']) {
+                    dbUpdate(array('dashboard'=>$vars['dashboard']), 'users', 'user_id = ?', array($vars['user_id']));
+                    print_message("User default dashboard updated");
+                }
+                echo "<form class='form-horizontal' role='form' method='post' action=''>
   <input type='hidden' name='user_id' value='".$vars['user_id']."'>
   <input type='hidden' name='cur_username' value='" . $users_details['username'] . "'>
   <input type='hidden' name='edit' value='yes'>


### PR DESCRIPTION
Pulls most edit user fields into functions to allow selective construction of the edituser page.
If can_update_users() returns 1 all applicable fields are displayed otherwise only the default dashboard select and twofactor auth sections display.