### PR TITLE
fix: HTML Purifier would create tmp caches within the vendor folder, moved to users tmp dir #5561

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1503,9 +1503,10 @@ function clean($value)
  */
 function display($value)
 {
-    $purifier = new HTMLPurifier(
-        HTMLPurifier_Config::createDefault()
-    );
+    global $config;
+    $p_config = HTMLPurifier_Config::createDefault();
+    $p_config->set('Cache.SerializerPath', $config['temp_dir']);
+    $purifier = new HTMLPurifier($p_config);
     return $purifier->purify(stripslashes($value));
 }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #5561 

HTMLPurifier will create a file in /opt/librenms/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer/HTML/ which is owned by your web server so a php composer update stops.
