### PR TITLE
Adds column sort persistence

### DIFF
--- a/html/includes/common/alerts.inc.php
+++ b/html/includes/common/alerts.inc.php
@@ -264,6 +264,17 @@ var alerts_grid = $("#alerts_'.$unique_id.'").bootgrid({
         }
       });
     });
+    if(sessionStorage.getItem("refresh")) {
+        sessionStorage.removeItem("refresh");
+        var $sortDictionary = JSON.parse(sessionStorage.getItem("sortDictionary"));
+        alerts_grid.bootgrid("sort", $sortDictionary);
+    }
+    alerts_grid.find("[data-column-id=rule], [data-column-id=hostname], [data-column-id=timestamp], [data-column-id=severity]").on("click", function(e) {
+        setTimeout(function() {
+            var $sortDictionary = alerts_grid.bootgrid("getSortDictionary");
+            window.sessionStorage.setItem("sortDictionary", JSON.stringify($sortDictionary));
+        }, 0);
+    });
     alerts_grid.find(".command-open-proc").on("click", function(e) {
         e.preventDefault();
         var alert_id = $(this).data("alert_id");
@@ -294,7 +305,7 @@ var alerts_grid = $("#alerts_'.$unique_id.'").bootgrid({
                 toastr.success(msg);
                 if(msg.indexOf("ERROR:") <= -1) {
                     var $sortDictionary = alerts_grid.bootgrid("getSortDictionary");
-                    alerts_grid.bootgrid("sort", $sortDictionary); 
+                    alerts_grid.bootgrid("sort", $sortDictionary);
                 }
             },
             error: function(){
@@ -302,6 +313,10 @@ var alerts_grid = $("#alerts_'.$unique_id.'").bootgrid({
             }
         });
     });
+});
+$(document).ready(function() {
+    var $sortDictionary = JSON.parse(sessionStorage.getItem("sortDictionary"));
+    alerts_grid.bootgrid("sort", $sortDictionary);
 });
 </script>';
 }

--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -607,6 +607,7 @@ foreach (dbFetchRows("SELECT * FROM `widgets` ORDER BY `widget_title`") as $widg
         new_refresh = refresh * 1000;
         setTimeout(function() {
             grab_data(id,refresh,data_type);
+            sessionStorage.setItem('refresh', 'true');
         },
         new_refresh);
     }


### PR DESCRIPTION
Adds session storage variables to persist the bootgrid column sorting for the alerts after both page refresh and automated ajax refresh.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
