### PR TITLE
Added section on smokeping and rrdcached

### DIFF
--- a/doc/Extensions/Smokeping.md
+++ b/doc/Extensions/Smokeping.md
@@ -141,6 +141,34 @@ Add the following line at the end:
 
 Exit and save.
 
+### Smokeping and RRDCached ###
+
+If you are using the standard smokeping data dir (/opt/smokeping/data) then you may need to alter the rrdcached config slightly.
+
+In the standard configuration the -B argument may have been used to restrict rrdcached to read only from a single base dir.
+
+
+If this is true, when you try an open one of the smokeping graphs from within LibreNMS you will see something like this error at the end of the rrdcached command:
+
+```bash
+ERROR: rrdcached: /var/lib/smokeping/<device name>.rrd: Permission denied
+```
+
+So you will need to either change the dir in which smokeping saves its rrd files to be the same as the main librenms dir or you can remove the -B argument from the rrdcached config to allow it to read from more than one dir.
+
+To remove the -B switch:
+
+```bash
+sudo nano /etc/default/rrdcached
+```
+then find:
+
+```bash
+BASE_OPTIONS=
+```
+ 
+If -B is in the list of arguments delete it.
+
 ### Configure LibreNMS ###
 
 ```bash


### PR DESCRIPTION
@Rosiak 
added new section describing how to remove the -B switch from the rrdcached arguments.
This is needed if users are getting and error like this: "ERROR: rrdcached: /var/lib/smokeping/<device name>.rrd: Permission denied" when trying to view smokeping graphs in librenms.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
