### PR TITLE
fix: Updated enterasys proc discovery by setting correct index

### DIFF
--- a/includes/discovery/processors/enterasys.inc.php
+++ b/includes/discovery/processors/enterasys.inc.php
@@ -14,11 +14,13 @@ if ($device['os'] == 'enterasys') {
     $divisor = 10;
     $oids = snmp_walk($device, 'etsysResourceCpuLoad5min', '-Osqn', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
 
+    $proc_count = 0;
     foreach (explode("\n", $oids) as $data) {
         list($oid, $usage) = explode(" ", $data);
-        $usage = $usage/10;
+        $usage = $usage/$divisor;
         if (is_numeric($usage)) {
-            discover_processor($valid['processor'], $device, $oid, '0', 'enterasys', $descr, $divisor, $usage);
+            discover_processor($valid['processor'], $device, $oid, $proc_count, 'enterasys', $descr, $divisor, $usage);
+            $proc_count++;
         }
     }
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6225 

$index was set to 0 for all procs.

This does mean that the cpu graphs may jump as I think the 1st cpu will now become what was the 3rd cpu but I don't see a fix unless we count down instead of up but that limits the # of cpus.