### PR TITLE
fix: Moved get_client_ip() to common

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1013,18 +1013,6 @@ function demo_account()
     print_error("You are logged in as a demo account, this page isn't accessible to you");
 }//end demo_account()
 
-
-function get_client_ip()
-{
-    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        $client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-    } else {
-        $client_ip = $_SERVER['REMOTE_ADDR'];
-    }
-
-    return $client_ip;
-}//end get_client_ip()
-
 /**
  * @param $string
  * @param int $max

--- a/includes/common.php
+++ b/includes/common.php
@@ -1810,3 +1810,15 @@ function str_to_class($name, $namespace = null)
     $class = str_replace(' ', '', ucwords(strtolower($pre_format)));
     return $namespace . $class;
 }
+
+function get_client_ip()
+{
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    } else {
+        $client_ip = $_SERVER['REMOTE_ADDR'];
+    }
+
+    return $client_ip;
+}//end get_client_ip()
+

--- a/includes/common.php
+++ b/includes/common.php
@@ -1821,4 +1821,3 @@ function get_client_ip()
 
     return $client_ip;
 }//end get_client_ip()
-


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes:

```
./scripts/auth_test.php -u username -d -v
SQL[SET NAMES 'utf8']
SQL[SET CHARACTER SET 'utf8']
SQL[SET COLLATION_CONNECTION = 'utf8_unicode_ci']
SQL[SELECT config_name,config_valueFROMconfig]
SQL[select * from graph_types]
SQL[DELETE FROM session WHERE session_expiry < '1494936175']
PHP Fatal error: Uncaught Error: Call to undefined function get_client_ip() in /opt/librenms/html/includes/authenticate.inc.php:83
Stack trace:
```