### PR TITLE
Add multiples servers into the ldap auth

### DIFF
--- a/html/includes/authentication/ldap-authorization.inc.php
+++ b/html/includes/authentication/ldap-authorization.inc.php
@@ -47,15 +47,39 @@ function init_auth()
     if (! isset($_SESSION['username'])) {
         $_SESSION['username'] = '';
     }
-
-    /**
-     * Set up connection to LDAP server
-     */
-    $ldap_connection = @ldap_connect($config['auth_ldap_server'], $config['auth_ldap_port']);
-    if (! $ldap_connection) {
-        echo '<h2>Fatal error while connecting to LDAP server ' . $config['auth_ldap_server'] . ':' . $config['auth_ldap_port'] . ': ' . ldap_error($ldap_connection) . '</h2>';
+    
+    if (!isset($config['auth_ldap_server'])) {
+        echo '<h2>Fatal error while connecting to LDAP server you must fill at least the "auth_ldap_server" in config.php.</h2>';
         exit;
     }
+
+    /* need if we use multiples ldap server */
+    if (gettype($config['auth_ldap_server']) == 'array') {
+        foreach ($config['auth_ldap_server'] as $ldap_server) {
+            if (preg_match('/^ldap/', $ldap_server)) {
+                $ldap_connection = @ldap_connect($ldap_server);
+            } elseif (isset($config['auth_ldap_port'])) {
+                $ldap_connection = @ldap_connect($ldap_server, $config['auth_ldap_port']);
+            }
+            if ($ldap_connection) {
+                break;
+            }
+        }
+        if (!$ldap_connection) {
+            echo '<h2>Fatal error while connecting to LDAP servers ' . join(',', $config['auth_ldap_server']) . '</h2>';
+            exit;
+        }
+    } else {
+        /**
+         * Set up connection to LDAP server
+         */
+        $ldap_connection = @ldap_connect($config['auth_ldap_server'], $config['auth_ldap_port']);
+        if (! $ldap_connection) {
+            echo '<h2>Fatal error while connecting to LDAP server ' . $config['auth_ldap_server'] . ':' . $config['auth_ldap_port'] . ': ' . ldap_error($ldap_connection) . '</h2>';
+            exit;
+        }
+    }
+    
     if ($config['auth_ldap_version']) {
         ldap_set_option($ldap_connection, LDAP_OPT_PROTOCOL_VERSION, $config['auth_ldap_version']);
     }

--- a/html/includes/authentication/ldap.inc.php
+++ b/html/includes/authentication/ldap.inc.php
@@ -5,8 +5,40 @@ use LibreNMS\Exceptions\AuthenticationException;
 function init_auth()
 {
     global $config, $ldap_connection;
-
-    $ldap_connection = @ldap_connect($config['auth_ldap_server'], $config['auth_ldap_port']);
+    
+    
+    if (!isset($config['auth_ldap_server'])) {
+        echo '<h2>Fatal error while connecting to LDAP server you must fill at least the "auth_ldap_server" in config.php.</h2>';
+        exit;
+    }
+    
+    /* need if we use multiples ldap server */
+    if (gettype($config['auth_ldap_server']) == 'array') {
+        foreach ($config['auth_ldap_server'] as $ldap_server) {
+            if (preg_match('/^ldap/', $ldap_server)) {
+                $ldap_connection = @ldap_connect($ldap_server);
+            } elseif (isset($config['auth_ldap_port'])) {
+                $ldap_connection = @ldap_connect($ldap_server, $config['auth_ldap_port']);
+            }
+            
+            if ($ldap_connection) {
+                break;
+            }
+        }
+        if (!$ldap_connection) {
+            echo '<h2>Fatal error while connecting to LDAP servers ' . join(',', $config['auth_ldap_server']) . '</h2>';
+            exit;
+        }
+    } else {
+        /**
+         * Set up connection to LDAP server
+         */
+        $ldap_connection = @ldap_connect($config['auth_ldap_server'], $config['auth_ldap_port']);
+        if (!$ldap_connection) {
+            echo '<h2>Fatal error while connecting to LDAP server ' . $config['auth_ldap_server'] . ':' . $config['auth_ldap_port'] . ': ' . ldap_error($ldap_connection) . '</h2>';
+            exit;
+        }
+    }
 
     if ($config['auth_ldap_starttls'] && ($config['auth_ldap_starttls'] == 'optional' || $config['auth_ldap_starttls'] == 'require')) {
         $tls = ldap_start_tls($ldap_connection);

--- a/includes/polling/applications/ntp-client.inc.php
+++ b/includes/polling/applications/ntp-client.inc.php
@@ -2,17 +2,45 @@
 
 use LibreNMS\RRD\RrdDefinition;
 
+global $config;
+
 //NET-SNMP-EXTEND-MIB::nsExtendOutputFull."ntp-client"
 $name = 'ntp-client';
 $app_id = $app['app_id'];
 $oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.10.110.116.112.45.99.108.105.101.110.116';
 $ntpclient = snmp_get($device, $oid, '-Oqv');
 $ntpclient = str_replace('"', '', $ntpclient);
-update_application($app, $ntpclient);
 
 echo ' '.$name;
 
 list ($offset, $frequency, $jitter, $noise, $stability) = explode("\n", $ntpclient);
+
+/* 
+    return Like Nagios
+
+	0 = Ok
+	1 = Warning
+	2 = Critical
+*/
+
+$crit = 50; // in 50 ms
+$warn = 25; // warning in +- 25ms
+
+if (isset($config['apps'][$name]['critical']) && is_numeric($config['apps'][$name]['critical'])) {
+    $crit = $config['apps'][$name]['critical'];
+}
+
+if (isset($config['apps'][$name]['warning']) && is_numeric($config['apps'][$name]['warning'])) {
+    $warn = $config['apps'][$name]['warning'];
+}
+$status=0;
+if ($offset >= $crit || $offset <= (-1 * $crit)) {
+    $status=2; // critical
+} elseif ($offset >= $warn || $offset <= (-1 * $warn)) {
+    $status=1; // warning
+}
+
+update_application($app, $ntpclient, $status);
 
 $rrd_name = array('app', $name, $app_id);
 $rrd_def = RrdDefinition::make()


### PR DESCRIPTION
Add multiples servers into the ldap auth
example in config.php:
$config['auth_ldap_server'] = ["ldaps://ldap1.example.net","ldaps://ldap2.example.net","ldap://ldap3.example.net"];
the auth ldap chek the uri or not in server name.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7274)
<!-- Reviewable:end -->
