### PR TITLE
Throw error when host already exists rather than say it is due to snmp

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -684,6 +684,8 @@ function createHost($host, $community, $snmpver, $port = 161, $transport = 'udp'
                 oxidized_reload_nodes();
                 return $device_id;
             }
+        } else {
+            throw new HostExistsException("Already have host $host ($snmphost)");
         }
     }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Shows the difference:

```
-bash-4.2$ ./addhost.php netbotz03 netbotz01 v2c 1161
Could not connect, please check the snmp details and snmp reachability
-bash-4.2$ ./addhost.php netbotz03 netbotz01 v2c 1161
Already have host netbotz03 (NETBOTZ01)
```