### PR TITLE
Fix Navibar Linebreaks

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1590,6 +1590,12 @@ tr.search:nth-child(odd) {
   line-height: 32px;
 }
 
+@media (min-width: 992px) and (max-width: 1280px) {
+  .navbar-brand {
+    display: none !important;
+  }
+}
+
 .navbar-brand img {
   height: 100%;
   max-width: 170px;


### PR DESCRIPTION
On width between 1199px and 1280px there is a navibar linebreak, and on
some lists there are controlles hidden.
This is related to the closed ( but in my case unfixed) issue #4604