### PR TITLE
feature: Improve install process

### DIFF
--- a/html/ajax_output.php
+++ b/html/ajax_output.php
@@ -14,7 +14,6 @@
 
 session_start();
 if (isset($_SESSION['stage']) && $_SESSION['stage'] == 2) {
-    $_SESSION['build-ok'] = true;
     $init_modules = array('web', 'nodb');
     require realpath(__DIR__ . '/..') . '/includes/init.php';
 } else {

--- a/html/includes/output/db-update.inc.php
+++ b/html/includes/output/db-update.inc.php
@@ -61,7 +61,11 @@ if (($fp = popen($cmd . ' 2>&1', "r"))) {
     if (pclose($fp) === 0) {
         echo "Database is up to date!";
         $_SESSION['build-ok'] = true;
+    } else {
+        echo "Database schema update failed!";
     }
 }
 
+ob_end_flush();
+flush();
 session_write_close();


### PR DESCRIPTION
Fix incorrectly updating session with build-ok before start of schema update
Set a timeout for progress on the schema build 40s (lock wait time is 30s, so must be more than that).  Allow the user to restart the process if this timeout is reached.
Animate the progress bar while waiting for the schema update. Stop animation on failure or success.
Properly destroy the session after install.  This allows the user to restart if they need to without any tricks. Only need to make sure config.php does not exist.
Move next step buttons to the right.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
