### PR TITLE
fix: Fixed netman voltage and load divisor values

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -966,6 +966,11 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
         return 100;
     } elseif (($device['os'] == 'netmanplus') && ($sensor_type == 'load')) {
         return 1;
+    } elseif (($device['os'] == 'netmanplus') && ($sensor_type == 'voltage')) {
+        if (preg_match('/.1.3.6.1.2.1.33.1.2.5./', $oid)) {
+            return 10;
+        }
+        return 1;
     } elseif ($device['os'] == 'generex-ups') {
         if ($sensor_type == 'load') {
             return 1;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -964,7 +964,7 @@ function get_device_divisor($device, $os_version, $sensor_type, $oid)
         }
     } elseif (($device['os'] == 'huaweiups') && ($sensor_type == 'frequency')) {
         return 100;
-    } elseif (($device['os'] == 'netmanplus') && ($sensor_type == 'voltage')) {
+    } elseif (($device['os'] == 'netmanplus') && ($sensor_type == 'load')) {
         return 1;
     } elseif ($device['os'] == 'generex-ups') {
         if ($sensor_type == 'load') {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Voltage has technically been there since the fork but was checking voltages until that was fixed a few months ago and in turn enabling the code and breaking the divisor - I'm assuming it's broken for more than just the reporter.

load needed to be a divisor of 1 rather than default to 10.

Fixes: #6893 - Hope it doesn't break other installs