### PR TITLE
Graph for services would not work

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -152,7 +152,7 @@ function poll_service($service)
             $DS[$k] = $v['uom'];
         }
         d_echo("Service DS: "._json_encode($DS)."\n");
-        if ( ($service['service_ds'] == "{}") || ($service['service_ds'] == "") {
+        if (($service['service_ds'] == "{}") || ($service['service_ds'] == "")) {
             $update['service_ds'] = json_encode($DS);
         }
 

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -152,7 +152,7 @@ function poll_service($service)
             $DS[$k] = $v['uom'];
         }
         d_echo("Service DS: "._json_encode($DS)."\n");
-        if ($service['service_ds'] == "") {
+        if ($service['service_ds'] == "{}") {
             $update['service_ds'] = json_encode($DS);
         }
 

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -152,7 +152,7 @@ function poll_service($service)
             $DS[$k] = $v['uom'];
         }
         d_echo("Service DS: "._json_encode($DS)."\n");
-        if ($service['service_ds'] == "{}") {
+        if ( ($service['service_ds'] == "{}") || ($service['service_ds'] == "") {
             $update['service_ds'] = json_encode($DS);
         }
 


### PR DESCRIPTION
I agree to the conditions of the Contributor Agreement contained in doc/General/Contributing.md.

Just found an bug, when adding an new service is sets the server_ds to {} [See here, end of line L46](https://github.com/librenms/librenms/blob/d5296319fbadd41dc5a82cbe4bbc6e3fa82b1cb7/includes/services.inc.php#L46)
And here we check if service is equal to {} and not empty

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
