### PR TITLE
Change locks to use flock, instead of pid checking

### DIFF
--- a/LibreNMS/FileLock.php
+++ b/LibreNMS/FileLock.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * LibreNMS
+ *
+ *   This file is part of LibreNMS.
+ *
+ * @package    LibreNMS
+ * @subpackage FileLock
+ * @copyright  (C) 2017
+ *
+ */
+
+namespace LibreNMS;
+
+class FileLock
+{
+    private $name = "";
+    private $file = "";
+    /**
+     * @var resource | false
+     */
+    private $handle = false;
+    private $acquired = false;
+
+    private function __construct($lock_name)
+    {
+        global $config;
+
+        $this->name = $lock_name;
+        $this->file = "$config[install_dir]/.$lock_name.lock";
+        $this->handle = fopen($this->file, "w+");
+    }
+
+    public function __destruct()
+    {
+        $this->release();
+    }
+
+    /**
+     * Release the lock.
+     */
+    public function release()
+    {
+        if (!$this->acquired) {
+            return;
+        }
+
+        if ($this->handle !== false) {
+            flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+        }
+        if (file_exists($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    /**
+     * Given a lock name, try to acquire the lock.
+     * On success return a FileLock object, or on failure return false.
+     * @param string $lock_name Name of lock
+     * @return mixed
+     */
+    public static function lock($lock_name)
+    {
+        $lock = new self($lock_name);
+        if ($lock->handle === false) {
+            return false;
+        }
+
+        if (flock($lock->handle, LOCK_EX | LOCK_NB)) {
+            $lock->acquired = true;
+            return $lock;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Given a lock name, try to acquire the lock, exiting on failure.
+     * On success return a FileLock object.
+     * @param string $lock_name Name of lock
+     * @return FileLock
+     */
+    public static function lockOrDie($lock_name)
+    {
+        $lock = self::lock($lock_name);
+
+        if ($lock === false) {
+            echo "Failed to acquire lock $lock_name, exiting\n";
+            exit(1);
+        }
+        return $lock;
+    }
+}

--- a/alerts.php
+++ b/alerts.php
@@ -30,7 +30,7 @@ require __DIR__ . '/includes/init.php';
 
 $options = getopt('d::');
 
-set_lock('alerts');
+$alerts_lock = \LibreNMS\FileLock::lockOrDie('alerts');
 
 if (isset($options['d'])) {
     echo "DEBUG!\n";
@@ -60,4 +60,4 @@ if (!defined('TEST') && $config['alert']['disable'] != 'true') {
     echo 'End  : '.date('r')."\r\n";
 }
 
-release_lock('alerts');
+$alerts_lock->release();

--- a/discovery.php
+++ b/discovery.php
@@ -33,7 +33,7 @@ if (isset($options['h'])) {
         $where = ' ';
         $doing = 'all';
     } elseif ($options['h'] == 'new') {
-        set_lock('new-discovery');
+        $new_discovery_lock = \LibreNMS\FileLock::lockOrDie('new-discovery');
         $where = 'AND `last_discovered` IS NULL';
         $doing = 'new';
     } elseif ($options['h']) {
@@ -140,8 +140,11 @@ if ($discovered_devices) {
     if ($doing === 'new') {
         // We have added a new device by this point so we might want to do some other work
         oxidized_reload_nodes();
-        release_lock('new-discovery');
     }
+}
+
+if ($doing === 'new') {
+    $new_discovery_lock->release();
 }
 
 $string = $argv[0]." $doing ".date($config['dateformat']['compact'])." - $discovered_devices devices discovered in $proctime secs";


### PR DESCRIPTION
Change locks to use flock, as pid checking is not sufficient when PID Namespaces are involved.

On my system I use pid namespaces for cron jobs. So when `discovery.php -h new` runs, it always has the pid of 3 - which prevents the pid based locks from working. Using flock instead gets around this issue.

An alternative to this would be to use mysql advisory locks (the `GET_LOCK()` function).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`