### PR TITLE
Updated Cisco ASA state sensors descr to be a bit more verbose

### DIFF
--- a/includes/discovery/sensors/states/asa.inc.php
+++ b/includes/discovery/sensors/states/asa.inc.php
@@ -47,7 +47,7 @@ if ($device['os_group'] == 'cisco' && $device['os'] == 'asa') {
             }
 
             foreach ($temp as $index => $entry) {
-                $descr = ucwords(trim(preg_replace('/\s*\([^)]*\)/', '', $temp[$index]['cfwHardwareInformation'])));
+                $descr = ucwords(trim(preg_replace('/\s*\([^\s)]*\)/', '', $temp[$index]['cfwHardwareInformation'])));
                 if ($index == 'netInterface') {
                     $index = 4;
                 } elseif ($index == 'primaryUnit') {


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Goes from:

```
mysql> select device_id,sensor_descr, sensor_current from sensors where device_id=2263 or device_id=2264\G
*************************** 1. row ***************************
     device_id: 2263
  sensor_descr: Failover LAN Interface
sensor_current: 2
*************************** 2. row ***************************
     device_id: 2263
  sensor_descr: Primary Unit
sensor_current: 10
*************************** 3. row ***************************
     device_id: 2263
  sensor_descr: Secondary Unit
sensor_current: 9
*************************** 4. row ***************************
     device_id: 2264
  sensor_descr: Failover LAN Interface
sensor_current: 2
*************************** 5. row ***************************
     device_id: 2264
  sensor_descr: Primary Unit
sensor_current: 10
*************************** 6. row ***************************
     device_id: 2264
  sensor_descr: Secondary Unit
sensor_current: 9
6 rows in set (0.00 sec)
```

to:

```
mysql> select device_id,sensor_descr, sensor_current from sensors where device_id=2393 or device_id=2394\G
*************************** 1. row ***************************
     device_id: 2393
  sensor_descr: Failover LAN Interface
sensor_current: 2
*************************** 2. row ***************************
     device_id: 2393
  sensor_descr: Primary Unit
sensor_current: 9
*************************** 3. row ***************************
     device_id: 2393
  sensor_descr: Secondary Unit (this Device)
sensor_current: 10
*************************** 4. row ***************************
     device_id: 2394
  sensor_descr: Failover LAN Interface
sensor_current: 2
*************************** 5. row ***************************
     device_id: 2394
  sensor_descr: Primary Unit (this Device)
sensor_current: 9
*************************** 6. row ***************************
     device_id: 2394
  sensor_descr: Secondary Unit
sensor_current: 10
6 rows in set (0.00 sec)
```