### PR TITLE
fix: Updated edit snmp to set default poller_group

### DIFF
--- a/html/pages/device/edit/snmp.inc.php
+++ b/html/pages/device/edit/snmp.inc.php
@@ -8,7 +8,7 @@ if ($_POST['editing']) {
         $port         = $_POST['port'] ? mres($_POST['port']) : $config['snmp']['port'];
         $timeout      = mres($_POST['timeout']);
         $retries      = mres($_POST['retries']);
-        $poller_group = mres($_POST['poller_group']);
+        $poller_group = isset($_POST['poller_group']) ? mres($_POST['poller_group']) : 0;
         $port_assoc_mode = mres($_POST['port_assoc_mode']);
         $max_repeaters = mres($_POST['max_repeaters']);
         $v3           = array(


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

dbUpdate call would fail because the poller_group was `''` rather than numerical so set to default.