### PR TITLE
More complete peer_data_checking

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -25,7 +25,7 @@ if ($config['enable_bgp']) {
             if (!empty($peer['bgpPeerIdentifier'])) {
                 if ($device['os'] != 'junos') {
                     // v4 BGP4 MIB
-                    if (count($peer_data_check) > 0) {
+                    if (count($peer_data_check) > 0 and !empty($peer_data_check[0][0])) {
                         if (strstr($peer['bgpPeerIdentifier'], ':')) {
                             $bgp_peer_ident = ipv62snmp($peer['bgpPeerIdentifier']);
                         } else {


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

When checking for peer data, if the CISCO-BGP4-MIB check fails, it returns a nested array with an empty value.  php count() returns 1 in this case, even though the nested value is empty.