### PR TITLE
fix: RouterOS: don't detect ccq sensors when they aren't returning data

### DIFF
--- a/LibreNMS/OS/Routeros.php
+++ b/LibreNMS/OS/Routeros.php
@@ -49,11 +49,27 @@ class Routeros extends OS implements
      */
     public function discoverWirelessCcq()
     {
-        return $this->discoverSensor(
-            'ccq',
-            'mtxrWlApOverallTxCCQ',
-            '.1.3.6.1.4.1.14988.1.1.1.3.1.10.'
-        );
+        $data = $this->fetchData();
+
+        $sensors = array();
+        foreach ($data as $index => $entry) {
+            // skip sensors with no data (nv2 should report 1 client, but doesn't report ccq)
+            if ($entry['mtxrWlApClientCount'] > 0 && $entry['mtxrWlApOverallTxCCQ'] == 0) {
+                continue;
+            }
+
+            $sensors[] = new WirelessSensor(
+                'ccq',
+                $this->getDeviceId(),
+                '.1.3.6.1.4.1.14988.1.1.1.3.1.10.' . $index,
+                'mikrotik',
+                $index,
+                'SSID: ' . $entry['mtxrWlApSsid'],
+                $entry['mtxrWlApOverallTxCCQ']
+            );
+        }
+
+        return $sensors;
     }
 
     /**


### PR DESCRIPTION
If clients == 0, ccq is probably 0 too, but if there is a client and ccq is 0.  The device is probably using nv2

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
