### PR TITLE
refactor: populate native vlans in the ports_vlan table for cisco devices too

### DIFF
--- a/html/includes/print-vlan.inc.php
+++ b/html/includes/print-vlan.inc.php
@@ -19,17 +19,17 @@ foreach ($otherports as $otherport) {
     if ($otherport['untagged']) {
         $traverse_ifvlan = false;
     }
-    $vlan_ports[$otherport[ifIndex]] = $otherport;
+    $vlan_ports[$otherport['ifIndex']] = $otherport;
 }
 
 if ($traverse_ifvlan) {
     $otherports = dbFetchRows('SELECT * FROM ports WHERE `device_id` = ? AND `ifVlan` = ?', array($device['device_id'], $vlan['vlan_vlan']));
     foreach ($otherports as $otherport) {
-        $vlan_ports[$otherport[ifIndex]] = array_merge($otherport, array('untagged' => '1'));
+        $vlan_ports[$otherport['ifIndex']] = array_merge($otherport, array('untagged' => '1'));
     }
 }
 
-  ksort($vlan_ports);
+ksort($vlan_ports);
 
 foreach ($vlan_ports as $port) {
     $port = ifLabel($port, $device);

--- a/includes/discovery/vlans/cisco-vtp.inc.php
+++ b/includes/discovery/vlans/cisco-vtp.inc.php
@@ -3,6 +3,9 @@
 if ($device['os_group'] == 'cisco') {
     echo "Cisco VLANs:\n";
 
+    $native_vlans = snmpwalk_cache_oid($device, 'vlanTrunkPortNativeVlan', array(), 'CISCO-VTP-MIB');
+    $native_vlans = snmpwalk_cache_oid($device, 'vmVlan', $native_vlans, 'CISCO-VLAN-MEMBERSHIP-MIB');
+
     // Not sure why we check for VTP, but this data comes from that MIB, so...
     $vtpversion = snmp_get($device, 'vtpVersion.0', '-OnvQ', 'CISCO-VTP-MIB');
     if ($vtpversion == '1' || $vtpversion == '2' || $vtpversion == '3' || $vtpversion == 'one' || $vtpversion == 'two' || $vtpversion == 'three' || $vtpversion == 'none') {
@@ -21,8 +24,42 @@ if ($device['os_group'] == 'cisco') {
                     echo '+';
                 }
                 $device['vlans'][$vtpdomain_id][$vlan_id] = $vlan_id;
+
+                if (is_numeric($vlan_id) && ($vlan_id < 1002 || $vlan_id > 1005)) {
+                    // Ignore reserved VLAN IDs
+                    // get dot1dStpPortEntry within the vlan context
+                    $vlan_device = array_merge($device, array('community' => $device['community'] . '@' . $vlan_id, 'context_name' => "vlan-$vlan_id"));
+                    $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dStpPortEntry', array(), 'BRIDGE-MIB');
+
+                    // may need to fetch additional dot1dBasePortIfIndex mappings
+                    $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dBasePortIfIndex', $tmp_vlan_data, 'BRIDGE-MIB');
+                    $vlan_data = array();
+                    // flatten the array, use ifIndex instead of dot1dBasePortId
+                    foreach ($tmp_vlan_data as $index => $array) {
+                        if (isset($array['dot1dBasePortIfIndex'])) {
+                            $base_to_index[$index] = $array['dot1dBasePortIfIndex'];
+                            $index_to_base[$array['dot1dBasePortIfIndex']] = $index;
+                        }
+                        $vlan_data[$base_to_index[$index]] = $array;
+                    }
+
+                    $per_vlan_data[$vlan_id] = $vlan_data;
+                }
             }
             echo PHP_EOL;
+
+            // set all untagged vlans
+            foreach ($native_vlans as $ifIndex => $data) {
+                if (isset($data['vmVlan'])) {
+                    $vlan_id = $data['vmVlan'];
+                } else {
+                    $vlan_id = $data['vlanTrunkPortNativeVlan'];
+                }
+                $base = $index_to_base[$ifIndex];
+                echo "Vlan: $vlan_id tagged on $base (ifIndex $ifIndex)\n";
+                $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = 1;
+            }
         }
     }
+    echo PHP_EOL;
 }

--- a/includes/discovery/vlans/q-bridge-mib.inc.php
+++ b/includes/discovery/vlans/q-bridge-mib.inc.php
@@ -6,12 +6,10 @@ $vlanversion = snmp_get($device, 'dot1qVlanVersionNumber.0', '-Oqv', 'IEEE8021-Q
 if ($vlanversion == 'version1' || $vlanversion == '2') {
     echo "ver $vlanversion ";
 
-    $qbridge_data = array();
     $vtpdomain_id = '1';
     $vlans        = snmpwalk_cache_oid($device, 'dot1qVlanStaticName', array(), 'Q-BRIDGE-MIB');
     $tagoruntag   = snmpwalk_cache_oid($device, 'dot1qVlanCurrentEgressPorts', array(), 'Q-BRIDGE-MIB', null, '-OQUs --hexOutputLength=0');
     $untag        = snmpwalk_cache_oid($device, 'dot1qVlanCurrentUntaggedPorts', array(), 'Q-BRIDGE-MIB', null, '-OQUs --hexOutputLength=0');
-    $base_indexes = snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', array(), 'BRIDGE-MIB');
 
     foreach ($vlans as $vlan_id => $vlan) {
         d_echo(" $vlan_id");
@@ -31,12 +29,12 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
         $device['vlans'][$vtpdomain_id][$vlan_id] = $vlan_id;
 
         $id = "0.$vlan_id";
-        $untagged_indexes = q_bridge_bits2indices($untag[$id]['dot1qVlanCurrentUntaggedPorts']);
-        $egress_indexes = q_bridge_bits2indices($tagoruntag[$id]['dot1qVlanCurrentEgressPorts']);
+        $untagged_ids = q_bridge_bits2indices($untag[$id]['dot1qVlanCurrentUntaggedPorts']);
+        $egress_ids = q_bridge_bits2indices($tagoruntag[$id]['dot1qVlanCurrentEgressPorts']);
 
-        foreach ($egress_indexes as $port_index) {
-            $qbridge_data[$vlan_id][$port_index] = $base_indexes[$port_index];
-            $qbridge_data[$vlan_id][$port_index]['untagged'] = (in_array($port_index, $untagged_indexes) ? 1 : 0);
+        foreach ($egress_ids as $port_id) {
+            $ifIndex = $base_to_index[$port_id];
+            $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = (in_array($port_id, $untagged_ids) ? 1 : 0);
         }
     }
 }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Store vlans in temp array indexed by ifIndex instead of dot1q base id
Improves vlan accuracy, ifVlan is not very reliable