### PR TITLE
fix: api rate percent calculation incorrect

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -94,10 +94,12 @@ function get_port_stats_by_port_hostname()
     $ifName    = urldecode($router['ifname']);
     $port     = dbFetchRow('SELECT * FROM `ports` WHERE `device_id`=? AND `ifName`=?', array($device_id, $ifName));
 
-    $port['in_rate'] = (formatRates($port['ifInOctets_rate'] * 8));
-    $port['out_rate'] = (formatRates($port['ifOutOctets_rate'] * 8));
-    $port['in_perc'] = @round(($port['in_rate'] / $port['ifSpeed'] * 100));
-    $port['out_perc'] = @round(($port['in_rate'] / $port['ifSpeed'] * 100));
+    $in_rate = $port['ifInOctets_rate'] * 8;
+    $out_rate = $port['ifOutOctets_rate'] * 8;
+    $port['in_rate'] = formatRates($in_rate);
+    $port['out_rate'] = formatRates($out_rate);
+    $port['in_perc'] = number_format($in_rate / $port['ifSpeed'] * 100, 2, '.', '');
+    $port['out_perc'] = number_format($out_rate / $port['ifSpeed'] * 100, 2, '.', '');
     $port['in_pps'] = format_bi($port['ifInUcastPkts_rate']);
     $port['out_pps'] = format_bi($port['ifOutUcastPkts_rate']);
     


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Now outputs percent with with two decimal places.
If ifSpeed = 0, the output will be "inf"