### PR TITLE
feature: Added functionality to support recording status info

### DIFF
--- a/includes/polling/applications/os-updates.inc.php
+++ b/includes/polling/applications/os-updates.inc.php
@@ -11,7 +11,7 @@ $rrd_name = array('app', $name, $app_id);
 $rrd_def = RrdDefinition::make()->addDataset('packages', 'GAUGE', 0);
 
 $osupdates = snmp_get($device, $oid, $options, $mib);
-update_application($app, $osupdates);
+update_application($app, $osupdates, $osupdates);
 
 $fields = array('packages' => $osupdates,);
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -549,7 +549,7 @@ function location_to_latlng($device)
  * @param array $app app from the db, including app_id
  * @param string $response This should be the full output
  */
-function update_application($app, $response)
+function update_application($app, $response, $current = '')
 {
     if (!is_numeric($app['app_id'])) {
         d_echo('$app does not contain app_id, could not update');
@@ -557,8 +557,9 @@ function update_application($app, $response)
     }
 
     $data = array(
-        'app_state' => 'UNKNOWN',
-        'timestamp' => array('NOW()'),
+        'app_state'  => 'UNKNOWN',
+        'app_status' => $current,
+        'timestamp'  => array('NOW()'),
     );
 
     if ($response != '' && $response !== false) {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -548,6 +548,7 @@ function location_to_latlng($device)
  *
  * @param array $app app from the db, including app_id
  * @param string $response This should be the full output
+ * @param string $current This is the current value we store in rrd for graphing
  */
 function update_application($app, $response, $current = '')
 {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

We don't currently store any data from the applications when polled. I've used the app_status column to store the response from the os-updates application poller. This could be done for other applications as well.