### PR TITLE
fix: poweralert divisor voltages

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -882,10 +882,14 @@ function avtech_add_sensor($device, $sensor)
  */
 function get_device_divisor($device, $serial, $sensor)
 {
-    if (($device['os'] == 'poweralert') && ($sensor == 'current' || $sensor == 'frequencies' || $sensor == 'voltages')) {
-        if (version_compare($serial, '12.06.0068', '>=')) {
-            $divisor = 10;
-        } elseif (version_compare($serial, '12.04.0055', '>=')) {
+    if ($device['os'] == 'poweralert') {
+        if ($sensor == 'current' || $sensor == 'frequencies') {
+            if (version_compare($serial, '12.06.0068', '>=')) {
+                $divisor = 10;
+            } elseif (version_compare($serial, '12.04.0055', '>=')) {
+                $divisor = 1;
+            }
+        } elseif ($sensor == 'voltages') {
             $divisor = 1;
         }
     } elseif (($device['os'] == 'huaweiups') && ($sensor == 'frequencies')) {


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

as per user feedback seems that voltages divisor value didn't change in newer versions

