### PR TITLE
Wifi Polling for 0 Clients fix

### DIFF
--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -80,7 +80,7 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         include 'includes/polling/mib/ubnt-unifi-mib.inc.php';
     }
 
-    if (isset($wificlients1) && $wificlients1 != '') {
+    if (is_numeric($wificlients1)) {
         $tags = array(
             'rrd_def'   => 'DS:wificlients:GAUGE:600:-273:1000',
             'rrd_name'  => array('wificlients', 'radio1'),
@@ -90,7 +90,7 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         $graphs['wifi_clients'] = true;
     }
 
-    if (isset($wificlients2) && $wificlients2 != '') {
+    if (is_numeric($wificlients2)) {
         $tags = array(
             'rrd_def'   => 'DS:wificlients:GAUGE:600:-273:1000',
             'rrd_name'  => array('wificlients', 'radio2'),


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

So something has been bothering me about the wireless client graphs.  It would never graph when an AP had 0 clients on it.  I initially thought this was a rrdgraph issue, but I re-built the graph code and it still didn't improve the situation.  I also thought it odd that the snmpwalk result and the poller result I saw in debug reported 0 clients, yet the graph never reported less than 1.  rrdtool dumping the file also showed it never reported a value of 0 clients (which for some of my AP radios was just impossible).  

I believe the attached code is the culprit.  As @murrant just mentioned to me on IRC, isset for 0 returns false so this if statement doesn't pass and wificlients1 or 2 isn't updated to zero.  Now what I think then happens if it stays like that is the heartbeat eventually drops out and the graph stops recording.  So it opens up the hole in the graph you see above instead of graphing at zero.  My guess is that has always just been perceived as the zero value.  

This diff sets the if check to use is_numeric();.  I'm not sure if that's appropriate but it does work here.  0's are now being recorded.  