### PR TITLE
Fix: Add support to use IP addresses for NfSen filenames

### DIFF
--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -397,7 +397,12 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
                     $nfsensuffix = $config['nfsen_suffix'];
                 }
 
-                $basefilename_underscored = preg_replace('/\./', $config['nfsen_split_char'], $device['hostname']);
+                if($config['nfsen_split_char']) {
+                    $basefilename_underscored = preg_replace('/\./', $config['nfsen_split_char'], $device['hostname']);
+                } else {
+                    $basefilename_underscored = $device['hostname'];
+                }
+
                 $nfsen_filename           = preg_replace('/'.$nfsensuffix.'/', '', $basefilename_underscored);
                 if (is_file($nfsenrrds.$nfsen_filename.'.rrd')) {
                     $nfsen_rrd_file = $nfsenrrds.$nfsen_filename.'.rrd';

--- a/html/pages/device.inc.php
+++ b/html/pages/device.inc.php
@@ -397,7 +397,7 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
                     $nfsensuffix = $config['nfsen_suffix'];
                 }
 
-                if($config['nfsen_split_char']) {
+                if (isset($config['nfsen_split_char']) && !empty($config['nfsen_split_char'])) {
                     $basefilename_underscored = preg_replace('/\./', $config['nfsen_split_char'], $device['hostname']);
                 } else {
                     $basefilename_underscored = $device['hostname'];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Many environments that I've worked on doesn't add a DNS name to it's network devices. So I usually have IP addresses in monitoring systems. However, NfSen integration assumes using an fqdn. So I'm thinking if we do not set $config['nfsen_split_char'] it assumes we're using an IP or a hostname (not a fqdn)