### PR TITLE
Fix:empty routing menu where only CEF is present

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -160,6 +160,7 @@ LibreNMS contributors:
 - Martin Zatloukal <slezi2@pvfree.net> (erotel)
 - Matthew Schwen <mschwen@gmail.com> (mattschwen)
 - Joel Cant <joel@linuxmod.co.uk> (NerdBlender
+- Aldemir Akpinar <aldemir.akpinar@gmail.com> (aldemir_a)
 
 [1]: http://observium.org/ "Observium web site"
 Observium was written by:

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -490,6 +490,16 @@ if ($_SESSION['userlevel'] >= '5' && $routing_count['bgp']) {
             <li><a href="routing/protocol=bgp/type=internal/graph=NULL/"><i class="fa fa-external-link fa-rotate-180 fa-fw fa-lg" aria-hidden="true"></i> BGP Internal</a></li>');
 }
 
+    // CEF info
+if ($_SESSION['userlevel'] >= '5' && $routing_count['cef']) {
+    if ($separator) {
+        echo('            <li role="presentation" class="divider"></li>');
+        $separator = 0;
+    }
+    echo('<li><a href="routing/protocol=cef/"><i class="fa fa-exchange fa-fw fa-lg" aria-hidden="true"></i> Cisco CEF </a></li>');
+    $separator++;
+}
+
   // Do Alerts at the bottom
 if ($bgp_alerts) {
     echo('


### PR DESCRIPTION
I agree to the conditions of the Contributor Agreement contained
in doc/General/Contributing.md.

When only CEF is present but no BGP, OSPF, or VRF is present, routing
menu becomes empty. This patch fixes that adding a CEF line.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
