### PR TITLE
fix: Remove the ability to activate statistics by non-admins

### DIFF
--- a/html/pages/about.inc.php
+++ b/html/pages/about.inc.php
@@ -84,10 +84,14 @@ if (extension_loaded('curl')) {
 echo "
 <div class='table-responsive'>
     <table class='table table-condensed'>
-      <tr>
-        <td colspan='4'><span class='bg-danger'>$callback</span><br />
-        Online stats: <a href='https://stats.librenms.org/'>stats.librenms.org</a></td>
       <tr>";
+
+if (is_admin() === true) {
+    echo "        <td colspan='4'><span class='bg-danger'>$callback</span><br />
+          Online stats: <a href='https://stats.librenms.org/'>stats.librenms.org</a></td>
+        <tr>
+    ";
+}
 
 if (dbFetchCell("SELECT `value` FROM `callback` WHERE `name` = 'uuid'") != '' && $callback_status != 2) {
     echo "


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)



<img width="1262" alt="screen shot 2017-02-08 at 16 30 05" src="https://cloud.githubusercontent.com/assets/1927109/22743997/3552158e-ee1c-11e6-9430-ebce1f6e0b8b.png">
<img width="760" alt="screen shot 2017-02-08 at 16 30 00" src="https://cloud.githubusercontent.com/assets/1927109/22743996/35159c8a-ee1c-11e6-9987-7e6a44beccfd.png">
