### PR TITLE
refactor: Remove unecessary OS checks in proc / mem polling

### DIFF
--- a/includes/polling/mempools/avaya-ers.inc.php
+++ b/includes/polling/mempools/avaya-ers.inc.php
@@ -1,15 +1,13 @@
 <?php
 
-if ($device['os'] == 'avaya-ers') {
-    // Memory information only known to work with 5500 and 5600 switches
-    if (preg_match('/5[56][0-9][0-9]/', $device['sysDescr'])) {
-        $index = $mempool['mempool_index'];
+// Memory information only known to work with 5500 and 5600 switches
+if (preg_match('/5[56][0-9][0-9]/', $device['sysDescr'])) {
+    $index = $mempool['mempool_index'];
 
-        $total = (snmp_get($device, ".1.3.6.1.4.1.45.1.6.3.8.1.1.12$index", '-Oqv') * 1048576);
-        $avail = (snmp_get($device, ".1.3.6.1.4.1.45.1.6.3.8.1.1.13$index", '-Oqv') * 1048576);
+    $total = (snmp_get($device, ".1.3.6.1.4.1.45.1.6.3.8.1.1.12$index", '-Oqv') * 1048576);
+    $avail = (snmp_get($device, ".1.3.6.1.4.1.45.1.6.3.8.1.1.13$index", '-Oqv') * 1048576);
 
-        $mempool['total'] = $total;
-        $mempool['free']  = $avail;
-        $mempool['used']  = ($total - $avail);
-    }
+    $mempool['total'] = $total;
+    $mempool['free']  = $avail;
+    $mempool['used']  = ($total - $avail);
 }

--- a/includes/polling/mempools/ciscowlc.inc.php
+++ b/includes/polling/mempools/ciscowlc.inc.php
@@ -1,12 +1,10 @@
 <?php
 
-if ($device['os'] == 'ciscowlc') {
-    echo "Cisco WLC";
+echo "Cisco WLC";
 
-    $total = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.14179.1.1.5.2.0", '-OvQ'));
-    $avail = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.14179.1.1.5.3.0", '-OvQ'));
+$total = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.14179.1.1.5.2.0", '-OvQ'));
+$avail = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.14179.1.1.5.3.0", '-OvQ'));
 
-    $mempool['total'] = ($total * 1024);
-    $mempool['free']  = ($avail * 1024);
-    $mempool['used']  = (($total - $avail) * 1024);
-}
+$mempool['total'] = ($total * 1024);
+$mempool['free']  = ($avail * 1024);
+$mempool['used']  = (($total - $avail) * 1024);

--- a/includes/polling/mempools/edgeswitch.inc.php
+++ b/includes/polling/mempools/edgeswitch.inc.php
@@ -10,10 +10,8 @@
  * the source code distribution for details.
  */
 
-if ($device['os'] == 'edgeswitch') {
-    $total = snmp_get($device, '.1.3.6.1.4.1.4413.1.1.1.1.4.2.0', '-Oqv');
-    $free = snmp_get($device, '.1.3.6.1.4.1.4413.1.1.1.1.4.1.0', '-Oqv');
-    $mempool['total'] = $total;
-    $mempool['free'] = $free;
-    $mempool['used'] = $total - $free;
-}
+$total = snmp_get($device, '.1.3.6.1.4.1.4413.1.1.1.1.4.2.0', '-Oqv');
+$free = snmp_get($device, '.1.3.6.1.4.1.4413.1.1.1.1.4.1.0', '-Oqv');
+$mempool['total'] = $total;
+$mempool['free'] = $free;
+$mempool['used'] = $total - $free;

--- a/includes/polling/mempools/enterasys.inc.php
+++ b/includes/polling/mempools/enterasys.inc.php
@@ -10,11 +10,9 @@
  * the source code distribution for details.
  */
 
-if ($device['os'] == "enterasys") {
-    $free = snmp_get($device, 'etsysResourceStorageAvailable.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
-    $total  = snmp_get($device, 'etsysResourceStorageSize.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
+$free = snmp_get($device, 'etsysResourceStorageAvailable.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
+$total  = snmp_get($device, 'etsysResourceStorageSize.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
 
-    $mempool['used'] = (($total - $free) * 1024);
-    $mempool['free'] = ($free * 1024);
-    $mempool['total'] = ($total * 1024);
-}
+$mempool['used'] = (($total - $free) * 1024);
+$mempool['free'] = ($free * 1024);
+$mempool['total'] = ($total * 1024);

--- a/includes/polling/mempools/extreme-mem.inc.php
+++ b/includes/polling/mempools/extreme-mem.inc.php
@@ -1,12 +1,10 @@
 <?php
 
-if ($device['os'] == 'xos') {
-    echo 'EXTREME-SOFTWARE-MONITOR-MIB';
+echo 'EXTREME-SOFTWARE-MONITOR-MIB';
 
-    $total = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.1916.1.32.2.2.1.2.1", '-OvQ'));
-    $avail = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.1916.1.32.2.2.1.3.1", '-OvQ'));
+$total = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.1916.1.32.2.2.1.2.1", '-OvQ'));
+$avail = str_replace('"', "", snmp_get($device, "1.3.6.1.4.1.1916.1.32.2.2.1.3.1", '-OvQ'));
 
-    $mempool['total'] = ($total * 1024);
-    $mempool['free']  = ($avail * 1024);
-    $mempool['used']  = (($total - $avail) * 1024);
-}
+$mempool['total'] = ($total * 1024);
+$mempool['free']  = ($avail * 1024);
+$mempool['used']  = (($total - $avail) * 1024);

--- a/includes/polling/mempools/hirschmann.inc.php
+++ b/includes/polling/mempools/hirschmann.inc.php
@@ -1,14 +1,12 @@
 <?php
 
-if ($device['os'] == 'hirschmann') {
-    $mem_allocated = snmp_get($device, 'HMPRIV-MGMT-SNMP-MIB::hmMemoryAllocated.0', '-OvQU');
-    $mem_free = snmp_get($device, 'HMPRIV-MGMT-SNMP-MIB::hmMemoryFree.0', '-OvQU');
-    $perc = $mem_allocated / ($mem_allocated + $mem_free) * 100;
+$mem_allocated = snmp_get($device, 'HMPRIV-MGMT-SNMP-MIB::hmMemoryAllocated.0', '-OvQU');
+$mem_free = snmp_get($device, 'HMPRIV-MGMT-SNMP-MIB::hmMemoryFree.0', '-OvQU');
+$perc = $mem_allocated / ($mem_allocated + $mem_free) * 100;
 
-    $mempool['perc'] = $perc;
-    $mempool['total'] = ($mem_allocated + $mem_free);
-    $mempool['used'] = $mem_allocated;
-    $mempool['free'] = $mem_free;
+$mempool['perc'] = $perc;
+$mempool['total'] = ($mem_allocated + $mem_free);
+$mempool['used'] = $mem_allocated;
+$mempool['free'] = $mem_free;
 
-    echo '(U: '.$mempool['used'].' T: '.$mempool['total'].' F: '.$mempool['free'].') ';
-}
+echo '(U: '.$mempool['used'].' T: '.$mempool['total'].' F: '.$mempool['free'].') ';

--- a/includes/polling/mempools/hpblmos.inc.php
+++ b/includes/polling/mempools/hpblmos.inc.php
@@ -10,13 +10,11 @@
  * the source code distribution for details.
  */
 
-if ($device['os'] == "hpblmos") {
-    //UCD-SNMP-MIB::memAvailReal.0
-    $free = intval(preg_replace('/[^0-9]+/', '', snmp_get($device, '.1.3.6.1.4.1.2021.4.6.0', '-Oqv')), 10);
-    //UCD-SNMP-MIB::memTotalReal.0
-    $total = intval(preg_replace('/[^0-9]+/', '', snmp_get($device, '.1.3.6.1.4.1.2021.4.5.0', '-Oqv')), 10);
-    $used = $total - $free;
-    $mempool['total'] = $total;
-    $mempool['free'] = $free;
-    $mempool['used'] = $total - $free;
-}
+//UCD-SNMP-MIB::memAvailReal.0
+$free = intval(preg_replace('/[^0-9]+/', '', snmp_get($device, '.1.3.6.1.4.1.2021.4.6.0', '-Oqv')), 10);
+//UCD-SNMP-MIB::memTotalReal.0
+$total = intval(preg_replace('/[^0-9]+/', '', snmp_get($device, '.1.3.6.1.4.1.2021.4.5.0', '-Oqv')), 10);
+$used = $total - $free;
+$mempool['total'] = $total;
+$mempool['free'] = $free;
+$mempool['used'] = $total - $free;

--- a/includes/polling/mempools/jetstream.inc.php
+++ b/includes/polling/mempools/jetstream.inc.php
@@ -23,13 +23,11 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
-if ($device['os'] === 'jetstream') {
-    $oid = '.1.3.6.1.4.1.11863.6.4.1.2.1.1.2.' . $mempool['mempool_index'];
-    $used = snmp_get($device, $oid, '-OvQ');
-    $mempool['total'] = 100;
-    $mempool['free']  = ($mempool['total'] - $used);
-    $mempool['used']  = $used;
-}
+$oid = '.1.3.6.1.4.1.11863.6.4.1.2.1.1.2.' . $mempool['mempool_index'];
+$used = snmp_get($device, $oid, '-OvQ');
+$mempool['total'] = 100;
+$mempool['free']  = ($mempool['total'] - $used);
+$mempool['used']  = $used;
 
 unset(
     $oid,

--- a/includes/polling/mempools/moxa-etherdevice-mem.inc.php
+++ b/includes/polling/mempools/moxa-etherdevice-mem.inc.php
@@ -20,8 +20,6 @@
             "The usage of memory size in %."
 */
 
-if ($device['os'] == 'moxa-etherdevice') {
-    $mempool['total'] = snmp_get($device, "totalMemory.0", '-OvQ', 'MOXA-IKS6726A-MIB');
-    $mempool['used'] = snmp_get($device, "usedMemory.0", '-OvQ', 'MOXA-IKS6726A-MIB');
-    $mempool['free'] = snmp_get($device, "freeMemory.0", '-OvQ', 'MOXA-IKS6726A-MIB');
-}
+$mempool['total'] = snmp_get($device, "totalMemory.0", '-OvQ', 'MOXA-IKS6726A-MIB');
+$mempool['used'] = snmp_get($device, "usedMemory.0", '-OvQ', 'MOXA-IKS6726A-MIB');
+$mempool['free'] = snmp_get($device, "freeMemory.0", '-OvQ', 'MOXA-IKS6726A-MIB');

--- a/includes/polling/mempools/netonix.inc.php
+++ b/includes/polling/mempools/netonix.inc.php
@@ -23,11 +23,9 @@
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
-if ($device['os'] == 'netonix') {
-    $total = snmp_get($device, "UCD-SNMP-MIB::memTotalReal.0", "-OvQU") * 1024;
-    $free = snmp_get($device, "UCD-SNMP-MIB::memAvailReal.0", "-OvQU") * 1024;
+$total = snmp_get($device, "UCD-SNMP-MIB::memTotalReal.0", "-OvQU") * 1024;
+$free = snmp_get($device, "UCD-SNMP-MIB::memAvailReal.0", "-OvQU") * 1024;
 
-    $mempool['total'] = $total;
-    $mempool['free']  = $free;
-    $mempool['used']  = $total - $free;
-}
+$mempool['total'] = $total;
+$mempool['free']  = $free;
+$mempool['used']  = $total - $free;

--- a/includes/polling/mempools/nxos.inc.php
+++ b/includes/polling/mempools/nxos.inc.php
@@ -10,12 +10,10 @@
  * the source code distribution for details.
  */
 
-if ($device['os'] == "nxos") {
-    echo "Cisco Nexus";
-    $used = snmp_get($device, '.1.3.6.1.4.1.9.9.109.1.1.1.1.12.1', '-OvQ');
-    $free = snmp_get($device, '.1.3.6.1.4.1.9.9.109.1.1.1.1.13.1', '-OvQ');
+echo "Cisco Nexus";
+$used = snmp_get($device, '.1.3.6.1.4.1.9.9.109.1.1.1.1.12.1', '-OvQ');
+$free = snmp_get($device, '.1.3.6.1.4.1.9.9.109.1.1.1.1.13.1', '-OvQ');
 
-    $mempool['used'] = ($used * 1024);
-    $mempool['free'] = ($free * 1024);
-    $mempool['total'] = (($used + $free) * 1024);
-}
+$mempool['used'] = ($used * 1024);
+$mempool['free'] = ($free * 1024);
+$mempool['total'] = (($used + $free) * 1024);

--- a/includes/polling/mempools/pbn-mem.inc.php
+++ b/includes/polling/mempools/pbn-mem.inc.php
@@ -2,23 +2,21 @@
 
 echo 'PBN MemPool'.'\n';
 
-if ($device['os'] == 'pbn') {
-    // find out wich build number we have
-    preg_match('/^.* Build (?<build>\d+)/', $device['version'], $version);
-    d_echo($version);
+// find out wich build number we have
+preg_match('/^.* Build (?<build>\d+)/', $device['version'], $version);
+d_echo($version);
 
-    // specified MIB supported since build 16607
-    if ($version[build] >= 16607) {
-        $perc = snmp_get($device, 'nmsMemoryPoolUtilization.0', '-OUvQ', 'NMS-MEMORY-POOL-MIB', 'pbn');
-        $memory_available = snmp_get($device, 'nmsMemoryPoolTotalMemorySize.0', '-OUvQ', 'NMS-MEMORY-POOL-MIB', 'pbn');
-        $mempool['total'] = $memory_available;
+// specified MIB supported since build 16607
+if ($version[build] >= 16607) {
+    $perc = snmp_get($device, 'nmsMemoryPoolUtilization.0', '-OUvQ', 'NMS-MEMORY-POOL-MIB', 'pbn');
+    $memory_available = snmp_get($device, 'nmsMemoryPoolTotalMemorySize.0', '-OUvQ', 'NMS-MEMORY-POOL-MIB', 'pbn');
+    $mempool['total'] = $memory_available;
 
-        if (is_numeric($perc)) {
-            $mempool['used'] = ($memory_available / 100 * $perc);
-            $mempool['free'] = ($memory_available - $mempool['used']);
-        }
-
-        echo "PERC " .$perc."%\n";
-        echo "Avail " .$mempool['total']."\n";
+    if (is_numeric($perc)) {
+        $mempool['used'] = ($memory_available / 100 * $perc);
+        $mempool['free'] = ($memory_available - $mempool['used']);
     }
+
+    echo "PERC " .$perc."%\n";
+    echo "Avail " .$mempool['total']."\n";
 }

--- a/includes/polling/mempools/pulse-mem.inc.php
+++ b/includes/polling/mempools/pulse-mem.inc.php
@@ -14,16 +14,14 @@
 
 echo 'Pulse Secure MemPool'.'\n';
 
-if ($device['os'] == 'pulse') {
-    $perc     = str_replace('"', "", snmp_get($device, "PULSESECURE-PSG-MIB::iveMemoryUtil.0", '-OvQ'));
-    $memory_available = str_replace('"', "", snmp_get($device, "UCD-SNMP-MIB::memTotalReal.0", '-OvQ'));
-    $mempool['total'] = $memory_available;
+$perc     = str_replace('"', "", snmp_get($device, "PULSESECURE-PSG-MIB::iveMemoryUtil.0", '-OvQ'));
+$memory_available = str_replace('"', "", snmp_get($device, "UCD-SNMP-MIB::memTotalReal.0", '-OvQ'));
+$mempool['total'] = $memory_available;
 
-    if (is_numeric($perc)) {
-        $mempool['used'] = ($memory_available / 100 * $perc);
-        $mempool['free'] = ($memory_available - $mempool['used']);
-    }
-
-    echo "PERC " .$perc."%\n";
-    echo "Avail " .$mempool['total']."\n";
+if (is_numeric($perc)) {
+    $mempool['used'] = ($memory_available / 100 * $perc);
+    $mempool['free'] = ($memory_available - $mempool['used']);
 }
+
+echo "PERC " .$perc."%\n";
+echo "Avail " .$mempool['total']."\n";

--- a/includes/polling/mempools/sgos.inc.php
+++ b/includes/polling/mempools/sgos.inc.php
@@ -4,13 +4,11 @@
 
 echo 'ProxySG MemPool'.'\n';
 
-if ($device['os'] == 'sgos') {
-    $used = str_replace('"', "", snmp_get($device, "BLUECOAT-SG-PROXY-MIB::sgProxyMemSysUsage.0", '-OUvQ'));
-    $total = str_replace('"', "", snmp_get($device, "BLUECOAT-SG-PROXY-MIB::sgProxyMemAvailable.0", '-OUvQ'));
-    $free = ($total - $used);
-    $percent = ($used / $total * 100);
+$used = str_replace('"', "", snmp_get($device, "BLUECOAT-SG-PROXY-MIB::sgProxyMemSysUsage.0", '-OUvQ'));
+$total = str_replace('"', "", snmp_get($device, "BLUECOAT-SG-PROXY-MIB::sgProxyMemAvailable.0", '-OUvQ'));
+$free = ($total - $used);
+$percent = ($used / $total * 100);
 
-    $mempool['used'] = ($used);
-    $mempool['free'] = ($free);
-    $mempool['total'] = (($used + $free));
-}
+$mempool['used'] = ($used);
+$mempool['free'] = ($free);
+$mempool['total'] = (($used + $free));

--- a/includes/polling/mempools/sonicwall-mem.inc.php
+++ b/includes/polling/mempools/sonicwall-mem.inc.php
@@ -9,13 +9,12 @@
  * option) any later version.  Please see LICENSE.txt at the top level of
  * the source code distribution for details.
  */
-if ($device['os'] == 'sonicwall') {
-    echo 'SonicWALL-MEMORY-POOL: ';
-    $perc = str_replace('"', "", snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-OvQ'));
-    if (is_numeric($perc)) {
-        $mempool['perc'] = $perc;
-        $mempool['used'] = $perc;
-        $mempool['total'] = 100;
-        $mempool['free'] = 100 - $perc;
-    }
+
+echo 'SonicWALL-MEMORY-POOL: ';
+$perc = str_replace('"', "", snmp_get($device, 'SONICWALL-FIREWALL-IP-STATISTICS-MIB::sonicCurrentRAMUtil.0', '-OvQ'));
+if (is_numeric($perc)) {
+    $mempool['perc'] = $perc;
+    $mempool['used'] = $perc;
+    $mempool['total'] = 100;
+    $mempool['free'] = 100 - $perc;
 }

--- a/includes/polling/mempools/zywall.inc.php
+++ b/includes/polling/mempools/zywall.inc.php
@@ -10,13 +10,11 @@
  * the source code distribution for details.
  */
 
-if ($device['os'] == 'zywall') {
-    d_echo('Zywall');
-    $perc = snmp_get($device, ".1.3.6.1.4.1.890.1.6.22.1.2.0", '-OvQ');
-    if (is_numeric($perc)) {
-        $mempool['perc'] = $perc;
-        $mempool['used'] = $perc;
-        $mempool['total'] = 100;
-        $mempool['free'] = 100 - $perc;
-    }
+d_echo('Zywall');
+$perc = snmp_get($device, ".1.3.6.1.4.1.890.1.6.22.1.2.0", '-OvQ');
+if (is_numeric($perc)) {
+    $mempool['perc'] = $perc;
+    $mempool['used'] = $perc;
+    $mempool['total'] = 100;
+    $mempool['free'] = 100 - $perc;
 }

--- a/includes/polling/mempools/zyxel.inc.php
+++ b/includes/polling/mempools/zyxel.inc.php
@@ -23,16 +23,14 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
-if ($device['group'] == 'zyxel') {
-    echo 'Zyxel: ';
-    $oid = '.1.3.6.1.4.1.890.1.15.3.2.5.0';
-    $perc = snmp_get($device, $oid, '-OvQ');
-    if (is_numeric($perc)) {
-        $mempool['perc'] = $perc;
-        $mempool['used'] = $perc;
-        $mempool['total'] = 100;
-        $mempool['free'] = 100 - $perc;
-    }
+echo 'Zyxel: ';
+$oid = '.1.3.6.1.4.1.890.1.15.3.2.5.0';
+$perc = snmp_get($device, $oid, '-OvQ');
+if (is_numeric($perc)) {
+    $mempool['perc'] = $perc;
+    $mempool['used'] = $perc;
+    $mempool['total'] = 100;
+    $mempool['free'] = 100 - $perc;
 }
 
 unset(

--- a/includes/polling/processors/cambium-cpu.inc.php
+++ b/includes/polling/processors/cambium-cpu.inc.php
@@ -9,10 +9,8 @@
  */
 echo 'Cambium CPU Usage';
 
-if ($device['os'] == 'cambium') {
-    $usage = str_replace('"', "", snmp_get($device, 'CAMBIUM-PMP80211-MIB::sysCPUUsage.0', '-OvQ'));
+$usage = str_replace('"', "", snmp_get($device, 'CAMBIUM-PMP80211-MIB::sysCPUUsage.0', '-OvQ'));
 
-    if (is_numeric($usage)) {
-        $proc = ($usage / 10);
-    }
+if (is_numeric($usage)) {
+    $proc = ($usage / 10);
 }

--- a/includes/polling/processors/dnos-cpu.inc.php
+++ b/includes/polling/processors/dnos-cpu.inc.php
@@ -1,15 +1,14 @@
 <?php
 echo 'DNOS CPU Usage';
-if ($device['os'] == 'dnos') {
-    $get_series = explode('.', snmp_get($device, 'mib-2.1.2.0', '-Onvsbq', 'F10-PRODUCTS-MIB', 'dnos'), 2); // Get series From MIB
-    $series = $get_series[0];
-    $descr = 'CPU';
-    if ($series == 'f10SSeriesProducts') {
-        $proc = trim(snmp_get($device, 'chStackUnitCpuUtil5Sec.1', '-OvQ', 'F10-S-SERIES-CHASSIS-MIB'));
-    } elseif ($series == 'f10CSeriesProducts') {
-        $proc = trim(snmp_get($device, 'chLineCardCpuUtil5Sec.1', '-OvQ', 'F10-S-SERIES-CHASSIS-MIB'));
-    } else {
-        preg_match('/(\d*\.\d*)/', snmp_get($device, '.1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.9.0', '-OvQ'), $matches);
-        $proc = $matches[0];
-    }
+
+$get_series = explode('.', snmp_get($device, 'mib-2.1.2.0', '-Onvsbq', 'F10-PRODUCTS-MIB', 'dnos'), 2); // Get series From MIB
+$series = $get_series[0];
+$descr = 'CPU';
+if ($series == 'f10SSeriesProducts') {
+    $proc = trim(snmp_get($device, 'chStackUnitCpuUtil5Sec.1', '-OvQ', 'F10-S-SERIES-CHASSIS-MIB'));
+} elseif ($series == 'f10CSeriesProducts') {
+    $proc = trim(snmp_get($device, 'chLineCardCpuUtil5Sec.1', '-OvQ', 'F10-S-SERIES-CHASSIS-MIB'));
+} else {
+    preg_match('/(\d*\.\d*)/', snmp_get($device, '.1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.9.0', '-OvQ'), $matches);
+    $proc = $matches[0];
 }

--- a/includes/polling/processors/edgeswitch.inc.php
+++ b/includes/polling/processors/edgeswitch.inc.php
@@ -11,9 +11,7 @@
  */
 
 d_echo('EdgeSwitch CPU usage:');
-if ($device['os'] == 'edgeswitch') {
-    //SNMPv2-SMI::enterprises.4413.1.1.1.1.4.9.0
-    $proc_usage = snmp_get($device, '.1.3.6.1.4.1.4413.1.1.1.1.4.9.0', '-Ovq');
-    preg_match('/([0-9]+.[0-9]+)/', $proc_usage, $usage);
-    $proc = $usage[0];
-}
+//SNMPv2-SMI::enterprises.4413.1.1.1.1.4.9.0
+$proc_usage = snmp_get($device, '.1.3.6.1.4.1.4413.1.1.1.1.4.9.0', '-Ovq');
+preg_match('/([0-9]+.[0-9]+)/', $proc_usage, $usage);
+$proc = $usage[0];

--- a/includes/polling/processors/extreme-cpu.inc.php
+++ b/includes/polling/processors/extreme-cpu.inc.php
@@ -4,11 +4,9 @@
 // Hardcoded polling of CPU usage on Extreme devices due to the lack of multiplier for CPU usage.
 //
 // iso.3.6.1.4.1.1916.1.32.1.4.1.9.1 = STRING: "7.3"
-if ($device['os'] == 'xos') {
-    $usage = str_replace('"', "", snmp_get($device, '1.3.6.1.4.1.1916.1.32.1.4.1.9.1', '-OvQ', 'EXTREME-BASE-MIB'));
+$usage = str_replace('"', "", snmp_get($device, '1.3.6.1.4.1.1916.1.32.1.4.1.9.1', '-OvQ', 'EXTREME-BASE-MIB'));
 
-    if (is_numeric($usage)) {
-        $proc = ($usage * 100);
-//substr(snmp_get($device, '1.3.6.1.4.1.1916.1.32.1.4.1.9.1', '-Ovq', 'EXTREME-BASE-MIB'), 0, 2);
-    }
+if (is_numeric($usage)) {
+    $proc = ($usage * 100);
+    //substr(snmp_get($device, '1.3.6.1.4.1.1916.1.32.1.4.1.9.1', '-Ovq', 'EXTREME-BASE-MIB'), 0, 2);
 }

--- a/includes/polling/processors/hpblmos.inc.php
+++ b/includes/polling/processors/hpblmos.inc.php
@@ -10,8 +10,6 @@
  * the source code distribution for details.
  */
 
-if ($device['os'] == 'hpblmos') {
-    $idle = snmp_get($device, '.1.3.6.1.4.1.2021.11.11.0', '-Ovqn');
-    $usage = 100 - $idle;
-    $proc = $usage;
-}
+$idle = snmp_get($device, '.1.3.6.1.4.1.2021.11.11.0', '-Ovqn');
+$usage = 100 - $idle;
+$proc = $usage;

--- a/includes/polling/processors/moxa-etherdevice-cpu.inc.php
+++ b/includes/polling/processors/moxa-etherdevice-cpu.inc.php
@@ -12,10 +12,8 @@
 
 echo 'Moxa EtherDevice CPU Usage';
 
-if ($device['os'] == 'moxa-etherdevice') {
-    $usage = snmp_get($device, 'cpuLoading30s.0', '-OvQ', 'MOXA-IKS6726A-MIB');
+$usage = snmp_get($device, 'cpuLoading30s.0', '-OvQ', 'MOXA-IKS6726A-MIB');
 
-    if (is_numeric($usage)) {
-        $proc = ($usage * 100);
-    }
+if (is_numeric($usage)) {
+    $proc = ($usage * 100);
 }

--- a/includes/polling/processors/pbn-cpu.inc.php
+++ b/includes/polling/processors/pbn-cpu.inc.php
@@ -1,18 +1,16 @@
 <?php
 
-if ($device['os'] == 'pbn') {
-    echo 'PBN CPU Usage';
+echo 'PBN CPU Usage';
 
-    // find out wich build number we have
-    preg_match('/^.* Build (?<build>\d+)/', $device['version'], $version);
-    d_echo($version);
+// find out wich build number we have
+preg_match('/^.* Build (?<build>\d+)/', $device['version'], $version);
+d_echo($version);
 
-    // specified MIB supported since build 16607
-    if ($version[build] >= 16607) {
-        $usage = snmp_get($device, 'nmspmCPUTotal5min.1', '-OUvQ', 'NMS-PROCESS-MIB', 'pbn');
+// specified MIB supported since build 16607
+if ($version[build] >= 16607) {
+    $usage = snmp_get($device, 'nmspmCPUTotal5min.1', '-OUvQ', 'NMS-PROCESS-MIB', 'pbn');
 
-        if (is_numeric($usage)) {
-            $proc = ($usage * 100);
-        }
+    if (is_numeric($usage)) {
+        $proc = ($usage * 100);
     }
 }

--- a/includes/polling/processors/pulse-cpu.inc.php
+++ b/includes/polling/processors/pulse-cpu.inc.php
@@ -14,10 +14,8 @@
 
 echo 'Pulse Secure CPU Usage';
 
-if ($device['os'] == 'pulse') {
-    $usage = str_replace('"', "", snmp_get($device, 'PULSESECURE-PSG-MIB::iveCpuUtil.0', '-OvQ'));
+$usage = str_replace('"', "", snmp_get($device, 'PULSESECURE-PSG-MIB::iveCpuUtil.0', '-OvQ'));
 
-    if (is_numeric($usage)) {
-        $proc = ($usage * 100);
-    }
+if (is_numeric($usage)) {
+    $proc = ($usage * 100);
 }

--- a/includes/polling/processors/sgos.inc.php
+++ b/includes/polling/processors/sgos.inc.php
@@ -2,10 +2,8 @@
 
 echo 'ProxySG CPU Usage';
 
-if ($device['os'] == 'sgos') {
-    $usage = str_replace('"', "", snmp_get($device, 'BLUECOAT-SG-PROXY-MIB::sgProxyCpuCoreBusyPerCent.0', '-OvQ'));
+$usage = str_replace('"', "", snmp_get($device, 'BLUECOAT-SG-PROXY-MIB::sgProxyCpuCoreBusyPerCent.0', '-OvQ'));
 
-    if (is_numeric($usage)) {
-        $proc = ($usage * 100);
-    }
+if (is_numeric($usage)) {
+    $proc = ($usage * 100);
 }

--- a/includes/polling/processors/viprinux.inc.php
+++ b/includes/polling/processors/viprinux.inc.php
@@ -1,9 +1,7 @@
 <?php
 echo 'Viprinet CPU Usage';
 
-if ($device['os'] == 'viprinux') {
-    $usage = str_replace('"', "", snmp_get($device, 'VIPRINET-MIB::vpnRouterCPULoad.0', '-OvQ'));
-    if (is_numeric($usage)) {
-        $proc = ($usage * 100);
-    }
+$usage = str_replace('"', "", snmp_get($device, 'VIPRINET-MIB::vpnRouterCPULoad.0', '-OvQ'));
+if (is_numeric($usage)) {
+    $proc = ($usage * 100);
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

For mem and proc polling, we decide which files to load by the entries in the DB so checking again then the OS is pointless. I was led to this by https://community.librenms.org/t/processor-usage-at-0-with-dell-powerconnect-dnos-cpu/1007/2 due to the dnos change recently.