### PR TITLE
fix: possible additional fix for non-terminating rrdtool processes.

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -81,10 +81,10 @@ function rrdtool_close()
     /** @var Proc $rrd_async_process */
 
     if (rrdtool_running($rrd_sync_process)) {
-        $rrd_sync_process->close('quit');
+        $rrd_sync_process->sendCommand('quit');
     }
     if (rrdtool_running($rrd_async_process)) {
-        $rrd_async_process->close('quit');
+        $rrd_async_process->sendCommand('quit');
     }
 }
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Sends the quit command to the process, but doesn't call close as that can block the php process.
When the process exits all objects are destroyed and Proc::terminate() is called, this will terminate 15 then kill 9.