### PR TITLE
Update Centos 7 nginx install steps

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -47,7 +47,6 @@ yum install php70w php70w-cli php70w-gd php70w-mysql php70w-snmp php70w-pear php
 pear install Net_IPv4-1.3.4
 pear install Net_IPv6-1.2.2b2
 ```
-#### Configure PHP
 
 In `/etc/php.ini` ensure date.timezone is set to your preferred time zone.  See http://php.net/manual/en/timezones.php for a list of supported timezones.  Valid examples are: "America/New_York", "Australia/Brisbane", "Etc/UTC".
 
@@ -61,7 +60,7 @@ listen.owner = nginx
 listen.group = nginx
 listen.mode = 0660
 ```
-#### Restart PHP
+Restart PHP.
 
 ```bash
 service php-fpm restart

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -47,8 +47,21 @@ yum install php70w php70w-cli php70w-gd php70w-mysql php70w-snmp php70w-pear php
 pear install Net_IPv4-1.3.4
 pear install Net_IPv6-1.2.2b2
 ```
+#### Configure PHP
 
 In `/etc/php.ini` ensure date.timezone is set to your preferred time zone.  See http://php.net/manual/en/timezones.php for a list of supported timezones.  Valid examples are: "America/New_York", "Australia/Brisbane", "Etc/UTC".
+
+In `/etc/php-fpm.d/www.conf` make these changes:
+
+```nginx
+;listen = 127.0.0.1:9000
+listen = /var/run/php/php7.0-fpm.sock
+
+listen.owner = nginx
+listen.group = nginx
+listen.mode = 0660
+```
+#### Restart PHP
 
 ```bash
 service php-fpm restart


### PR DESCRIPTION
Found some issues on a fresh install of Centos 7. PHP defaults to listening on a port, while LibreNMS expects a unix socket. Also, the listen owner has to match the account that nginx runs under.
This is my first proposed change on Github so if I'm doing this all wrong, feel free to smack me down.
Thanks.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
