### PR TITLE
Include PHP Install instructions for MySQL app

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -135,6 +135,7 @@ LibreNMS contributors:
 - Florent Bruchez <ftbz@me.com> (ftbz)
 - Bartosz Radwan <b.radwan@citypartner.pl> (bartoszradwan)
 - Kate Gerry <kate@fansubber.com> (kate66)
+- Ryan Gibbons <rtgibbons23@gmail.com> (rtgibbons)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -130,6 +130,16 @@ extend memcached /etc/snmp/memcached
 
 The MySQL script requires PHP-CLI and the PHP MySQL extension, so please verify those are installed.
 
+CentOS
+```
+yum install php-cli php-mysql
+```
+
+Debian
+```
+apt-get install php5-cli php5-mysql
+```
+
 Unlike most other scripts, the MySQL script requires a configuration file `/usr/lib/check_mk_agent/local/mysql.cnf` with following content:
 
 ```php


### PR DESCRIPTION
This step is skimmed over frequently, by including the code blocks I'm
hoping to make this step more noticeable.