### PR TITLE
webui: Always show the Services menu if global show_service is enabled

### DIFF
--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -278,11 +278,13 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
                 </li>';
         }
 
-        echo '<li class="'.$select['services'].'">
-            <a href="'.generate_device_url($device, array('tab' => 'services')).'">
-            <i class="fa fa-cogs fa-lg icon-theme"  aria-hidden="true"></i> Services
-            </a>
-            </li>';
+        if ($config['show_services']) {
+            echo '<li class="'.$select['services'].'">
+                <a href="'.generate_device_url($device, array('tab' => 'services')).'">
+                <i class="fa fa-cogs fa-lg icon-theme"  aria-hidden="true"></i> Services
+                </a>
+                </li>';
+        }
 
         if (@dbFetchCell("SELECT COUNT(toner_id) FROM toner WHERE device_id = '".$device['device_id']."'") > '0') {
             echo '<li class="'.$select['toner'].'">

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -278,13 +278,11 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
                 </li>';
         }
 
-        if (dbFetchCell("SELECT COUNT(service_id) FROM services WHERE device_id = '".$device['device_id']."'") > '0') {
-            echo '<li class="'.$select['services'].'">
-                <a href="'.generate_device_url($device, array('tab' => 'services')).'">
-                <i class="fa fa-cogs fa-lg icon-theme"  aria-hidden="true"></i> Services
-                </a>
-                </li>';
-        }
+        echo '<li class="'.$select['services'].'">
+            <a href="'.generate_device_url($device, array('tab' => 'services')).'">
+            <i class="fa fa-cogs fa-lg icon-theme"  aria-hidden="true"></i> Services
+            </a>
+            </li>';
 
         if (@dbFetchCell("SELECT COUNT(toner_id) FROM toner WHERE device_id = '".$device['device_id']."'") > '0') {
             echo '<li class="'.$select['toner'].'">


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)


---------------------

- This PR always show the Services menu if global show_service is enabled. 
- It's more convenient to add a service, because you don't need to choose the linked device on a long list and it's IMHO a more logical choice to add a service.