### PR TITLE
Localizes alerts_grid variable to fix errors with multiple alerts tables

### DIFF
--- a/html/includes/common/alerts.inc.php
+++ b/html/includes/common/alerts.inc.php
@@ -243,6 +243,7 @@ var alerts_grid = $("#alerts_'.$unique_id.'").bootgrid({
     templates: {
     }
 }).on("loaded.rs.jquery.bootgrid", function() {
+    alerts_grid = $(this);
     alerts_grid.find(".incident-toggle").each( function() {
       $(this).parent().addClass(\'incident-toggle-td\');
     }).on("click", function(e) {
@@ -293,8 +294,11 @@ var alerts_grid = $("#alerts_'.$unique_id.'").bootgrid({
             success: function(msg){
                 toastr.success(msg);
                 if(msg.indexOf("ERROR:") <= -1) {
-                    var $sortDictionary = alerts_grid.bootgrid("getSortDictionary");
-                    alerts_grid.bootgrid("sort", $sortDictionary); 
+                    $(".alerts").each(function(index) {
+                        var $sortDictionary = $(this).bootgrid("getSortDictionary");
+                        $(this).reload;
+                        $(this).bootgrid("sort", $sortDictionary);
+                    });
                 }
             },
             error: function(){


### PR DESCRIPTION
Fixes click listeners not being attached to acknowledge buttons in first alerts table when more than one alerts table is open in dashboard (e.g. one table for unacknowledged alerts and one for acknowledged alerts) by localizing alerts_grid variable. Also reloads all alerts tables on ack.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
