### PR TITLE
feature: Create librenms-irc.service

### DIFF
--- a/misc/librenms-irc.service
+++ b/misc/librenms-irc.service
@@ -1,8 +1,8 @@
 # /etc/systemd/system/librenms-irc.service 
 
-librenms-irc.service
 [Unit]
 Description=Librenms IRC bot
+After=network.target
 
 [Service]
 ExecStart=/opt/librenms/irc.php

--- a/misc/librenms-irc.service
+++ b/misc/librenms-irc.service
@@ -1,0 +1,12 @@
+# /etc/systemd/system/librenms-irc.service 
+
+librenms-irc.service
+[Unit]
+Description=Librenms IRC bot
+
+[Service]
+ExecStart=/opt/librenms/irc.php
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
basic systemd start up script that goes in /etc/systemd/system/librenms-irc.service it is set to start at boot, but it can be stopped or started just like any other systemd script ie. systemctl start librenms-irc.service

I will update doc's on how to implement for systemd on pull request #7084

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
