### PR TITLE
Do not show unintended debug messages

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1552,7 +1552,7 @@ function load_os(&$device)
         log_event('Device type changed ' . $device['type'] . ' => ' . $config['os'][$device['os']]['type'], $device, 'system', 3);
         $device['type'] = $config['os'][$device['os']]['type'];
         dbUpdate(array('type' => $device['type']), 'devices', 'device_id=?', array($device['device_id']));
-        echo "Device type changed to " . $device['type'] . "!\n";
+        d_echo "Device type changed to " . $device['type'] . "!\n";
     }
 
     if ($config['os'][$device['os']]['group']) {

--- a/includes/common.php
+++ b/includes/common.php
@@ -1552,7 +1552,7 @@ function load_os(&$device)
         log_event('Device type changed ' . $device['type'] . ' => ' . $config['os'][$device['os']]['type'], $device, 'system', 3);
         $device['type'] = $config['os'][$device['os']]['type'];
         dbUpdate(array('type' => $device['type']), 'devices', 'device_id=?', array($device['device_id']));
-        d_echo "Device type changed to " . $device['type'] . "!\n";
+        d_echo("Device type changed to " . $device['type'] . "!\n");
     }
 
     if ($config['os'][$device['os']]['group']) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


![screen shot 2017-03-29 at 15 39 28](https://cloud.githubusercontent.com/assets/1029270/24454818/fba40f9a-1495-11e7-84a4-99493cba9504.png)

As seen in the screenshot above, this message should only be shown when debugging is enabled.