### PR TITLE
refactor: Add an option to force transport for the snmp auto discovery

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -106,13 +106,19 @@ Enabled by default.
 This module is invoked from bgp-peers discovery module.
 
 #### SNMP Scan
-This isn't actually an auto- mechanism but manually invoked.
+This isn't actually an auto-mechanism but manually invoked.
 
 It's designed to scan through all of the subnets in your config or what you have manually specified 
 to automatically add devices. An example of it's usage is:
 
 ```bash
 ./snmp-scan.php -r 192.168.0.0/24
+```
+
+You can choose to use UDP, TCP or both protocols for discovering your devices. Running only UDP can speed up your discovery if you're not using TCP for SNMP:
+
+```bash
+./snmp-scan.php -r 192.168.0.0/24 -t udp
 ```
 
 #### Discovering devices by IP

--- a/snmp-scan.php
+++ b/snmp-scan.php
@@ -41,7 +41,7 @@ if ($config['autodiscovery']['snmpscan'] === false) {
     exit(2);
 }
 
-function perform_snmp_scan($net, $force_network, $force_broadcast)
+function perform_snmp_scan($net, $force_network, $force_broadcast, $force_transport)
 {
     global $stats, $config, $debug, $vdebug, $more_info;
     echo 'Range: '.$net->network.'/'.$net->bitmask.PHP_EOL;
@@ -108,7 +108,7 @@ function perform_snmp_scan($net, $force_network, $force_broadcast)
             }
             continue;
         }
