### PR TITLE
Revert "fix: make mono theme panel headers black"

### DIFF
--- a/html/css/mono.css
+++ b/html/css/mono.css
@@ -22,16 +22,6 @@
     color: black;
 }
 
-.panel-default>.panel-heading {
-  background: black;
-  color: white;
-}
-
-.panel-default>.panel-heading .icon-theme,
-.panel-default>.panel-heading a:visited,
-.panel-default>.panel-heading a:link {
-  color: white;
-}
 
 .twitter-typeahead .tt-hint {
     border-color: #000 !important;

--- a/html/includes/authentication/twofactor.lib.php
+++ b/html/includes/authentication/twofactor.lib.php
@@ -161,7 +161,7 @@ function verify_hotp($key, $otp, $counter = false)
 /**
  * Print TwoFactor Input-Form
  * @param boolean $form Include FORM-tags
- * @return string
+ * @return void|string
  */
 function twofactor_form($form = true)
 {
@@ -174,7 +174,7 @@ function twofactor_form($form = true)
           <div class="panel panel-default">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <img src="' . $config['title_image'] . '">
+                <img src="images/librenms_logo_light.svg">
               </h3>
             </div>
             <div class="panel-body">
@@ -189,7 +189,7 @@ function twofactor_form($form = true)
         </div>
         <div class="form-group">
           <div class="col-md-12">
-            <button type="submit" class="btn btn-default btn-block" name="submit">Login</button>
+            <button type="submit" class="btn btn-default btn-block" name="submit" type="submit">Login</button>
           </div>
          </div>
         </div>';

--- a/html/pages/logon.inc.php
+++ b/html/pages/logon.inc.php
@@ -8,7 +8,13 @@ if ($config['twofactor'] && isset($twofactorform)) {
           <div class="panel panel-default">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <?php echo '<img src="' . $config['title_image'] . '">'; ?>
+                <?php
+                if ($config['title_image']) {
+                    echo '<img src="' . $config['title_image'] . '">';
+                } else {
+                    echo '<img src="images/librenms_logo_light.svg">';
+                }
+                ?>
               </h3>
             </div>
             <div class="panel-body">


### PR DESCRIPTION
Reverts librenms/librenms#5705

Not sure this was intentional:

![image](https://cloud.githubusercontent.com/assets/3941142/22531079/beeb38e8-e8d6-11e6-8641-1bdae8fa4c57.png)

@murrant I'd like to revert this if you don't mind