### PR TITLE
feature: Oxidized basic config search

### DIFF
--- a/html/includes/forms/search-oxidized-config.inc.php
+++ b/html/includes/forms/search-oxidized-config.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS
  *
- * Copyright (c) 2015 Søren Friis Rosiak <sorenrosiak@gmail.com>
+ * Copyright (c) 2017 Søren Friis Rosiak <sorenrosiak@gmail.com>
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation, either version 3 of the License, or (at your

--- a/html/includes/forms/search-oxidized-config.inc.php
+++ b/html/includes/forms/search-oxidized-config.inc.php
@@ -13,18 +13,19 @@ header('Content-type: application/json');
 
 $status    = 'error';
 $message   = 'unknown error';
-$parameters = mres($_POST['search_in_conf_textbox']);
+$parameters = clean($_POST['search_in_conf_textbox']);
 if (isset($parameters)) {
     $status  = 'ok';
     $message = 'Queried';
-    $output = search_oxidized_config($parameters);
+    $output = clean(search_oxidized_config($parameters));
 } else {
     $status  = 'error';
     $message = 'ERROR: Could not query';
 }
-die(json_encode(array(
+
+echo _json_encode(array(
      'status'                   => $status,
      'message'                  => $message,
      'search_in_conf_textbox'   => $parameters,
      'output'                   => $output
-)));
+));

--- a/html/includes/forms/search-oxidized-config.inc.php
+++ b/html/includes/forms/search-oxidized-config.inc.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2015 Søren Friis Rosiak <sorenrosiak@gmail.com>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+header('Content-type: application/json');
+
+$status    = 'error';
+$message   = 'unknown error';
+$parameters = mres($_POST['search_in_conf_textbox']);
+if (isset($parameters)) {
+    $status  = 'ok';
+    $message = 'Queried';
+    $output = search_oxidized_config($parameters);
+} else {
+    $status  = 'error';
+    $message = 'ERROR: Could not query';
+}
+die(json_encode(array(
+     'status'                   => $status,
+     'message'                  => $message,
+     'search_in_conf_textbox'   => $parameters,
+     'output'                   => $output
+)));

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1362,3 +1362,23 @@ function get_rules_from_json()
     global $config;
     return json_decode(file_get_contents($config['install_dir'] . '/misc/alert_rules.json'), true);
 }
+
+function search_oxidized_config($search_in_conf_textbox)
+{
+    global $config;
+    $oxidized_search_url = $config['oxidized']['url'] . '/nodes/conf_search?format=json';
+    $postdata = http_build_query(
+        array(
+            'search_in_conf_textbox' => $search_in_conf_textbox,
+        )
+    );
+    $opts = array('http' =>
+        array(
+            'method'  => 'POST',
+            'header'  => 'Content-type: application/x-www-form-urlencoded',
+            'content' => $postdata
+        )
+    );
+    $context  = stream_context_create($opts);
+    return json_decode(file_get_contents($oxidized_search_url, false, $context), true);
+}

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -89,6 +89,12 @@ if ($config['title_image']) {
            <a href="<?php echo(generate_url(array('page'=>'overview'))); ?>"><i class="fa fa-wrench fa-fw fa-lg" aria-hidden="true"></i> Tools</a>
            <ul class="dropdown-menu scrollable-menu">
            <li><a href="<?php echo(generate_url(array('page'=>'ripenccapi'))); ?>"><i class="fa fa-arrow-circle-up fa-fw fa-lg" aria-hidden="true"></i> RIPE NCC API</a></li>
+<?php
+if ($config['oxidized']['enabled'] === true && isset($config['oxidized']['url'])) {
+    echo '<li><a href="'.generate_url(array('page'=>'oxidized')).'"><i class="fa fa-arrow-circle-up fa-fw fa-lg" aria-hidden="true"></i> Oxidized</a></li>';
+}
+
+?>
            </ul>
           </li>
             <li role="presentation" class="divider"></li>

--- a/html/pages/oxidized.inc.php
+++ b/html/pages/oxidized.inc.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2017 Søren Friis Rosiak <sorenrosiak@gmail.com>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+$pagetitle[] = 'Oxidized';
+?>
+<h3> Oxidized - Config Search </h3>
+<hr>
+<form class="form-horizontal" action="" method="post">
+    <br />
+    <div class="input-group">
+        <input type="text" class="form-control" id="input-parameter" placeholder="service password-encryption etc.">
+        <span class="input-group-btn">
+        <button type="submit" name="btn-search" id="btn-search" class="btn btn-primary">Search</button>
+        </span>
+    </div>
+</form>
+<br />
+<div id="search-output" class="alert alert-success" style="display: none;"></div>
+<br />
+<script>
+    $("[name='btn-search']").on('click', function(event) {
+        event.preventDefault();
+        var $this = $(this);
+        var search_in_conf_textbox = $("#input-parameter").val();
+        $.ajax({
+            type: 'POST',
+            url: 'ajax_form.php',
+            data: {
+                type: "oxidized-search-config",
+                search_in_conf_textbox: search_in_conf_textbox
+            },
+            dataType: "json",
+            success: function(data) {
+                $('#search-output').empty();
+                $("#search-output").show();
+                if (data.output)
+                    $('#search-output').append('Config appears on the folllowing device(s):<br />');
+                    $.each(data.output, function(row, value) {
+                        $('#search-output').append(value['full_name'] + '<br />');
+                    });
+            },
+            error: function() {
+                toastr.error('Error');
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Hacked this together this eve.

Depending on the progress of https://github.com/ytti/oxidized-web/pull/111

This enables you to leverage the Oxidized's API Config search function, giving you the ability to search through configs stored in Oxidized. Example could be that you want to find all the Cisco devices with "no service password-encryption" command set.

This is VERY basic, code should be refactored and prettified some. 
Output should also be better as it only yields matches for now.
Feel free to take it from here, at least this is a start.

<img width="399" alt="screen shot 2017-01-07 at 00 10 04" src="https://cloud.githubusercontent.com/assets/6378934/21736281/d34a18c0-d46f-11e6-9802-e300a452115b.png">
