### PR TITLE
Do not Initialize auth for cli commands, as they do not use auth anyway

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -149,7 +149,9 @@ if (!module_selected('nodb', $init_modules)) {
 if (file_exists($config['install_dir'] . '/html/includes/authentication/'.$config['auth_mechanism'].'.inc.php')) {
     require_once $install_dir . '/html/includes/authentication/functions.php';
     require_once $config['install_dir'] . '/html/includes/authentication/'.$config['auth_mechanism'].'.inc.php';
-    init_auth();
+    if (! isCli()) {
+        init_auth();
+    }
 } else {
     print_error('ERROR: no valid auth_mechanism defined!');
     exit();


### PR DESCRIPTION
Currently, every new poller will initiate authentication, but does not use authentication in any way.  This adds unnecessary time to the poller process, and creates a ton of unused connections from polling workers to whatever auth source is being used.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7237)
<!-- Reviewable:end -->
