### PR TITLE
fix: AD authentication when auth_ad_base_dn is an OU

### DIFF
--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -231,7 +231,7 @@ function get_domain_sid()
     global $config, $ldap_connection;
 
     // remove OUs, they don't have an SID
-    $dn_candidate = preg_replace('/OU=[^,]+,/', '', $config['auth_ad_base_dn']);
+    $dn_candidate = preg_replace('/^(OU=[^,]+,)+/', '', $config['auth_ad_base_dn']);
 
     $search = ldap_read(
         $ldap_connection,

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -230,9 +230,12 @@ function get_domain_sid()
 {
     global $config, $ldap_connection;
 
+    // remove OUs, they don't have an SID
+    $dn_candidate = preg_replace('/OU=[^,]+,/', '', $config['auth_ad_base_dn']);
+
     $search = ldap_read(
         $ldap_connection,
-        $config['auth_ad_base_dn'],
+        $dn_candidate,
         '(objectClass=*)',
         array('objectsid')
     );

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -230,8 +230,8 @@ function get_domain_sid()
 {
     global $config, $ldap_connection;
 
-    // remove OUs, they don't have an SID
-    $dn_candidate = preg_replace('/^(OU=[^,]+,)+/', '', $config['auth_ad_base_dn']);
+    // Extract only the domain components
+    $dn_candidate = preg_replace('/^.*?DC=/i', 'DC=', $config['auth_ad_base_dn']);
 
     $search = ldap_read(
         $ldap_connection,


### PR DESCRIPTION
OUs don't have SID, so we can't use them to figure out the domain SID

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
