### PR TITLE
Fix GE UPS voltage factor

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -959,8 +959,12 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
         } elseif ($sensor_type == 'voltage' && !starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
             return 1;
         }
-    } elseif (($device['os'] == 'ge-digitalenergy') && ($sensor_type == 'load')) {
-        return 1;
+    } elseif ($device['os'] == 'ge-ups') {
+        if ($sensor_type == 'load') {
+            return 1;
+        } elseif ($sensor_type == 'voltage' && !starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.')) {
+            return 1;
+        }
     }
 
     return 10; //default


### PR DESCRIPTION
Voltage factor should be 1 on GE UPS
And btw I forgot to change the os name yesterday.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
