### PR TITLE
fix: Changing device type now is persistant

### DIFF
--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -22,6 +22,7 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
 
     $device  = device_by_id_cache($vars['device']);
     $attribs = get_dev_attribs($device['device_id']);
+    $device['attribs'] = $attribs;
     load_os($device);
 
     $entity_state = get_dev_entity_state($device['device_id']);

--- a/html/pages/device/edit/device.inc.php
+++ b/html/pages/device/edit/device.inc.php
@@ -24,17 +24,27 @@ if ($_POST['editing']) {
             dbUpdate(array('location'=>$override_sysLocation_string), 'devices', '`device_id`=?', array($device['device_id']));
         }
 
+        if ($device['type'] != $vars['type']) {
+            $param['type'] = $vars['type'];
+            $update_type = true;
+        }
+
         #FIXME needs more sanity checking! and better feedback
 
-        $param = array('purpose' => $vars['descr'], 'type' => $vars['type'], 'ignore' => set_numeric($vars['ignore']), 'disabled' => set_numeric($vars['disabled']));
+        $param['purpose']  = $vars['descr'];
+        $param['ignore']   = set_numeric($vars['ignore']);
+        $param['disabled'] = set_numeric($vars['disabled']);
 
         $rows_updated = dbUpdate($param, 'devices', '`device_id` = ?', array($device['device_id']));
 
         if ($rows_updated > 0 || $updated) {
+            if ($update_type === true) {
+                set_dev_attrib($device, 'override_device_type', true);
+            }
             $update_message = "Device record updated.";
             $updated = 1;
             $device = dbFetchRow("SELECT * FROM `devices` WHERE `device_id` = ?", array($device['device_id']));
-        } elseif ($rows_updated = '-1') {
+        } elseif ($rows_updated == 0) {
             $update_message = "Device record unchanged. No update necessary.";
             $updated = -1;
         } else {

--- a/includes/common.php
+++ b/includes/common.php
@@ -1533,7 +1533,7 @@ function load_os(&$device)
     }
 
     // Set type to a predefined type for the OS if it's not already set
-    if ($config['os'][$device['os']]['type'] != $device['type']) {
+    if ($device['attribs']['override_device_type'] != 1 && $config['os'][$device['os']]['type'] != $device['type']) {
         log_event('Device type changed '.$device['type'].' => '.$config['os'][$device['os']]['type'], $device, 'system');
         $device['type'] = $config['os'][$device['os']]['type'];
         dbUpdate(array('type' => $device['type']), 'devices', 'device_id=?', array($device['device_id']));

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -94,6 +94,7 @@ function discover_device($device, $options = null)
     $valid = array();
     // Reset $valid array
     $attribs = get_dev_attribs($device['device_id']);
+    $device['attribs'] = $attribs;
     $device['snmp_max_repeaters'] = $attribs['snmp_max_repeaters'];
 
     $device_start = microtime(true);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -636,7 +636,7 @@ function createHost($host, $community, $snmpver, $port = 161, $transport = 'udp'
         if (host_exists($host, $snmphost) === false) {
             $device_id = dbInsert($device, 'devices');
             if ($device_id) {
-                oxidized_reload_nodes();
+                oxidized_reload_§nodes();
                 return $device_id;
             }
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -636,7 +636,7 @@ function createHost($host, $community, $snmpver, $port = 161, $transport = 'udp'
         if (host_exists($host, $snmphost) === false) {
             $device_id = dbInsert($device, 'devices');
             if ($device_id) {
-                oxidized_reload_§nodes();
+                oxidized_reload_nodes();
                 return $device_id;
             }
         }

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -165,9 +165,11 @@ function poll_device($device, $options)
 {
     global $config, $device, $polled_devices, $memcache;
 
+    $attribs = get_dev_attribs($device['device_id']);
+    $device['attribs'] = $attribs;
+
     load_os($device);
 
-    $attribs = get_dev_attribs($device['device_id']);
     $device['snmp_max_repeaters'] = $attribs['snmp_max_repeaters'];
     $device['snmp_max_oid'] = $attribs['snmp_max_oid'];
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

A bit of a quick hash for now. Changing device types is broken at the moment as load_os detects it's different from the what it's supposed to be and changes it back as soon as the page loads.