### PR TITLE
Add if statement for ROS os when querying remote port id for LLDP map

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -181,7 +181,11 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                     if ($remote_device_id) {
                         $if             = $lldp['lldpRemPortDesc'];
                         $id             = $lldp['lldpRemPortId'];
-                        $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));
+                        if ($device['os'] == 'ros') {
+                            $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($id, $remote_port_mac_address, $remote_device_id));
+                        } else {
+                            $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));
+                        }
                     } else {
                         $remote_port_id = '0';
                     }

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -181,11 +181,7 @@ if ($device['os'] == 'pbn' && $config['autodiscovery']['xdp'] === true) {
                     if ($remote_device_id) {
                         $if             = $lldp['lldpRemPortDesc'];
                         $id             = $lldp['lldpRemPortId'];
-                        if ($device['os'] == 'ros') {
-                            $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($id, $remote_port_mac_address, $remote_device_id));
-                        } else {
-                            $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));
-                        }
+                        $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));
                     } else {
                         $remote_port_id = '0';
                     }

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -525,7 +525,13 @@ foreach ($ports as $port) {
         // FIXME use $q_bridge_mib[$this_port['ifIndex']] to see if it is a trunk (>1 array count)
         echo 'VLAN == '.$this_port['ifVlan'];
 
-    // When devices do not provide ifAlias data, populate with ifDescr data if configured
+        // When devices do not provide ifDescr data, populate with ifName data if available
+        if ($this_port['ifDescr'] == '' || $this_port['ifDescr'] == null) {
+            $this_port['ifDescr'] = $this_port['ifName'];
+            d_echo('Using ifName as ifDescr');
+        }
+
+        // When devices do not provide ifAlias data, populate with ifDescr data if configured
         if ($this_port['ifAlias'] == '' || $this_port['ifAlias'] == null) {
             $this_port['ifAlias'] = $this_port['ifDescr'];
             d_echo('Using ifDescr as ifAlias');


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Siemens Ruggedcom switches does not have the functionality to give ports/interfaces descriptions. When you do an snmpwalk on oid `ifDescr' for each port, it is empty and therefore inserts a whitespace into the 'ifDescr' field in the ports table.

When you do an snmpwalk on oid 'lldpRemoteSystemsData', you get the following: https://pastebin.com/LbechkBG

The `discovery-protocols` module will then query the database for a remote_port_id using this `ifDescr` which will always return the first port (port 1) because all of the `ifDescr` for each port on that device is a whitespace. I created an if statement that will search the `ifName` only instead of `ifDescr` OR `ifName`.

Instead of an if-statement, another solution I suggest is re-arranging the query from this:

`$remote_port_id = dbFetchCell('SELECT \`port_id\` FROM \`ports\` WHERE (\`ifDescr\` = ? OR \`ifName\` = ? OR \`ifDescr\` = ? OR \`ifName\` = ? OR \`ifPhysAddress\` = ?) AND \`device_id\` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));`

to this:

`$remote_port_id = dbFetchCell('SELECT \`port_id\` FROM \`ports\` WHERE (\`ifName\` = ? OR \`ifDescr\` = ? OR \`ifDescr\` = ? OR \`ifName\` = ? OR \`ifPhysAddress\` = ?) AND \`device_id\` = ?', array($id, $id, $if, $if, $remote_port_mac_address, $remote_device_id));`

but I'm not sure how this will break the map for other OS'. 

We can also store the `ifName` as the `ifDescr` in the `ports` module if the `ifDescr` oid is empty. That way, it will fix any other issues caused by `ifDescr` being empty. Let me know what is preferred

