### PR TITLE
Swap order of tests, and error our if one fails rather than continuing

### DIFF
--- a/scripts/pre-commit.php
+++ b/scripts/pre-commit.php
@@ -48,7 +48,7 @@ $completed_tests = array(
 $all = !check_opt($options, 'l', 'lint', 's', 'style', 'u', 'unit');
 if ($all) {
     // no test specified, run all tests in this order
-    $options += array('u' => false, 's' => false, 'l' => false);
+    $options += array('l' => false, 's' => false, 'u' => false);
 }
 
 // run tests in the order they were specified
@@ -131,6 +131,7 @@ function check_lint($passthru = false, $command_only = false)
 
         if ($lint_ret > 0) {
             print(implode(PHP_EOL, $lint_output) . PHP_EOL);
+            exit(1);
         } else {
             echo "success\n";
         }
@@ -177,6 +178,7 @@ function check_style($passthru = false, $command_only = false)
         if ($cs_ret > 0) {
             echo "failed\n";
             print(implode(PHP_EOL, $cs_output) . PHP_EOL);
+            exit(1);
         } else {
             echo "success\n";
         }
@@ -231,6 +233,7 @@ function check_unit($passthru = false, $command_only = false, $snmpsim = false)
             echo "failed\n";
             echo implode(PHP_EOL, $phpunit_output) . PHP_EOL;
             echo 'snmpsimd: output at /tmp/snmpsimd.log';
+            exit(1);
         } else {
             echo "success\n";
         }


### PR DESCRIPTION
The pre-check often fails on style and lint, but I spend ages waiting for the unit tests to complete before getting to this.

I've swapped the default order of the tests, and made it bomb out if one of the tests fail so they can be corrected.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
