### PR TITLE
refactor: Updated validate.php to only warn users the install is out of date if > 24 hours

### DIFF
--- a/validate.php
+++ b/validate.php
@@ -298,8 +298,7 @@ if (isset($config['rrdtool_version']) && (version_compare($config['rrdtool_versi
 if (check_git_exists() === true) {
     if ($config['update_channel'] == 'master' && $versions['local_sha'] != $versions['github']['sha']) {
         $commit_date = new DateTime('@'.$versions['local_date'], new DateTimeZone(date_default_timezone_get()));
-        $new_date    = new DateTime("now");
-        if ($commit_date->diff($new_date)->days > 1) {
+        if ($commit_date->diff(new DateTime())->days > 0) {
             print_warn("Your install is over 24 hours out of date, last update: " . $commit_date->format('r'));
         }
     }

--- a/validate.php
+++ b/validate.php
@@ -298,7 +298,10 @@ if (isset($config['rrdtool_version']) && (version_compare($config['rrdtool_versi
 if (check_git_exists() === true) {
     if ($config['update_channel'] == 'master' && $versions['local_sha'] != $versions['github']['sha']) {
         $commit_date = new DateTime('@'.$versions['local_date'], new DateTimeZone(date_default_timezone_get()));
-        print_warn("Your install is out of date, last update: " . $commit_date->format('r'));
+        $new_date    = new DateTime("now");
+        if ($commit_date->diff($new_date)->days > 1) {
+            print_warn("Your install is over 24 hours out of date, last update: " . $commit_date->format('r'));
+        }
     }
 
     if ($versions['local_branch'] != 'master') {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

General update. We shouldn't warn users that the install is only just out of date.