### PR TITLE
fix: rrdtool web settings

### DIFF
--- a/html/pages/settings/external.inc.php
+++ b/html/pages/settings/external.inc.php
@@ -61,7 +61,6 @@ $rrdtool_conf = array(
     ),
     array('name'               => 'rrd.heartbeat',
         'descr'                => 'Change the rrd heartbeat value (default 600)',
-
         'type'                 => 'text',
     ),
 );

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -42,8 +42,6 @@ $config['db_socket']             = null;
 $config['own_hostname'] = 'localhost';
 
 // Location of executables
-$config['rrdtool']                  = '/usr/bin/rrdtool';
-$config['rrdtool_version']          = 1.4; // Doesn't need to contain minor numbers.
 $config['fping']                    = '/usr/bin/fping';
 $config['fping6']                   = 'fping6';
 $config['fping_options']['retries'] = 3;

--- a/includes/mergecnf.inc.php
+++ b/includes/mergecnf.inc.php
@@ -37,7 +37,7 @@ function mergedb()
     foreach (dbFetchRows('SELECT `config_name`,`config_value` FROM `config`') as $obj) {
         assign_array_by_path($db_config, $obj['config_name'], $obj['config_value']);
     }
-    $config = array_replace_recursive($config, $db_config);
+    $config = array_replace_recursive($db_config, $config);
 }
 
 /**

--- a/includes/mergecnf.inc.php
+++ b/includes/mergecnf.inc.php
@@ -27,7 +27,7 @@
 
 /**
  * merge the database config with the global config
- * DB Config overwrites the files (to fully implement web settings)
+ * Global config overrides db
  */
 function mergedb()
 {

--- a/includes/mergecnf.inc.php
+++ b/includes/mergecnf.inc.php
@@ -27,7 +27,7 @@
 
 /**
  * merge the database config with the global config
- * Global config overrides db
+ * DB Config overwrites the files (to fully implement web settings)
  */
 function mergedb()
 {
@@ -37,7 +37,7 @@ function mergedb()
     foreach (dbFetchRows('SELECT `config_name`,`config_value` FROM `config`') as $obj) {
         assign_array_by_path($db_config, $obj['config_name'], $obj['config_value']);
     }
-    $config = array_replace_recursive($db_config, $config);
+    $config = array_replace_recursive($config, $db_config);
 }
 
 /**

--- a/includes/process_config.inc.php
+++ b/includes/process_config.inc.php
@@ -26,3 +26,11 @@
 if (empty($config['email_from'])) {
     $config['email_from'] = '"' . $config['project_name'] . '" <' . $config['email_user'] . '@' . php_uname('n') . '>';
 }
+
+// We need rrdtool so ensure it's set
+if (empty($config['rrdtool'])) {
+    $config['rrdtool'] = '/usr/bin/rrdtool';
+}
+if (empty($config['rrdtool_verion'])) {
+    $config['rrdtool_version'] = 1.4;
+}


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

to fully implement web settings (or db config) the db configs should overwrite the global ones (from files). 

discovered this issue when tried to change the rrdtool bin from web but it was still using the defaults.