### PR TITLE
fix: Fix toner detection discovery #5391

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -662,7 +662,7 @@ function discover_toner(&$valid, $device, $oid, $index, $type, $descr, $capacity
 {
     d_echo("Discover Toner: $oid, $index, $type, $descr, $capacity_oid, $capacity, $current\n");
 
-    if (dbFetchCell('SELECT COUNT(toner_id) FROM `toner` WHERE device_id = ? AND toner_type = ? AND `toner_index` = ? AND `toner_capacity_oid` =?', array($device['device_id'], $type, $index, $capacity_oid)) == '0') {
+    if (dbFetchCell('SELECT COUNT(toner_id) FROM `toner` WHERE device_id = ? AND toner_type = ? AND `toner_index` = ? AND `toner_oid` =?', array($device['device_id'], $type, $index, $oid)) == '0') {
         $inserted = dbInsert(array('device_id' => $device['device_id'], 'toner_oid' => $oid, 'toner_capacity_oid' => $capacity_oid, 'toner_index' => $index, 'toner_type' => $type, 'toner_descr' => $descr, 'toner_capacity' => $capacity, 'toner_current' => $current), 'toner');
         echo '+';
         log_event('Toner added: type ' . mres($type) . ' index ' . mres($index) . ' descr ' . mres($descr), $device, 'toner', $inserted);
@@ -676,7 +676,7 @@ function discover_toner(&$valid, $device, $oid, $index, $type, $descr, $capacity
         }
     }
 
-    $valid[$type][$index] = 1;
+    $valid[$type][$oid] = 1;
 }
 
 //end discover_toner()

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -18,19 +18,30 @@ if ($device['os_group'] == 'printer') {
 
     foreach ($oids as $index => $data) {
         $last_index = substr($index, strrpos($index, '.') + 1);
-        if ($device['os'] == 'ricoh' || $device['os'] == 'nrg' || $device['os'] == 'lanier') {
+        
+        $raw_toner     = $data['prtMarkerSuppliesLevel'];
+        $descr         = $data['prtMarkerSuppliesDescription'];
+        $raw_capacity  = $data['prtMarkerSuppliesMaxCapacity'];
+        $raw_toner     = $data['prtMarkerSuppliesLevel'];
+        $toner_oid     = ".1.3.6.1.2.1.43.11.1.1.9.$index";
+        $capacity_oid  = ".1.3.6.1.2.1.43.11.1.1.8.$index";
+
+        if (empty($raw_toner)) {
             $toner_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.5.$last_index";
-            $descr_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.3.$last_index";
-            $capacity_oid = '';
-
-            $descr = snmp_get($device, $descr_oid, '-Oqva');
             $raw_toner = snmp_get($device, $toner_oid, '-Oqv');
-        } else {
-            $toner_oid = ".1.3.6.1.2.1.43.11.1.1.9.$index";
-            $capacity_oid = ".1.3.6.1.2.1.43.11.1.1.8.$index";
+        }
 
-            $descr = $data['prtMarkerSuppliesDescription'];
-            $raw_toner = $data['prtMarkerSuppliesLevel'];
+        if (empty($descr)) {
+            $descr_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.3.$last_index";
+            $descr = snmp_get($device, $descr_oid, '-Oqva');
+        }
+
+        if (empty($raw_toner)) {
+            $raw_toner = snmp_get($device, $toner_oid, '-Oqv');
+        }
+
+        if (!empty($data['prtMarkerColorantValue'])) {
+            $descr = ucfirst($data['prtMarkerColorantValue']);
         }
 
         $type = 'jetdirect';
@@ -60,7 +71,6 @@ d_echo($sql);
 foreach ($sql as $test_toner) {
     $toner_oid = $test_toner['toner_oid'];
     $toner_type = $test_toner['toner_type'];
-    echo "$toner_oid and $toner_type\n";
     if (!$valid_toner[$toner_type][$toner_oid]) {
         echo '-';
         dbDelete('toner', '`toner_id` = ?', array($test_toner['toner_id']));

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -13,11 +13,12 @@ if ($device['os_group'] == 'printer') {
         $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesLevel', $oids, 'Printer-MIB');
         $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesMaxCapacity', $oids, 'Printer-MIB');
         $oids = snmpwalk_cache_oid($device, 'prtMarkerSuppliesDescription', $oids, 'Printer-MIB', null, '-OQUsa');
+        $oids = snmpwalk_cache_oid($device, 'prtMarkerColorantValue', $oids, 'Printer-MIB', null, '-OQUsa');
     }
 
     foreach ($oids as $index => $data) {
         $last_index = substr($index, strrpos($index, '.') + 1);
-        if ($os == 'ricoh' || $os == 'nrg' || $os == 'lanier') {
+        if ($device['os'] == 'ricoh' || $device['os'] == 'nrg' || $device['os'] == 'lanier') {
             $toner_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.5.$last_index";
             $descr_oid = ".1.3.6.1.4.1.367.3.2.1.2.24.1.1.3.$last_index";
             $capacity_oid = '';
@@ -54,11 +55,13 @@ if ($device['os_group'] == 'printer') {
 d_echo("\n Checking valid toner ... \n");
 d_echo($valid_toner);
 
-$sql = "SELECT * FROM toner WHERE device_id = '" . $device['device_id'] . "'";
-foreach (dbFetchRows($sql) as $test_toner) {
-    $toner_index = $test_toner['toner_index'];
+$sql = dbFetchRows("SELECT * FROM toner WHERE device_id = '" . $device['device_id'] . "'");
+d_echo($sql);
+foreach ($sql as $test_toner) {
+    $toner_oid = $test_toner['toner_oid'];
     $toner_type = $test_toner['toner_type'];
-    if (!$valid_toner[$toner_type][$toner_index]) {
+    echo "$toner_oid and $toner_type\n";
+    if (!$valid_toner[$toner_type][$toner_oid]) {
         echo '-';
         dbDelete('toner', '`toner_id` = ?', array($test_toner['toner_id']));
     }

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -66,9 +66,9 @@ if ($device['os_group'] == 'printer') {
 d_echo("\n Checking valid toner ... \n");
 d_echo($valid_toner);
 
-$sql = dbFetchRows("SELECT * FROM toner WHERE device_id = '" . $device['device_id'] . "'");
-d_echo($sql);
-foreach ($sql as $test_toner) {
+$toners = dbFetchRows("SELECT * FROM toner WHERE device_id = '" . $device['device_id'] . "'");
+d_echo($toners);
+foreach ($toners as $test_toner) {
     $toner_oid = $test_toner['toner_oid'];
     $toner_type = $test_toner['toner_type'];
     if (!$valid_toner[$toner_type][$toner_oid]) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

I think this is right.

Fixes: #5391 

Before hand duplicates were detected by capacity_oid which could be null, switched to oid as that will be unique (or should be).

The old if `($os` check was fundamentally wrong as $os is not defined.

The idea being now we use the standard Printer-MIB details and fall back if they are empty which in some situations they are. We also get the internationalised text to use for descr if it's available.
 