### PR TITLE
Updating help text when validate cannot find a bin

### DIFF
--- a/validate.php
+++ b/validate.php
@@ -207,7 +207,7 @@ $space_check = (disk_free_space($config['install_dir']) / 1024 / 1024);
 if ($space_check < 512 && $space_check > 1) {
     print_warn('Disk space where '.$config['install_dir'].' is located is less than 512Mb');
 }
-d
+
 if ($space_check < 1) {
     print_fail('Disk space where '.$config['install_dir'].' is located is empty!!!');
 }

--- a/validate.php
+++ b/validate.php
@@ -207,7 +207,7 @@ $space_check = (disk_free_space($config['install_dir']) / 1024 / 1024);
 if ($space_check < 512 && $space_check > 1) {
     print_warn('Disk space where '.$config['install_dir'].' is located is less than 512Mb');
 }
-
+d
 if ($space_check < 1) {
     print_fail('Disk space where '.$config['install_dir'].' is located is empty!!!');
 }
@@ -218,9 +218,7 @@ $suid_bins = array('fping', 'fping6');
 foreach ($bins as $bin) {
     $cmd = rtrim(shell_exec("which {$config[$bin]} 2>/dev/null"));
     if (!$cmd) {
-        print_fail("$bin location is incorrect or bin not installed");
-        print_fail("You can also manually set the path to $bin by placing the following in config.php:");
-        print_fail("\$config['$bin'] = \"/path/to/$bin\";");
+        print_fail("$bin location is incorrect or bin not installed. \n\tYou can also manually set the path to $bin by placing the following in config.php: \n\t\$config['$bin'] = \"/path/to/$bin\";");
     } elseif (in_array($bin, $suid_bins) && !(fileperms($cmd) & 2048)) {
         print_fail("$bin should be suid, please chmod u+s $cmd");
     }

--- a/validate.php
+++ b/validate.php
@@ -219,6 +219,8 @@ foreach ($bins as $bin) {
     $cmd = rtrim(shell_exec("which {$config[$bin]} 2>/dev/null"));
     if (!$cmd) {
         print_fail("$bin location is incorrect or bin not installed");
+        print_fail("You can also manually set the path to $bin by placing the following in config.php:");
+        print_fail("\$config['$bin'] = \"/path/to/$bin\";");
     } elseif (in_array($bin, $suid_bins) && !(fileperms($cmd) & 2048)) {
         print_fail("$bin should be suid, please chmod u+s $cmd");
     }


### PR DESCRIPTION
Adding additional help text to help new users configure their librenms install. In my install, fping was not at the expected path. This help text would have helped me.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
