### PR TITLE
Possible fix for #5318, if delete_device called in webui then continue to run

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -317,7 +317,7 @@ function delete_device($id)
 {
     global $config, $debug;
 
-    if (php_sapi_name() !== 'cli') {
+    if (isCli() === false) {
         ignore_user_abort(true);
         set_time_limit(0);
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -316,6 +316,12 @@ function renamehost($id, $new, $source = 'console')
 function delete_device($id)
 {
     global $config, $debug;
+
+    if (php_sapi_name() !== 'cli') {
+        ignore_user_abort(true);
+        set_time_limit(0);
+    }
+
     $ret = '';
 
     $host = dbFetchCell("SELECT hostname FROM devices WHERE device_id = ?", array($id));


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Possibly fixes #5318 

The code does cleanup all tables but things like, eventlog, syslog, alerts could be huge in size. I expect what's happened is either this call has timed out (when done from webui) or the page was closed part way through. This addresses that if it was the cause.