### PR TITLE
refactor: toner

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -897,66 +897,14 @@ function get_device_divisor($device, $serial, $sensor)
 }
 
 /**
- * @param $device
- * @param $capacity_oid
- * @return int
+ * @param int $raw_capacity The value return from snmp
+ * @return int normalized capacity value
  */
-function get_toner_capacity($device, $capacity_oid)
+function get_toner_capacity($raw_capacity)
 {
-    if ($device['os'] == 'ricoh' || $device['os'] == 'nrg' || $device['os'] == 'lanier') {
-        $capacity = 100;
-    } else {
-        $capacity = snmp_get($device, $capacity_oid, '-Oqv');
+    // unknown or unrestricted capacity, assume 100
+    if (empty($raw_capacity) || $raw_capacity < 0) {
+        return 100;
     }
-
-    return $capacity;
-}
-
-/**
- * @param $device
- * @param $oid_value
- * @param $oid_capacity
- * @return float|int
- */
-function get_toner_levels($device, $oid_value, $oid_capacity)
-{
-    if ($device['os'] == 'ricoh' || $device['os'] == 'nrg' || $device['os'] == 'lanier') {
-        if ($oid_value == '-3') {
-            $current = 50;
-        } elseif ($oid_value == '-100') {
-            $current = 0;
-        } else {
-            $current = ($oid_value / $oid_capacity * 100);
-        }
-    } elseif ($device['os'] == 'brother') {
-        if (str_contains($device['hardware'], 'NC-8600h')) {
-            switch ($oid_value) {
-                case '0':
-                    $current = 0;
-                    break;
-                case '-3':
-                    $current = 50;
-                    break;
-            }
-        } else {
-            switch ($oid_value) {
-                case '0':
-                    $current = 100;
-                    break;
-                case '1':
-                    $current = 5;
-                    break;
-                case '2':
-                    $current = 0;
-                    break;
-                case '3':
-                    $current = 1;
-                    break;
-            }
-        }
-    } else {
-        $current = ($oid_value / $oid_capacity * 100);
-    }
-
-    return $current;
+    return $raw_capacity;
 }

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -3,69 +3,55 @@
 $valid_toner = array();
 
 if ($device['os_group'] == 'printer') {
-    $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.12.1.1.2.1 ', '-OsqnU'));
-    if (!$oids) {
-        $oids = trim(snmp_walk($device, 'SNMPv2-SMI::mib-2.43.11.1.1.2.1 ', '-OsqnU'));
+    echo 'Toner: ';
+    $oids = snmpwalk_cache_oid($device, 'prtMarkerColorantMarkerIndex', array(), 'Printer-MIB');
+    if (empty($oids)) {
+        $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesMarkerIndex', $oids, 'Printer-MIB');
     }
 
-    d_echo($oids . "\n");
-
-    if ($oids) {
-        echo 'Jetdirect ';
+    if (!empty($oids)) {
+        $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesLevel', $oids, 'Printer-MIB');
+        $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesMaxCapacity', $oids, 'Printer-MIB');
+        $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesDescription', $oids, 'Printer-MIB', null, '-OQUsa');
     }
 
-    //samsung ml series does not responde to snmpwalk
-    if ($os == 'samsungprinter' && str_contains($device['sysDescr'], 'Samsung ML')) {
-        $toner_oid = '.1.3.6.1.2.1.43.11.1.1.9.1.1';
-        $descr_oid = '.1.3.6.1.2.1.43.11.1.1.6.1.1';
-        $capacity_oid = '.1.3.6.1.2.1.43.11.1.1.8.1.1';
-        $descr = trim(str_replace("\n", '', preg_replace('/[^ \w]+/', '', snmp_get($device, $descr_oid, '-Oqv'))));
-        $oid_toner = snmp_get($device, $toner_oid, '-Oqv');
-        $oid_capacity = snmp_get($device, $capacity_oid, '-Oqv');
-        $capacity = get_toner_capacity($device, $oid_capacity);
-        $current = get_toner_levels($device, $oid_toner, $oid_capacity);
+    foreach ($oids as $index => $data) {
+        $last_index = substr($index, strrpos($index, '.') + 1);
+        if ($os == 'ricoh' || $os == 'nrg' || $os == 'lanier') {
+            $toner_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.5.$last_index";
+            $descr_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.3.$last_index";
+            $capacity_oid = '';
 
-        discover_toner($valid_toner, $device, $toner_oid, 1, 'jetdirect', $descr, $capacity_oid, $capacity, $current);
-    } else {
-        foreach (explode("\n", $oids) as $data) {
-            $data = trim($data);
-            if ($data) {
-                list($oid, $role) = explode(' ', $data);
-                $split_oid = explode('.', $oid);
-                $index = $split_oid[(count($split_oid) - 1)];
-                if (is_numeric($role)) {
-                    //ricoh using private oids to expose toner levels
-                    if ($os == 'ricoh' || $os == 'nrg' || $os == 'lanier') {
-                        $toner_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.5.$index";
-                        $descr_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.3.$index";
-                        $capacity_oid = '';
-                    } else {
-                        $toner_oid = ".1.3.6.1.2.1.43.11.1.1.9.1.$index";
-                        $descr_oid = ".1.3.6.1.2.1.43.11.1.1.6.1.$index";
-                        $capacity_oid = ".1.3.6.1.2.1.43.11.1.1.8.1.$index";
-                    }
+            $descr = snmp_get($device, $descr_oid, '-Oqva');
+            $raw_toner = snmp_get($device, $toner_oid, '-Oqv');
+        } else {
+            $toner_oid = ".1.3.6.1.2.1.43.11.1.1.9.$index";
+            $capacity_oid = ".1.3.6.1.2.1.43.11.1.1.8.$index";
 
-                    $descr = trim(str_replace("\n", '', preg_replace('/[^ \w]+/', '', snmp_get($device, $descr_oid, '-Oqva'))));
-
-                    if ($descr != '') {
-                        $oid_toner = snmp_get($device, $toner_oid, '-Oqv');
-                        $oid_capacity = snmp_get($device, $capacity_oid, '-Oqv');
-
-                        $capacity = get_toner_capacity($device, $oid_capacity);
-                        $current = get_toner_levels($device, $oid_toner, $oid_capacity);
-
-                        $type = 'jetdirect';
-
-                        discover_toner($valid_toner, $device, $toner_oid, $index, $type, $descr, $capacity_oid, $capacity, $current);
-                    }
-                }
-            }
+            $descr = $data['prtMarkerSuppliesDescription'];
+            $raw_toner = $data['prtMarkerSuppliesLevel'];
         }
+
+        $type = 'jetdirect';
+        $capacity = get_toner_capacity($data['prtMarkerSuppliesMaxCapacity']);
+        $current = get_toner_levels($device, $raw_toner, $capacity);
+
+        discover_toner(
+            $valid_toner,
+            $device,
+            $toner_oid,
+            $last_index,
+            $type,
+            $descr,
+            $capacity_oid,
+            $capacity,
+            $current
+        );
     }
 }
 
 // Delete removed toners
-d_echo("\n Checking ... \n");
+d_echo("\n Checking valid toner ... \n");
 d_echo($valid_toner);
 
 $sql = "SELECT * FROM toner WHERE device_id = '" . $device['device_id'] . "'";
@@ -79,4 +65,4 @@ foreach (dbFetchRows($sql) as $test_toner) {
 }
 
 unset($valid_toner);
-echo "\n";
+echo PHP_EOL;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1721,7 +1721,7 @@ function get_toner_levels($device, $raw_value, $capacity)
             return 0;
         }
     } elseif ($device['os'] == 'brother') {
-        if (!str_contains($device['hardware'], 'NC-8600h')) {
+        if (!str_contains($device['hardware'], 'MFC-L8850')) {
             switch ($raw_value) {
                 case '0':
                     return 100;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -811,8 +811,7 @@ function snmp_hexstring($hex)
 }
 
 # Check if the supplied string is an SNMP hex string
-function
-isHexString($str)
+function isHexString($str)
 {
     return preg_match("/^[a-f0-9][a-f0-9]( [a-f0-9][a-f0-9])*$/is", trim($str));
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -811,7 +811,8 @@ function snmp_hexstring($hex)
 }
 
 # Check if the supplied string is an SNMP hex string
-function isHexString($str)
+function
+isHexString($str)
 {
     return preg_match("/^[a-f0-9][a-f0-9]( [a-f0-9][a-f0-9])*$/is", trim($str));
 }
@@ -1694,4 +1695,45 @@ function q_bridge_bits2indices($hex_data)
         }
     }
     return $indices;
+}
+
+/**
+ * @param array $device
+ * @param int|string $raw_value The value returned from snmp
+ * @param int $capacity the normalized capacity
+ * @return int the toner level as a percentage
+ */
+function get_toner_levels($device, $raw_value, $capacity)
+{
+    // -3 means some toner is left
+    if ($raw_value == '-3') {
+        return 50;
+    }
+
+    // -2 means unknown, -1 mean no restrictions
+    if ($raw_value == '-2' || $raw_value == '-1') {
+        return 0;  // FIXME: is 0 what we should return?
+    }
+
+    // Non-standard snmp values
+    if ($device['os'] == 'ricoh' || $device['os'] == 'nrg' || $device['os'] == 'lanier') {
+        if ($raw_value == '-100') {
+            return 0;
+        }
+    } elseif ($device['os'] == 'brother') {
+        if (!str_contains($device['hardware'], 'NC-8600h')) {
+            switch ($raw_value) {
+                case '0':
+                    return 100;
+                case '1':
+                    return 5;
+                case '2':
+                    return 0;
+                case '3':
+                    return 1;
+            }
+        }
+    }
+
+    return round($raw_value / $capacity * 100);
 }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

snmpwalk one level higher in the snmp tree, use mib for discovery
Negative values have special meaning according to the mib, recognize those.
Clean up calculations and use the get_toner_levels() in both discovery and polling
Don't fetch the capacity during polling, only discovery
Log when toner reaches 0
fixes: #4767 #4637
