### PR TITLE
fix: Remove usage of -CI, it is not allowed for snmpbulkwalk

### DIFF
--- a/html/includes/graphs/device/bits.inc.php
+++ b/html/includes/graphs/device/bits.inc.php
@@ -16,7 +16,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ?', array($devic
 
     if (is_array($config['device_traffic_descr'])) {
         foreach ($config['device_traffic_descr'] as $ifdescr) {
-            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName']) || preg_match($ifdescr.'i', $port['portName'])) {
+            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName'])) {
                 $ignore = 1;
             }
         }

--- a/html/includes/graphs/global/bits.inc.php
+++ b/html/includes/graphs/global/bits.inc.php
@@ -15,7 +15,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` AS P, `devices` AS D WHERE D.device_
 
     if (is_array($config['device_traffic_descr'])) {
         foreach ($config['device_traffic_descr'] as $ifdescr) {
-            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName']) || preg_match($ifdescr.'i', $port['portName'])) {
+            if (preg_match($ifdescr.'i', $port['ifDescr']) || preg_match($ifdescr.'i', $port['ifName'])) {
                 $ignore = 1;
             }
         }

--- a/html/includes/graphs/location/bits.inc.php
+++ b/html/includes/graphs/location/bits.inc.php
@@ -18,7 +18,7 @@ foreach ($devices as $device) {
 
         if (is_array($config['device_traffic_descr'])) {
             foreach ($config['device_traffic_descr'] as $ifdescr) {
-                if (preg_match($ifdescr.'i', $int['ifDescr']) || preg_match($ifdescr.'i', $int['ifName']) || preg_match($ifdescr.'i', $int['portName'])) {
+                if (preg_match($ifdescr.'i', $int['ifDescr']) || preg_match($ifdescr.'i', $int['ifName'])) {
                     $ignore = 1;
                 }
             }

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -187,13 +187,9 @@ if ($config['enable_ports_poe']) {
 // foreach ($cisco_oids as $oid)     { $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, "OLD-CISCO-INTERFACES-MIB"); }
 // foreach ($pagp_oids as $oid)      { $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, "CISCO-PAGP-MIB"); }
 if ($device['os_group'] == 'cisco' && $device['os'] != 'asa') {
-    $port_stats = snmp_cache_portIfIndex($device, $port_stats);
-    $port_stats = snmp_cache_portName($device, $port_stats);
     foreach ($pagp_oids as $oid) {
         $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'CISCO-PAGP-MIB');
     }
-
-    $data_oids[] = 'portName';
 
     // Grab data to put ports into vlans or make them trunks
     // FIXME we probably shouldn't be doing this from the VTP MIB, right?

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -570,7 +570,7 @@ function snmp_cache_port_oids($oids, $port, $device, $array, $mib = 0)
 
 function snmp_cache_portIfIndex($device, $array)
 {
-    $cmd = gen_snmpwalk_cmd($device, 'portIfIndex', ' -CI -Oq', 'CISCO-STACK-MIB');
+    $cmd = gen_snmpwalk_cmd($device, 'portIfIndex', ' -Oq', 'CISCO-STACK-MIB');
     $output    = trim(external_exec($cmd));
 
     foreach (explode("\n", $output) as $entry) {
@@ -588,7 +588,7 @@ function snmp_cache_portIfIndex($device, $array)
 
 function snmp_cache_portName($device, $array)
 {
-    $cmd = gen_snmpwalk_cmd($device, 'portName', ' -CI -OQs', 'CISCO-STACK-MIB');
+    $cmd = gen_snmpwalk_cmd($device, 'portName', ' -OQs', 'CISCO-STACK-MIB');
     $output    = trim(external_exec($cmd));
 
     // echo("Caching: portName\n");

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -568,46 +568,6 @@ function snmp_cache_port_oids($oids, $port, $device, $array, $mib = 0)
 }//end snmp_cache_port_oids()
 
 
-function snmp_cache_portIfIndex($device, $array)
-{
-    $cmd = gen_snmpwalk_cmd($device, 'portIfIndex', ' -Oq', 'CISCO-STACK-MIB');
-    $output    = trim(external_exec($cmd));
-
-    foreach (explode("\n", $output) as $entry) {
-        $entry                    = str_replace('CISCO-STACK-MIB::portIfIndex.', '', $entry);
-        list($slotport, $ifIndex) = explode(' ', $entry, 2);
-        if ($slotport && $ifIndex) {
-            $array[$ifIndex]['portIfIndex'] = $slotport;
-            $array[$slotport]['ifIndex']    = $ifIndex;
-        }
-    }
-
-    return $array;
-}//end snmp_cache_portIfIndex()
-
-
-function snmp_cache_portName($device, $array)
-{
-    $cmd = gen_snmpwalk_cmd($device, 'portName', ' -OQs', 'CISCO-STACK-MIB');
-    $output    = trim(external_exec($cmd));
-
-    // echo("Caching: portName\n");
-    foreach (explode("\n", $output) as $entry) {
-        $entry = str_replace('portName.', '', $entry);
-        list($slotport, $portName) = explode('=', $entry, 2);
-        $slotport                  = trim($slotport);
-        $portName                  = trim($portName);
-        if ($array[$slotport]['ifIndex']) {
-            $ifIndex = $array[$slotport]['ifIndex'];
-            $array[$slotport]['portName'] = $portName;
-            $array[$ifIndex]['portName']  = $portName;
-        }
-    }
-
-    return $array;
-}//end snmp_cache_portName()
-
-
 function snmp_gen_auth(&$device)
 {
     global $debug, $vdebug;


### PR DESCRIPTION
As far as I can tell, -CI only has a possibility to affect the results when the number of objects is 0-1 and these two queries only seem to be for cisco devices.
The fact that the queries were completely failing against non-snmpv1 devices should be a clue that either -CI isn't needed, or these queries aren't needed.
Please test this to see if it increases polling time, as snmpbulkwalk doesn't return instantly anymore with this.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
