### PR TITLE
Fix: APC/MGE discovery for some models

### DIFF
--- a/includes/definitions/apc-mgeups.yaml
+++ b/includes/definitions/apc-mgeups.yaml
@@ -16,4 +16,5 @@ discovery:
             - .1.3.6.1.4.1.705.1
         sysDescr_regex:
             - '/^Galaxy/'
+            - '/^GALAXY/'
             # Upsilon too (no data)


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

------

- My APC Galaxy 5000 were discovered as EATON
- sysDescr for Galaxy 5000 is in capitals