### PR TITLE
Update graphs to use safer RRD check

### DIFF
--- a/html/includes/graphs/device/bigip_ltm_allpm_bytesin.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allpm_bytesin.inc.php
@@ -52,7 +52,7 @@ if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
         $label = $comp['label'];
         $hash = $comp['hash'];
         $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
 
             // Grab a colour from the array.

--- a/html/includes/graphs/device/bigip_ltm_allpm_bytesout.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allpm_bytesout.inc.php
@@ -52,7 +52,7 @@ if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
         $label = $comp['label'];
         $hash = $comp['hash'];
         $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
 
             // Grab a colour from the array.

--- a/html/includes/graphs/device/bigip_ltm_allpm_conns.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allpm_conns.inc.php
@@ -52,7 +52,7 @@ if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
         $label = $comp['label'];
         $hash = $comp['hash'];
         $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
 
             // Grab a colour from the array.

--- a/html/includes/graphs/device/bigip_ltm_allpm_pktsin.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allpm_pktsin.inc.php
@@ -52,7 +52,7 @@ if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
         $label = $comp['label'];
         $hash = $comp['hash'];
         $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
 
             // Grab a colour from the array.

--- a/html/includes/graphs/device/bigip_ltm_allpm_pktsout.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allpm_pktsout.inc.php
@@ -52,7 +52,7 @@ if ($components[$vars['id']]['type'] == 'f5-ltm-pool') {
         $label = $comp['label'];
         $hash = $comp['hash'];
         $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             d_echo("\n  Adding PM: " . $label . "\t+ added to the graph");
 
             // Grab a colour from the array.

--- a/html/includes/graphs/device/bigip_ltm_allvs_bytesin.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allvs_bytesin.inc.php
@@ -31,7 +31,7 @@ foreach ($components as $compid => $comp) {
     $label = $comp['label'];
     $hash = $comp['hash'];
     $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a colour from the array.
         if (isset($colours[$colcount])) {
             $colour = $colours[$colcount];

--- a/html/includes/graphs/device/bigip_ltm_allvs_bytesout.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allvs_bytesout.inc.php
@@ -31,7 +31,7 @@ foreach ($components as $compid => $comp) {
     $label = $comp['label'];
     $hash = $comp['hash'];
     $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a colour from the array.
         if (isset($colours[$colcount])) {
             $colour = $colours[$colcount];

--- a/html/includes/graphs/device/bigip_ltm_allvs_conns.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allvs_conns.inc.php
@@ -31,7 +31,7 @@ foreach ($components as $compid => $comp) {
     $label = $comp['label'];
     $hash = $comp['hash'];
     $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a colour from the array.
         if (isset($colours[$colcount])) {
             $colour = $colours[$colcount];

--- a/html/includes/graphs/device/bigip_ltm_allvs_pktsin.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allvs_pktsin.inc.php
@@ -31,7 +31,7 @@ foreach ($components as $compid => $comp) {
     $label = $comp['label'];
     $hash = $comp['hash'];
     $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a colour from the array.
         if (isset($colours[$colcount])) {
             $colour = $colours[$colcount];

--- a/html/includes/graphs/device/bigip_ltm_allvs_pktsout.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_allvs_pktsout.inc.php
@@ -31,7 +31,7 @@ foreach ($components as $compid => $comp) {
     $label = $comp['label'];
     $hash = $comp['hash'];
     $rrd_filename = rrd_name($device['hostname'], array($comp['type'], $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a colour from the array.
         if (isset($colours[$colcount])) {
             $colour = $colours[$colcount];

--- a/html/includes/graphs/device/bigip_ltm_vs_bytes.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_vs_bytes.inc.php
@@ -29,7 +29,7 @@ if (isset($components[$vars['id']])) {
     $rrd_options .= " COMMENT:'Bits           Now      Ave      Max\\n'";
 
     $rrd_filename = rrd_name($device['hostname'], array('f5-ltm-vs', $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         $rrd_options .= " DEF:INBYTES=" . $rrd_filename . ":bytesin:AVERAGE ";
         $rrd_options .= " CDEF:INBITS=INBYTES,8,* ";
         $rrd_options .= " LINE1.25:INBITS#330033:'Bits In '";

--- a/html/includes/graphs/device/bigip_ltm_vs_conns.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_vs_conns.inc.php
@@ -25,7 +25,7 @@ if (isset($components[$vars['id']])) {
     $hash = $components[$vars['id']]['hash'];
 
     $rrd_filename = rrd_name($device['hostname'], array('f5-ltm-vs', $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         require 'includes/graphs/common.inc.php';
         $ds = 'totconns';
 

--- a/html/includes/graphs/device/bigip_ltm_vs_pkts.inc.php
+++ b/html/includes/graphs/device/bigip_ltm_vs_pkts.inc.php
@@ -25,7 +25,7 @@ if (isset($components[$vars['id']])) {
     $hash = $components[$vars['id']]['hash'];
 
     $rrd_filename = rrd_name($device['hostname'], array('f5-ltm-vs', $label, $hash));
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         $ds_in  = 'pktsin';
         $ds_out = 'pktsout';
 

--- a/html/includes/graphs/device/cambium-epmp-frameUtilization.inc.php
+++ b/html/includes/graphs/device/cambium-epmp-frameUtilization.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-frameUtilization');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'%                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:dlwlanframeutilization='.$rrdfilename.':dlwlanfrut:AVERAGE ';
     $rrd_options .= ' DEF:ulwlanframeutilization='.$rrdfilename.':ulwlanfrut:AVERAGE ';

--- a/html/includes/graphs/device/cambium_250_dataRate.inc.php
+++ b/html/includes/graphs/device/cambium_250_dataRate.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-250-dataRate');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Mbps                        Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:receiveDataRate='.$rrdfilename.':receiveDataRate:AVERAGE ';
     $rrd_options .= ' DEF:transmitDataRate='.$rrdfilename.':transmitDataRate:AVERAGE ';

--- a/html/includes/graphs/device/cambium_250_modulationMode.inc.php
+++ b/html/includes/graphs/device/cambium_250_modulationMode.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-250-modulationMode');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Mode                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rxModulation='.$rrdfilename.':rxModulation:AVERAGE ';
     $rrd_options .= ' DEF:txModulation='.$rrdfilename.':txModulation:AVERAGE ';

--- a/html/includes/graphs/device/cambium_250_receivePower.inc.php
+++ b/html/includes/graphs/device/cambium_250_receivePower.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-250-receivePower');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:receivePower='.$rrdfilename.':receivePower:AVERAGE ';
     $rrd_options .= ' DEF:noiseFloor='.$rrdfilename.':noiseFloor:AVERAGE ';

--- a/html/includes/graphs/device/cambium_250_ssr.inc.php
+++ b/html/includes/graphs/device/cambium_250_ssr.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-250-ssr');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                        Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:ssr='.$rrdfilename.':ssr:AVERAGE ';
     $rrd_options .= " LINE2:ssr#9B30FF:'Signal Strength Ratio ' ";

--- a/html/includes/graphs/device/cambium_250_transmitPower.inc.php
+++ b/html/includes/graphs/device/cambium_250_transmitPower.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-250-transmitPower');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:transmitPower='.$rrdfilename.':transmitPower:AVERAGE ';
     $rrd_options .= " LINE2:transmitPower#FF0000:'Transmit Power         ' ";

--- a/html/includes/graphs/device/cambium_650_dataRate.inc.php
+++ b/html/includes/graphs/device/cambium_650_dataRate.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-650-dataRate');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Mbps                        Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:receiveDataRate='.$rrdfilename.':receiveDataRate:AVERAGE ';
     $rrd_options .= ' DEF:transmitDataRate='.$rrdfilename.':transmitDataRate:AVERAGE ';

--- a/html/includes/graphs/device/cambium_650_gps.inc.php
+++ b/html/includes/graphs/device/cambium_650_gps.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-650-gps');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'\\n'";
     $rrd_options .= ' DEF:gps='.$rrdfilename.':gps:AVERAGE ';
     $rrd_options .= " LINE2:gps#9B30FF:'GPS Status' ";

--- a/html/includes/graphs/device/cambium_650_modulationMode.inc.php
+++ b/html/includes/graphs/device/cambium_650_modulationMode.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-650-modulationMode');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Mode                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rxModulation='.$rrdfilename.':rxModulation:AVERAGE ';
     $rrd_options .= ' DEF:txModulation='.$rrdfilename.':txModulation:AVERAGE ';

--- a/html/includes/graphs/device/cambium_650_rawReceivePower.inc.php
+++ b/html/includes/graphs/device/cambium_650_rawReceivePower.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-650-rawReceivePower');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rawReceivePower='.$rrdfilename.':rawReceivePower:AVERAGE ';
     $rrd_options .= " LINE2:rawReceivePower#00FF00:'Receive Power         ' ";

--- a/html/includes/graphs/device/cambium_650_ssr.inc.php
+++ b/html/includes/graphs/device/cambium_650_ssr.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-650-ssr');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                      Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:ssr='.$rrdfilename.':ssr:AVERAGE ';
     $rrd_options .= " LINE2:ssr#9B30FF:'Signal Strength Ratio ' ";

--- a/html/includes/graphs/device/cambium_650_transmitPower.inc.php
+++ b/html/includes/graphs/device/cambium_650_transmitPower.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'cambium-650-transmitPower');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:transmitPower='.$rrdfilename.':transmitPower:AVERAGE ';
     $rrd_options .= " -l 0 ";

--- a/html/includes/graphs/device/cambium_epmp_RFStatus.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_RFStatus.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-RFStatus');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:cambiumSTADLRSSI='.$rrdfilename.':cambiumSTADLRSSI:AVERAGE ';
     $rrd_options .= ' DEF:cambiumSTADLSNR='.$rrdfilename.':cambiumSTADLSNR:AVERAGE ';

--- a/html/includes/graphs/device/cambium_epmp_access.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_access.inc.php
@@ -10,7 +10,7 @@
  */
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-access');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Value                Now     \\n'";
     $rrd_options .= ' DEF:entryAttempt='.$rrdfilename.':entryAttempt:AVERAGE ';
     $rrd_options .= ' DEF:entryAccess='.$rrdfilename.':entryAccess:AVERAGE ';

--- a/html/includes/graphs/device/cambium_epmp_freq.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_freq.inc.php
@@ -10,7 +10,7 @@
  */
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-freq');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Mhz         \\n'";
     $rrd_options .= ' DEF:freq='.$rrdfilename.':freq:AVERAGE ';
     $rrd_options .= " LINE2:freq#008080:'Frequency  ' ";

--- a/html/includes/graphs/device/cambium_epmp_gps.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_gps.inc.php
@@ -10,7 +10,7 @@
  */
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-gps');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:numTracked='.$rrdfilename.':numTracked:AVERAGE ';
     $rrd_options .= ' DEF:numVisible='.$rrdfilename.':numVisible:AVERAGE ';

--- a/html/includes/graphs/device/cambium_epmp_gpsSync.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_gpsSync.inc.php
@@ -10,7 +10,7 @@
  */
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-gpsSync');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'1 - GPS Sync Up       2 - GPS Sync Down      3 - CMM Sync     \\n'";
     $rrd_options .= ' DEF:gpsSync='.$rrdfilename.':gpsSync:AVERAGE ';
     $rrd_options .= " -l 1 ";

--- a/html/includes/graphs/device/cambium_epmp_modulation.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_modulation.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-modulation');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Value                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:uplinkMCSMode='.$rrdfilename.':uplinkMCSMode:AVERAGE ';
     $rrd_options .= ' DEF:downlinkMCSMode='.$rrdfilename.':downlinkMCSMode:AVERAGE ';

--- a/html/includes/graphs/device/cambium_epmp_registeredSM.inc.php
+++ b/html/includes/graphs/device/cambium_epmp_registeredSM.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cambium-epmp-registeredSM');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Value                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:regSM='.$rrdfilename.':regSM:AVERAGE ';
     $rrd_options .= " LINE2:regSM#73b0c2:'Registered SM       ' ";

--- a/html/includes/graphs/device/canopy-generic-frameUtilization.inc.php
+++ b/html/includes/graphs/device/canopy-generic-frameUtilization.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-frameUtilization');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'%                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:downlinkutilization='.$rrdfilename.':downlinkutilization:AVERAGE ';
     $rrd_options .= ' DEF:uplinkutilization='.$rrdfilename.':uplinkutilization:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_450_linkRadioDbm.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_linkRadioDbm.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-linkRadioDbm');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:vertical='.$rrdfilename.':vertical:AVERAGE ';
     $rrd_options .= ' DEF:horizontal='.$rrdfilename.':horizontal:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_450_masterSSR.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_masterSSR.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-masterSSR');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:ssr='.$rrdfilename.':ssr:AVERAGE ';
     $rrd_options .= " LINE2:ssr#9B30FF:'Signal Strength Ratio ' ";

--- a/html/includes/graphs/device/canopy_generic_450_powerlevel.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_powerlevel.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-powerlevel');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:last='.$rrdfilename.':last:AVERAGE ';
     $rrd_options .= " LINE2:last#003EFF:'Last      ' ";

--- a/html/includes/graphs/device/canopy_generic_450_ptpSNR.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_ptpSNR.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-ptpSNR');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:vertical='.$rrdfilename.':vertical:AVERAGE ';
     $rrd_options .= ' DEF:horizontal='.$rrdfilename.':horizontal:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_450_slaveHV.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_slaveHV.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-slaveHV');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:vertical='.$rrdfilename.':vertical:AVERAGE ';
     $rrd_options .= ' DEF:horizontal='.$rrdfilename.':horizontal:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_450_slaveSNR.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_slaveSNR.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-slaveSNR');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:vertical='.$rrdfilename.':vertical:AVERAGE ';
     $rrd_options .= ' DEF:horizontal='.$rrdfilename.':horizontal:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_450_slaveSSR.inc.php
+++ b/html/includes/graphs/device/canopy_generic_450_slaveSSR.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-450-slaveSSR');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:ssr='.$rrdfilename.':ssr:AVERAGE ';
     $rrd_options .= " LINE2:ssr#9B30FF:'Signal Strength Ratio ' ";

--- a/html/includes/graphs/device/canopy_generic_crcErrors.inc.php
+++ b/html/includes/graphs/device/canopy_generic_crcErrors.inc.php
@@ -12,7 +12,7 @@
 require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-crcErrors');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:crcErrors='.$rrdfilename.':crcErrors:AVERAGE ';
     $rrd_options .= " LINE2:crcErrors#FF0000:'CRC Errors        ' ";

--- a/html/includes/graphs/device/canopy_generic_errorCount.inc.php
+++ b/html/includes/graphs/device/canopy_generic_errorCount.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-errorCount');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:fecInErrorsCount='.$rrdfilename.':fecInErrorsCount:AVERAGE ';
     $rrd_options .= ' DEF:fecOutErrorsCount='.$rrdfilename.':fecOutErrorsCount:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_freq.inc.php
+++ b/html/includes/graphs/device/canopy_generic_freq.inc.php
@@ -10,7 +10,7 @@
  */
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-freq');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Ghz           Now     \\n'";
     $rrd_options .= ' DEF:freq='.$rrdfilename.':freq:AVERAGE ';
     $rrd_options .= " LINE2:freq#FF0000:'Frequency       ' ";

--- a/html/includes/graphs/device/canopy_generic_gpsStats.inc.php
+++ b/html/includes/graphs/device/canopy_generic_gpsStats.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-gpsStats');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Amount                Now       Ave      Max   \\n'";
     $rrd_options .= ' DEF:visible='.$rrdfilename.':visible:AVERAGE ';
     $rrd_options .= ' DEF:tracked='.$rrdfilename.':tracked:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_jitter.inc.php
+++ b/html/includes/graphs/device/canopy_generic_jitter.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-jitter');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:jitter='.$rrdfilename.':jitter:AVERAGE ';
     $rrd_options .= " AREA:jitter#3333cc:'Jitter       ' ";

--- a/html/includes/graphs/device/canopy_generic_radioDbm.inc.php
+++ b/html/includes/graphs/device/canopy_generic_radioDbm.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-radioDbm');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:dbm='.$rrdfilename.':dbm:AVERAGE ';
     $rrd_options .= ' DEF:min='.$rrdfilename.':min:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_regCount.inc.php
+++ b/html/includes/graphs/device/canopy_generic_regCount.inc.php
@@ -13,7 +13,7 @@ $scale_min = 0;
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-regCount');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:regCount='.$rrdfilename.':regCount:AVERAGE ';
     $rrd_options .= ' DEF:failed='.$rrdfilename.':failed:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_rssi.inc.php
+++ b/html/includes/graphs/device/canopy_generic_rssi.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-rssi');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rssi='.$rrdfilename.':rssi:AVERAGE ';
     $rrd_options .= " AREA:rssi#FF0000:'RSSI       ' ";

--- a/html/includes/graphs/device/canopy_generic_signalHV.inc.php
+++ b/html/includes/graphs/device/canopy_generic_signalHV.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-signalHV');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:vertical='.$rrdfilename.':vertical:AVERAGE ';
     $rrd_options .= ' DEF:horizontal='.$rrdfilename.':horizontal:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_snrHV.inc.php
+++ b/html/includes/graphs/device/canopy_generic_snrHV.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-snrHV');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:vertical='.$rrdfilename.':vertical:AVERAGE ';
     $rrd_options .= ' DEF:horizontal='.$rrdfilename.':horizontal:AVERAGE ';

--- a/html/includes/graphs/device/canopy_generic_whispGPSStats.inc.php
+++ b/html/includes/graphs/device/canopy_generic_whispGPSStats.inc.php
@@ -13,7 +13,7 @@ $scale_min = 0;
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'canopy-generic-whispGPSStats');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Value    1 = Synched   2 = Lost Sync    3 = Generating   \\n'";
     $rrd_options .= ' DEF:whispGPSStats='.$rrdfilename.':whispGPSStats:AVERAGE ';
     $rrd_options .= " -l 1 ";

--- a/html/includes/graphs/device/cisco-iosdsp.inc.php
+++ b/html/includes/graphs/device/cisco-iosdsp.inc.php
@@ -15,7 +15,7 @@ include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
 $rrd_filename = rrd_name($device['hostname'], 'cisco-iosdsp');
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                            Cur   Min  Max\\n'";
     $rrd_options .= " DEF:Total=" . $rrd_filename . ":total:AVERAGE ";
     $rrd_options .= " AREA:Total#c099ff ";

--- a/html/includes/graphs/device/cisco-iosmtp.inc.php
+++ b/html/includes/graphs/device/cisco-iosmtp.inc.php
@@ -15,7 +15,7 @@ include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
 $rrd_filename = rrd_name($device['hostname'], 'cisco-iosmtp');
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                            Cur   Min  Max\\n'";
     $rrd_options .= " DEF:Total=" . $rrd_filename . ":total:AVERAGE ";
     $rrd_options .= " AREA:Total#c099ff ";

--- a/html/includes/graphs/device/cisco-iospri.inc.php
+++ b/html/includes/graphs/device/cisco-iospri.inc.php
@@ -15,7 +15,7 @@ include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
 $rrd_filename = rrd_name($device['hostname'], 'cisco-iospri');
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                            Cur   Min  Max\\n'";
     $rrd_options .= " DEF:Total=" . $rrd_filename . ":total:AVERAGE ";
     $rrd_options .= " AREA:Total#c099ff ";

--- a/html/includes/graphs/device/cisco-iosxcode.inc.php
+++ b/html/includes/graphs/device/cisco-iosxcode.inc.php
@@ -15,7 +15,7 @@ include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
 $rrd_filename = rrd_name($device['hostname'], 'cisco-iosxcode');
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                            Cur   Min  Max\\n'";
     $rrd_options .= " DEF:Total=" . $rrd_filename . ":total:AVERAGE ";
     $rrd_options .= " AREA:Total#c099ff ";

--- a/html/includes/graphs/device/cisco-otv-mac.inc.php
+++ b/html/includes/graphs/device/cisco-otv-mac.inc.php
@@ -28,7 +28,7 @@ foreach ($components as $id => $array) {
     if ($array['otvtype'] == 'endpoint') {
         $rrd_filename = rrd_name($device['hostname'], array('cisco', 'otv', $array['endpoint'], 'mac'));
 
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
             $stack = "";
             if ($count != 0) {

--- a/html/includes/graphs/device/cisco-otv-vlan.inc.php
+++ b/html/includes/graphs/device/cisco-otv-vlan.inc.php
@@ -28,7 +28,7 @@ foreach ($components as $id => $array) {
     if ($array['otvtype'] == 'overlay') {
         $rrd_filename = rrd_name($device['hostname'], array('cisco', 'otv', $array['label'], 'vlan'));
 
-        if (file_exists($rrd_filename)) {
+        if (rrdtool_check_rrd_exists($rrd_filename)) {
             // Stack the area on the second and subsequent DS's
             $stack = "";
             if ($count != 0) {

--- a/html/includes/graphs/device/cisco_wwan_mnc.inc.php
+++ b/html/includes/graphs/device/cisco_wwan_mnc.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cisco-wwan-mnc');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= ' DEF:mnc='.$rrdfilename.':mnc:LAST ';
     $rrd_options .= ' --lower-limit 0 ';
     $rrd_options .= " --vertical-label='MNC'";

--- a/html/includes/graphs/device/cisco_wwan_rssi.inc.php
+++ b/html/includes/graphs/device/cisco_wwan_rssi.inc.php
@@ -11,7 +11,7 @@
 
 require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'cisco-wwan-rssi');
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm              Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rssi='.$rrdfilename.':rssi:AVERAGE ';
     $rrd_options .= ' --alt-autoscale';

--- a/html/includes/graphs/device/ntp_delay.inc.php
+++ b/html/includes/graphs/device/ntp_delay.inc.php
@@ -28,7 +28,7 @@ $count = 0;
 foreach ($components as $id => $array) {
     $rrd_filename = rrd_name($device['hostname'], array('ntp', $array['peer']));
 
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a color from the array.
         if (isset($config['graph_colours']['mixed'][$count])) {
             $color = $config['graph_colours']['mixed'][$count];

--- a/html/includes/graphs/device/ntp_dispersion.inc.php
+++ b/html/includes/graphs/device/ntp_dispersion.inc.php
@@ -28,7 +28,7 @@ $count = 0;
 foreach ($components as $id => $array) {
     $rrd_filename = rrd_name($device['hostname'], array('ntp', $array['peer']));
 
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a color from the array.
         if (isset($config['graph_colours']['mixed'][$count])) {
             $color = $config['graph_colours']['mixed'][$count];

--- a/html/includes/graphs/device/ntp_offset.inc.php
+++ b/html/includes/graphs/device/ntp_offset.inc.php
@@ -28,7 +28,7 @@ $count = 0;
 foreach ($components as $id => $array) {
     $rrd_filename = rrd_name($device['hostname'], array('ntp', $array['peer']));
 
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a color from the array.
         if (isset($config['graph_colours']['mixed'][$count])) {
             $color = $config['graph_colours']['mixed'][$count];

--- a/html/includes/graphs/device/ntp_stratum.inc.php
+++ b/html/includes/graphs/device/ntp_stratum.inc.php
@@ -28,7 +28,7 @@ $count = 0;
 foreach ($components as $id => $array) {
     $rrd_filename = rrd_name($device['hostname'], array('ntp', $array['peer']));
 
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         // Grab a color from the array.
         if (isset($config['graph_colours']['mixed'][$count])) {
             $color = $config['graph_colours']['mixed'][$count];

--- a/html/includes/graphs/device/service.inc.php
+++ b/html/includes/graphs/device/service.inc.php
@@ -68,7 +68,7 @@ if ($services[$vars['service']]['service_ds'] != "") {
     $ds = $vars['ds'];
     $label = $graphinfo[$vars['ds']];
 
-    if (file_exists($rrd_filename)) {
+    if (rrdtool_check_rrd_exists($rrd_filename)) {
         if (isset($check_graph)) {
             // We have a graph definition, use it.
             $rrd_additions .= $check_graph[$ds];

--- a/html/includes/graphs/device/siklu_rfAverageCinr.inc.php
+++ b/html/includes/graphs/device/siklu_rfAverageCinr.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-wireless');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'db                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:rfAverageCinr='.$rrdfilename.':rfAverageCinr:AVERAGE ';
     $rrd_options .= " LINE1:rfAverageCinr#CC0000:'CINR                 ' ";

--- a/html/includes/graphs/device/siklu_rfAverageRssi.inc.php
+++ b/html/includes/graphs/device/siklu_rfAverageRssi.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-wireless');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:rfAverageRssi='.$rrdfilename.':rfAverageRssi:AVERAGE ';
     $rrd_options .= " LINE1:rfAverageRssi#CC0000:'RSSI                 ' ";

--- a/html/includes/graphs/device/siklu_rfOperationalFrequency.inc.php
+++ b/html/includes/graphs/device/siklu_rfOperationalFrequency.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-wireless');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Hz                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:rfOperFreq='.$rrdfilename.':rfOperFreq:AVERAGE ';
     $rrd_options .= " LINE1:rfOperFreq#CC0000:'GHz                 ' ";

--- a/html/includes/graphs/device/siklu_rfinterfaceOctets.inc.php
+++ b/html/includes/graphs/device/siklu_rfinterfaceOctets.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-interface');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'bps      Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rfInOctets='.$rrdfilename.':rfInOctets:AVERAGE ';
     $rrd_options .= ' DEF:rfOutOctets='.$rrdfilename.':rfOutOctets:AVERAGE ';

--- a/html/includes/graphs/device/siklu_rfinterfaceOtherOctets.inc.php
+++ b/html/includes/graphs/device/siklu_rfinterfaceOtherOctets.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-interface');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'bps      Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rfInGoodOctets='.$rrdfilename.':rfInGoodOctets:AVERAGE ';
     $rrd_options .= ' DEF:rfInErroredOctets='.$rrdfilename.':rfInErroredOctets:AVERAGE ';

--- a/html/includes/graphs/device/siklu_rfinterfaceOtherPkts.inc.php
+++ b/html/includes/graphs/device/siklu_rfinterfaceOtherPkts.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-interface');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'pps      Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rfInGoodPkts='.$rrdfilename.':rfInGoodPkts:AVERAGE ';
     $rrd_options .= ' DEF:rfInErroredPkts='.$rrdfilename.':rfInErroredPkts:AVERAGE ';

--- a/html/includes/graphs/device/siklu_rfinterfacePkts.inc.php
+++ b/html/includes/graphs/device/siklu_rfinterfacePkts.inc.php
@@ -4,7 +4,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename = rrd_name($device['hostname'], 'siklu-interface');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'pps      Now       Ave      Max     \\n'";
     $rrd_options .= ' DEF:rfInPkts='.$rrdfilename.':rfInPkts:AVERAGE ';
     $rrd_options .= ' DEF:rfOutPkts='.$rrdfilename.':rfOutPkts:AVERAGE ';

--- a/html/includes/graphs/device/sla_icmpjitter_iajitter.inc.php
+++ b/html/includes/graphs/device/sla_icmpjitter_iajitter.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'icmpjitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":JitterIAJOut:AVERAGE ";

--- a/html/includes/graphs/device/sla_icmpjitter_jitter.inc.php
+++ b/html/includes/graphs/device/sla_icmpjitter_jitter.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'icmpjitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":JitterAvgSD:AVERAGE ";

--- a/html/includes/graphs/device/sla_icmpjitter_latency.inc.php
+++ b/html/includes/graphs/device/sla_icmpjitter_latency.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'icmpjitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":LatencyOWAvgSD:AVERAGE ";

--- a/html/includes/graphs/device/sla_icmpjitter_lost.inc.php
+++ b/html/includes/graphs/device/sla_icmpjitter_lost.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'icmpjitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur  Min  Max  Avg\\n'";
 
     $rrd_options .= " DEF:PL=" . $rrd_filename . ":PacketLoss:AVERAGE ";

--- a/html/includes/graphs/device/sla_icmpjitter_oos.inc.php
+++ b/html/includes/graphs/device/sla_icmpjitter_oos.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'icmpjitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":PacketOosSD:AVERAGE ";

--- a/html/includes/graphs/device/sla_jitter-icpif.inc.php
+++ b/html/includes/graphs/device/sla_jitter-icpif.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'jitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                           Cur  Min  Max  Avg\\n'";
 
     $rrd_options .= " DEF:ICPIF=" . $rrd_filename . ":ICPIF:AVERAGE ";

--- a/html/includes/graphs/device/sla_jitter-latency.inc.php
+++ b/html/includes/graphs/device/sla_jitter-latency.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'jitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":OWAvgSD:AVERAGE ";

--- a/html/includes/graphs/device/sla_jitter-loss.inc.php
+++ b/html/includes/graphs/device/sla_jitter-loss.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'jitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":PacketLossSD:AVERAGE ";

--- a/html/includes/graphs/device/sla_jitter-lost.inc.php
+++ b/html/includes/graphs/device/sla_jitter-lost.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'jitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur  Min  Max  Avg\\n'";
 
     $rrd_options .= " DEF:POS=" . $rrd_filename . ":PacketOutOfSequence:AVERAGE ";

--- a/html/includes/graphs/device/sla_jitter-mos.inc.php
+++ b/html/includes/graphs/device/sla_jitter-mos.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'jitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                           Cur   Min   Max   Avg\\n'";
 
     $rrd_options .= " DEF:MOS=" . $rrd_filename . ":MOS:AVERAGE ";

--- a/html/includes/graphs/device/sla_jitter.inc.php
+++ b/html/includes/graphs/device/sla_jitter.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = rrd_name($device['hostname'], array('sla', $sla['sla_nr'], 'jitter'));
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                          Cur    Min    Max    Avg\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":AvgSDJ:AVERAGE ";

--- a/html/includes/graphs/device/sub10_sub10RadioLclAFER.inc.php
+++ b/html/includes/graphs/device/sub10_sub10RadioLclAFER.inc.php
@@ -7,7 +7,7 @@ require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'sub10systems');
 
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                           Now   Min    Max\\n'";
     $rrd_options .= ' DEF:sub10RadioLclAFER='.$rrdfilename.':sub10RadioLclAFER:AVERAGE ';
     $rrd_options .= " LINE1:sub10RadioLclAFER#CC0000:'Percent               ' ";

--- a/html/includes/graphs/device/sub10_sub10RadioLclDataRate.inc.php
+++ b/html/includes/graphs/device/sub10_sub10RadioLclDataRate.inc.php
@@ -7,7 +7,7 @@ require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'sub10systems');
 
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:sub10RadioLclDataRa='.$rrdfilename.':sub10RadioLclDataRa:AVERAGE ';
     $rrd_options .= " LINE1:sub10RadioLclDataRa#CC0000:'Tx Power         ' ";

--- a/html/includes/graphs/device/sub10_sub10RadioLclLnkLoss.inc.php
+++ b/html/includes/graphs/device/sub10_sub10RadioLclLnkLoss.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'sub10systems');
 
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dB                         Now    Min     Max\\n'";
     $rrd_options .= ' DEF:sub10RadioLclLnkLos='.$rrdfilename.':sub10RadioLclLnkLos:AVERAGE ';
     $rrd_options .= " LINE1:sub10RadioLclLnkLos#CC0000:'Link Loss            ' ";

--- a/html/includes/graphs/device/sub10_sub10RadioLclRxPower.inc.php
+++ b/html/includes/graphs/device/sub10_sub10RadioLclRxPower.inc.php
@@ -7,7 +7,7 @@ require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'sub10systems');
 
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:sub10RadioLclRxPowe='.$rrdfilename.':sub10RadioLclRxPowe:AVERAGE ';
     $rrd_options .= " LINE1:sub10RadioLclRxPowe#CC0000:'Rx Power             ' ";

--- a/html/includes/graphs/device/sub10_sub10RadioLclTxPower.inc.php
+++ b/html/includes/graphs/device/sub10_sub10RadioLclTxPower.inc.php
@@ -7,7 +7,7 @@ require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'sub10systems');
 
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dBm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:sub10RadioLclTxPowe='.$rrdfilename.':sub10RadioLclTxPowe:AVERAGE ';
     $rrd_options .= " LINE1:sub10RadioLclTxPowe#CC0000:'Tx Power         ' ";

--- a/html/includes/graphs/device/sub10_sub10RadioLclVectErr.inc.php
+++ b/html/includes/graphs/device/sub10_sub10RadioLclVectErr.inc.php
@@ -7,7 +7,7 @@ require 'includes/graphs/common.inc.php';
 $rrdfilename = rrd_name($device['hostname'], 'sub10systems');
 
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dB                         Now    Min     Max\\n'";
     $rrd_options .= ' DEF:sub10RadioLclVectEr='.$rrdfilename.':sub10RadioLclVectEr:AVERAGE ';
     $rrd_options .= " LINE1:sub10RadioLclVectEr#CC0000:'Vector Error         ' ";

--- a/html/includes/graphs/device/ubnt_airfiber_Capacity.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_Capacity.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'mbps                   Now      Min       Max\\n'";
     $rrd_options .= ' DEF:rxCapacity='.$rrdfilename.':rxCapacity:AVERAGE ';
     $rrd_options .= ' DEF:txCapacity='.$rrdfilename.':txCapacity:AVERAGE ';

--- a/html/includes/graphs/device/ubnt_airfiber_LinkDist.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_LinkDist.inc.php
@@ -6,7 +6,7 @@ $rrd_options .= ' -l 0 -E ';
 
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Metres                     Now    Min     Max\\n'";
     $rrd_options .= ' DEF:radioLinkDistM='.$rrdfilename.':radioLinkDistM:AVERAGE ';
     $rrd_options .= " LINE1:radioLinkDistM#CC0000:'Distance             ' ";

--- a/html/includes/graphs/device/ubnt_airfiber_RFTotOctetsRx.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_RFTotOctetsRx.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Octets                 Now      Min     Max\\n'";
     $rrd_options .= ' DEF:rxoctetsAll='.$rrdfilename.':rxoctetsAll:AVERAGE ';
     $rrd_options .= " LINE1:rxoctetsAll#00CC00:'Rx Octets      ' ";

--- a/html/includes/graphs/device/ubnt_airfiber_RFTotOctetsTx.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_RFTotOctetsTx.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Octets                 Now      Min     Max\\n'";
     $rrd_options .= ' DEF:txoctetsAll='.$rrdfilename.':txoctetsAll:AVERAGE ';
     $rrd_options .= " LINE1:txoctetsAll#CC0000:'Tx Octets      ' ";

--- a/html/includes/graphs/device/ubnt_airfiber_RFTotPktsRx.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_RFTotPktsRx.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Packets                Now      Min     Max\\n'";
     $rrd_options .= ' DEF:rxpktsAll='.$rrdfilename.':rxpktsAll:AVERAGE ';
     $rrd_options .= " LINE1:rxpktsAll#CC0000:'Rx Packets     ' ";

--- a/html/includes/graphs/device/ubnt_airfiber_RFTotPktsTx.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_RFTotPktsTx.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Packets                Now      Min     Max\\n'";
     $rrd_options .= ' DEF:txpktsAll='.$rrdfilename.':txpktsAll:AVERAGE ';
     $rrd_options .= " LINE1:txpktsAll#CC0000:'Tx Packets     ' ";

--- a/html/includes/graphs/device/ubnt_airfiber_RadioFreqs.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_RadioFreqs.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                       Now     Min      Max\\n'";
     $rrd_options .= ' DEF:rxFrequency='.$rrdfilename.':rxFrequency:AVERAGE ';
     $rrd_options .= ' DEF:txFrequency='.$rrdfilename.':txFrequency:AVERAGE ';

--- a/html/includes/graphs/device/ubnt_airfiber_RadioTemp.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_RadioTemp.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Celcius               Now     Min      Max\\n'";
     $rrd_options .= ' DEF:radio0TempC='.$rrdfilename.':radio0TempC:AVERAGE ';
     $rrd_options .= ' DEF:radio1TempC='.$rrdfilename.':radio1TempC:AVERAGE ';

--- a/html/includes/graphs/device/ubnt_airfiber_TxPower.inc.php
+++ b/html/includes/graphs/device/ubnt_airfiber_TxPower.inc.php
@@ -6,7 +6,7 @@ $rrd_options .= ' -l 0 -E ';
 
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airfiber-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:txPower='.$rrdfilename.':txPower:AVERAGE ';
     $rrd_options .= " LINE1:txPower#CC0000:'Tx Power             ' ";

--- a/html/includes/graphs/device/ubnt_airmax_AirMaxCapacity.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_AirMaxCapacity.inc.php
@@ -8,7 +8,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                         Now   Min  Max\\n'";
     $rrd_options .= ' DEF:AirMaxCapacity='.$rrdfilename.':AirMaxCapacity:AVERAGE ';
     $rrd_options .= " LINE1:AirMaxCapacity#CC0000:'Percent              ' ";

--- a/html/includes/graphs/device/ubnt_airmax_AirMaxQuality.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_AirMaxQuality.inc.php
@@ -8,7 +8,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                         Now   Min  Max\\n'";
     $rrd_options .= ' DEF:AirMaxQuality='.$rrdfilename.':AirMaxQuality:AVERAGE ';
     $rrd_options .= " LINE1:AirMaxQuality#CC0000:'Percent              ' ";

--- a/html/includes/graphs/device/ubnt_airmax_RadioDistance.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_RadioDistance.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Metres                     Now    Min     Max\\n'";
     $rrd_options .= ' DEF:RadioDistance='.$rrdfilename.':RadioDistance:AVERAGE ';
     $rrd_options .= " LINE1:RadioDistance#CC0000:'Distance             ' ";

--- a/html/includes/graphs/device/ubnt_airmax_RadioFreq.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_RadioFreq.inc.php
@@ -6,7 +6,7 @@ $rrd_options .= ' -l 0 -E ';
 
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                           Now    Min     Max\\n'";
     $rrd_options .= ' DEF:RadioFreq='.$rrdfilename.':RadioFreq:AVERAGE ';
     $rrd_options .= " LINE1:RadioFreq#CC0000:'Frequency            ' ";

--- a/html/includes/graphs/device/ubnt_airmax_RadioRssi_0.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_RadioRssi_0.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:RadioRssi_0='.$rrdfilename.':RadioRssi_0:AVERAGE ';
     $rrd_options .= " LINE1:RadioRssi_0#CC0000:'RSSI                 ' ";

--- a/html/includes/graphs/device/ubnt_airmax_RadioRssi_1.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_RadioRssi_1.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:RadioRssi_1='.$rrdfilename.':RadioRssi_1:AVERAGE ';
     $rrd_options .= " LINE1:RadioRssi_1#00FF00:'RSSI                 ' ";

--- a/html/includes/graphs/device/ubnt_airmax_RadioTxPower.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_RadioTxPower.inc.php
@@ -9,7 +9,7 @@ $rrd_options .= ' -l 0 -E ';
 
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:RadioTxPower='.$rrdfilename.':RadioTxPower:AVERAGE ';
     $rrd_options .= " LINE1:RadioTxPower#CC0000:'Tx Power             ' ";

--- a/html/includes/graphs/device/ubnt_airmax_WlStatCcq.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatCcq.inc.php
@@ -9,7 +9,7 @@ $rrd_options .= ' -l 0 -E ';
 
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'Percent                    Now    Min     Max\\n'";
     $rrd_options .= ' DEF:WlStatCcq='.$rrdfilename.':WlStatCcq:AVERAGE ';
     $rrd_options .= " LINE1:WlStatCcq#CC0000:'CCQ                  ' ";

--- a/html/includes/graphs/device/ubnt_airmax_WlStatNoiseFloor.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatNoiseFloor.inc.php
@@ -8,7 +8,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                      Now      Min     Max\\n'";
     $rrd_options .= ' DEF:WlStatNoiseFloor='.$rrdfilename.':WlStatNoiseFloor:AVERAGE ';
     $rrd_options .= " LINE1:WlStatNoiseFloor#CC0000:'Noise             ' ";

--- a/html/includes/graphs/device/ubnt_airmax_WlStatRssi.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatRssi.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                        Now    Min     Max\\n'";
     $rrd_options .= ' DEF:WlStatRssi='.$rrdfilename.':WlStatRssi:AVERAGE ';
     $rrd_options .= " LINE1:WlStatRssi#CC0000:'RSSI                 ' ";

--- a/html/includes/graphs/device/ubnt_airmax_WlStatRxRate.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatRxRate.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'mbps                   Now      Min       Max\\n'";
     $rrd_options .= ' DEF:WlStatRxRate='.$rrdfilename.':WlStatRxRate:AVERAGE ';
     $rrd_options .= ' CDEF:WlStatRxRateC=WlStatRxRate,1000,/ ';

--- a/html/includes/graphs/device/ubnt_airmax_WlStatSignal.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatSignal.inc.php
@@ -9,7 +9,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrdfilename  = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'dbm                      Now      Min     Max\\n'";
     $rrd_options .= " DEF:WlStatSignal=".$rrdfilename.":WlStatSignal:AVERAGE ";
     $rrd_options .= " LINE1:WlStatSignal#CC0000:'Signal            ' ";

--- a/html/includes/graphs/device/ubnt_airmax_WlStatStaCount.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatStaCount.inc.php
@@ -6,7 +6,7 @@ $rrd_options .= ' -l 0 -E ';
 
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'                         Now   Min  Max\\n'";
     $rrd_options .= ' DEF:WlStatStaCount='.$rrdfilename.':WlStatStaCount:AVERAGE ';
     $rrd_options .= " LINE1:WlStatStaCount#CC0000:'Stations             ' ";

--- a/html/includes/graphs/device/ubnt_airmax_WlStatTxRate.inc.php
+++ b/html/includes/graphs/device/ubnt_airmax_WlStatTxRate.inc.php
@@ -5,7 +5,7 @@ require 'includes/graphs/common.inc.php';
 // $rrd_options .= " -l 0 -E ";
 $rrdfilename = rrd_name($device['hostname'], 'ubnt-airmax-mib');
 
-if (file_exists($rrdfilename)) {
+if (rrdtool_check_rrd_exists($rrdfilename)) {
     $rrd_options .= " COMMENT:'mbps                   Now      Min       Max\\n'";
     $rrd_options .= ' DEF:WlStatTxRate='.$rrdfilename.':WlStatTxRate:AVERAGE ';
     $rrd_options .= ' CDEF:WlStatTxRateC=WlStatTxRate,1000,/ ';

--- a/html/includes/graphs/port/cbqos_bufferdrops.inc.php
+++ b/html/includes/graphs/port/cbqos_bufferdrops.inc.php
@@ -61,7 +61,7 @@ foreach ($components as $id => $array) {
             d_echo("\n  Class: ".$components[$id]['label']."\t+ added to the graph");
             $rrd_filename = rrd_name($device['hostname'], array('port', $array['ifindex'], 'cbqos', $array['sp-id'], $array['sp-obj']));
 
-            if (file_exists($rrd_filename)) {
+            if (rrdtool_check_rrd_exists($rrd_filename)) {
                 // Stack the area on the second and subsequent DS's
                 $stack = "";
                 if ($count != 0) {

--- a/html/includes/graphs/port/cbqos_qosdrops.inc.php
+++ b/html/includes/graphs/port/cbqos_qosdrops.inc.php
@@ -61,7 +61,7 @@ foreach ($components as $id => $array) {
             d_echo("\n  Class: ".$components[$id]['label']."\t+ added to the graph");
             $rrd_filename = rrd_name($device['hostname'], array('port', $array['ifindex'], 'cbqos', $array['sp-id'], $array['sp-obj']));
 
-            if (file_exists($rrd_filename)) {
+            if (rrdtool_check_rrd_exists($rrd_filename)) {
                 // Stack the area on the second and subsequent DS's
                 $stack = "";
                 if ($count != 0) {

--- a/html/includes/graphs/port/cbqos_traffic.inc.php
+++ b/html/includes/graphs/port/cbqos_traffic.inc.php
@@ -61,7 +61,7 @@ foreach ($components as $id => $array) {
             d_echo("\n  Class: ".$components[$id]['label']."\t+ added to the graph");
             $rrd_filename = rrd_name($device['hostname'], array('port', $array['ifindex'], 'cbqos', $array['sp-id'], $array['sp-obj']));
 
-            if (file_exists($rrd_filename)) {
+            if (rrdtool_check_rrd_exists($rrd_filename)) {
                 // Stack the area on the second and subsequent DS's
                 $stack = "";
                 if ($count != 0) {

--- a/html/includes/graphs/sla-jitter-jitter.inc.php
+++ b/html/includes/graphs/sla-jitter-jitter.inc.php
@@ -17,7 +17,7 @@ require 'includes/graphs/common.inc.php';
 $rrd_options .= ' -l 0 -E ';
 $rrd_filename = $config['rrd_dir']."/".$device['hostname']."/".safename('sla-'.$sla['sla_nr'].'-jitter.rrd');
 
-if (file_exists($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_options .= " COMMENT:'                            Cur   Min  Max\\n'";
 
     $rrd_options .= " DEF:SD=" . $rrd_filename . ":AvgSDJ:AVERAGE ";

--- a/html/includes/graphs/smokeping/in.inc.php
+++ b/html/includes/graphs/smokeping/in.inc.php
@@ -30,13 +30,13 @@ if ($width > '500') {
 $filename_dir = generate_smokeping_file($device);
 if ($src['hostname'] == $config['own_hostname']) {
     $filename = $filename_dir . $device['hostname'].'.rrd';
-    if (!file_exists($filename_dir.$device['hostname'].'.rrd')) {
+    if (!rrdtool_check_rrd_exists($filename_dir.$device['hostname'].'.rrd')) {
         // Try with dots in hostname replaced by underscores
         $filename = $filename_dir . str_replace('.', '_', $device['hostname']).'.rrd';
     }
 } else {
     $filename = $filename_dir . $device['hostname'] .'~'.$src['hostname'].'.rrd';
-    if (!file_exists($filename)) {
+    if (!rrdtool_check_rrd_exists($filename)) {
         // Try with dots in hostname replaced by underscores
         $filename = $filename_dir . str_replace('.', '-', $device['hostname']) .'~'.$src['hostname'].'.rrd';
     }

--- a/html/includes/graphs/smokeping/out.inc.php
+++ b/html/includes/graphs/smokeping/out.inc.php
@@ -29,13 +29,13 @@ if ($width > '500') {
 
 if ($device['hostname'] == $config['own_hostname']) {
     $filename = $config['smokeping']['dir'].$dest['hostname'].'.rrd';
-    if (!file_exists($filename)) {
+    if (!rrdtool_check_rrd_exists($filename)) {
         // Try with dots in hostname replaced by underscores
         $filename = $config['smokeping']['dir'].str_replace('.', '_', $dest['hostname']).'.rrd';
     }
 } else {
     $filename = $config['smokeping']['dir'].$dest['hostname'].'~'.$device['hostname'].'.rrd';
-    if (!file_exists($filename)) {
+    if (!rrdtool_check_rrd_exists($filename)) {
         // Try with dots in hostname replaced by underscores
         $filename = $config['smokeping']['dir'].str_replace('.', '_', $dest['hostname']).'~'.$device['hostname'].'.rrd';
     }


### PR DESCRIPTION
Graphs that were using `file_exists()` to check for the presence of RRD
files now use `rrdtool_check_rrd_exists()` instead. This is a fix for
distributed poller configurations that are running `rrdcached` on a
different host.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
