### PR TITLE
refactor: Added lock support to ./discovery.php -h new to prevent overlap

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -33,6 +33,7 @@ if (isset($options['h'])) {
         $where = ' ';
         $doing = 'all';
     } elseif ($options['h'] == 'new') {
+        set_lock('new-discovery');
         $where = 'AND `last_discovered` IS NULL';
         $doing = 'new';
     } elseif ($options['h']) {
@@ -137,6 +138,7 @@ if ($discovered_devices) {
     if ($doing === 'new') {
         // We have added a new device by this point so we might want to do some other work
         oxidized_reload_nodes();
+        release_lock('new-discovery');
     }
 }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #4459 

The proof will be in the schema lock pudding over the next few days but I'm confident. This will stop discovery from firing against the same device multiple times and potentially allowing the processes to run away with themselves.