### PR TITLE
Fix typo in configuration documentation

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -552,7 +552,7 @@ You can use this array to rewrite the description of ASes that you have discover
 [Updating](../General/Updating.md)
 
 ### IPMI
-Setup the types of IPMI protocols to test a host for and it what order. Don't forget to install ipmitool on the monitoring host.
+Setup the types of IPMI protocols to test a host for and in what order. Don't forget to install ipmitool on the monitoring host.
 
 ```php
 $config['ipmi']['type'] = array();


### PR DESCRIPTION

- [x] followed [code guidelines](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


Just a small typo fix... at least that way the sentence makes more sense to me.
Simply delete this PR if I'm wrong. Thanks!