### PR TITLE
Correct snmp_get of sysDescr.0 to identify PMP450 as AP

### DIFF
--- a/html/includes/graphs/device/canopy_generic_regCount.inc.php
+++ b/html/includes/graphs/device/canopy_generic_regCount.inc.php
@@ -9,6 +9,8 @@
  * the source code distribution for details.
  */
 
+$scale_min = 0;
+
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-regCount');
 if (file_exists($rrdfilename)) {

--- a/html/includes/graphs/device/canopy_generic_whispGPSStats.inc.php
+++ b/html/includes/graphs/device/canopy_generic_whispGPSStats.inc.php
@@ -8,6 +8,9 @@
  * option) any later version.  Please see LICENSE.txt at the top level of
  * the source code distribution for details.
  */
+
+$scale_min = 0;
+
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-whispGPSStats');
 if (file_exists($rrdfilename)) {

--- a/includes/definitions/canopy.yaml
+++ b/includes/definitions/canopy.yaml
@@ -4,6 +4,7 @@ type: wireless
 icon: cambium
 over:
     - { graph: device_bits, text: 'Device Traffic' }
+    - { graph: device_canopy_generic_regCount, text: 'Registered SMs' }
 group: cambium
 discovery:
     - sysDescr_regex:

--- a/includes/polling/os/canopy.inc.php
+++ b/includes/polling/os/canopy.inc.php
@@ -9,7 +9,7 @@
  * the source code distribution for details.
  */
 
-$cambium_type = snmp_get($device, 'sysDescr.0', '-Oqv', '');
+$cambium_type = snmp_get($device, 'sysDescr.0', '-Oqv', 'SNMPv2-MIB');
 $PMP = snmp_get($device, 'boxDeviceType.0', '-Oqv', 'WHISP-BOX-MIBV2-MIB');
 $version = $cambium_type;
 $filtered_words = array(

--- a/includes/polling/os/canopy.inc.php
+++ b/includes/polling/os/canopy.inc.php
@@ -9,7 +9,7 @@
  * the source code distribution for details.
  */
 
-$cambium_type = snmp_get($device, 'sysDescr.0', '-Oqv', 'SNMPv2-MIB');
+$cambium_type = $poll_device['sysDescr'];
 $PMP = snmp_get($device, 'boxDeviceType.0', '-Oqv', 'WHISP-BOX-MIBV2-MIB');
 $version = $cambium_type;
 $filtered_words = array(


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Added SNMPv2-MIB name to snmp_get of sysDescr.0 since it was not polling correctly.
This was setting $cambium_type to '' and device type identification was falling through to default for PMP450.