### PR TITLE
Set allow_duplicate_sysName to be false by default

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -124,3 +124,8 @@ and you would like to still add devices automatically then you will need to set 
 
 If your devices only return a short hostname such as lax-fa0-dc01 but the full name should be lax-fa0-dc01.example.com then you can 
 set `$config['mydomain'] = 'example.com';`
+
+#### Unique sysName
+
+By default we require unique sysNames when adding devices (this is returned over snmp by your devices). If you would like to allow 
+devices to be added with duplicate sysNames then please set `$config['allow_duplicate_sysName'] = true;`.

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -798,7 +798,7 @@ $config['enable_clear_discovery'] = 1;
 $config['force_ip_to_sysname']    = false;// Set to true if you want to use sysName in place of IPs
 
 // Allow duplicate devices by sysName
-$config['allow_duplicate_sysName'] = true;// Set to false if you want to only allow unique sysName's
+$config['allow_duplicate_sysName'] = false;// Set to true if you want to allow duplicate sysName's
 
 $config['enable_port_relationship'] = true;
 // Set this to false to not display neighbour relationships for ports


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

sysName is one of the best ways we have of detecting duplicates, we defaulted to true previously for allow_duplicate_sysName to maintain backwards compatibility. imho we should have this as false now as it stops duplicate devices being added and shouldn't stop legitimate devices from being added.