### PR TITLE
fix unbound, config options were missing

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -334,12 +334,16 @@ Unbound configuration:
 ```text
 # Enable extended statistics.
 server:
-        statistics-interval: 0
         extended-statistics: yes
         statistics-cumulative: yes
+
+remote-control:
+        control-enable: yes
+	control-interface: 127.0.0.1
+
 ```
 
-Restart your unbound after changing the configuration,v erify it is working by running /usr/lib/check_mk_agent/local/unbound.sh
+Restart your unbound after changing the configuration, verify it is working by running /usr/lib/check_mk_agent/local/unbound.sh
 
 
 


### PR DESCRIPTION
This wasn't working, as relevant config options were missing. Also, statistics-interval: 0 just dumps stats to the log, if someone decides they want to do it; ok. It has no influence on functionality.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
