### PR TITLE
docs: Updated install docs + perf to support compressing file types and using http/2

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -102,7 +102,7 @@ server {
  access_log  /opt/librenms/logs/access_log;
  error_log   /opt/librenms/logs/error_log;
  gzip on;
- gzip_types text/css application/x-javascript text/richtext image/svg+xml text/plain    text/xsd text/xsl text/xml image/x-icon;
+ gzip_types text/css application/javascript text/javascript application/x-javascript image/svg+xml text/plain text/xsd text/xsl text/xml image/x-icon;
  location / {
   try_files $uri $uri/ @librenms;
  }

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -78,7 +78,7 @@ server {
  access_log  /opt/librenms/logs/access_log;
  error_log   /opt/librenms/logs/error_log;
  gzip on;
- gzip_types text/css application/x-javascript text/richtext image/svg+xml text/plain    text/xsd text/xsl text/xml image/x-icon;
+ gzip_types text/css application/javascript text/javascript application/x-javascript image/svg+xml text/plain text/xsd text/xsl text/xml image/x-icon;
  location / {
   try_files $uri $uri/ @librenms;
  }

--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -89,3 +89,13 @@ If you would like to see if you should turn this on then run this query in MySQL
 |        81 |     2 |
 
 Here device id 128 and potentially 92 and 41 are likely candidates for this feature to be enabled on. Turn it on and then closely monitor the device for the next 15-30 minutes.
+
+### Web interface
+
+#### HTTP/2
+
+If you are running https then you should enable http/2 support in whatever web server you use:
+
+For Nginx (1.9.5 and above) change `listen 443 http2;` to `listen 443 ssl http2;` in the Virtualhost config.
+
+For Apache (2.4.17 an above) set `Protocols h2 http/1.1` in the Virtualhost config.

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -6,7 +6,16 @@ Options FollowSymlinks Multiviews
 AddType image/svg+xml .svg
 <IfModule mod_filter.c>
   <IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/css
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE text/javascript
+    AddOutputFilterByType DEFLATE application/x-javascript
     AddOutputFilterByType DEFLATE image/svg+xml
+    AddOutputFilterByType DEFLATE text/plain
+    AddOutputFilterByType DEFLATE text/xsd
+    AddOutputFilterByType DEFLATE text/xsl
+    AddOutputFilterByType DEFLATE text/xml
+    AddOutputFilterByType DEFLATE image/x-icon
   </IfModule>
 </IfModule>
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I'm not sure all these file types are needed but I've added more JS to be compressed which helps with page load times. Standardised the file types across apache + nginx.

Added an entry to Performance docs to say to enable http/2 where possible.