### PR TITLE
authorize logrotate to change log in librenms directory

### DIFF
--- a/misc/librenms.logrotate
+++ b/misc/librenms.logrotate
@@ -1,5 +1,6 @@
 # /etc/logrotate.d/librenms
 /opt/librenms/logs/*.log {
+    su librenms librenms
     weekly
     rotate 6
     compress


### PR DESCRIPTION
On redhat 7, logrotate need " su" command to rotate logs in /opt/librenms/logs, here is the errors:

error: skipping "/opt/librenms/logs/daily.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
error: skipping "/opt/librenms/logs/librenms.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
