### PR TITLE
fix: validate.php mysql queries

### DIFF
--- a/validate.php
+++ b/validate.php
@@ -229,24 +229,26 @@ if (!function_exists('openssl_random_pseudo_bytes')) {
 }
 
 // check discovery last run
-if (dbFetchCell('SELECT COUNT(`device_id`) FROM `devices` WHERE `last_discovered` IS NOT NULL') == 0) {
+if (dbFetchCell('SELECT COUNT(*) FROM `devices` WHERE `last_discovered` IS NOT NULL') == 0) {
     print_fail('Discovery has never run, check the cron job');
-} elseif (dbFetchCell("SELECT COUNT(`device_id`) FROM `devices` WHERE `last_discovered` <= DATE_ADD(NOW(), INTERVAL - 24 hours) AND `ignore` = 0 AND `disabled` = 0 AND `status` = 1") > 0) {
-    print_fail("Discovery has not run in the last 24 hours, check the cron job");
+} elseif (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `last_discovered` <= DATE_ADD(NOW(), INTERVAL - 24 hour) AND `ignore` = 0 AND `disabled` = 0 AND `status` = 1") > 0) {
+    print_fail("Discovery has not completed in the last 24 hours, check the cron job");
 }
 
 // check poller
-if (dbFetchCell('SELECT COUNT(`device_id`) FROM `devices` WHERE `last_polled` IS NOT NULL') == 0) {
+if (dbFetchCell('SELECT COUNT(*) FROM `devices` WHERE `last_polled` IS NOT NULL') == 0) {
     print_fail('The poller has never run, check the cron job');
-} elseif (dbFetchCell("SELECT COUNT(`device_id`) FROM `devices` WHERE `last_polled` < DATE_ADD(NOW(), INTERVAL - 5 minute) AND `ignore` = 0 AND `disabled` = 0 AND `status` = 1") > 0) {
+} elseif (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `last_polled` >= DATE_ADD(NOW(), INTERVAL - 5 minute) AND `ignore` = 0 AND `disabled` = 0 AND `status` = 1") == 0) {
     print_fail("The poller has not run in the last 5 minutes, check the cron job");
 } elseif (count($devices = dbFetchColumn("SELECT `hostname` FROM `devices` WHERE (`last_polled` < DATE_ADD(NOW(), INTERVAL - 5 minute) OR `last_polled` IS NULL) AND `ignore` = 0 AND `disabled` = 0 AND `status` = 1")) > 0) {
-    print_warn("Some devices have not been polled in the last 5 minutes, check your poll log");
+    print_warn("Some devices have not been polled in the last 5 minutes.
+        You may have performance issues. Check your poll log and see: http://docs.librenms.org/Support/Performance/");
     print_list($devices, "\t %s\n");
 }
 
 if (count($devices = dbFetchColumn('SELECT `hostname` FROM `devices` WHERE last_polled_timetaken > 300 AND `ignore` = 0 AND `disabled` = 0 AND `status` = 1')) > 0) {
-    print_fail("Some devices have not completed their polling run in 5 minutes, this will create gaps in data.\n        Check your poll log and refer to http://docs.librenms.org/Support/Performance/");
+    print_fail("Some devices have not completed their polling run in 5 minutes, this will create gaps in data.
+        Check your poll log and refer to http://docs.librenms.org/Support/Performance/");
     print_list($devices, "\t %s\n");
 }
 


### PR DESCRIPTION
fix poller query to correctly detect only when all devices haven't been polled in the last 5 minutes
Point users to the performance doc if the poller hasn't completed all devices in 5 minutes
We ignore the case where the user has no devices :)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
