### PR TITLE
Add xdp device exclusion filters

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -140,6 +140,7 @@ LibreNMS contributors:
 - Layne Breitkreutz <github@thelenon.com> (Gorian)
 - Karl Shea <karl@karlshea.com> (karlshea)
 - Justin Settle <jus10@partlycloudy.org> (jquagga)
+- Eric Conroy <eric@conroy.co> (NetworkNub)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -67,17 +67,23 @@ Enabled by default.
 
 This includes FDP, CDP and LLDP support based on the device type.
 
-Devices may be excluded from xdp discovery by name, description, or platform.
+Devices may be excluded from xdp discovery by sysname and sysdesc.
 
 ```php
 //Exclude devices by name
-$config['autodiscovery']['xdp_exclude']['sysname_regexp'][] = '/^dev/'
+$config['autodiscovery']['xdp_exclude']['sysname_regexp'][] = '/host1/';
+$config['autodiscovery']['xdp_exclude']['sysname_regexp'][] = '/^dev/';
 
 //Exclude devices by description
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/unmanaged switch/'
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/Vendor X/';
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/Vendor Y/';
+```
 
+Devices may be excluded from cdp discovery by platform.
+
+```php
 //Exclude devices by platform(Cisco only)
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = 'WS-C3750G-12S'
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/WS-C3750G/';
 ```
 
 These devices are excluded by default:

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -67,6 +67,27 @@ Enabled by default.
 
 This includes FDP, CDP and LLDP support based on the device type.
 
+Devices may be excluded from xdp discovery by name, description, or platform.
+
+```php
+//Exclude devices by name
+$config['autodiscovery']['xdp_exclude']['sysname_regexp'][] = '/^dev/'
+
+//Exclude devices by description
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/unmanaged switch/'
+
+//Exclude devices by platform(Cisco only)
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = 'WS-C3750G-12S'
+```
+
+These devices are excluded by default:
+
+```php
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^CIVS-IPC-/'; //Cisco IP Camera
+```
+
 #### OSPF
 Enabled by default.
 

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -86,6 +86,13 @@ Devices may be excluded from cdp discovery by platform.
 $config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/WS-C3750G/';
 ```
 
+These devices are excluded by default:
+
+```php
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
+```
+
 #### OSPF
 Enabled by default.
 

--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -86,14 +86,6 @@ Devices may be excluded from cdp discovery by platform.
 $config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/WS-C3750G/';
 ```
 
-These devices are excluded by default:
-
-```php
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^CIVS-IPC-/'; //Cisco IP Camera
-```
-
 #### OSPF
 Enabled by default.
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -199,6 +199,8 @@ $config['icmp_check'] = true;
 
 // Autodiscovery Settings
 $config['autodiscovery']['xdp'] = true;
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
 // Autodiscover hosts via discovery protocols
 $config['autodiscovery']['ospf'] = true;
 // Autodiscover hosts via OSPF

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -199,9 +199,6 @@ $config['icmp_check'] = true;
 
 // Autodiscovery Settings
 $config['autodiscovery']['xdp'] = true;
-$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
-$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^CIVS-IPC-/'; //Cisco IP Camera
 // Autodiscover hosts via discovery protocols
 $config['autodiscovery']['ospf'] = true;
 // Autodiscover hosts via OSPF

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -199,6 +199,9 @@ $config['icmp_check'] = true;
 
 // Autodiscovery Settings
 $config['autodiscovery']['xdp'] = true;
