### PR TITLE
changed the way snmpwalk is done for yaml sensors

### DIFF
--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -28,6 +28,8 @@ Currently we have support for the following health metrics along with the values
 
 We have support for defining health / sensor discovery using YAML files so that you don't need to know how to write PHP.
 
+> Please note that DISPLAY-HINTS are disabled so ensure you use the correct divisor / multiplier if applicable.
+
 All yaml files are located in `includes/definitions/discovery/$os.yaml`. Defining the information hear is not always 
 possible and is heavily reliant on vendors being sensible with the MIBs they generate. Only snmp walks are supported 
 and you must provide a sane table that can be traversed and contains all of the data you need. We will use netbotz as 

--- a/includes/definitions/discovery/routeros.yaml
+++ b/includes/definitions/discovery/routeros.yaml
@@ -15,6 +15,7 @@ modules:
                     oid: mtxrOpticalTable
                     value: mtxrOpticalSupplyVoltage
                     num_oid: .1.3.6.1.4.1.14988.1.1.19.1.1.7.
+                    divisor: 1000
                     descr: mtxrOpticalName
                     index: 'mtxrOpticalSupplyVoltage.{{ $index }}'
         current:
@@ -32,12 +33,14 @@ modules:
                     oid: mtxrOpticalTable
                     value: mtxrOpticalTxPower
                     num_oid: .1.3.6.1.4.1.14988.1.1.19.1.1.9.
+                    divisor: 1000
                     descr: '{{ $mtxrOpticalName }} Tx'
                     index: 'mtxrOpticalTxPower.{{ $index }}'
                 -
                     oid: mtxrOpticalTable
                     value: mtxrOpticalRxPower
                     num_oid: .1.3.6.1.4.1.14988.1.1.19.1.1.10.
+                    divisor: 1000
                     descr: '{{ $mtxrOpticalName }} Rx'
                     index: 'mtxrOpticalRxPower.{{ $index }}'
         state:

--- a/includes/discovery/sensors.inc.php
+++ b/includes/discovery/sensors.inc.php
@@ -23,6 +23,7 @@ if (isset($device['dynamic_discovery']['modules']['sensors'])) {
                     } else {
                         $snmp_flag = '-OeQUs';
                     }
+                    $snmp_flag .= ' -Ih';
                     $pre_cache[$tmp_name] = snmpwalk_cache_oid($device, $oid, array(), $device['dynamic_discovery']['mib'], null, $snmp_flag);
                 }
             }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I'll be merging this once checks pass but to give some background on it as this is the first time I've come across this with snmp.

Using the MIB a walk provides the data as you would expect to see it because the MIB uses display-hints which basically does the division / multiplier role for us. Which is great and sensors are detected ok. When a poll is done because we don't use the mib we get the data back which then needs to be divided / multiplied as normal. So the issue with this is either the value is wrong on polling or the high/low calculated value is way off.

To fix this here we elect to never apply DISPLAY-HINTS when snmpwalking. This is backwards compatible with the current yaml sensors as none of them use DISPLAY-HINTS aside from the mikrotik mib (well, OIDs we use). If we convert some existing sensors to yaml we might have to be careful but this is honestly the first time I've ever come across this so I doubt we'll hit it often / at all again.