### PR TITLE
fix: Service module has conflicted configuration files #5903

### DIFF
--- a/includes/services/check_ftp.inc.php
+++ b/includes/services/check_ftp.inc.php
@@ -1,3 +1,0 @@
-<?php
-
-$check_cmd = $config['nagios_plugins'] . "/check_ftp -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_http.inc.php
+++ b/includes/services/check_http.inc.php
@@ -1,3 +1,0 @@
-<?php
-
-$check_cmd = $config['nagios_plugins'] . "/check_http -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_imap.inc.php
+++ b/includes/services/check_imap.inc.php
@@ -1,3 +1,0 @@
-<?php
-
-$check_cmd = $config['nagios_plugins'] . "/check_imap -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_ircd.inc.php
+++ b/includes/services/check_ircd.inc.php
@@ -1,3 +1,0 @@
-<?php
-
-$check_cmd = $config['nagios_plugins'] . "/check_ircd -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_ntp.inc.php
+++ b/includes/services/check_ntp.inc.php
@@ -1,2 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_ntp -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_pop.inc.php
+++ b/includes/services/check_pop.inc.php
@@ -1,2 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_pop -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_simap.inc.php
+++ b/includes/services/check_simap.inc.php
@@ -1,2 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_simap -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_smtp.inc.php
+++ b/includes/services/check_smtp.inc.php
@@ -1,2 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_smtp -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_spop.inc.php
+++ b/includes/services/check_spop.inc.php
@@ -1,2 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_spop -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_ssh.inc.php
+++ b/includes/services/check_ssh.inc.php
@@ -1,2 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_ssh -H ".$service['hostname']." ".$service['service_param'];

--- a/includes/services/check_ssl_cert.inc.php
+++ b/includes/services/check_ssl_cert.inc.php
@@ -1,8 +1,0 @@
-<?php
-$check_cmd = $config['nagios_plugins'] . "/check_ssl_cert -H ";
-if (!empty($service['service_ip'])) {
-    $check_cmd .= $service['service_ip'];
-} else {
-    $check_cmd .= $service['hostname'];
-}
-$check_cmd .= " ".$service['service_param'];


### PR DESCRIPTION
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

--------------

Fix for #5903 

- This PR tries to solve a problem where the $ip variable is ignored with many Nagios services. The files using exactly the same command as the default in services.inc.php have been removed.
- Tested with some services, but not all a double check from other members will be appreciated.