### PR TITLE
refactor: Remove eval() from multi-tenancy code

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -84,14 +84,10 @@ if (strstr($_SERVER['REQUEST_URI'], 'widescreen=no')) {
 
 # Load the settings for Multi-Tenancy.
 if (isset($config['branding']) && is_array($config['branding'])) {
-    if ($config['branding'][$_SERVER['SERVER_NAME']]) {
-        foreach ($config['branding'][$_SERVER['SERVER_NAME']] as $confitem => $confval) {
-            eval("\$config['" . $confitem . "'] = \$confval;");
-        }
+    if (isset($config['branding'][$_SERVER['SERVER_NAME']])) {
+        $config = array_replace_recursive($config, $config['branding'][$_SERVER['SERVER_NAME']]);
     } else {
-        foreach ($config['branding']['default'] as $confitem => $confval) {
-            eval("\$config['" . $confitem . "'] = \$confval;");
-        }
+        $config = array_replace_recursive($config, $config['branding']['default']);
     }
 }
 

--- a/html/network-map.php
+++ b/html/network-map.php
@@ -25,15 +25,11 @@ if (strpos($_SERVER['REQUEST_URI'], 'anon')) {
     $anon = 1;
 }
 
-if (is_array($config['branding'])) {
-    if ($config['branding'][$_SERVER['SERVER_NAME']]) {
-        foreach ($config['branding'][$_SERVER['SERVER_NAME']] as $confitem => $confval) {
-            eval("\$config['" . $confitem . "'] = \$confval;");
-        }
+if (isset($config['branding']) && is_array($config['branding'])) {
+    if (isset($config['branding'][$_SERVER['SERVER_NAME']])) {
+        $config = array_replace_recursive($config, $config['branding'][$_SERVER['SERVER_NAME']]);
     } else {
-        foreach ($config['branding']['default'] as $confitem => $confval) {
-            eval("\$config['" . $confitem . "'] = \$confval;");
-        }
+        $config = array_replace_recursive($config, $config['branding']['default']);
     }
 }
 


### PR DESCRIPTION
I couldn't figure out how much use this is since you can't have multiple databases.
If anyone wants to keep this, at least we should replace the eval() with array_replace_recursive()

Code origin: https://github.com/librenms/librenms/commit/371e394d8663991ad0f4997c7d83093f1e4af8ba

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
