### PR TITLE
Set travis to use php 5.6.29 whilst upstream issue is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     env: SKIP_STYLE_CHECK=1
   - php: 5.5
     env: SKIP_STYLE_CHECK=1
-  - php: 5.6
+  - php: 5.6.29
     env: SKIP_STYLE_CHECK=1 EXECUTE_BUILD_DOCS=true EXECUTE_BUILD_SCHEMA=false
 #  - php: hhvm
 #    env: SKIP_STYLE_CHECK=1


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Work around for travis 5.6 build failures.