### PR TITLE
fix: incomplete polling on aruba controllers

### DIFF
--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -23,22 +23,26 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
     $switch_apname_oids = array('wlsxWlanRadioEntry.16');
 
 
+    // initialize arrays to avoid overwriting them in foreach loops below
+    $aruba_stats = array();
+    $aruba_apstats = array();
+    $aruba_apnames = array();
 
     $aruba_oids = array_merge($switch_info_oids, $switch_counter_oids);
     echo 'Caching Oids: ';
     foreach ($aruba_oids as $oid) {
         echo "$oid ";
-        $aruba_stats = snmpwalk_cache_oid($device, $oid, array(), 'WLSX-SWITCH-MIB');
+        $aruba_stats = snmpwalk_cache_oid($device, $oid, $aruba_stats, 'WLSX-SWITCH-MIB');
     }
 
     foreach ($switch_apinfo_oids as $oid) {
         echo "$oid ";
-        $aruba_apstats = snmpwalk_cache_oid_num($device, $oid, array(), 'WLSX-WLAN-MIB');
+        $aruba_apstats = snmpwalk_cache_oid_num($device, $oid, $aruba_apstats, 'WLSX-WLAN-MIB');
     }
 
     foreach ($switch_apname_oids as $oid) {
         echo "$oid ";
-        $aruba_apnames = snmpwalk_cache_oid_num($device, $oid, array(), 'WLSX-WLAN-MIB');
+        $aruba_apnames = snmpwalk_cache_oid_num($device, $oid, $aruba_apnames, 'WLSX-WLAN-MIB');
     }
 
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Details:
RRD graphs are incomplete because, while the poller is gathering all of the desired data, the foreach loops overwrite all gathered data except for the data gathered in the last iteration.

This causes certain info, such as the number of APs, or most AP stats to be discarded and not stored in the RRD.

Fix:
1) initialize the three arrays storing gathered data before looping.
2) reference the previously initialized arrays when calling snmpwalk_cache_oid_num() in each loop, so that the information accumulates with each iteration.