### PR TITLE
Altered NTP insanity message

### DIFF
--- a/includes/discovery/ntp/cisco.inc.php
+++ b/includes/discovery/ntp/cisco.inc.php
@@ -52,7 +52,7 @@ if (is_null($cntpPeersVarEntry)) {
         // Set the status, 16 = Bad
         if ($result['stratum'] == 16) {
             $result['status'] = 2;
-            $result['error'] = 'NTP Stratum is Insane';
+            $result['error'] = 'NTP is not in sync';
         } else {
             $result['status'] = 0;
             $result['error'] = '';

--- a/includes/polling/ntp/cisco.inc.php
+++ b/includes/polling/ntp/cisco.inc.php
@@ -45,7 +45,7 @@ if (count($components > 0)) {
         // Set the status, 16 = Bad
         if ($array['stratum'] == 16) {
             $array['status'] = 2;
-            $array['error'] = 'NTP Stratum is Insane';
+            $array['error'] = 'NTP is not in sync';
         } else {
             $array['status'] = 0;
             $array['error'] = '';


### PR DESCRIPTION
~ Changed: Message for the NTP discovery and polling altered. A stratum of 16
is not 'Insane' its actually not in sync as per the RFC 5909 specification.
See: https://tools.ietf.org/html/rfc5905#page-21 Fig. 11 for reference.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/)
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
