### PR TITLE
add to ipmi definitions

### DIFF
--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -721,6 +721,7 @@ $config['ipmi_unit']['degrees C'] = 'temperature';
 $config['ipmi_unit']['RPM']       = 'fanspeed';
 $config['ipmi_unit']['Watts']     = 'power';
 $config['ipmi_unit']['Amps']      = 'current';
+$config['ipmi_unit']['percent']   = 'load';
 $config['ipmi_unit']['discrete']  = '';
 
 // Define some variables if they aren't set by user definition in config.php

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -720,6 +720,7 @@ $config['ipmi_unit']['Volts']     = 'voltage';
 $config['ipmi_unit']['degrees C'] = 'temperature';
 $config['ipmi_unit']['RPM']       = 'fanspeed';
 $config['ipmi_unit']['Watts']     = 'power';
+$config['ipmi_unit']['Amps']      = 'current';
 $config['ipmi_unit']['discrete']  = '';
 
 // Define some variables if they aren't set by user definition in config.php


### PR DESCRIPTION
Add "Amps" to ipmi_unit definitions

```
# ipmitool sensor | grep Amps
Current 1        | 0.400      | Amps       | ok    | na        | na        | na        | na        | na        | na        
Current 2        | 0.200      | Amps       | ok    | na        | na        | na        | na        | na        | na
```

I've added this as the "current" metric as that seems to be whats used for my APC ups for tracking Amps on that.

---

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
