### PR TITLE
fix: additional protection from leaking rrdtool processes

### DIFF
--- a/LibreNMS/Proc.php
+++ b/LibreNMS/Proc.php
@@ -197,11 +197,10 @@ class Proc
 
         if (!$closed) {
             // try harder
-            $pid = $status['pid'];
-            $killed = posix_kill($pid, 9); //9 is the SIGKILL signal
+            $killed = posix_kill($status['pid'], 9); //9 is the SIGKILL signal
             proc_close($this->_process);
 
-            if (!$killed) {
+            if (!$killed && $this->isRunning()) {
                 throw new Exception("Terminate failed!");
             }
         }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Double check before throwing an exception.
Since we are running two processes, we could leak one if we throw an exception and execution stops.