### PR TITLE
fix: Fixed poweralert discovery, check is now case insensitive

### DIFF
--- a/includes/discovery/os/poweralert.inc.php
+++ b/includes/discovery/os/poweralert.inc.php
@@ -1,5 +1,5 @@
 <?php
 
-if (starts_with($sysDescr, 'POWERALERT')) {
+if (starts_with($sysDescr, 'POWERALERT', true)) {
     $os = 'poweralert';
 }

--- a/tests/OSDiscoveryTest.php
+++ b/tests/OSDiscoveryTest.php
@@ -1047,6 +1047,7 @@ class DiscoveryTest extends \PHPUnit_Framework_TestCase
     public function testPoweralert()
     {
         $this->checkOS('poweralert');
+        $this->checkOS('poweralert', 'poweralert1');
     }
 
     public function testPowerconnect()


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #4944 Simple one.