### PR TITLE
Fix exim queue graph

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -182,6 +182,7 @@ LibreNMS contributors:
 - Robert Penziol <rpenziol@pdx.edu> (rpenziol)
 - Stefan Behte <craig at haquarter.de> (craig)
 - Zane C. Bowers-Hadley <vvelox@vvelox.net> (vvelox)
+- Valentin Polonuyer <valik.vicious@gmail.com> (valikvicious)
 
 Observium was written by:
 - Adam Armstrong

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -182,7 +182,7 @@ LibreNMS contributors:
 - Robert Penziol <rpenziol@pdx.edu> (rpenziol)
 - Stefan Behte <craig at haquarter.de> (craig)
 - Zane C. Bowers-Hadley <vvelox@vvelox.net> (vvelox)
-- Valentin Polonuyer <valik.vicious@gmail.com> (valikvicious)
+- Valentin Polonuyer <valik.vicious@gmail.com> (ValikVicious)
 
 Observium was written by:
 - Adam Armstrong

--- a/html/includes/graphs/application/exim-stats_queue.inc.php
+++ b/html/includes/graphs/application/exim-stats_queue.inc.php
@@ -35,7 +35,7 @@ $transparency  = 33;
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
 $array = array(
-    'frozen' => array('descr' => 'Queue emails','colour' => 'c13a38',),
+    'queue' => array('descr' => 'Queue emails','colour' => 'c13a38',),
 );
 
 $i = 0;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)


The exim-stats app shows frozen messages in the queue graph, instead of the full queue amount. Refer to issue #5935 for more details.

This is corrected here.