### PR TITLE
feature: Added support for show faults array in recovery alerts

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -498,7 +498,15 @@ function DescribeAlert($alert)
         }
         $obj['elapsed'] = TimeFormat(strtotime($alert['time_logged']) - strtotime($id['time_logged']));
         $obj['id']      = $id['id'];
-        $obj['faults']  = false;
+        foreach ($extra['rule'] as $incident) {
+            $i++;
+            $obj['faults'][$i] = $incident;
+            foreach ($incident as $k => $v) {
+                if (!empty($v) && $k != 'device_id' && (stristr($k, 'id') || stristr($k, 'desc') || stristr($k, 'msg')) && substr_count($k, '_') <= 1) {
+                    $obj['faults'][$i]['string'] .= $k.' => '.$v.'; ';
+                }
+            }
+        }
     } else {
         return 'Unknown State';
     }//end if


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Adds the ability to use faults array in recovery to see what's resolved.

Fixes: #4701 (well tested by @ipguru99 )