### PR TITLE
Replace escapeshellcmd with Purifier in service checks

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -202,6 +202,7 @@ function poll_service($service)
 
 function check_service($command)
 {
+    global $config;
     // This array is used to test for valid UOM's to be used for graphing.
     // Valid values from: https://nagios-plugins.org/doc/guidelines.html#AEN200
     // Note: This array must be decend from 2 char to 1 char so that the search works correctly.

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -208,7 +208,11 @@ function check_service($command)
     $valid_uom = array ('us', 'ms', 'KB', 'MB', 'GB', 'TB', 'c', 's', '%', 'B');
 
     // Make our command safe.
-    $command = 'LC_NUMERIC="C" '. escapeshellcmd($command);
+    $p_config = HTMLPurifier_Config::createDefault();
+    $p_config->set('Cache.SerializerPath', $config['temp_dir']);
+    $purifier = new HTMLPurifier($p_config);
+
+    $command = 'LC_NUMERIC="C" '. $purifier->purify($command);
 
     // Run the command and return its response.
     exec($command, $response_array, $status);


### PR DESCRIPTION
Required for service checks, which include multiple quotes in arguments or regex.

Proposed patch tested, works.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
