### PR TITLE
newdevice: improve IOS-XE detection

### DIFF
--- a/includes/definitions/ios.yaml
+++ b/includes/definitions/ios.yaml
@@ -8,6 +8,14 @@ over:
     - { graph: device_processor, text: 'CPU Usage' }
     - { graph: device_mempool, text: 'Memory Usage' }
 icon: cisco
+discovery:
+    -
+      sysDescr:
+          - 'Cisco Internetwork Operating System Software'
+          - 'IOS (tm)'
+          - 'Cisco IOS Software'
+          - 'Global Site Selector'
+      sysDescr_regex: '/^((?!LINUX_IOSD).)*$/' #IOS-XE adding more regex will break detection, modify instead
 bad_ifXEntry:
     - cisco1941
     - cisco886Va

--- a/includes/definitions/iosxe.yaml
+++ b/includes/definitions/iosxe.yaml
@@ -34,5 +34,4 @@ register_mibs:
     ciscoAAASessionMIB: CISCO-AAA-SESSION-MIB
 discovery:
     - sysDescr:
-        - IOS-XE
-        - X86_64_LINUX_IOSD
+        - LINUX_IOSD

--- a/includes/discovery/os/ios.inc.php
+++ b/includes/discovery/os/ios.inc.php
@@ -1,5 +1,0 @@
-<?php
-
-if (str_contains($sysDescr, array('Cisco Internetwork Operating System Software', 'IOS (tm)', 'Cisco IOS Software', 'Global Site Selector')) && !str_contains($sysDescr, array('IOS-XE', 'X86_64_LINUX_IOSD'))) {
-    $os = 'ios';
-}


### PR DESCRIPTION
PPC_LINUX_IOSD or X86_64_LINUX_IOSD means IOS-XE, Drop the X86_64_ as that gives us full coverage.
Drop IOS-XE usage for detection.  Allows us to migrate ios detection to yaml.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
