### PR TITLE
multiple fixes under agentStpSwitchConfigGroup in EdgeSwitch-SWITCHING-MIB

### DIFF
--- a/mibs/edgeswitch/EdgeSwitch-SWITCHING-MIB
+++ b/mibs/edgeswitch/EdgeSwitch-SWITCHING-MIB
@@ -6798,7 +6798,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
          STATUS      current
          DESCRIPTION
                      "STP port table."
-         ::= { agentStpSwitchConfigGroup 7 }
+         ::= { agentStpSwitchConfigGroup 9 }
 
     agentStpPortEntry OBJECT-TYPE
          SYNTAX      AgentStpPortEntry
@@ -6922,12 +6922,20 @@ agentPortMirrorTypeTable OBJECT-TYPE
                      A non-zero value indicates that BPDUs are to be sent on the specified port."
          ::= { agentStpPortEntry 9 }
 
+   agentStpPortHelloTime OBJECT-TYPE
+         SYNTAX      Unsigned32 (1..65535)
+         MAX-ACCESS  read-write
+         STATUS      current
+         DESCRIPTION
+                     "The spanning-tree hello time for the specified port."
+         ::= { agentStpPortEntry 10 }
+
     --**************************************************************************************
     -- agentStpCstConfigGroup
     --
     --**************************************************************************************
 
-    agentStpCstConfigGroup                      OBJECT IDENTIFIER ::= { agentStpSwitchConfigGroup 8 }
+    agentStpCstConfigGroup                      OBJECT IDENTIFIER ::= { agentStpSwitchConfigGroup 10 }
 
     agentStpCstHelloTime OBJECT-TYPE
          SYNTAX      Unsigned32
@@ -7046,7 +7054,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
          STATUS      current
          DESCRIPTION
                      "CIST port table."
-         ::= { agentStpSwitchConfigGroup 9 }
+         ::= { agentStpSwitchConfigGroup 11 }
 
     agentStpCstPortEntry OBJECT-TYPE
          SYNTAX      AgentStpCstPortEntry
@@ -7346,7 +7354,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
          STATUS      current
          DESCRIPTION
                      "MST table."
-         ::= { agentStpSwitchConfigGroup 10 }
+         ::= { agentStpSwitchConfigGroup 12 }
 
     agentStpMstEntry OBJECT-TYPE
          SYNTAX      AgentStpMstEntry
@@ -7481,7 +7489,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
          STATUS      current
          DESCRIPTION
                      "MST port table."
-         ::= { agentStpSwitchConfigGroup 11 }
+         ::= { agentStpSwitchConfigGroup 13 }
 
     agentStpMstPortEntry OBJECT-TYPE
          SYNTAX      AgentStpMstPortEntry
@@ -7623,7 +7631,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
          STATUS      current
          DESCRIPTION
                      "MST VLAN table."
-         ::= { agentStpSwitchConfigGroup 12 }
+         ::= { agentStpSwitchConfigGroup 14 }
 
     agentStpMstVlanEntry OBJECT-TYPE
          SYNTAX      AgentStpMstVlanEntry
@@ -7667,7 +7675,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
                      disable(2) - disables BPDU Guard Mode on the switch.
 
                      The default status is disabled."
-         ::= { agentStpSwitchConfigGroup 13 }
+         ::= { agentStpSwitchConfigGroup 7 }
 
 
     agentStpBpduFilterDefault OBJECT-TYPE
@@ -7685,7 +7693,7 @@ agentPortMirrorTypeTable OBJECT-TYPE
                      disable(2) - disables BPDU Filter Mode on the switch.
 
                      The default status is disabled."
-         ::= { agentStpSwitchConfigGroup 14 }
+         ::= { agentStpSwitchConfigGroup 8 }
 
 --**************************************************************************************
 --    agentAuthenticationGroup


### PR DESCRIPTION
I was unable to find anywhere to submit these changes upstream, so I'm just
submitting them to you so that you can have them (since you were nice enough
to have the MIB for me to start with).

Corrections here have been verified both in the firmware (which, if you peel
it apart, contains both the OIDs and associated names), and by pulling the
associated data from switches and comparing the results to the expected
results gleaned from the switch's human-targeted interfaces.

Specific corrections:
  agentStpPortTable should be at agentStpSwitchConfigGroup.9, not .7
  agentStpCstConfigGroup should be at .10, not .8
  agentStpCstPortTable should be at .11, not .9
  agentStpMstTable should be at .12, not .10
  agentStpMstPortTable should be at .13, not .11
  agentStpMstVlanTable should be at .14, not .12
  agentStpBpduGuardMode should be at .7, not .13
  agentStpBpduFilterDefault should be at .8, not .14

  ...and agentStpPortHelloTime should exist at agentStpPortEntry.10

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
