### PR TITLE
fix: Toner graphs with invalid chars

### DIFF
--- a/html/includes/graphs/device/toner.inc.php
+++ b/html/includes/graphs/device/toner.inc.php
@@ -46,7 +46,7 @@ foreach (dbFetchRows('SELECT * FROM toner where device_id = ?', array($device['d
 
     $hostname = gethostbyid($toner['device_id']);
 
-    $descr        = substr(str_pad($toner['toner_descr'], 16), 0, 16);
+    $descr        = safedescr(substr(str_pad($toner['toner_descr'], 16), 0, 16));
     $rrd_filename = rrd_name($device['hostname'], array('toner', $toner['toner_index']));
     $toner_id     = $toner['toner_id'];
 

--- a/html/includes/graphs/toner/usage.inc.php
+++ b/html/includes/graphs/toner/usage.inc.php
@@ -11,7 +11,7 @@ if ($colour['left'] == null) {
     $colour['left'] = 'CC0000';
 }
 
-$descr = substr(str_pad($toner['toner_descr'], 26), 0, 26);
+$descr = safedescr(substr(str_pad($toner['toner_descr'], 26), 0, 26));
 
 $background = get_percentage_colours((100 - $toner['toner_current']));
 

--- a/includes/common.php
+++ b/includes/common.php
@@ -492,7 +492,7 @@ function safename($name)
 
 function safedescr($descr)
 {
-    return safename($descr);
+    return preg_replace('/[^a-zA-Z0-9,._\-\/\ ]/', ' ', $descr);
 }
 
 function zeropad($num, $length = 2)

--- a/includes/common.php
+++ b/includes/common.php
@@ -490,6 +490,11 @@ function safename($name)
     return preg_replace('/[^a-zA-Z0-9,._\-]/', '_', $name);
 }
 
+/**
+ * Function format the rrdtool description text correctly.
+ * @param $descr
+ * @return mixed
+ */
 function safedescr($descr)
 {
     return preg_replace('/[^a-zA-Z0-9,._\-\/\ ]/', ' ', $descr);

--- a/includes/common.php
+++ b/includes/common.php
@@ -490,6 +490,11 @@ function safename($name)
     return preg_replace('/[^a-zA-Z0-9,._\-]/', '_', $name);
 }
 
+function safedescr($descr)
+{
+    return safename($descr);
+}
+
 function zeropad($num, $length = 2)
 {
     while (strlen($num) < $length) {

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -80,8 +80,7 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
 
     public function testRrdDescriptions()
     {
-        $data = 'Toner S/N:CRUM-1';
-
-        $this->assertEquals('Toner S/N CRUM-1', safedescr($data));
+        $data = 'Toner, S/N:CR_UM-1.';
+        $this->assertEquals('Toner, S/N CR_UM-1.', safedescr($data));
     }
 }

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -80,7 +80,7 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
 
     public function testRrdDescriptions()
     {
-        $data = 'Toner, S/N:CR_UM-1.';
-        $this->assertEquals('Toner, S/N CR_UM-1.', safedescr($data));
+        $data = 'Toner, S/N:CR_UM-16021314488.';
+        $this->assertEquals('Toner, S/N CR_UM-16021314488.', safedescr($data));
     }
 }

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -77,4 +77,11 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(ends_with($data, array('this', 'tesTing', 'no'), true));
         $this->assertFalse(ends_with($data, array('this', 'Test'), true));
     }
+
+    public function testRrdDescriptions()
+    {
+        $data = 'Toner S/N:CRUM-1';
+
+        $this->assertEquals('Toner S/N CRUM-1', safedescr($data));
+    }
 }


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Added a function to do this, it re-uses an existing function for simplicity for now but I expect the two to diverge at some stage.
