### PR TITLE
fix: Strip " and / from snmpwalk_cache_oid()

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -369,6 +369,7 @@ function snmpwalk_cache_oid($device, $oid, $array, $mib = null, $mibdir = null, 
         list($oid,$value)  = explode('=', $entry, 2);
         $oid               = trim($oid);
         $value             = trim($value);
+        $value             = trim($value, '\"');
         list($oid, $index) = explode('.', $oid, 2);
         if (!strstr($value, 'at this OID') && isset($oid) && isset($index)) {
             $array[$index][$oid] = $value;

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -368,7 +368,6 @@ function snmpwalk_cache_oid($device, $oid, $array, $mib = null, $mibdir = null, 
     foreach (explode("\n", $data) as $entry) {
         list($oid,$value)  = explode('=', $entry, 2);
         $oid               = trim($oid);
-        $value             = trim($value);
         $value             = trim($value, '\" \\\n\r');
         list($oid, $index) = explode('.', $oid, 2);
         if (!strstr($value, 'at this OID') && isset($oid) && isset($index)) {

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -369,7 +369,7 @@ function snmpwalk_cache_oid($device, $oid, $array, $mib = null, $mibdir = null, 
         list($oid,$value)  = explode('=', $entry, 2);
         $oid               = trim($oid);
         $value             = trim($value);
-        $value             = trim($value, '\"');
+        $value             = trim($value, '\" \\\n\r');
         list($oid, $index) = explode('.', $oid, 2);
         if (!strstr($value, 'at this OID') && isset($oid) && isset($index)) {
             $array[$index][$oid] = $value;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #6993 

I've not done any other snmp functions yet but they probably should be done to save trim() being used everywhere.