### PR TITLE
Disco / Poller tidy up + Added display of module mem usage

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -82,7 +82,17 @@ foreach ($vrfs_lite_cisco as $vrf) {
                 );
             }
         }
+
+        unset(
+            $interface
+        );
     }
+
+    unset(
+        $arp_data,
+        $ipv4_addresses,
+        $data
+    );
 
     // add new entries
     if (!empty($insert_data)) {
@@ -100,7 +110,15 @@ foreach ($vrfs_lite_cisco as $vrf) {
         }
     }
     echo PHP_EOL;
-    unset($existing_data, $arp_table, $insert_data, $sql, $params, $context);
-    unset($device['context_name']);
+    unset(
+        $existing_data,
+        $arp_table,
+        $insert_data,
+        $sql,
+        $params,
+        $context,
+        $entry,
+        $device['context_name']
+    );
 }
 unset($vrfs_lite_cisco);

--- a/includes/discovery/cisco-cef.inc.php
+++ b/includes/discovery/cisco-cef.inc.php
@@ -32,7 +32,9 @@ if (is_array($cefs)) {
             }
         }
     }
+    unset($cefs);
 }//end if
 
 // FIXME - need to delete old ones. FIXME REALLY.
 echo "\n";
+unset($entity_array);

--- a/includes/discovery/cisco-vrf.inc.php
+++ b/includes/discovery/cisco-vrf.inc.php
@@ -110,6 +110,10 @@ if ($config['enable_vrfs']) {
             }//end if
         }//end foreach
 
+        unset(
+            $descr_table,
+            $port_table
+        );
         echo "\n";
 
         $sql = "SELECT * FROM ports WHERE device_id = '".$device['device_id']."'";
@@ -137,8 +141,12 @@ if ($config['enable_vrfs']) {
             }
         }
 
-        unset($valid_vrf_if);
-        unset($valid_vrf);
+        unset(
+            $valid_vrf_if,
+            $valid_vrf,
+            $row,
+            $sql
+        );
 
         echo "\n";
     } //end if

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -107,8 +107,10 @@ if ($config['autodiscovery']['xdp'] === true) {
     }//end if
 }//end if
 
-
-unset($lldp_array);
+unset(
+    $lldp_array,
+    $cdp_array
+);
 
 if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
     echo ' NMS-LLDP-MIB: ';
@@ -217,7 +219,14 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
             }//end foreach
         }//end foreach
     }//end if
+    unset(
+        $dot1d_array
+    );
 }//end elseif
+
+unset(
+    $lldp_array
+);
 
 echo ' OSPF Discovery: ';
 
@@ -258,5 +267,8 @@ foreach (dbFetchRows($sql) as $test) {
     }
 }
 
-unset($link_exists);
+unset(
+    $link_exists,
+    $sql
+);
 echo "\n";

--- a/includes/discovery/entity-physical.inc.php
+++ b/includes/discovery/entity-physical.inc.php
@@ -18,6 +18,11 @@ if ($config['enable_inventory']) {
             dbDelete('entPhysical', 'entPhysical_id = ?', array ($test['entPhysical_id']));
         }
     }
+    unset(
+        $sql,
+        $test,
+        $valid
+    );
 } else {
     echo 'Disabled!';
 }//end if

--- a/includes/discovery/entity-physical/entity-physical.inc.php
+++ b/includes/discovery/entity-physical/entity-physical.inc.php
@@ -83,6 +83,7 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
     } else {
         $ifIndex_array = explode('.', $ifIndex);
         $ifIndex       = $ifIndex_array[1];
+        unset($ifIndex_array);
     }
 
     if ($entPhysicalVendorTypes[$entPhysicalVendorType] && !$entPhysicalModelName) {
@@ -147,3 +148,9 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
     }//end if
 }//end foreach
 echo "\n";
