### PR TITLE
fix: allow remember_token to be null

### DIFF
--- a/sql-schema/179.sql
+++ b/sql-schema/179.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` CHANGE `remember_token` `remember_token` VARCHAR(100) NULL;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


Please, someone help me. This is getting embarrassing O.o

Blocks users from being created :/