### PR TITLE
fix: Fixed http-auth not honouring http_auth_guest

### DIFF
--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -60,8 +60,6 @@ try {
             } elseif ($config['auth_mechanism'] === 'http-auth') {
                 if (isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER']) {
                     $username = clean($_SERVER['PHP_AUTH_USER']);
-                } elseif (isset($config['http_auth_guest'])) {
-                    $username = $config['http_auth_guest'];
                 }
             }
 

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -56,9 +56,13 @@ try {
                 $username = clean($_REQUEST['username']);
                 $password = $_REQUEST['password'];
             } elseif (isset($_SERVER['REMOTE_USER'])) {
-                $username = $_SERVER['REMOTE_USER'];
-            } elseif (isset($_SERVER['PHP_AUTH_USER']) && $config['auth_mechanism'] === 'http-auth') {
-                $username = $_SERVER['PHP_AUTH_USER'];
+                $username = clean($_SERVER['REMOTE_USER']);
+            } elseif ($config['auth_mechanism'] === 'http-auth') {
+                if (isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER']) {
+                    $username = clean($_SERVER['PHP_AUTH_USER']);
+                } elseif (isset($config['http_auth_guest'])) {
+                    $username = $config['http_auth_guest'];
+                }
             }
 
             // form authentication

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -57,10 +57,8 @@ try {
                 $password = $_REQUEST['password'];
             } elseif (isset($_SERVER['REMOTE_USER'])) {
                 $username = clean($_SERVER['REMOTE_USER']);
-            } elseif ($config['auth_mechanism'] === 'http-auth') {
-                if (isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER']) {
-                    $username = clean($_SERVER['PHP_AUTH_USER']);
-                }
+            } elseif (isset($_SERVER['PHP_AUTH_USER']) && $config['auth_mechanism'] === 'http-auth') {
+                $username = clean($_SERVER['PHP_AUTH_USER']);
             }
 
             // form authentication

--- a/html/includes/authentication/http-auth.inc.php
+++ b/html/includes/authentication/http-auth.inc.php
@@ -3,27 +3,13 @@
 use LibreNMS\Exceptions\AuthenticationException;
 use Phpass\PasswordHash;
 
-if (!isset($_SESSION['username'])) {
-    $_SESSION['username'] = '';
-}
-
-
 function authenticate($username, $password)
 {
-    global $config;
-
-    if (isset($_SERVER['REMOTE_USER']) || isset($_SERVER['PHP_AUTH_USER'])) {
-        $_SESSION['username'] = mres($_SERVER['REMOTE_USER']) ?: mres($_SERVER['PHP_AUTH_USER']);
-
-        $row = @dbFetchRow('SELECT username FROM `users` WHERE `username`=?', array($_SESSION['username']));
-        if (isset($row['username']) && $row['username'] == $_SESSION['username']) {
-            return true;
-        } else {
-            $_SESSION['username'] = $config['http_auth_guest'];
-            return true;
-        }
+    if (user_exists($username)) {
+        return true;
     }
-    throw new AuthenticationException();
+
+    throw new AuthenticationException('No matching user found and http_auth_guest is not set');
 }
 
 
@@ -73,25 +59,34 @@ function adduser($username, $password, $level, $email = '', $realname = '', $can
 
 function user_exists($username)
 {
-    // FIXME this doesn't seem right? (adama)
-    return dbFetchCell('SELECT * FROM `users` WHERE `username` = ?', array($username));
+    global $config;
+
+    return dbFetchCell(
+        'SELECT COUNT(*) FROM `users` WHERE `username`=? OR `username`=?',
+        array($username, $config['http_auth_guest'])
+    ) > 0;
 }
 
 
 function get_userlevel($username)
 {
     global $config;
-    $level = dbFetchCell('SELECT `level` FROM `users` WHERE `username`= ?', array($username));
-    if (empty($level)) {
-        $level = dbFetchCell('SELECT `level` FROM `users` WHERE `username`= ?', array($config['http_auth_guest']));
-    }
-    return $level;
+
+    return dbFetchCell(
+        'SELECT `level` FROM `users` WHERE `username`=? OR `username`=?',
+        array($username, $config['http_auth_guest'])
+    );
 }
 
 
 function get_userid($username)
 {
-    return dbFetchCell('SELECT `user_id` FROM `users` WHERE `username`= ?', array($username));
+    global $config;
+
+    return dbFetchCell(
+        'SELECT `user_id` FROM `users` WHERE `username`=? OR `username`=?',
+        array($username, $config['http_auth_guest'])
+    );
 }
 
 

--- a/html/includes/authentication/http-auth.inc.php
+++ b/html/includes/authentication/http-auth.inc.php
@@ -80,7 +80,12 @@ function user_exists($username)
 
 function get_userlevel($username)
 {
-    return dbFetchCell('SELECT `level` FROM `users` WHERE `username`= ?', array($username));
+    global $config;
+    $level = dbFetchCell('SELECT `level` FROM `users` WHERE `username`= ?', array($username));
+    if (empty($level)) {
+        $level = dbFetchCell('SELECT `level` FROM `users` WHERE `username`= ?', array($config['http_auth_guest']));
+    }
+    return $level;
 }
 
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6697 

Users don't have to exist in the db for http-auth, when they don't we fall back to checking the http_auth_guest variable as that's defined as a fall back.