+unset(
+    $update_data,
+    $insert_data,
+    $entry,
+    $entity_array
+);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -140,11 +140,13 @@ function discover_device($device, $options = null)
             ($os_module_status && !isset($attribs['discover_' . $module])) ||
             ($module_status && !isset($os_module_status) && !isset($attribs['discover_' . $module]))) {
             $module_start = microtime(true);
+            $start_memory = memory_get_usage();
             echo "\n#### Load disco module $module ####\n";
             include "includes/discovery/$module.inc.php";
             $module_time = microtime(true) - $module_start;
             $module_time = substr($module_time, 0, 5);
-            printf("\n>> Runtime for discovery module '%s': %.4f seconds\n", $module, $module_time);
+            $module_mem  = (memory_get_usage() - $start_memory);
+            printf("\n>> Runtime for discovery module '%s': %.4f seconds with %s bytes\n", $module, $module_time, $module_mem);
             echo "#### Unload disco module $module ####\n\n";
         } elseif (isset($attribs['discover_' . $module]) && $attribs['discover_' . $module] == '0') {
             echo "Module [ $module ] disabled on host.\n\n";

--- a/includes/discovery/mempools.inc.php
+++ b/includes/discovery/mempools.inc.php
@@ -23,5 +23,9 @@ foreach (dbFetchRows($sql) as $test_mempool) {
     unset($mempool_type);
 }
 
-unset($valid_mempool);
+unset(
+    $valid_mempool,
+    $sql,
+    $test_mempool
+);
 echo "\n";

--- a/includes/discovery/mempools/cmp.inc.php
+++ b/includes/discovery/mempools/cmp.inc.php
@@ -15,4 +15,5 @@ if (($device['os_group'] == 'cisco') && $cemp_count == '0') {
             }
         }
     }
+    unset($cmp_array);
 }

--- a/includes/discovery/ports-stack.inc.php
+++ b/includes/discovery/ports-stack.inc.php
@@ -5,6 +5,10 @@ $sql = "SELECT * FROM `ports_stack` WHERE `device_id` = '".$device['device_id'].
 foreach (dbFetchRows($sql) as $entry) {
     $stack_db_array[$entry['port_id_high']][$entry['port_id_low']]['ifStackStatus'] = $entry['ifStackStatus'];
 }
+unset(
+    $sql,
+    $entry
+);
 
 $stack_poll_array = snmpwalk_cache_twopart_oid($device, 'ifStackStatus', array());
 
@@ -25,7 +29,12 @@ foreach ($stack_poll_array as $port_id_high => $entry_high) {
             echo '+';
         }
     }//end foreach
+    unset(
+        $port_id_low,
+        $entry_low
+    );
 }//end foreach
+unset($stack_poll_array);
 
 foreach ($stack_db_array as $port_id_high => $array) {
     foreach ($array as $port_id_low => $blah) {
@@ -36,3 +45,9 @@ foreach ($stack_db_array as $port_id_high => $array) {
 }
 
 echo "\n";
+unset(
+    $stack_db_array,
+    $array,
+    $port_id_high,
+    $entry_high
+);

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -77,6 +77,11 @@ foreach ($port_stats as $ifIndex => $port) {
     }//end if
 }//end foreach
 
+unset(
+    $ports_mapped,
+    $port
+);
+
 // End New interface detection
 // Interface Deletion
 // If it's in our $ports_l list, that means it's not been seen. Mark it deleted.

--- a/includes/discovery/processors.inc.php
+++ b/includes/discovery/processors.inc.php
@@ -28,3 +28,7 @@ foreach (dbFetchRows($sql) as $test_processor) {
 }
 
 echo "\n";
+
+unset(
+    $sql
+);

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -41,4 +41,8 @@ $run_sensors = array(
     'voltages',
 );
 sensors($run_sensors, $device, $valid, $pre_cache);
-unset($pre_cache);
+unset(
+    $pre_cache,
+    $run_sensors,
+    $entitysensor
+);

--- a/includes/discovery/sensors/cisco-entity-sensor.inc.php
+++ b/includes/discovery/sensors/cisco-entity-sensor.inc.php
@@ -181,4 +181,7 @@ if ($device['os_group'] == 'cisco') {
             }//end if
         }//end foreach
     }//end if
+    unset(
+        $entity_array
+    );
 }//end if

--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -117,6 +117,9 @@ if (is_array($oids)) {
             }
         }//end if
     }//end foreach
+    unset(
+        $entity_array
+    );
 }//end if
 
 echo "\n";

--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -5,6 +5,9 @@ $vlans_db_raw = dbFetchRows('SELECT * FROM `vlans` WHERE `device_id` = ?', array
 foreach ($vlans_db_raw as $vlan_db) {
     $vlans_db[$vlan_db['vlan_domain']][$vlan_db['vlan_vlan']] = $vlan_db;
 }
+unset(
+    $vlans_db_raw
+);
 
 // Create an empty array to record what VLANs we discover this session.
 $device['vlans'] = array();

--- a/includes/discovery/vlans/cisco-vtp.inc.php
+++ b/includes/discovery/vlans/cisco-vtp.inc.php
@@ -42,6 +42,9 @@ if ($device['os_group'] == 'cisco') {
                         }
                         $vlan_data[$base_to_index[$index]] = $array;
                     }
