### PR TITLE
fix: restore usage of -i -n in polling

### DIFF
--- a/poller.php
+++ b/poller.php
@@ -57,7 +57,7 @@ if (isset($options['i']) && $options['i'] && isset($options['n'])) {
     // FIXME
     $query = 'SELECT * FROM (SELECT @rownum :=0) r,
         (
-            SELECT @rownum := @rownum +1 AS rownum, `device_id`
+            SELECT @rownum := @rownum +1 AS rownum, `devices`.*
             FROM `devices`
             WHERE `disabled` = 0
             ORDER BY `device_id` ASC


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #5206 