### PR TITLE
White pages using PHP 7.1.x and Nginx 1.12.1

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -112,6 +112,7 @@ server {
   include fastcgi.conf;
   fastcgi_split_path_info ^(.+\.php)(/.+)$;
   fastcgi_pass unix:/var/run/php-fpm/php7.0-fpm.sock;
+  fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
  }
  location ~ /\.ht {
   deny all;


### PR DESCRIPTION
Set SCRIPT_FILENAME to prevent white pages on PHP 7.1.x

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
