### PR TITLE
newdevice: Added further sensor support for Geist Watchdog

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1674,6 +1674,19 @@ function fahrenheit_to_celsius($scale, $value)
     }
     return sprintf('%.02f', $value);
 }
+
+/**
+ *
+ * Simply passes the fahrenheit value to fahrenheit_to_celsius()
+ *
+ * @param $value
+ * @return float
+ */
+function conv_fahrenheit($value)
+{
+    return fahrenheit_to_celsius('fahrenheit', $value);
+}
+
 function uw_to_dbm($value)
 {
     return 10 * log10($value / 1000);

--- a/includes/definitions/discovery/geist-watchdog.yaml
+++ b/includes/definitions/discovery/geist-watchdog.yaml
@@ -1,0 +1,73 @@
+mib: GEIST-V4-MIB
+modules:
+    sensors:
+        temperature:
+            data:
+                -
+                    oid: internalTable
+                    value: internalTemp
+                    num_oid: .1.3.6.1.4.1.21239.5.1.2.1.5.
+                    descr: internalName
+                -
+                    oid: tempSensorTable
+                    value: tempSensorTemp
+                    num_oid: .1.3.6.1.4.1.21239.5.1.4.1.5.
+                    descr: tempSensorName
+                -
+                    oid: airFlowSensorTable
+                    value: airFlowSensorTemp
+                    num_oid: .1.3.6.1.4.1.21239.5.1.5.1.5.
+                    descr: airFlowSensorName
+                -
+                    oid: dewPointSensorTable
+                    value: dewPointSensorTemp
+                    num_oid: .1.3.6.1.4.1.21239.5.1.6.1.5.
+                    descr: dewPointSensorName
+                -
+                    oid: t3hdSensorTable
+                    value: t3hdSensorIntTemp
+                    num_oid: .1.3.6.1.4.1.21239.5.1.8.1.6.
+                    descr: t3hdSensorIntName
+                -
+                    oid: thdSensorTable
+                    value: thdSensorTemp
+                    num_oid: .1.3.6.1.4.1.21239.5.1.9.1.5.
+                    descr: thdSensorName
+        current:
+            data:
+                -
+                    oid: rpmSensorTable
+                    value: rpmSensorCurrent
+                    num_oid: .1.3.6.1.4.1.21239.5.1.10.1.10.
+                    descr: rpmSensorName
+        voltage:
+            data:
+                -
+                    oid: rpmSensorTable
+                    value: rpmSensorVoltage
+                    num_oid: .1.3.6.1.4.1.21239.5.1.10.1.6.
+                    descr: rpmSensorName
+        humidty:
+            data:
+                -
+                    oid: thdSensorTable
+                    value: thdSensorHumidity
+                    num_oid: .1.3.6.1.4.1.21239.5.1.9.1.6.
+                    descr: thdSensorName
+                -
+                    oid: t3hdSensorTable
+                    value: t3hdSensorIntHumidity
+                    num_oid: .1.3.6.1.4.1.21239.5.1.8.1.7.
+                    descr: t3hdSensorIntName
+                -
+                    oid: internalTable
+                    value: internalHumidity
+                    num_oid: .1.3.6.1.4.1.21239.5.1.2.1.6.
+                    descr: internalName
+        airflow:
+            data:
+                -
+                    oid: airFlowSensorTable
+                    value: airFlowSensorFlow
+                    num_oid: .1.3.6.1.4.1.21239.5.1.5.1.6.
+                    descr: airFlowSensorName

--- a/includes/discovery/sensors/airflow/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/airflow/geist-watchdog.inc.php
@@ -26,4 +26,6 @@
 $value = snmp_get($device, 'climateAirflow', '-Oqv', 'GEIST-MIB-V3');
 $current_oid = '.1.3.6.1.4.1.21239.2.2.1.9.1';
 $descr = 'Airflow';
-discover_sensor($valid['sensor'], 'airflow', $device, $current_oid, 'climateAirflow', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+if (is_numeric($value)) {
+    discover_sensor($valid['sensor'], 'airflow', $device, $current_oid, 'climateAirflow', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+}

--- a/includes/discovery/sensors/humidity/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/humidity/geist-watchdog.inc.php
@@ -23,14 +23,14 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 
-$value = snmp_get($device, 'climateHumidity', '-Oqv', 'GEIST-MIB-V3');
+$value = return_number(snmp_get($device, 'climateHumidity', '-Oqv', 'GEIST-MIB-V3'));
 if ($value) {
     $current_oid = '.1.3.6.1.4.1.21239.2.2.1.7.1';
     $descr = 'Humidity';
     discover_sensor($valid['sensor'], 'humidity', $device, $current_oid, 'climateHumidity', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
 }
 
-$value = snmp_get($device, 'internalHumidity.1', '-Oqv', 'GEIST-V4-MIB');
+$value = return_number(snmp_get($device, 'internalHumidity.1', '-Oqv', 'GEIST-V4-MIB'));
 if ($value) {
     $current_oid = '.1.3.6.1.4.1.21239.5.1.2.1.6.1';
     $descr = 'Internal humidity';

--- a/includes/discovery/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/discovery/sensors/temperature/geist-watchdog.inc.php
@@ -30,6 +30,13 @@ if ($value) {
     discover_sensor($valid['sensor'], 'temperature', $device, $current_oid, 'climateTempC', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
 }
 
+$value = snmp_get($device, 'climateTempF', '-Oqv', 'GEIST-MIB-V3');
+if ($value) {
+    $current_oid = '.1.3.6.1.4.1.21239.2.2.1.6.1';
+    $descr = 'Temperature';
+    discover_sensor($valid['sensor'], 'temperature', $device, $current_oid, 'climateTempF', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value, null, null, null, 'conv_fahrenheit');
+}
+
 $value = snmp_get($device, 'internalTemp.1', '-Oqv', 'GEIST-V4-MIB');
 if ($value) {
     $current_oid = '.1.3.6.1.4.1.21239.5.1.2.1.5.1';

--- a/includes/polling/sensors/pre-cache/geist-watchdog.inc.php
+++ b/includes/polling/sensors/pre-cache/geist-watchdog.inc.php
@@ -2,7 +2,7 @@
 /**
  * geist-watchdog.inc.php
  *
- * LibreNMS voltage discovery module for Geist Watchdog
+ * LibreNMS pre-cache poller module for Geist Watchdog
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,9 +23,4 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 
-$value = snmp_get($device, 'climateVolts', '-Oqv', 'GEIST-MIB-V3');
-$current_oid = '.1.3.6.1.4.1.21239.2.2.1.14.1';
-$descr = 'Voltage';
-if (is_numeric($value)) {
-    discover_sensor($valid['sensor'], 'voltage', $device, $current_oid, 'climateVolts', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
-}
+$sensor_config['geist_temp_unit'] = snmp_get($device, 'temperatureUnits.0', '-Oqv', 'GEIST-V4-MIB');

--- a/includes/polling/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/polling/sensors/temperature/geist-watchdog.inc.php
@@ -23,6 +23,6 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 
-if ($sensor_config['geist_temp_unit'] === 0) {
+if ($sensor_config['geist_temp_unit'] == 0) {
     $sensor_value = conv_fahrenheit($sensor_value);
 }

--- a/includes/polling/sensors/temperature/geist-watchdog.inc.php
+++ b/includes/polling/sensors/temperature/geist-watchdog.inc.php
@@ -2,7 +2,7 @@
 /**
  * geist-watchdog.inc.php
  *
- * LibreNMS voltage discovery module for Geist Watchdog
+ * LibreNMS temperature poller module for Geist Watchdog
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,9 +23,6 @@
  * @author     Neil Lathwood <gh+n@laf.io>
  */
 
-$value = snmp_get($device, 'climateVolts', '-Oqv', 'GEIST-MIB-V3');
-$current_oid = '.1.3.6.1.4.1.21239.2.2.1.14.1';
-$descr = 'Voltage';
-if (is_numeric($value)) {
-    discover_sensor($valid['sensor'], 'voltage', $device, $current_oid, 'climateVolts', 'geist-watchdog', $descr, 1, 1, null, null, null, null, $value);
+if ($sensor_config['geist_temp_unit'] === 0) {
+    $sensor_value = conv_fahrenheit($sensor_value);
 }

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -1416,3 +1416,16 @@ function apc_relay_state($state)
             break;
     }
 }
+
+/**
+ * @param $value
+ * @return mixed
+ */
+function return_number($value)
+{
+    preg_match('/[\d\.\-]+/', $value, $temp_response);
+    if (!empty($temp_response[0])) {
+        $value = $temp_response[0];
+    }
+    return $value;
+}


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #7082 

Adds some more functions:

`conv_fahrenheit()` This converts fahrenheit to celsius. It re-uses another function to simplify things

`return_number()` This parses the value passed and returns just a numerical value.

Fixes issues with existing sensor discovery in some files.

Added new ones via yaml. The device provided to test against barely had any sensors available so this is all from the mib....

![image](https://user-images.githubusercontent.com/3941142/29231651-ebe9331e-7edf-11e7-93c5-40a81f294ebe.png)
