### PR TITLE
Prevent accidental anonymous binds

### DIFF
--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -25,7 +25,7 @@ function authenticate($username, $password)
 
     if ($ldap_connection) {
         // bind with sAMAccountName instead of full LDAP DN
-        if ($username && ldap_bind($ldap_connection, "{$username}@{$config['auth_ad_domain']}", $password)) {
+        if ($username && $password && ldap_bind($ldap_connection, "{$username}@{$config['auth_ad_domain']}", $password)) {
             // group membership in one of the configured groups is required
             if (isset($config['auth_ad_require_groupmembership']) &&
                 $config['auth_ad_require_groupmembership']) {
@@ -66,7 +66,9 @@ function authenticate($username, $password)
         }
     }
 
-    if (isset($config['auth_ad_debug']) && $config['auth_ad_debug']) {
+    if (!isset($password) || $password == '') {
+        $auth_error = "A password is required";
+    } elseif (isset($config['auth_ad_debug']) && $config['auth_ad_debug']) {
         ldap_get_option($ldap_connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $extended_error);
         $auth_error = ldap_error($ldap_connection).'<br />'.$extended_error;
     } else {

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -38,7 +38,7 @@ function authenticate($username, $password)
                 }
             }
         } elseif (!isset($password) || $password == '') {
-           echo "A password is required"; 
+            echo 'A password is required';
         } else {
             echo ldap_error($ldap_connection);
         }

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -20,7 +20,7 @@ function authenticate($username, $password)
             ldap_set_option($ldap_connection, LDAP_OPT_PROTOCOL_VERSION, $config['auth_ldap_version']);
         }
 
-        if (ldap_bind($ldap_connection, $config['auth_ldap_prefix'].$username.$config['auth_ldap_suffix'], $password)) {
+        if ($password && ldap_bind($ldap_connection, $config['auth_ldap_prefix'].$username.$config['auth_ldap_suffix'], $password)) {
             if (!$config['auth_ldap_group']) {
                 return 1;
             } else {
@@ -37,6 +37,8 @@ function authenticate($username, $password)
                     }
                 }
             }
+        } elseif (!isset($password) || $password == '') {
+           echo "A password is required"; 
         } else {
             echo ldap_error($ldap_connection);
         }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

By design, or by bug, PHP's ldap_bind function will automatically attempt an anonymous bind if either the bind_rdn (username) or bind_password arguments are empty.   This behavior may allow a non-existent user to authenticate to librenms with minimal (Level 1?) privileges.

Proposed fix -- Enforce a non-blank password when authenticating via ldap or active directory.