### PR TITLE
Fix for sql-schema/137 line for name mistype

### DIFF
--- a/sql-schema/138.sql
+++ b/sql-schema/138.sql
@@ -1,0 +1,1 @@
+UPDATE `config` SET `config_name` = 'webui.availability_map_compact', `config_hidden` = '0' WHERE `config_name` = 'webui.availability_map_old';

--- a/sql-schema/138.sql
+++ b/sql-schema/138.sql
@@ -1,1 +1,2 @@
 UPDATE `config` SET `config_name` = 'webui.availability_map_compact', `config_hidden` = '0' WHERE `config_name` = 'webui.availability_map_old';
+UPDATE `widgets` SET `base_dimensions` = '6,3';


### PR DESCRIPTION
SQL Schema 137 queries for  a config_name =webui.old_availability_map but the actual config name was webui.availability_map_old