### PR TITLE
fix: stop uptime alerts

### DIFF
--- a/html/includes/print-alert-rules.php
+++ b/html/includes/print-alert-rules.php
@@ -19,14 +19,18 @@ if (isset($_POST['create-default'])) {
         'disabled'  => 0,
         'name'      => 'Devices up/down',
     );
-    $default_rules[] = array(
-        'device_id' => '-1',
-        'rule'      => '%devices.uptime < "300" && %macros.device = "1"',
-        'severity'  => 'critical',
-        'extra'     => '{"mute":false,"count":"1","delay":"300"}',
-        'disabled'  => 0,
-        'name'      => 'Device rebooted',
-    );
+
+    if ($config['os'][$device['os']]['bad_uptime'] !== true) {
+        $default_rules[] = array(
+            'device_id' => '-1',
+            'rule'      => '%devices.uptime < "300" && %macros.device = "1"',
+            'severity'  => 'critical',
+            'extra'     => '{"mute":false,"count":"1","delay":"300"}',
+            'disabled'  => 0,
+            'name'      => 'Device rebooted',
+        );
+    }
+
     $default_rules[] = array(
         'device_id' => '-1',
         'rule'      => '%bgpPeers.bgpPeerState != "established" && %macros.device_up = "1"',


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

stop uptime alerts for devices with $config bad_uptime (like cisco's meraki ap) #4691 

this should be tested as i don't own any device with bad uptime
