### PR TITLE
fix: Remove the non-functional buttons for non-admins in services

### DIFF
--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -134,8 +134,12 @@ foreach (dbFetchRows($host_sql, $host_par) as $device) {
         <td><span class='box-desc'><?php echo nl2br(display($service['service_message']))?></span></td>
         <td><span class='box-desc'><?php echo nl2br(display($service['service_desc']))?></span></td>
         <td>
-            <button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='<?php echo $service['service_id']?>' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
-            <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='<?php echo $service['service_id']?>' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>
+<?php
+    if (is_admin() === true) {
+            echo "<button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='{$service['service_id']}' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
+            <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='{$service['service_id']}' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>";
+    }
+?>
         </td>
     </tr>
 <?php

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -135,10 +135,10 @@ foreach (dbFetchRows($host_sql, $host_par) as $device) {
         <td><span class='box-desc'><?php echo nl2br(display($service['service_desc']))?></span></td>
         <td>
 <?php
-    if (is_admin() === true) {
-            echo "<button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='{$service['service_id']}' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
-            <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='{$service['service_id']}' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>";
-    }
+if (is_admin() === true) {
+    echo "<button type='button' class='btn btn-primary btn-sm' aria-label='Edit' data-toggle='modal' data-target='#create-service' data-service_id='{$service['service_id']}' name='edit-service'><i class='fa fa-pencil' aria-hidden='true'></i></button>
+    <button type='button' class='btn btn-danger btn-sm' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-service_id='{$service['service_id']}' name='delete-service'><i class='fa fa-trash' aria-hidden='true'></i></button>";
+}
 ?>
         </td>
     </tr>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

**Admins:**
<img width="1327" alt="screen shot 2017-02-08 at 21 14 08" src="https://cloud.githubusercontent.com/assets/1927109/22755583/126a3952-ee44-11e6-8821-dbfa8aeac582.png">

**Non-admins:**
<img width="1320" alt="screen shot 2017-02-08 at 21 13 54" src="https://cloud.githubusercontent.com/assets/1927109/22755582/1265fcc0-ee44-11e6-9d0a-8a8281c67f63.png">
