### PR TITLE
fix: marking invalid ports as deleted in discovery

### DIFF
--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -65,11 +65,11 @@ foreach ($port_stats as $ifIndex => $port) {
 
         // We've seen it. Remove it from the cache.
         unset($ports_l[$ifIndex]);
-    } // Port vanished (mark as deleted)
-    else {
+    } else {
+        // Port vanished (mark as deleted)
         if (is_array($ports_db[$port_id])) {
             if ($ports_db[$port_id]['deleted'] != '1') {
-                dbUpdate(array('deleted' => '1'), 'ports', "`port_id` = ?, `ifName` => '?', `ifAlias` => '?', `ifDescr` => '?'", array($port_id, $ifName, $ifAlias, $ifDescr));
+                dbUpdate(array('deleted' => '1'), 'ports', '`port_id` = ?', array($port_id));
                 $ports_db[$port_id]['deleted'] = '1';
                 echo '-';
             }


### PR DESCRIPTION
There seem to be other issues in this file, such as $ports_l is never defined...

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
