### PR TITLE
fix: os type and group not being set

### DIFF
--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -22,15 +22,12 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
 
     $device  = device_by_id_cache($vars['device']);
     $attribs = get_dev_attribs($device['device_id']);
+    load_os($device);
 
     $entity_state = get_dev_entity_state($device['device_id']);
 
     // print_r($entity_state);
     $pagetitle[] = $device['hostname'];
-
-    if ($config['os'][$device['os']]['group']) {
-        $device['os_group'] = $config['os'][$device['os']]['group'];
-    }
 
     echo '<div class="panel panel-default">';
         echo '<table class="device-header-table" style="margin: 0px 7px 7px 7px;" cellspacing="0" class="devicetable" width="99%">';

--- a/includes/common.php
+++ b/includes/common.php
@@ -1509,16 +1509,32 @@ function display($value)
 }
 
 /**
- * @param $os
- * @return array|mixed
+ * Load the os definition for the device and set type and os_group
+ * $device['os'] must be set
+ *
+ * @param array $device
+ * @throws Exception No OS to load
  */
-function load_os($os)
+function load_os(&$device)
 {
     global $config;
-    if (isset($os)) {
-        return Symfony\Component\Yaml\Yaml::parse(
-            file_get_contents($config['install_dir'] . '/includes/definitions/' . $os . '.yaml')
-        );
+    if (!isset($device['os'])) {
+        throw new Exception('No OS to load');
+    }
+
+    $config['os'][$device['os']] = Symfony\Component\Yaml\Yaml::parse(
+        file_get_contents($config['install_dir'] . '/includes/definitions/' . $device['os'] . '.yaml')
+    );
+
+    // Set type to a predefined type for the OS if it's not already set
+    if ($device['type'] == 'unknown' || $device['type'] == '') {
+        if ($config['os'][$device['os']]['type']) {
+            $device['type'] = $config['os'][$device['os']]['type'];
+        }
+    }
+
+    if ($config['os'][$device['os']]['group']) {
+        $device['os_group'] = $config['os'][$device['os']]['group'];
     }
 }
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -110,21 +110,9 @@ function discover_device($device, $options = null)
         }
     }
 
-    $config['os'][$device['os']] = load_os($device['os']);
+    load_os($device);
     if (is_array($config['os'][$device['os']]['register_mibs'])) {
         register_mibs($device, $config['os'][$device['os']]['register_mibs'], 'includes/discovery/os/' . $device['os'] . '.inc.php');
-    }
-
-    // Set type to a predefined type for the OS if it's not already set
-    if ($device['type'] == 'unknown' || $device['type'] == '') {
-        if ($config['os'][$device['os']]['type']) {
-            $device['type'] = $config['os'][$device['os']]['type'];
-        }
-    }
-
-    if ($config['os'][$device['os']]['group']) {
-        $device['os_group'] = $config['os'][$device['os']]['group'];
-        echo ' (' . $device['os_group'] . ')';
     }
 
     echo "\n";

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -149,7 +149,7 @@ function poll_device($device, $options)
 {
     global $config, $device, $polled_devices, $memcache;
 
-    $config['os'][$device['os']] = load_os($device['os']);
+    load_os($device);
 
     $attribs = get_dev_attribs($device['device_id']);
     $device['snmp_max_repeaters'] = $attribs['snmp_max_repeaters'];

--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -66,20 +66,21 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         echo (($wificlients1 + 0).' clients on wireless connector, ');
     } elseif ($device['os'] == 'unifi') {
         echo 'Checking Unifi Wireless clients... ';
+        $wificlients1 = 0;
+        $wificlients2 = 0;
 
-        $clients = snmp_walk($device, 'unifiVapNumStations', '-Oqv', 'UBNT-UniFi-MIB');
-        $bands = snmp_walk($device, 'unifiVapRadio', '-Oqv', 'UBNT-UniFi-MIB');
-        $clients = explode("\n", $clients);
-        $bands = explode("\n", $bands);
+        $clients = explode("\n", snmp_walk($device, 'unifiVapNumStations', '-Oqv', 'UBNT-UniFi-MIB'));
+        $bands = explode("\n", snmp_walk($device, 'unifiVapRadio', '-Oqv', 'UBNT-UniFi-MIB'));
+
         foreach ($bands as $index => $band_index) {
             if ($band_index == "ng") {
-                $wificlients1 = $wificlients1 + $clients[$index] + 0;
+                $wificlients1 += $clients[$index];
             } else {
-                $wificlients2 = $wificlients2 + $clients[$index] + 0;
+                $wificlients2 += $clients[$index];
             }
         }
 
-        echo (($wificlients1 + 0).' clients on Radio0, '.($wificlients2 + 0)." clients on Radio1\n");
+        echo $wificlients1 . ' clients on Radio0, ' . $wificlients2 . " clients on Radio1\n";
         include 'includes/polling/mib/ubnt-unifi-mib.inc.php';
     }
 


### PR DESCRIPTION
This breaks a few things, like wireless polling is skipped if type is unset.
Also, a small cleanup for the unifi client count.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

fixes: #5271 