### PR TITLE
Fixed typo: Predicated -> Predicted (2 instances)

### DIFF
--- a/html/pages/bill.inc.php
+++ b/html/pages/bill.inc.php
@@ -176,7 +176,7 @@ if (bill_permitted($bill_id)) {
         <tr>
             <td colspan="2">
 <?php
-            echo 'Predicated usage: ' . format_bytes_billing(getPredictedUsage($bill_data['bill_day'], $bill_data['total_data']));
+            echo 'Predicted usage: ' . format_bytes_billing(getPredictedUsage($bill_data['bill_day'], $bill_data['total_data']));
 ?>
             </td>
 <?php
@@ -198,7 +198,7 @@ if (bill_permitted($bill_id)) {
         <tr>
             <td colspan="2">
 <?php
-            echo 'Predicated usage: ' . format_bytes_billing(getPredictedUsage($bill_data['bill_day'], $bill_data['rate_95th']));
+            echo 'Predicted usage: ' . format_bytes_billing(getPredictedUsage($bill_data['bill_day'], $bill_data['rate_95th']));
 ?>
             </td>
 


### PR DESCRIPTION
The text that should have been "Predicted usage" was written as "Predicated usage" for both occurrences in the file.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
