### PR TITLE
feature: add timeout to AD auth, default is 5s

### DIFF
--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -156,12 +156,13 @@ If you set ```$config['auth_ad_require_groupmembership']``` to 1, the authentica
 ##### Sample configuration
 
 ```
-$config['auth_ad_url']                     = "ldaps://<your-domain.controll.er>";
+$config['auth_ad_url']                     = "ldaps://<your-domain.controll.er>";  // you can add multiple servers, separated by a space
 $config['auth_ad_domain']                  = "<your-domain.com>";
 $config['auth_ad_base_dn']                 = "<dc=your-domain,dc=com>";
 $config['auth_ad_check_certificates']      = true;  // require a valid ssl certificate
 $config['auth_ad_binduser']                = 'examplebinduser';
 $config['auth_ad_bindpassword']            = 'examplepassword';
+$config['auth_ad_timeout']                 = 5; // time to wait before giving up (or trying the next server)
 $config['auth_ad_debug']                   = false; // enable for verbose debug messages
 $config['active_directory']['users_purge'] = 30;    // purge users who haven't logged in for 30 days.
 $config['auth_ad_require_groupmembership'] = false; // require users to be members of a group listed below

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -21,8 +21,14 @@ function init_auth()
     $ad_init = false;  // this variable tracks if bind has been called so we don't call it multiple times
     $ldap_connection = @ldap_connect($config['auth_ad_url']);
 
-// disable referrals and force ldap version to 3
+    // set timeout
+    ldap_set_option(
+        $ldap_connection,
+        LDAP_OPT_NETWORK_TIMEOUT,
+        isset($config['auth_ad_timeout']) ? isset($config['auth_ad_timeout']) : 5
+    );
 
+    // disable referrals and force ldap version to 3
     ldap_set_option($ldap_connection, LDAP_OPT_REFERRALS, 0);
     ldap_set_option($ldap_connection, LDAP_OPT_PROTOCOL_VERSION, 3);
 }

--- a/html/includes/authentication/active_directory.inc.php
+++ b/html/includes/authentication/active_directory.inc.php
@@ -21,13 +21,6 @@ function init_auth()
     $ad_init = false;  // this variable tracks if bind has been called so we don't call it multiple times
     $ldap_connection = @ldap_connect($config['auth_ad_url']);
 
-    // set timeout
-    ldap_set_option(
-        $ldap_connection,
-        LDAP_OPT_NETWORK_TIMEOUT,
-        isset($config['auth_ad_timeout']) ? isset($config['auth_ad_timeout']) : 5
-    );
-
     // disable referrals and force ldap version to 3
     ldap_set_option($ldap_connection, LDAP_OPT_REFERRALS, 0);
     ldap_set_option($ldap_connection, LDAP_OPT_PROTOCOL_VERSION, 3);
@@ -458,21 +451,33 @@ function ad_bind($connection, $allow_anonymous = true, $force = false)
         return true; // bind already attempted
     }
 
+    // set timeout
+    ldap_set_option(
+        $connection,
+        LDAP_OPT_NETWORK_TIMEOUT,
+        isset($config['auth_ad_timeout']) ? isset($config['auth_ad_timeout']) : 5
+    );
+
     // With specified bind user
     if (isset($config['auth_ad_binduser'], $config['auth_ad_bindpassword'])) {
         $ad_init = true;
-        return ldap_bind(
+        $bind = ldap_bind(
             $connection,
             "${config['auth_ad_binduser']}@${config['auth_ad_domain']}",
             "${config['auth_ad_bindpassword']}"
         );
+        ldap_set_option($connection, LDAP_OPT_NETWORK_TIMEOUT, -1); // restore timeout
+        return $bind;
     }
+
+    $bind = false;
 
     // Anonymous
     if ($allow_anonymous) {
         $ad_init = true;
-        return ldap_bind($connection);
+        $bind = ldap_bind($connection);
     }
 
-    return false;
+    ldap_set_option($connection, LDAP_OPT_NETWORK_TIMEOUT, -1); // restore timeout
+    return $bind;
 }


### PR DESCRIPTION
Can be configured by $config['auth_ad_timeout']

One of my ad servers stop responding to ldap requests and LibreNMS never tried to use the second ad server, just gave a http timeout error.

Adding a timeout allows ldap to give up and try additional servers, or at least actually return some html (which will print an connection failed error).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
