### PR TITLE
fix: Do not create rrd folder when -r is specified for poller

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -184,7 +184,7 @@ function poll_device($device, $options)
     $update_array = array();
 
     $host_rrd = $config['rrd_dir'].'/'.$device['hostname'];
-    if (!is_dir($host_rrd)) {
+    if ($config['norrd'] !== true && !is_dir($host_rrd)) {
         mkdir($host_rrd);
         echo "Created directory : $host_rrd\n";
     }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

This stops poller creating the rrd/devicename folder when -r is specified (no rrd flag) as when running capture in webui it would create folders with the web server user.