### PR TITLE
fix: Actually reload oxidized when we should not when we think we should

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -131,6 +131,10 @@ $proctime = substr($run, 0, 5);
 
 if ($discovered_devices) {
     dbInsert(array('type' => 'discover', 'doing' => $doing, 'start' => $start, 'duration' => $proctime, 'devices' => $discovered_devices, 'poller' => $config['distributed_poller_name']), 'perf_times');
+    if ($doing === 'new') {
+        // We have added a new device by this point so we might want to do some other work
+        oxidized_reload_nodes();
+    }
 }
 
 $string = $argv[0]." $doing ".date($config['dateformat']['compact'])." - $discovered_devices devices discovered in $proctime secs";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -371,6 +371,7 @@ function delete_device($id)
 
     $ret .= "Removed device $host\n";
     log_event("Device $host has been removed", 0, 'system', 3);
+    oxidized_reload_nodes();
     return $ret;
 }
 
@@ -718,7 +719,6 @@ function createHost(
 
     $device_id = dbInsert($device, 'devices');
     if ($device_id) {
-        oxidized_reload_nodes();
         return $device_id;
     }
 
@@ -1559,7 +1559,7 @@ function oxidized_reload_nodes()
     global $config;
 
     if ($config['oxidized']['enabled'] === true && $config['oxidized']['reload_nodes'] === true && isset($config['oxidized']['url'])) {
-        $oxidized_reload_url = $config['oxidized']['url'] . '/reload?format=json';
+        $oxidized_reload_url = $config['oxidized']['url'] . '/reload.json';
         $ch = curl_init($oxidized_reload_url);
 
         curl_setopt($ch, CURLOPT_TIMEOUT, 5);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #3592 

In the end managed to replicate this so I'm confident this fix works + added support for reloading when deleting devices.

The short of it is, I don't think the OS had been discovered by the time the API call was made from Oxidized back to LibreNMS to tell it a new device was ready. This call is now done when new device discovery is called so every 5 mins which I think is acceptable. It's probably possible to move the call somewhere else but where it was before was pretty much at the end of the process of adding a new device anyway, the only other place would be in `addHost()` but I don't think it will make a difference.