### PR TITLE
Update exim-stats.inc.php

### DIFF
--- a/includes/polling/applications/exim-stats.inc.php
+++ b/includes/polling/applications/exim-stats.inc.php
@@ -36,8 +36,8 @@ $rrd_def = array(
 );
 
 $fields = array(
-    'frozen' => intval($frozen),
-    'queue' => intval($queue)
+    'frozen' => intval(trim($frozen, '"')),
+    'queue' => intval(trim($queue, '"'))
 );
 
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');

--- a/includes/polling/applications/exim-stats.inc.php
+++ b/includes/polling/applications/exim-stats.inc.php
@@ -36,8 +36,8 @@ $rrd_def = array(
 );
 
 $fields = array(
-    'frozen' => $frozen,
-    'queue' => $queue
+    'frozen' => intval($frozen),
+    'queue' => intval($queue)
 );
 
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');


### PR DESCRIPTION
Output from debug of poller.php:

```
SNMP[/usr/bin/snmpget -v2c -c COMMUNITY -Oqv -M /opt/librenms/mibs:/opt/librenms/mibs/supermicro udp:HOSTNAME:161 .1.3.6.1.4.1.8072.1.3.2.3.1.2.10.101.120.105.109.45.115.116.97.116.115]
"0
0"

 exim-statsRRD[update /opt/librenms/rrd/monitoring2/app-exim-stats-5.rrd N:0:0]

```
So we have two resulting variables from that outpu (note additional quotes there)
```
$frozen = '"0';
$queue = '0"';
```

And it fails. My graphs contain nan instead of real values. I think same issue is with apache application.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
