### PR TITLE
fix: Fixed SQL query for bgpPeers check to remove stale sessions

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -214,7 +214,7 @@ if ($config['enable_bgp']) {
         }
 
             // Delete removed peers
-            $sql = "SELECT * FROM bgpPeers WHERE device_id = '".$device['device_id']."' AND context_name = '".$device['context_name']."'";
+            $sql = "SELECT * FROM bgpPeers WHERE device_id = '".$device['device_id']."' AND (context_name = '".$device['context_name']."' OR context_name IS NULL)";
 
         foreach (dbFetchRows($sql) as $entry) {
             unset($exists);


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

The db schema for bgpPeers context_name is NULL. However the query checks for ='' so never matches. I did think about not allowing NULL but then we'd have to set context_name in many other places and it genuinely should be allowed to be NULL here anyway.

Fixes: #4635 