### PR TITLE
Fix height of widget boxes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -195,6 +195,7 @@ LibreNMS contributors:
 - Hubert Ladet <mail4git38@gmail.com> (mail4git38)
 - Deeps (deepseth)
 - Jari Schäfer <jari.schaefer@gmail.com> (jarischaefer)
+- Jan-Philipp Litza <janphilipp@litza.de> (jplitza)
 
 Observium was written by:
 - Adam Armstrong

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1895,7 +1895,7 @@ label {
 .widget_body {
     overflow-y: auto;
     width: 100%;
-    height: calc(100% - 5px);
+    height: calc(100% - 38px);
 }
 
 .device-availability, .service-availability {

--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -583,7 +583,7 @@ foreach (dbFetchRows("SELECT * FROM `widgets` ORDER BY `widget_title`") as $widg
         $.ajax({
             type: 'POST',
             url: 'ajax_dash.php',
-            data: {type: data_type, id: id, dimensions: {x:$("#widget_body_"+id).innerWidth()-50, y:$("#widget_body_"+id).innerHeight()-50}, settings:settings},
+            data: {type: data_type, id: id, dimensions: {x:$("#widget_body_"+id).innerWidth()-20, y:$("#widget_body_"+id).innerHeight()-20}, settings:settings},
             dataType: "json",
             success: function (data) {
                 if (data.status == 'ok') {


### PR DESCRIPTION
This fixes overflowing scrollable widgets (see screenshot) without breaking the intention of #5644

![overflow screenshot](https://cloud.githubusercontent.com/assets/3628012/24359003/3cc736da-1303-11e7-8097-a6f8ee2f8852.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
