### PR TITLE
fix whitespace display on RRDTool Command

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -838,7 +838,7 @@ a.interface-upup:hover, a.interface-updown:hover, a.interface-admindown:hover {
   margin: 8px;
 }
 
-.infobox pre {
+.infobox .rrd-pre {
   background-color: #CCCCFF;
   font-size: 12px;
   white-space: pre-wrap;

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -838,6 +838,13 @@ a.interface-upup:hover, a.interface-updown:hover, a.interface-admindown:hover {
   margin: 8px;
 }
 
+.infobox pre {
+  background-color: #CCCCFF;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+
 .infobox-down {
 
 }

--- a/html/includes/graphs/graph.inc.php
+++ b/html/includes/graphs/graph.inc.php
@@ -118,12 +118,12 @@ if ($error_msg) {
     } elseif ($command_only) {
         echo "<div class='infobox'>";
         echo "<p style='font-size: 16px; font-weight: bold;'>RRDTool Command</p>";
-        echo "<pre>";
+        echo "<pre class='rrd-pre'>";
         echo "rrdtool graph $graphfile $rrd_options";
         echo "</pre>";
         $return = rrdtool_graph($graphfile, $rrd_options);
         echo "<p style='font-size: 16px; font-weight: bold;'>RRDTool Output</p>";
-        echo "<pre>";
+        echo "<pre class='rrd-pre'>";
         echo "$return";
         echo "</pre>";
         unlink($graphfile);

--- a/html/includes/graphs/graph.inc.php
+++ b/html/includes/graphs/graph.inc.php
@@ -118,11 +118,14 @@ if ($error_msg) {
     } elseif ($command_only) {
         echo "<div class='infobox'>";
         echo "<p style='font-size: 16px; font-weight: bold;'>RRDTool Command</p>";
+        echo "<pre>";
         echo "rrdtool graph $graphfile $rrd_options";
-        echo '</span>';
+        echo "</pre>";
         $return = rrdtool_graph($graphfile, $rrd_options);
-        echo '<br /><br />';
-        echo "<p style='font-size: 16px; font-weight: bold;'>RRDTool Output</p>$return";
+        echo "<p style='font-size: 16px; font-weight: bold;'>RRDTool Output</p>";
+        echo "<pre>";
+        echo "$return";
+        echo "</pre>";
         unlink($graphfile);
         echo '</div>';
     } else {

--- a/html/index.php
+++ b/html/index.php
@@ -139,7 +139,7 @@ if (empty($config['favicon'])) {
   <link href="css/MarkerCluster.css" rel="stylesheet" type="text/css" />
   <link href="css/MarkerCluster.Default.css" rel="stylesheet" type="text/css" />
   <link href="css/leaflet.awesome-markers.css" rel="stylesheet" type="text/css" />
-  <link href="<?php echo($config['stylesheet']);  ?>?ver=291727420" rel="stylesheet" type="text/css" />
+  <link href="<?php echo($config['stylesheet']);  ?>?ver=291727421" rel="stylesheet" type="text/css" />
   <link href="css/<?php echo $config['site_style']; ?>.css?ver=632417639" rel="stylesheet" type="text/css" />
 <?php
 


### PR DESCRIPTION
*edit* update images*

The RRDTool command section removes extra white-space which is used in formatting

See example images

![rrd-old](https://cloud.githubusercontent.com/assets/239857/24671446/6f343be2-1969-11e7-8def-bad5ae33b4a0.png)
![rrd-new](https://cloud.githubusercontent.com/assets/239857/24671445/6f30075c-1969-11e7-9736-349d0a000775.png)


#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
