### PR TITLE
fix: Fixed F5 ports not using hc counters

### DIFF
--- a/includes/polling/ports/f5.inc.php
+++ b/includes/polling/ports/f5.inc.php
@@ -25,8 +25,11 @@
 
 $f5_stats = snmpwalk_cache_oid($device, 'sysIfxStat', array(), 'F5-BIGIP-SYSTEM-MIB');
 unset($f5_stats[0]);
-$tmp_port_stats = snmpwalk_cache_oid($device, 'ifEntry', array(), 'IF-MIB', null, '-OQUst');
-$tmp_port_stats = snmpwalk_cache_oid($device, 'ifXEntry', $tmp_port_stats, 'IF-MIB', null, '-OQUst');
+
+foreach ($ifmib_oids as $oid) {
+    echo "$oid ";
+    $tmp_port_stats = snmpwalk_cache_oid($device, $oid, $tmp_port_stats, 'IF-MIB', null, '-OQUst');
+}
 
 $required = array(
     'ifName' => 'sysIfxStatName',


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

#6106 introduced a bug for f5 as they report both hc and non-hc counters so it default to using non-hc.