### PR TITLE
fix: Fixed JunOS bgpPeers_cbgp mistakenly removed + better support for mysql strict mode #5531

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -281,14 +281,14 @@ if ($config['enable_bgp']) {
 
                     // FIXME THESE FIELDS DO NOT EXIST IN THE DATABASE!
                     $update = 'UPDATE bgpPeers_cbgp SET';
-                    $peer['c_update']['AcceptedPrefixes']     = $cbgpPeerAcceptedPrefixes;
-                    $peer['c_update']['DeniedPrefixes']       = $cbgpPeerDeniedPrefixes;
-                    $peer['c_update']['PrefixAdminLimit']     = $cbgpPeerAdminLimit;
-                    $peer['c_update']['PrefixThreshold']      = $cbgpPeerPrefixThreshold;
-                    $peer['c_update']['PrefixClearThreshold'] = $cbgpPeerPrefixClearThreshold;
-                    $peer['c_update']['AdvertisedPrefixes']   = $cbgpPeerAdvertisedPrefixes;
-                    $peer['c_update']['SuppressedPrefixes']   = $cbgpPeerSuppressedPrefixes;
-                    $peer['c_update']['WithdrawnPrefixes']    = $cbgpPeerWithdrawnPrefixes;
+                    $peer['c_update']['AcceptedPrefixes']     = set_numeric($cbgpPeerAcceptedPrefixes);
+                    $peer['c_update']['DeniedPrefixes']       = set_numeric($cbgpPeerDeniedPrefixes);
+                    $peer['c_update']['PrefixAdminLimit']     = set_numeric($cbgpPeerAdminLimit);
+                    $peer['c_update']['PrefixThreshold']      = set_numeric($cbgpPeerPrefixThreshold);
+                    $peer['c_update']['PrefixClearThreshold'] = set_numeric($cbgpPeerPrefixClearThreshold);
+                    $peer['c_update']['AdvertisedPrefixes']   = set_numeric($cbgpPeerAdvertisedPrefixes);
+                    $peer['c_update']['SuppressedPrefixes']   = set_numeric($cbgpPeerSuppressedPrefixes);
+                    $peer['c_update']['WithdrawnPrefixes']    = set_numeric($cbgpPeerWithdrawnPrefixes);
 
                     $oids = array(
                         'AcceptedPrefixes',
@@ -299,8 +299,8 @@ if ($config['enable_bgp']) {
                     );
 
                     foreach ($oids as $oid) {
-                        $peer['c_update'][$oid.'_delta'] = $peer['c_update'][$oid] - $peer_afi[$oid];
-                        $peer['c_update'][$oid.'_prev'] = $peer_afi[$oid];
+                        $peer['c_update'][$oid.'_delta'] = set_numeric($peer['c_update'][$oid] - $peer_afi[$oid]);
+                        $peer['c_update'][$oid.'_prev'] = set_numeric($peer_afi[$oid]);
                     }
 
                     dbUpdate($peer['c_update'], 'bgpPeers_cbgp', '`device_id` = ? AND bgpPeerIdentifier = ? AND afi = ? AND safi = ?', array($device['device_id'], $peer['bgpPeerIdentifier'], $afi, $safi));


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #5531 

Updated discovery so that junos is now the same as cisco for checking bgpPeers_cbgp.

Updated queries so mysql strict works better.