### PR TITLE
Remove escape characters to display the strings in a form

### DIFF
--- a/html/includes/forms/create-service.inc.php
+++ b/html/includes/forms/create-service.inc.php
@@ -17,11 +17,11 @@ if (is_admin() === false) {
 }
 
 $service_id = $vars['service_id'];
-$type = mres($vars['stype']);
-$desc = mres($vars['desc']);
-$ip = mres($vars['ip']);
-$param = mres($vars['param']);
-$device_id = mres($vars['device_id']);
+$type = $vars['stype'];
+$desc = $vars['desc'];
+$ip = $vars['ip'];
+$param = $vars['param'];
+$device_id = $vars['device_id'];
 
 if (is_numeric($service_id) && $service_id > 0) {
     // Need to edit.

--- a/html/includes/modal/new_service.inc.php
+++ b/html/includes/modal/new_service.inc.php
@@ -55,7 +55,7 @@ if (is_admin() !== false) {
                     <div class='form-service'>
                         <label for='desc' class='col-sm-3 control-label'>Description: </label>
                         <div class='col-sm-9'>
-                            <input type='text' id='desc' name='desc' class='form-control'/>
+                            <textarea id='desc' name='desc' class='form-control'></textarea>
                         </div>
                     </div>
                     <div class="form-service">

--- a/html/includes/vars.inc.php
+++ b/html/includes/vars.inc.php
@@ -38,5 +38,5 @@ foreach ($_GET as $name => $value) {
 }
 
 foreach ($_POST as $name => $value) {
-    $vars[$name] = clean($value);
+    $vars[$name] = ($value);
 }

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -131,8 +131,8 @@ foreach (dbFetchRows($host_sql, $host_par) as $device) {
         <td><?php echo $devlink?></td>
         <td><?php echo $status?></td>
         <td><?php echo formatUptime(time() - $service['service_changed'])?></td>
-        <td><span class='box-desc'><?php echo nl2br(trim($service['service_message']))?></span></td>
-        <td><span class='box-desc'><?php echo nl2br(trim($service['service_desc']))?></span></td>
+        <td><span class='box-desc'><?php echo nl2br(trim(stripslashes($service['service_message'])))?></span></td>
+        <td><span class='box-desc'><?php echo nl2br(trim(stripslashes($service['service_desc'])))?></span></td>
         <td>
             <button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='<?php echo $service['service_id']?>' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
             <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='<?php echo $service['service_id']?>' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -132,7 +132,7 @@ foreach (dbFetchRows($host_sql, $host_par) as $device) {
         <td><?php echo $status?></td>
         <td><?php echo formatUptime(time() - $service['service_changed'])?></td>
         <td><span class='box-desc'><?php echo nl2br(trim(stripslashes($service['service_message'])))?></span></td>
-        <td><span class='box-desc'><?php echo display($service['service_desc'])?></span></td>
+        <td><span class='box-desc'><?php echo nl2br(display($service['service_desc']))?></span></td>
         <td>
             <button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='<?php echo $service['service_id']?>' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
             <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='<?php echo $service['service_id']?>' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -131,7 +131,7 @@ foreach (dbFetchRows($host_sql, $host_par) as $device) {
         <td><?php echo $devlink?></td>
         <td><?php echo $status?></td>
         <td><?php echo formatUptime(time() - $service['service_changed'])?></td>
-        <td><span class='box-desc'><?php echo nl2br(trim(stripslashes($service['service_message'])))?></span></td>
+        <td><span class='box-desc'><?php echo nl2br(display($service['service_message']))?></span></td>
         <td><span class='box-desc'><?php echo nl2br(display($service['service_desc']))?></span></td>
         <td>
             <button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='<?php echo $service['service_id']?>' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -132,7 +132,7 @@ foreach (dbFetchRows($host_sql, $host_par) as $device) {
         <td><?php echo $status?></td>
         <td><?php echo formatUptime(time() - $service['service_changed'])?></td>
         <td><span class='box-desc'><?php echo nl2br(trim(stripslashes($service['service_message'])))?></span></td>
-        <td><span class='box-desc'><?php echo nl2br(trim(stripslashes($service['service_desc'])))?></span></td>
+        <td><span class='box-desc'><?php echo display($service['service_desc'])?></span></td>
         <td>
             <button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='<?php echo $service['service_id']?>' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
             <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='<?php echo $service['service_id']?>' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

A possible solution to the self replicating escape characters in the Service description and parameters fields.  Because the PHP function mres (mysql_real_escape_string) adds them, this removes them before writing them back out to the form.  

This addresses issue #4891 

As a note, mres is going to be removed from PHP 7....
