### PR TITLE
drop tables that should have been removed a while ago

### DIFF
--- a/sql-schema/172.sql
+++ b/sql-schema/172.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS `cmpMemPool`;
+DROP TABLE IF EXISTS `current`;
+DROP TABLE IF EXISTS `fanspeed`;
+DROP TABLE IF EXISTS `frequency`;
+DROP TABLE IF EXISTS `voltage`;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

None of these should exist but a handful of users still have them so retrying to drop them.