### PR TITLE
Add an option for ad authentication to have a default level

### DIFF
--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -140,7 +140,8 @@ If you have issues with secure LDAP try setting `$config['auth_ad_check_certific
 
 ##### Require actual membership of the configured groups
 
-If you set ```$config['auth_ad_require_groupmembership']``` to 1, the authenticated user has to be a member of the specific group. Otherwise all users can authenticate, but are limited to user level 0 and only have access to shared dashboards.
+If you set ```$config['auth_ad_require_groupmembership']``` to 1, the authenticated user has to be a member of the specific group. Otherwise all users can authenticate, and will be either level 0 (shared dashboard without content only) or
+```$config['auth_ad_default_level']```(valid options are the user levels defined above).
 
 > Cleanup of old accounts is done using the authlog. You will need to set the cleanup date for when old accounts will be purged which will happen AUTOMATICALLY.
 > Please ensure that you set the $config['authlog_purge'] value to be greater than $config['active_directory]['users_purge'] otherwise old users won't be removed.

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -140,8 +140,7 @@ If you have issues with secure LDAP try setting `$config['auth_ad_check_certific
 
 ##### Require actual membership of the configured groups
 
-If you set ```$config['auth_ad_require_groupmembership']``` to 1, the authenticated user has to be a member of the specific group. Otherwise all users can authenticate, and will be either level 0 (shared dashboard without content only) or
-```$config['auth_ad_default_level']```(valid options are the user levels defined above).
+If you set ```$config['auth_ad_require_groupmembership']``` to 1, the authenticated user has to be a member of the specific group. Otherwise all users can authenticate, and will be either level 0 or you may set ```$config['auth_ad_global_read']``` to 1 and all users will have read only access unless otherwise specified.
 
 > Cleanup of old accounts is done using the authlog. You will need to set the cleanup date for when old accounts will be purged which will happen AUTOMATICALLY.
 > Please ensure that you set the $config['authlog_purge'] value to be greater than $config['active_directory]['users_purge'] otherwise old users won't be removed.

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -156,6 +156,9 @@ function get_userlevel($username)
     global $config, $ldap_connection;
 
     $userlevel = 0;
+    if (isset($config['auth_ad_require_groupmembership']) && $config['auth_ad_require_groupmembership'] == 0 && isset($config['auth_ad_default_level'])) {
+        $userlevel = $config['auth_ad_default_level'];
+    }
 
     // Find all defined groups $username is in
     $search = ldap_search(
@@ -254,7 +257,7 @@ function get_userlist()
             'email'    => $userhash[$key]['email']
         );
     }
-    
+
     return $userlist;
 }
 

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -156,8 +156,10 @@ function get_userlevel($username)
     global $config, $ldap_connection;
 
     $userlevel = 0;
-    if (isset($config['auth_ad_require_groupmembership']) && $config['auth_ad_require_groupmembership'] == 0 && isset($config['auth_ad_default_level'])) {
-        $userlevel = $config['auth_ad_default_level'];
+    if (isset($config['auth_ad_require_groupmembership']) && $config['auth_ad_require_groupmembership'] == 0) {
+       if (isset($config['auth_ad_global_read']) && $config['auth_ad_global_read'] === 1) {
+           $userlevel = 5;
+       }
     }
 
     // Find all defined groups $username is in

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -157,9 +157,9 @@ function get_userlevel($username)
 
     $userlevel = 0;
     if (isset($config['auth_ad_require_groupmembership']) && $config['auth_ad_require_groupmembership'] == 0) {
-       if (isset($config['auth_ad_global_read']) && $config['auth_ad_global_read'] === 1) {
-           $userlevel = 5;
-       }
+        if (isset($config['auth_ad_global_read']) && $config['auth_ad_global_read'] === 1) {
+            $userlevel = 5;
+        }
     }
 
     // Find all defined groups $username is in


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Add a config option to allow modifying the default user level for AD authentication when auth_ad_require_groupmembership == 0.