### PR TITLE
feature: Added custom css and include directories which are ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@
 /composer.lock
 Thumbs.db
 config.php
+html/css/custom/*
 html/plugins/*
 !html/plugins/Test/
+includes/custom/*
 junk
 logs
 nbproject

--- a/doc/Developing/Code-Structure.md
+++ b/doc/Developing/Code-Structure.md
@@ -17,6 +17,8 @@ This is the API routing file which directs users to the correct API function bas
 This is the main file which all links within LibreNMS are parsed through. It loads the majority of the relevant includes needed for the control panel to function. CSS and JS files are also loaded here.
 ### html/css
 All used css files are located here. Apart from legacy files, anything in here is now a symlink.
+### html/css/custom
+This is a folder you can put custom css files into that won't interfere with auto updates
 ### html/forms
 This folder contains all of the files that are dynamically included from an ajax call to html/ajax_form.php.
 ### html/includes

--- a/doc/Extensions/Port-Description-Parser.md
+++ b/doc/Extensions/Port-Description-Parser.md
@@ -83,5 +83,5 @@ It's also possible to write your own parser, the existing one is: includes/port-
 Once you've created your own then you can enable it with:
 
 ```php
-$config['port_descr_parser'] = "includes/my-port-descr-parser.inc.php";
+$config['port_descr_parser'] = "includes/custom/my-port-descr-parser.inc.php";
 ```

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -131,9 +131,11 @@ $config['site_style']       = "light";
 Currently we have a number of styles which can be set which will alter the navigation bar look. dark, light and mono with light being the default.
 
 ```php
-$config['stylesheet']       = "css/styles.css";
+$config['webui']['custom_css'][]       = "css/custom/styles.css";
 ```
-You can override a large number of visual elements by creating your own css stylesheet and referencing it here.
+You can override a large number of visual elements by creating your own css stylesheet and referencing it here, place any custom css files into 
+`html/css/custom` so they will be ignored by auto updates. You can specify as many css files as you like, the order they are within your config 
+will be the order they are loaded in the browser.
 
 ```php
 $config['page_refresh']     = "300";

--- a/html/index.php
+++ b/html/index.php
@@ -148,6 +148,13 @@ if (empty($config['favicon'])) {
   <link href="css/leaflet.awesome-markers.css" rel="stylesheet" type="text/css" />
   <link href="<?php echo($config['stylesheet']);  ?>" rel="stylesheet" type="text/css" />
   <link href="css/<?php echo $config['site_style']; ?>.css" rel="stylesheet" type="text/css" />
+<?php
+
+foreach ((array)$config['webui']['custom_css'] as $custom_css) {
+    echo '<link href="' . $custom_css . '" rel="stylesheet" type="text/css" />';
+}
+
+?>
   <script src="js/jquery.min.js"></script>
   <script src="js/bootstrap.min.js"></script>
   <script src="js/bootstrap-hover-dropdown.min.js"></script>


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #4863 

Adds two folders people can use to place custom files to be ignored by auto updates. The use of these locations is part of config.php.

`html/css/custom/` - People can now specify custom css files (multiple supported via array). Changed the docs to show this as the only option but left legacy config option in for those with it configured.

`includes/custom/` - Mainly for use with custom port parser but maybe other uses in time.