### PR TITLE
remove 'Wrong Type' string when we ask LocalAS to switch

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -6,7 +6,7 @@ if ($config['enable_bgp']) {
         $vrfs_lite_cisco = array(array('context_name'=>null));
     }
 
-    $bgpLocalAs = trim(snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn', 'BGP4-MIB'));
+    $bgpLocalAs = trim(preg_replace("/Wrong Type .*:/", "", snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn', 'BGP4-MIB')));
 
     foreach ($vrfs_lite_cisco as $vrf) {
         $device['context_name'] = $vrf['context_name'];

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -6,7 +6,7 @@ if ($config['enable_bgp']) {
         $vrfs_lite_cisco = array(array('context_name'=>null));
     }
 
-    $bgpLocalAs = trim(preg_replace("/Wrong Type .*:/", "", snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn', 'BGP4-MIB')));
+    $bgpLocalAs = trim(snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn'));
 
     foreach ($vrfs_lite_cisco as $vrf) {
         $device['context_name'] = $vrf['context_name'];


### PR DESCRIPTION
 (bug with at least Dell ON Switch)

Hi,
I am on last commit on GIT ( 6a79d44 1.28).
When i run the discover, on our Brocade switch, or fortinet, all is OK.
On our Dell Network Switch (S4810 Dell Networking OS 9.10(0.1) ), there is an error during discover :

SNMP[^[[0;36m/usr/bin/snmpbulkwalk -v2c -c COMMUNITY -Oqvn -m BGP4-MIB -M /opt/librenms/mibs:/opt/librenms/mibs/dell:/opt/librenms/mibs/f10 udp:HOSTNAME:161 .1.3.6.1.2.1.15.2^[[0m]
Wrong Type (should be INTEGER): 65050

Dell switch seems to use gauge32 return and no INTEGER (but send the good AS values).
There is only the problem during discover : If I populate the DB, the poller manage to update all other field (uptime, state, ...)

I made a very little patch in my installation and seems to work.

"-" $bgpLocalAs = trim(snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn', 'BGP4-MIB'));
"+" $bgpLocalAs = trim(preg_replace("/Wrong Type .*:/","",snmp_walk($device, '.1.3.6.1.2.1.15.2', '-Oqvn', 'BGP4-MIB')));

As we test after if it is numeric, if we have a no such id or other, the tests will be always good.

I don't know if we can do better, if the switch manufacturer does not send good type for value...



DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
