### PR TITLE
newdevice: Added state support for HP servers #5113

### DIFF
--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -26,6 +26,10 @@ if (strstr($device['hardware'], 'Dell')) {
     include 'includes/discovery/sensors/temperatures/dell.inc.php';
 }
 
+if (strstr($device['hardware'], 'ProLiant')) {
+    include 'includes/discovery/sensors/states/hp.inc.php';
+}
+
 $run_sensors = array(
     'airflow',
     'current',

--- a/includes/discovery/sensors/states/hp.inc.php
+++ b/includes/discovery/sensors/states/hp.inc.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * hp.inc.php
+ *
+ * LibreNMS state sensor discovery module for HP Hardware devices
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2017 Neil Lathwood
+ * @author     Neil Lathwood <neil@lathwood.co.uk>
+ */
+
+$tables = array(
+    // One could add more entrys from deviceGroup, but this will do as a start
+    array('cpqDaPhyDrvStatus','.1.3.6.1.4.1.232.3.2.5.1.1.6.','cpqDaPhyDrvStatus','DriveStatus','CPQSINFO-MIB'),
+    array('cpqDaPhyDrvSmartStatus','.1.3.6.1.4.1.232.3.2.5.1.1.57.','cpqDaPhyDrvSmartStatus','SmartStatus','CPQSINFO-MIB'),
+);
+
+$x=0;
+foreach ($tables as $tablevalue) {
+    $temp = snmpwalk_cache_multi_oid($device, $tablevalue[0], array(), $tablevalue[4], 'hp');
+    $cur_oid = $tablevalue[1];
+
+    if (is_array($temp)) {
+        //Create State Index
+        $state_name = $tablevalue[2];
+        $state_index_id = create_state_index($state_name);
+
+        //Create State Translation
+        if ($state_index_id !== null) {
+            if ($state_name == 'cpqDaPhyDrvStatus') {
+                $states = array(
+                    array($state_index_id,'other',1,1,3),
+                    array($state_index_id,'ok',1,2,0),
+                    array($state_index_id,'failed',1,3,2),
+                    array($state_index_id,'predictiveFailure',1,4,2),
+                    array($state_index_id,'erasing',1,5,1),
+                    array($state_index_id,'eraseDone',1,6,1),
+                    array($state_index_id,'eraseQueued',1,7,1),
+                    array($state_index_id,'ssdWearOut',1,8,2),
+                    array($state_index_id,'notAuthenticated',1,9,3),
+                );
+            } elseif ($state_name == 'cpqDaPhyDrvSmartStatus') {
+                $states = array(
+                    array($state_index_id,'other',1,1,3),
+                    array($state_index_id,'ok',1,2,0),
+                    array($state_index_id,'replaceDrive',1,3,1),
+                    array($state_index_id,'replaceDriveSSDWearOut',1,4,1),
+                );
+            }
+
+            foreach ($states as $value) {
+                $insert = array(
+                    'state_index_id' => $value[0],
+                    'state_descr' => $value[1],
+                    'state_draw_graph' => $value[2],
+                    'state_value' => $value[3],
+                    'state_generic_value' => $value[4]
+                );
+                dbInsert($insert, 'state_translations');
+            }
+        }
+
+        foreach ($temp as $index => $entry) {
+            $descr = 'Disk #'.trim(snmp_get($device, ".1.3.6.1.4.1.232.3.2.5.1.1.5.1.$index", "-Ovqn"), '"');
+            //Discover Sensors
+            discover_sensor($valid['sensor'], 'state', $device, $cur_oid.$index, $x . $index, $state_name, $descr, '1', '1', null, null, null, null, $temp[$index][$tablevalue[2]], 'snmp', $index);
+            //Create Sensor To State Index
+            create_sensor_to_state_index($device, $state_name, $index);
+        }
+    }
+    $x++;
+}

--- a/includes/polling/os/unix.inc.php
+++ b/includes/polling/os/unix.inc.php
@@ -42,6 +42,13 @@ if ($device['os'] == "linux" || $device['os'] == "endian") {
     if ($hw) {
         $hardware = "Dell " . $hw;
     } else {
+        $hw = trim(snmp_get($device, 'cpqSiProductName.0', '-Oqv', 'CPQSINFO-MIB', 'hp'), '"');
+        if (!empty($hw)) {
+            $hardware = $hw;
+        }
+    }
+
+    if (empty($hw)) {
     # Try detect using the extended option (dmidecode)
         $version_dmide = str_replace("\"", "", snmp_get($device, ".1.3.6.1.4.1.2021.7890.2.4.1.2.8.104.97.114.100.119.97.114.101.1", "-Oqv"));
         $version_dmide = trim(str_replace("\"", "", $version_dmide));

--- a/includes/polling/os/windows.inc.php
+++ b/includes/polling/os/windows.inc.php
@@ -120,4 +120,9 @@ if (!empty($hw)) {
 
     $serial = snmp_get($device, '.1.3.6.1.4.1.674.10892.1.300.10.1.11.1', '-Oqv', 'MIB-Dell-10892');
     $serial = trim(str_replace('"', '', $serial));
+} else {
+    $hw = trim(snmp_get($device, 'cpqSiProductName.0', '-Oqv', 'CPQSINFO-MIB', 'hp'), '"');
+    if (!empty($hw)) {
+        $hardware = $hw;
+    }
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #5113

Adds support for physical drive state + smart state to HP servers (also shows hardware for HP servers correctly).