### PR TITLE
webui: Remove ifIndex from ports list and add debug button for data access

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1396,3 +1396,17 @@ function search_oxidized_config($search_in_conf_textbox)
     $context  = stream_context_create($opts);
     return json_decode(file_get_contents($oxidized_search_url, false, $context), true);
 }
+
+/**
+ * @param $data
+ * @return bool|mixed
+ */
+function array_to_htmljson($data)
+{
+    if (is_array($data)) {
+        $data = htmlentities(json_encode($data));
+        return str_replace(',', ',<br />', $data);
+    } else {
+        return false;
+    }
+}

--- a/html/includes/print-interface.inc.php
+++ b/html/includes/print-interface.inc.php
@@ -1,3 +1,8 @@
+<script>
+$(function () {
+    $('[data-toggle="popover"]').popover()
+})
+</script>
 <?php
 
 // This file prints a table row for each interface
@@ -35,16 +40,14 @@ if (dbFetchCell('SELECT COUNT(*) FROM `mac_accounting` WHERE `port_id` = ?', arr
 echo "<tr style=\"background-color: $row_colour;\" valign=top onmouseover=\"this.style.backgroundColor='$list_highlight';\" onmouseout=\"this.style.backgroundColor='$row_colour';\" style='cursor: pointer;'>
     <td valign=top width=350>";
 
-// Don't echo out ports ifIndex if it's a NOS device since their ifIndex is, for lack of better words....different
-if ($device['os'] == 'nos') {
+if (is_admin() || is_read()) {
+    $port_data = array_to_htmljson($port);
+    echo '<i class="fa fa-tag" data-toggle="popover" data-content="'.$port_data.'" data-html="true"></i>';
+}
+
     echo '        <span class=list-large>
         '.generate_port_link($port, $port['label'])." $error_img $mac
         </span><br /><span class=interface-desc>".display($port['ifAlias']).'</span>';
-} else {
-    echo '        <span class=list-large>
-    '.generate_port_link($port, $port['ifIndex'].'. '.$port['label'])." $error_img $mac
-    </span><br /><span class=interface-desc>".display($port['ifAlias']).'</span>';
-}
 
 if ($port['ifAlias']) {
     echo '<br />';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Removed the ifIndex as discussed here: https://community.librenms.org/t/benefit-of-listing-ifindex-number/467/3

The only way to get the ifIndex after that would be a db lookup so I've added a small tag icon which you can click to get more info.

![image](https://cloud.githubusercontent.com/assets/3941142/22440139/2f5ca52a-e72a-11e6-851d-1071eedbbe8f.png)