+$config['autodiscovery']['xdp_exclude']['sysdesc_regexp'][] = '/-K9W8-/'; // Cisco Lightweight Access Point
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^Cisco IP Phone/'; //Cisco IP Phone
+$config['autodiscovery']['cdp_exclude']['platform_regexp'][] = '/^CIVS-IPC-/'; //Cisco IP Camera
 // Autodiscover hosts via discovery protocols
 $config['autodiscovery']['ospf'] = true;
 // Autodiscover hosts via OSPF

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -19,7 +19,23 @@ if ($device['os'] == 'ironware' && $config['autodiscovery']['xdp'] === true) {
                 $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']));
 
                 if (!$remote_device_id) {
-                    $remote_device_id = discover_new_device($fdp['snFdpCacheDeviceId'], $device, 'FDP', $interface);
+                    unset($skip_discovery);
+                    foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
+                        if (preg_match($filter ."i", $fdp['snFdpCacheDeviceId'])) {
+                            $skip_discovery = 1;
+                            d_echo("{$fdp['snFdpCacheDeviceId']} - regexp '{$filter}' matches '{$fdp['snFdpCacheDeviceId']}' - skipping device discovery \n");
+                        }
+                    }
+                    foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
+                        if (preg_match($filter ."i", $fdp['cdpCacheVersion'])) {
+                            $skip_discovery = 1;
+                            d_echo("{$fdp['snFdpCacheDeviceId']} - regexp '{$filter}' matches '{$fdp['cdpCacheVersion']}' - skipping device discovery \n");
+                        }
+                    }
+
+                    if (!$skip_discovery) {
+                        $remote_device_id = discover_new_device($fdp['snFdpCacheDeviceId'], $device, 'FDP', $interface);
+                    }
                 }
 
                 if ($remote_device_id) {
@@ -52,19 +68,41 @@ if ($config['autodiscovery']['xdp'] === true) {
                     $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']));
 
                     if (!$remote_device_id) {
-                        if ($config['discovery_by_ip'] !== true) {
-                            $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
-                        } else {
-                            $ip_arr = explode(" ", $cdp['cdpCacheAddress']);
+                        unset($skip_discovery);
+                        foreach ($config['autodiscovery']['cdp_exclude']['platform_regexp'] as $filter) {
+                            if (preg_match($filter ."i", $cdp['cdpCachePlatform'])) {
+                                $skip_discovery = 1;
+                                d_echo("{$cdp['cdpCacheDeviceId']} - regexp '{$filter}' matches '{$cdp['cdpCachePlatform']}' - skipping device discovery \n");
+                            }
+                        }
+                        foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
+                            if (preg_match($filter ."i", $cdp['cdpCacheDeviceId'])) {
+                                $skip_discovery = 1;
+                                d_echo("{$cdp['cdpCacheDeviceId']} - regexp '{$filter}' matches '{$cdp['cdpCacheDeviceId']}' - skipping device discovery \n");
+                            }
+                        }
+                        foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
+                            if (preg_match($filter ."i", $cdp['cdpCacheVersion'])) {
+                                $skip_discovery = 1;
+                                d_echo("{$cdp['cdpCacheDeviceId']} - regexp '{$filter}' matches '{$cdp['cdpCacheVersion']}' - skipping device discovery \n");
+                            }
+                        }
 
-                            $a = hexdec($ip_arr[0]);
-                            $b = hexdec($ip_arr[1]);
-                            $c = hexdec($ip_arr[2]);
-                            $d = hexdec($ip_arr[3]);
+                        if (!$skip_discovery) {
+                            if ($config['discovery_by_ip'] !== true) {
+                                $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
+                            } else {
+                                $ip_arr = explode(" ", $cdp['cdpCacheAddress']);
 
-                            $cdp_ip = "$a.$b.$c.$d";
+                                $a = hexdec($ip_arr[0]);
+                                $b = hexdec($ip_arr[1]);
+                                $c = hexdec($ip_arr[2]);
+                                $d = hexdec($ip_arr[3]);
 
-                            $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
+                                $cdp_ip = "$a.$b.$c.$d";
+
+                                $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
+                            }
                         }
                     }
 
@@ -102,7 +140,23 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
             $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
 
             if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
-                $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+                unset($skip_discovery);
+                foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
+                    if (preg_match($filter ."i", $lldp['lldpRemSysName'])) {
+                        $skip_discovery = 1;
+                        d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysName']}' - skipping device discovery \n");
+                    }
+                }
+                foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
+                    if (preg_match($filter ."i", $lldp['lldpRemSysDesc'])) {
+                        $skip_discovery = 1;
+                        d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysDesc']}' - skipping device discovery \n");
+                    }
+                }
+
+                if (!$skip_discovery) {
+                    $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+                }
             }
 
             if ($remote_device_id) {
@@ -144,7 +198,23 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                     $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
 
                     if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
-                        $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+                        unset($skip_discovery);
+                        foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
+                            if (preg_match($filter ."i", $lldp['lldpRemSysName'])) {
+                                $skip_discovery = 1;
+                                d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysName']}' - skipping device discovery \n");
+                            }
+                        }
+                        foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
+                            if (preg_match($filter ."i", $lldp['lldpRemSysDesc'])) {
+                                $skip_discovery = 1;
+                                d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysDesc']}' - skipping device discovery \n");
+                            }
+                        }
+
+                        if (!$skip_discovery) {
+                            $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+                        }
                     }
                     // normalize MAC address if present
                     $remote_port_mac_address = '';

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -24,7 +24,7 @@ if ($device['os'] == 'ironware' && $config['autodiscovery']['xdp'] === true) {
                         $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysname_regexp'], $fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']);
                     }
                     if ($skip_discovery === false) {
-                        $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $fdp['cdpCacheVersion'], $fdp['snFdpCacheDeviceId']);
+                        $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $fdp['snFdpCacheVersion'], $fdp['snFdpCacheDeviceId']);
                     }
 
                     if ($skip_discovery === false) {

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -19,21 +19,15 @@ if ($device['os'] == 'ironware' && $config['autodiscovery']['xdp'] === true) {
                 $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']));
 
                 if (!$remote_device_id) {
-                    unset($skip_discovery);
-                    foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
-                        if (preg_match($filter ."i", $fdp['snFdpCacheDeviceId'])) {
-                            $skip_discovery = 1;
-                            d_echo("{$fdp['snFdpCacheDeviceId']} - regexp '{$filter}' matches '{$fdp['snFdpCacheDeviceId']}' - skipping device discovery \n");
-                        }
+                    $skip_discovery = false;
+                    if ($skip_discovery === false) {
+                        $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysname_regexp'], $fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']);
                     }
-                    foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
-                        if (preg_match($filter ."i", $fdp['cdpCacheVersion'])) {
-                            $skip_discovery = 1;
-                            d_echo("{$fdp['snFdpCacheDeviceId']} - regexp '{$filter}' matches '{$fdp['cdpCacheVersion']}' - skipping device discovery \n");
-                        }
+                    if ($skip_discovery === false) {
+                        $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $fdp['cdpCacheVersion'], $fdp['snFdpCacheDeviceId']);
                     }
 
