### PR TITLE
Enhance Unifi Wireless Client count for multiple VAPs

### DIFF
--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -61,13 +61,22 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         $wificlients1 = snmp_get($device, '.1.3.6.1.4.1.388.11.2.4.2.100.10.1.18.1', '-Ovq', '""');
 
         echo (($wificlients1 + 0).' clients on wireless connector, ');
-    } else if ($device['os'] == 'unifi') {
+    } else if ($device['os'] == 'unifi' && $device['type'] == 'wireless') {
         echo 'Checking Unifi Wireless clients... ';
 
-        $wificlients1 = snmp_get($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.8.0', '-Ovq', '""');
-        $wificlients2 = snmp_get($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.8.1', '-Ovq', '""');
+        $clients = snmp_walk($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.8', '-Oqv');
+        $bands = snmp_walk($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.9', '-Oqv');
+        $clients = explode("\n", $clients);
+        $bands = explode("\n", $bands);
+        foreach ($bands as $index => $band_index) {
+            if ($band_index == "ng") {
+                $wificlients1 = $wificlients1 + $clients[$index] + 0;
+            } else {
+                $wificlients2 = $wificlients2 + $clients[$index] + 0;
+            }
+        }
 
-        echo (($wificlients1 + 0).' clients on radio0, '.($wificlients2 + 0)." clients on radio1\n");
+        echo (($wificlients1 + 0).' clients on Radio0, '.($wificlients2 + 0)." clients on Radio1\n");
     }
 
     if (isset($wificlients1) && $wificlients1 != '') {

--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -4,19 +4,19 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
     if ($device['os'] == 'airos') {
         echo 'It Is Airos' . PHP_EOL;
         include 'includes/polling/mib/ubnt-airmax-mib.inc.php';
-    } else if ($device['os'] == 'airos-af') {
+    } elseif ($device['os'] == 'airos-af') {
         echo 'It Is AirFIBER' . PHP_EOL;
         include 'includes/polling/mib/ubnt-airfiber-mib.inc.php';
-    } else if ($device['os'] == 'siklu') {
+    } elseif ($device['os'] == 'siklu') {
         echo 'It is Siklu' . PHP_EOL;
         include 'includes/polling/mib/siklu-mib.inc.php';
-    } else if ($device['os'] == 'saf') {
+    } elseif ($device['os'] == 'saf') {
         echo 'It is SAF Tehnika' . PHP_EOL;
         include 'includes/polling/mib/saf-mib.inc.php';
-    } else if ($device['os'] == 'sub10') {
+    } elseif ($device['os'] == 'sub10') {
         echo 'It is Sub10' . PHP_EOL;
         include 'includes/polling/mib/sub10-mib.inc.php';
-    } else if ($device['os'] == 'airport') {
+    } elseif ($device['os'] == 'airport') {
         // # GENERIC FRAMEWORK, FILLING VARIABLES
         echo 'Checking Airport Wireless clients... ';
 
@@ -25,18 +25,18 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         echo $wificlients1." clients\n";
 
         // FIXME Also interesting to poll? dhcpNumber.0 for number of active dhcp leases
-    } else if ($device['os'] == 'ios' and substr($device['hardware'], 0, 4) == 'AIR-' || ($device['os'] == 'ios' && strpos($device['hardware'], 'ciscoAIR') !== false)) {
+    } elseif ($device['os'] == 'ios' and substr($device['hardware'], 0, 4) == 'AIR-' || ($device['os'] == 'ios' && strpos($device['hardware'], 'ciscoAIR') !== false)) {
         echo 'Checking Aironet Wireless clients... ';
 
         $wificlients1 = snmp_get($device, 'cDot11ActiveWirelessClients.1', '-OUqnv', 'CISCO-DOT11-ASSOCIATION-MIB');
         $wificlients2 = snmp_get($device, 'cDot11ActiveWirelessClients.2', '-OUqnv', 'CISCO-DOT11-ASSOCIATION-MIB');
 
         echo (($wificlients1 + 0).' clients on dot11Radio0, '.($wificlients2 + 0)." clients on dot11Radio1\n");
-    } else if ($device['os'] == 'hpmsm') {
+    } elseif ($device['os'] == 'hpmsm') {
         echo 'Checking HP MSM Wireless clients... ';
         $wificlients1 = snmp_get($device, '.1.3.6.1.4.1.8744.5.25.1.7.2.0', '-OUqnv');
         echo $wificlients1." clients\n";
-    } else if ($device['os'] == 'routeros') {
+    } elseif ($device['os'] == 'routeros') {
         // MikroTik RouterOS
         // Check inventory for wireless card in device. Valid types be here:
         $wirelesscards = array(
@@ -55,13 +55,13 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
 
             unset($wirelesscards);
         }
-    } else if ($device['os'] == 'symbol' and (stristr($device['hardware'], 'AP'))) {
+    } elseif ($device['os'] == 'symbol' and (stristr($device['hardware'], 'AP'))) {
         echo 'Checking Symbol Wireless clients... ';
 
         $wificlients1 = snmp_get($device, '.1.3.6.1.4.1.388.11.2.4.2.100.10.1.18.1', '-Ovq', '""');
 
         echo (($wificlients1 + 0).' clients on wireless connector, ');
-    } else if ($device['os'] == 'unifi' && $device['type'] == 'wireless') {
+    } elseif ($device['os'] == 'unifi') {
         echo 'Checking Unifi Wireless clients... ';
 
         $clients = snmp_walk($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.8', '-Oqv');


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

The proposed patch below enhances the original unifi wifi client polling.  The original code only works properly if on Virtual Access Point is configured on the router.  If more than one exists, the existing commit code takes the first two 2.4ghz AP clients as the 2.4 and the 5 ghz total client count.  That's not what we want.  

This code snmpwalk's all of the VAPs for their client and their band.  Then we if the band is ng, add it to wirelessclients1.  If not, it's on wirelessclients2.  

I've also added a check in the initial if statement to make sure this unifi device is wireless.  Otherwise it shouldn't have any wireless clients.  

Two issues to note at the moment.  One is that ./scripts/pre-commit.php is throwing errors on the VlanFunctionsTest.  I'm not sure what's causing that or if it is related to this patch.  I didn't think it was touching anything vlan related.  

The other issue is that comparing the unifi controller (the Unifi management software) and the snmpwalk results, the snmpwalk is adding 1 additional client to the results.  I think that's a Unifi bug and I'm going to discuss that with Ubiquiti.  This code is reporting the total reported from snmpwalk happily and graphing those totals.  

