### PR TITLE
fix: perf_times cleanup

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -83,7 +83,7 @@ status_run() {
 # Arguments:
 #   args:
 #        Array of arguments to pass to
-#        daily.php 
+#        daily.php
 # Returns:
 #   Exit-Code of Command
 #######################################
@@ -100,7 +100,7 @@ call_daily_php() {
 # Globals:
 #   LIBRENMS_DIR
 # Arguments:
-#   
+#
 # Returns:
 #   Exit-Code of Command
 #######################################
@@ -178,7 +178,7 @@ main () {
                                "syslog"
                                "eventlog"
                                "authlog"
-                               "perf_time"
+                               "perf_times"
                                "callback"
                                "device_perf"
                                "purgeusers"

--- a/sql-schema/197.sql
+++ b/sql-schema/197.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE `perf_times`;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This table wasn't being cleaned up. Examples of freed up space:
Total DB Size:
21GB -> 6GB
7GB -> 4GB
1.3GB -> 200MB