### PR TITLE
fix: Stop openbsd using snmpEngineTime #5047

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -286,9 +286,10 @@ $config['os'][$os]['group'] = 'unix';
 $config['os'][$os]['text']  = 'pfSense';
 
 $os = 'openbsd';
-$config['os'][$os]['type']  = 'server';
-$config['os'][$os]['group'] = 'unix';
-$config['os'][$os]['text']  = 'OpenBSD';
+$config['os'][$os]['type']               = 'server';
+$config['os'][$os]['group']              = 'unix';
+$config['os'][$os]['text']               = 'OpenBSD';
+$config['os'][$os]['bad_snmpEngineTime'] = true;
 
 $os = 'netbsd';
 $config['os'][$os]['type']  = 'server';
@@ -1854,16 +1855,17 @@ $config['os'][$os]['over'][2]['text']  = 'Memory Usage';
 
 // UBNT EdgeSwitch 750W
 $os = 'edgeswitch';
-$config['os'][$os]['text']             = 'EdgeSwitch';
-$config['os'][$os]['type']             = 'network';
-$config['os'][$os]['icon']             = 'ubiquiti';
-$config['os'][$os]['over'][0]['graph'] = 'device_bits';
-$config['os'][$os]['over'][0]['text']  = 'Device Traffic';
-$config['os'][$os]['ifname']           = 1;
-$config['os'][$os]['over'][1]['graph'] = 'device_processor';
-$config['os'][$os]['over'][1]['text']  = 'CPU Usage';
-$config['os'][$os]['over'][2]['graph'] = 'device_mempool';
-$config['os'][$os]['over'][2]['text']  = 'Memory Usage';
+$config['os'][$os]['text']               = 'EdgeSwitch';
+$config['os'][$os]['type']               = 'network';
+$config['os'][$os]['icon']               = 'ubiquiti';
+$config['os'][$os]['ifname']             = 1;
+$config['os'][$os]['bad_snmpEngineTime'] = true;
+$config['os'][$os]['over'][0]['graph']   = 'device_bits';
+$config['os'][$os]['over'][0]['text']    = 'Device Traffic';
+$config['os'][$os]['over'][1]['graph']   = 'device_processor';
+$config['os'][$os]['over'][1]['text']    = 'CPU Usage';
+$config['os'][$os]['over'][2]['graph']   = 'device_mempool';
+$config['os'][$os]['over'][2]['text']    = 'Memory Usage';
 
 // Fiberhome
 $os = 'fiberhome';

--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -43,7 +43,7 @@ if (empty($uptime)) {
     }//end if
 }//end if
 
-if ($device["os"] != "edgeswitch") {
+if ($config['os'][$device['os']]['bad_snmpEngineTime'] !== true) {
     if ($snmp_uptime > $uptime && is_numeric($snmp_uptime)) {
         $uptime = $snmp_uptime;
         d_echo('hrSystemUptime or sysUpTime looks like to have rolled, using snmpEngineTime instead');


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #5047 

A slightly different fix was tested in that issue but I decided to move it to definitions rather than maintain an array of OS' to exclude from the check.