### PR TITLE
Expose ports in API requests for bills

### DIFF
--- a/doc/API/API-Docs.md
+++ b/doc/API/API-Docs.md
@@ -1711,7 +1711,14 @@ Output:
    "allowed": "10Mbps",
    "used": "0bps",
    "percent": 0,
-   "overuse": "-"
+   "overuse": "-",
+   "ports": [
+       {
+           "device_id": "168",
+           "port_id": "35146",
+           "ifName": "eth0"
+       }
+   ]
   }
  ]
 }
@@ -1771,7 +1778,14 @@ Output:
    "allowed": "10Mbps",
    "used": "0bps",
    "percent": 0,
-   "overuse": "-"
+   "overuse": "-",
+   "ports": [
+       {
+           "device_id": "168",
+           "port_id": "35146",
+           "ifName": "eth0"
+       }
+   ]
   }
  ]
 }

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1272,6 +1272,9 @@ function list_bills()
         $bill['used'] = $used;
         $bill['percent'] = $percent;
         $bill['overuse'] = $overuse;
+
+        $bill['ports'] = dbFetchRows("SELECT D.device_id,P.port_id,P.ifName FROM `bill_ports` AS B, `ports` AS P, `devices` AS D WHERE B.bill_id = 1 AND P.port_id = B.port_id AND D.device_id = P.device_id", array($bills["bill_id"]));
+
         $bills[] = $bill;
     }
     $count = count($bills);

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1273,7 +1273,7 @@ function list_bills()
         $bill['percent'] = $percent;
         $bill['overuse'] = $overuse;
 
-        $bill['ports'] = dbFetchRows("SELECT D.device_id,P.port_id,P.ifName FROM `bill_ports` AS B, `ports` AS P, `devices` AS D WHERE B.bill_id = 1 AND P.port_id = B.port_id AND D.device_id = P.device_id", array($bills["bill_id"]));
+        $bill['ports'] = dbFetchRows("SELECT `D`.`device_id`,`P`.`port_id`,`P`.`ifName` FROM `bill_ports` AS `B`, `ports` AS `P`, `devices` AS `D` WHERE `B`.`bill_id` = ? AND `P`.`port_id` = `B`.`port_id` AND `D`.`device_id` = `P`.`device_id`", array($bill["bill_id"]));
 
         $bills[] = $bill;
     }


### PR DESCRIPTION
This is a simple addition to the API to expose the ports along with its device from the API when we call to view bills.

Example from output when calling to `bills/1`:
```json
...
            "bill_notes": "",
            "bill_autoadded": "0",
            "ports_total": "1",
            "ports": [
                {
                    "device_id": "8",
                    "port_id": "263",
                    "ifName": "etc"
                }
            ],
            "allowed": "0.000B",
            "used": "10.000GB",
            "percent": "INF",
...
```

This allows us to then get graphs for bills. 🎉 

----------

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

**./scripts/pre-commit.php output:**
```
➜  librenms git:(bills-api) ./scripts/pre-commit.php
Running unit tests... success
Running style check... success
Running lint check... success
Tests ok, submit away :)
```

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`