### PR TITLE
a small amount more logging for uptime

### DIFF
--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -34,9 +34,6 @@ if (empty($uptime)) {
     $snmp_uptime = (integer)$uptime_data['snmpEngineTime'];
     $hrSystemUptime = $uptime_data['hrSystemUptime'];
     if (!empty($hrSystemUptime) && !strpos($hrSystemUptime, 'No') && ($device['os'] != 'windows')) {
-        // Move uptime into agent_uptime
-        $agent_uptime = $uptime;
-
         $uptime = floor($hrSystemUptime / 100);
         echo 'Using hrSystemUptime (' . $uptime . "s)\n";
     } else {
@@ -54,7 +51,7 @@ if ($config['os'][$device['os']]['bad_snmpEngineTime'] !== true) {
 
 if (is_numeric($uptime) && ($config['os'][$device['os']]['bad_uptime'] !== true)) {
     if ($uptime < $device['uptime']) {
-        log_event('Device rebooted after ' . formatUptime($device['uptime']), $device, 'reboot', 4, $device['uptime']);
+        log_event('Device rebooted after ' . formatUptime($device['uptime']) . ' -> ' . formatUptime($uptime), $device, 'reboot', 4, $device['uptime']);
     }
 
     $tags = array(

--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -51,7 +51,7 @@ if ($config['os'][$device['os']]['bad_snmpEngineTime'] !== true) {
 
 if (is_numeric($uptime) && ($config['os'][$device['os']]['bad_uptime'] !== true)) {
     if ($uptime < $device['uptime']) {
-        log_event('Device rebooted after ' . formatUptime($device['uptime']) . ' -> ' . formatUptime($uptime), $device, 'reboot', 4, $device['uptime']);
+        log_event('Device rebooted after ' . formatUptime($device['uptime']) . ' -> ' . $uptime, $device, 'reboot', 4, $device['uptime']);
     }
 
     $tags = array(


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Spent a bit of time looking at this and I'm certain the way we do the uptime calculation is actually fine and that the issue in #6025 is down to purely bad snmp response.

I've added a bit more logging in so we can see what the new $uptime value would have been. If we have further reports we can check that eventlog item to see what it would have changed to (unformatted in case it's not numerical).

Fixes: #6025 (ish)