### PR TITLE
fix: Fix the displaying of alert info for historical alerts #6092

### DIFF
--- a/html/includes/table/alertlog.inc.php
+++ b/html/includes/table/alertlog.inc.php
@@ -44,12 +44,17 @@ if ($rowCount != -1) {
     $sql .= " LIMIT $limit_low,$limit_high";
 }
 
-$sql = "SELECT D.device_id,name AS alert,state,time_logged,DATE_FORMAT(time_logged, '".$config['dateformat']['mysql']['compact']."') as humandate,details $sql";
+$sql = "SELECT D.device_id,name AS alert,rule_id, state,time_logged,DATE_FORMAT(time_logged, '".$config['dateformat']['mysql']['compact']."') as humandate,details $sql";
 
 $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alertlog) {
     $dev          = device_by_id_cache($alertlog['device_id']);
-    $fault_detail = alert_details($alertlog['details']);
+    logfile($alertlog['rule_id']);
+    $log          = dbFetchCell('SELECT details FROM alert_log WHERE rule_id = ? AND device_id = ? AND `state` = 1 ORDER BY id DESC LIMIT 1', array($alertlog['rule_id'], $alertlog['device_id']));
+    $fault_detail = alert_details($log);
+    if (empty($fault_detail)) {
+        $fault_detail = 'Rule created, no faults found';
+    }
     $alert_state  = $alertlog['state'];
     if ($alert_state == '0') {
         $fa_icon  = 'check';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

The way alerts work is they register an alert_log entry for every device and every rule (not sure why). Because of this rules / devices that have never triggered will have blank details (now shows 'Rule created, no faults found') and rules which have previously triggered we look for the last alert where the state = 1 which means it was triggered and grabs the data we need from that.

Fixes: #6092 