### PR TITLE
fix: Updated enterasys mempools disco/polling to support multiple ram…

### DIFF
--- a/includes/discovery/mempools/enterasys.inc.php
+++ b/includes/discovery/mempools/enterasys.inc.php
@@ -3,6 +3,7 @@
  * LibreNMS Enterasys memory information module
  *
  * Copyright (c) 2017 Dave Bell <me@geordish.org>
+ * Copyright (c) 2017 Neil Lathwood <gh+n@laf.io>
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation, either version 3 of the License, or (at your
@@ -11,10 +12,15 @@
  */
 
 if ($device['os'] == 'enterasys') {
-    $free = snmp_get($device, 'etsysResourceStorageAvailable.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
-    $total  = snmp_get($device, 'etsysResourceStorageSize.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
-
-    if (is_numeric($free) && is_numeric($total)) {
-        discover_mempool($valid_mempool, $device, 0, 'enterasys', 'Memory', '1', null, null);
+    $enterasys_mem = snmpwalk_cache_threepart_oid($device, 'etsysResourceStorageTable', array(), 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
+    foreach ($enterasys_mem as $index => $mem_data) {
+        foreach ($mem_data['ram'] as $mem_id => $ram) {
+            $free = $ram['etsysResourceStorageAvailable'];
+            $total = $ram['etsysResourceStorageSize'];
+            $descr = $ram['etsysResourceStorageDescr'];
+            if (is_numeric($free) && is_numeric($total)) {
+                discover_mempool($valid_mempool, $device, $index, 'enterasys', $descr, '1', $mem_id, null);
+            }
+        }
     }
 }

--- a/includes/polling/mempools/enterasys.inc.php
+++ b/includes/polling/mempools/enterasys.inc.php
@@ -10,8 +10,8 @@
  * the source code distribution for details.
  */
 
-$free = snmp_get($device, 'etsysResourceStorageAvailable.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
-$total  = snmp_get($device, 'etsysResourceStorageSize.3.ram.0', '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
+$free = snmp_get($device, "etsysResourceStorageAvailable.{$mempool['mempool_index']}.ram.{$mempool['entPhysicalIndex']}", '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
+$total  = snmp_get($device, "etsysResourceStorageSize.{$mempool['mempool_index']}.ram.{$mempool['entPhysicalIndex']}", '-OvQ', 'ENTERASYS-RESOURCE-UTILIZATION-MIB');
 
 $mempool['used'] = (($total - $free) * 1024);
 $mempool['free'] = ($free * 1024);


### PR DESCRIPTION
… devices

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This is now changed to dynamically discover the memory for enterasys. Existing mempools will break as it uses an index value of 0 which seems to not be valid in the snmp output. I'll happily do a notification for this.

Fixes: #6225 
