### PR TITLE
Fix hardware detection for 2.1.7 hardware

### DIFF
--- a/includes/polling/os/sub10.inc.php
+++ b/includes/polling/os/sub10.inc.php
@@ -2,6 +2,8 @@
 
 if (preg_match("/Sub10 Systems - ([\s\d\w]+)/", $poll_device['sysDescr'], $hardware)) {
     $hardware = $hardware[1];
+} else {
+    $hardware = $poll_device['sysDescr'];
 }
 
 $version = str_replace('"', '', snmp_get($device, 'sub10UnitLclFirmwareVersion.0', '-Osqnv', 'SUB10SYSTEMS-MIB'));


### PR DESCRIPTION
Looks like they changed the output in the 2.1.7 release


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
