### PR TITLE
Update Oxidized.md

### DIFF
--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -43,8 +43,6 @@ You will need to configure default credentials for your devices in the Oxidized 
         debug: false
         http:
           url: https://librenms/api/v0/oxidized
-          scheme: https
-          delimiter: !ruby/regexp /:/
           map:
             name: hostname
             model: os
@@ -75,6 +73,12 @@ To match on a device os of edgeos then please use the following:
 
 ```php
 $config['oxidized']['group']['os'][] = array('match' => 'edgeos', 'group' => 'wireless');
+```
+
+Verify the return of groups by querying the API:
+
+```
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/oxidized				
 ```
 
 If you need to, you can specify credentials for groups by using the following in your Oxidized config:


### PR DESCRIPTION
Removed:
          scheme: https
          delimiter: !ruby/regexp /:/

from config example since it's deprecated according to https://github.com/ytti/oxidized/issues/646#issuecomment-268675774

Also added example to verify return of groups in json

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
