### PR TITLE
fix: Updated the arista initial current value for dbm sensors

### DIFF
--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -115,7 +115,7 @@ if (is_array($oids)) {
                 // Check to make sure we've not already seen this sensor via cisco's entity sensor mib
                 if ($type == "power" && $device['os'] == "arista_eos" && preg_match("/DOM (R|T)x Power/i", $descr)) {
                     $type = "dbm";
-                    $current = round(10 * log10($sensor_value / 10000), 3);
+                    $current = round(10 * log10($entry['entPhySensorValue'] / 10000), 3);
                     $multiplier = 1;
                     $divisor = 1;
                     discover_sensor($valid['sensor'], $type, $device, $oid, $index, 'entity-sensor', $descr, $divisor, $multiplier, null, null, null, null, $current, 'snmp', $entPhysicalIndex, $entry['entSensorMeasuredEntity']);

--- a/includes/process_config.inc.php
+++ b/includes/process_config.inc.php
@@ -31,6 +31,6 @@ if (empty($config['email_from'])) {
 if (empty($config['rrdtool'])) {
     $config['rrdtool'] = '/usr/bin/rrdtool';
 }
-if (empty($config['rrdtool_verion'])) {
+if (empty($config['rrdtool_version'])) {
     $config['rrdtool_version'] = 1.4;
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Because the initial `$current` value was set wrong, the high / low thresholds were also wrong. 