### PR TITLE
Fix for syslog-messages from zywall (USG series)

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -113,6 +113,18 @@ function process_syslog($entry, $update)
                 $entry['program'] = $matches['program'];
             }
             unset($matches);
+        } elseif ($os == 'zywall') {
+            // Zwwall sends messages without all the fields, so the offset is wrong
+            $msg = preg_replace("/\" /", '";', stripslashes($entry['program'].':'.$entry['msg']));
+            $msg = str_getcsv($msg, ';');
+            $entry['program'] = null;
+            foreach ($msg as $param) {
+                list($var, $val) = explode("=", $param);
+                if ($var == 'cat') {
+                    $entry['program'] = str_replace('"', '', $val);
+                }
+            }
+            $entry['msg'] = join(" ", $msg);
         }//end if
 
         if (!isset($entry['program'])) {

--- a/tests/SyslogTest.php
+++ b/tests/SyslogTest.php
@@ -234,4 +234,18 @@ class SyslogTest extends \PHPUnit_Framework_TestCase
             array('device_id'=>1, 'program'=>'SNTP', 'msg'=>'updated time by -4 seconds')
         );
     }
+    public function testZywallSyslog()
+    {
+        // populate fake $dev_cache and $config
+        global $config, $dev_cache;
+        $dev_cache['1.1.1.1'] = array('device_id' => 1, 'os' => 'zywall', 'version' => 1);
+        $config = array();
+        $config['syslog_filter'] = array();
+
+        // ---- USG60W ----
+        $this->checkSyslog(
+            "1.1.1.1||local1||info||info||8e||2017-06-14 17:51:25||0\" dst=\"0.0.0.0:0\" msg=\"DHCP server assigned 195.159.132.109 to Chromecast(6C:AD:F8:B1:10:1D)\" note=\"DHCP ACK\" user=\"unknown\" devID=\"a0e4cb7d7f52\" cat=\"DHCP\"||src=\"0.0.0.0",
+            array('device_id'=>1, 'program'=>'DHCP', 'msg'=>'src="0.0.0.0:0" dst="0.0.0.0:0" msg="DHCP server assigned 195.159.132.109 to Chromecast(6C:AD:F8:B1:10:1D)" note="DHCP ACK" user="unknown" devID="a0e4cb7d7f52" cat="DHCP"')
+        );
+    }
 }


### PR DESCRIPTION
I am not sure this works for ALL ZyWalls, but it seems like host os is used before, so I just assumed Zyxel have some kind of consistency in their bugs...
This patch makes nicely formatted Syslog entries from my USG60 at least.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
