### PR TITLE
Improve stats data scrubbing

### DIFF
--- a/includes/callback.php
+++ b/includes/callback.php
@@ -79,8 +79,25 @@ if ($enabled == 1) {
 
     // sanitize sysDescr
     $device_info = array_map(function ($entry) {
-        $entry['sysDescr'] = preg_replace('/^Linux [A-Za-z\-0-9\.]+ (?=[0-9\.]{5,9})/', 'Linux hostname ', $entry['sysDescr']);
-        $entry['sysDescr'] = preg_replace('/ SN: [A-Z0-9]{12}/', ' SN: 0A0A0A0A0A0A ', $entry['sysDescr']);
+        // remove hostnames from linux and macosx
+        $entry['sysDescr'] = preg_replace_callback('/^(Linux |Darwin )[A-Za-z0-9._\-]+ ([0-9.]{5,9})/', function ($matches) {
+            return $matches[1] . 'hostname ' .$matches[2];
+        }, $entry['sysDescr']);
+
+        // wipe serial numbers, preserve the format
+        $entry['sysDescr'] = preg_replace_callback('/(SN[:=]? ?)([A-Za-z0-9.\-]{4,16})/', function ($matches) {
+            $patterns = array(
+                '/[A-Z]/',
+                '/[a-z]/',
+                '/[0-9]/'
+            );
+            $replacements = array(
+                'A',
+                'a',
+                '0'
+            );
+            return $matches[1] . preg_replace($patterns, $replacements, $matches[2]);
+        }, $entry['sysDescr']);
         return $entry;
     }, $device_info);
 


### PR DESCRIPTION
Include Darwin (OSX) in the Linux hostname scrubbing, add underscores too.
Way more generic serial number replacement.  Preserves the format of the serial number, but removes the data.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
