### PR TITLE
Updated poll_device and os module to prettify output

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -153,7 +153,9 @@ function poll_device($device, $options)
     unset($array);
     $device_start = microtime(true);
     // Start counting device poll time
-    echo $device['hostname'].' '.$device['device_id'].' '.$device['os'].' ';
+    echo 'Hostname: ' . $device['hostname'] . PHP_EOL;
+    echo 'Device ID: ' . $device['device_id'] . PHP_EOL;
+    echo 'OS: ' . $device['os'];
     $ip = dnslookup($device);
 
     if (!empty($ip) && $ip != inet6_ntop($device['ip'])) {
@@ -164,7 +166,7 @@ function poll_device($device, $options)
 
     if ($config['os'][$device['os']]['group']) {
         $device['os_group'] = $config['os'][$device['os']]['group'];
-        echo '('.$device['os_group'].')';
+        echo ' ('.$device['os_group'].')' . PHP_EOL;
     }
 
     echo "\n";

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -166,10 +166,10 @@ function poll_device($device, $options)
 
     if ($config['os'][$device['os']]['group']) {
         $device['os_group'] = $config['os'][$device['os']]['group'];
-        echo ' ('.$device['os_group'].')' . PHP_EOL;
+        echo ' ('.$device['os_group'].')';
     }
 
-    echo "\n";
+    echo PHP_EOL.PHP_EOL;
 
     unset($poll_update);
     unset($poll_update_query);

--- a/includes/polling/os.inc.php
+++ b/includes/polling/os.inc.php
@@ -35,4 +35,7 @@ if ($icon && $icon != $device['icon']) {
     log_event('Icon -> '.$icon, $device, 'system');
 }
 
-echo "\nHardware: ".$hardware.' Version: '.$version.' Features: '.$features.' Serial: '.$serial."\n";
+echo 'Hardware: ' . $hardware . PHP_EOL;
+echo 'Version: ' . $version . PHP_EOL;
+echo 'Features: ' . $features . PHP_EOL;
+echo 'Serial: ' . $serial . PHP_EOL;


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

```bash
[librenms@librenms ~]$ ./poller.php -h localhost -r -f -m os
LibreNMS Poller
Version info:
Commit SHA: 28424abdc6a98108ddcafb1f24922a40dc55b2a9
Commit Date: 1475715654
DB Schema: 143
PHP: 7.0.6
MySQL: 5.5.47-MariaDB
RRDTool: 1.4.8
SNMP: NET-SNMP 5.7.2
Starting polling run:

Hostname: localhost
Device ID: 2
OS: linux (unix)

Using hrSystemUptime (56893s)
[RRD Disabled]Uptime: 15h 48m 13s

#### Load poller module os ####
Hardware: Generic x86 64-bit
Version: 3.10.0-327.13.1.el7.x86_64
Features: CentOS 7.2.1511
Serial:

>> Runtime for poller module 'os': 0.18562602996826 seconds
#### Unload poller module os ####
```