### PR TITLE
fix: cisco 4948 detection

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -467,6 +467,8 @@ function get_main_serial($device)
         $serial_output = snmp_get_multi($device, 'entPhysicalSerialNum.1 entPhysicalSerialNum.1001', '-OQUs', 'ENTITY-MIB:OLD-CISCO-CHASSIS-MIB');
         if (!empty($serial_output[1]['entPhysicalSerialNum'])) {
             return $serial_output[1]['entPhysicalSerialNum'];
+        } elseif (!empty($serial_output[1000]['entPhysicalSerialNum'])) {
+            return $serial_output[1000]['entPhysicalSerialNum'];
         } elseif (!empty($serial_output[1001]['entPhysicalSerialNum'])) {
             return $serial_output[1001]['entPhysicalSerialNum'];
         }

--- a/includes/polling/os/ios.inc.php
+++ b/includes/polling/os/ios.inc.php
@@ -34,7 +34,12 @@ if ($data[1]['entPhysicalContainedIn'] == '0') {
         $hardware = $data[1]['entPhysicalModelName'];
     }
 }
-if (!empty($data[1001]['entPhysicalModelName'])) {
+
+if (!empty($data[1000]['entPhysicalModelName'])) {
+    $hardware = $data[1000]['entPhysicalModelName'];
+} elseif (!empty($data[1000]['entPhysicalContainedIn'])) {
+    $hardware = $data[$data[1000]['entPhysicalContainedIn']]['entPhysicalName'];
+} elseif (!empty($data[1001]['entPhysicalModelName'])) {
     $hardware = $data[1001]['entPhysicalModelName'];
 } elseif (!empty($data[1001]['entPhysicalContainedIn'])) {
     $hardware = $data[$data[1001]['entPhysicalContainedIn']]['entPhysicalName'];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

fixed hardware match for cisco 4948 series:

before:
<img width="838" alt="screen shot 2017-03-18 at 3 06 29 am" src="https://cloud.githubusercontent.com/assets/3048315/24067667/7ef9f10a-0b88-11e7-96c3-dba72a5c7cbf.png">

after:
<img width="752" alt="screen shot 2017-03-18 at 3 04 58 am" src="https://cloud.githubusercontent.com/assets/3048315/24067660/75d714e0-0b88-11e7-9f11-dbe8205b26e7.png">