### PR TITLE
IP and Port API additions

### DIFF
--- a/doc/API/API-Docs.md
+++ b/doc/API/API-Docs.md
@@ -16,6 +16,7 @@ source: API/API-Docs.md
         - [`get_health_graph`](#api-route-get_health_graph)
         - [`get_graph_generic_by_hostname`](#api-route-6)
         - [`get_port_graphs`](#api-route-7)
+        - [`get_device_ip_addresses`](#api-route-get_device_ip_addresses)
         - [`get_port_stack`](#api-route-29)
         - [`get_components`](#api-route-25)
         - [`add_components`](#api-route-26)
@@ -31,6 +32,10 @@ source: API/API-Docs.md
     - [`devicegroups`](#api-devicegroups)
         - [`get_devicegroups`](#api-route-get_devicegroups)
         - [`get_devices_by_group`](#api-route-get_devices_by_group)
+    - [`ports`](#api-ports)
+        - [`get_all_ports`](#api-get_all_ports)
+        - [`get_port_info`](#api-route-get_port_info)
+        - [`get_port_ip_info`](#api-route-get_port_ip_info)
     - [`portgroups`](#api-portgroups)
         - [`get_graph_by_portgroup`](#api-route-get_graph_by_portgroup)
     - [`routing`](#api-routing)
@@ -231,13 +236,13 @@ This function allows to do three things:
   - Get a list of overall health graphs available.
   - Get a list of health graphs based on provided class.
   - Get the health sensors information based on ID.
-  
+
 Route: /api/v0/devices/:hostname/health(/:type)(/:sensor_id)
 
   - hostname can be either the device hostname or id
   - type (optional) is health type / sensor class
   - sensor_id (optional) is the sensor id to retreive specific information.
-  
+
 Input:
 
   -
@@ -332,7 +337,7 @@ Output:
 
 ### <a name="api-route-get_health_graph">Function: `get_health_graph`</a> [`top`](#top)
 
-Get a particular health class graph for a device, if you provide a sensor_id as well then a single sensor graph 
+Get a particular health class graph for a device, if you provide a sensor_id as well then a single sensor graph
 will be provided. If no sensor_id value is provided then you will be sent a stacked sensor graph.
 
 Route: /api/v0/devices/:hostname/graphs/health/:type(/:sensor_id)
@@ -364,7 +369,7 @@ Output:
 Output is the graph of the particular health type sensor provided.
 
 
- 
+
 ### <a name="api-route-6">Function: `get_graph_generic_by_hostname`</a> [`top`](#top)
 
 Get a specific graph for a device, this does not include ports.
@@ -423,6 +428,37 @@ Output:
         },
         {
             "ifName": "eth1"
+        }
+    ]
+}
+```
+### <a name="api-route-get_device_ip_addresses">Function: `get_device_ip_addresses`</a> [`top`](#top)
+
+Get a list of IP addresses (v4 and v6) associated with a device.
+
+Route: /api/v0/devices/:hostname/ip
+
+  - hostname can be either the device hostname or id
+
+Example:
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/devices/localhost/ip
+```
+
+Output:
+
+```text
+{
+    "status": "ok",
+    "err-msg": "",
+    "addresses": [
+        {
+          "ipv4_address_id": "290",
+          "ipv4_address": "192.168.99.292",
+          "ipv4_prefixlen": "30",
+          "ipv4_network_id": "247",
+          "port_id": "323",
+          "context_name": ""
         }
     ]
 }
@@ -926,6 +962,189 @@ Output:
         ]
     }
 ]
+```
+
+## <a name="api-ports">`Ports`</a> [`top`](#top)
+
+### <a name="api-get_all_ports">Function `get_all_ports`</a> [`top`](#top)
+
+Get info for all ports on all devices.
+Strongly recommend that you use the `columns` parameter to avoid pulling too much data.
+
+Route: /api/v0/ports
+
+  -
+
+Input:
+
+  - columns: Comma separated list of columns you want returned.
+
+
+Example:
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/ports?columns=ifName%2Cport_id
+```
+
+Output:
+
+```text
+{
+  "status": "ok",
+  "err-msg": "",
+  "ports": [
+        {
+          "ifName": "Gi0/0/0",
+          "port_id": "1"
+        },
+        {
+          "ifName": "Gi0/0/1",
+          "port_id": "2"
+        },
+        ...
+        {
+          "ifName": "Vlan 3615",
+          "port_id": "5488"
+        }
+    ]
+}
+```
+
+### <a name="api-route-get_port_info">Function `get_port_info`</a> [`top`](#top)
+
+Get all info for a particular port.
+
+Route: /api/v0/ports/:portid
+
+  - portid must be an integer
+
+Input:
+
+  -
+
+Example:
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/ports/323
+```
+
+Output:
+
+```text
+{
+  "status": "ok",
+  "err-msg": "",
+  "port": [
+    {
+      "port_id": "323",
+      "device_id": "55",
+      "port_descr_type": null,
+      "port_descr_descr": null,
+      "port_descr_circuit": null,
+      "port_descr_speed": null,
+      "port_descr_notes": null,
+      "ifDescr": "GigabitEthernet0/0/0",
+      "ifName": "Gi0/0/0",
+      "portName": null,
+      "ifIndex": "1",
+      "ifSpeed": "1000000000",
+      "ifConnectorPresent": "true",
+      "ifPromiscuousMode": "false",
+      "ifHighSpeed": "1000",
+      "ifOperStatus": "up",
+      "ifOperStatus_prev": null,
+      "ifAdminStatus": "up",
+      "ifAdminStatus_prev": null,
+      "ifDuplex": "fullDuplex",
+      "ifMtu": "1560",
+      "ifType": "ethernetCsmacd",
+      "ifAlias": "ASR Interconnect Trunk",
+      "ifPhysAddress": "84bf20853e00",
+      "ifHardType": null,
+      "ifLastChange": "42407358",
+      "ifVlan": "",
+      "ifTrunk": "",
+      "ifVrf": "0",
+      "counter_in": null,
+      "counter_out": null,
+      "ignore": "0",
+      "disabled": "0",
+      "detailed": "0",
+      "deleted": "0",
+      "pagpOperationMode": null,
+      "pagpPortState": null,
+      "pagpPartnerDeviceId": null,
+      "pagpPartnerLearnMethod": null,
+      "pagpPartnerIfIndex": null,
+      "pagpPartnerGroupIfIndex": null,
+      "pagpPartnerDeviceName": null,
+      "pagpEthcOperationMode": null,
+      "pagpDeviceId": null,
+      "pagpGroupIfIndex": null,
+      "ifInUcastPkts": "128518576",
+      "ifInUcastPkts_prev": "128517284",
+      "ifInUcastPkts_delta": "1292",
+      "ifInUcastPkts_rate": "4",
+      "ifOutUcastPkts": "128510560",
+      "ifOutUcastPkts_prev": "128509268",
+      "ifOutUcastPkts_delta": "1292",
+      "ifOutUcastPkts_rate": "4",
+      "ifInErrors": "0",
+      "ifInErrors_prev": "0",
+      "ifInErrors_delta": "0",
+      "ifInErrors_rate": "0",
+      "ifOutErrors": "0",
+      "ifOutErrors_prev": "0",
+      "ifOutErrors_delta": "0",
+      "ifOutErrors_rate": "0",
+      "ifInOctets": "12827393730",
+      "ifInOctets_prev": "12827276736",
+      "ifInOctets_delta": "116994",
+      "ifInOctets_rate": "387",
+      "ifOutOctets": "14957481766",
+      "ifOutOctets_prev": "14957301765",
+      "ifOutOctets_delta": "180001",
+      "ifOutOctets_rate": "596",
+      "poll_time": "1483779150",
+      "poll_prev": "1483778848",
+      "poll_period": "302"
+    }
+  ]
+}
+```
+
+### <a name="api-route-get_port_info">Function `get_port_info`</a> [`top`](#top)
+
+Get all IP info (v4 and v6) for a given port id.
+
+Route: /api/v0/ports/:portid/ip
+
+  - portid must be an integer
+
+Input:
+
+  -
+
+Example:
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/ports/323/ip
+```
+
+Output:
+
+```text
+{
+  "status": "ok",
+  "err-msg": "",
+  "addresses": [
+    {
+      "ipv4_address_id": "290",
+      "ipv4_address": "192.168.99.292",
+      "ipv4_prefixlen": "30",
+      "ipv4_network_id": "247",
+      "port_id": "323",
+      "context_name": ""
+    }
+  ]
+}
 ```
 
 ### <a name="api-route-get_devices_by_group">Function `get_devices_by_group`</a> [`top`](#top)

--- a/html/api_v0.php
+++ b/html/api_v0.php
@@ -78,7 +78,7 @@ $app->group(
                         $app->get('/:portid/ip', 'authToken', 'get_port_ip_info')->name('get_port_ip_info');
                     }
                 );
-                $app->get('/ports', 'authToken', 'get_ports')->name('get_ports');
+                $app->get('/ports', 'authToken', 'get_all_ports')->name('get_all_ports');
                 $app->group(
                     '/portgroups',
                     function () use ($app) {

--- a/html/api_v0.php
+++ b/html/api_v0.php
@@ -43,6 +43,7 @@ $app->group(
                         $app->get('/:hostname/health(/:type)(/:sensor_id)', 'authToken', 'list_available_health_graphs')->name('list_available_health_graphs');
                         // api/v0/devices/$hostname/health
                         $app->get('/:hostname/ports', 'authToken', 'get_port_graphs')->name('get_port_graphs');
+                        $app->get('/:hostname/ip', 'authToken', 'get_device_ip_addresses')->name('get_device_ip_addresses');
                         $app->get('/:hostname/port_stack', 'authToken', 'get_port_stack')->name('get_port_stack');
                         // api/v0/devices/$hostname/ports
                         $app->get('/:hostname/components', 'authToken', 'get_components')->name('get_components');
@@ -57,7 +58,6 @@ $app->group(
                         // api/v0/devices/$hostname/ports/$ifName
                         $app->get('/:hostname/ports/:ifname/:type', 'authToken', 'get_graph_by_port_hostname')->name('get_graph_by_port_hostname');
                         // api/v0/devices/$hostname/ports/$ifName/$type
-                        $app->get('/:hostname/ip', 'authToken', 'get_device_ip_addresses')->name('get_device_ip_addresses');
                     }
                 );
                 $app->get('/devices', 'authToken', 'list_devices')->name('list_devices');

--- a/html/api_v0.php
+++ b/html/api_v0.php
@@ -43,7 +43,7 @@ $app->group(
                         $app->get('/:hostname/health(/:type)(/:sensor_id)', 'authToken', 'list_available_health_graphs')->name('list_available_health_graphs');
                         // api/v0/devices/$hostname/health
                         $app->get('/:hostname/ports', 'authToken', 'get_port_graphs')->name('get_port_graphs');
-                        $app->get('/:hostname/ip', 'authToken', 'get_device_ip_addresses')->name('get_device_ip_addresses');
+                        $app->get('/:hostname/ip', 'authToken', 'get_ip_addresses')->name('get_device_ip_addresses');
                         $app->get('/:hostname/port_stack', 'authToken', 'get_port_stack')->name('get_port_stack');
                         // api/v0/devices/$hostname/ports
                         $app->get('/:hostname/components', 'authToken', 'get_components')->name('get_components');
@@ -75,7 +75,7 @@ $app->group(
                     '/ports',
                     function () use ($app) {
                         $app->get('/:portid', 'authToken', 'get_port_info')->name('get_port_info');
-                        $app->get('/:portid/ip', 'authToken', 'get_port_ip_info')->name('get_port_ip_info');
+                        $app->get('/:portid/ip', 'authToken', 'get_ip_addresses')->name('get_port_ip_info');
                     }
                 );
                 $app->get('/ports', 'authToken', 'get_all_ports')->name('get_all_ports');

--- a/html/api_v0.php
+++ b/html/api_v0.php
@@ -57,6 +57,7 @@ $app->group(
                         // api/v0/devices/$hostname/ports/$ifName
                         $app->get('/:hostname/ports/:ifname/:type', 'authToken', 'get_graph_by_port_hostname')->name('get_graph_by_port_hostname');
                         // api/v0/devices/$hostname/ports/$ifName/$type
+                        $app->get('/:hostname/ip', 'authToken', 'get_device_ip_addresses')->name('get_device_ip_addresses');
                     }
                 );
                 $app->get('/devices', 'authToken', 'list_devices')->name('list_devices');
@@ -70,6 +71,14 @@ $app->group(
                     }
                 );
                 $app->get('/devicegroups', 'authToken', 'get_device_groups')->name('get_devicegroups');
+                $app->group(
+                    '/ports',
+                    function () use ($app) {
+                        $app->get('/:portid', 'authToken', 'get_port_info')->name('get_port_info');
+                        $app->get('/:portid/ip', 'authToken', 'get_port_ip_info')->name('get_port_ip_info');
+                    }
+                );
+                $app->get('/ports', 'authToken', 'get_ports')->name('get_ports');
                 $app->group(
                     '/portgroups',
                     function () use ($app) {

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -781,8 +781,8 @@ function get_device_ip_addresses()
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
 
-    $ipv4   = dbFetchRows("SELECT * FROM `ipv4_addresses` WHERE `device_id` = ? AND `deleted` = 0", array($device_id));
-    $ipv6   = dbFetchRows("SELECT * FROM `ipv6_addresses` WHERE `device_id` = ? AND `deleted` = 0", array($device_id));
+    $ipv4   = dbFetchRows("SELECT `ipv4_addresses`.* FROM `ipv4_addresses` JOIN `ports` ON `ports`.`port_id`=`ipv4_addresses`.`port_id` WHERE `ports`.`device_id` = ? AND `deleted` = 0", array($device_id));
+    $ipv6   = dbFetchRows("SELECT `ipv6_addresses`.* FROM `ipv6_addresses` JOIN `ports` ON `ports`.`port_id`=`ipv6_addresses`.`port_id` WHERE `ports`.`device_id` = ? AND `deleted` = 0", array($device_id));
     $output = array(
         'status'    => 'ok',
         'err-msg'   => '',

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -836,17 +836,21 @@ function get_all_ports()
 {
     global $config;
     $app = \Slim\Slim::getInstance();
-
-    $ports = dbFetchRows("SELECT * FROM `ports` WHERE `deleted` = 0");
+    if (isset($_GET['columns'])) {
+        $columns = $_GET['columns'];
+    } else {
+        $columns = 'ifName';
+    }
+    $ports = dbFetchRows("SELECT $columns FROM `ports` WHERE `deleted` = 0");
 
     $output = array(
         'status' => 'ok',
         'err-msg' => '',
-        'addresses' => $ports,
+        'addresses' => '$ports',
     );
     $app->response->setStatus('200');
     $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($outbut);
+    echo _json_encode($output);
 }
 
 function get_port_stack()

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -844,9 +844,9 @@ function get_all_ports()
     $ports = dbFetchRows("SELECT $columns FROM `ports` WHERE `deleted` = 0");
 
     $output = array(
-        'status' => 'ok',
+        'status'  => 'ok',
         'err-msg' => '',
-        'addresses' => '$ports',
+        'ports'   => $ports,
     );
     $app->response->setStatus('200');
     $app->response->headers->set('Content-Type', 'application/json');

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -771,6 +771,84 @@ function get_port_graphs()
     echo _json_encode($output);
 }
 
+function get_device_ip_addresses()
+{
+    global $config;
+    $app      = \Slim\Slim::getInstance();
+    $router   = $app->router()->getCurrentRoute()->getParams();
+    $hostname = $router['hostname'];
+
+    // use hostname as device_id if it's all digits
+    $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+
+    $ipv4   = dbFetchRows("SELECT * FROM `ipv4_addresses` WHERE `device_id` = ? AND `deleted` = 0", array($device_id));
+    $ipv6   = dbFetchRows("SELECT * FROM `ipv6_addresses` WHERE `device_id` = ? AND `deleted` = 0", array($device_id));
+    $output = array(
+        'status'    => 'ok',
+        'err-msg'   => '',
+        'addresses' => array_merge($ipv4, $ipv6),
+    );
+
+    $app->response->setStatus('200');
+    $app->response->headers->set('Content-Type', 'application/json');
+    echo _json_encode($output);
+}
+
+function get_port_info()
+{
+    global $config;
+    $app      = \Slim\Slim::getInstance();
+    $router   = $app->router()->getCurrentRoute()->getParams();
+    $port_id  = urldecode($router['portid']);
+
+    // use hostname as device_id if it's all digits
+    $port   = dbFetchRows("SELECT * FROM `ports` WHERE `port_id` = ? AND `deleted` = 0", array($port_id));
+    $output = array(
+        'status'  => 'ok',
+        'err-msg' => '',
+        'port'    => $port,
+    );
+    $app->response->setStatus('200');
+    $app->response->headers->set('Content-Type', 'application/json');
+    echo _json_encode($output);
+}
+
+function get_port_ip_info()
+{
+    global $config;
+    $app     = \Slim\Slim::getInstance();
+    $router  = $app->router()->getCurrentRoute()->getParams();
+    $port_id = urldecode($router['portid']);
+
+    $ipv4   = dbFetchRows("SELECT * FROM `ipv4_addresses` WHERE `port_id` = ?", array($port_id));
+    $ipv6   = dbFetchRows("SELECT * FROM `ipv6_addresses` WHERE `port_id` = ?", array($port_id));
+    $output = array(
+        'status'    => 'ok',
+        'err-msg'   => '',
+        'addresses' => array_merge($ipv4, $ipv6),
+    );
+    $app->response->setStatus('200');
+    $app->response->headers->set('Content-Type', 'application/json');
+    echo _json_encode($output);
+}
+
+function get_all_ports()
+{
+    global $config;
+    $app = \Slim\Slim::getInstance();
+
+    $ports = dbFetchRows("SELECT * FROM `ports` WHERE `deleted` = 0");
+
+    $output = array(
+        'status' => 'ok',
+        'err-msg' => '',
+        'addresses' => $ports,
+    );
+    $app->response->setStatus('200');
+    $app->response->headers->set('Content-Type', 'application/json');
+    echo _json_encode($outbut);
+}
+
 function get_port_stack()
 {
     global $config;
@@ -1414,26 +1492,26 @@ function list_services()
     $services = array();
     $where    = '';
     $devicewhere = '';
-    
+
     // Filter BY STATE
     if (isset($_GET['state'])) {
         $where  = " AND S.service_status= ? AND S.service_disabled='0' AND S.service_ignore='0'";
         $host_par[] = $_GET['state'];
-        
+
         if (!is_numeric($_GET['state'])) {
             $status   = 'error';
             $message = "No valid service state provided, valid option is 0=Ok, 1=Warning, 2=Critical";
         }
     }
-    
+
     // GET BY HOST
     if (isset($router['hostname'])) {
         $hostname = $router['hostname'];
         $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
-        
+
         $where .= " AND S.device_id = ?";
         $host_par[] = $device_id;
-        
+
         if (!is_numeric($device_id)) {
             $status   = 'error';
             $message = "No valid hostname or device id provided";
@@ -1442,12 +1520,12 @@ function list_services()
 
     // DEVICE
     $host_sql = 'SELECT * FROM devices AS D, services AS S WHERE D.device_id = S.device_id '.$where.' GROUP BY D.hostname ORDER BY D.hostname';
-    
+
     // SERVICE
     foreach (dbFetchRows($host_sql, $host_par) as $device) {
         $device_id = $device['device_id'];
         $sql_param[0] = $device_id;
-        
+
         // FILTER BY TYPE
         if (isset($_GET['type'])) {
             $devicewhere  = " AND `service_type` LIKE ?";


### PR DESCRIPTION
* `/api/v0/devices/:hostname/ip`: returns info for any IP addresses (4 or 6) on any interfaces on this device
* `/api/v0/ports`: returns same info (and honors same `columns` parameter) as `/api/v0/devices/:hostname/ports`, but for *all* undeleted ports.  Purpose is to avoid many recursive calls if you know you need all of them anyway.
* `/api/v0/ports/:portid`: returns info for specific port, by `port_id`.
* `/api/v0/ports/:portid/ip`: returns any ip addresses (4 or 6) on a specific port, by `port_id`


Also it looks like my editor played some whitespace shenanigans lower in the file?  Not sure what happened there.  If it's a problem I can dig in further.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
