### PR TITLE
newdevice: HPE RT3000 UPS

### DIFF
--- a/includes/definitions/hpe-rtups.yaml
+++ b/includes/definitions/hpe-rtups.yaml
@@ -1,0 +1,15 @@
+os: hpe-rtups
+text: 'HP UPS'
+group: ups
+type: power
+icon: hpe
+rfc1628_compat: 1
+mib_dir:
+    - mge
+over:
+    - { graph: device_current, text: Current }
+    - { graph: device_voltage, text: Voltage }
+    - { graph: device_load, text: Load }
+discovery:
+    - sysObjectId:
+        - .1.3.6.1.4.1.232.165.3

--- a/includes/definitions/hpe-rtups.yaml
+++ b/includes/definitions/hpe-rtups.yaml
@@ -5,7 +5,7 @@ type: power
 icon: hpe
 rfc1628_compat: 1
 mib_dir:
-    - mge
+    - hp
 over:
     - { graph: device_current, text: Current }
     - { graph: device_voltage, text: Voltage }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -969,6 +969,10 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
         if ($sensor_type == 'load') {
             return 1;
         }
+    } elseif ($device['os'] == 'hpe-rtups') {
+        if ($sensor_type == 'load') {
+            return 1;
+        }
     }
 
     return 10; //default

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -975,7 +975,6 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
         } elseif ($sensor_type == 'voltage' && !starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.') && !starts_with($oid, '.1.3.6.1.2.1.33.1.3.3.1.3')) {
             return 1;
         }
-
     }
 
     return 10; //default

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -972,7 +972,10 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
     } elseif ($device['os'] == 'hpe-rtups') {
         if ($sensor_type == 'load') {
             return 1;
+        } elseif ($sensor_type == 'voltage' && !starts_with($oid, '.1.3.6.1.2.1.33.1.2.5.') && !starts_with($oid, '.1.3.6.1.2.1.33.1.3.3.1.3')) {
+            return 1;
         }
+
     }
 
     return 10; //default

--- a/includes/polling/os/hpe-rtups.inc.php
+++ b/includes/polling/os/hpe-rtups.inc.php
@@ -1,8 +1,7 @@
 <?php
+$rtups_data = snmp_get_multi_oid($device, 'deviceSerialNumber.0 deviceFirmwareVersion.0', '-OQs', 'CPQPOWER-MIB');
 
-$version = trim(snmp_get($device, 'upsmgIdentFirmwareVersion.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
+$serial  = $rtups_data['deviceSerialNumber.0'];
+$version = $rtups_data['deviceFirmwareVersion.0'];
 
-$hardware  = trim(snmp_get($device, 'upsmgIdentFamilyName.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
-$hardware .= ' '.trim(snmp_get($device, 'upsmgIdentModelName.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
-
-$serial = trim(snmp_get($device, 'upsmgIdentSerialNumber.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
+unset($rtups_data);

--- a/includes/polling/os/hpe-rtups.inc.php
+++ b/includes/polling/os/hpe-rtups.inc.php
@@ -1,0 +1,8 @@
+<?php
+
+$version = trim(snmp_get($device, 'upsmgIdentFirmwareVersion.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
+
+$hardware  = trim(snmp_get($device, 'upsmgIdentFamilyName.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
+$hardware .= ' '.trim(snmp_get($device, 'upsmgIdentModelName.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');
+
+$serial = trim(snmp_get($device, 'upsmgIdentSerialNumber.0', '-OQv', 'MG-SNMP-UPS-MIB'), '" ');

--- a/tests/snmpsim/hpe-rtups.snmprec
+++ b/tests/snmpsim/hpe-rtups.snmprec
@@ -1,0 +1,2 @@
+1.3.6.1.2.1.1.1.0|4|HP UPS Network Module, revision BD06, firmware revision 1.05.001
+1.3.6.1.2.1.1.2.0|6|.1.3.6.1.4.1.232.165.3


### PR DESCRIPTION
Initial support for HP(E) R/T3000 UPS which is basically a rebranded EATON 5P UPS.
That's why MG-SNMP-UPS-MIB is used instead of a specific HPE MIB.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
