### PR TITLE
feature: log event if device polling takes too long

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -184,9 +184,7 @@ function discover_device(&$device, $options = null)
         register_mibs($device, $devicemib, "includes/discovery/functions.inc.php");
     }
 
-    $device_end = microtime(true);
-    $device_run = ($device_end - $device_start);
-    $device_time = substr($device_run, 0, 5);
+    $device_time  = round(microtime(true) - $device_start, 3);
 
     dbUpdate(array('last_discovered' => array('NOW()'), 'last_discovered_timetaken' => $device_time), 'devices', '`device_id` = ?', array($device['device_id']));
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -207,7 +207,7 @@ function record_sensor_data($device, $all_sensors)
 
 function poll_device($device, $options)
 {
-    global $config, $device, $polled_devices, $memcache;
+    global $config, $device;
 
     $attribs = get_dev_attribs($device['device_id']);
     $device['attribs'] = $attribs;
@@ -279,8 +279,6 @@ function poll_device($device, $options)
                 ($os_module_status && !isset($attribs['poll_'.$module])) ||
                 ($module_status && !isset($os_module_status) && !isset($attribs['poll_' . $module]))) {
                 $start_memory = memory_get_usage();
-                $module_start = 0;
-                $module_time  = 0;
                 $module_start = microtime(true);
                 echo "\n#### Load poller module $module ####\n";
                 include "includes/polling/$module.inc.php";
@@ -341,23 +339,6 @@ function poll_device($device, $options)
             }
         }//end if
 
-        $device_end  = microtime(true);
-        $device_run  = ($device_end - $device_start);
-        $device_time = substr($device_run, 0, 5);
-
-        // Poller performance
-        if (!empty($device_time)) {
-            $tags = array(
-                'rrd_def' => RrdDefinition::make()->addDataset('poller', 'GAUGE', 0),
-                'module'  => 'ALL',
-            );
-            $fields = array(
-                'poller' => $device_time,
-            );
-
-            data_update($device, 'poller-perf', $tags, $fields);
-        }
-
         // Ping response
         if (can_ping_device($attribs) === true  &&  !empty($response['ping_time'])) {
             $tags = array(
@@ -373,11 +354,32 @@ function poll_device($device, $options)
             data_update($device, 'ping-perf', $tags, $fields);
         }
 
+        $device_time  = round(microtime(true) - $device_start, 3);
+
+        // Poller performance
+        if (!empty($device_time)) {
+            $tags = array(
+                'rrd_def' => RrdDefinition::make()->addDataset('poller', 'GAUGE', 0),
+                'module'  => 'ALL',
+            );
+            $fields = array(
+                'poller' => $device_time,
+            );
+
+            data_update($device, 'poller-perf', $tags, $fields);
+        }
+
         $update_array['last_polled']           = array('NOW()');
         $update_array['last_polled_timetaken'] = $device_time;
 
         // echo("$device_end - $device_start; $device_time $device_run");
         echo "Polled in $device_time seconds\n";
+
+        // check if the poll took to long and log an event
+        if ($device_time > $config['rrd']['step']) {
+            log_event("Polling took longer than " . round($config['rrd']['step'] / 60, 2) .
+                ' minutes!  This will cause gaps in graphs.', $device, 'system', 5);
+        }
 
         d_echo('Updating '.$device['hostname']."\n");
 


### PR DESCRIPTION
Move $device_time closer to end of poll_device(), and simplify
remove some unused variables
simplify $device_time in discover_device() too

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