+                    unset(
+                        $tmp_vlan_data
+                    );
 
                     $per_vlan_data[$vlan_id] = $vlan_data;
                 }
@@ -59,6 +62,9 @@ if ($device['os_group'] == 'cisco') {
                 echo "Vlan: $vlan_id tagged on $base (ifIndex $ifIndex)\n";
                 $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = 1;
             }
+            unset(
+                $data
+            );
         }
     }
     echo PHP_EOL;

--- a/includes/polling/applications.inc.php
+++ b/includes/polling/applications.inc.php
@@ -14,3 +14,5 @@ if (count($app_rows) > 0) {
 
     echo "\n";
 }
+
+unset($app_rows);

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -337,5 +337,4 @@ if ($config['enable_bgp']) {
     } //end if
 } //end if
 
-unset($$peer_data_tmp);
-unset($j_prefixes);
+unset($peers, $peer_data_tmp, $j_prefixes);

--- a/includes/polling/cipsec-tunnels.inc.php
+++ b/includes/polling/cipsec-tunnels.inc.php
@@ -125,3 +125,10 @@ if ($device['os_group'] == 'cisco') {
 
     unset($rrd_name, $rrd_def, $fields, $oids, $data, $data, $oid, $tunnel);
 }
+
+unset(
+    $ipsec_array,
+    $ike_array,
+    $tunnels_db,
+    $valid_tunnels
+);

--- a/includes/polling/cisco-ace-loadbalancer.inc.php
+++ b/includes/polling/cisco-ace-loadbalancer.inc.php
@@ -63,3 +63,8 @@ if ($device['os_group'] == 'cisco') {
 
     unset($rrd_name, $rrd_def, $oids, $oid, $serverfarm);
 }
+
+unset(
+    $rserver_array,
+    $rserver_db
+);

--- a/includes/polling/cisco-ace-serverfarms.inc.php
+++ b/includes/polling/cisco-ace-serverfarms.inc.php
@@ -67,3 +67,8 @@ if ($device['os_group'] == 'cisco') {
 
     unset($rrd_name, $rrd_def, $oids, $oid, $vserver);
 }
+
+unset(
+    $serverfarm_array,
+    $serverfarm_db
+);

--- a/includes/polling/cisco-cbqos.inc.php
+++ b/includes/polling/cisco-cbqos.inc.php
@@ -12,10 +12,10 @@
  */
 
 if ($device['os_group'] == "cisco") {
-    $module = 'Cisco-CBQOS';
+    $tmp_module = 'Cisco-CBQOS';
 
     $component = new LibreNMS\Component();
-    $options['filter']['type'] = array('=',$module);
+    $options['filter']['type'] = array('=',$tmp_module);
     $options['filter']['disabled'] = array('=',0);
     $options['filter']['ignore'] = array('=',0);
     $components = $component->getComponents($device['device_id'], $options);
@@ -66,5 +66,5 @@ if ($device['os_group'] == "cisco") {
     } // end if count components
 
     // Clean-up after yourself!
-    unset($type, $components, $component, $options, $module);
+    unset($type, $components, $component, $options, $tmp_module, $tblcbQosClassMapStats);
 }

--- a/includes/polling/cisco-cef.inc.php
+++ b/includes/polling/cisco-cef.inc.php
@@ -102,3 +102,10 @@ if ($device['os_group'] == 'cisco') {
 
     echo "\n";
 } //end if
+
+unset(
+    $cefs,
+    $polled,
+    $cefs_query,
+    $entity_array
+);

--- a/includes/polling/cisco-mac-accounting.inc.php
+++ b/includes/polling/cisco-mac-accounting.inc.php
@@ -93,3 +93,11 @@ if ($device['os_group'] == 'cisco') {
 
     echo "\n";
 }//end if
+
+unset(
+    $cip_oids,
+    $oid,
+    $polled,
+    $mac_entries,
+    $acc_rows
+);

