### PR TITLE
fix: Fixed the empty() vlan detection check

### DIFF
--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -29,7 +29,7 @@ if ($device['os'] === 'junos') {
     require 'includes/discovery/vlans/avaya-ers.inc.php';
 }
 
-if (is_array($device['vlans']) == false) {
+if (empty($device['vlans']) === true) {
     require 'includes/discovery/vlans/q-bridge-mib.inc.php';
     require 'includes/discovery/vlans/cisco-vtp.inc.php';
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Turns out `$device['vlans']` is an array even when no data exists.

Fixes: #7233 