### PR TITLE
fix: Ability to detect Cisco ASA version when polling a security context

### DIFF
--- a/includes/polling/os/asa.inc.php
+++ b/includes/polling/os/asa.inc.php
@@ -34,3 +34,8 @@ if (isset($data[1]['entPhysicalSerialNum']) && $data[1]['entPhysicalSerialNum'] 
 if (empty($hardware)) {
     $hardware = snmp_get($device, 'sysObjectID.0', '-Osqv', 'SNMPv2-MIB:CISCO-PRODUCTS-MIB');
 }
+
+if (empty($version)) {
+    $explodeddata = explode(" ", $poll_device['sysDescr']);
+    $version = $explodeddata['5'];
+}


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

sysDescr is the only place where context based asa's publish the software version info.
