### PR TITLE
fix: missing leading . on riverbed os test

### DIFF
--- a/tests/OSDiscoveryTest.php
+++ b/tests/OSDiscoveryTest.php
@@ -1135,7 +1135,7 @@ class DiscoveryTest extends \PHPUnit_Framework_TestCase
 
     public function testRiverbed()
     {
-        $this->checkOS('riverbed', 'Something that we do not have', '1.3.6.1.4.1.17163.1.1');
+        $this->checkOS('riverbed', 'Something that we do not have', '.1.3.6.1.4.1.17163.1.1');
     }
 
     public function testRouteros()


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

