### PR TITLE
Updated validate to detect lower case tables + added support for checking mariadb 10.2 timestamps

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -27,6 +27,7 @@ Within the [mysqld] section please add:
 ```bash
 innodb_file_per_table=1
 sql-mode=""
+lower_case_table_names=0
 ```
 
 ```

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -27,6 +27,7 @@ Within the [mysqld] section please add:
 ```bash
 innodb_file_per_table=1
 sql-mode=""
+lower_case_table_names=0
 ```
 
 ```

--- a/doc/Installation/Installation-Ubuntu-1604-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Apache.md
@@ -27,6 +27,7 @@ Within the [mysqld] section please add:
 ```bash
 innodb_file_per_table=1
 sql-mode=""
+lower_case_table_names=0
 ```
 
 ```systemctl restart mysql```

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -27,6 +27,7 @@ Within the [mysqld] section please add:
 ```bash
 innodb_file_per_table=1
 sql-mode=""
+lower_case_table_names=0
 ```
 
 ```systemctl restart mysql```

--- a/validate.php
+++ b/validate.php
@@ -174,6 +174,12 @@ if (str_contains($strict_mode, 'STRICT_TRANS_TABLES')) {
     //print_fail('You have MySQL STRICT_TRANS_TABLES enabled, please disable this until full support has been added: https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html');
 }
 
+// Test for lower case table name support
+$lc_mode = dbFetchCell("SELECT @@global.lower_case_table_names");
+if ($lc_mode != 0) {
+    print_fail('You have lower_case_table_names set to 1 or true in mysql config.', 'Set lower_case_table_names=0 in your mysql config file');
+}
+
 if (empty($strict_mode) === false) {
     print_fail("You have not set sql_mode='' in your mysql config");
 }
@@ -215,6 +221,12 @@ if (is_file('misc/db_schema.yaml')) {
             $previous_column = '';
             foreach ($data['Columns'] as $column => $cdata) {
                 $cur = $current_schema[$table]['Columns'][$column];
+                if ($cur['Default'] == 'current_timestamp()') {
+                    $cur['Default'] = 'CURRENT_TIMESTAMP';
+                }
+                if ($cur['Extra'] == 'on update current_timestamp()') {
+                    $cur['Extra'] = 'on update CURRENT_TIMESTAMP';
+                }
                 if (empty($current_schema[$table]['Columns'][$column])) {
                     print_fail("Database: missing column ($table/$column)");
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Two fixes in this. One is a check for lower_case_table_names to make sure it's set to be off (also updated install docs).

Other fix is where CURRENT_TIMESTAMP is returned as current_timestamp() so our checks failed. This seems to be an update for MariaDB 10.2