### PR TITLE
refactor: modest speedup to database config population

### DIFF
--- a/includes/mergecnf.inc.php
+++ b/includes/mergecnf.inc.php
@@ -33,41 +33,39 @@ function mergedb()
 {
     global $config;
 
-    $clone = $config;
-    foreach (dbFetchRows('select config_name,config_value from config') as $obj) {
-        $clone = array_replace_recursive($clone, mergecnf($obj));
+    $db_config = array();
+    foreach (dbFetchRows('SELECT `config_name`,`config_value` FROM `config`') as $obj) {
+        assign_array_by_path($db_config, $obj['config_name'], $obj['config_value']);
     }
-    $config = array_replace_recursive($clone, $config);
+    $config = array_replace_recursive($db_config, $config);
 }
 
-
 /**
- * @param $obj
- * @return array
+ * Assign a value into the passed array by a path
+ * 'snmp.version' = 'v1' becomes $arr['snmp']['version'] = 'v1'
+ *
+ * @param array $arr the array to insert the value into, will be modified in place
+ * @param string $path the path to insert the value at
+ * @param mixed $value the value to insert, will be type cast
+ * @param string $separator path separator
  */
-function mergecnf($obj)
+function assign_array_by_path(&$arr, $path, $value, $separator = '.')
 {
-    $pointer = array();
-    $val     = $obj['config_value'];
-    $obj     = $obj['config_name'];
-    $obj     = explode('.', $obj, 2);
-    if (!isset($obj[1])) {
-        if (filter_var($val, FILTER_VALIDATE_INT)) {
-            $val = (int) $val;
-        } elseif (filter_var($val, FILTER_VALIDATE_FLOAT)) {
-            $val = (float) $val;
-        } elseif (filter_var($val, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null) {
-            $val = filter_var($val, FILTER_VALIDATE_BOOLEAN);
-        }
-
-        if (!empty($obj[0])) {
-            return array($obj[0] => $val);
-        } else {
-            return array($val);
-        }
-    } else {
-        $pointer[$obj[0]] = mergecnf(array('config_name' => $obj[1], 'config_value' => $val));
+    // type cast value. Is this needed here?
+    if (filter_var($value, FILTER_VALIDATE_INT)) {
+        $value = (int) $value;
+    } elseif (filter_var($value, FILTER_VALIDATE_FLOAT)) {
+        $value = (float) $value;
+    } elseif (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null) {
+        $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 
-    return $pointer;
-}//end mergecnf()
+    $keys = explode($separator, $path);
+
+    // walk the array creating keys if they don't exist
+    foreach ($keys as $key) {
+        $arr = &$arr[$key];
+    }
+   // assign the variable
+    $arr = $value;
+}


### PR DESCRIPTION
Page/Graph speedup part 3

use references to assign values into the config array more efficiently, prevents a lot of memory churn caused by the recursive approach

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
