### PR TITLE
move version info into debug to save exec calls under normal use

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -20,15 +20,6 @@ $options       = getopt('h:m:i:n:d::v::a::q', array('os:','type:'));
 
 if (!isset($options['q'])) {
     echo $config['project_name_version']." Discovery\n";
-    $versions = version_info(false);
-    echo "Version info:\n";
-    $cur_sha = $versions['local_sha'];
-    echo "Commit SHA: $cur_sha\n";
-    echo "DB Schema: ".$versions['db_schema']."\n";
-    echo "PHP: ".$versions['php_ver']."\n";
-    echo "MySQL: ".$versions['mysql_ver']."\n";
-    echo "RRDTool: ".$versions['rrdtool_ver']."\n";
-    echo "SNMP: ".$versions['netsnmp_ver']."\n";
 }
 
 if (isset($options['h'])) {
@@ -71,6 +62,20 @@ if (isset($options['i']) && $options['i'] && isset($options['n'])) {
 }
 
 if (isset($options['d']) || isset($options['v'])) {
+    $versions = version_info(false);
+    echo <<<EOH
+===================================
+Version info:
+Commit SHA: {$versions['local_sha']}
+Commit Date: {$versions['local_date']}
+DB Schema: {$versions['db_schema']}
+PHP: {$versions['php_ver']}
+MySQL: {$versions['mysql_ver']}
+RRDTool: {$versions['rrdtool_ver']}
+SNMP: {$versions['netsnmp_ver']}
+==================================
+EOH;
+
     echo "DEBUG!\n";
     if (isset($options['v'])) {
         $vdebug = true;

--- a/poller.php
+++ b/poller.php
@@ -16,16 +16,6 @@ require __DIR__ . '/includes/init.php';
 
 $poller_start = microtime(true);
 echo $config['project_name_version']." Poller\n";
-$versions = version_info(false);
-echo "Version info:\n";
-$cur_sha = $versions['local_sha'];
-echo "Commit SHA: $cur_sha\n";
-echo "Commit Date: ".$versions['local_date']."\n";
-echo "DB Schema: ".$versions['db_schema']."\n";
-echo "PHP: ".$versions['php_ver']."\n";
-echo "MySQL: ".$versions['mysql_ver']."\n";
-echo "RRDTool: ".$versions['rrdtool_ver']."\n";
-echo "SNMP: ".$versions['netsnmp_ver']."\n";
 
 $options = getopt('h:m:i:n:r::d::v::a::f::q');
 
@@ -85,6 +75,20 @@ if (!$where) {
 }
 
 if (isset($options['d']) || isset($options['v'])) {
+    $versions = version_info(false);
+    echo <<<EOH
+===================================
+Version info:
+Commit SHA: {$versions['local_sha']}
+Commit Date: {$versions['local_date']}
+DB Schema: {$versions['db_schema']}
+PHP: {$versions['php_ver']}
+MySQL: {$versions['mysql_ver']}
+RRDTool: {$versions['rrdtool_ver']}
+SNMP: {$versions['netsnmp_ver']}
+==================================
+EOH;
+
     echo "DEBUG!\n";
     if (isset($options['v'])) {
         $vdebug = true;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Ever so slight change, only show version info when debug is enabled. It will save some exec calls, this info is only useful for debug.

I'll move this to a function so don't merge.