### PR TITLE
Escape sensor_descr_fixed in dBm sensors graph

### DIFF
--- a/html/includes/graphs/sensor/dbm.inc.php
+++ b/html/includes/graphs/sensor/dbm.inc.php
@@ -6,7 +6,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrd_options .= " COMMENT:'                       Min       Last      Max\\n'";
 
-$sensor['sensor_descr_fixed'] = rrdtool_escape(substr(str_pad($sensor['sensor_descr'], 18), 0, 18));
+$sensor['sensor_descr_fixed'] = rrdtool_escape($sensor['sensor_descr'], 18);
 
 $rrd_options .= " DEF:sensor=$rrd_filename:sensor:AVERAGE";
 $rrd_options .= " LINE1.5:sensor#cc0000:'".$sensor['sensor_descr_fixed']."'";

--- a/html/includes/graphs/sensor/dbm.inc.php
+++ b/html/includes/graphs/sensor/dbm.inc.php
@@ -6,7 +6,7 @@ require 'includes/graphs/common.inc.php';
 
 $rrd_options .= " COMMENT:'                       Min       Last      Max\\n'";
 
-$sensor['sensor_descr_fixed'] = substr(str_pad($sensor['sensor_descr'], 18), 0, 18);
+$sensor['sensor_descr_fixed'] = rrdtool_escape(substr(str_pad($sensor['sensor_descr'], 18), 0, 18));
 
 $rrd_options .= " DEF:sensor=$rrd_filename:sensor:AVERAGE";
 $rrd_options .= " LINE1.5:sensor#cc0000:'".$sensor['sensor_descr_fixed']."'";


### PR DESCRIPTION
This fixes issue with mrv fiberdriver using port description as name causing graph's to not render when using librenms-style interface descriptions.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
