### PR TITLE
Changed the default options allowed to accept blank values

### DIFF
--- a/sql-schema/160.sql
+++ b/sql-schema/160.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `devices` CHANGE `cryptoalgo` `cryptoalgo` ENUM('AES','DES','') NULL DEFAULT NULL;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

When not running in sql_mode='' this fails as we try and insert '', we can't set null earlier on as this just then becomes blank and reverts to '' rather than NULL in mysql.