### PR TITLE
fix: make mono theme panel headers black

### DIFF
--- a/html/css/mono.css
+++ b/html/css/mono.css
@@ -22,6 +22,16 @@
     color: black;
 }
 
+.panel-default>.panel-heading {
+  background: black;
+  color: white;
+}
+
+.panel-default>.panel-heading .icon-theme,
+.panel-default>.panel-heading a:visited,
+.panel-default>.panel-heading a:link {
+  color: white;
+}
 
 .twitter-typeahead .tt-hint {
     border-color: #000 !important;

--- a/html/includes/authentication/twofactor.lib.php
+++ b/html/includes/authentication/twofactor.lib.php
@@ -161,7 +161,7 @@ function verify_hotp($key, $otp, $counter = false)
 /**
  * Print TwoFactor Input-Form
  * @param boolean $form Include FORM-tags
- * @return void|string
+ * @return string
  */
 function twofactor_form($form = true)
 {
@@ -174,7 +174,7 @@ function twofactor_form($form = true)
           <div class="panel panel-default">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <img src="images/librenms_logo_light.svg">
+                <img src="' . $config['title_image'] . '">
               </h3>
             </div>
             <div class="panel-body">
@@ -189,7 +189,7 @@ function twofactor_form($form = true)
         </div>
         <div class="form-group">
           <div class="col-md-12">
-            <button type="submit" class="btn btn-default btn-block" name="submit" type="submit">Login</button>
+            <button type="submit" class="btn btn-default btn-block" name="submit">Login</button>
           </div>
          </div>
         </div>';

--- a/html/pages/logon.inc.php
+++ b/html/pages/logon.inc.php
@@ -8,13 +8,7 @@ if ($config['twofactor'] && isset($twofactorform)) {
           <div class="panel panel-default">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <?php
-                if ($config['title_image']) {
-                    echo '<img src="' . $config['title_image'] . '">';
-                } else {
-                    echo '<img src="images/librenms_logo_light.svg">';
-                }
-                ?>
+                <?php echo '<img src="' . $config['title_image'] . '">'; ?>
               </h3>
             </div>
             <div class="panel-body">


### PR DESCRIPTION
Fixes issue where the librenms_logo_mono.svg is now loaded by making the background black to match the logo.
Update twofactor.lib.php.
Remove unused if statement, $config['title_image'] is always set.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
