### PR TITLE
correct spelling of get_disks, adding missing s for device/health/diskio.inc.php 

### DIFF
--- a/html/pages/device/health/diskio.inc.php
+++ b/html/pages/device/health/diskio.inc.php
@@ -2,7 +2,7 @@
 
 $row = 1;
 
-foreach (get_disk($device['device_id']) as $drive) {
+foreach (get_disks($device['device_id']) as $drive) {
     if (is_integer($row / 2)) {
         $row_colour = $list_colour_a;
     } else {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`



Whoops. It appeared I had it with an s in my live system but it got drop when getting this into git.