### PR TITLE
docs: php-fpm grant access

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -74,6 +74,7 @@ systemctl restart php-fpm
 ```bash
 useradd librenms -d /opt/librenms -M -r
 usermod -a -G librenms nginx
+usermod -a -G librenms apache
 ```
 
 #### Clone repo


### PR DESCRIPTION
php-fpm runs as the apache user, add it to the librenms group too.
Changing the user of php-fpm breaks other things, so this is the better fix
Primarily broken when using rrdcached.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
