### PR TITLE
Ignore toners with values -2 which is unknown #5637

### DIFF
--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -48,17 +48,19 @@ if ($device['os_group'] == 'printer') {
         $capacity = get_toner_capacity($data['prtMarkerSuppliesMaxCapacity']);
         $current = get_toner_levels($device, $raw_toner, $capacity);
 
-        discover_toner(
-            $valid_toner,
-            $device,
-            $toner_oid,
-            $last_index,
-            $type,
-            $descr,
-            $capacity_oid,
-            $capacity,
-            $current
-        );
+        if (is_numeric($current)) {
+            discover_toner(
+                $valid_toner,
+                $device,
+                $toner_oid,
+                $last_index,
+                $type,
+                $descr,
+                $capacity_oid,
+                $capacity,
+                $current
+            );
+        }
     }
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1821,8 +1821,13 @@ function get_toner_levels($device, $raw_value, $capacity)
         return 50;
     }
 
-    // -2 means unknown, -1 mean no restrictions
-    if ($raw_value == '-2' || $raw_value == '-1') {
+    // -2 means unknown
+    if ($raw_value == '-2') {
+        return false;
+    }
+
+    // -1 mean no restrictions
+    if ($raw_value == '-1') {
         return 0;  // FIXME: is 0 what we should return?
     }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Fixes: #5637 

` The current level if this supply is a container;the remaining
space if this supply is a receptacle.  If this supply
container/receptacle can reliably sense this value, the value
is reported by the printer and is read-only;otherwise, the
value may be written (by a Remote Control Panel or a Management
Application).  The value (-1) means other and specifically
indicates that the sub-unit places no restrictions on this
parameter.  The value (-2) means unknown.  A value of (-3) means
that the printer knows that there is some supply/remaining
space, respectively.`

We ignore -2 now.