### PR TITLE
fix for cisco hardware name detection

### DIFF
--- a/includes/polling/os/ios.inc.php
+++ b/includes/polling/os/ios.inc.php
@@ -1,47 +1,51 @@
 <?php
+/**
+ * LibreNMS
+ *
+ *   This file is part of LibreNMS.
+ *
+ * @package    LibreNMS
+ * @subpackage polling
+ * @copyright  (C) 2016 Librenms
+ */
 
-// 7200 and IOS-XE (ASR1k)
 if (preg_match('/^Cisco IOS Software, .+? Software \([^\-]+-([^\-]+)-\w\),.+?Version ([^, ]+)/', $poll_device['sysDescr'], $regexp_result)) {
     $features = $regexp_result[1];
     $version  = $regexp_result[2];
 } elseif (preg_match('/Cisco Internetwork Operating System Software\s+IOS \(tm\) [^ ]+ Software \([^\-]+-([^\-]+)-\w\),.+?Version ([^, ]+)/', $poll_device['sysDescr'], $regexp_result)) {
     $features = $regexp_result[1];
     $version  = $regexp_result[2];
-} // If we have not managed to match any IOS string yet (and that would be surprising)
-// we can try to poll the Entity Mib to see what's inside
-else {
-    $oids = 'entPhysicalModelName.1 entPhysicalContainedIn.1 entPhysicalName.1 entPhysicalSoftwareRev.1 entPhysicalModelName.1001 entPhysicalContainedIn.1001 cardDescr.1 cardSlotNumber.1';
-
-    $data = snmp_get_multi($device, $oids, '-OQUs', 'ENTITY-MIB:OLD-CISCO-CHASSIS-MIB');
-
-    if ($data[1]['entPhysicalContainedIn'] == '0') {
-        if (!empty($data[1]['entPhysicalSoftwareRev'])) {
-            $version = $data[1]['entPhysicalSoftwareRev'];
-        }
-
-        if (!empty($data[1]['entPhysicalName'])) {
-            $hardware = $data[1]['entPhysicalName'];
-        }
-
-        if (!empty($data[1]['entPhysicalModelName'])) {
-            $hardware = $data[1]['entPhysicalModelName'];
-        }
-    }
 }
 
-// if ($slot_1 == "-1" && strpos($descr_1, "No") === FALSE) { $ciscomodel = $descr_1; }
-// if (($contained_1 == "0" || $name_1 == "Chassis") && strpos($model_1, "No") === FALSE) { $ciscomodel = $model_1; list($version_1) = explode(",",$ver_1); }
-// if ($contained_1001 == "0" && strpos($model_1001, "No") === FALSE) { $ciscomodel = $model_1001; }
-// $ciscomodel = str_replace("\"","",$ciscomodel);
-// if ($ciscomodel) { $hardware = $ciscomodel; unset($ciscomodel); }
+$oids = 'entPhysicalModelName.1 entPhysicalContainedIn.1 entPhysicalName.1 entPhysicalSoftwareRev.1 entPhysicalModelName.1001 entPhysicalContainedIn.1001 cardDescr.1 cardSlotNumber.1';
+
+$data = snmp_get_multi($device, $oids, '-OQUs', 'ENTITY-MIB:OLD-CISCO-CHASSIS-MIB');
+
+if ($data[1]['entPhysicalContainedIn'] == '0') {
+    if (!empty($data[1]['entPhysicalSoftwareRev'])) {
+        $version = $data[1]['entPhysicalSoftwareRev'];
+    }
+
+    if (!empty($data[1]['entPhysicalName'])) {
+        $hardware = $data[1]['entPhysicalName'];
+    }
+
+    if (!empty($data[1]['entPhysicalModelName'])) {
+        $hardware = $data[1]['entPhysicalModelName'];
+    }
+}
+if (!empty($data[1001]['entPhysicalModelName'])) {
+    $hardware = $data[1001]['entPhysicalModelName'];
+} elseif (!empty($data[1001]['entPhysicalContainedIn'])) {
+    $hardware = $data[$data[1001]['entPhysicalContainedIn']]['entPhysicalName'];
+}
+
 if (empty($hardware)) {
     $hardware = snmp_get($device, 'sysObjectID.0', '-Osqv', 'SNMPv2-MIB:CISCO-PRODUCTS-MIB');
 }
 
-// if(isset($cisco_hardware_oids[$poll_device['sysObjectID']])) { $hardware = $cisco_hardware_oids[$poll_device['sysObjectID']]; }
 $serial = get_main_serial($device);
 
-
 if (strstr($hardware, 'cisco819')) {
-      include 'includes/polling/wireless/cisco-wwan.inc.php';
+    include 'includes/polling/wireless/cisco-wwan.inc.php';
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

fixed cisco hardware name detection (always returning value from SNMPv2-MIB:CISCO-PRODUCTS-MIB, which is ugly formatted).

tested on ASR1001, me3400, 2960, 2960X, 3020 - hp blade switch, 1941, 3560x, 3845, 4507

previous i.e.: 
cisco340024TSA 
cat29xxStack

now i.e.: 
ME-3400-24TS-A
WS-C2960X-24TS-L
