### PR TITLE
Update fabos.inc.php

### DIFF
--- a/includes/discovery/sensors/state/fabos.inc.php
+++ b/includes/discovery/sensors/state/fabos.inc.php
@@ -51,7 +51,7 @@ foreach ($pre_cache['fabos_sensors'] as $data) {
         $index = $data['swSensorIndex'];
         $oid = '.1.3.6.1.4.1.1588.2.1.1.1.1.22.1.3.' . $index;
         $value = $data['swSensorStatus'];
-        discover_sensor($valid['sensor'], 'state', $device, $oid, $index, 'fabos_state', $descr, '1', '1', null, null, null, null, $value);
-        create_sensor_to_state_index($device, 'fabos_state', 1);
+        discover_sensor($valid['sensor'], 'state', $device, $oid, $index, $descr, $descr, '1', '1', null, null, null, null, $value);
+        create_sensor_to_state_index($device, $descr, $index);
     }
 }


### PR DESCRIPTION
The state of the sensors was a value (#1-4) not an actual state (nominal, faulty etc.) on UI.

Tested device:
Brocade 300 Switch (Brocade FabricOS v6.4.1)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
