### PR TITLE
Loading speed improvement when viewing syslogs for specific device

### DIFF
--- a/html/pages/syslog.inc.php
+++ b/html/pages/syslog.inc.php
@@ -49,7 +49,12 @@ print_optionbar_start();
                         <select name="program" id="program" class="form-control input-sm">
                             <option value="">All Programs</option>
                                 <?php
-                                foreach (dbFetchRows('SELECT DISTINCT `program` FROM `syslog` ORDER BY `program`') as $data) {
+                                $sqlstatement = 'SELECT DISTINCT `program` FROM `syslog`';
+                                if (is_numeric($vars['device'])) {
+                                    $sqlstatement = $sqlstatement . ' WHERE device_id=' . $vars['device'];
+                                }
+                                $sqlstatement = $sqlstatement .' ORDER BY `program`';
+                                foreach (dbFetchRows($sqlstatement) as $data) {
                                     echo '"<option value="'.mres($data['program']).'"';
                                     if ($data['program'] == $vars['program']) {
                                         echo ' selected';
@@ -64,7 +69,12 @@ print_optionbar_start();
                         <select name="priority" id="priority" class="form-control input-sm">
                             <option value="">All Priorities</option>
                                 <?php
-                                foreach (dbFetchRows('SELECT DISTINCT `priority` FROM `syslog` ORDER BY `level`') as $data) {
+                                $sqlstatement = 'SELECT DISTINCT `priority` FROM `syslog`';
+                                if (is_numeric($vars['device'])) {
+                                    $sqlstatement = $sqlstatement . ' WHERE device_id=' . $vars['device'];
+                                }
+                                $sqlstatement = $sqlstatement .' ORDER BY `level`';
+                                foreach (dbFetchRows($sqlstatement) as $data) {
                                     echo '"<option value="'.mres($data['priority']).'"';
                                     if ($data['priority'] == $vars['priority']) {
                                         echo ' selected';

--- a/html/pages/syslog.inc.php
+++ b/html/pages/syslog.inc.php
@@ -23,7 +23,6 @@ print_optionbar_start();
                 <form method="post" action="" class="form-inline" role="form" id="result_form">
                     <div class="form-group">
                         <?php
-                        $params = array();
                         if (!is_numeric($vars['device'])) {
                         ?>
                         <select name="device" id="device" class="form-control input-sm">
@@ -43,7 +42,6 @@ print_optionbar_start();
                         <?php
                         } else {
                             echo '<input type="hidden" name="device" id="device" value="' . $vars['device'] . '">';
-                            $params[] = $vars['device'];
                         }
                         ?>
                     </div>
@@ -54,9 +52,10 @@ print_optionbar_start();
                                 $sqlstatement = 'SELECT DISTINCT `program` FROM `syslog`';
                                 if (is_numeric($vars['device'])) {
                                     $sqlstatement = $sqlstatement . ' WHERE device_id=?';
+                                    $param[] = $vars['device'];
                                 }
                                 $sqlstatement = $sqlstatement .' ORDER BY `program`';
-                                foreach (dbFetchRows($sqlstatement, $params) as $data) {
+                                foreach (dbFetchRows($sqlstatement, $param) as $data) {
                                     echo '"<option value="'.mres($data['program']).'"';
                                     if ($data['program'] == $vars['program']) {
                                         echo ' selected';
@@ -76,7 +75,7 @@ print_optionbar_start();
                                     $sqlstatement = $sqlstatement . ' WHERE device_id=?';
                                 }
                                 $sqlstatement = $sqlstatement .' ORDER BY `level`';
-                                foreach (dbFetchRows($sqlstatement, $params) as $data) {
+                                foreach (dbFetchRows($sqlstatement, $param) as $data) {
                                     echo '"<option value="'.mres($data['priority']).'"';
                                     if ($data['priority'] == $vars['priority']) {
                                         echo ' selected';

--- a/html/pages/syslog.inc.php
+++ b/html/pages/syslog.inc.php
@@ -73,6 +73,7 @@ print_optionbar_start();
                                 $sqlstatement = 'SELECT DISTINCT `priority` FROM `syslog`';
                                 if (is_numeric($vars['device'])) {
                                     $sqlstatement = $sqlstatement . ' WHERE device_id=?';
+                                    $param[] = $vars['device'];
                                 }
                                 $sqlstatement = $sqlstatement .' ORDER BY `level`';
                                 foreach (dbFetchRows($sqlstatement, $param) as $data) {

--- a/html/pages/syslog.inc.php
+++ b/html/pages/syslog.inc.php
@@ -23,6 +23,7 @@ print_optionbar_start();
                 <form method="post" action="" class="form-inline" role="form" id="result_form">
                     <div class="form-group">
                         <?php
+                        $params = array();
                         if (!is_numeric($vars['device'])) {
                         ?>
                         <select name="device" id="device" class="form-control input-sm">
@@ -42,6 +43,7 @@ print_optionbar_start();
                         <?php
                         } else {
                             echo '<input type="hidden" name="device" id="device" value="' . $vars['device'] . '">';
+                            $params[] = $vars['device'];
                         }
                         ?>
                     </div>
@@ -51,10 +53,10 @@ print_optionbar_start();
                                 <?php
                                 $sqlstatement = 'SELECT DISTINCT `program` FROM `syslog`';
                                 if (is_numeric($vars['device'])) {
-                                    $sqlstatement = $sqlstatement . ' WHERE device_id=' . $vars['device'];
+                                    $sqlstatement = $sqlstatement . ' WHERE device_id=?';
                                 }
                                 $sqlstatement = $sqlstatement .' ORDER BY `program`';
-                                foreach (dbFetchRows($sqlstatement) as $data) {
+                                foreach (dbFetchRows($sqlstatement, $params) as $data) {
                                     echo '"<option value="'.mres($data['program']).'"';
                                     if ($data['program'] == $vars['program']) {
                                         echo ' selected';
@@ -71,10 +73,10 @@ print_optionbar_start();
                                 <?php
                                 $sqlstatement = 'SELECT DISTINCT `priority` FROM `syslog`';
                                 if (is_numeric($vars['device'])) {
-                                    $sqlstatement = $sqlstatement . ' WHERE device_id=' . $vars['device'];
+                                    $sqlstatement = $sqlstatement . ' WHERE device_id=?';
                                 }
                                 $sqlstatement = $sqlstatement .' ORDER BY `level`';
-                                foreach (dbFetchRows($sqlstatement) as $data) {
+                                foreach (dbFetchRows($sqlstatement, $params) as $data) {
                                     echo '"<option value="'.mres($data['priority']).'"';
                                     if ($data['priority'] == $vars['priority']) {
                                         echo ' selected';


### PR DESCRIPTION
When trying to view the syslogs for a specific device 
(for example http://[hostname]/device/device=[device_id]/tab=logs/section=syslog/) 
the dropdown for 'priorities' and 'programs' are not filtered to search only for that specific device_id. This causes the SQL query to be extremely slow and sometimes causes the browser to crash when there are lots of syslog entries in the database.

Also, since the syslog entries in the table themselves are filtered by device_id, I think that the 'programs' and 'priorities' dropdown should be as well; to reflect the entries in the syslog table.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
