### PR TITLE
fix: When force adding, use the provided snmp details rather than from $config

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -94,7 +94,7 @@ if (!empty($argv[1])) {
             }
 
             if ($seclevel === 'nanp') {
-                array_push($config['snmp']['v3'], $v3);
+                array_unshift($config['snmp']['v3'], $v3);
             }
         } elseif ($seclevel === 'anp' or $seclevel === 'authNoPriv') {
             $v3['authlevel'] = 'authNoPriv';
@@ -116,7 +116,7 @@ if (!empty($argv[1])) {
                 }
             }
 
-            array_push($config['snmp']['v3'], $v3);
+            array_unshift($config['snmp']['v3'], $v3);
         } elseif ($seclevel === 'ap' or $seclevel === 'authPriv') {
             $v3['authlevel']  = 'authPriv';
             $v3args           = array_slice($argv, 4);
@@ -158,7 +158,7 @@ if (!empty($argv[1])) {
         }
 
         if ($community) {
-            $config['snmp']['community'] = array($community);
+            array_unshift($config['snmp']['community'], $community);
         }
     }//end if
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6997 

Before hand with force add, we used the first snmp info from config for 2 out of the 3 snmp v3 details (one was correct) so fixed the other two and added the same to v1 / v2c. If no details are passed as before we iterate through $config.