### PR TITLE
fix: Fix Generex load sensor divisor

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -921,6 +921,8 @@ function get_device_divisor($device, $serial, $sensor)
         $divisor = 100;
     } elseif (($device['os'] == 'netmanplus') && ($sensor == 'voltages')) {
         $divisor = 1;
+    } elseif (($device['os'] == 'generex-ups') && ($sensor == 'load')) {
+        $divisor = 1;
     } else {
         $divisor = 10;
     }


### PR DESCRIPTION
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

-------------

![screen shot 2017-03-09 at 14 13 00](https://cloud.githubusercontent.com/assets/1927109/23751698/c0903ba4-04d2-11e7-8218-886e816d7c0b.png)

- As confirmed by many members, the load sensor seems to be using a wrong divisor on with Generex card

Details: #5977 