### PR TITLE
docs: Update to remove the old method of signing the CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ DO NOT DELETE THIS TEXT
 
 > Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.
 
-- [ ] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
 - [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
 
 #### Testers

--- a/doc/General/Contributing.md
+++ b/doc/General/Contributing.md
@@ -30,14 +30,9 @@ any other means), you assert that:
   systems.
 
 
-To agree with these assertions, please submit a GitHub pull request against
-[AUTHORS.md][5], adding or altering a **single line** *containing your name,
-email address, and GitHub user id* in the file (so that it can be matched to
-your commits), and stating in the *commit log* (not the pull request text):
-
-```
-I agree to the conditions of the Contributor Agreement contained in doc/General/Contributing.md.
-```
+To agree with these assertions, when you submit your first pull request you 
+will be asked after submitting to sign the CLA, you do this by following the 
+link provided in the PR and agreeing to the CLA using your GitHub account. 
 
 Local patches
 -------------
@@ -71,7 +66,7 @@ the package information to the header.
  * @package    LibreNMS
  * @subpackage webui
  * @link       http://librenms.org
- * @copyright  2016 Internet Widgitz Pty Ltd <info@widgitz.com>
+ * @copyright  2017 Internet Widgitz Pty Ltd <info@widgitz.com>
  * @author     Me <me@infowidgitz.com>
 
 ```


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you signed the [Contributors agreement](http://docs.librenms.org/General/Contributing/) - please do NOT submit a pull request unless you have (signing the agreement in the same pull request is fine). Your commit message for signing the agreement must appear as per the docs.
- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This gets rid of our old CLA stuff