### PR TITLE
refactor: Move mib based polling into yaml config files

### DIFF
--- a/doc/Extensions/MIB-based-polling.md
+++ b/doc/Extensions/MIB-based-polling.md
@@ -152,7 +152,8 @@ Alternatively you can enable MIB polling per device by enabling it within the mo
 
 ### Discovery
 
-You need to add your desired MIBs to `/opt/librenms/mibs` folder. Afterwards you need to register your MIBs to the OS definition. 
+You need to add your desired MIBs to `/opt/librenms/mibs` folder. 
+You will then need to create a list of the OIDs you wish to use in the OS definition
 
 #### Example
 `/opt/librenms/includes/definitions/ruckuswireless.yaml`

--- a/doc/Extensions/MIB-based-polling.md
+++ b/doc/Extensions/MIB-based-polling.md
@@ -153,7 +153,7 @@ Alternatively you can enable MIB polling per device by enabling it within the mo
 ### Discovery
 
 You need to add your desired MIBs to `/opt/librenms/mibs` folder. 
-You will then need to create a list of the OIDs you wish to use in the OS definition
+You will then need to create a list of the OIDs you wish to use in the OS definition.
 
 #### Example
 `/opt/librenms/includes/definitions/ruckuswireless.yaml`

--- a/doc/Extensions/MIB-based-polling.md
+++ b/doc/Extensions/MIB-based-polling.md
@@ -147,32 +147,25 @@ graph.
 
 ## Configuration
 ### Main Configuration
-In `/opt/librenms/config.php` add `$config['poller_modules']['mib'] = 1;`
+In `/opt/librenms/config.php` add `$config['poller_modules']['mib'] = 1;` to enable MIB polling globally.
+Alternatively you can enable MIB polling per device by enabling it within the modules section for the specific device.
 
 ### Discovery
 
-You need to add your desired MIBs to `/opt/librenms/mibs` folder. Afterwards you need to register your MIBs to the discovery function. 
+You need to add your desired MIBs to `/opt/librenms/mibs` folder. Afterwards you need to register your MIBs to the OS definition. 
 
 #### Example
-`/opt/librenms/includes/discovery/os/f5.inc.php`
+`/opt/librenms/includes/definitions/ruckuswireless.yaml`
 
