### PR TITLE
fix: Fixed CPU/Mem polling for Cyberoam-UTM devices

### DIFF
--- a/includes/discovery/processors/cyberoam-utm.inc.php
+++ b/includes/discovery/processors/cyberoam-utm.inc.php
@@ -26,7 +26,7 @@
 if ($device['os'] === 'cyberoam-utm') {
     echo 'Cyberoam UTM : ';
 
-    $oid = '.1.3.6.1.4.1.21067.2.1.1.3.0';
+    $oid = '.1.3.6.1.4.1.21067.2.1.2.2.1.0';
     $descr = 'Processor';
     $usage = snmp_get($device, $oid, '-Ovqn');
 

--- a/includes/polling/mempools/cyberoam-utm.inc.php
+++ b/includes/polling/mempools/cyberoam-utm.inc.php
@@ -23,17 +23,19 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
-if ($mempool['mempool_index'] === 0) {
+if ($mempool['mempool_index'] == 0) {
     $mem_perc = snmp_get($device, '.1.3.6.1.4.1.21067.2.1.2.4.2.0', '-OvQ');
     $mem_capacity = snmp_get($device, '.1.3.6.1.4.1.21067.2.1.2.4.1.0', '-OvQ');
+    $mem_capacity = ($mem_capacity*1024*1024);
     $mempool['total'] = $mem_capacity;
     $mempool['used']  = ($mem_capacity / 100) * $mem_perc;
     $mempool['free']  = $mempool['total'] - $mempool['used'];
 }
 
-if ($mempool['mempool_index'] === 1) {
+if ($mempool['mempool_index'] == 1) {
     $swap_perc = snmp_get($device, '.1.3.6.1.4.1.21067.2.1.2.4.4.0', '-OvQ');
     $swap_capacity = snmp_get($device, '.1.3.6.1.4.1.21067.2.1.2.4.3.0', '-OvQ');
+    $swap_capacity = ($swap_capacity*1024*1024);
     $mempool['total'] = $swap_capacity;
     $mempool['used']  = ($swap_capacity / 100) * $swap_perc;
     $mempool['free']  = $mempool['total'] - $mempool['used'];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes some glaring errors in mem/cpu polling for cyberoam :(