### PR TITLE
fixed auth when proxy is involved #6183

### DIFF
--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -46,7 +46,7 @@ if (isset($_POST['username']) && isset($_POST['password'])) {
     $_SESSION['password'] = $_GET['password'];
 } elseif (isset($_SERVER['REMOTE_USER'])) {
     $_SESSION['username'] = $_SERVER['REMOTE_USER'];
-} elseif (isset($_SERVER['PHP_AUTH_USER'])) {
+} elseif (isset($_SERVER['PHP_AUTH_USER']) && $config['auth_mechanism'] === 'http-auth') {
     $_SESSION['username'] = $_SERVER['PHP_AUTH_USER'];
 }
 
@@ -97,7 +97,7 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
 
         $permissions = permissions_cache($_SESSION['user_id']);
         if (isset($_POST['username'])) {
-            header('Location: '.$_SERVER['REQUEST_URI'], true, 303);
+            header('Location: '.$_SERVER['REQUEST_URI'] ?: $config['base_url'], true, 303);
             exit;
         }
     } elseif (isset($_SESSION['username'])) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6183 

So the issue is that when using nginx as the proxy with basic auth on it (but mysql auth for LibreNMS) to say apache and you don't remember the login then the next page refresh looks for PHP_AUTH_USER which does exist so it tries to use it.

We only want that value when using http-auth.

I've also included a fix that REQUEST_URI isn't available in nginx so we fall back to base_url that's been configured.