### PR TITLE
webui: display sysnames/hostnames instead of ip addresses (#4155)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -152,6 +152,7 @@ LibreNMS contributors:
 - Markus Wigge <markus@cultcom.de> (cultcom)
 - Matthew Wall <llawwehttam@gmail.com> (llawwehttam)
 - Andres Rahn <andreser@gmail.com> (Andreser)
+- Philippe Mathieu-Daudé <philmd@users.noreply.github.com> (philmd)
 - Christoph Zilian <czilian@hotmail.com> (czilian)
 - Guillem Mateos <bbguillem@gmail.com> (guillemmateos)
 - Joachim Tingvold <joachim@tingvold.com> (jallakim)

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -226,16 +226,17 @@ if (defined('SHOW_SETTINGS')) {
                 $deviceLabelOld = 'availability-map-oldview-box-down';
                 $host_down_count++;
             }
+            $device_system_name = ip_to_sysname($device, $device['hostname']);
 
             if ($config['webui']['availability_map_compact'] == 0) {
                 if ($directpage == "yes") {
                     $deviceIcon = getIconTag($device);
                     $temp_output[] = '
-                    <a href="' .generate_device_url($device). '" title="' . $device['hostname'] . " - " . formatUptime($device['uptime']) . '">
+                    <a href="' .generate_device_url($device). '" title="' . $device_system_name . " - " . formatUptime($device['uptime']) . '">
                     <div class="device-availability ' . $deviceState . '" style="width:' . $config['webui']['availability_map_box_size'] . 'px;">
                         <span class="availability-label label ' . $deviceLabel . ' label-font-border">' . $deviceState . '</span>
                         <span class="device-icon">' . $deviceIcon . '</span><br>
-                        <span class="small">' . shorthost(ip_to_sysname($device, $device['hostname'])) . '</span>
+                        <span class="small">' . shorthost($device_system_name) . '</span>
                     </div>
                     </a>';
                 } else {
@@ -244,12 +245,12 @@ if (defined('SHOW_SETTINGS')) {
                         $deviceLabel .= ' widget-availability-fixed';
                     }
                     $temp_output[] = '
-                    <a href="' .generate_device_url($device). '" title="' . $device['hostname'] . " - " . formatUptime($device['uptime']) . '">
+                    <a href="' .generate_device_url($device). '" title="' . $device_system_name . " - " . formatUptime($device['uptime']) . '">
                         <span class="label ' . $deviceLabel . ' widget-availability label-font-border">' . $deviceState . '</span>
                     </a>';
                 }
             } else {
-                $temp_output[] = "<a href='" . generate_device_url($device) . "' title='" . $device['hostname'] . ' - ' . formatUptime($device['uptime']) . "'><div class='" . $deviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
+                $temp_output[] = "<a href='" . generate_device_url($device) . "' title='" . $device_system_name . ' - ' . formatUptime($device['uptime']) . "'><div class='" . $deviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
             }
         }
     }
@@ -275,17 +276,18 @@ if (defined('SHOW_SETTINGS')) {
                     $serviceState = "down";
                     $service_down_count++;
                 }
+                $service_system_name = ip_to_sysname($service, $service['hostname']);
 
                 if ($config['webui']['availability_map_compact'] == 0) {
                     if ($directpage == "yes") {
                         $deviceIcon = getIconTag($service);
                         $temp_output[] = '
-                        <a href="' . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . '" title="' . $service['hostname'] . " - " . $service['service_type'] . " - " . $service['service_desc'] . '">
+                        <a href="' . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . '" title="' . $service_system_name . " - " . $service['service_type'] . " - " . $service['service_desc'] . '">
                             <div class="service-availability ' . $serviceState . '" style="width:' . $config['webui']['availability_map_box_size'] . 'px;">
                                 <span class="service-name-label label ' . $serviceLabel . ' label-font-border">' . $service["service_type"] . '</span>
                                 <span class="availability-label label ' . $serviceLabel . ' label-font-border">' . $serviceState . '</span>
                                 <span class="device-icon">' . $deviceIcon . '</span><br>
-                                <span class="small">' . shorthost(ip_to_sysname($service, $service['hostname'])) . '</span>
+                                <span class="small">' . shorthost($service_system_name) . '</span>
                             </div>
                         </a>';
                     } else {
@@ -295,12 +297,12 @@ if (defined('SHOW_SETTINGS')) {
                             $serviceLabel .= ' widget-availability-fixed';
                         }
                         $temp_output[] = '
-                        <a href="' . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . '" title="' . shorthost(ip_to_sysname($service, $service['hostname'])) . " - " . $service['service_type'] . " - " . $service['service_desc'] . '">
+                        <a href="' . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . '" title="' . shorthost($service_system_name) . " - " . $service['service_type'] . " - " . $service['service_desc'] . '">
                             <span class="label ' . $serviceLabel . ' widget-availability label-font-border">' . $serviceText . '</span>
                         </a>';
                     }
                 } else {
-                    $temp_output[] = "<a href='" . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . "' title='${service['hostname']} - ${service['service_type']} - ${service['service_desc']}'><div class='" . $serviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
+                    $temp_output[] = "<a href='" . generate_url(array('page' => 'device', 'tab' => 'services', 'device' => $service['device_id'])) . "' title='${service_system_name} - ${service['service_type']} - ${service['service_desc']}'><div class='" . $serviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
                 }
             }
         } else {

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -28,7 +28,7 @@ if (device_permitted($vars['device']) || $check_device == $vars['device']) {
     $entity_state = get_dev_entity_state($device['device_id']);
 
     // print_r($entity_state);
-    $pagetitle[] = $device['hostname'];
+    $pagetitle[] = ip_to_sysname($device, $device['hostname']);
 
     $component = new LibreNMS\Component();
     $component_count = $component->getComponentCount($device['device_id']);


### PR DESCRIPTION
When a network is mostly assigned using RFC 1918, DNS resolution is not useful
and devices are displayed by IP address.

When `$config['force_ip_to_sysname']` is enabled, use `ip_to_sysname()` to display
the device hostname or SNMP sysName if present instead of the device IP address.

UI modified by this patch:
- Hover in Dashboard Availability Map (`/overview`)
- Name in Availability Map (`/availability-map/`)
- Title of device page (`/device/device=...`)

GitHub-issue: #4155
Suggested-by: Andres Rahn <andreser@gmail.com>
Signed-off-by: Philippe Mathieu-Daudé <f4bug@amsat.org>

#### screenshots:

- Availability Map hover before (mouse pointer not in screenshot):
![avmap-hover-before](https://cloud.githubusercontent.com/assets/71631/23531319/97232e82-ff84-11e6-84c5-2eaa4ce520c0.png)
- after:
![avmap-hover-after](https://cloud.githubusercontent.com/assets/71631/23531325/9cad27c2-ff84-11e6-9865-f7a957cf31a8.png)

- Device page title (using chrome):
![device-title-before-after](https://cloud.githubusercontent.com/assets/71631/23531333/9fe6b638-ff84-11e6-98d5-d77f4d63d393.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
