### PR TITLE
fix: only update components if data exists in cimc entity-physical discovery

### DIFF
--- a/includes/discovery/entity-physical/cimc.inc.php
+++ b/includes/discovery/entity-physical/cimc.inc.php
@@ -590,7 +590,9 @@ if (is_null($tblUCSObjects)) {
             $component->deleteComponent($key);
         }
     }
-    // Write the Components back to the DB.
-    $component->setComponentPrefs($device['device_id'], $components);
-    echo "\n";
+    if (is_array($components)) {
+        // Write the Components back to the DB.
+        $component->setComponentPrefs($device['device_id'], $components);
+        echo "\n";
+    }
 } // End if not error


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #4902 

Not sure why it segfaults but we don't need to try and store data that doesn't exist.