### PR TITLE
Fix duplicate dBm readings for single-lane optics

### DIFF
--- a/includes/discovery/sensors/dbm/junos.inc.php
+++ b/includes/discovery/sensors/dbm/junos.inc.php
@@ -40,7 +40,7 @@ foreach ($pre_cache['junos_oids'] as $index => $entry) {
         $entPhysicalIndex_measured = 'ports';
         discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-'.$index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
     }
-    if (is_numeric($entry['jnxDomCurrentModuleLaneCount'])) {
+    if (is_numeric($entry['jnxDomCurrentModuleLaneCount']) && $entry['jnxDomCurrentModuleLaneCount'] > 1) {
         for ($x=0; $x<$entry['jnxDomCurrentModuleLaneCount']; $x++) {
             $lane = $pre_cache['junos_multilane_oids'][$index.'.'.$x];
             if (is_numeric($lane['jnxDomCurrentLaneRxLaserPower']) && $lane['jnxDomCurrentLaneRxLaserPower'] != 0 && $lane['jnxDomCurrentLaneTxLaserOutputPower'] != 0) {


### PR DESCRIPTION
The previous PR (GH-6377) caused single-lane optics to be graphed twice, once with the regular optic name and once with the optic name + lane 0. This change makes sure only multi-lane optics are processed as such.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
