### PR TITLE
fix: html purify init wasn't done always when it was used

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1504,7 +1504,14 @@ function clean($value)
 function display($value)
 {
     /** @var HTMLPurifier $purifier */
-    global $purifier;
+    global $config, $purifier;
+    if (!isset($purifier)) {
+        // initialize HTML Purifier here since this is the only user
+        $p_config = HTMLPurifier_Config::createDefault();
+        $p_config->set('Cache.SerializerPath', $config['temp_dir']);
+        $purifier = new HTMLPurifier($p_config);
+    }
+
     return $purifier->purify(stripslashes($value));
 }
 

--- a/includes/init.php
+++ b/includes/init.php
@@ -135,11 +135,6 @@ if (module_selected('web', $init_modules)) {
         $os_list[] = $config['install_dir'].'/includes/definitions/'. $v['os'] . '.yaml';
     }
     load_all_os($os_list);
-
-    // initialize HTML Purifier
-    $p_config = HTMLPurifier_Config::createDefault();
-    $p_config->set('Cache.SerializerPath', $config['temp_dir']);
-    $purifier = new HTMLPurifier($p_config);
 }
 
 $console_color = new Console_Color2();


### PR DESCRIPTION
Since we only have one consumer, just do the init there for now.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
