### PR TITLE
fix: When force adding devices with v3, actually store the details

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -140,7 +140,7 @@ if (!empty($argv[1])) {
                 }
             }//end while
 
-            array_push($config['snmp']['v3'], $v3);
+            array_unshift($config['snmp']['v3'], $v3);
         }
     } else {
         // v2c or v1


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Seen a couple of comments recently that force adding a device with snmpv3 config drops the v3 settings. 