### PR TITLE
UniFi Wireless MIB polling for Capacity

### DIFF
--- a/html/includes/graphs/device/ubnt_unifi_RadioCu_0.inc.php
+++ b/html/includes/graphs/device/ubnt_unifi_RadioCu_0.inc.php
@@ -1,0 +1,35 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'ubnt-unifi-mib');
+
+$colours = 'mixed';
+$unit_text = '% used';
+$scale_min = '0';
+$scale_max = '100';
+$rigid = true;
+$print_total = true;
+$simple_rrd = true;
+
+if (is_file($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'ds' => 'Radio0OtherBss',
+            'filename' => $rrd_filename,
+            'descr' => 'Radio0 Others',
+        ),
+        array(
+            'ds' => 'Radio0CuSelfRx',
+            'filename' => $rrd_filename,
+            'descr' => 'Radio0 RX',
+        ),
+        array(
+            'ds' => 'Radio0CuSelfTx',
+            'filename' => $rrd_filename,
+            'descr' => 'Radio0 TX',
+        ),
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi.inc.php';

--- a/html/includes/graphs/device/ubnt_unifi_RadioCu_0.inc.php
+++ b/html/includes/graphs/device/ubnt_unifi_RadioCu_0.inc.php
@@ -10,7 +10,7 @@ $rigid = true;
 $print_total = true;
 $simple_rrd = true;
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'ds' => 'Radio0OtherBss',

--- a/html/includes/graphs/device/ubnt_unifi_RadioCu_1.inc.php
+++ b/html/includes/graphs/device/ubnt_unifi_RadioCu_1.inc.php
@@ -1,0 +1,35 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'ubnt-unifi-mib');
+
+$colours = 'mixed';
+$unit_text = '% used';
+$scale_min = '0';
+$scale_max = '100';
+$rigid = true;
+$print_total = true;
+$simple_rrd = true;
+
+if (is_file($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'ds' => 'Radio1OtherBss',
+            'filename' => $rrd_filename,
+            'descr' => 'Radio1 Others',
+        ),
+        array(
+            'ds' => 'Radio1CuSelfRx',
+            'filename' => $rrd_filename,
+            'descr' => 'Radio1 RX',
+        ),
+        array(
+            'ds' => 'Radio1CuSelfTx',
+            'filename' => $rrd_filename,
+            'descr' => 'Radio1 TX',
+        ),
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi.inc.php';

--- a/html/includes/graphs/device/ubnt_unifi_RadioCu_1.inc.php
+++ b/html/includes/graphs/device/ubnt_unifi_RadioCu_1.inc.php
@@ -10,7 +10,7 @@ $rigid = true;
 $print_total = true;
 $simple_rrd = true;
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'ds' => 'Radio1OtherBss',

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -2288,6 +2288,15 @@ $config['graph_types']['device']['ubnt_airfiber_RFTotPktsRx']['section'] = 'wire
 $config['graph_types']['device']['ubnt_airfiber_RFTotPktsRx']['order'] = '7';
 $config['graph_types']['device']['ubnt_airfiber_RFTotPktsRx']['descr'] = 'RF Total Packets Rx';
 
+// Unifi Support
+$config['graph_types']['device']['ubnt_unifi_RadioCu_0']['section'] = 'wireless';
+$config['graph_types']['device']['ubnt_unifi_RadioCu_0']['order'] = '0';
+$config['graph_types']['device']['ubnt_unifi_RadioCu_0']['descr'] = 'Radio0 Capacity Used';
+
+$config['graph_types']['device']['ubnt_unifi_RadioCu_1']['section'] = 'wireless';
+$config['graph_types']['device']['ubnt_unifi_RadioCu_1']['order'] = '1';
+$config['graph_types']['device']['ubnt_unifi_RadioCu_1']['descr'] = 'Radio1 Capacity Used';
+
 // Siklu support
 $config['graph_types']['device']['siklu_rfAverageRssi']['section'] = 'wireless';
 $config['graph_types']['device']['siklu_rfAverageRssi']['order'] = '0';

--- a/includes/polling/mib/ubnt-unifi-mib.inc.php
+++ b/includes/polling/mib/ubnt-unifi-mib.inc.php
@@ -1,0 +1,69 @@
+<?php
+// Polling of UniFi MIB AP for Ubiquiti Unifi Radios
+// based on Airfiber MIB work of Mark Gibbons
+
+// UBNT-UniFi-MIB
+echo ' UBNT-UniFi-MIB ';
+
+// $mib_oids     (oidindex,dsname,dsdescription,dstype)
+$mib_oids = array(
+    'unifiRadioCuTotal.0'                 => array(
+        '',
+        'Radio0CuTotal',
+        'Radio0 Channel Utilized',
+        'GAUGE',
+    ),
+    'unifiRadioCuTotal.1'                 => array(
+        '',
+        'Radio1CuTotal',
+        'Radio1 Channel Utilized',
+        'GAUGE',
+    ),
+    'unifiRadioCuSelfRx.0'                 => array(
+        '',
+        'Radio0CuSelfRx',
+        'Radio0 Channel Utilized Rx',
+        'GAUGE',
+    ),
+    'unifiRadioCuSelfRx.1'                 => array(
+        '',
+        'Radio1CuSelfRx',
+        'Radio1 Channel Utilized Rx',
+        'GAUGE',
+    ),
+    'unifiRadioCuSelfTx.0'                 => array(
+        '',
+        'Radio0CuSelfTx',
+        'Radio0 Channel Utilized Tx',
+        'GAUGE',
+    ),
+    'unifiRadioCuSelfTx.1'                 => array(
+        '',
+        'Radio1CuSelfTx',
+        'Radio1 Channel Utilized Tx',
+        'GAUGE',
+    ),
+    'unifiRadioOtherBss.0'                 => array(
+        '',
+        'Radio0OtherBss',
+        'Radio0 Channel Utilized by Others',
+        'GAUGE',
+    ),
+    'unifiRadioOtherBss.1'                 => array(
+        '',
+        'Radio1OtherBss',
+        'Radio1 Channel Utilized by Others',
+        'GAUGE',
+    ),
+);
+
+
+$mib_graphs = array(
+    'ubnt_unifi_RadioCu_0',
+    'ubnt_unifi_RadioCu_1',
+);
+
+unset($graph, $oids, $oid);
+
+poll_mib_def($device, 'UBNT-UniFi-MIB:UBNT', 'ubiquiti', $mib_oids, $mib_graphs, $graphs);
+// EOF

--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -77,6 +77,7 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         }
 
         echo (($wificlients1 + 0).' clients on Radio0, '.($wificlients2 + 0)." clients on Radio1\n");
