### PR TITLE
fix: correct icon for ciscosb

### DIFF
--- a/includes/definitions/ciscosb.yaml
+++ b/includes/definitions/ciscosb.yaml
@@ -3,7 +3,7 @@ group: cisco
 text: 'Cisco Small Business'
 ifname: 1
 type: network
-icon: linksys
+icon: cisco
 over:
     - { graph: device_bits, text: 'Device Traffic' }
     - { graph: device_processor, text: 'CPU Usage' }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Replaced the linksys icon for ciscosb with the correct cisco one.