### PR TITLE
fix: inconsistent device discovery

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -116,6 +116,7 @@ if (!empty($config['distributed_poller_group'])) {
     $where .= ' AND poller_group IN('.$config['distributed_poller_group'].')';
 }
 
+global $device;
 foreach (dbFetch("SELECT * FROM `devices` WHERE status = 1 AND disabled = 0 $where ORDER BY device_id DESC", $sqlparams) as $device) {
     discover_device($device, $options);
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -88,7 +88,7 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
 
 //end discover_new_device()
 
-function discover_device($device, $options = null)
+function discover_device(&$device, $options = null)
 {
     global $config, $valid;
 

--- a/includes/discovery/os.inc.php
+++ b/includes/discovery/os.inc.php
@@ -1,10 +1,15 @@
 <?php
 
-$os   = getHostOS($device);
+$os = getHostOS($device);
 if ($os != $device['os']) {
     log_event('Device OS changed ' . $device['os'] . " => $os", $device, 'system', 3);
     $device['os'] = $os;
     $sql = dbUpdate(array('os' => $os), 'devices', 'device_id=?', array($device['device_id']));
+
+    if (!isset($config['os'][$device['os']])) {
+        load_os($device);
+    }
+
     echo "Changed OS! : $os\n";
 }
 


### PR DESCRIPTION
There were two or more separate $device arrays during discovery. When one was updated, others were not.
Combine those all.
Make sure the new os is loaded if the os changed.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
