### PR TITLE
fix: Fix Generex voltage sensor divisor

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -897,7 +897,7 @@ function avtech_add_sensor($device, $sensor)
  * @param $sensor
  * @return int
  */
-function get_device_divisor($device, $serial, $sensor)
+function get_device_divisor($device, $serial, $sensor, $exclude)
 {
     if ($device['os'] == 'poweralert') {
         if ($sensor == 'current' || $sensor == 'frequencies') {
@@ -920,6 +920,8 @@ function get_device_divisor($device, $serial, $sensor)
     } elseif (($device['os'] == 'huaweiups') && ($sensor == 'frequencies')) {
         $divisor = 100;
     } elseif (($device['os'] == 'netmanplus') && ($sensor == 'voltages')) {
+        $divisor = 1;
+    } elseif (($device['os'] == 'generex-ups') && ($sensor == 'voltages') && ($exclude !== 1)) {
         $divisor = 1;
     } else {
         $divisor = 10;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -904,37 +904,35 @@ function avtech_add_sensor($device, $sensor)
  */
 function get_device_divisor($device, $os_version, $sensor_type, $oid)
 {
-    $divisor = 10; // default
-
     if ($device['os'] == 'poweralert') {
         if ($sensor_type == 'current' || $sensor_type == 'frequencies') {
             if (version_compare($os_version, '12.06.0068', '>=')) {
-                $divisor = 10;
+                return 10;
             } elseif (version_compare($os_version, '12.04.0055', '=')) {
-                $divisor = 10;
+                return 10;
             } elseif (version_compare($os_version, '12.04.0056', '>=')) {
-                $divisor = 1;
+                return 1;
             }
         } elseif ($sensor_type == 'load') {
             if (version_compare($os_version, '12.06.0064', '=')) {
-                $divisor = 10;
+                return 10;
             } else {
-                $divisor = 1;
+                return 1;
             }
         } elseif ($sensor_type == 'voltages') {
-            $divisor = 1;
+            return 1;
         }
     } elseif (($device['os'] == 'huaweiups') && ($sensor_type == 'frequencies')) {
-        $divisor = 100;
+        return 100;
     } elseif (($device['os'] == 'netmanplus') && ($sensor_type == 'voltages')) {
-        $divisor = 1;
+        return 1;
     } elseif ($device['os'] == 'generex-ups') {
-        if ($sensor_type == 'voltages' && starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
-            $divisor = 1;
+        if ($sensor_type == 'voltages' && !starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
+            return 1;
         }
     }
 
-    return $divisor;
+    return 10; //default
 }
 
 /**

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -891,41 +891,49 @@ function avtech_add_sensor($device, $sensor)
     return true;
 }
 
+
 /**
- * @param $device
- * @param $serial
- * @param $sensor
+ * Get the device divisor, account for device specific quirks
+ * The default divisor is 10
+ *
+ * @param array $device device array
+ * @param string $os_version firmware version poweralert quirks
+ * @param string $sensor_type the type of this sensor
+ * @param string $oid the OID of this sensor
  * @return int
  */
-function get_device_divisor($device, $serial, $sensor, $exclude)
+function get_device_divisor($device, $os_version, $sensor_type, $oid)
 {
+    $divisor = 10; // default
+
     if ($device['os'] == 'poweralert') {
-        if ($sensor == 'current' || $sensor == 'frequencies') {
-            if (version_compare($serial, '12.06.0068', '>=')) {
+        if ($sensor_type == 'current' || $sensor_type == 'frequencies') {
+            if (version_compare($os_version, '12.06.0068', '>=')) {
                 $divisor = 10;
-            } elseif (version_compare($serial, '12.04.0055', '=')) {
+            } elseif (version_compare($os_version, '12.04.0055', '=')) {
                 $divisor = 10;
-            } elseif (version_compare($serial, '12.04.0056', '>=')) {
+            } elseif (version_compare($os_version, '12.04.0056', '>=')) {
                 $divisor = 1;
             }
-        } elseif ($sensor == 'load') {
-            if (version_compare($serial, '12.06.0064', '=')) {
+        } elseif ($sensor_type == 'load') {
+            if (version_compare($os_version, '12.06.0064', '=')) {
                 $divisor = 10;
             } else {
                 $divisor = 1;
             }
-        } elseif ($sensor == 'voltages') {
+        } elseif ($sensor_type == 'voltages') {
             $divisor = 1;
         }
-    } elseif (($device['os'] == 'huaweiups') && ($sensor == 'frequencies')) {
+    } elseif (($device['os'] == 'huaweiups') && ($sensor_type == 'frequencies')) {
         $divisor = 100;
-    } elseif (($device['os'] == 'netmanplus') && ($sensor == 'voltages')) {
+    } elseif (($device['os'] == 'netmanplus') && ($sensor_type == 'voltages')) {
         $divisor = 1;
-    } elseif (($device['os'] == 'generex-ups') && ($sensor == 'voltages') && ($exclude !== 1)) {
-        $divisor = 1;
-    } else {
-        $divisor = 10;
+    } elseif ($device['os'] == 'generex-ups') {
+        if ($sensor_type == 'voltages' && starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
+            $divisor = 1;
+        }
     }
+
     return $divisor;
 }
 

--- a/includes/discovery/sensors/current/rfc1628.inc.php
+++ b/includes/discovery/sensors/current/rfc1628.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current');
+$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current',);
 
 echo 'RFC1628 ';
 

--- a/includes/discovery/sensors/current/rfc1628.inc.php
+++ b/includes/discovery/sensors/current/rfc1628.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current',);
-
 echo 'RFC1628 ';
 
 $oids = snmp_walk($device, '.1.3.6.1.2.1.33.1.2.6', '-Osqn', 'UPS-MIB');
@@ -15,8 +13,8 @@ foreach (explode("\n", $oids) as $data) {
         $split_oid        = explode('.', $oid);
         $current_id       = $split_oid[(count($split_oid) - 1)];
         $current_oid      = ".1.3.6.1.2.1.33.1.2.6.$current_id";
-        $precision        = 10;
-        $current          = (snmp_get($device, $current_oid, '-O vq') / $precision);
+        $divisor          = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current', $current_oid);
+        $current          = (snmp_get($device, $current_oid, '-O vq') / $divisor);
         $descr            = 'Battery'.(count(explode("\n", $oids)) == 1 ? '' : ' '.($current_id + 1));
         $type             = 'rfc1628';
         $index            = (500 + $current_id);
@@ -36,8 +34,8 @@ for ($i = 1; $i <= $numPhase; $i++) {
         $descr .= " Phase $i";
     }
 
-    $precision = 10;
-    $current   = (snmp_get($device, $current_oid, '-Oqv') / $precision);
+    $divisor   = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current', $current_oid);
+    $current   = (snmp_get($device, $current_oid, '-Oqv') / $divisor);
     $type      = 'rfc1628';
     $index     = $i;
 
@@ -55,8 +53,8 @@ for ($i = 1; $i <= $numPhase; $i++) {
         $descr .= " Phase $i";
     }
 
-    $precision = 10;
-    $current   = (snmp_get($device, $current_oid, '-Oqv') / $precision);
+    $divisor   = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current', $current_oid);
+    $current   = (snmp_get($device, $current_oid, '-Oqv') / $divisor);
     $type      = 'rfc1628';
     $index     = (100 + $i);
 
@@ -74,8 +72,8 @@ for ($i = 1; $i <= $numPhase; $i++) {
         $descr .= " Phase $i";
     }
 
-    $precision = 10;
-    $current   = (snmp_get($device, $current_oid, '-Oqv') / $precision);
+    $divisor   = get_device_divisor($device, $pre_cache['poweralert_serial'], 'current', $current_oid);
+    $current   = (snmp_get($device, $current_oid, '-Oqv') / $divisor);
     $type      = 'rfc1628';
     $index     = (200 + $i);
 

--- a/includes/discovery/sensors/frequencies/rfc1628.inc.php
+++ b/includes/discovery/sensors/frequencies/rfc1628.inc.php
@@ -12,7 +12,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
     if ($numPhase > 1) {
         $descr .= " Phase $i";
     }
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'frequencies');
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'frequencies', $freq_oid);
     $current = (snmp_get($device, $freq_oid, '-Oqv') / $divisor);
     $type    = 'rfc1628';
 
@@ -22,7 +22,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
 
 $freq_oid = '.1.3.6.1.2.1.33.1.4.2.0';
 $descr    = 'Output';
-$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'frequencies');
+$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'frequencies', $freq_oid);
 $current  = (snmp_get($device, $freq_oid, '-Oqv') / $divisor);
 $type     = 'rfc1628';
 
@@ -31,7 +31,7 @@ discover_sensor($valid['sensor'], 'frequency', $device, $freq_oid, $index, $type
 
 $freq_oid = '.1.3.6.1.2.1.33.1.5.1.0';
 $descr    = 'Bypass';
-$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'frequencies');
+$divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'frequencies', $freq_oid);
 $current  = (snmp_get($device, $freq_oid, '-Oqv') / $divisor);
 $type     = 'rfc1628';
 

--- a/includes/discovery/sensors/load/rfc1628.inc.php
+++ b/includes/discovery/sensors/load/rfc1628.inc.php
@@ -11,9 +11,9 @@ foreach (explode("\n", $oids) as $data) {
     if ($data) {
         list($oid,$descr) = explode(' ', $data, 2);
         $split_oid        = explode('.', $oid);
-        $divisor          = get_device_divisor($device, $pre_cache['poweralert_serial'], 'load');
         $current_id       = $split_oid[(count($split_oid) - 1)];
         $current_oid      = ".1.3.6.1.2.1.33.1.4.4.1.5.$current_id";
+        $divisor          = get_device_divisor($device, $pre_cache['poweralert_serial'], 'load', $current_oid);
         $current          = (snmp_get($device, $current_oid, '-O vq') / $divisor);
         $descr            = 'Percentage load'.(count(explode("\n", $oids)) == 1 ? '' : ' '.($current_id + 1));
         $type             = 'rfc1628';

--- a/includes/discovery/sensors/voltages/rfc1628.inc.php
+++ b/includes/discovery/sensors/voltages/rfc1628.inc.php
@@ -13,8 +13,7 @@ foreach (explode("\n", $oids) as $data) {
         $split_oid        = explode('.', $oid);
         $volt_id          = $split_oid[(count($split_oid) - 1)];
         $volt_oid         = ".1.3.6.1.2.1.33.1.2.5.$volt_id";
-        $exclude          = 1;
-        $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages', $exclude);
+        $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages', $volt_oid);
 
         $volt  = (snmp_get($device, $volt_oid, '-O vq') / $divisor);
         $descr = 'Battery'.(count(explode("\n", $oids)) == 1 ? '' : ' '.($volt_id + 1));
@@ -37,7 +36,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
     }
 
     $type    = 'rfc1628';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages');
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages', $volt_oid);
 
     $current = (snmp_get($device, $volt_oid, '-Oqv') / $divisor);
     $index   = $i;
@@ -57,10 +56,10 @@ for ($i = 1; $i <= $numPhase; $i++) {
     }
 
     $type    = 'rfc1628';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages');
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages', $volt_oid);
 
     $current = (snmp_get($device, $volt_oid, '-Oqv') / $divisor);
-    $divisor = get_device_divisor($device, $_tmp_serial, 'voltages');
+
     $index   = (100 + $i);
 
     discover_sensor($valid['sensor'], 'voltage', $device, $volt_oid, $index, $type, $descr, $divisor, '1', null, null, null, null, $current);
@@ -78,7 +77,7 @@ for ($i = 1; $i <= $numPhase; $i++) {
     }
 
     $type    = 'rfc1628';
-    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages');
+    $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages', $volt_oid);
 
     $current = (snmp_get($device, $volt_oid, '-Oqv') / $divisor);
     $index   = (200 + $i);

--- a/includes/discovery/sensors/voltages/rfc1628.inc.php
+++ b/includes/discovery/sensors/voltages/rfc1628.inc.php
@@ -13,7 +13,8 @@ foreach (explode("\n", $oids) as $data) {
         $split_oid        = explode('.', $oid);
         $volt_id          = $split_oid[(count($split_oid) - 1)];
         $volt_oid         = ".1.3.6.1.2.1.33.1.2.5.$volt_id";
-        $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages');
+        $exclude          = 1;
+        $divisor = get_device_divisor($device, $pre_cache['poweralert_serial'], 'voltages', $exclude);
 
         $volt  = (snmp_get($device, $volt_oid, '-O vq') / $divisor);
         $descr = 'Battery'.(count(explode("\n", $oids)) == 1 ? '' : ' '.($volt_id + 1));


### PR DESCRIPTION
- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

![screen shot 2017-03-09 at 15 03 30](https://cloud.githubusercontent.com/assets/1927109/23753474/ed3d46a4-04d9-11e7-8e2b-5cee0c2f061d.png)

- Fixed the sensor divisors for voltages (issue confirmed by many members)
- Added an option to exclude a specific sensor because Generex card use different divisors for the same sensor type

Details: #5977 