-```
-<?php
-if (starts_with($sysObjectId, '.1.3.6.1.4.1.3375.2.1')) {
-    $os = 'f5';
-}
-
-### MIB definition as an array 
-$f5_mibs = array(
-    'ltmVirtualServStatEntry' => 'F5-BIGIP-LOCAL-MIB',
-);
-
-### Actual registering of the MIB
-register_mibs($device, $f5_mibs, "includes/discovery/os/f5.inc.php");
-
+```yaml
+register_mibs:
+    ruckusZDSystemStats: RUCKUS-ZD-SYSTEM-MIB
+    ruckusZDWLANTable: RUCKUS-ZD-WLAN-MIB
+    ruckusZDWLANAPTable: RUCKUS-ZD-WLAN-MIB
+    ruckusZDWLANAPRadioStatsTable: RUCKUS-ZD-WLAN-MIB
 ```
 
-The important thing is the array $f5_mibs where you define which parts (ltmVirtualServStatEntry) of the MIB (F5-BIGIP-LOCAL-MIB) you are going to add. The registering is also important, otherwise poller cannot make use of the MIB.
+These OIDs and MIBs will then be registered as part of the OS discovery ready for mib polling to work.
 
 ## TODO ##
 

--- a/html/pages/device/mib.inc.php
+++ b/html/pages/device/mib.inc.php
@@ -16,7 +16,7 @@
 if (!isset($vars['section'])) {
     $vars['section'] = "mib";
 }
-if (is_module_enabled('poller', 'mib')) {
+if (is_mib_poller_enabled($device)) {
 ?>
 
 <h4><i class="fa fa-file-text-o"></i> Device MIB associations</h4>

--- a/includes/common.php
+++ b/includes/common.php
@@ -1057,7 +1057,7 @@ function print_mib_poller_disabled()
 {
     echo '<h4>MIB polling is not enabled</h4>
 <p>
-Set <tt>$config[\'poller_modules\'][\'mib\'] = 1;</tt> in <tt>config.php</tt> to enable.
+Set <tt>$config[\'poller_modules\'][\'mib\'] = 1;</tt> in <tt>config.php</tt> or enable for this device specifically to enable.
 </p>';
 } // print_mib_poller_disabled
 

--- a/includes/definitions/ios.yaml
+++ b/includes/definitions/ios.yaml
@@ -34,3 +34,5 @@ discovery_modules:
     cisco-pw: 1
     cisco-vrf: 1
     cisco-vrf-lite: 1
+register_mibs:
+    ciscoAAASessionMIB: CISCO-AAA-SESSION-MIB

--- a/includes/definitions/iosxe.yaml
+++ b/includes/definitions/iosxe.yaml
@@ -31,3 +31,5 @@ discovery_modules:
     cisco-pw: 1
     cisco-vrf: 1
     cisco-vrf-lite: 1
+register_mibs:
+    ciscoAAASessionMIB: CISCO-AAA-SESSION-MIB

--- a/includes/definitions/iosxr.yaml
+++ b/includes/definitions/iosxr.yaml
@@ -31,3 +31,5 @@ discovery_modules:
     cisco-pw: 1
     cisco-vrf: 1
     cisco-vrf-lite: 1
+register_mibs:
+    ciscoAAASessionMIB: CISCO-AAA-SESSION-MIB

--- a/includes/definitions/lenovoemc.yaml
+++ b/includes/definitions/lenovoemc.yaml
@@ -9,3 +9,8 @@ over:
     - { graph: device_bits, text: 'Device Traffic' }
     - { graph: device_processor, text: 'CPU Usage' }
     - { graph: device_mempool, text: 'Memory Usage' }
+register_mibs:
+    fanValue: IOMEGANAS-MIB
+    tempValue: IOMEGANAS-MIB
+    raidStatus: IOMEGANAS-MIB
+    diskStatus: IOMEGANAS-MIB

--- a/includes/definitions/linux.yaml
+++ b/includes/definitions/linux.yaml
@@ -22,3 +22,12 @@ discovery_modules:
     toner: 0
     vmware-vminfo: 1
 processor_stacked: 1
+register_mibs:
+    rxCounter: GANDI-MIB
+    txCounter: GANDI-MIB
+    dropCounter: GANDI-MIB
+    acldropCounter: GANDI-MIB
+    ratedropCounter: GANDI-MIB
+    KNIrxCounter: GANDI-MIB
+    KNItxCounter: GANDI-MIB
+    KNIdropCounter: GANDI-MIB

--- a/includes/definitions/routeros.yaml
+++ b/includes/definitions/routeros.yaml
@@ -8,3 +8,5 @@ over:
     - { graph: device_bits, text: 'Device Traffic' }
     - { graph: device_processor, text: 'CPU Usage' }
     - { graph: device_mempool, text: 'Memory Usage' }
+register_mibs:
+    ciscoAAASessionMIB: CISCO-AAA-SESSION-MIB

--- a/includes/definitions/ruckuswireless.yaml
+++ b/includes/definitions/ruckuswireless.yaml
@@ -6,3 +6,8 @@ mib_dir:
     - ruckus
 over:
     - { graph: device_bits, text: Traffic }
+register_mibs:
+    ruckusZDSystemStats: RUCKUS-ZD-SYSTEM-MIB
+    ruckusZDWLANTable: RUCKUS-ZD-WLAN-MIB
+    ruckusZDWLANAPTable: RUCKUS-ZD-WLAN-MIB
+    ruckusZDWLANAPRadioStatsTable: RUCKUS-ZD-WLAN-MIB

--- a/includes/definitions/serveriron.yaml
+++ b/includes/definitions/serveriron.yaml
@@ -7,3 +7,11 @@ over:
     - { graph: device_processor, text: 'CPU Usage' }
     - { graph: device_mempool, text: 'Memory Usage' }
 icon: brocade
+register_mibs:
+    snL4slbTotalConnections: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB
+    snL4slbLimitExceeds: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB
+    snL4slbForwardTraffic: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB
+    snL4slbReverseTraffic: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB
+    snL4slbFinished: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB
+    snL4FreeSessionCount: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB
+    snL4unsuccessfulConn: FOUNDRY-SN-SW-L4-SWITCH-GROUP-MIB

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -111,6 +111,9 @@ function discover_device($device, $options = null)
     }
 
     $config['os'][$device['os']] = load_os($device);
+    if (is_array($config['os'][$device['os']]['register_mibs'])) {
+        register_mibs($device, $config['os'][$device['os']]['register_mibs'], 'includes/discovery/os/' . $device['os'] . '.inc.php');
+    }
 
     // Set type to a predefined type for the OS if it's not already set
     if ($device['type'] == 'unknown' || $device['type'] == '') {

--- a/includes/discovery/os/ios.inc.php
+++ b/includes/discovery/os/ios.inc.php
@@ -2,9 +2,4 @@
 
 if (str_contains($sysDescr, array('Cisco Internetwork Operating System Software', 'IOS (tm)', 'Cisco IOS Software', 'Global Site Selector')) && !str_contains($sysDescr, array('IOS-XE', 'X86_64_LINUX_IOSD'))) {
     $os = 'ios';
-
-    $extra_mibs = array(
-        "ciscoAAASessionMIB" => "CISCO-AAA-SESSION-MIB",
-    );
-    register_mibs($device, $extra_mibs, "includes/discovery/os/ios.inc.php");
 }

--- a/includes/discovery/os/iosxe.inc.php
+++ b/includes/discovery/os/iosxe.inc.php
@@ -2,9 +2,4 @@
 
 if (str_contains($sysDescr, array('IOS-XE', 'X86_64_LINUX_IOSD'))) {
     $os = 'iosxe';
-
-    $extra_mibs = array(
-        "ciscoAAASessionMIB" => "CISCO-AAA-SESSION-MIB",
-    );
-    register_mibs($device, $extra_mibs, "includes/discovery/os/iosxe.inc.php");
 }

--- a/includes/discovery/os/iosxr.inc.php
+++ b/includes/discovery/os/iosxr.inc.php
@@ -2,9 +2,4 @@
 
 if (str_contains($sysDescr, 'IOS XR')) {
     $os = 'iosxr';
-
-    $extra_mibs = array(
-        "ciscoAAASessionMIB" => "CISCO-AAA-SESSION-MIB",
-    );
-    register_mibs($device, $extra_mibs, "includes/discovery/os/iosxr.inc.php");
 }

--- a/includes/discovery/os/lenovoemc.inc.php
+++ b/includes/discovery/os/lenovoemc.inc.php
@@ -2,12 +2,4 @@
 
 if (str_contains($sysDescr, 'EMC SOHO-NAS Storage.')) {
     $os = 'lenovoemc';
-
-    $lenovoemc_mibs = array(
-        "fanValue"  => "IOMEGANAS-MIB",
-        "tempValue"     => "IOMEGANAS-MIB",
-        "raidStatus"    => "IOMEGANAS-MIB",
-        "diskStatus"    => "IOMEGANAS-MIB"
-    );
-    register_mibs($device, $lenovoemc_mibs, "includes/discovery/os/lenovoemc.inc.php");
 }

--- a/includes/discovery/os/linux.inc.php
+++ b/includes/discovery/os/linux.inc.php
@@ -33,17 +33,6 @@ if (starts_with($sysDescr, 'Linux') && !starts_with($sysObjectId, $skip_oids)) {
         }
     } elseif (snmp_get($device, 'GANDI-MIB::rxCounter.0', '-Osqnv', 'GANDI-MIB') !== false) {
         $os = 'pktj';
-        $pktj_mibs = array(
-            "rxCounter" => "GANDI-MIB",  // RX Packets
-            "txCounter" => "GANDI-MIB",  // TX Packets
-            "dropCounter" => "GANDI-MIB",  // Dropped counters
-            "acldropCounter" => "GANDI-MIB",  // ACL Dropped counter
-            "ratedropCounter" => "GANDI-MIB",  // Rate Dropped counter
-            "KNIrxCounter" => "GANDI-MIB",  // KNI RX counter
-            "KNItxCounter" => "GANDI-MIB",  // KNI TX counter
-            "KNIdropCounter" => "GANDI-MIB",  // KNI DROP counter
-        );
-        register_mibs($device, $pktj_mibs, "include/discovery/os/linux.inc.php");
     } elseif (starts_with($sysObjectId, '.1.3.6.1.4.1.40310')) {
         $os = 'cumulus';
     } elseif (str_contains($sysDescr, array('g56fa85e', 'gc80f187', 'g829be90', 'g63c0044', 'gba768e5'))) {

--- a/includes/discovery/os/routeros.inc.php
+++ b/includes/discovery/os/routeros.inc.php
@@ -7,10 +7,3 @@ if (starts_with($sysDescr, 'router') && is_numeric(snmp_get($device, 'SNMPv2-SMI
 if (starts_with($sysDescr, 'RouterOS')) {
     $os = 'routeros';
 }
-
-if (!empty($os)) {
-    $extra_mibs = array(
-        "ciscoAAASessionMIB" => "CISCO-AAA-SESSION-MIB",
-    );
-    register_mibs($device, $extra_mibs, "includes/discovery/os/routeros.inc.php");
-}

--- a/includes/discovery/os/ruckuswireless.inc.php
+++ b/includes/discovery/os/ruckuswireless.inc.php
@@ -14,12 +14,4 @@
 
 if (starts_with($sysObjectId, '.1.3.6.1.4.1.25053.3.1')) {
     $os = 'ruckuswireless';
-
-    $ruckus_mibs = array(
-        "ruckusZDSystemStats"           => "RUCKUS-ZD-SYSTEM-MIB",
-        "ruckusZDWLANTable"             => "RUCKUS-ZD-WLAN-MIB",
-        "ruckusZDWLANAPTable"           => "RUCKUS-ZD-WLAN-MIB",
-        "ruckusZDWLANAPRadioStatsTable" => "RUCKUS-ZD-WLAN-MIB",
-    );
-    register_mibs($device, $ruckus_mibs, "includes/discovery/os/ruckuswireless.inc.php");
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Moved mib polling calls into discover_device() function so they only need defining in the yaml definitions file now.

Updated docs to show new examples.

Updated html page to tell users they can enable per device + have per device check to show mib page.

Move code from `includes/discovery/os/*.inc.php` to `includes/definitions/*.yaml`.
