### PR TITLE
fix: use password type for SMTP Auth

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1212,6 +1212,11 @@ function generate_dynamic_config_panel($title, $config_groups, $items = array(),
                 <input id="'.$item['name'].'" class="form-control" type="text" name="global-config-input" value="'.$config_groups[$item['name']]['config_value'].'" data-config_id="'.$config_groups[$item['name']]['config_id'].'">
                 <span class="form-control-feedback"><i class="fa" aria-hidden="true"></i></span>
                 ';
+            } elseif ($item['type'] == 'password') {
+                $output .= '
+                <input id="'.$item['name'].'" class="form-control" type="password" name="global-config-input" value="'.$config_groups[$item['name']]['config_value'].'" data-config_id="'.$config_groups[$item['name']]['config_id'].'">
+                <span class="form-control-feedback"><i class="fa" aria-hidden="true"></i></span>
+                ';
             } elseif ($item['type'] == 'numeric') {
                 $output .= '
                 <input id="'.$item['name'].'" class="form-control" onkeypress="return (event.charCode == 8 || event.charCode == 0) ? null : event.charCode >= 48 && event.charCode <= 57" type="text" name="global-config-input" value="'.$config_groups[$item['name']]['config_value'].'" data-config_id="'.$config_groups[$item['name']]['config_id'].'">

--- a/html/pages/settings/alerting.inc.php
+++ b/html/pages/settings/alerting.inc.php
@@ -288,7 +288,7 @@ $mail_conf = array(
     ),
     array('name'               => 'email_smtp_password',
           'descr'              => 'SMTP Authentication Password',
-          'type'               => 'text',
+          'type'               => 'password',
     ),
 );
 


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Add support for password type to generate_dynamic_config_panel()
fixes: #5051