### PR TITLE
feature: Added rrdtool version check to compare installed version with defined version

### DIFF
--- a/validate.php
+++ b/validate.php
@@ -334,8 +334,8 @@ foreach ($bins as $bin) {
 }
 
 // Check that rrdtool config version is what we see
-if (isset($config['rrdtool_version']) && ($versions['rrdtool_ver'] != $config['rrdtool_version'])) {
-    print_fail('The rrdtool version you have specified is not what is installed.', "Either comment out \$config['rrdtool_version'] = {$config['rrdtool_version']}; or set \$config['rrdtool_version'] = {$versions['rrdtool_ver']};");
+if (isset($config['rrdtool_version']) && (version_compare($config['rrdtool_version'], $versions['rrdtool_ver'], '>'))) {
+    print_fail('The rrdtool version you have specified is newer than what is installed.', "Either comment out \$config['rrdtool_version'] = {$config['rrdtool_version']}; or set \$config['rrdtool_version'] = {$versions['rrdtool_ver']};");
 }
 
 $disabled_functions = explode(',', ini_get('disable_functions'));

--- a/validate.php
+++ b/validate.php
@@ -333,6 +333,11 @@ foreach ($bins as $bin) {
     }
 }
 
+// Check that rrdtool config version is what we see
+if (isset($config['rrdtool_version']) && ($versions['rrdtool_ver'] != $config['rrdtool_version'])) {
+    print_fail('The rrdtool version you have specified is not what is installed.', "Either comment out \$config['rrdtool_version'] = {$config['rrdtool_version']}; or set \$config['rrdtool_version'] = {$versions['rrdtool_ver']};");
+}
+
 $disabled_functions = explode(',', ini_get('disable_functions'));
 $required_functions = array('exec','passthru','shell_exec','escapeshellarg','escapeshellcmd','proc_close','proc_open','popen');
 foreach ($required_functions as $function) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Came across a user this week who had blindly set `$config['rrdtool_version'] = '1.6.0';` when running 1.4.3 resulting in poor performance apparently. Easy enough to test for.