### PR TITLE
Update wifi clients polling to support more than 2 radios

### DIFF
--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -64,8 +64,8 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
     } elseif ($device['os'] == 'unifi') {
         echo 'Checking Unifi Wireless clients... ';
 
-        $clients = snmp_walk($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.8', '-Oqv');
-        $bands = snmp_walk($device, '.1.3.6.1.4.1.41112.1.6.1.2.1.9', '-Oqv');
+        $clients = snmp_walk($device, 'unifiVapNumStations', '-Oqv', 'UBNT-UniFi-MIB');
+        $bands = snmp_walk($device, 'unifiVapRadio', '-Oqv', 'UBNT-UniFi-MIB');
         $clients = explode("\n", $clients);
         $bands = explode("\n", $bands);
         foreach ($bands as $index => $band_index) {
@@ -80,27 +80,19 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         include 'includes/polling/mib/ubnt-unifi-mib.inc.php';
     }
 
-    if (is_numeric($wificlients1)) {
+    // Loop through all $wificlients# and data_update()
+    $i = 1;
+    while (is_numeric(${'wificlients'.$i})) {
         $tags = array(
             'rrd_def'   => 'DS:wificlients:GAUGE:600:-273:1000',
-            'rrd_name'  => array('wificlients', 'radio1'),
-            'radio'     => 1,
+            'rrd_name'  => array('wificlients', "radio$i"),
+            'radio'     => $i,
         );
-        data_update($device, 'wificlients', $tags, $wificlients1);
+        data_update($device, 'wificlients', $tags, ${'wificlients'.$i});
         $graphs['wifi_clients'] = true;
+        unset(${'wificlients'.$i});
+        $i++;
     }
-
-    if (is_numeric($wificlients2)) {
-        $tags = array(
-            'rrd_def'   => 'DS:wificlients:GAUGE:600:-273:1000',
-            'rrd_name'  => array('wificlients', 'radio2'),
-            'radio'     => 2,
-        );
-        data_update($device, 'wificlients', $tags, $wificlients2);
-        $graphs['wifi_clients'] = true;
-    }
-
-    unset($wificlients2, $wificlients1);
 }//end if
 
 echo "\n";


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

PR #4846 updated the wireless clients graph with a ```while()``` loop to graph as many radios as rrd files are provided.  This PR updates the wifi polling code to generate as many rrd files as ```$wificlients#``` are provided by the polling.  In short, it eliminates the bottleneck for the day when APs have more than 2 radios.  

Also while I was here, I updated the UBNT-Unifi polling code to use the UniFi MIB since it is now in LibreNMS.  I feel it makes that section of code a tiny bit more readable.  

While referencing the internet on how to convert ```$wificlients1``` to ```${'wificlients'.$i}```  pretty much everything said "You don't want this; you want to use an array".  I could modify this to make ```$wificlients1``` and ```$wificlients2``` into ```$wificlients[1]``` and ```$wificlients[2]``` I think if that's preferable.  That would involve changing more lines, but doesn't seem like a big deal.  I just tend to approach my changes as changing as little as possible to accomplish my goals.  So I started here.  

I don't think there's any rush on this as presently there aren't any devices being polled which have a ```$wificlients3``` or greater.  It's just to resolve the issue for the day when 802.11ad or whatever adds another radio.  
