### PR TITLE
small fix, specify .0 for the oid on powerwalker current sensors

### DIFF
--- a/includes/discovery/sensors/current/powerwalker.inc.php
+++ b/includes/discovery/sensors/current/powerwalker.inc.php
@@ -37,13 +37,13 @@ if ($device['os'] === 'powerwalker') {
 
     if (is_numeric($pw_oids['upsInputCurrent'][1])) {
         $descr = 'Input Voltage';
-        $oid = '.1.3.6.1.2.1.33.1.3.3.1.4.1';
+        $oid = '.1.3.6.1.2.1.33.1.3.3.1.4.1.0';
         discover_sensor($valid['sensor'], 'current', $device, $oid, 2, 'powerwalker', $descr, '1', '1', null, null, null, null, $value);
     }
 
     if (is_numeric($pw_oids['upsOutputCurrent'][1])) {
         $descr = 'Output Voltage';
-        $oid = '.1.3.6.1.2.1.33.1.4.4.1.3.1';
+        $oid = '.1.3.6.1.2.1.33.1.4.4.1.3.1.0';
         discover_sensor($valid['sensor'], 'current', $device, $oid, 3, 'powerwalker', $descr, '1', '1', null, null, null, null, $value);
     }
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Oid should have had .0 at the end. fixed - sensors currently broken so no issue with loss of data in rrd.