### PR TITLE
refactor: Remove inappropriate usages of truncate()

### DIFF
--- a/html/includes/graphs/cefswitching/graph.inc.php
+++ b/html/includes/graphs/cefswitching/graph.inc.php
@@ -11,7 +11,7 @@ $i    = 0;
 if (rrdtool_check_rrd_exists($rrd_filename)) {
     foreach ($oids as $oid) {
         $oid    = str_replace('dot3Stats', '', $oid);
-        $oid_ds = truncate($oid, 19, '');
+        $oid_ds = substr($oid, 0, 19);
         $rrd_list[$i]['filename'] = $rrd_filename;
         $rrd_list[$i]['descr']    = $oid;
         $rrd_list[$i]['ds']       = $oid_ds;

--- a/html/includes/graphs/generic_simplex.inc.php
+++ b/html/includes/graphs/generic_simplex.inc.php
@@ -7,8 +7,8 @@ if ($config['old_graphs']) {
     // args: ds_in, ds_out, rrd_filename, bg, legend, from, to, width, height, inverse, percentile
     include 'includes/graphs/common.inc.php';
 
-    $unit_text = str_pad(truncate($unit_text, 18, ''), 18);
-    $line_text = str_pad(truncate($line_text, 12, ''), 12);
+    $unit_text = str_pad(substr($unit_text, 0, 18), 18);
+    $line_text = str_pad(substr($line_text, 0, 12), 12);
 
     if ($multiplier) {
         $rrd_options .= ' DEF:'.$ds.'_o='.$rrd_filename.':'.$ds.':AVERAGE';

--- a/html/includes/graphs/netscalervsvr/hitmiss.inc.php
+++ b/html/includes/graphs/netscalervsvr/hitmiss.inc.php
@@ -8,7 +8,7 @@ $oids = array(
 $i = 0;
 
 foreach ($oids as $oid) {
-    $oid_ds                   = truncate($oid, 19, '');
+    $oid_ds                   = substr($oid, 0, 19);
     $rrd_list[$i]['filename'] = $rrd_filename;
     $rrd_list[$i]['descr']    = $oid;
     $rrd_list[$i]['ds']       = $oid_ds;

--- a/html/includes/graphs/old_generic_simplex.inc.php
+++ b/html/includes/graphs/old_generic_simplex.inc.php
@@ -4,8 +4,8 @@
 // args: ds_in, ds_out, rrd_filename, bg, legend, from, to, width, height, inverse, percentile
 require 'includes/graphs/common.inc.php';
 
-$unit_text = str_pad(truncate($unit_text, 18, ''), 18);
-$line_text = str_pad(truncate($line_text, 12, ''), 12);
+$unit_text = str_pad(substr($unit_text, 0, 18), 18);
+$line_text = str_pad(substr($line_text, 0, 12), 12);
 
 if ($multiplier) {
     if (empty($multiplier_action)) {

--- a/html/includes/graphs/port/etherlike.inc.php
+++ b/html/includes/graphs/port/etherlike.inc.php
@@ -23,7 +23,7 @@ $rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'do
 if (rrdtool_check_rrd_exists($rrd_filename)) {
     foreach ($oids as $oid) {
         $oid        = str_replace('dot3Stats', '', $oid);
-        $oid_ds = truncate($oid, 19, '');
+        $oid_ds = substr($oid, 0, 19);
         $rrd_list[$i]['filename'] = $rrd_filename;
         $rrd_list[$i]['descr']    = $oid;
         $rrd_list[$i]['ds']       = $oid_ds;

--- a/html/includes/hostbox-public.inc.php
+++ b/html/includes/hostbox-public.inc.php
@@ -62,6 +62,6 @@ echo '</td>';
 echo '    <td>'.$device['hardware'].' '.$device['features'].'</td>';
 echo '    <td>'.formatUptime($device['uptime'], 'short').' <br />';
 
-echo '    '.truncate($device['location'], 32, '').'</td>';
+echo '    '.substr($device['location'], 0, 32).'</td>';
 
 echo ' </tr>';

--- a/html/includes/print-vlan.inc.php
+++ b/html/includes/print-vlan.inc.php
@@ -42,7 +42,7 @@ foreach ($vlan_ports as $port) {
     <img src=\'graph.php?type=$graph_type&amp;id=".$port['port_id'].'&amp;from='.$config['time']['twoday'].'&amp;to='.$config['time']['now']."&amp;width=450&amp;height=150\'>\
     ', CENTER, LEFT, FGCOLOR, '#e5e5e5', BGCOLOR, '#e5e5e5', WIDTH, 400, HEIGHT, 150);\" onmouseout=\"return nd();\"  >"."<img src='graph.php?type=$graph_type&amp;id=".$port['port_id'].'&amp;from='.$config['time']['twoday'].'&amp;to='.$config['time']['now']."&amp;width=132&amp;height=40&amp;legend=no'>
     </a>
-    <div style='font-size: 9px;'>".truncate(short_port_descr($port['ifAlias']), 22, '').'</div>
+    <div style='font-size: 9px;'>".substr(short_port_descr($port['ifAlias']), 0, 22).'</div>
    </div>';
     } else {
         echo $vlan['port_sep'].generate_port_link($port, makeshortif($port['label']));

--- a/html/includes/print-vrf.inc.php
+++ b/html/includes/print-vrf.inc.php
@@ -25,7 +25,7 @@ foreach (dbFetchRows('SELECT * FROM ports WHERE `device_id` = ? AND `ifVrf` = ?'
     <img src=\'graph.php?type=$graph_type&amp;id=".$port['port_id'].'&amp;from='.$config['time']['twoday'].'&amp;to='.$config['time']['now']."&amp;width=450&amp;height=150\'>\
     ', CENTER, LEFT, FGCOLOR, '#e5e5e5', BGCOLOR, '#e5e5e5', WIDTH, 400, HEIGHT, 150);\" onmouseout=\"return nd();\"  >"."<img src='graph.php?type=$graph_type&amp;id=".$port['port_id'].'&amp;from='.$config['time']['twoday'].'&amp;to='.$config['time']['now']."&amp;width=132&amp;height=40&amp;legend=no'>
     </a>
-    <div style='font-size: 9px;'>".truncate(short_port_descr($port['ifAlias']), 22, '').'</div>
+    <div style='font-size: 9px;'>".substr(short_port_descr($port['ifAlias']), 0, 22).'</div>
    </div>';
     } else {
         echo $vrf['port_sep'].generate_port_link($port, makeshortif($port['ifDescr']));

--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -190,7 +190,7 @@ foreach (dbFetchRows($sql, $param) as $device) {
     if (extension_loaded('mbstring')) {
         $location = mb_substr($device['location'], 0, 32, 'utf8');
     } else {
-        $location = truncate($device['location'], 32, '');
+        $location = substr($device['location'], 0, 32);
     }
 
     if ($subformat == 'detail') {

--- a/html/includes/table/sensors.inc.php
+++ b/html/includes/table/sensors.inc.php
@@ -93,7 +93,7 @@ foreach (dbFetchRows($sql, $param) as $sensor) {
     $graph_array['from'] = $config['time']['day'];
     $sensor_minigraph =  generate_lazy_graph_tag($graph_array);
 
-    $sensor['sensor_descr'] = truncate($sensor['sensor_descr'], 48, '');
+    $sensor['sensor_descr'] = substr($sensor['sensor_descr'], 0, 48);
 
     $response[] = array(
         'hostname'       => generate_device_link($sensor),

--- a/html/pages/device/overview/generic/sensor.inc.php
+++ b/html/pages/device/overview/generic/sensor.inc.php
@@ -44,9 +44,9 @@ if (count($sensors)) {
         $link = generate_url($link_array);
 
         if ($sensor['poller_type'] == "ipmi") {
-            $sensor['sensor_descr'] = truncate(ipmiSensorName($device['hardware'], $sensor['sensor_descr'], $ipmiSensorsNames), 48, '');
+            $sensor['sensor_descr'] = substr(ipmiSensorName($device['hardware'], $sensor['sensor_descr'], $ipmiSensorsNames), 0, 48);
         } else {
-            $sensor['sensor_descr'] = truncate($sensor['sensor_descr'], 48, '');
+            $sensor['sensor_descr'] = substr($sensor['sensor_descr'], 0, 48);
         }
 
         $overlib_content = '<div style="width: 580px;"><h2>'.$device['hostname'].' - '.$sensor['sensor_descr'].'</h1>';

--- a/html/pages/device/ports.inc.php
+++ b/html/pages/device/ports.inc.php
@@ -112,7 +112,7 @@ if ($vars['view'] == 'minigraphs') {
             </div>\
             ', CENTER, LEFT, FGCOLOR, '#e5e5e5', BGCOLOR, '#e5e5e5', WIDTH, 400, HEIGHT, 150);\" onmouseout=\"return nd();\"  >"."<img src='graph.php?type=".$graph_type.'&amp;id='.$port['port_id'].'&amp;from='.$from.'&amp;to='.$config['time']['now']."&amp;width=180&amp;height=45&amp;legend=no'>
             </a>
-            <div style='font-size: 9px;'>".truncate(short_port_descr($port['ifAlias']), 32, '').'</div>
+            <div style='font-size: 9px;'>".substr(short_port_descr($port['ifAlias']), 0, 32).'</div>
             </div>';
     }
 

--- a/html/pages/front/default.php
+++ b/html/pages/front/default.php
@@ -65,8 +65,8 @@ if ($config['warn']['ifdown']) {
                 generate_device_link($interface, shorthost($interface['hostname'])) . "<br />
         <span class=\"interface-updown\">Port Down</span><br />
 <!--      <img src='graph.php?type=bits&amp;if=" . $interface['port_id'] . '&amp;from=' . $config['time']['day'] . '&amp;to=' . $config['time']['now'] . "&amp;width=100&amp;height=32' /> -->
-        " . generate_port_link($interface, truncate(makeshortif($interface['label']), 13, '')) . ' <br />
-        ' . ($interface['ifAlias'] ? '<span class="body-date-1">' . truncate($interface['ifAlias'], 20, '') . '</span>' : '')
+        " . generate_port_link($interface, substr(makeshortif($interface['label']), 0, 13)) . ' <br />
+        ' . ($interface['ifAlias'] ? '<span class="body-date-1">' . substr($interface['ifAlias'], 0, 20) . '</span>' : '')
             );
             ++$count_boxes;
         }
@@ -109,7 +109,7 @@ if (isset($config['enable_bgp']) && $config['enable_bgp']) {
             generate_device_link($peer, shorthost($peer['hostname'])) . "<br />
     <span class=bgp-down>BGP Down</span>
     <span class='" . (strstr($peer['bgpPeerIdentifier'], ':') ? 'front-page-bgp-small' : 'front-page-bgp-normal') . "'>" . $peer['bgpPeerIdentifier'] . '</span><br />
-    <span class=body-date-1>AS' . truncate($peer['bgpPeerRemoteAs'] . ' ' . $peer['astext'], 14, '') . '</span>'
+    <span class=body-date-1>AS' . substr($peer['bgpPeerRemoteAs'] . ' ' . $peer['astext'], 0, 14) . '</span>'
         );
         ++$count_boxes;
     }

--- a/html/pages/routing/vrf.inc.php
+++ b/html/pages/routing/vrf.inc.php
@@ -167,7 +167,7 @@ if ($_SESSION['userlevel'] >= '5') {
                             text-align: center; float: left; background-color: ".$list_colour_b_b.";'>
                                 <div style='font-weight: bold;'>".makeshortif($port['ifDescr']).'</div>';
                             print_port_thumbnail($port);
-                            echo "<div style='font-size: 9px;'>".truncate(short_port_descr($port['ifAlias']), 22, '').'</div>
+                            echo "<div style='font-size: 9px;'>".substr(short_port_descr($port['ifAlias']), 0, 22).'</div>
                                 </div>';
                             break;
 

--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -89,7 +89,7 @@ if ($device['os_group'] == 'cisco') {
         $rrd_name = array('ipsectunnel', $address);
         $rrd_def = array();
         foreach ($oids as $oid) {
-            $oid_ds = truncate(str_replace('cipSec', '', $oid), 19, '');
+            $oid_ds = substr(str_replace('cipSec', '', $oid), 0, 19);
             $rrd_def[] = "DS:$oid_ds:COUNTER:600:U:1000000000";
         }
 

--- a/includes/polling/cisco-ace-loadbalancer.inc.php
+++ b/includes/polling/cisco-ace-loadbalancer.inc.php
@@ -40,7 +40,7 @@ if ($device['os_group'] == 'cisco') {
 
         $rrd_def = array();
         foreach ($oids as $oid) {
-            $oid_ds = truncate(str_replace('cesServerFarm', '', $oid), 19, '');
+            $oid_ds = substr(str_replace('cesServerFarm', '', $oid), 0, 19);
             $rrd_def[] = "DS:$oid_ds:GAUGE:600:-1:100000000";
         }
 

--- a/includes/polling/cisco-ace-serverfarms.inc.php
+++ b/includes/polling/cisco-ace-serverfarms.inc.php
@@ -45,7 +45,7 @@ if ($device['os_group'] == 'cisco') {
         $rrd_name = array('vserver', $classmap_id);
         $rrd_def = array();
         foreach ($oids as $oid) {
-            $oid_ds = truncate(str_replace('slbVServer', '', $oid), 19, '');
+            $oid_ds = substr(str_replace('slbVServer', '', $oid), 0, 19);
             $rrd_def[] = "DS:$oid_ds:COUNTER:600:U:1000000000";
         }
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -392,7 +392,7 @@ function poll_mib_def($device, $mib_name_table, $mib_subdir, $mib_oids, $mib_gra
         $oiddsopts = $param[4];
 
         if (strlen($oiddsname) > 19) {
-            $oiddsname = truncate($oiddsname, 19, '');
+            $oiddsname = substr($oiddsname, 0, 19);
         }
 
         if (empty($oiddsopts)) {

--- a/includes/polling/ipSystemStats.inc.php
+++ b/includes/polling/ipSystemStats.inc.php
@@ -99,7 +99,7 @@ if ($data) {
 
         foreach ($oids as $oid) {
             $oid_ds      = str_replace('ipSystemStats', '', $oid);
-            $oid_ds      = truncate($oid_ds, 19, '');
+            $oid_ds      = substr($oid_ds, 0, 19);
             $rrd_def[]   = "DS:$oid_ds:COUNTER:600:U:100000000000";
             if (strstr($stats[$oid], 'No') || strstr($stats[$oid], 'd') || strstr($stats[$oid], 's')) {
                 $stats[$oid] = '0';

--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -55,11 +55,11 @@ if ($device['os'] == 'netscaler') {
 
     $rrd_def = array();
     foreach ($oids_gauge as $oid) {
-        $oid_ds    = truncate(str_replace('vsvr', '', $oid), 19, '');
+        $oid_ds    = substr(str_replace('vsvr', '', $oid), 0, 19);
         $rrd_def[] = "DS:$oid_ds:GAUGE:600:U:100000000000";
     }
     foreach ($oids_counter as $oid) {
-        $oid_ds    = truncate(str_replace('vsvr', '', $oid), 19, '');
+        $oid_ds    = substr(str_replace('vsvr', '', $oid), 0, 19);
         $rrd_def[] = "DS:$oid_ds:COUNTER:600:U:100000000000";
     }
 

--- a/includes/polling/netstats/netstats-icmp.inc.php
+++ b/includes/polling/netstats/netstats-icmp.inc.php
@@ -40,7 +40,7 @@ if ($device['os'] != 'Snom') {
         $rrd_def = array();
         $fields = array();
         foreach ($oids as $oid) {
-            $oid_ds    = truncate($oid, 19, '');
+            $oid_ds    = substr($oid, 0, 19);
             $rrd_def[] = "DS:$oid_ds:COUNTER:600:U:100000000000";
             $fields[$oid] = isset($data[$oid]) ? $data[$oid] : 'U';
         }

--- a/includes/polling/netstats/netstats-ip.inc.php
+++ b/includes/polling/netstats/netstats-ip.inc.php
@@ -26,7 +26,7 @@ if ($device['os'] != 'Snom') {
     $rrd_def = array();
     $snmpstring = '';
     foreach ($oids as $oid) {
-        $oid_ds      = truncate($oid, 19, '');
+        $oid_ds      = substr($oid, 0, 19);
         $rrd_def[]   = "DS:$oid_ds:COUNTER:600:U:100000000000";
         $snmpstring .= ' IP-MIB::'.$oid.'.0';
     }

--- a/includes/polling/netstats/netstats-ip_forward.inc.php
+++ b/includes/polling/netstats/netstats-ip_forward.inc.php
@@ -11,7 +11,7 @@ if ($device['os'] != 'Snom') {
     $rrd_def = array();
     $snmpstring = '';
     foreach ($oids as $oid) {
-        $oid_ds       = truncate($oid, 19, '');
+        $oid_ds       = substr($oid, 0, 19);
         $rrd_create[] = "DS:$oid_ds:GAUGE:600:U:1000000"; // Limit to 1MPPS?
         $snmpstring .= ' IP-FORWARD-MIB::'.$oid.'.0';
     }

--- a/includes/polling/netstats/netstats-snmp.inc.php
+++ b/includes/polling/netstats/netstats-snmp.inc.php
@@ -42,7 +42,7 @@ if ($device['os'] != 'Snom') {
         $rrd_def = array();
         $fields = array();
         foreach ($oids as $oid) {
-            $oid_ds    = truncate($oid, 19, '');
+            $oid_ds    = substr($oid, 0, 19);
             $rrd_def[] = "DS:$oid_ds:COUNTER:600:U:100000000000";
             $fields[$oid] = isset($data[0][$oid]) ? $data[0][$oid] : 'U';
         }

--- a/includes/polling/netstats/netstats-tcp.inc.php
+++ b/includes/polling/netstats/netstats-tcp.inc.php
@@ -19,7 +19,7 @@ if ($device['os'] != 'Snom') {
     $rrd_def = array();
     $snmpstring = '';
     foreach ($oids as $oid) {
-        $oid_ds      = truncate($oid, 19, '');
+        $oid_ds      = substr($oid, 0, 19);
         $rrd_def[]   = " DS:$oid_ds:COUNTER:600:U:10000000"; // Limit to 10MPPS
         $snmpstring .= ' TCP-MIB::'.$oid.'.0';
     }

--- a/includes/polling/netstats/netstats-udp.inc.php
+++ b/includes/polling/netstats/netstats-udp.inc.php
@@ -14,7 +14,7 @@ if ($device['os'] != 'Snom') {
     $rrd_def = array();
     $snmpstring = '';
     foreach ($oids as $oid) {
-        $oid_ds      = truncate($oid, 19, '');
+        $oid_ds      = substr($oid, 0, 19);
         $rrd_def[]   = " DS:$oid_ds:COUNTER:600:U:1000000"; // Limit to 1MPPS?
         $snmpstring .= ' UDP-MIB::'.$oid.'.0';
     }

--- a/includes/polling/os/misc/netscaler-stats.inc.php
+++ b/includes/polling/os/misc/netscaler-stats.inc.php
@@ -99,11 +99,11 @@ if ($device['os'] == 'netscaler') {
 
     $rrd_def = array();
     foreach ($oids_gauge as $oid) {
-        $oid_ds    = truncate(str_replace('tcp', '', str_replace('Active', 'Ac', str_replace('Passive', 'Ps', str_replace('Zombie', 'Zom', $oid)))), 19, '');
+        $oid_ds    = substr(str_replace('tcp', '', str_replace('Active', 'Ac', str_replace('Passive', 'Ps', str_replace('Zombie', 'Zom', $oid)))), 0, 19);
         $rrd_def[] = "DS:$oid_ds:GAUGE:600:U:100000000000";
     }
     foreach ($oids_counter as $oid) {
-        $oid_ds    = truncate(str_replace('tcp', '', str_replace('Active', 'Ac', str_replace('Passive', 'Ps', str_replace('Zombie', 'Zom', $oid)))), 19, '');
+        $oid_ds    = substr(str_replace('tcp', '', str_replace('Active', 'Ac', str_replace('Passive', 'Ps', str_replace('Zombie', 'Zom', $oid)))), 0, 19);
         $rrd_def[] = "DS:$oid_ds:COUNTER:600:U:100000000000";
     }
 

--- a/includes/polling/ports/port-etherlike.inc.php
+++ b/includes/polling/ports/port-etherlike.inc.php
@@ -7,7 +7,7 @@ if ($this_port['dot3StatsIndex'] and $port['ifType'] == 'ethernetCsmacd') {
 
     $rrd_create = $config['rrd_rra'];
     foreach ($etherlike_oids as $oid) {
-        $oid       = truncate(str_replace('dot3Stats', '', $oid), 19, '');
+        $oid       = substr(str_replace('dot3Stats', '', $oid), 0, 19);
         $rrd_def[] = "DS:$oid:COUNTER:600:U:100000000000";
     }
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Where truncate() is used as substr(), replace with substr()