### PR TITLE
append Avaya VSP HW revision to serial number

### DIFF
--- a/includes/polling/os/avaya-vsp.inc.php
+++ b/includes/polling/os/avaya-vsp.inc.php
@@ -21,10 +21,7 @@ $version = str_replace('"', '', $version);
 $serial   = snmp_get($device, 'rcChasSerialNumber.0', '-Osqv', 'RAPID-CITY');
 $serial = str_replace('"', '', $serial);
 
-// rcChasHardwareRevision
-$sysDescr = $poll_device['sysDescr'];
-$sysDescr = explode(' ', $sysDescr);
-$sysDescr = $sysDescr[0];
+// Appended Hard revision to serial number
 $hwrevision = snmp_get($device, 'rcChasHardwareRevision.0', '-Osqv', 'RAPID-CITY');
-$hardware = $sysDescr . " HW: $hwrevision";
-$hardware = str_replace('"', '', $hardware);
+$hwrevision = str_replace('"', '', $hwrevision);
+$serial = $serial . " HW:$hwrevision";

--- a/includes/polling/os/avaya-vsp.inc.php
+++ b/includes/polling/os/avaya-vsp.inc.php
@@ -20,8 +20,3 @@ $version = str_replace('"', '', $version);
 // rcChasSerialNumber
 $serial   = snmp_get($device, 'rcChasSerialNumber.0', '-Osqv', 'RAPID-CITY');
 $serial = str_replace('"', '', $serial);
-
-// Appended Hard revision to serial number
-$hwrevision = snmp_get($device, 'rcChasHardwareRevision.0', '-Osqv', 'RAPID-CITY');
-$hwrevision = str_replace('"', '', $hwrevision);
-$serial = $serial . " HW:$hwrevision";

--- a/includes/polling/os/avaya-vsp.inc.php
+++ b/includes/polling/os/avaya-vsp.inc.php
@@ -20,3 +20,10 @@ $version = str_replace('"', '', $version);
 // rcChasSerialNumber
 $serial   = snmp_get($device, 'rcChasSerialNumber.0', '-Osqv', 'RAPID-CITY');
 $serial = str_replace('"', '', $serial);
+
+// rcChasHardwareRevision
+$sysDescr = $poll_device['sysDescr'];
+$sysDescr = explode(' ', $sysDescr);
+$sysDescr = $sysDescr[0];
+$hardware = $sysDescr; 
+$hardware = str_replace('"', '', $hardware);

--- a/includes/polling/os/avaya-vsp.inc.php
+++ b/includes/polling/os/avaya-vsp.inc.php
@@ -25,5 +25,5 @@ $serial = str_replace('"', '', $serial);
 $sysDescr = $poll_device['sysDescr'];
 $sysDescr = explode(' ', $sysDescr);
 $sysDescr = $sysDescr[0];
-$hardware = $sysDescr; 
+$hardware = $sysDescr;
 $hardware = str_replace('"', '', $hardware);


### PR DESCRIPTION
The old way added the HW revision to the sysDescr.  When managing a bunch of switches with different versions this made it look like you had a lot of different kinds of switches.  These are all the switches.  Just add it to the serial number so you can have the hw version for reference if needed.  Just makes more sense not to appended to sysDescr.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
