### PR TITLE
Use $install_dir var for auth_mechanism require_once

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -146,9 +146,9 @@ if (!module_selected('nodb', $init_modules)) {
     require $install_dir . '/includes/process_config.inc.php';
 }
 
-if (file_exists($config['install_dir'] . '/html/includes/authentication/'.$config['auth_mechanism'].'.inc.php')) {
+if (file_exists($install_dir . '/html/includes/authentication/'.$config['auth_mechanism'].'.inc.php')) {
     require_once $install_dir . '/html/includes/authentication/functions.php';
-    require_once $config['install_dir'] . '/html/includes/authentication/'.$config['auth_mechanism'].'.inc.php';
+    require_once $install_dir . '/html/includes/authentication/'.$config['auth_mechanism'].'.inc.php';
     init_auth();
 } else {
     print_error('ERROR: no valid auth_mechanism defined!');


### PR DESCRIPTION
This PR fixes the following error that showed up after upgrading to 1.31.
```
Array ( [0] => 1 [1] => Uncaught Error: Call to undefined function init_auth() in /srv/deployment/librenms/librenms-cache/revs/8c9da11850ecbf2a949b9317d1fce75301bfd13b/includes/init.php:152 Stack trace: #0 /srv/deployment/librenms/librenms-cache/revs/8c9da11850ecbf2a949b9317d1fce75301bfd13b/html/index.php(59): require() #1 {main} thrown [2] => /srv/deployment/librenms/librenms-cache/revs/8c9da11850ecbf2a949b9317d1fce75301bfd13b/includes/init.php [3] => 152 ) 
```
it's most likeley related to the fact that we use a symlink, and $config['install_dir'] is the symlink, and $install_dir is the real folder.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
