### PR TITLE
fix: Only pre-cache APC oids if device is APC

### DIFF
--- a/includes/discovery/sensors/pre-cache/apc.inc.php
+++ b/includes/discovery/sensors/pre-cache/apc.inc.php
@@ -23,4 +23,8 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
-$cooling_unit_analog = snmpwalk_cache_oid($device, 'coolingUnitStatusAnalogEntry', array(), 'PowerNet-MIB');
+if ($device['os'] == 'apc') {
+    echo 'Pre-cache APC: ';
+
+    $cooling_unit_analog = snmpwalk_cache_oid($device, 'coolingUnitStatusAnalogEntry', array(), 'PowerNet-MIB');
+}


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
