### PR TITLE
fix: Old / duplicate sensors would never be removed, this is fixed by setting the $type correctly #6044

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -982,7 +982,7 @@ function sensors($types, $device, $valid, $pre_cache = array())
     global $config;
     foreach ((array)$types as $type) {
         echo ucfirst($type) . ': ';
-
+        $sensor_type = $type;
         $dir = $config['install_dir'] . '/includes/discovery/sensors/' . $type .'/';
 
         if (is_file($dir . $device['os_group'] . '.inc.php')) {
@@ -997,7 +997,7 @@ function sensors($types, $device, $valid, $pre_cache = array())
             }
         }
         d_echo($valid['sensor'][$type]);
-        check_valid_sensors($device, $type, $valid['sensor']);
+        check_valid_sensors($device, $sensor_type, $valid['sensor']);
         echo "\n";
     }
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6044

$type was being overwritten in many of the included files, we can't fix those properly as it's used to generate the filename. Probably best we don't use such a generic variable name anyway.