### PR TITLE
fix: add semicolons in sql scripts

### DIFF
--- a/sql-schema/004.sql
+++ b/sql-schema/004.sql
@@ -5,7 +5,7 @@ DROP TABLE `frequency`;
 ALTER TABLE  `mempools` CHANGE  `mempool_index`  `mempool_index` VARCHAR( 16 ) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL;
 ALTER TABLE `vrfs` CHANGE `mplsVpnVrfRouteDistinguisher` `mplsVpnVrfRouteDistinguisher` varchar(26) NOT NULL;
 ## Change port rrds
-ALTER TABLE  `perf_times` CHANGE  `duration`  `duration` DOUBLE( 8, 2 ) NOT NULL
+ALTER TABLE  `perf_times` CHANGE  `duration`  `duration` DOUBLE( 8, 2 ) NOT NULL;
 ## Extend port descriptions
 ALTER TABLE ports MODIFY port_descr_circuit VARCHAR(255);
 ALTER TABLE ports MODIFY port_descr_descr VARCHAR(255);

--- a/sql-schema/057.sql
+++ b/sql-schema/057.sql
@@ -1,3 +1,3 @@
-ALTER TABLE  `ipv4_mac` CHANGE  `mac_address`  `mac_address` VARCHAR( 32 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL , CHANGE  `ipv4_address`  `ipv4_address` VARCHAR( 32 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL
-ALTER TABLE  `ipv4_mac` ADD INDEX (  `port_id`), ADD INDEX (`mac_address` )
-ALTER TABLE `ipv4_mac` DROP INDEX `interface_id`, DROP INDEX `interface_id_2`
+ALTER TABLE  `ipv4_mac` CHANGE  `mac_address`  `mac_address` VARCHAR( 32 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL , CHANGE  `ipv4_address`  `ipv4_address` VARCHAR( 32 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;
+ALTER TABLE  `ipv4_mac` ADD INDEX (  `port_id`), ADD INDEX (`mac_address` );
+ALTER TABLE `ipv4_mac` DROP INDEX `interface_id`, DROP INDEX `interface_id_2`;


### PR DESCRIPTION
Adds missing semicolons in SQL scripts.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
