### PR TITLE
fix: Fixed trying to map devices to alert rules

### DIFF
--- a/html/ajax_search.php
+++ b/html/ajax_search.php
@@ -59,7 +59,7 @@ if (isset($_REQUEST['search'])) {
 
                 foreach ($results as $result) {
                     $name = $result['hostname'];
-                    if ($result['sysName'] != $name && !empty($result['sysName'])) {
+                    if ($_REQUEST['map'] != 1 && $result['sysName'] != $name && !empty($result['sysName'])) {
                         $name .= ' ('.$result['sysName'].') ';
                     }
                     if ($result['disabled'] == 1) {


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

An earlier improvement for device search results meant that `HOSTNAME (SYSNAME)` was returned sometimes which breaks device mapping in alerts. We now check for map=1 before doing this now.