### PR TITLE
webui: Set the device logo and cell to have a max width

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2166,7 +2166,17 @@ label {
   max-width: 250px;
 }
 
-.device-title-bar {
-  width: 300px;
-  max-width: 300px;
+.device-title-bar-1 {
+  width: 25%;
+  max-width: 25%;
+}
+
+.device-title-bar-2 {
+  width: 25%;
+  max-width: 25%;
+ }
+
+.device-title-bar-3 {
+  width: 50%;
+  max-width: 50%;
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2163,5 +2163,10 @@ label {
 
 .device-icon-48h img {
   height: 48px;
-  max-width: 220px
+  max-width: 250px;
+}
+
+.device-title-bar {
+  width: 300px;
+  max-width: 300px;
 }

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2163,4 +2163,5 @@ label {
 
 .device-icon-48h img {
   height: 48px;
+  max-width: 220px
 }

--- a/html/includes/device-header.inc.php
+++ b/html/includes/device-header.inc.php
@@ -21,7 +21,7 @@ $host_id = get_vm_parent_id($device);
 
 echo '
             <tr bgcolor="'.$device_colour.'" class="alert '.$class.'">
-             <td><span class="device-icon-48h">'.getLogoTag($device).'</span></td>
+             <td width="250px"><span class="device-icon-48h">'.getLogoTag($device).'</span></td>
              <td>';
 if ($host_id > 0) {
     echo '

--- a/html/includes/device-header.inc.php
+++ b/html/includes/device-header.inc.php
@@ -20,8 +20,9 @@ if ($device['disabled'] == '1') {
 $host_id = get_vm_parent_id($device);
 
 echo '
+            <colgroup><col class="device-title-bar"></colgroup>
             <tr bgcolor="'.$device_colour.'" class="alert '.$class.'">
-             <td width="250px"><span class="device-icon-48h">'.getLogoTag($device).'</span></td>
+             <td><span class="device-icon-48h">'.getLogoTag($device).'</span></td>
              <td>';
 if ($host_id > 0) {
     echo '

--- a/html/includes/device-header.inc.php
+++ b/html/includes/device-header.inc.php
@@ -20,7 +20,11 @@ if ($device['disabled'] == '1') {
 $host_id = get_vm_parent_id($device);
 
 echo '
-            <colgroup><col class="device-title-bar"></colgroup>
+	    <colgroup>
+	    <col class="device-title-bar-1">
+	    <col class="device-title-bar-2">
+	    <col class="device-title-bar-3">
+            </colgroup>
             <tr bgcolor="'.$device_colour.'" class="alert '.$class.'">
              <td><span class="device-icon-48h">'.getLogoTag($device).'</span></td>
              <td>';


### PR DESCRIPTION

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

- Set a maximum width for the device logo.
- Set a maximum width for the <td> cell that the device image is displayed in.

This keeps the device name text in the same place where in the past it would be moving all over the place.