### PR TITLE
fix: Fixed the previous graphs for diskio/bits #6077

### DIFF
--- a/html/includes/graphs/generic_multi_seperated.inc.php
+++ b/html/includes/graphs/generic_multi_seperated.inc.php
@@ -162,33 +162,5 @@ if (!$args['nototal']) {
     $rrd_options .= " COMMENT:'\\n'";
 }
 
-if (!$args['nototal'] && $_GET['previous'] == 'yes') {
-    $rrd_options .= ' VDEF:totinX=inBX,TOTAL';
-    $rrd_options .= ' VDEF:totoutX=outBX,TOTAL';
-    $rrd_options .= ' VDEF:totX=octetsX,TOTAL';
-    $rrd_options .= " COMMENT:' \\n'";
-
-    $rrd_options .= " HRULE:999999999999999#aaaaaa:'".str_pad('Total', 11)."In ':";
-    $rrd_options .= ' GPRINT:inbitsX:LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:inbitsX:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:inbitsX:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:totinX:%6.2lf%s$total_units";
-    $rrd_options .= " COMMENT:'\\n'";
-
-    $rrd_options .= " HRULE:999999999999990#aaaaaa:'".str_pad('', 11)."Out':";
-    $rrd_options .= ' GPRINT:outbitsX:LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:outbitsX:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:outbitsX:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:totoutX:%6.2lf%s$total_units";
-    $rrd_options .= " COMMENT:'\\n'";
-
-    $rrd_options .= " HRULE:999999999999990#aaaaaa:'".str_pad('', 11)."Agg':";
-    $rrd_options .= ' GPRINT:bitsX:LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:bitsX:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:bitsX:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:totX:%6.2lf%s$total_units";
-    $rrd_options .= " COMMENT:'\\n'";
-}
-
 $rrd_options .= $rrd_optionsb;
 $rrd_options .= ' HRULE:0#999999';

--- a/html/pages/device/health/diskio.inc.php
+++ b/html/pages/device/health/diskio.inc.php
@@ -2,7 +2,7 @@
 
 $row = 1;
 
-foreach (get_disk($device['device_id']) as $drive) {
+foreach (get_disks($device['device_id']) as $drive) {
     if (is_integer($row / 2)) {
         $row_colour = $list_colour_a;
     } else {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6077 

I can't find any adverse effect to removing this part of the code which was unnecessary for the previous command to work.