### PR TITLE
Revert "fix: possible additional fix for non-terminating rrdtool processes."

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -81,10 +81,10 @@ function rrdtool_close()
     /** @var Proc $rrd_async_process */
 
     if (rrdtool_running($rrd_sync_process)) {
-        $rrd_sync_process->sendCommand('quit');
+        $rrd_sync_process->close('quit');
     }
     if (rrdtool_running($rrd_async_process)) {
-        $rrd_async_process->sendCommand('quit');
+        $rrd_async_process->close('quit');
     }
 }
 


### PR DESCRIPTION
Reverts librenms/librenms#4565

Causes:

```bash
Fatal error: Uncaught Exception: Terminate failed! in /opt/librenms/LibreNMS/Proc.php:206
Stack trace:
#0 /opt/librenms/LibreNMS/Proc.php(85): LibreNMS\Proc->terminate()
#1 [internal function]: LibreNMS\Proc->__destruct()
#2 {main}
  thrown in /opt/librenms/LibreNMS/Proc.php on line 206
```