### PR TITLE
check if this script is run by the librenms user

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -16,6 +16,15 @@
 cd "$(dirname "$0")"
 arg="$1"
 
+# check if the script is run by user librenms
+MYUID=`id -u librenms`
+
+# Make sure only librenms user can run our script
+if [[ $EUID -ne "$MYUID" ]]; then
+   echo "Please run this script as librenms user." 1>&2
+   exit 1
+fi
+
 # Fancy-Print and run commands
 # @arg    Text
 # @arg    Command


### PR DESCRIPTION
Check if daily.sh is run by the librenms user. Accidentally run as root changes the file permissions of the librenms installation and needs to be chown manually.