### PR TITLE
dont run ipmitool without knowing a type - issue #6503

### DIFF
--- a/includes/polling/ipmi.inc.php
+++ b/includes/polling/ipmi.inc.php
@@ -18,9 +18,15 @@ if (is_array($ipmi_rows)) {
             $remote = " -H " . $ipmi['host'] . " -U '" . $ipmi['user'] . "' -P '" . $ipmi['password'] . "' -L USER";
         }
 
-        $results = external_exec($config['ipmitool'] . ' -I ' . $ipmi['type'] . ' -c ' . $remote . ' sdr 2>/dev/null');
-        d_echo($results);
-        echo " done.\n";
+        // Check to see if we know which IPMI interface to use
+        // so we dont use wrong arguments for ipmitool
+        if ($ipmi['type'] != '') {
+            $results = external_exec($config['ipmitool'] . ' -I ' . $ipmi['type'] . ' -c ' . $remote . ' sdr 2>/dev/null');
+            d_echo($results);
+            echo " done.\n";
+        } else {
+            echo " type not yet discovered.\n";
+        }
 
         foreach (explode("\n", $results) as $row) {
             list($desc, $value, $type, $status) = explode(',', $row);


### PR DESCRIPTION
Per commit message - dont run ipmitool unless we've discovered an ipmi interface to use.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6503 