### PR TITLE
Update Installation-Ubuntu-1604-Nginx.md

### DIFF
--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -108,8 +108,8 @@ Now head to: http://librenms.example.com/install.php and follow the on-screen in
 #### Configure snmpd
 
 ```bash
-cp /opt/librenms/snmpd.conf.example /etc/snmpd/snmpd.conf
-vim /etc/snmpd/snmpd.conf
+cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
+vim /etc/snmp/snmpd.conf
 ```
 
 Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community string.


### PR DESCRIPTION
snmp configs in ubuntu 16.04 for both snmp and snmpd are by default located under /etc/snmp and not /etc/snmpd

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
