### PR TITLE
fix: skip ip_exists function when we force add

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -300,7 +300,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
     } else {
         $ip = $host;
     }
-    if (ip_exists($ip)) {
+    if ($force_add !== true && ip_exists($ip)) {
         throw new HostIpExistsException("Already have host with this IP $host");
     }
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: https://community.librenms.org/t/schrodingers-device/111/2