-                    if (!$skip_discovery) {
+                    if ($skip_discovery === false) {
                         $remote_device_id = discover_new_device($fdp['snFdpCacheDeviceId'], $device, 'FDP', $interface);
                     }
                 }
@@ -68,27 +62,18 @@ if ($config['autodiscovery']['xdp'] === true) {
                     $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']));
 
                     if (!$remote_device_id) {
-                        unset($skip_discovery);
-                        foreach ($config['autodiscovery']['cdp_exclude']['platform_regexp'] as $filter) {
-                            if (preg_match($filter ."i", $cdp['cdpCachePlatform'])) {
-                                $skip_discovery = 1;
-                                d_echo("{$cdp['cdpCacheDeviceId']} - regexp '{$filter}' matches '{$cdp['cdpCachePlatform']}' - skipping device discovery \n");
-                            }
+                        $skip_discovery = false;
+                        if ($skip_discovery === false) {
+                            $skip_discovery = can_skip_discovery($config['autodiscovery']['cdp_exclude']['platform_regexp'], $cdp['cdpCachePlatform'], $cdp['cdpCacheDeviceId']);
                         }
-                        foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
-                            if (preg_match($filter ."i", $cdp['cdpCacheDeviceId'])) {
-                                $skip_discovery = 1;
-                                d_echo("{$cdp['cdpCacheDeviceId']} - regexp '{$filter}' matches '{$cdp['cdpCacheDeviceId']}' - skipping device discovery \n");
-                            }
+                        if ($skip_discovery === false) {
+                            $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysname_regexp'], $cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']);
                         }
-                        foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
-                            if (preg_match($filter ."i", $cdp['cdpCacheVersion'])) {
-                                $skip_discovery = 1;
-                                d_echo("{$cdp['cdpCacheDeviceId']} - regexp '{$filter}' matches '{$cdp['cdpCacheVersion']}' - skipping device discovery \n");
-                            }
+                        if ($skip_discovery === false) {
+                            $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $cdp['cdpCacheVersion'], $cdp['cdpCacheDeviceId']);
                         }
 
