### PR TITLE
fix: Use the correct high/high warn thresholds for junos dbm sensors

### DIFF
--- a/includes/discovery/sensors/dbm/junos.inc.php
+++ b/includes/discovery/sensors/dbm/junos.inc.php
@@ -33,8 +33,8 @@ foreach ($pre_cache['junos_oids'] as $index => $entry) {
         $descr = dbFetchCell('SELECT `ifDescr` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ?', array($index, $device['device_id'])) . ' Tx Power';
         $limit_low = $entry['jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold']/$divisor;
         $warn_limit_low = $entry['jnxDomCurrentTxLaserOutputPowerLowWarningThreshold']/$divisor;
-        $limit = $entry['jnxDomCurrentModuleTemperatureHighAlarmThreshold']/$divisor;
-        $warn_limit = $entry['jnxDomCurrentModuleTemperatureHighWarningThreshold']/$divisor;
+        $limit = $entry['jnxDomCurrentTxLaserOutputPowerHighAlarmThreshold']/$divisor;
+        $warn_limit = $entry['jnxDomCurrentTxLaserOutputPowerHighWarningThreshold']/$divisor;
         $current = $entry['jnxDomCurrentTxLaserOutputPower'];
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
@@ -60,8 +60,8 @@ foreach ($pre_cache['junos_oids'] as $index => $entry) {
                 $descr = dbFetchCell('SELECT `ifDescr` FROM `ports` WHERE `ifIndex`= ? AND `device_id` = ?', array($index, $device['device_id'])) . ' lane ' . $x . ' Tx Power';
                 $limit_low = $entry['jnxDomCurrentTxLaserOutputPowerLowAlarmThreshold']/$divisor;
                 $warn_limit_low = $entry['jnxDomCurrentTxLaserOutputPowerLowWarningThreshold']/$divisor;
-                $limit = $entry['jnxDomCurrentModuleTemperatureHighAlarmThreshold']/$divisor;
-                $warn_limit = $entry['jnxDomCurrentModuleTemperatureHighWarningThreshold']/$divisor;
+                $limit = $entry['jnxDomCurrentTxLaserOutputPowerHighAlarmThreshold']/$divisor;
+                $warn_limit = $entry['jnxDomCurrentTxLaserOutputPowerHighWarningThreshold']/$divisor;
                 $current = $lane['jnxDomCurrentLaneTxLaserOutputPower']/$divisor;
                 $entPhysicalIndex = $index;
                 $entPhysicalIndex_measured = 'ports';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Wrong OID's used here for the high sensors. Fixes: #7032 