--- a/includes/polling/cisco-otv.inc.php
+++ b/includes/polling/cisco-otv.inc.php
@@ -56,10 +56,10 @@ if ($device['os_group'] == "cisco") {
     $error_overlay[5] = "createAndWait";
     $error_overlay[6] = "destroy";
 
-    $module = 'Cisco-OTV';
+    $tmp_module = 'Cisco-OTV';
 
     $component = new LibreNMS\Component();
-    $options['filter']['type'] = array('=',$module);
+    $options['filter']['type'] = array('=',$tmp_module);
     $options['filter']['disabled'] = array('=',0);
     $components = $component->getComponents($device['device_id'], $options);
 
@@ -189,5 +189,12 @@ if ($device['os_group'] == "cisco") {
     } // end if count components
 
     // Clean-up after yourself!
-    unset($components, $component, $module);
+    unset(
+        $components,
+        $component,
+        $tmp_module,
+        $error_vpn,
+        $error_aed,
+        $error_overlay
+    );
 }

--- a/includes/polling/cisco-remote-access-monitor.inc.php
+++ b/includes/polling/cisco-remote-access-monitor.inc.php
@@ -60,5 +60,5 @@ if ($device['os_group'] == 'cisco') {
         $graphs['cras_sessions'] = true;
     }
 
-    unset($data, $rrd_def, $fields);
+    unset($data, $rrd_def, $fields, $oid_list);
 }//end if

--- a/includes/polling/cisco-sla.inc.php
+++ b/includes/polling/cisco-sla.inc.php
@@ -123,3 +123,5 @@ if (count($slas) > 0) {
         }
     }
 }
+
+unset($slas);

--- a/includes/polling/cisco-voice.inc.php
+++ b/includes/polling/cisco-voice.inc.php
@@ -36,3 +36,8 @@ if ($device['os_group'] == "cisco") {
      */
     include "cisco-voice/cisco-iosxcode.inc.php";
 }
+
+unset(
+    $output,
+    $key
+);

--- a/includes/polling/entity-physical.inc.php
+++ b/includes/polling/entity-physical.inc.php
@@ -16,3 +16,8 @@ if ($config['enable_inventory']) {
 } else {
     echo 'Disabled!';
 }//end if
+
+unset(
+    $mod_stats,
+    $chan_stats
+);

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -29,9 +29,28 @@ function sensor_precache($device)
     return $sensor_config;
 }
 
-function poll_sensor($device, $class, $unit)
+function poll_sensor($device, $class)
 {
     global $config, $memcache, $agent_sensors;
+
+    $supported_sensors = array(
+        'current'     => 'A',
+        'frequency'   => 'Hz',
+        'runtime'     => 'Min',
+        'humidity'    => '%',
+        'fanspeed'    => 'rpm',
+        'power'       => 'W',
+        'voltage'     => 'V',
+        'temperature' => 'C',
+        'dbm'         => 'dBm',
+        'charge'      => '%',
+        'load'        => '%',
+        'state'       => '#',
+        'signal'      => 'dBm',
+        'airflow'     => 'cfm',
+    );
+
+    $unit = $supported_sensors[$class];
 
     $sensors = array();
     $misc_sensors = array();
@@ -158,6 +177,7 @@ function poll_sensor($device, $class, $unit)
             log_event($class . ' sensor has changed from ' . $sensor['sensor_current'] . ' to ' . $sensor_value, $device, $class, $sensor['sensor_id']);
         }
         dbUpdate(array('sensor_current' => $sensor_value, 'sensor_prev' => $sensor['sensor_current'], 'lastupdate' => array('NOW()')), 'sensors', '`sensor_class` = ? AND `sensor_id` = ?', array($class,$sensor['sensor_id']));
+        unset($supported_sensors);
     }
 }//end poll_sensor()
 
