### PR TITLE
feature: Added snmp_check() to decide if a device is up/down for snmp #5946

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -557,15 +557,16 @@ function isSNMPable($device)
 {
     global $config;
 
-    $pos = snmp_get($device, "sysObjectID.0", "-Oqv", "SNMPv2-MIB");
-    if (empty($pos)) {
-        // Support for Hikvision
-        $pos = snmp_get($device, "SNMPv2-SMI::enterprises.39165.1.1.0", "-Oqv", "SNMPv2-MIB");
-    }
-    if ($pos === '' || $pos === false) {
-        return false;
-    } else {
+    $pos = snmp_check($device);
+    if ($pos === true) {
         return true;
+    } else {
+        $pos = snmp_get($device, "sysObjectID.0", "-Oqv", "SNMPv2-MIB");
+        if ($pos === '' || $pos === false) {
+            return false;
+        } else {
+            return true;
+        }
     }
 }
 

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -269,6 +269,9 @@ function snmp_check($device)
     $cmd = gen_snmpget_cmd($device, $oid, $options);
     exec($cmd, $data, $code);
     d_echo("SNMP Check response code: $code".PHP_EOL);
+
+    recordSnmpStatistic('snmpget', $time_start);
+
     if ($code === 0) {
         return true;
     }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -265,7 +265,6 @@ function snmp_check($device)
 
     $oid = '.1.3.6.1.2.1.1.2.0';
     $options = '-Oqvn';
-
     $cmd = gen_snmpget_cmd($device, $oid, $options);
     exec($cmd, $data, $code);
     d_echo("SNMP Check response code: $code".PHP_EOL);

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -255,6 +255,25 @@ function snmp_get($device, $oid, $options = null, $mib = null, $mibdir = null)
     }
 }//end snmp_get()
 
+/**
+ * @param $device
+ * @return bool
+ */
+function snmp_check($device)
+{
+    $time_start = microtime(true);
+
+    $oid = '.1.3.6.1.2.1.1.2.0';
+    $options = '-Oqvn';
+
+    $cmd = gen_snmpget_cmd($device, $oid, $options);
+    exec($cmd, $data, $code);
+    d_echo("SNMP Check response code: $code".PHP_EOL);
+    if ($code === 0) {
+        return true;
+    }
+    return false;
+}//end snmp_check()
 
 function snmp_walk($device, $oid, $options = null, $mib = null, $mibdir = null)
 {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Pretty sure this fixes: #5946 

It falls back to the old way if this doesn't work (or should). Removed the hack for hikvision as it shouldn't have been done like that.

The idea behind this is that we only care if we have a response code of 0 from the call, which any lookup that gets a form of snmp response has. I checked with snmpsimd and added a file with just sysDescr response, this is detected as being ok and returns true (we don't care we have a sysObjectId we just want to know snmp is up).