### PR TITLE
Option to display devices as a uniform size w/o labels

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1994,6 +1994,12 @@ label {
   curosr: pointer;
 }
 
+.widget-availability-fixed {
+  min-width: 2.4em;
+  min-height: 1.3em;
+  max-height: 1.6em;
+}
+
 .widget-availability-host {
   float:left;
   margin-bottom: 10px;
@@ -2035,7 +2041,7 @@ label {
 }
 
 .availability-map-widget-header {
-  line-height:30px;
+  line-height:34px;
 }
 
 @media only screen and (max-width: 1240px) and (min-width: 1200px) {

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -213,7 +213,7 @@ if (defined('SHOW_SETTINGS')) {
                     </a>';
                 } else {
                     if ($widget_settings['color_only_select'] == 1) {
-                        $deviceState = ' '; 
+                        $deviceState = ' ';
                         $deviceLabel .= ' widget-availability-fixed';
                     }
                     $temp_output[] = '
@@ -263,7 +263,7 @@ if (defined('SHOW_SETTINGS')) {
                         </a>';
                     } else {
                         if ($widget_settings['color_only_select'] == 1) {
-                            $serviceState = ' '; 
+                            $serviceState = ' ';
                             $serviceLabel .= ' widget-availability-fixed';
                         }
                         $temp_output[] = '

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -42,6 +42,22 @@ if (defined('SHOW_SETTINGS')) {
             </div>
         </div>';
 
+    if ($config['webui']['availability_map_compact'] == false) {
+        $common_output[] = '
+    <div class="form-group">
+        <div class="col-sm-4">
+            <label for="color_only_select" class="control-label availability-map-widget-header">Uniform Tiles</label>
+        </div>
+        <div class="col-sm-6">
+            <select class="form-control" name="color_only_select">
+                <option value="1"' . ($widget_settings['color_only_select'] == 1 ? ' selected' : '')  . ' >yes</option>
+                <option value="0"' . ($widget_settings['color_only_select'] == 1 ? '' : ' selected')  . ' >no</option>
+            </select>
+        </div>
+    </div>
+';
+    }
+
     if ($config['webui']['availability_map_compact'] == 1) {
         $common_output[] = '
         <div class="form-group">
@@ -196,6 +212,10 @@ if (defined('SHOW_SETTINGS')) {
                     </div>
                     </a>';
                 } else {
+                    if ($widget_settings['color_only_select'] == 1) {
+                        $deviceState = ' '; 
+                        $deviceLabel .= ' widget-availability-fixed';
+                    }
                     $temp_output[] = '
                     <a href="' . generate_url(array('page' => 'device', 'device' => $device['device_id'])) . '" title="' . $device['hostname'] . " - " . formatUptime($device['uptime']) . '">
                         <span class="label ' . $deviceLabel . ' widget-availability label-font-border">' . $deviceState . '</span>
@@ -242,6 +262,10 @@ if (defined('SHOW_SETTINGS')) {
                             </div>
                         </a>';
                     } else {
+                        if ($widget_settings['color_only_select'] == 1) {
+                            $serviceState = ' '; 
+                            $serviceLabel .= ' widget-availability-fixed';
+                        }
                         $temp_output[] = '
                         <a href="' . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . '" title="' . $service['hostname'] . " - " . $service['service_type'] . " - " . $service['service_desc'] . '">
                             <span class="label ' . $serviceLabel . ' widget-availability label-font-border">' . $service['service_type'] . ' - ' . $serviceState . '</span>

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -42,7 +42,7 @@ if (defined('SHOW_SETTINGS')) {
             </div>
         </div>';
 
-    if ($config['webui']['availability_map_compact'] == false) {
+    if ($config['webui']['availability_map_compact'] === false) {
         $common_output[] = '
     <div class="form-group">
         <div class="col-sm-4">


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Add an option in the widget to display the device tiles without a label (up/warn/down...) and as a uniform size.  For those of us who like things to line up and to have division between each device tile.