### PR TITLE
Zombies arghhhhhhhhh

### DIFF
--- a/html/includes/graphs/graph.inc.php
+++ b/html/includes/graphs/graph.inc.php
@@ -76,7 +76,6 @@ function graph_error($string)
             fpassthru($fd);
             fclose($fd);
             unlink($graphfile);
-            //exit();
         }
     } else {
         if (!$debug) {
@@ -88,7 +87,6 @@ function graph_error($string)
         imagestring($im, 3, $px, ($height / 2 - 8), $string, imagecolorallocate($im, 128, 0, 0));
         imagepng($im);
         imagedestroy($im);
-        //exit();
     }
 }
 

--- a/html/includes/graphs/graph.inc.php
+++ b/html/includes/graphs/graph.inc.php
@@ -53,7 +53,6 @@ if ($auth === true && is_custom_graph($type, $subtype, $device)) {
     // Graph Template Missing");
 }
 
-
 function graph_error($string)
 {
     global $vars, $config, $debug, $graphfile;
@@ -77,7 +76,7 @@ function graph_error($string)
             fpassthru($fd);
             fclose($fd);
             unlink($graphfile);
-            exit();
+            //exit();
         }
     } else {
         if (!$debug) {
@@ -89,10 +88,9 @@ function graph_error($string)
         imagestring($im, 3, $px, ($height / 2 - 8), $string, imagecolorallocate($im, 128, 0, 0));
         imagepng($im);
         imagedestroy($im);
-        exit();
+        //exit();
     }
 }
-
 
 if ($error_msg) {
     // We have an error :(


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

No not

![image](https://cloud.githubusercontent.com/assets/3941142/21598119/6ec468e8-d14e-11e6-8393-08f9afe1dbe0.png)

Rather

![image](https://cloud.githubusercontent.com/assets/3941142/21598121/7b82582e-d14e-11e6-9b64-31e53f4d3b35.png)

It looks like when a graph errors (for whatever reason), the graph_error() function is called which would run exit(); and not allow rrdtool_close() to run leaving zombiesssssss....

Sorry to tag you @murrant but you've looked at the graph code the most in recent times, does the above seem likely and therefore the fix?