### PR TITLE
fix: Fix broken mysql application polling

### DIFF
--- a/includes/polling/applications/mysql.inc.php
+++ b/includes/polling/applications/mysql.inc.php
@@ -9,9 +9,7 @@ if (!empty($agent_data['app'][$name])) {
     $mysql = $agent_data['app'][$name];
 } else {
     // Polls MySQL  statistics from script via SNMP
-    $mysql_cmd  = $config['snmpget'].' -O qv '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'];
-    $mysql_cmd .= '.1.3.6.1.4.1.8072.1.3.2.3.1.2.5.109.121.115.113.108';
-    $mysql      = shell_exec($mysql_cmd);
+    $mysql = snmp_get($device, '.1.3.6.1.4.1.8072.1.3.2.3.1.2.5.109.121.115.113.108', '-Ovq');
 }
 
 update_application($app, $mysql);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Broke because it was missing the space before the oid, switched to proper snmp call though instead to fix.