-        foreach (array('udp','tcp') as $transport) {
+        foreach ($force_transport as $transport) {
             try {
                 addHost(gethostbyaddr($host), '', $config['snmp']['port'], $transport, $config['distributed_poller_group']);
                 $stats['added']++;
@@ -155,12 +155,13 @@ function perform_snmp_scan($net, $force_network, $force_broadcast)
     echo PHP_EOL;
 }
 
-$opts  = getopt('r:d::v::i::n::b::l::h::');
+$opts  = getopt('r:t:d::v::i::n::b::l::h::');
 $stats = array('count'=> 0, 'known'=>0, 'added'=>0, 'failed'=>0);
 $start = false;
 $debug = false;
 $quiet = 1;
 $net   = false;
+$force_transport = array('udp','tcp');
 
 if (isset($opts['h']) || (empty($opts) && (!isset($config['nets']) || empty($config['nets'])))) {
     echo 'Usage: '.$argv[0].' -r <CIDR_Range> [-d] [-l] [-h]'.PHP_EOL;
@@ -177,6 +178,7 @@ if (isset($opts['h']) || (empty($opts) && (!isset($config['nets']) || empty($con
     echo '  -i                Provide more information on actions'.PHP_EOL;
     echo '  -l                Show Legend'.PHP_EOL;
     echo '  -h                Print this text'.PHP_EOL;
+    echo '  -t                Force transport protocol. Ex : -t udp or -t tcp. If not set => both'.PHP_EOL;
     exit(0);
 }
 if (isset($opts['d']) || isset($opts['v'])) {
@@ -201,10 +203,21 @@ if (isset($opts['i'])) {
     $more_info = true;
 }
 
+if (isset($opts['t'])) {
+    switch ($opts['t']) {
+        case 'udp':
+            $force_transport = array('udp');
+        break;
+        case 'tcp':
+            $force_transport = array('tcp');
+        break;
+    }
+}
+
 if (isset($opts['r'])) {
     $net = Net_IPv4::parseAddress($opts['r']);
     if (ip2long($net->network) !== false) {
-        perform_snmp_scan($net, $force_network, $force_broadcast);
+        perform_snmp_scan($net, $force_network, $force_broadcast, $force_transport);
         echo 'Scanned '.$stats['count'].' IPs, Already known '.$stats['known'].' Devices, Added '.$stats['added'].' Devices, Failed to add '.$stats['failed'].' Devices.'.PHP_EOL;
         echo 'Runtime: '.(microtime(true)-$ts).' secs'.PHP_EOL;
     } else {
@@ -217,7 +230,7 @@ if (isset($opts['r'])) {
     }
     foreach ($config['nets'] as $subnet) {
         $net = Net_IPv4::parseAddress($subnet);
-        perform_snmp_scan($net, $force_network, $force_broadcast);
+        perform_snmp_scan($net, $force_network, $force_broadcast, $force_transport);
     }
     echo 'Scanned '.$stats['count'].' IPs, Already know '.$stats['known'].' Devices, Added '.$stats['added'].' Devices, Failed to add '.$stats['failed'].' Devices.'.PHP_EOL;
     echo 'Runtime: '.(microtime(true)-$ts).' secs'.PHP_EOL;

--- a/snmp-scan.php
+++ b/snmp-scan.php
@@ -41,7 +41,7 @@ if ($config['autodiscovery']['snmpscan'] === false) {
     exit(2);
 }
 
-function perform_snmp_scan($net, $force_network, $force_broadcast, $force_transport)
+function perform_snmp_scan($net, $force_network, $force_broadcast, $transport_protocol)
 {
     global $stats, $config, $debug, $vdebug, $more_info;
     echo 'Range: '.$net->network.'/'.$net->bitmask.PHP_EOL;
@@ -108,7 +108,7 @@ function perform_snmp_scan($net, $force_network, $force_broadcast, $force_transp
             }
             continue;
         }
-        foreach ($force_transport as $transport) {
+        foreach ($transport_protocol as $transport) {
             try {
                 addHost(gethostbyaddr($host), '', $config['snmp']['port'], $transport, $config['distributed_poller_group']);
                 $stats['added']++;
@@ -161,7 +161,7 @@ $start = false;
 $debug = false;
 $quiet = 1;
 $net   = false;
-$force_transport = array('udp','tcp');
+$transport_protocol = array('udp','tcp');
 
 if (isset($opts['h']) || (empty($opts) && (!isset($config['nets']) || empty($config['nets'])))) {
     echo 'Usage: '.$argv[0].' -r <CIDR_Range> [-d] [-l] [-h]'.PHP_EOL;
@@ -178,7 +178,7 @@ if (isset($opts['h']) || (empty($opts) && (!isset($config['nets']) || empty($con
     echo '  -i                Provide more information on actions'.PHP_EOL;
     echo '  -l                Show Legend'.PHP_EOL;
     echo '  -h                Print this text'.PHP_EOL;
-    echo '  -t                Force transport protocol. Ex : -t udp or -t tcp. If not set => both'.PHP_EOL;
+    echo '  -t                Select transport protocol. Ex : -t udp or -t tcp, not set => both'.PHP_EOL;
     exit(0);
 }
 if (isset($opts['d']) || isset($opts['v'])) {
@@ -206,10 +206,10 @@ if (isset($opts['i'])) {
 if (isset($opts['t'])) {
     switch ($opts['t']) {
         case 'udp':
-            $force_transport = array('udp');
+            $transport_protocol = array('udp');
             break;
         case 'tcp':
-            $force_transport = array('tcp');
+            $transport_protocol = array('tcp');
             break;
     }
 }
@@ -217,7 +217,7 @@ if (isset($opts['t'])) {
 if (isset($opts['r'])) {
     $net = Net_IPv4::parseAddress($opts['r']);
     if (ip2long($net->network) !== false) {
-        perform_snmp_scan($net, $force_network, $force_broadcast, $force_transport);
+        perform_snmp_scan($net, $force_network, $force_broadcast, $transport_protocol);
         echo 'Scanned '.$stats['count'].' IPs, Already known '.$stats['known'].' Devices, Added '.$stats['added'].' Devices, Failed to add '.$stats['failed'].' Devices.'.PHP_EOL;
         echo 'Runtime: '.(microtime(true)-$ts).' secs'.PHP_EOL;
     } else {
@@ -230,7 +230,7 @@ if (isset($opts['r'])) {
     }
     foreach ($config['nets'] as $subnet) {
         $net = Net_IPv4::parseAddress($subnet);
-        perform_snmp_scan($net, $force_network, $force_broadcast, $force_transport);
+        perform_snmp_scan($net, $force_network, $force_broadcast, $transport_protocol);
     }
     echo 'Scanned '.$stats['count'].' IPs, Already know '.$stats['known'].' Devices, Added '.$stats['added'].' Devices, Failed to add '.$stats['failed'].' Devices.'.PHP_EOL;
     echo 'Runtime: '.(microtime(true)-$ts).' secs'.PHP_EOL;

--- a/snmp-scan.php
+++ b/snmp-scan.php
@@ -207,10 +207,10 @@ if (isset($opts['t'])) {
     switch ($opts['t']) {
         case 'udp':
             $force_transport = array('udp');
-        break;
+            break;
         case 'tcp':
             $force_transport = array('tcp');
-        break;
+            break;
     }
 }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

---------------------------

- When TCP scan is running, the auto discovery with snmp scan is really slow
- Add an option to choose to use only tcp, udp or both

Thanks @schubling for the code.