@@ -273,13 +293,15 @@ function poll_device($device, $options)
                 $attribs['poll_'.$module] ||
                 ($os_module_status && !isset($attribs['poll_'.$module])) ||
                 ($module_status && !isset($os_module_status) && !isset($attribs['poll_' . $module]))) {
+                $start_memory = memory_get_usage();
                 $module_start = 0;
                 $module_time  = 0;
                 $module_start = microtime(true);
                 echo "\n#### Load poller module $module ####\n";
                 include "includes/polling/$module.inc.php";
                 $module_time = microtime(true) - $module_start;
-                printf("\n>> Runtime for poller module '%s': %.4f seconds\n", $module, $module_time);
+                $module_mem  = (memory_get_usage() - $start_memory);
+                printf("\n>> Runtime for poller module '%s': %.4f seconds with %s bytes\n", $module, $module_time, $module_mem);
                 echo "#### Unload poller module $module ####\n\n";
 
                 // save per-module poller stats
@@ -298,6 +320,8 @@ function poll_device($device, $options)
                 if (is_file($oldrrd)) {
                     unlink($oldrrd);
                 }
+                unset($tags, $fields, $oldrrd);
+                print_r(get_defined_vars());
             } elseif (isset($attribs['poll_'.$module]) && $attribs['poll_'.$module] == '0') {
                 echo "Module [ $module ] disabled on host.\n\n";
             } elseif (isset($os_module_status) && $os_module_status == '0') {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -321,7 +321,6 @@ function poll_device($device, $options)
                     unlink($oldrrd);
                 }
                 unset($tags, $fields, $oldrrd);
