### PR TITLE
fix: Check HC counters individually

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -443,7 +443,7 @@ foreach ($ports as $port) {
         }
 
         if ($device['os'] === 'airos-af' && $port['ifAlias'] === 'eth0') {
-            $airos_stats = snmpwalk_cache_oid($device, '.1.3.6.1.4.1.41112.1.3.3.1', $airos_stats, 'UBNT-AirFIBER-MIB');
+            $airos_stats = snmpwalk_cache_oid($device, '.1.3.6.1.4.1.41112.1.3.3.1', array(), 'UBNT-AirFIBER-MIB');
             $this_port['ifInOctets'] = $airos_stats[1]['rxOctetsOK'];
             $this_port['ifOutOctets'] = $airos_stats[1]['txOctetsOK'];
             $this_port['ifInErrors'] = $airos_stats[1]['rxErroredFrames'];
@@ -483,7 +483,7 @@ foreach ($ports as $port) {
         }
 
         if (isset($this_port['ifHighSpeed']) && is_numeric($this_port['ifHighSpeed'])) {
-            d_echo('HighSpeed ');
+            d_echo('ifHighSpeed ');
             $this_port['ifSpeed'] = ($this_port['ifHighSpeed'] * 1000000);
         } elseif (isset($this_port['ifSpeed']) && is_numeric($this_port['ifSpeed'])) {
             d_echo('ifSpeed ');

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -119,6 +119,17 @@ $table_base_oids = array(
     'ifAdminStatus',
 );
 
+$hc_mappings = array(
+    'ifHCInOctets' => 'ifInOctets',
+    'ifHCOutOctets' => 'ifOutOctets',
+    'ifHCInUcastPkts' => 'ifInUcastPkts',
+    'ifHCOutUcastPkts' => 'ifOutUcastPkts',
+    'ifHCInBroadcastPkts' => 'ifInBroadcastPkts',
+    'ifHCOutBroadcastPkts' => 'ifOutBroadcastPkts',
+    'ifHCInMulticastPkts' => 'ifInMulticastPkts',
+    'ifHCOutMulticastPkts' => 'ifOutMulticastPkts',
+);
+
 $hc_oids = array(
     'ifInMulticastPkts',
     'ifInBroadcastPkts',
@@ -431,15 +442,6 @@ foreach ($ports as $port) {
             $port['update']['poll_period'] = $polled_period;
         }
 
-        // use HC values if they are available
-        if (!isset($this_port['ifInOctets'])) {
-            echo "HC ";
-            $this_port['ifInOctets'] = $this_port['ifHCInOctets'];
-            $this_port['ifOutOctets'] = $this_port['ifHCOutOctets'];
-            $this_port['ifInUcastPkts'] = $this_port['ifHCInUcastPkts'];
-            $this_port['ifOutUcastPkts'] = $this_port['ifHCOutUcastPkts'];
-        }
-
         if ($device['os'] === 'airos-af' && $port['ifAlias'] === 'eth0') {
             $airos_stats = snmpwalk_cache_oid($device, '.1.3.6.1.4.1.41112.1.3.3.1', $airos_stats, 'UBNT-AirFIBER-MIB');
             $this_port['ifInOctets'] = $airos_stats[1]['rxOctetsOK'];
@@ -470,12 +472,14 @@ foreach ($ports as $port) {
             $this_port['ifPhysAddress']              = zeropad($a_a).zeropad($a_b).zeropad($a_c).zeropad($a_d).zeropad($a_e).zeropad($a_f);
         }
 
-        if (is_numeric($this_port['ifHCInBroadcastPkts']) && is_numeric($this_port['ifHCOutBroadcastPkts']) && is_numeric($this_port['ifHCInMulticastPkts']) && is_numeric($this_port['ifHCOutMulticastPkts']) && $device['os'] !== 'ciscosb') {
-            echo 'HC ';
-            $this_port['ifInBroadcastPkts']  = $this_port['ifHCInBroadcastPkts'];
-            $this_port['ifOutBroadcastPkts'] = $this_port['ifHCOutBroadcastPkts'];
-            $this_port['ifInMulticastPkts']  = $this_port['ifHCInMulticastPkts'];
-            $this_port['ifOutMulticastPkts'] = $this_port['ifHCOutMulticastPkts'];
+        // use HC values if they are available
+        foreach ($hc_mappings as $hc_oid => $if_oid) {
+            if (isset($this_port[$hc_oid]) && $this_port[$hc_oid] > $this_port[$if_oid]) {
+                d_echo("$hc_oid ");
+                $this_port[$if_oid] = $this_port[$hc_oid];
+            } else {
+                d_echo("$if_oid ");
+            }
         }
 
         if (isset($this_port['ifHighSpeed']) && is_numeric($this_port['ifHighSpeed'])) {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -474,7 +474,7 @@ foreach ($ports as $port) {
 
         // use HC values if they are available
         foreach ($hc_mappings as $hc_oid => $if_oid) {
-            if (isset($this_port[$hc_oid]) && $this_port[$hc_oid] > $this_port[$if_oid]) {
+            if (isset($this_port[$hc_oid]) && $this_port[$hc_oid]) {
                 d_echo("$hc_oid ");
                 $this_port[$if_oid] = $this_port[$hc_oid];
             } else {


### PR DESCRIPTION
Vendors are very inconsistent returning ifXTable values.
Some only implement some of them (seemingly randomly).
Others return them, but they are always 0.

This attempts to fix that by checking each value individually.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
