### PR TITLE
fix: Netbotz state sensors using wrong value

### DIFF
--- a/includes/definitions/discovery/netbotz.yaml
+++ b/includes/definitions/discovery/netbotz.yaml
@@ -70,7 +70,7 @@ modules:
                         - { descr: motionDetected, graph: 0, value: 1, generic: 2 }
                 -
                     oid: otherStateSensorTable
-                    value: otherStateSensorValue
+                    value: otherStateSensorErrorStatus
                     num_oid: .1.3.6.1.4.1.5528.100.4.2.10.1.3.
                     descr: otherStateSensorLabel
                     index: '{{ $index }}'

--- a/includes/definitions/discovery/netbotz.yaml
+++ b/includes/definitions/discovery/netbotz.yaml
@@ -70,7 +70,7 @@ modules:
                         - { descr: motionDetected, graph: 0, value: 1, generic: 2 }
                 -
                     oid: otherStateSensorTable
-                    value: otherStateSensorErrorStatus
+                    value: otherStateSensorValue
                     num_oid: .1.3.6.1.4.1.5528.100.4.2.10.1.3.
                     descr: otherStateSensorLabel
                     index: '{{ $index }}'

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1064,14 +1064,14 @@ function can_skip_sensor($value, $data, $group)
         }
     }
 
-    $skip_values_lt = array_replace((array)$group['skip_value_lt'], (array)$data['skip_value_lt']);
+    $skip_value_lt = array_replace((array)$group['skip_value_lt'], (array)$data['skip_value_lt']);
     foreach ($skip_value_lt as $skip_value) {
         if ($value < $skip_value) {
             return true;
         }
     }
 
-    $skip_values_gt = array_reduce((array)$group['skip_value_gt'], (array)$data['skip_value_gt']);
+    $skip_value_gt = array_reduce((array)$group['skip_value_gt'], (array)$data['skip_value_gt']);
     foreach ($skip_value_gt as $skip_value) {
         if ($value > $skip_value) {
             return true;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1098,7 +1098,7 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
             $tmp_name = $data['oid'];
             $raw_data = $pre_cache[$tmp_name];
             foreach ($raw_data as $index => $snmp_data) {
-                $value = $snmp_data[$data['value']] ?: $snmp_data[$data['oid']];
+                $value = is_numeric($snmp_data[$data['value']]) ? $snmp_data[$data['value']] : ($snmp_data[$data['oid']] ?: false);
                 if (can_skip_sensor($value, $data, $sensor_options) === false && is_numeric($value)) {
                     $oid = $data['num_oid'] . $index;
                     if (isset($snmp_data[$data['descr']])) {
@@ -1106,8 +1106,8 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
                     } else {
                         $descr = str_replace('{{ $index }}', $index, $data['descr']);
                     }
-                    $divisor = $data['divisor'] ?: $sensor_options['divisor'] ?: 1;
-                    $multiplier = $data['multiplier'] ?: $sensor_options['multiplier'] ?: 1;
+                    $divisor = $data['divisor'] ?: ($sensor_options['divisor'] ?: 1);
+                    $multiplier = $data['multiplier'] ?: ($sensor_options['multiplier'] ?: 1);
                     $low_limit = $data['low_limit'] ?: 'null';
                     $low_warn_limit = $data['low_warn_limit'] ?: 'null';
                     $warn_limit = $data['warn_limit'] ?: 'null';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #7025 

Needed parenthesis around the stacked ternary operators.