### PR TITLE
Add logrotate config

### DIFF
--- a/doc/Installation/Installation-CentOS-6-Apache-Nginx.md
+++ b/doc/Installation/Installation-CentOS-6-Apache-Nginx.md
@@ -185,7 +185,7 @@ If you are running Apache 2.2.18 or higher (current version in Centos 7 official
   </Directory>
 </VirtualHost>
 ```
-If the file `/etc/httpd/conf.d/welcome.conf` exists, you will want to remove that as well unless you're familiar with [Name-based Virtual Hosts](https://httpd.apache.org/docs/2.2/vhosts/name-based.html). 
+If the file `/etc/httpd/conf.d/welcome.conf` exists, you will want to remove that as well unless you're familiar with [Name-based Virtual Hosts](https://httpd.apache.org/docs/2.2/vhosts/name-based.html).
 ```bash
 rn /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/welcome.conf.bak
 ```
@@ -376,6 +376,12 @@ If the thread count needs to be changed, you can do so by editing the cron file 
 Create the cronjob
 
     cp librenms.nonroot.cron /etc/cron.d/librenms
+
+### Copy logrotate config ###
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
 
 ### Daily Updates ###
 

--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -137,6 +137,12 @@ systemctl restart snmpd
 
 `cp librenms.nonroot.cron /etc/cron.d/librenms`
 
+#### Copy logrotate config
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+
 #### Final steps
 
 ```bash

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -35,7 +35,7 @@ sql-mode=""
 
 ### Web Server ###
 
-#### Install / Configure Nginx 
+#### Install / Configure Nginx
 
 ```bash
 yum install epel-release
@@ -159,6 +159,12 @@ systemctl restart snmpd
 #### Cron job
 
 `cp librenms.nonroot.cron /etc/cron.d/librenms`
+
+#### Copy logrotate config
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
 
 #### Final steps
 

--- a/doc/Installation/Installation-Ubuntu-1404-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1404-Apache.md
@@ -206,6 +206,12 @@ Create the cronjob
 
     cp librenms.nonroot.cron /etc/cron.d/librenms
 
+### Copy logrotate config ###
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+
 ### Daily Updates ###
 
 LibreNMS performs daily updates by default.  At 00:15 system time every day, a `git pull --no-edit --quiet` is performed.  You can override this default by editing your `config.php` file.  Remove the comment (the `#` mark) on the line:

--- a/doc/Installation/Installation-Ubuntu-1404-Lighttpd.md
+++ b/doc/Installation/Installation-Ubuntu-1404-Lighttpd.md
@@ -185,6 +185,12 @@ Create the cronjob
 
     cp librenms.nonroot.cron /etc/cron.d/librenms
 
+### Copy logrotate config ###
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+
 ### Daily Updates ###
 
 LibreNMS performs daily updates by default.  At 00:15 system time every day, a `git pull --no-edit --quiet` is performed.  You can override this default by editing your `config.php` file.  Remove the comment (the `#` mark) on the line:

--- a/doc/Installation/Installation-Ubuntu-1404-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1404-Nginx.md
@@ -212,6 +212,12 @@ Create the cronjob
 
     cp librenms.nonroot.cron /etc/cron.d/librenms
 
+### Copy logrotate config ###
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+
 ### Daily Updates ###
 
 LibreNMS performs daily updates by default.  At 00:15 system time every day, a `git pull --no-edit --quiet` is performed.  You can override this default by editing your `config.php` file.  Remove the comment (the `#` mark) on the line:

--- a/doc/Installation/Installation-Ubuntu-1604-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Apache.md
@@ -121,6 +121,12 @@ systemctl restart snmpd
 
 `cp librenms.nonroot.cron /etc/cron.d/librenms`
 
+#### Copy logrotate config
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+
 #### Final steps
 
 ```bash

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -125,6 +125,12 @@ systemctl restart snmpd
 
 `cp librenms.nonroot.cron /etc/cron.d/librenms`
 
+#### Copy logrotate config
+
+LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
+
+    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+
 #### Final steps
 
 ```bash

--- a/misc/librenms.logrotate
+++ b/misc/librenms.logrotate
@@ -1,0 +1,9 @@
+# /etc/logrotate.d/librenms
+/opt/librenms/logs/*.log {
+    weekly
+    rotate 6
+    compress
+    delaycompress
+    missingok
+    notifempty
+}


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)


This adds a logrotate config I've been using for a while now.  Wasn't sure where to place the file as it seemed most setup-type things are just in base of repo.  Let me know if it should be somewhere else / feel free to move it yourself

These are the file sizes I get with the weekly rotation with 15 devices

```
# ls -lh /opt/librenms/logs
total 6.0M
-rw-rw-r-- 1 librenms www-data  981 Jan 19 00:15 daily.log
-rw-rw-r-- 1 librenms www-data 1.4K Jan 15 00:15 daily.log.1
-rw-rw-r-- 1 librenms www-data  924 Jan  9 00:15 daily.log.2.gz
-rw-rw-r-- 1 librenms www-data  901 Jan  1 00:15 daily.log.3.gz
-rw-rw-r-- 1 librenms www-data  862 Dec 25 00:15 daily.log.4.gz
-rw-rw-r-- 1 librenms www-data  914 Dec 19 00:15 daily.log.5.gz
-rw-rw-r-- 1 librenms www-data  887 Dec 11 06:53 daily.log.6.gz
-rw-rw-r-- 1 librenms www-data 2.0M Jan 19 23:25 librenms.log
-rw-rw-r-- 1 librenms www-data 2.6M Jan 15 06:35 librenms.log.1
-rw-rw-r-- 1 librenms www-data 303K Jan  9 06:50 librenms.log.2.gz
-rw-rw-r-- 1 librenms www-data 266K Jan  1 06:51 librenms.log.3.gz
-rw-rw-r-- 1 librenms www-data 230K Dec 25 06:42 librenms.log.4.gz
-rw-rw-r-- 1 librenms www-data 305K Dec 19 06:56 librenms.log.5.gz
-rw-rw-r-- 1 librenms www-data 266K Dec 11 06:53 librenms.log.6.gz```