### PR TITLE
Update Installation-CentOS-7-Apache.md

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -9,7 +9,7 @@ source: Installation/Installation-CentOS-7-Apache.md
 ```bash
 yum install mariadb-server mariadb
 systemctl restart mariadb
-mysql -uroot -p
+mysql -uroot
 ```
 
 ```sql


### PR DESCRIPTION
The -p option is not needed by the default installation of mariadb-server on CentOS Linux release 7.3.1611 (Core)

Including it without knowing to press enter for no password results in an authentication error:

root@netmon ~# mysql -u root -p
Enter password:
ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)

Alternatively, it could be noted to leave the password field blank when asked.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
