### PR TITLE
fix: Fix for Rittal LCP graphs divisors

### DIFF
--- a/includes/definitions/rittal-lcp.yaml
+++ b/includes/definitions/rittal-lcp.yaml
@@ -4,16 +4,16 @@ type: environment
 icon: rittal
 mib_dir:
     - rittal
+discovery_modules:
+    storage: 0
+    mempools: 0
+    processors: 0
 discovery:
     -
         sysObjectId:
             - .1.3.6.1.4.1.2606.7
     - sysDescr:
         - 'Rittal LCP'
-discovery_modules:
-    storage: 0
-    mempools: 0
-    processors: 0
 over:
     - { graph: device_temperature, text: 'Temperatures' }
     - { graph: device_power, text: 'Cooling capacity' }

--- a/includes/definitions/rittal-lcp.yaml
+++ b/includes/definitions/rittal-lcp.yaml
@@ -2,6 +2,9 @@ os: rittal-lcp
 text: 'Rittal LCP'
 type: environment
 icon: rittal
+over:
+    - { graph: device_temperature, text: 'Temperatures' }
+    - { graph: device_power, text: 'Cooling capacity' }
 mib_dir:
     - rittal
 discovery_modules:
@@ -14,6 +17,3 @@ discovery:
             - .1.3.6.1.4.1.2606.7
     - sysDescr:
         - 'Rittal LCP'
-over:
-    - { graph: device_temperature, text: 'Temperatures' }
-    - { graph: device_power, text: 'Cooling capacity' }

--- a/includes/definitions/rittal-lcp.yaml
+++ b/includes/definitions/rittal-lcp.yaml
@@ -4,14 +4,16 @@ type: environment
 icon: rittal
 mib_dir:
     - rittal
-over:
-    - { graph: device_processor, text: 'Processor Usage' }
-    - { graph: device_ucd_memory, text: 'Memory Usage' }
-    - { graph: device_storage, text: 'Storage Usage' }
 discovery:
     -
         sysObjectId:
             - .1.3.6.1.4.1.2606.7
     - sysDescr:
         - 'Rittal LCP'
-        
+discovery_modules:
+    storage: 0
+    mempools: 0
+    processors: 0
+over:
+    - { graph: device_temperature, text: 'Temperatures' }
+    - { graph: device_power, text: 'Cooling capacity' }

--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -109,6 +109,21 @@ if (is_array($oids)) {
                 } $descr = preg_replace('/[T|t]emperature[|s]/', '', $descr);
             }
 
+            if ($device['os'] == 'rittal-lcp') {
+                if ($type == 'voltage') {
+                    $divisor = 1000;
+                }
+                if ($descr == 'Temperature.Value') {
+                    $divisor = 1000;
+                }
+                if ($descr == 'System.Temperature.Value') {
+                    $divisor = 1000;
+                }
+                if ($type == 'humidity' && $current == '0') {
+                    $valid_sensor = false;
+                }
+            }
+
             // echo($descr . "|" . $index . "|" .$current . "|" . $multiplier . "|" . $divisor ."|" . $entry['entPhySensorScale'] . "|" . $entry['entPhySensorPrecision'] . "\n");
             if ($current == '-127' || ($device['os'] == 'asa' && str_contains($device['hardware'], 'sc'))) {
                 $valid_sensor = false;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


---------------------

- Disabled unnecessary discovery modules
- Corrected wrong divisors

Can't find a way to disable the wrong over graphs or to change them by the ones included in the definitions file.
