### PR TITLE
refactor: snmp cleanup

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1461,6 +1461,30 @@ function starts_with($haystack, $needles, $case_insensitive = false)
     return false;
 }
 
+/**
+ * Search backwards for the $needle, returning $count found occurrence
+ *
+ * @param string $haystack
+ * @param string $needle
+ * @param int $count
+ * @return bool|int
+ */
+function strrpos_count($haystack, $needle, $count = 1)
+{
+    if ($count <= 0) {
+        return false;
+    }
+
+    $len = strlen($haystack);
+    $pos = $len;
+
+    for ($i = 0; $i < $count && $pos; $i++) {
+        $pos = strrpos($haystack, $needle, $pos - $len - 1);
+    }
+
+    return $pos;
+}
+
 function get_auth_ad_user_filter($username)
 {
     global $config;

--- a/includes/discovery/sensors/states/ibm-amm.inc.php
+++ b/includes/discovery/sensors/states/ibm-amm.inc.php
@@ -126,8 +126,7 @@ if ($device['os'] == 'ibm-amm') {
      *   notAvailable(3),
      *   critical(4)
      */
-    foreach ($data as $oid => $array) {
-        $state = current($array);  // get the first (and only) item from the array
+    foreach ($data as $oid => $state) {
         $descr = $state_descr . $index;
 
         if (is_numeric($state) && $state != 3) {

--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -81,16 +81,16 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
 
     foreach ($aruba_apnames as $key => $value) {
         $radioid       = str_replace('1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.16.', '', $key);
-        $name          = $value[''];
-        $type          = $aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.2.$radioid"][''];
-        $channel       = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.3.$radioid"][''] + 0);
-        $txpow         = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.4.$radioid"][''] + 0);
-        $radioutil     = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.6.$radioid"][''] + 0);
-        $numasoclients = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.7.$radioid"][''] + 0);
-        $nummonclients = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.8.$radioid"][''] + 0);
-        $numactbssid   = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.9.$radioid"][''] + 0);
-        $nummonbssid   = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.10.$radioid"][''] + 0);
-        $interference  = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.3.1.6.1.11.$radioid"][''] + 0);
+        $name          = $value;
+        $type          = $aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.2.$radioid"];
+        $channel       = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.3.$radioid"] + 0);
+        $txpow         = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.4.$radioid"] + 0);
+        $radioutil     = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.6.$radioid"] + 0);
+        $numasoclients = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.7.$radioid"] + 0);
+        $nummonclients = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.8.$radioid"] + 0);
+        $numactbssid   = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.9.$radioid"] + 0);
+        $nummonbssid   = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.10.$radioid"] + 0);
+        $interference  = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.3.1.6.1.11.$radioid"] + 0);
 
         $radionum = substr($radioid, (strlen($radioid) - 1), 1);
 

--- a/includes/polling/cisco-voice/cisco-iosdsp.inc.php
+++ b/includes/polling/cisco-voice/cisco-iosdsp.inc.php
@@ -15,14 +15,14 @@ if ($device['os_group'] == "cisco") {
     // Total
     $total = 0;
     foreach (snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.9.86.1.2.1.1.6", null) as $key => $value) {
-        $total += $value[''];
+        $total += $value;
     }
 
     if (isset($total) && ($total != "") && ($total != 0)) {
         // Active
         $active = 0;
         foreach (snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.9.86.1.2.1.1.7", null) as $key => $value) {
-            $active += $value[''];
+            $active += $value;
         }
 
         $rrd_def = array(

--- a/includes/polling/cisco-voice/cisco-iosmtp.inc.php
+++ b/includes/polling/cisco-voice/cisco-iosmtp.inc.php
@@ -14,12 +14,13 @@
 if ($device['os_group'] == "cisco") {
     // Total
     $total = snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.9.86.1.6.4.1.3", null);
-    $total = $total['1.3.6.1.4.1.9.9.86.1.6.4.1.3'][''];
+    $total = $total['1.3.6.1.4.1.9.9.86.1.6.4.1.3'];
+    // FIXME why isn't this using an snmpget?
 
     if (isset($total) && ($total != "") && ($total != 0)) {
         // Available
         $available = snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.9.86.1.6.4.1.4", null);
-        $available = $available['1.3.6.1.4.1.9.9.86.1.6.4.1.4'][''];
+        $available = $available['1.3.6.1.4.1.9.9.86.1.6.4.1.4'];
 
         // Active
         $active = $total - $available;

--- a/includes/polling/cisco-voice/cisco-iospri.inc.php
+++ b/includes/polling/cisco-voice/cisco-iospri.inc.php
@@ -18,14 +18,15 @@ if ($device['os_group'] == "cisco") {
     $total = 0;
     foreach (snmpwalk_cache_oid_num($device, "1.3.6.1.2.1.2.2.1.3", null) as $key => $value) {
         // 81 is the ifType for DS0's
-        if ($value[''] == "81") {
+        if ($value == "81") {
             $total++;
         }
     }
 
     // Active
     $active = snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.10.19.1.1.4.0", null);
-    $active = $active['1.3.6.1.4.1.9.10.19.1.1.4.0'][''];
+    $active = $active['1.3.6.1.4.1.9.10.19.1.1.4.0'];
+    // FIXME why isn't this using snmpget?
 
     if (isset($active) && ($active != "") && ($total != 0)) {
         $rrd_def = array(

--- a/includes/polling/cisco-voice/cisco-iosxcode.inc.php
+++ b/includes/polling/cisco-voice/cisco-iosxcode.inc.php
@@ -14,12 +14,13 @@
 if ($device['os_group'] == "cisco") {
     // Total
     $total = snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.9.86.1.7.1.0", null);
-    $total = $total['1.3.6.1.4.1.9.9.86.1.7.1.0'][''];
+    $total = $total['1.3.6.1.4.1.9.9.86.1.7.1.0'];
+    // FIXME why isn't this using snmpget?
 
     if (isset($total) && ($total != "") && ($total != 0)) {
         // Available
         $available = snmpwalk_cache_oid_num($device, "1.3.6.1.4.1.9.9.86.1.7.2.0", null);
-        $available = $available['1.3.6.1.4.1.9.9.86.1.7.2.0'][''];
+        $available = $available['1.3.6.1.4.1.9.9.86.1.7.2.0'];
 
         // Active
         $active = $total - $available;

--- a/includes/polling/test.inc.php
+++ b/includes/polling/test.inc.php
@@ -1,5 +1,0 @@
-<?php
-
-print_r(snmpwalk_cache_oid($device, 'system', array()));
-
-print_r(snmp_cache_oid('system', $device, array()));

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -39,6 +39,20 @@ function prep_snmp_setting($device, $setting)
 
 
 /**
+ * Checks for bad options and throws an exception if one is found
+ *
+ * @param string $options The options to check
+ * @param string|array $bad_opts option or array of bad options to check for
+ * @throws Exception SNMP options not allowed
+ */
+function snmp_check_options($options, $bad_opts = 'v')
+{
+    if (str_contains($options, $bad_opts)) {
+        throw new Exception('SNMP options not allowed: '.implode(',', (array)$bad_opts));
+    }
+}
+
+/**
  * Generate the mib search directory argument for snmpcmd
  * If null return the default mib dir
  * If $mibdir is empty '', return an empty string
@@ -161,6 +175,7 @@ function snmp_get_multi($device, $oids, $options = '-OQUs', $mib = null, $mibdir
     $data = trim(external_exec($cmd));
 
     $runtime_stats['snmpget']++;
+    // TODO switch to snmp_output_to_array() will result in cleaner output, but a change in behaviour
     $array = array();
     foreach (explode("\n", $data) as $entry) {
         list($oid,$value)  = explode('=', $entry, 2);
@@ -189,7 +204,7 @@ function snmp_get($device, $oid, $options = null, $mib = null, $mibdir = null)
 
     $runtime_stats['snmpget']++;
 
-    if (is_string($data) && (preg_match('/(No Such Instance|No Such Object|No more variables left|Authentication failure)/i', $data))) {
+    if (preg_match('/(No Such Instance|No Such Object|No more variables left|Authentication failure)/i', $data)) {
         return false;
     } elseif ($data || $data === '0') {
         return $data;
@@ -206,18 +221,12 @@ function snmp_walk($device, $oid, $options = null, $mib = null, $mibdir = null)
     $cmd = gen_snmpwalk_cmd($device, $oid, $options, $mib, $mibdir);
     $data = trim(external_exec($cmd));
 
-    $data = str_replace('"', '', $data);
-    $data = str_replace('End of MIB', '', $data);
+    $data = str_replace(array('"', 'End of MIB'), '', $data);
 
-    if (is_string($data) && (preg_match('/No Such (Object|Instance)/i', $data))) {
+    if (preg_match('/No Such (Object|Instance)/i', $data)) {
         $data = false;
     } else {
-        if (preg_match('/No more variables left in this MIB View \(It is past the end of the MIB tree\)$/', $data)) {
-            // Bit ugly :-(
-            $d_ex = explode("\n", $data);
-            unset($d_ex[(count($d_ex) - 1)]);
-            $data = implode("\n", $d_ex);
-        }
+        preg_replace('/No more variables left in this MIB View \(It is past the end of the MIB tree\)$/', '', $data);
     }
 
     $runtime_stats['snmpwalk']++;
@@ -261,42 +270,11 @@ function snmpwalk_cache_cip($device, $oid, $array = array(), $mib = 0)
 }//end snmpwalk_cache_cip()
 
 
-function snmp_cache_ifIndex($device)
+function snmpwalk_cache_oid($device, $oid, $array = array(), $mib = null, $mibdir = null, $snmpflags = '-OQUs')
 {
-    // FIXME: this is not yet using our own snmp_*
-    $cmd = gen_snmpwalk_cmd($device, 'ifIndex', ' -OQs', 'IF-MIB');
-    $data      = trim(external_exec($cmd));
-
-    $array = array();
-    foreach (explode("\n", $data) as $entry) {
-        list ($this_oid, $this_value) = preg_split('/=/', $entry);
-        list ($this_oid, $this_index) = explode('.', $this_oid, 2);
-        $this_index                   = trim($this_index);
-        $this_oid   = trim($this_oid);
-        $this_value = trim($this_value);
-        if (!strstr($this_value, 'at this OID') && $this_index) {
-            $array[] = $this_value;
-        }
-    }
-
-    return $array;
-}//end snmp_cache_ifIndex()
-
-
-function snmpwalk_cache_oid($device, $oid, $array, $mib = null, $mibdir = null, $snmpflags = '-OQUs')
-{
+    snmp_check_options($snmpflags);
     $data = snmp_walk($device, $oid, $snmpflags, $mib, $mibdir);
-    foreach (explode("\n", $data) as $entry) {
-        list($oid,$value)  = explode('=', $entry, 2);
-        $oid               = trim($oid);
-        $value             = trim($value);
-        list($oid, $index) = explode('.', $oid, 2);
-        if (!strstr($value, 'at this OID') && isset($oid) && isset($index)) {
-            $array[$index][$oid] = $value;
-        }
-    }
-
-    return $array;
+    return snmp_output_to_array($data, $array);
 }//end snmpwalk_cache_oid()
 
 function snmpwalk_cache_long_oid($device, $oid, $noid, $array, $mib = null, $mibdir = null, $snmpflags = '-OQnU')
@@ -307,7 +285,7 @@ function snmpwalk_cache_long_oid($device, $oid, $noid, $array, $mib = null, $mib
         $tmp_oid               = trim($tmp_oid);
         $value                 = trim($value);
         $tmp_index                 = str_replace($noid, '', $tmp_oid);
-        $index                 = md5($tmp_index);
+        $index                 = md5($tmp_index); // FIXME why?
         if (!empty($index) && !empty($oid)) {
             $array[$index][$oid] = $value;
             if (empty($array[$index]['orig'])) {
@@ -320,10 +298,7 @@ function snmpwalk_cache_long_oid($device, $oid, $noid, $array, $mib = null, $mib
 }//end snmpwalk_cache_oid()
 
 /**
- * Just like snmpwalk_cache_oid except that it returns the numerical oid as the index
- * this is useful when the oid is indexed by the mac address and snmpwalk would
- * return periods (.) for non-printable numbers, thus making many different indexes appear
- * to be the same.
+ * Just like snmpwalk_cache_oid except that it returns the full numerical oid as the index
  *
  * @param array $device
  * @param string $oid
@@ -332,9 +307,10 @@ function snmpwalk_cache_long_oid($device, $oid, $noid, $array, $mib = null, $mib
  * @param string $mibdir
  * @return boolean|array
  */
-function snmpwalk_cache_oid_num($device, $oid, $array, $mib = null, $mibdir = null)
+function snmpwalk_cache_oid_num($device, $oid, $array = array(), $mib = null, $mibdir = null)
 {
-    return snmpwalk_cache_oid($device, $oid, $array, $mib, $mibdir, $snmpflags = '-OQUn');
+    $data = snmp_walk($device, $oid, '-OQUn', $mib, $mibdir);
+    return snmp_output_to_array($data, $array, 0); // 0 = do not split the oid
 }//end snmpwalk_cache_oid_num()
 
 
@@ -370,138 +346,27 @@ function snmpwalk_cache_multi_oid($device, $oid, $array, $mib = null, $mibdir = 
 function snmpwalk_cache_double_oid($device, $oid, $array, $mib = null, $mibdir = null)
 {
     $data = snmp_walk($device, $oid, '-OQUs', $mib, $mibdir);
-
-    foreach (explode("\n", $data) as $entry) {
-        list($oid,$value) = explode('=', $entry, 2);
-        $oid              = trim($oid);
-        $value            = trim($value);
-        list($oid, $first, $second) = explode('.', $oid);
-        if (!strstr($value, 'at this OID') && isset($oid) && isset($first) && isset($second)) {
-            $double               = $first.'.'.$second;
-            $array[$double][$oid] = $value;
-        }
-    }
-
-    return $array;
+    return snmp_output_to_array($data, $array, 2);
 }//end snmpwalk_cache_double_oid()
 
 
 function snmpwalk_cache_triple_oid($device, $oid, $array, $mib = null, $mibdir = null)
 {
     $data = snmp_walk($device, $oid, '-OQUs', $mib, $mibdir);
-
-    foreach (explode("\n", $data) as $entry) {
-        list($oid,$value) = explode('=', $entry, 2);
-        $oid              = trim($oid);
-        $value            = trim($value);
-        list($oid, $first, $second, $third) = explode('.', $oid);
-        if (!strstr($value, 'at this OID') && isset($oid) && isset($first) && isset($second)) {
-            $index               = $first.'.'.$second.'.'.$third;
-            $array[$index][$oid] = $value;
-        }
-    }
-
-    return $array;
+    return snmp_output_to_array($data, $array, 3);
 }//end snmpwalk_cache_triple_oid()
 
-
-function snmpwalk_cache_twopart_oid($device, $oid, $array, $mib = 0)
+// TODO kill
+function snmpwalk_cache_twopart_oid($device, $oid, $array, $mib = null)
 {
-    $cmd = gen_snmpwalk_cmd($device, $oid, ' -OQUs', $mib);
-    $data = trim(external_exec($cmd));
-
-    foreach (explode("\n", $data) as $entry) {
-        list($oid,$value) = explode('=', $entry, 2);
-        $oid              = trim($oid);
-        $value            = trim($value);
-        $value            = str_replace('"', '', $value);
-        list($oid, $first, $second) = explode('.', $oid);
-        if (!strstr($value, 'at this OID') && isset($oid) && isset($first) && isset($second)) {
-            $array[$first][$second][$oid] = $value;
-        }
-    }
-
-    return $array;
+    return snmpwalk_cache_oid($device, $oid, $array, $mib);
 }//end snmpwalk_cache_twopart_oid()
 
-
-function snmpwalk_cache_threepart_oid($device, $oid, $array, $mib = 0)
+// TODO kill
+function snmpwalk_cache_threepart_oid($device, $oid, $array, $mib = null)
 {
-    global $debug;
-
-    $cmd = gen_snmpwalk_cmd($device, $oid, ' -OQUs', $mib);
-    $data = trim(external_exec($cmd));
-
-    foreach (explode("\n", $data) as $entry) {
-        list($oid,$value) = explode('=', $entry, 2);
-        $oid              = trim($oid);
-        $value            = trim($value);
-        $value            = str_replace('"', '', $value);
-        list($oid, $first, $second, $third) = explode('.', $oid);
-
-        if ($debug) {
-            echo "$entry || $oid || $first || $second || $third\n";
-        }
-
-        if (!strstr($value, 'at this OID') && isset($oid) && isset($first) && isset($second) && isset($third)) {
-            $array[$first][$second][$third][$oid] = $value;
-        }
-    }
-
-    return $array;
+    return snmpwalk_cache_oid($device, $oid, $array, $mib);
 }//end snmpwalk_cache_threepart_oid()
-
-
-function snmp_cache_slotport_oid($oid, $device, $array, $mib = 0)
-{
-    $cmd = gen_snmpwalk_cmd($device, $oid, ' -OQUs', $mib);
-    $data      = trim(external_exec($cmd));
-
-    foreach (explode("\n", $data) as $entry) {
-        $entry                  = str_replace($oid.'.', '', $entry);
-        list($slotport, $value) = explode('=', $entry, 2);
-        $slotport               = trim($slotport);
-        $value                  = trim($value);
-        if ($array[$slotport]['ifIndex']) {
-            $ifIndex               = $array[$slotport]['ifIndex'];
-            $array[$ifIndex][$oid] = $value;
-        }
-    }
-
-    return $array;
-}//end snmp_cache_slotport_oid()
-
-
-function snmp_cache_oid($oid, $device, $array, $mib = 0)
-{
-    $array = snmpwalk_cache_oid($device, $oid, $array, $mib);
-    return $array;
-}//end snmp_cache_oid()
-
-
-function snmp_cache_port_oids($oids, $port, $device, $array, $mib = 0)
-{
-    $string = '';
-    foreach ($oids as $oid) {
-        $string .= " $oid.$port";
-    }
-
-    $cmd = gen_snmpget_cmd($device, $string, ' -Ovq', $mib);
-    $data   = trim(external_exec($cmd));
-
-    $x      = 0;
-    $values = explode("\n", $data);
-    // echo("Caching: ifIndex $port\n");
-    foreach ($oids as $oid) {
-        if (!strstr($values[$x], 'at this OID')) {
-            $array[$port][$oid] = $values[$x];
-        }
-
-        $x++;
-    }
-
-    return $array;
-}//end snmp_cache_port_oids()
 
 
 function snmp_cache_portIfIndex($device, $array)
@@ -543,6 +408,39 @@ function snmp_cache_portName($device, $array)
     return $array;
 }//end snmp_cache_portName()
 
+
+/**
+ * Split the data into an array with the format of $array[$index][$oid] = $value
+ * index is always the last part of the $oid (after the last period)
+ *
+ * @param string $data The output from snmpget or snmpwalk. Data must have oid = value format.
+ * @param array $array optionally add data to an existing array
+ * @param int $index_parts use this many parts of the oid for the array index
+ * @return array The resulting array
+ */
+function snmp_output_to_array($data, $array = array(), $index_parts = 1)
+{
+    foreach (explode(PHP_EOL, $data) as $entry) {
+        // split data and value
+        list($oid, $value) = explode('=', $entry, 2);
+        $oid = trim($oid);
+        $value = trim($value, " \t\n\r\0\x0B\""); //remove surrounding whitespace and double quotes
+
+        if (!str_contains($value, 'at this OID')) {
+            // split the oid into index and prefix
+            $split = strrpos_count($oid, '.', $index_parts);
+            if ($split !== false) {
+                $index = substr($oid, $split + 1);
+                $oid = substr($oid, 0, $split);
+                $array[$index][$oid] = $value;
+            } else {
+                // no periods in oid or no split requested, use full oid as index
+                $array[$oid] = $value;
+            }
+        }
+    }
+    return $array;
+}
 
 function snmp_gen_auth(&$device)
 {
@@ -1096,10 +994,7 @@ function snmpwalk_array_num($device, $oid, $indexes = 1)
 
     // Let's turn the string into something we can work with.
     foreach (explode("\n", $string) as $line) {
-        if ($line[0] == '.') {
-            // strip the leading . if it exists.
-            $line = substr($line, 1);
-        }
+        $line = ltrim($line, '.'); // strip the any leading .
         list($key, $value) = explode(' ', $line, 2);
         $prop_id = explode('.', $key);
         $value = trim($value);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -421,9 +421,8 @@ function snmp_cache_portName($device, $array)
 function snmp_output_to_array($data, $array = array(), $index_parts = 1)
 {
     foreach (explode(PHP_EOL, $data) as $entry) {
-        // split data and value
-        list($oid, $value) = explode('=', $entry, 2);
-        $oid = trim($oid);
+        // split oid and value
+        list($oid, $value) = explode(' = ', $entry, 2);
         $value = trim($value, " \t\n\r\0\x0B\""); //remove surrounding whitespace and double quotes
 
         if (!str_contains($value, 'at this OID')) {


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Move common code to turn values to an array to a function.
Many snmp functions become an alias,  we can remove those.
snmp_cache_oid_num() has a slight change in result, it doesn't add an extra [''] into the array, just straight $array[$oid] = $value now.
remove unused functions