### PR TITLE
validate improvements

### DIFF
--- a/html/pages/about.inc.php
+++ b/html/pages/about.inc.php
@@ -155,7 +155,7 @@ $mysql_version   = $versions['mysql_ver'];
 $netsnmp_version = $versions['netsnmp_ver'];
 $rrdtool_version = $versions['rrdtool_ver'];
 $schema_version  = $versions['db_schema'];
-$version         = `git rev-parse --short HEAD`;
+$version         = $versions['local_ver'];
 $version_date    = $versions['local_date'];
 
 echo "

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -19,6 +19,16 @@
 
 use LibreNMS\Exceptions\DatabaseConnectException;
 
+function dbIsConnected()
+{
+    global $database_link;
+    if (empty($database_link)) {
+        return false;
+    }
+
+    return mysqli_ping($database_link);
+}
+
 /**
  * Connect to the database.
  * Will use global $config variables if they are not sent: db_host, db_user, db_pass, db_name, db_port, db_socket
@@ -35,6 +45,11 @@ use LibreNMS\Exceptions\DatabaseConnectException;
 function dbConnect($host = null, $user = '', $password = '', $database = '', $port = null, $socket = null)
 {
     global $config, $database_link;
+
+    if (dbIsConnected()) {
+        return $database_link;
+    }
+
     $host = empty($host) ? $config['db_host'] : $host;
     $user = empty($user) ? $config['db_user'] : $user;
     $password = empty($password) ? $config['db_pass'] : $password;

--- a/includes/init.php
+++ b/includes/init.php
@@ -34,8 +34,8 @@ $config['install_dir'] = $install_dir;
 chdir($install_dir);
 
 if (!getenv('TRAVIS')) {
-    require_once 'Net/IPv4.php';
-    require_once 'Net/IPv6.php';
+    include_once 'Net/IPv4.php';
+    include_once 'Net/IPv6.php';
 }
 
 # composer autoload


### PR DESCRIPTION
Always output header (may be missing mysql data)
Improve version display, now looks like '1.28-129-g74e6c3edf' <tag>-<commits since tag>-<shortag>
Add mysqli to the list of required extensions, check extensions before init
Add dbIsConnected() function, used to check if we have db in version_info()
Do not die on IPv4 and IPv6 so validate can print errors.
Move git checks so they are output together
fix rrdtool 1.7.0 reports version as 1.7.01.7.0

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