-                        if (!$skip_discovery) {
+                        if ($skip_discovery === false) {
                             if ($config['discovery_by_ip'] !== true) {
                                 $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
                             } else {
@@ -140,21 +125,15 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
             $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
 
             if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
-                unset($skip_discovery);
-                foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
-                    if (preg_match($filter ."i", $lldp['lldpRemSysName'])) {
-                        $skip_discovery = 1;
-                        d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysName']}' - skipping device discovery \n");
-                    }
+                $skip_discovery = false;
+                if ($skip_discovery === false) {
+                    $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysname_regexp'], $lldp['lldpRemSysName'], $lldp['lldpRemSysName']);
                 }
-                foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
-                    if (preg_match($filter ."i", $lldp['lldpRemSysDesc'])) {
-                        $skip_discovery = 1;
-                        d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysDesc']}' - skipping device discovery \n");
-                    }
+                if ($skip_discovery === false) {
+                    $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $lldp['lldpRemSysDesc'], $lldp['lldpRemSysName']);
                 }
 
-                if (!$skip_discovery) {
+                if ($skip_discovery === false) {
                     $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
                 }
             }
@@ -198,21 +177,15 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                     $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
 
                     if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
-                        unset($skip_discovery);
-                        foreach ($config['autodiscovery']['xdp_exclude']['sysname_regexp'] as $filter) {
-                            if (preg_match($filter ."i", $lldp['lldpRemSysName'])) {
-                                $skip_discovery = 1;
-                                d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysName']}' - skipping device discovery \n");
-                            }
+                        $skip_discovery = false;
+                        if ($skip_discovery === false) {
+                            $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysname_regexp'], $lldp['lldpRemSysName'], $lldp['lldpRemSysName']);
                         }
-                        foreach ($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'] as $filter) {
-                            if (preg_match($filter ."i", $lldp['lldpRemSysDesc'])) {
-                                $skip_discovery = 1;
-                                d_echo("{$lldp['lldpRemSysName']} - regexp '{$filter}' matches '{$lldp['lldpRemSysDesc']}' - skipping device discovery \n");
-                            }
+                        if ($skip_discovery === false) {
+                            $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $lldp['lldpRemSysDesc'], $lldp['lldpRemSysName']);
                         }
 
-                        if (!$skip_discovery) {
+                        if ($skip_discovery === true) {
                             $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
                         }
                     }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -185,7 +185,7 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                             $skip_discovery = can_skip_discovery($config['autodiscovery']['xdp_exclude']['sysdesc_regexp'], $lldp['lldpRemSysDesc'], $lldp['lldpRemSysName']);
                         }
 
-                        if ($skip_discovery === true) {
+                        if ($skip_discovery === false) {
                             $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
                         }
                     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1736,3 +1736,21 @@ function get_toner_levels($device, $raw_value, $capacity)
 
     return round($raw_value / $capacity * 100);
 }
+
+/**
+ * check if we should skip this device from discovery
+ * @param $needles
+ * @param $haystack
+ * @param $name
+ * @return bool
+ */
+function can_skip_discovery($needles, $haystack, $name)
+{
+    foreach ((array)$needles as $needle) {
+        if (preg_match($needle ."i", $haystack)) {
+            d_echo("{$name} - regexp '{$needle}' matches '{$haystack}' - skipping device discovery \n");
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes #2968

Adds filters to exclude devices from being discovered via xdp. This increases discovery performance of devices when connected to non snmp capable devices like phones and APs.