### PR TITLE
replace /var/run/php/ by /var/run/php-fpm

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -54,7 +54,7 @@ In `/etc/php-fpm.d/www.conf` make these changes:
 
 ```nginx
 ;listen = 127.0.0.1:9000
-listen = /var/run/php/php7.0-fpm.sock
+listen = /var/run/php-fpm/php7.0-fpm.sock
 
 listen.owner = nginx
 listen.group = nginx

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -107,7 +107,7 @@ server {
  location ~ \.php {
   include fastcgi.conf;
   fastcgi_split_path_info ^(.+\.php)(/.+)$;
-  fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+  fastcgi_pass unix:/var/run/php-fpm/php7.0-fpm.sock;
  }
  location ~ /\.ht {
   deny all;


### PR DESCRIPTION
on CentOS 7 with PHP 7.0 /var/run/php don't exist
it's /var/run/php-fpm/

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
