### PR TITLE
remove utf8 encoding for json function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1129,9 +1129,6 @@ if (!defined('JSON_UNESCAPED_UNICODE')) {
 
 function _json_encode($data, $options = 448)
 {
-    array_walk_recursive($data, function (&$val) {
-        $val = utf8_encode($val);
-    });
     if (version_compare(PHP_VERSION, '5.4', '>=')) {
         return json_encode($data, $options);
     } else {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Now the utf8 encoding is setup in the db correctly, I don't believe this is needed now.