### PR TITLE
fix: update notification for users with updates disabled

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -151,7 +151,7 @@ main () {
         up=$(php daily.php -f update >&2; echo $?)
         if [[ "$up" == "0" ]]; then
             ${DAILY_SCRIPT} no-code-update
-            set_notification update 0  # make sure there are no update notifications if update is disabled
+            set_notification update 1  # make sure there are no update notifications if update is disabled
             exit
         fi
 

--- a/html/index.php
+++ b/html/index.php
@@ -302,7 +302,7 @@ if (dbFetchCell("SELECT COUNT(*) FROM `devices` WHERE `last_polled` <= DATE_ADD(
     $msg_box[] = array('type' => 'warning', 'message' => "<a href=\"poll-log/filter=unpolled/\">It appears as though you have some devices that haven't completed polling within the last 15 minutes, you may want to check that out :)</a>",'title' => 'Devices unpolled');
 }
 
-foreach (dbFetchRows('SELECT * FROM `notifications` WHERE `severity` > 1') as $notification) {
+foreach (dbFetchRows('SELECT `notifications`.* FROM `notifications` WHERE NOT exists( SELECT 1 FROM `notifications_attribs` WHERE `notifications`.`notifications_id` = `notifications_attribs`.`notifications_id` AND `notifications_attribs`.`user_id` = ?) AND `severity` > 1', array($_SESSION['user_id'])) as $notification) {
     $msg_box[] = array(
         'type' => 'error',
         'message' => "<a href='notifications/'>${notification['body']}</a>",


### PR DESCRIPTION
Don't show the toast when the notification is marked as read

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
