### PR TITLE
fix $device['icon'] is empty

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1994,13 +1994,13 @@ function recordSnmpStatistic($stat, $start_time)
     return $runtime;
 }
 
-function update_device_logo($device)
+function update_device_logo(&$device)
 {
     $icon = getImageName($device, false);
     if ($icon != $device['icon']) {
         log_event('Device Icon changed ' . $device['icon'] . " => $icon", $device, 'system', 3);
         $device['icon'] = $icon;
-        $sql = dbUpdate(array('icon' => $icon), 'devices', 'device_id=?', array($device['device_id']));
+        dbUpdate(array('icon' => $icon), 'devices', 'device_id=?', array($device['device_id']));
         echo "Changed Icon! : $icon\n";
     }
 }


### PR DESCRIPTION
Icon was updated to an empty variable because it was not set on the $device array()

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
