### PR TITLE
Update Cisco IOS XE Version Parsing

### DIFF
--- a/includes/polling/os/cisco.inc.php
+++ b/includes/polling/os/cisco.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if (preg_match('/^Cisco IOS Software, .+? Software(\, )?([\s\w\d]+)? \([^\-]+-([\w\d]+)-\w\), Version ([^,]+)/', $poll_device['sysDescr'], $regexp_result)) {
+if (preg_match('/^Cisco IOS Software.*?, .+? Software(\, )?([\s\w\d]+)? \([^\-]+-([\w\d]+)-\w\), Version ([^,]+)/', $poll_device['sysDescr'], $regexp_result)) {
     $features = $regexp_result[3];
     $version  = $regexp_result[4];
     $hardware = $regexp_result[2];


### PR DESCRIPTION
Add support for IOS XE 16+ that has release names (Denali, Everset) in the sysDescr string.

Example:
Cisco IOS Software [Denali], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.3.4, RELEASE SOFTWARE (fc3)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
