### PR TITLE
Add support for dynamic interfaces in ifAlias script

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -183,6 +183,7 @@ LibreNMS contributors:
 - Stefan Behte <craig at haquarter.de> (craig)
 - Zane C. Bowers-Hadley <vvelox@vvelox.net> (vvelox)
 - Valentin Polonuyer <valik.vicious@gmail.com> (ValikVicious)
+- Olivier Le Brouster <olb@nebkha.net> (ollb)
 
 Observium was written by:
 - Adam Armstrong

--- a/scripts/ifAlias
+++ b/scripts/ifAlias
@@ -1,58 +1,128 @@
-#!/bin/bash
-# (c) 2013, 2014, f0o@devilcode.org
+#!/bin/sh
+# (c) 2013-2017, f0o@devilcode.org, olb@nebkha.net
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+DISTRO_BIN="/usr/bin/distro"
 BASE='.1.3.6.1.2.1.31.1.1.1.18'
-ID=$(cut -d . -f 13 <<< $2)
-cache=$(ip l)
+GET_TYPE="$1"
+GET_OID="$2"
 
-if [ -z "$ID" ]; then
-	ID=1
-else
-    ID=$(($ID+1))
-fi
+# cache ip link output
+IP_LINK="$(ip link)"
 
-IFACE=$(grep "^${ID}: " <<<"$cache" | sed 's/[:@]\s/ /g'| cut -d " " -f 2 | cut -d @ -f 1)
+# Get interface id from GET_OID script parameter depending on the get type -g
+# or -n.
+#
+# snmpd specify two behaviors: GETNEXT and GET.
+#
+# script -g  <GET_OID>
+#
+# :    Should return OID value
+#
+# script -n <GET_OID>
+#
+# :    Should return next OID value
+#
+#      Note that interface id are not necessarly following incrementally.
+#      We need tho find the next interface id (which is not necessarily n+1).
+#
+interface_id()
+{
+    local N=
+    local L=
+    local ID="${GET_OID#${BASE}.}"
 
-echo ${BASE}.${ID}
-if [ "X${IFACE}" = "X" ]; then
-    echo noSuchName
-else
-    echo "string"
-    if [ -x /usr/bin/distro ]; then
-        case $(distro | cut -d " " -f 1) in
+    case "$GET_TYPE" in
+        -g)
+            echo "$ID"
+            return 0
+            ;;
+        -n)
+            if [ "$ID" = "$BASE" ]
+            then
+                # find the first iface_id
+                echo "$IP_LINK" | grep -oE "^[0-9]+:" | head -n 1 | cut -d':' -f 1
+                return 0
+            else
+                # find the next iface_id
+                for N in $(echo "$IP_LINK" | grep -oE "^[0-9]+:" | cut -d':' -f 1)
+                do
+                    if [ "$L" = "$ID" -o ! "$ID" ]
+                    then
+                        echo -n "$N"
+                        return 0
+                    fi
+                    L="$N"
+                done
+            fi
+            ;;
+    esac
+    return 1
+}
+
+interface_name()
+{
+    local IFACE_ID="$1"
+    echo "$IP_LINK" | grep -oE "^${IFACE_ID}: [^:@ ]*" | cut -d " " -f 2
+}
+
+alias_from_interfaces_config_file()
+{
+    local IFACE="$1"
+    local CONFIG_FILE=
+
+    if [ -x "$DISTRO_BIN" ]
+    then
+        case "$("$DISTRO_BIN" | cut -d " " -f 1)" in
             Debian)
-                cnf="/etc/network/interfaces"
+                CONFIG_FILE="/etc/network/interfaces"
             ;;
             Gentoo)
-                cnf="/etc/conf.d/net"
+                CONFIG_FILE="/etc/conf.d/net"
             ;;
             CentOS|RedHat|SuSE|Mandriva|Mandrake)
-                cnf="/etc/sysconfig/network-scripts/ifcfg-$IFACE"
+                CONFIG_FILE="/etc/sysconfig/network-scripts/ifcfg-$IFACE"
             ;;
             Archlinux)
-                cnf="/etc/conf.d/net-conf-$IFACE"
-            ;;
-            *)
-                cnf=""
+                CONFIG_FILE="/etc/conf.d/net-conf-$IFACE"
             ;;
         esac
     fi
-    if [ -n "$cnf" ]; then
-        echo $(grep -i "^# $IFACE:" $cnf | sed "s/^# $IFACE: //i")
-    else
-        echo
+    if [ "$CONFIG_FILE" ]
+    then
+         echo "$(grep -i "^# $IFACE:" $CONFIG_FILE | sed "s/^# $IFACE: //i")"
     fi
-fi
+}
+
+alias_from_ip_link()
+{
+    local IFACE="$1"
+    ip link show "$IFACE" | grep -e "^[[:space:]]*alias[[:space:]]" | sed -e 's/^[[:space:]]*alias //'
+}
+
+IFACE_ID="$(interface_id)"
+[ "$IFACE_ID" ] || exit
+
+IFACE="$(interface_name "$IFACE_ID")"
+
+VALUE=
+# we first try to get alias from interface config file
+[ "$VALUE" ] || VALUE="$(alias_from_interfaces_config_file "$IFACE")"
+# then from ip link show $IFACE output
+[ "$VALUE" ] || VALUE="$(alias_from_ip_link "$IFACE")"
+
+echo "${BASE}.${IFACE_ID}"
+echo "string"
+echo "$VALUE"
 exit 0


### PR DESCRIPTION
Sometimes there are dynamic interfaces and retrieving aliases from config files is not possible. The idea is to use alias from netlink if there is no alias information in config file. It is useful for example when you have ppp links or dynamic tunnel links. In such cases, you can use the `ip link set IFACE alias ALIAS` command when initializing your interface.

* netlink and ip support alias (`ip link set IFACE alias ALIAS`). In an
  environment with dynamic interfaces, it is useful to be able retrieve
  aliases from ip.

* we cannot assume next iface oid is n + 1 since they do not follow
  incrementally when some interfaces has been destroyed and recreated.

* use straight POSIX shell

Tested on Debian GNU/Linux Jessie with snmpwalk & snmpbulkwalk.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
