### PR TITLE
Fix: Retrieval of hardware and version from AirOS 8.x

### DIFF
--- a/includes/polling/os/airos.inc.php
+++ b/includes/polling/os/airos.inc.php
@@ -3,7 +3,9 @@
 foreach (array(10,5) as $i) {
     $result = snmp_get_multi_oid($device, "dot11manufacturerProductName.$i dot11manufacturerProductVersion.$i", '-OQUs', 'IEEE802dot11-MIB');
 
-    if (is_array($result)) {
+    // If invalid, $result contains one empty element.
+    // So we have to verify it contains exactly two elements.
+    if (count($result) == 2) {
         $hardware = 'Ubiquiti ' . $result["dot11manufacturerProductName.$i"];
         $version  = $result["dot11manufacturerProductVersion.$i"];
         list(, $version) = preg_split('/\.v/', $version);

--- a/includes/polling/os/airos.inc.php
+++ b/includes/polling/os/airos.inc.php
@@ -1,8 +1,16 @@
 <?php
 
-$hardware = 'Ubiquiti '.trim(snmp_get($device, 'dot11manufacturerProductName.10', '-Ovq', 'IEEE802dot11-MIB'));
+foreach (array(10,5) as $i) {
+    $result = snmp_get_multi_oid($device,"dot11manufacturerProductName.$i dot11manufacturerProductVersion.$i", '-OQUs', 'IEEE802dot11-MIB');
 
-$version         = trim(snmp_get($device, 'dot11manufacturerProductVersion.10', '-Ovq', 'IEEE802dot11-MIB'));
-list(, $version) = preg_split('/\.v/', $version);
+    if ($result) {
+        $hardware = 'Ubiquiti ' . $result["dot11manufacturerProductName.$i"];
+        $version  = $result["dot11manufacturerProductVersion.$i"];
+        list(, $version) = preg_split('/\.v/', $version);
+        break;
+    }
+}
+
+unset($result);
 
 // EOF

--- a/includes/polling/os/airos.inc.php
+++ b/includes/polling/os/airos.inc.php
@@ -1,9 +1,9 @@
 <?php
 
 foreach (array(10,5) as $i) {
-    $result = snmp_get_multi_oid($device,"dot11manufacturerProductName.$i dot11manufacturerProductVersion.$i", '-OQUs', 'IEEE802dot11-MIB');
+    $result = snmp_get_multi_oid($device, "dot11manufacturerProductName.$i dot11manufacturerProductVersion.$i", '-OQUs', 'IEEE802dot11-MIB');
 
-    if (!empty($result)) {
+    if (is_array($result)) {
         $hardware = 'Ubiquiti ' . $result["dot11manufacturerProductName.$i"];
         $version  = $result["dot11manufacturerProductVersion.$i"];
         list(, $version) = preg_split('/\.v/', $version);

--- a/includes/polling/os/airos.inc.php
+++ b/includes/polling/os/airos.inc.php
@@ -1,8 +1,8 @@
 <?php
 
-$hardware = 'Ubiquiti '.trim(snmp_get($device, 'dot11manufacturerProductName.5', '-Ovq', 'IEEE802dot11-MIB'));
+$hardware = 'Ubiquiti '.trim(snmp_get($device, 'dot11manufacturerProductName.10', '-Ovq', 'IEEE802dot11-MIB'));
 
-$version         = trim(snmp_get($device, 'dot11manufacturerProductVersion.5', '-Ovq', 'IEEE802dot11-MIB'));
+$version         = trim(snmp_get($device, 'dot11manufacturerProductVersion.10', '-Ovq', 'IEEE802dot11-MIB'));
 list(, $version) = preg_split('/\.v/', $version);
 
 // EOF

--- a/includes/polling/os/airos.inc.php
+++ b/includes/polling/os/airos.inc.php
@@ -3,7 +3,7 @@
 foreach (array(10,5) as $i) {
     $result = snmp_get_multi_oid($device,"dot11manufacturerProductName.$i dot11manufacturerProductVersion.$i", '-OQUs', 'IEEE802dot11-MIB');
 
-    if ($result) {
+    if (!empty($result)) {
         $hardware = 'Ubiquiti ' . $result["dot11manufacturerProductName.$i"];
         $version  = $result["dot11manufacturerProductVersion.$i"];
         list(, $version) = preg_split('/\.v/', $version);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I don't have old AirOS devices to test against.