### PR TITLE
fix: Use snmpv3 username even when NoAuthNoPriv is selected

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -135,6 +135,7 @@ LibreNMS contributors:
 - Florent Bruchez <ftbz@me.com> (ftbz)
 - Bartosz Radwan <b.radwan@citypartner.pl> (bartoszradwan)
 - Kate Gerry <kate@fansubber.com> (kate66)
+- Johan Zaxmy <johan@zaxmy.com> (Zaxmy)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -560,7 +560,7 @@ function snmp_gen_auth(&$device)
         
         if ($device['authlevel'] === 'noAuthNoPriv') {
             // We have to provide a username anyway (see Net-SNMP doc)
-            $username = isset($device['authname']) ? $device['authname'] : 'root';
+            $username = !empty($device['authname']) ? $device['authname'] : 'root';
             $cmd .= " -u '".$username."'";
         } elseif ($device['authlevel'] === 'authNoPriv') {
             $cmd .= " -a '".$device['authalgo']."'";

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -560,8 +560,8 @@ function snmp_gen_auth(&$device)
         
         if ($device['authlevel'] === 'noAuthNoPriv') {
             // We have to provide a username anyway (see Net-SNMP doc)
-            // FIXME: There are two other places this is set - why are they ignored here?
-            $cmd .= ' -u root';
+            $username = isset($device['authname']) ? $device['authname'] : 'root';
+            $cmd .= " -u '".$username."'";
         } elseif ($device['authlevel'] === 'authNoPriv') {
             $cmd .= " -a '".$device['authalgo']."'";
             $cmd .= " -A '".$device['authpass']."'";


### PR DESCRIPTION
Uses included authname or fall backs to root if non is supplied.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #4677 