### PR TITLE
update pbin defaults (secure always on, no-expire and dropped hostname from name)

### DIFF
--- a/pbin.sh
+++ b/pbin.sh
@@ -29,6 +29,15 @@ PROGRAM=${0##*/}
 # paste. take input from stdin
 pastebin() {
 	# show params
+
+        if [[ "${expire}" == "" ]]; then
+            expire=0;
+        fi
+
+        if [[ "${private}" == "" ]]; then
+            private=1;
+        fi
+
 	sed -e '/^$/d' >&2 <<-EOF
 		${title+title: "$title"}
 		${name+name: "$name"}
@@ -37,9 +46,6 @@ pastebin() {
 		${expire+expire: "$expire"}
 		${reply+reply: "$reply"}
 	EOF
-        if [$expire == '']; then
-            expire=0;
-        fi
 
 	# do paste
 	curl "$PASTE_URL" \
@@ -85,7 +91,7 @@ usage() {
 Options:
   -t, --title     title of this paste
   -n, --name      author of this paste
-  -p, --private   should this paste be private
+  -p, --private   should this paste be private (0 = public, 1 = private)
   -l, --language  language this paste is in
   -e, --expire    paste expiration in minutes
   -r, --reply     reply to existing paste
@@ -100,13 +106,13 @@ set_defaults() {
 	unset reply
 
 	# default to user@hostname
-	name=${SUDO_USER:-$USER}@${HOSTNAME:-$(hostname)}
+	name=${SUDO_USER:-$USER}
 }
 
 set_defaults
 
 # parse command line args
-t=$(getopt -o h,t:,n:,p,l:,e:,r:,b: --long help,title:,name:,private,language:,expire:,reply: -n "$PROGRAM" -- "$@")
+t=$(getopt -o h,t:,n:,p:,l:,e:,r:,b: --long help,title:,name:,private:,language:,expire:,reply: -n "$PROGRAM" -- "$@")
 eval set -- "$t"
 
 while :; do
@@ -124,7 +130,8 @@ while :; do
 		name="$1"
 	;;
 	-p|--private)
-		private=1
+                shift
+		private="$1"
 	;;
 	-l|--language)
 		shift


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Pastes are now secure by default with non-expiring links.

Also removed hostname in the from field so we don't leak info.