### PR TITLE
added agent setup to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ pages:
     - Extensions/Applications.md
     - Extensions/Authentication.md
     - Extensions/Auto-Discovery.md
+    - Extensions/Agent-Setup.md
     - Extensions/Billing-Module.md
     - Extensions/Component.md
     - Extensions/Dell-OpenManage.md


### PR DESCRIPTION
noticed that the Agent Setup doc is not listed under Extensions, but can be found by searching. Added to mkdocs.yml

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
