### PR TITLE
Make UBNT Airos type: wireless

### DIFF
--- a/includes/definitions/airos.yaml
+++ b/includes/definitions/airos.yaml
@@ -1,6 +1,6 @@
 os: airos
 text: 'Ubiquiti AirOS'
-type: network
+type: wireless
 icon: ubiquiti
 nobulk: 1
 group: ubnt


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Because it is. Also airos-af is type: wireless