+        include 'includes/polling/mib/ubnt-unifi-mib.inc.php';
     }
 
     if (isset($wificlients1) && $wificlients1 != '') {

--- a/mibs/UBNT-UniFi-MIB
+++ b/mibs/UBNT-UniFi-MIB
@@ -1,0 +1,606 @@
+UBNT-UniFi-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Unsigned32, Counter32, Gauge32, IpAddress, enterprises 
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString, MacAddress, DateAndTime, TruthValue 
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP 
+        FROM SNMPv2-CONF
+    ubntMIB, ubntUniFi, ubntUniFiGroups
+        FROM UBNT-MIB;
+
+ubntUniFi MODULE-IDENTITY
+  LAST-UPDATED "201606250000Z"
+  ORGANIZATION "Ubiquiti Networks, Inc."
+  CONTACT-INFO "support@ubnt.com"
+  DESCRIPTION "The UniFi MIB module for Ubiquiti Networks, Inc. entities"
+  REVISION "201606250000Z"
+  DESCRIPTION "Initial Revision."
+  ::= { ubntMIB 6 }
+
+unifiApWireless OBJECT IDENTIFIER ::= { ubntUniFi 1 }
+unifiApIf       OBJECT IDENTIFIER ::= { ubntUniFi 2 }
+unifiApSystem   OBJECT IDENTIFIER ::= { ubntUniFi 3 }
+
+
+TableIndex ::= TEXTUAL-CONVENTION
+	DISPLAY-HINT	"d"
+	STATUS			current
+	DESCRIPTION
+		"A unique value, greater than zero. It is recommended
+		that values are assigned contiguously starting from 1."
+	SYNTAX			Integer32 (1..2147483647)
+
+
+ObjectIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "x"
+    STATUS current
+    DESCRIPTION "Internal "
+    SYNTAX Integer32 (0..2147483647)
+-- SYNTAX Integer32 (-2147483648..2147483647)
+-- SYNTAX Unsigned32 (0..4294967295)
+
+Voltage ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d-2"
+    STATUS current
+    DESCRIPTION ""
+    SYNTAX Integer32 (-2147483648..2147483647)
+
+Temperature ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d-1"
+    STATUS current
+    DESCRIPTION ""
+    SYNTAX Integer32 (-2147483648..2147483647)
+
+unifiIfTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF UbntIfEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApIf 1 }
+
+unifiIfEntry OBJECT-TYPE
+    SYNTAX UbntIfEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION "Ethernet interface"
+    INDEX { unifiIfIndex }
+    ::= { unifiIfTable 1 }
+    
+UbntIfEntry ::= SEQUENCE {
+    unifiIfIndex ObjectIndex,
+    unifiIfFullDuplex TruthValue,
+    unifiIfIp IpAddress,
+    unifiIfMac MacAddress,
+    unifiIfName DisplayString,
+    unifiIfRxBytes Counter32,
+    unifiIfRxDropped Counter32,
+    unifiIfRxError Counter32,
+    unifiIfRxMulticast Counter32,
+    unifiIfRxPackets Counter32,
+    unifiIfSpeed Integer32,
+    unifiIfTxBytes Counter32,
+    unifiIfTxDropped Counter32,
+    unifiIfTxError Counter32,
+    unifiIfTxPackets Counter32,
+    unifiIfUp TruthValue
+}
+
+unifiIfIndex OBJECT-TYPE
+    SYNTAX ObjectIndex
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 1 }
+
+unifiIfFullDuplex OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 2 }
+
+unifiIfIp OBJECT-TYPE
+    SYNTAX IpAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 3 }
+
+unifiIfMac OBJECT-TYPE
+    SYNTAX MacAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 4 }
+
+unifiIfName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 5 }
+
+unifiIfRxBytes OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 6 }
+
+unifiIfRxDropped OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 7 }
+
+unifiIfRxError OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 8 }
+
+unifiIfRxMulticast OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 9 }
+
+unifiIfRxPackets OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 10 }
+
+unifiIfSpeed OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 11 }
+
+unifiIfTxBytes OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 12 }
+
+unifiIfTxDropped OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 13 }
+
+unifiIfTxError OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 14 }
+
+unifiIfTxPackets OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 15 }
+
+unifiIfUp OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiIfEntry 16 }
+
+unifiRadioTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF UbntRadioEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApWireless 1 }
+
+unifiRadioEntry OBJECT-TYPE
+    SYNTAX UbntRadioEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION "Wireless interface"
+    INDEX { unifiRadioIndex }
+    ::= { unifiRadioTable 1 }
+
+UbntRadioEntry ::= SEQUENCE {
+    unifiRadioIndex ObjectIndex,
+    unifiRadioName DisplayString,
+    unifiRadioRadio DisplayString,
+    unifiRadioRxPackets Counter32,
+    unifiRadioTxPackets Counter32,
+    unifiRadioCuTotal Integer32,
+    unifiRadioCuSelfRx Integer32,
+    unifiRadioCuSelfTx Integer32,
+    unifiRadioOtherBss Integer32
+}
+
+unifiRadioIndex OBJECT-TYPE
+    SYNTAX ObjectIndex
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 1 }
+
+unifiRadioName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 2 }
+
+unifiRadioRadio OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 3 }
+
+unifiRadioRxPackets OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 4 }
+
+unifiRadioTxPackets OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 5 }
+
+unifiRadioCuTotal OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 6 }
+
+unifiRadioCuSelfRx OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 7 }
+
+unifiRadioCuSelfTx OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 8 }
+
+unifiRadioOtherBss OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiRadioEntry 9 }
+
+unifiVapTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF UbntVapEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApWireless 2 }
+
+unifiVapEntry OBJECT-TYPE
+    SYNTAX UbntVapEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION "BSS"
+    INDEX { unifiVapIndex }
+    ::= { unifiVapTable 1 }
+
+UbntVapEntry ::= SEQUENCE {
+    unifiVapIndex ObjectIndex,
+    unifiVapBssId MacAddress,
+    unifiVapCcq Integer32,
+    unifiVapChannel Integer32,
+    unifiVapExtChannel Integer32,
+    unifiVapEssId DisplayString,
+    unifiVapName DisplayString,
+    unifiVapNumStations Integer32,
+    unifiVapRadio DisplayString,
+    unifiVapRxBytes Counter32,
+    unifiVapRxCrypts Counter32,
+    unifiVapRxDropped Counter32,
+    unifiVapRxErrors Counter32,
+    unifiVapRxFrags Counter32,
+    unifiVapRxPackets Counter32,
+    unifiVapTxBytes Counter32,
+    unifiVapTxDropped Counter32,
+    unifiVapTxErrors Counter32,
+    unifiVapTxPackets Counter32,
+    unifiVapTxRetries Counter32,
+    unifiVapTxPower Integer32,
+    unifiVapUp TruthValue,
+    unifiVapUsage DisplayString
+}
+
+unifiVapIndex OBJECT-TYPE
+    SYNTAX ObjectIndex
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 1 }
+
+unifiVapBssId OBJECT-TYPE
+    SYNTAX MacAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 2 }
+
+unifiVapCcq OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 3 }
+
+unifiVapChannel OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 4 }
+
+unifiVapExtChannel OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 5 }
+
+unifiVapEssId OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 6 }
+
+unifiVapName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 7 }
+
+unifiVapNumStations OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 8 }
+
+unifiVapRadio OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 9 }
+
+unifiVapRxBytes OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 10 }
+
+unifiVapRxCrypts OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 11 }
+
+unifiVapRxDropped OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 12 }
+
+unifiVapRxErrors OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 13 }
+
+unifiVapRxFrags OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 14 }
+
+unifiVapRxPackets OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 15 }
+
+unifiVapTxBytes OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 16 }
+
+unifiVapTxDropped OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 17 }
+
+unifiVapTxErrors OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 18 }
+
+unifiVapTxPackets OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 19 }
+
+unifiVapTxRetries OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 20 }
+
+unifiVapTxPower OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 21 }
+
+unifiVapUp OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiVapEntry 22 }
+
+unifiVapUsage OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION "guest or regular user"
+    ::= { unifiVapEntry 23 }
+
+unifiApSystemIp OBJECT-TYPE
+    SYNTAX IpAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApSystem 1 }
+
+unifiApSystemIsolated OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApSystem 2 }
+
+unifiApSystemModel OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApSystem 3 }
+
+unifiApSystemUplink OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApSystem 4 }
+
+unifiApSystemUptime OBJECT-TYPE
+    SYNTAX Counter32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApSystem 5 }
+
+unifiApSystemVersion OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION ""
+    ::= { unifiApSystem 6 }
+
+unifiIfGroup OBJECT-GROUP OBJECTS {
+    unifiIfFullDuplex,
+    unifiIfIp,
+    unifiIfMac,
+    unifiIfName,
+    unifiIfRxBytes,
+    unifiIfRxDropped,
+    unifiIfRxError,
+    unifiIfRxMulticast,
+    unifiIfRxPackets,
+    unifiIfSpeed,
+    unifiIfTxBytes,
+    unifiIfTxDropped,
+    unifiIfTxError,
+    unifiIfTxPackets,
+    unifiIfUp
+    }
+    STATUS current
+    DESCRIPTION ""
+    ::= { ubntUniFiGroups 1 }
+
+unifiRadioGroups OBJECT-GROUP OBJECTS {
+    unifiRadioName,
+    unifiRadioRadio,
+    unifiRadioRxPackets,
+    unifiRadioTxPackets,
+    unifiRadioCuTotal,
+    unifiRadioCuSelfRx,
+    unifiRadioCuSelfTx,
+    unifiRadioOtherBss 
+    }
+    STATUS current
+    DESCRIPTION ""
+    ::= { ubntUniFiGroups 2 }
+
+unifiVapGroups OBJECT-GROUP OBJECTS {
+    unifiVapBssId,
+    unifiVapCcq,
+    unifiVapChannel,
+    unifiVapExtChannel,
+    unifiVapEssId,
+    unifiVapName,
+    unifiVapNumStations,
+    unifiVapRadio, 
+    unifiVapRxBytes,
+    unifiVapRxCrypts,
+    unifiVapRxDropped,
+    unifiVapRxErrors,
+    unifiVapRxFrags,
+    unifiVapRxPackets,
+    unifiVapTxBytes,
+    unifiVapTxDropped,
+    unifiVapTxErrors,
+    unifiVapTxPackets,
+    unifiVapTxRetries,
+    unifiVapTxPower,
+    unifiVapUp,
+    unifiVapUsage
+    }
+    STATUS current
+    DESCRIPTION ""
+    ::= { ubntUniFiGroups 3 }
+
+unifiApSystemGroup OBJECT-GROUP OBJECTS {
+   unifiApSystemIp, unifiApSystemIsolated, unifiApSystemModel, unifiApSystemUplink, unifiApSystemUptime, unifiApSystemVersion
+   }
+   STATUS current
+   DESCRIPTION ""
+   ::= { ubntUniFiGroups 4 }
+
+END


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Ok, this is the code I'm presently using to monitor Ubiquiti Unifi Wireless AP's Capacity Used.  8 oids polled, 6 graphed, 3 each on 2 graphs, 1 for each radio.  The extra two oids are the Total's which I figure would be useful for alerts (i.e. your AP is at 95% usage).  

There are two commits in this PR.  The first is the MIB right from UBNT.  The other is the code to poll it and graph it based on the existing code for ubnt-AirFiber/AirMax and help from @laf / @murrant especially with the graphs!  

This may close #4266, it adds the mib and polling for one of the more desired OIDs.  It doesn't poll everything the MIB adds but I feel much of that is already provided by the IF polling.  This capacity graph was the biggest added item.  

![screenshot](https://cloud.githubusercontent.com/assets/5832772/19443659/707f973c-945b-11e6-8e06-08e05cc86ff5.png)

