### PR TITLE
fix: python poller service locking not working

### DIFF
--- a/poller-service.py
+++ b/poller-service.py
@@ -199,8 +199,10 @@ def lockFree(lock, db=db):
 
 
 def getLock(lock, db=db):
-    query = "SELECT GET_LOCK('{0}', 0)".format(lock)
-    return db.query(query)[0][0] == 1
+    if lockFree(lock):
+        query = "SELECT GET_LOCK('{0}', 0)".format(lock)
+        return db.query(query)[0][0] == 1
+    return False
 
 
 def releaseLock(lock, db=db):


### PR DESCRIPTION
I believe this will fix the locking on mysql >= 5.7.5.  As of that version, GET_LOCK will not return 0 if calling from the same connection.

Please test.

fixes: #5619 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
