### PR TITLE
fix: Fix Comware Processor Discovery && Hardware Info

### DIFF
--- a/includes/discovery/processors/comware.inc.php
+++ b/includes/discovery/processors/comware.inc.php
@@ -13,23 +13,16 @@
 
 if ($device['os'] == 'comware') {
     echo 'HPE Comware ';
+    $entity_data = snmpwalk_cache_oid($device, 'entPhysicalName', array(), 'ENTITY-MIB');
+    $procdata = snmpwalk_cache_oid($device, 'hh3cEntityExtCpuUsage', array(), 'HH3C-ENTITY-EXT-MIB');
 
-    $entity_data = snmpwalk_cache_oid($device, 'entPhysicalClass', array(), 'ENTITY-MIB');
-    $indexes = array_keys(array_filter($entity_data, function ($entry) {
-        return $entry['entPhysicalClass'] == 'module';
-    }));
-
-    if (!empty($indexes)) {
-        $procdata = snmpwalk_cache_oid($device, 'hh3cEntityExtCpuUsage', array(), 'HH3C-ENTITY-EXT-MIB');
-
-        foreach ($indexes as $i => $entIndex) {
-            if (isset($procdata[$entIndex])) {
-                $cur_oid = ".1.3.6.1.4.1.25506.2.6.1.1.1.1.6.$entIndex";
-                $cur_value = $procdata[$entIndex]['hh3cEntityExtCpuUsage'];
-                $descr = 'Slot ' . ++$i;
-                if ($cur_value > 0) {
-                    discover_processor($valid['processor'], $device, $cur_oid, $entIndex, 'comware', $descr, '1', $cur_value);
-                }
+    foreach ($entity_data as $entity => $value) {
+        if (str_contains($value['entPhysicalName'], array('Board', 'MPU', 'RPU')) && !str_contains($value['entPhysicalName'], array('Fixed SubCard on Board'))) {
+            if (isset($procdata[$entity]['hh3cEntityExtCpuUsage'])) {
+                $cur_oid = ".1.3.6.1.4.1.25506.2.6.1.1.1.1.6.$entity";
+                $cur_value = $procdata[$entity]['hh3cEntityExtCpuUsage'];
+                $descr = $value['entPhysicalName'];
+                discover_processor($valid['processor'], $device, $cur_oid, $entity, 'comware', $descr, '1', $cur_value);
             }
         }
     }

--- a/includes/polling/os/comware.inc.php
+++ b/includes/polling/os/comware.inc.php
@@ -6,8 +6,6 @@
 // SNMPv2-MIB::sysObjectID.0 = OID: HH3C-PRODUCT-ID-MIB::hh3c-S3100-8TP-EI
 echo 'Comware OS...';
 
-#$hardware = snmp_get($device, 'sysObjectID.0', '-Osqv', 'SNMPv2-MIB:HH3C-PRODUCT-ID-MIB');
-
 preg_match('/Version ([0-9.]+).*(Release|ESS) ([R0-9P]+).*\n(.*)/', $poll_device['sysDescr'], $version_match);
 $version = $version_match[1];
 $features = $version_match[3];

--- a/includes/polling/os/comware.inc.php
+++ b/includes/polling/os/comware.inc.php
@@ -6,11 +6,12 @@
 // SNMPv2-MIB::sysObjectID.0 = OID: HH3C-PRODUCT-ID-MIB::hh3c-S3100-8TP-EI
 echo 'Comware OS...';
 
-$hardware = snmp_get($device, 'sysObjectID.0', '-Osqv', 'SNMPv2-MIB:HH3C-PRODUCT-ID-MIB');
+#$hardware = snmp_get($device, 'sysObjectID.0', '-Osqv', 'SNMPv2-MIB:HH3C-PRODUCT-ID-MIB');
 
-preg_match('/Version ([0-9.]+).*Release ([0-9P]+)/', $poll_device['sysDescr'], $version_match);
+preg_match('/Version ([0-9.]+).*(Release|ESS) ([R0-9P]+).*\n(.*)/', $poll_device['sysDescr'], $version_match);
 $version = $version_match[1];
-$features = $version_match[2];
+$features = $version_match[3];
+$hardware = str_replace(array("HPE FF ", "HP ", "HPE "), '', $version_match[4]);
 
 $serial_nums = explode("\n", trim(snmp_walk($device, 'hh3cEntityExtManuSerialNum', '-Osqv', 'HH3C-ENTITY-EXT-MIB')));
 $serial = $serial_nums[0]; // use the first s/n


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Tested on MSR, VSR, 5800, 5900, 5940, 10500.

Processor:
Discovery broke if processor usage at discovery point was 0, hence we could risk having the processor added/removed during each run on devices with no load. Secondly, we can't rely on the class "module" as other entities are also branded as this hence adding bogus processors. This will not break graphs as we continue to use the same indexes. I have changed the descr as we should just present what HPE publish, even if the devices is IRF'ed(this now matches the descr in mempools).

Hardware:
The current MIB available doesn't support the newer models, also the model number listed in the sysDescr is a much better representation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7206)
<!-- Reviewable:end -->
