### PR TITLE
fix: Updated ipv4/ipv6 discovery to exclude IPs with invalid port_ids

### DIFF
--- a/includes/discovery/arp-table.inc.php
+++ b/includes/discovery/arp-table.inc.php
@@ -109,6 +109,11 @@ foreach ($vrfs_lite_cisco as $vrf) {
             d_echo(null, '-');
         }
     }
+
+    // remove entries that no longer have an owner
+    dbQuery('DELETE `ipv4_mac` FROM `ipv4_mac` LEFT JOIN `ports`
+ ON `ipv4_mac`.`port_id` = `ports`.`port_id` WHERE `ports`.`port_id` IS NULL');
+
     echo PHP_EOL;
     unset(
         $existing_data,

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -722,30 +722,39 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
     if (dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ? AND `ifIndex` = ?', array($device['device_id'], $ifIndex)) != '0' && $ipv6_prefixlen > '0' && $ipv6_prefixlen < '129' && $ipv6_compressed != '::1') {
         $port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE device_id = ? AND ifIndex = ?', array($device['device_id'], $ifIndex));
 
-        if (dbFetchCell('SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ?', array($ipv6_network)) < '1') {
-            dbInsert(array('ipv6_network' => $ipv6_network, 'context_name' => $context_name), 'ipv6_networks');
-            echo 'N';
-        } else {
-            //Update Context
-            dbUpdate(array('context_name' => $device['context_name']), 'ipv6_networks', '`ipv6_network` = ?', array($ipv6_network));
-            echo 'n';
+        if (is_numeric($port_id)) {
+            if (dbFetchCell('SELECT COUNT(*) FROM `ipv6_networks` WHERE `ipv6_network` = ?', array($ipv6_network)) < '1') {
+                dbInsert(array('ipv6_network' => $ipv6_network, 'context_name' => $context_name), 'ipv6_networks');
+                echo 'N';
+            } else {
+                //Update Context
+                dbUpdate(array('context_name' => $device['context_name']), 'ipv6_networks', '`ipv6_network` = ?', array($ipv6_network));
+                echo 'n';
+            }
+
+            $ipv6_network_id = dbFetchCell('SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name` = ?', array($ipv6_network, $context_name));
+
+            if (dbFetchCell('SELECT COUNT(*) FROM `ipv6_addresses` WHERE `ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', array($ipv6_address, $ipv6_prefixlen, $port_id)) == '0') {
+                dbInsert(array(
+                    'ipv6_address' => $ipv6_address,
+                    'ipv6_compressed' => $ipv6_compressed,
+                    'ipv6_prefixlen' => $ipv6_prefixlen,
+                    'ipv6_origin' => $ipv6_origin,
+                    'ipv6_network_id' => $ipv6_network_id,
+                    'port_id' => $port_id,
+                    'context_name' => $context_name
+                ), 'ipv6_addresses');
+                echo '+';
+            } else {
+                //Update Context
+                dbUpdate(array('context_name' => $device['context_name']), 'ipv6_addresses', '`ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', array($ipv6_address, $ipv6_prefixlen, $port_id));
+                echo '.';
+            }
+
+            $full_address = "$ipv6_address/$ipv6_prefixlen";
+            $valid_address = $full_address . '-' . $port_id;
+            $valid['ipv6'][$valid_address] = 1;
         }
-
-
-        $ipv6_network_id = dbFetchCell('SELECT `ipv6_network_id` FROM `ipv6_networks` WHERE `ipv6_network` = ? AND `context_name` = ?', array($ipv6_network, $context_name));
-
-        if (dbFetchCell('SELECT COUNT(*) FROM `ipv6_addresses` WHERE `ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', array($ipv6_address, $ipv6_prefixlen, $port_id)) == '0') {
-            dbInsert(array('ipv6_address' => $ipv6_address, 'ipv6_compressed' => $ipv6_compressed, 'ipv6_prefixlen' => $ipv6_prefixlen, 'ipv6_origin' => $ipv6_origin, 'ipv6_network_id' => $ipv6_network_id, 'port_id' => $port_id, 'context_name' => $context_name), 'ipv6_addresses');
-            echo '+';
-        } else {
-            //Update Context
-            dbUpdate(array('context_name' => $device['context_name']), 'ipv6_addresses', '`ipv6_address` = ? AND `ipv6_prefixlen` = ? AND `port_id` = ?', array($ipv6_address, $ipv6_prefixlen, $port_id));
-            echo '.';
-        }
-
-        $full_address = "$ipv6_address/$ipv6_prefixlen";
-        $valid_address = $full_address . '-' . $port_id;
-        $valid['ipv6'][$valid_address] = 1;
     }//end if
 }//end discover_process_ipv6()
 

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -59,8 +59,10 @@ foreach ($vrfs_lite_cisco as $vrf) {
         }//end if
     }//end foreach
 
-    $sql = "SELECT * FROM ipv4_addresses AS A, ports AS I WHERE I.device_id = '".$device['device_id']."' AND  A.port_id = I.port_id";
-    foreach (dbFetchRows($sql) as $row) {
+    $sql = 'SELECT `ipv4_addresses`.*, `ports`.`device_id`, `ports`.`ifIndex` FROM `ipv4_addresses`';
+    $sql .= ' LEFT JOIN `ports` ON `ipv4_addresses`.port_id = `ports`.port_id';
+    $sql .= ' WHERE `ports`.device_id = ? OR `ports`.`device_id` IS NULL';
+    foreach (dbFetchRows($sql, array($device['device_id'])) as $row) {
         $full_address = $row['ipv4_address'].'/'.$row['ipv4_prefixlen'].'|'.$row['ifIndex'];
 
         if (!$valid_v4[$full_address]) {

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -60,7 +60,7 @@ foreach ($vrfs_lite_cisco as $vrf) {
     }//end foreach
 
     $sql = 'SELECT `ipv4_addresses`.*, `ports`.`device_id`, `ports`.`ifIndex` FROM `ipv4_addresses`';
-    $sql .= ' LEFT JOIN `ports` ON `ipv4_addresses`.port_id = `ports`.port_id';
+    $sql .= ' LEFT JOIN `ports` ON `ipv4_addresses`.`port_id` = `ports`.`port_id`';
     $sql .= ' WHERE `ports`.device_id = ? OR `ports`.`device_id` IS NULL';
     foreach (dbFetchRows($sql, array($device['device_id'])) as $row) {
         $full_address = $row['ipv4_address'].'/'.$row['ipv4_prefixlen'].'|'.$row['ifIndex'];

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -21,30 +21,39 @@ foreach ($vrfs_lite_cisco as $vrf) {
         if (dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ? AND `ifIndex` = ?', array($device['device_id'], $ifIndex)) != '0' && $oid != '0.0.0.0' && $oid != 'ipAdEntIfIndex') {
             $port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE `device_id` = ? AND `ifIndex` = ?', array($device['device_id'], $ifIndex));
 
-            if (dbFetchCell('SELECT COUNT(*) FROM `ipv4_networks` WHERE `ipv4_network` = ?', array($network)) < '1') {
-                dbInsert(array('ipv4_network' => $network,'context_name' => $device['context_name']), 'ipv4_networks');
-                // echo("Create Subnet $network\n");
-                echo 'S';
+            if (is_numeric($port_id)) {
+                if (dbFetchCell('SELECT COUNT(*) FROM `ipv4_networks` WHERE `ipv4_network` = ?', array($network)) < '1') {
+                    dbInsert(array('ipv4_network' => $network, 'context_name' => $device['context_name']), 'ipv4_networks');
+                    // echo("Create Subnet $network\n");
+                    echo 'S';
+                } else {
+                    //Update Context
+                    dbUpdate(array('context_name' => $device['context_name']), 'ipv4_networks', '`ipv4_network` = ?', array($network));
+                    echo 's';
+                }
+
+                $ipv4_network_id = dbFetchCell('SELECT `ipv4_network_id` FROM `ipv4_networks` WHERE `ipv4_network` = ?', array($network));
+
+                if (dbFetchCell('SELECT COUNT(*) FROM `ipv4_addresses` WHERE `ipv4_address` = ? AND `ipv4_prefixlen` = ? AND `port_id` = ? ', array($oid, $cidr, $port_id)) == '0') {
+                    dbInsert(array(
+                        'ipv4_address' => $oid,
+                        'ipv4_prefixlen' => $cidr,
+                        'ipv4_network_id' => $ipv4_network_id,
+                        'port_id' => $port_id,
+                        'context_name' => $device['context_name']
+                    ), 'ipv4_addresses');
+                    // echo("Added $oid/$cidr to $port_id ( $hostname $ifIndex )\n $i_query\n");
+                    echo '+';
+                } else {
+                    //Update Context
+                    dbUpdate(array('context_name' => $device['context_name']), 'ipv4_addresses', '`ipv4_address` = ? AND `ipv4_prefixlen` = ? AND `port_id` = ?', array($oid, $cidr, $port_id));
+                    echo '.';
+                }
+                $full_address = "$oid/$cidr|$ifIndex";
+                $valid_v4[$full_address] = 1;
             } else {
-                //Update Context
-                dbUpdate(array('context_name' => $device['context_name']), 'ipv4_networks', '`ipv4_network` = ?', array($network));
-                echo 's';
+                d_echo("No port id found for $ifIndex");
             }
-
-            $ipv4_network_id = dbFetchCell('SELECT `ipv4_network_id` FROM `ipv4_networks` WHERE `ipv4_network` = ?', array($network));
-
-            if (dbFetchCell('SELECT COUNT(*) FROM `ipv4_addresses` WHERE `ipv4_address` = ? AND `ipv4_prefixlen` = ? AND `port_id` = ? ', array($oid, $cidr, $port_id)) == '0') {
-                dbInsert(array('ipv4_address' => $oid, 'ipv4_prefixlen' => $cidr, 'ipv4_network_id' => $ipv4_network_id, 'port_id' => $port_id, 'context_name' => $device['context_name']), 'ipv4_addresses');
-                // echo("Added $oid/$cidr to $port_id ( $hostname $ifIndex )\n $i_query\n");
-                echo '+';
-            } else {
-                //Update Context
-                dbUpdate(array('context_name' => $device['context_name']), 'ipv4_addresses', '`ipv4_address` = ? AND `ipv4_prefixlen` = ? AND `port_id` = ?', array($oid, $cidr, $port_id));
-                echo '.';
-            }
-
-            $full_address            = "$oid/$cidr|$ifIndex";
-            $valid_v4[$full_address] = 1;
         } else {
             echo '!';
         }//end if

--- a/includes/discovery/ipv6-addresses.inc.php
+++ b/includes/discovery/ipv6-addresses.inc.php
@@ -65,9 +65,10 @@ foreach ($vrfs_lite_cisco as $vrf) {
         } //end foreach
     } //end if
 
-    $sql = "SELECT * FROM ipv6_addresses AS A, ports AS I WHERE I.device_id = '".$device['device_id']."' AND  A.port_id = I.port_id";
-
-    foreach (dbFetchRows($sql) as $row) {
+    $sql = 'SELECT `ipv6_addresses`.*, `ports`.`device_id`, `ports`.`ifIndex` FROM `ipv6_addresses`';
+    $sql .= ' LEFT JOIN `ports` ON `ipv6_addresses`.port_id = `ports`.port_id';
+    $sql .= ' WHERE `ports`.device_id = ? OR `ports`.`device_id` IS NULL';
+    foreach (dbFetchRows($sql, array($device['device_id'])) as $row) {
         $full_address  = $row['ipv6_address'].'/'.$row['ipv6_prefixlen'];
         $port_id       = $row['port_id'];
         $valid_address = $full_address.'-'.$port_id;

--- a/includes/discovery/ipv6-addresses.inc.php
+++ b/includes/discovery/ipv6-addresses.inc.php
@@ -66,7 +66,7 @@ foreach ($vrfs_lite_cisco as $vrf) {
     } //end if
 
     $sql = 'SELECT `ipv6_addresses`.*, `ports`.`device_id`, `ports`.`ifIndex` FROM `ipv6_addresses`';
-    $sql .= ' LEFT JOIN `ports` ON `ipv6_addresses`.port_id = `ports`.port_id';
+    $sql .= ' LEFT JOIN `ports` ON `ipv6_addresses`.`port_id` = `ports`.`port_id`';
     $sql .= ' WHERE `ports`.device_id = ? OR `ports`.`device_id` IS NULL';
     foreach (dbFetchRows($sql, array($device['device_id'])) as $row) {
         $full_address  = $row['ipv6_address'].'/'.$row['ipv6_prefixlen'];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

We just check we have a valid port_id before we carry on, this should clear out stale entries if the device still exists in librenms.

Fixes: #6302