### PR TITLE
Make libvirt-vminfo play nice with oVirt

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -140,6 +140,7 @@ LibreNMS contributors:
 - Layne Breitkreutz <github@thelenon.com> (Gorian)
 - Karl Shea <karl@karlshea.com> (karlshea)
 - Justin Settle <jus10@partlycloudy.org> (jquagga)
+- Alexander Kratzsch <klump@devrandom.se> (klump)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/includes/discovery/libvirt-vminfo.inc.php
+++ b/includes/discovery/libvirt-vminfo.inc.php
@@ -31,7 +31,7 @@ if ($config['enable_libvirt'] == '1' && $device['os'] == 'linux') {
         if ($ssh_ok || !strstr($method, 'ssh')) {
             // Fetch virtual machine list
             unset($domlist);
-            exec($config['virsh'].' -c '.$uri.' list', $domlist);
+            exec($config['virsh'].' -rc '.$uri.' list', $domlist);
 
             foreach ($domlist as $dom) {
                 list($dom_id,) = explode(' ', trim($dom), 2);
@@ -39,7 +39,7 @@ if ($config['enable_libvirt'] == '1' && $device['os'] == 'linux') {
                 if (is_numeric($dom_id)) {
                     // Fetch the Virtual Machine information.
                     unset($vm_info_array);
-                    exec($config['virsh'].' -c '.$uri.' dumpxml '.$dom_id, $vm_info_array);
+                    exec($config['virsh'].' -rc '.$uri.' dumpxml '.$dom_id, $vm_info_array);
 
                     // <domain type='kvm' id='3'>
                     // <name>moo.example.com</name>
@@ -67,7 +67,7 @@ if ($config['enable_libvirt'] == '1' && $device['os'] == 'linux') {
                     $vmwVmGuestOS     = '';
                     // libvirt does not supply this
                     $vmwVmMemSize = ($xml->currentMemory / 1024);
-                    exec($config['virsh'].' -c '.$uri.' domstate '.$dom_id, $vm_state);
+                    exec($config['virsh'].' -rc '.$uri.' domstate '.$dom_id, $vm_state);
                     $vmwVmState = ucfirst($vm_state[0]);
                     $vmwVmCpus  = $xml->vcpu;
 


### PR DESCRIPTION
I have noticed that the stats for the virtual machines discovered with _libvirt-vminfo_ were quite off for the machines in my oVirt cluster (it reported Terabytes of RAM and way to many CPUs). I have fixed this detecting if the virtual machine is hosted in an oVirt cluster or not. If this is the case, we some use different values from XML file.
Also, `virsh` will now connect in read-only mode (`-r`) as it does not need to change any values.

- [ ] Tested on VMs in a non-oVirt environment
- [x] Ran `./scripts/pre-commit.php` successfully
- [x] Signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Followed the [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
