### PR TITLE
Update raspberrypi sensor discovery to check for sensor existance

### DIFF
--- a/includes/discovery/sensors/frequencies/linux.inc.php
+++ b/includes/discovery/sensors/frequencies/linux.inc.php
@@ -19,6 +19,8 @@ if (preg_match("/(bcm).+(boardrev)/", $raspberry)) {
                 break;
         }
         $value = snmp_get($device, $oid.$freq, '-Oqve');
-        discover_sensor($valid['sensor'], 'frequency', $device, $oid.$freq, $freq, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
+        if (is_numeric($value)) {
+            discover_sensor($valid['sensor'], 'frequency', $device, $oid.$freq, $freq, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
+        }
     }
 }

--- a/includes/discovery/sensors/states/linux.inc.php
+++ b/includes/discovery/sensors/states/linux.inc.php
@@ -31,7 +31,7 @@ if (preg_match("/(bcm).+(boardrev)/", $raspberry)) {
         }
         $value = snmp_get($device, $oid.$codec, '-Oqv');
 
-        if (!empty($value)) {
+        if (stripos($value, 'abled') !== false) {
             $state_index_id = create_state_index($state);
             if ($state_index_id) {
                 $states = array(
@@ -50,8 +50,8 @@ if (preg_match("/(bcm).+(boardrev)/", $raspberry)) {
                 );
                 dbInsert($insert, 'state_translations');
             }
+            discover_sensor($valid['sensor'], 'state', $device, $oid.$codec, $codec, $state, $descr, '1', '1', null, null, null, null, $value, 'snmp', $codec);
+            create_sensor_to_state_index($device, $state, $codec);
         }
-        discover_sensor($valid['sensor'], 'state', $device, $oid.$codec, $codec, $state, $descr, '1', '1', null, null, null, null, $value, 'snmp', $codec);
-        create_sensor_to_state_index($device, $state, $codec);
     }
 }

--- a/includes/discovery/sensors/temperatures/linux.inc.php
+++ b/includes/discovery/sensors/temperatures/linux.inc.php
@@ -11,7 +11,7 @@ if (preg_match("/(bcm).+(boardrev)/", $raspberry)) {
     $sensor_oid = ".1.3.6.1.4.1.8072.1.3.2.4.1.2.9.114.97.115.112.98.101.114.114.121.1";
     $descr = "CPU Temp";
     $value = snmp_get($device, $sensor_oid, '-Oqve');
-    if ($value > 0) {
+    if (is_numeric($value)) {
         discover_sensor($valid['sensor'], 'temperature', $device, $sensor_oid, 1, $sensor_type, $descr, 1, 1, null, null, null, null, $value);
     }
 }

--- a/includes/discovery/sensors/voltages/linux.inc.php
+++ b/includes/discovery/sensors/voltages/linux.inc.php
@@ -23,7 +23,9 @@ if (preg_match("/(bcm).+(boardrev)/", $raspberry)) {
                 break;
         }
         $value = snmp_get($device, $oid.$volt, '-Oqv');
-        discover_sensor($valid['sensor'], 'voltage', $device, $oid.$volt, $volt, $sensor_type, $descr, '1', '1', null, null, null, null, $value);
+        if (is_numeric($value)) {
+            discover_sensor($valid['sensor'], 'voltage', $device, $oid.$volt, $volt, $sensor_type, $descr, '1', '1', null, null, null, null, $value);
+        }
     }
     /*
      * other linux os


### PR DESCRIPTION
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

I recently added a RaspberryPi to my network to convert a USB UPS into a Network UPS.  As part of that I added snmp to the Pi and added it to my librenms install.  What I found is that the existing discovery code for the Pi just assumes that the snmp extend for raspberry.sh is enabled.  It discovers sensors which on my install, had no data and it made for a messy page.  So I offer this patch for consideration.  

It looks like 2 of the 4 sensors have code to validate the data before discovering the sensor, but only one of those works (temperature).  So these patches add if code to confirm we get something good back before ```discover_senors()```.  It's using ```is_numeric``` for all of the numeric sensors and for the codecs, I'm using ```stripos``` for "abled" since the options are enabled / disabled.  

My main use for this is that is allows me to run my own raspberry.sh snmp extend which only provides temperature data and doesn't require root/sudo.  I didn't want to give those permissions to the script/ run ```vcgencmd``` on the pi and this patch works nicely to enable that.  Also this is a headless box where I'm never going to change the voltage or enable codecs so didn't want to bother polling that.  

The attached screenshot shows the existing behavior with a snmp extend only providing temperature data, then the same situation after this patch (the unused sensors disappear).  Finally the bottom screenshot is after this patch is applied with a "stock" snmp extend showing the sensors still polled and working.  

![out-fs8](https://cloud.githubusercontent.com/assets/5832772/20887224/cc6f1c7e-bac7-11e6-901d-8230b80c69ec.png)

This code should only run on raspberry pi discovery since it's already in an ```if``` block identifying the device as a RPI.  