### PR TITLE
feature: Forced OS Cache rebuild for unit tests

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1646,15 +1646,16 @@ function load_all_os($existing = false, $cached = true)
 }
 
 /**
- * Update the OS cache file cache/os_defs.cache
+ * * Update the OS cache file cache/os_defs.cache
+ * @param bool $force
  */
-function update_os_cache()
+function update_os_cache($force = false)
 {
     global $config;
     $cache_file = $config['install_dir'] . '/cache/os_defs.cache';
     $cache_keep_time = $config['os_def_cache_time'] - 7200; // 2hr buffer
 
-    if (!is_file($cache_file) || time() - filemtime($cache_file) > $cache_keep_time) {
+    if ($force === true || !is_file($cache_file) || time() - filemtime($cache_file) > $cache_keep_time) {
         d_echo('Updating os_def.cache... ');
         load_all_os(false, false);
         file_put_contents($cache_file, serialize($config['os']));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -47,6 +47,7 @@ chdir($install_dir);
 ini_set('display_errors', 1);
 error_reporting(E_ALL & ~E_WARNING);
 
+update_os_cache(true); // Force update of OS Cache
 load_all_os();  // pre-load OS so we don't keep loading them
 
 if (getenv('DBTEST')) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Rebuilds OS cache when running unit tests. Stops the issue of switching between branches which have new OS' added.