### PR TITLE
fix: Strip " from rPi temp sensor discovery

### DIFF
--- a/includes/discovery/sensors/temperature/linux.inc.php
+++ b/includes/discovery/sensors/temperature/linux.inc.php
@@ -6,6 +6,7 @@
 
 $sensor_oid = ".1.3.6.1.4.1.8072.1.3.2.4.1.2.9.114.97.115.112.98.101.114.114.121.1";
 $value = snmp_get($device, $sensor_oid, '-Oqve');
+$value = trim($value, '"');
 if (is_numeric($value)) {
     $sensor_type = "raspberry_temp";
     $descr = "CPU Temp";


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I'm thinking we should strip "" from the start/end output of snmp results within snmp.inc.php. Coming across this too much now.