### PR TITLE
newdevice: Stop discoverying frequencies on Raritan devices that do not exist + added voltage

### DIFF
--- a/includes/discovery/sensors/frequency/raritan.inc.php
+++ b/includes/discovery/sensors/frequency/raritan.inc.php
@@ -16,9 +16,9 @@ foreach (explode("\n", $inlet_oids) as $inlet_data) {
 
         $inlet_oid       = ".1.3.6.1.4.1.13742.6.5.2.3.1.4.$inlet_index.23";
         $inlet_divisor   = pow(10, snmp_get($device, "inletSensorDecimalDigits.$inlet_index.frequency", '-Ovq', 'PDU2-MIB'));
-        $inlet_frequency = (snmp_get($device, "measurementsInletSensorValue.$inlet_index.frequency", '-Ovq', 'PDU2-MIB') / $inlet_divisor);
-
-        if ($inlet_frequency >= 0) {
+        $inlet_frequency = snmp_get($device, "measurementsInletSensorValue.$inlet_index.frequency", '-Ovq', 'PDU2-MIB');
+        if (is_numeric($inlet_frequency)) {
+            $inlet_frequency = ($inlet_frequency / $inlet_divisor);
             discover_sensor($valid['sensor'], 'frequency', $device, $inlet_oid, $inlet_index, 'raritan', $inlet_descr, $inlet_divisor, 1, null, null, null, null, $inlet_frequency);
         }
     }

--- a/includes/discovery/sensors/pre-cache/raritan.inc.php
+++ b/includes/discovery/sensors/pre-cache/raritan.inc.php
@@ -28,3 +28,6 @@ $pre_cache['raritan_inletTable'] = snmpwalk_group($device, 'inletTable', 'PDU-MI
 
 echo 'inletPoleTable ';
 $pre_cache['raritan_inletPoleTable'] = snmpwalk_group($device, 'inletPoleTable', 'PDU-MIB', 2);
+
+echo 'inletLabel ';
+$pre_cache['raritan_inletLabel'] = snmpwalk_cache_oid($device, 'inletLabel', array(), 'PDU2-MIB');

--- a/includes/discovery/sensors/voltage/raritan.inc.php
+++ b/includes/discovery/sensors/voltage/raritan.inc.php
@@ -38,3 +38,14 @@ foreach ($pre_cache['raritan_inletTable'] as $index => $raritan_data) {
         discover_sensor($valid["sensor"], "voltage", $device, $oid, $tmp_index, 'raritan', $descr, $divisor, 1, $low_limit, $low_limit, $warn_limit, $high_limit, $current);
     }
 }
+
+foreach ($pre_cache['raritan_inletLabel'] as $index => $inlet_data) {
+    $inlet_descr = $inlet_data['inletLabel'];
+    $inlet_oid     = ".1.3.6.1.4.1.13742.6.5.2.3.1.4.$index.5";
+    $inlet_divisor = pow(10, snmp_get($device, "inletSensorDecimalDigits.$index.rmsVoltage", '-Ovq', 'PDU2-MIB'));
+    $inlet_power   = (snmp_get($device, "measurementsInletSensorValue.$index.rmsVoltage", '-Ovq', 'PDU2-MIB') / $inlet_divisor);
+
+    if ($inlet_power >= 0) {
+        discover_sensor($valid['sensor'], 'voltage', $device, $inlet_oid, $index.'.rmsVoltage', 'raritan', $inlet_descr, $inlet_divisor, 1, null, null, null, null, $inlet_power);
+    }
+}

--- a/includes/discovery/sensors/voltage/raritan.inc.php
+++ b/includes/discovery/sensors/voltage/raritan.inc.php
@@ -41,7 +41,7 @@ foreach ($pre_cache['raritan_inletTable'] as $index => $raritan_data) {
 
 foreach ($pre_cache['raritan_inletLabel'] as $index => $inlet_data) {
     $inlet_descr = $inlet_data['inletLabel'];
-    $inlet_oid     = ".1.3.6.1.4.1.13742.6.5.2.3.1.4.$index.5";
+    $inlet_oid     = ".1.3.6.1.4.1.13742.6.5.2.3.1.4.$index.4";
     $inlet_divisor = pow(10, snmp_get($device, "inletSensorDecimalDigits.$index.rmsVoltage", '-Ovq', 'PDU2-MIB'));
     $inlet_power   = (snmp_get($device, "measurementsInletSensorValue.$index.rmsVoltage", '-Ovq', 'PDU2-MIB') / $inlet_divisor);
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #7171 

Small update to not detect the sensor. When dividing it previously the value was always 0.