### PR TITLE
Fix redirect on login for instances behind reverse proxies

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -196,6 +196,7 @@ LibreNMS contributors:
 - Deeps (deepseth)
 - Jari Schäfer <jari.schaefer@gmail.com> (jarischaefer)
 - Jan-Philipp Litza <janphilipp@litza.de> (jplitza)
+- Chris Putnam <chrisputnam@gmail.com> (putnam)
 
 Observium was written by:
 - Adam Armstrong

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -97,7 +97,7 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
         $permissions = permissions_cache($_SESSION['user_id']);
         if (isset($_POST['username'])) {
             // Trim the trailing slash off of base_url and concatenate the (relative) REQUEST_URI
-            header('Location: '.substr($config['base_url'], 0, -1).$_SERVER['REQUEST_URI'], true, 303);
+            header('Location: '.rtrim($config['base_url'], '/').$_SERVER['REQUEST_URI'], true, 303);
             exit;
         }
     } elseif (isset($_SESSION['username'])) {

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -96,7 +96,7 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
 
         $permissions = permissions_cache($_SESSION['user_id']);
         if (isset($_POST['username'])) {
-            header('Location: '.$_SERVER['REQUEST_URI'] ?: $config['base_url'], true, 303);
+            header('Location: '.substr($config['base_url'], 0, -1).$_SERVER['REQUEST_URI'], true, 303);
             exit;
         }
     } elseif (isset($_SESSION['username'])) {

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -96,6 +96,7 @@ if ((isset($_SESSION['username'])) || (isset($_COOKIE['sess_id'],$_COOKIE['token
 
         $permissions = permissions_cache($_SESSION['user_id']);
         if (isset($_POST['username'])) {
+            // Trim the trailing slash off of base_url and concatenate the (relative) REQUEST_URI
             header('Location: '.substr($config['base_url'], 0, -1).$_SERVER['REQUEST_URI'], true, 303);
             exit;
         }


### PR DESCRIPTION
On instances where base_url has been set for use behind a reverse proxy, logins are incorrectly redirected.

This happens because REQUEST_URI is set by the proxy:
  1. librenms has base_url set to http://site.com/nms/
  2. Browser requests http://site.com/nms/
  3. nginx reverse proxies /nms/ to librenms at http://somehost:1234/
  4. librenms sees REQUEST_URI as "/"
  5. librenms logs the user in, but sends "Location: /" to the browser. This redirects to the wrong location. Similar behavior occurs if REQUEST_URI points to some resource within librenms.

To resolve, concatenate REQUEST_URI (which is relative) to base_url. As base_url is slash-terminated, crop the trailing slash. This should have no effect on users with default settings and will correctly redirect instances behind reverse proxies.



DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`