### PR TITLE
Correct extra \ on wifi_clients graph MAX line

### DIFF
--- a/html/includes/graphs/device/wifi_clients.inc.php
+++ b/html/includes/graphs/device/wifi_clients.inc.php
@@ -13,12 +13,12 @@ if (file_exists($radio1)) {
     $rrd_options .= " LINE1:wificlients1#CC0000:'Clients on Radio1    ' ";
     $rrd_options .= ' GPRINT:wificlients1:LAST:%3.0lf ';
     $rrd_options .= ' GPRINT:wificlients1:MIN:%3.0lf ';
-    $rrd_options .= ' GPRINT:wificlients1:MAX:%3.0lf\\\l ';
+    $rrd_options .= ' GPRINT:wificlients1:MAX:%3.0lf\l ';
     if (file_exists($radio2)) {
         $rrd_options .= ' DEF:wificlients2='.$radio2.':wificlients:AVERAGE ';
         $rrd_options .= " LINE1:wificlients2#008C00:'Clients on Radio2    ' ";
         $rrd_options .= ' GPRINT:wificlients2:LAST:%3.0lf ';
         $rrd_options .= ' GPRINT:wificlients2:MIN:%3.0lf ';
-        $rrd_options .= ' GPRINT:wificlients2:MAX:%3.0lf\\\l ';
+        $rrd_options .= ' GPRINT:wificlients2:MAX:%3.0lf\l ';
     }
 }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

The wifi client graph has an extra \ tacked on to the end of the MAX line.  It looks like it may be from code to insert a newline, but instead a \l was added.  So, this humble PR simply deletes the "\\\\" which removes the extra \ from the generated graph.  

![screenshot-fs8](https://cloud.githubusercontent.com/assets/5832772/19519939/0fd72daa-95dc-11e6-9205-6703a2b85d5c.png)


