### PR TITLE
fix: fail2ban application was setting the wrong variables

### DIFF
--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -10,9 +10,10 @@ $app_id = $app['app_id'];
 $options      = '-O qv';
 $oid          = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.8.102.97.105.108.50.98.97.110';
 $f2b = snmp_walk($device, $oid, $options);
-update_application($app, $new_component);
+$f2b = trim($f2b, '"');
+update_application($app, $f2b);
 
-$bannedStuff = explode("\n", $new_component);
+$bannedStuff = explode("\n", $f2b);
 
 $total_banned=$bannedStuff[0];
 $firewalled=$bannedStuff[1];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Reported in irc. The variables were just wrong. Also stripped out the " that surrounded it.