### PR TITLE
Fix the definition. Should be mef instead of mef-evc

### DIFF
--- a/includes/definitions/coriant.yaml
+++ b/includes/definitions/coriant.yaml
@@ -13,7 +13,7 @@ discovery_modules:
     services: 0
     vlans: 0
     arp-table: 0
-    mef-evc: 1
+    mef: 1
     cisco-vrf-lite: 0
     storage: 0
 poller_modules:
@@ -29,7 +29,7 @@ poller_modules:
     vmware-vminfo: 0
     vlans: 0
     arp-table: 0
-    mef-evc: 1
+    mef: 1
     cisco-vrf-lite: 0
     storage: 0
 discovery:


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

#####

This fix the definition from "mef-evc" to "mef".
I have forgot it before the merge.