### PR TITLE
Fix the detection of NX-OS fan names

### DIFF
--- a/includes/discovery/sensors/states/nxos.inc.php
+++ b/includes/discovery/sensors/states/nxos.inc.php
@@ -22,15 +22,14 @@ if ($device['os'] == 'nxos') {
      */
 
     if (is_array($fan_trays)) {
-        $entity_oid = '.1.3.6.1.2.1.47.1.1.1.1.7';
-        $entities = snmpwalk_cache_oid_num($device, $entity_oid, array());
-
         foreach ($fan_trays as $oid => $array) {
             $state = current($array);
             $split_oid = explode('.', $oid);
             $index = $split_oid[(count($split_oid) - 1)];
             $current_oid = "$fan_tray_oid.$index";
-            $descr = current($entities["$entity_oid.$index"]);
+
+            $entity_oid = '.1.3.6.1.2.1.47.1.1.1.1.7';
+            $descr = trim(snmp_get($device, "$entity_oid.$index", '-Ovq'), '"');
 
             $state_name = "cefcFanTrayOperStatus";
             $state_index_id = create_state_index($state_name);


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

The patch that was commited to add this was modified so that the method of detecting the name of the fan was broken. This restores that.