### PR TITLE
added info on realStorageUnits

### DIFF
--- a/doc/Support/FAQ.md
+++ b/doc/Support/FAQ.md
@@ -24,6 +24,7 @@ source: Support/FAQ.md
  - [How do I move my LibreNMS install to another server?](#faq24)
  - [Why is my EdgeRouter device not detected?](#faq25)
  - [Why are some of my disks not showing?](#faq26)
+ - [Why are my disks reporting an incorrect size?](#faq27)
 
 ### Developing
  - [How do I add support for a new OS?](#faq8)
@@ -240,6 +241,11 @@ Or
 `disk /storage`
 
 Restart snmpd and LibreNMS should populate the additional disk after a fresh discovery.
+
+#### <a name="faq27"> Why are my disks reporting an incorrect size?</a>
+There is a known issue for net-snmp, which causes it to report incorrect disk size and disk usage when the size of the disk (or raid) are larger then 16TB, a workaround has been implemented but is not active on Centos 6.8 by default due to the fact that this workaround breaks official SNMP specs, and as such could cause unexpected behaviour in other SNMP tools. You can activate the workaround by adding to /etc/snmp/snmpd.conf :
+
+`realStorageUnits 0`
 
 #### <a name="faq8"> How do I add support for a new OS?</a>
 


### PR DESCRIPTION
added a FAQ to show the option to fix a bug when adding realStorageUnits 0 to /etc/snmpd.conf (tested on centos 6.8)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
