### PR TITLE
webui: Do not show disabled devices in alerts list as they stale #6213

### DIFF
--- a/html/includes/table/alerts.inc.php
+++ b/html/includes/table/alerts.inc.php
@@ -2,7 +2,7 @@
 
 require_once $config['install_dir'].'/includes/device-groups.inc.php';
 
-$where = 1;
+$where = ' `devices`.`disabled` = 0';
 
 $alert_states = array(
     // divined from librenms/alerts.php


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6213 

I've not provided an option to show hidden alerts, we might get asked for that but it adds unnecessary complicates.