### PR TITLE
refactor: Update ucd-diskio discovery to use index + descr as unique identifies #4670

### DIFF
--- a/includes/discovery/ucd-diskio.inc.php
+++ b/includes/discovery/ucd-diskio.inc.php
@@ -7,7 +7,7 @@ if (is_array($diskio_array)) {
         if ($entry['diskIONRead'] > '0' || $entry['diskIONWritten'] > '0') {
             d_echo("$index ".$entry['diskIODevice']."\n");
 
-            if (dbFetchCell('SELECT COUNT(*) FROM `ucd_diskio` WHERE `device_id` = ? AND `diskio_index` = ?', array($device['device_id'], $index)) == '0') {
+            if (dbFetchCell('SELECT COUNT(*) FROM `ucd_diskio` WHERE `device_id` = ? AND `diskio_index` = ? and `diskio_descr` = ?', array($device['device_id'], $index, $entry['diskIODevice'])) == '0') {
                 $inserted = dbInsert(array('device_id' => $device['device_id'], 'diskio_index' => $index, 'diskio_descr' => $entry['diskIODevice']), 'ucd_diskio');
                 echo '+';
                 d_echo($sql." - $inserted inserted ");
@@ -16,7 +16,7 @@ if (is_array($diskio_array)) {
                   // FIXME Need update code here!
             }
 
-                $valid_diskio[$index] = 1;
+                $valid_diskio[$index] = $entry['diskIODevice'];
         } //end if
     } //end foreach
 } //end if
@@ -29,7 +29,7 @@ d_echo($valid_diskio);
 foreach (dbFetchRows($sql) as $test) {
     d_echo($test['diskio_index'].' -> '.$test['diskio_descr']."\n");
 
-    if (!$valid_diskio[$test['diskio_index']]) {
+    if ($valid_diskio[$test['diskio_index']] !== $test['diskio_descr']) {
         echo '-';
         dbDelete('ucd_diskio', '`diskio_id` = ?', array($test['diskio_id']));
     }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #4670 - This issue shows that indexes can change which causes problems with detection of storage diskio. This PR updates the discovery to use descr and index as unique identifiers.