### PR TITLE
feature: Discovery modules will now auto-disable poller modules when no data found #5494

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -10,6 +10,7 @@ if ($config['enable_bgp']) {
 
     $bgpLocalAs = trim(snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn', 'BGP4-MIB'));
 
+    $found_data = 0;
     foreach ($vrfs_lite_cisco as $vrf) {
             $device['context_name'] = $vrf['context_name'];
         if (is_numeric($bgpLocalAs)) {
@@ -119,10 +120,11 @@ if ($config['enable_bgp']) {
                         $name             = gethostbyaddr($peer['ip']);
                         $remote_device_id = discover_new_device($name, $device, 'BGP');
                     }
-
+                    $found_data++;
                     echo '+';
                 } else {
                     $update = dbUpdate(array('bgpPeerRemoteAs' => $peer['as'], 'astext' => mres($astext)), 'bgpPeers', 'device_id=? AND bgpPeerIdentifier=?', array($device['device_id'], $peer['ip']));
+                    $found_data++;
                     echo '.';
                 }
 
@@ -280,7 +282,15 @@ if ($config['enable_bgp']) {
             echo "\n";
            unset($device['context_name']);
     }
-    unset($device['context_name']);
-    unset($vrfs_c);
+    if ($found_data > 0) {
+        $module_state = true;
+    } else {
+        $module_state = false;
+    }
+    unset(
+        $device['context_name'],
+        $vrfs_c,
+        $found_data
+    );
 }
 echo "FIN BGP \n\n\n";

--- a/includes/discovery/entity-physical.inc.php
+++ b/includes/discovery/entity-physical.inc.php
@@ -18,6 +18,13 @@ if ($config['enable_inventory']) {
             dbDelete('entPhysical', 'entPhysical_id = ?', array ($test['entPhysical_id']));
         }
     }
+
+    if (count($valid) > 0) {
+        $module_state = true;
+    } else {
+        $module_state = false;
+    }
+
     unset(
         $sql,
         $test,

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1001,13 +1001,14 @@ function sensors($types, $device, $valid, $pre_cache = array())
  */
 function toggle_poller_module($device, $module, $state)
 {
-    if ($state === true || $state === false) {
+    if (is_bool()) {
         if ($state === false) {
             $state = 0 ;
         }
         $updated = set_dev_attrib($device, 'poll_'.$module, $state);
         if ($updated > 0) {
-            log_event("Poller module $module state changed to $state", $device);
+            $msg = "Poller module $module " . ($state ? 'enabled' : 'disabled');
+            log_event($msg, $device);
         }
     }
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -147,6 +147,8 @@ function discover_device($device, $options = null)
             $module_time = substr($module_time, 0, 5);
             $module_mem  = (memory_get_usage() - $start_memory);
             printf("\n>> Runtime for discovery module '%s': %.4f seconds with %s bytes\n", $module, $module_time, $module_mem);
+            toggle_poller_module($device, $module, $module_state);
+            unset($module_state);
             echo "#### Unload disco module $module ####\n\n";
         } elseif (isset($attribs['discover_' . $module]) && $attribs['discover_' . $module] == '0') {
             echo "Module [ $module ] disabled on host.\n\n";
@@ -984,5 +986,28 @@ function sensors($types, $device, $valid, $pre_cache = array())
         d_echo($valid['sensor'][$type]);
         check_valid_sensors($device, $type, $valid['sensor']);
         echo "\n";
+    }
+    if (count($valid['sensor']) > 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * @param $device
+ * @param $module
+ * @param $state
+ */
+function toggle_poller_module($device, $module, $state)
+{
+    if ($state === true || $state === false) {
+        if ($state === false) {
+            $state = 0 ;
+        }
+        $updated = set_dev_attrib($device, 'poll_'.$module, $state);
+        if ($updated > 0) {
+            log_event("Poller module $module state changed to $state", $device);
+        }
     }
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1001,7 +1001,7 @@ function sensors($types, $device, $valid, $pre_cache = array())
  */
 function toggle_poller_module($device, $module, $state)
 {
-    if (is_bool()) {
+    if (is_bool($state)) {
         if ($state === false) {
             $state = 0 ;
         }

--- a/includes/discovery/junose-atm-vp.inc.php
+++ b/includes/discovery/junose-atm-vp.inc.php
@@ -41,6 +41,12 @@ if ($device['os'] == 'junose' && $config['enable_ports_junoseatmvp']) {
         unset($vp_id);
     }
 
+    if (count($valid_vp) > 0) {
+        $module_state = true;
+    } else {
+        $module_state = false;
+    }
+
     unset($valid_vp);
     echo "\n";
 }//end if

--- a/includes/discovery/mempools.inc.php
+++ b/includes/discovery/mempools.inc.php
@@ -23,6 +23,12 @@ foreach (dbFetchRows($sql) as $test_mempool) {
     unset($mempool_type);
 }
 
+if (count($valid_mempool) > 0) {
+    $module_state = true;
+} else {
+    $module_state = false;
+}
+
 unset(
     $valid_mempool,
     $sql,

--- a/includes/discovery/processors.inc.php
+++ b/includes/discovery/processors.inc.php
@@ -27,6 +27,12 @@ foreach (dbFetchRows($sql) as $test_processor) {
     unset($processor_type);
 }
 
+if (count($valid) > 0) {
+    $module_state = true;
+} else {
+    $module_state = false;
+}
+
 echo "\n";
 
 unset(

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -42,7 +42,7 @@ $run_sensors = array(
     'temperatures',
     'voltages',
 );
-sensors($run_sensors, $device, $valid, $pre_cache);
+$module_state = sensors($run_sensors, $device, $valid, $pre_cache);
 unset(
     $pre_cache,
     $run_sensors,

--- a/includes/discovery/storage.inc.php
+++ b/includes/discovery/storage.inc.php
@@ -23,5 +23,11 @@ foreach (dbFetchRows($sql) as $test_storage) {
     unset($storage_mib);
 }
 
+if (count($valid_storage) > 0) {
+    $module_state = true;
+} else {
+    $module_state = false;
+}
+
 unset($valid_storage);
 echo "\n";

--- a/includes/discovery/toner.inc.php
+++ b/includes/discovery/toner.inc.php
@@ -79,5 +79,11 @@ foreach ($toners as $test_toner) {
     }
 }
 
+if (count($valid_toner) > 0) {
+    $module_state = true;
+} else {
+    $module_state = false;
+}
+
 unset($valid_toner);
 echo PHP_EOL;

--- a/includes/discovery/ucd-diskio.inc.php
+++ b/includes/discovery/ucd-diskio.inc.php
@@ -35,5 +35,11 @@ foreach (dbFetchRows($sql) as $test) {
     }
 }
 
+if (count($valid_diskio) > 0) {
+    $module_state = true;
+} else {
+    $module_state = false;
+}
+
 unset($valid_diskio);
 echo "\n";


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Throwing this out there for feedback rather than merging.

One issue I can think of is if someone turns off the sensors polling module but leaves disco on, if discovery finds data we will turn the module back on.

murrant talked about linking both disco / poller modules together so you toggle them both on / off at the same time (from a users perspective) which would help with the above.

Thoughts @librenms/reviewers 