### PR TITLE
fix: Stop snmp_output_to_array creating an array when $data is empty

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -420,6 +420,9 @@ function snmp_cache_portName($device, $array)
  */
 function snmp_output_to_array($data, $array = array(), $index_parts = 1)
 {
+    if (empty($data)) {
+        return null;
+    }
     foreach (explode(PHP_EOL, $data) as $entry) {
         // split oid and value
         list($oid, $value) = explode(' = ', $entry, 2);


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

exploding an empty variable creates an array, skips that now.