-                print_r(get_defined_vars());
             } elseif (isset($attribs['poll_'.$module]) && $attribs['poll_'.$module] == '0') {
                 echo "Module [ $module ] disabled on host.\n\n";
             } elseif (isset($os_module_status) && $os_module_status == '0') {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -56,7 +56,7 @@ function poll_sensor($device, $class)
     $misc_sensors = array();
     $all_sensors = array();
 
-    foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ?', array($class, $device['device_id'])) as $sensor) {
+    foreach (dbFetchRows("SELECT * FROM `sensors` WHERE `sensor_class` = '?' AND `device_id` = ?", array($class, $device['device_id'])) as $sensor) {
         if ($sensor['poller_type'] == 'agent') {
             $misc_sensors[] = $sensor;
         } elseif ($sensor['poller_type'] == 'ipmi') {

--- a/includes/polling/hr-mib.inc.php
+++ b/includes/polling/hr-mib.inc.php
@@ -34,3 +34,5 @@ if (is_numeric($hrSystem[0]['hrSystemNumUsers'])) {
 }
 
 echo "\n";
+
+unset($oid_list, $hrSystem);

--- a/includes/polling/netstats.inc.php
+++ b/includes/polling/netstats.inc.php
@@ -8,3 +8,4 @@ require 'netstats/netstats-snmp.inc.php';
 require 'netstats/netstats-ip_forward.inc.php';
 
 echo "\n";
+unset($oid_ds);

--- a/includes/polling/ntp.inc.php
+++ b/includes/polling/ntp.inc.php
@@ -21,3 +21,7 @@
 if ($device['os_group'] == 'cisco') {
     include 'includes/polling/ntp/cisco.inc.php';
 }
+
+unset(
+    $cntpPeersVarEntry
+);

--- a/includes/polling/ntp/cisco.inc.php
+++ b/includes/polling/ntp/cisco.inc.php
@@ -11,11 +11,11 @@
  * the source code distribution for details.
  */
 
-$module = 'ntp';
+$tmp_module = 'ntp';
 
 $component = new LibreNMS\Component();
 $options = array();
-$options['filter']['type'] = array('=',$module);
+$options['filter']['type'] = array('=',$tmp_module);
 $options['filter']['disabled'] = array('=',0);
 $options['filter']['ignore'] = array('=',0);
 $components = $component->getComponents($device['device_id'], $options);
@@ -77,4 +77,4 @@ if (count($components > 0)) {
 } // end if count components
 
 // Clean-up after yourself!
-unset($type, $components, $component, $options, $module);
+unset($type, $components, $component, $options, $tmp_module);

--- a/includes/polling/ospf.inc.php
+++ b/includes/polling/ospf.inc.php
@@ -275,7 +275,7 @@ foreach ($vrfs_lite_cisco as $vrf_lite) {
             }//end if
         }//end foreach
     }//end if
-
+    unset($ospf_ports_poll);
 
 // OSPF-MIB::ospfNbrIpAddr.172.22.203.98.0 172.22.203.98
 // OSPF-MIB::ospfNbrAddressLessIndex.172.22.203.98.0 0
@@ -366,8 +366,7 @@ foreach ($vrfs_lite_cisco as $vrf_lite) {
     unset($ospf_nbrs_poll);
     echo "\n";
 }
-unset($device['context_name']);
-unset($vrfs_lite_cisco);
+unset($device['context_name'], $vrfs_lite_cisco, $vrf_lite);
 // Create device-wide statistics RRD
 $rrd_def = array(
     'DS:instances:GAUGE:600:0:1000000',
@@ -387,3 +386,19 @@ $tags = compact('rrd_def');
 data_update($device, 'ospf-statistics', $tags, $fields);
 
 echo "\n";
+
+unset(
+    $ospf_instance_count,
+    $ospf_port_count,
+    $ospf_area_count,
+    $ospf_neighbour_count,
+    $ospf_oids_db,
+    $ospf_area_oids,
+    $ospf_port_oids,
+    $ospf_nbr_oids_db,
+    $ospf_nbr_oids_rrd,
+    $ospf_nbr_oids,
+    $rrd_def,
+    $fields,
+    $tags
+);

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -715,9 +715,8 @@ foreach ($ports as $port) {
     echo "\n";
 
     // Clear Per-Port Variables Here
-    unset($this_port);
+    unset($this_port, $port);
 } //end port update
 
 // Clear Variables Here
-unset($port_stats);
-unset($ports_found);
+unset($port_stats, $ports_found, $data_oids, $stat_oids, $stat_oids_db, $stat_oids_db_extended, $etherlike_oids, $cisco_oids, $pagp_oids, $ifmib_oids, $hc_test, $ports_mapped, $ports, $_stat_oids, $rrd_def);

--- a/includes/polling/processors.inc.php
+++ b/includes/polling/processors.inc.php
@@ -35,3 +35,5 @@ foreach (dbFetchRows('SELECT * FROM processors WHERE device_id = ?', array($devi
 
     dbUpdate(array('processor_usage' => $proc), 'processors', '`processor_id` = ?', array($processor['processor_id']));
 }//end foreach
+
+unset($processor);

--- a/includes/polling/sensors.inc.php
+++ b/includes/polling/sensors.inc.php
@@ -11,24 +11,9 @@
  * See COPYING for more details.
  */
 
-// Call poll_sensor for each sensor type that we support.
-$supported_sensors = array(
-    'current'     => 'A',
-    'frequency'   => 'Hz',
-    'runtime'     => 'Min',
-    'humidity'    => '%',
-    'fanspeed'    => 'rpm',
-    'power'       => 'W',
-    'voltage'     => 'V',
-    'temperature' => 'C',
-    'dbm'         => 'dBm',
-    'charge'      => '%',
-    'load'        => '%',
-    'state'       => '#',
-    'signal'      => 'dBm',
-    'airflow'     => 'cfm',
-);
-
-foreach ($supported_sensors as $sensor_type => $sensor_unit) {
-    poll_sensor($device, $sensor_type, $sensor_unit);
+$sensors = dbFetchRows("SELECT `sensor_class` FROM `sensors` WHERE `device_id` = ? GROUP BY `sensor_class`", array($device['device_id']));
+foreach ($sensors as $sensor_type) {
+    poll_sensor($device, $sensor_type);
 }
+
+unset($sensors, $sensor_type);

--- a/includes/polling/stp.inc.php
+++ b/includes/polling/stp.inc.php
@@ -169,5 +169,20 @@ if ($stpprotocol == 'ieee8021d' || $stpprotocol == 'unknown') {
     }
 }
 
-unset($stp_raw, $stp, $stp_db, $stp_port);
+unset(
+    $stp_raw,
+    $stp,
+    $stp_db,
+    $stp_port,
+    $mac_array,
+    $stpprotocol,
+    $tm,
+    $mac_raw,
+    $time_since_change,
+    $dr,
+    $octet,
+    $port,
+    $db,
+    $dp
+);
 echo "\n";

--- a/includes/polling/wifi.inc.php
+++ b/includes/polling/wifi.inc.php
@@ -111,6 +111,7 @@ if ($device['type'] == 'network' || $device['type'] == 'firewall' || $device['ty
         unset(${'wificlients'.$i});
         $i++;
     }
+    unset($i);
 } else {
     echo 'Unsupported type: ' . $device['type'] . PHP_EOL;
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

This mostly just tidies up a lot of variable and array use (unsets to clear up mem).

Also added in the display of per module mem usage.

Changed sensors polling to not poll all sensors types and only what the device has defined.

Changed variable names in some cisco modules as they used `$module` which was globally used and was then unset. This caused these poller module graphs to not be recorded.