### PR TITLE
fix: bug in ipv62snmp function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -780,21 +780,15 @@ function snmp2ipv6($ipv6_snmp)
     return implode(':', $ipv6_2);
 }
 
-// FIXME port to LibreNMS\Util\IPv6 class
 function ipv62snmp($ipv6)
 {
     try {
-        $ipv6_ip = str_replace(':', '', IP::parse($ipv6)->compressed());
+        $ipv6 = IP::parse($ipv6)->uncompressed();
+        $ipv6_split = str_split(str_replace(':', '', $ipv6), 2);
+        return implode('.', array_map('hexdec', $ipv6_split));
     } catch (InvalidIpException $e) {
         return '';
     }
-
-    $ipv6_split = array();
-    for ($i = 0; $i < 32; $i+=2) {
-        $ipv6_split[] = hexdec(substr($ipv6_ip, $i, 2));
-    }
-
-    return implode('.', $ipv6_split);
 }
 
 function get_astext($asn)

--- a/tests/IpTest.php
+++ b/tests/IpTest.php
@@ -167,4 +167,11 @@ class IpTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('2001:db8:85a3:341a::370:7334/128', IP::parse('2001:db8:85a3:341a::370:7334')->getNetwork());
         $this->assertSame('2001:db8:85a3:341a::370:7334', IP::parse('2001:db8:85a3:341a::370:7334/128')->getNetworkAddress());
     }
+
+    public function testIpv62snmp()
+    {
+        $this->assertSame('32.1.8.120.224.0.130.226.134.161.0.0.0.0.0.0', ipv62snmp('2001:878:e000:82e2:86a1:0000:0000:0000'));
+        $this->assertSame('0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1', ipv62snmp('::1'));
+        $this->assertSame('32.1.8.120.0.0.224.0.0.130.0.226.0.136.0.161', ipv62snmp('2001:0878:0000:e000:0082:00e2:0088:00a1'));
+    }
 }


### PR DESCRIPTION
typo compressed instead of uncompressed
Tidied up the function and added unit tests.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
