### PR TITLE
Citrix Netscaler - Use vserver full names

### DIFF
--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-// NS-ROOT-MIB::vsvrName."librenms" = STRING: "librenms"
+// NS-ROOT-MIB::vsvrFullName."librenms" = STRING: "librenms"
 // NS-ROOT-MIB::vsvrIpAddress."librenms" = IpAddress: 195.78.84.141
 // NS-ROOT-MIB::vsvrPort."librenms" = INTEGER: 80
 // NS-ROOT-MIB::vsvrType."librenms" = INTEGER: http(0)
@@ -76,9 +76,9 @@ if ($device['os'] == 'netscaler') {
     d_echo($vsvrs);
 
     foreach ($vsvr_array as $index => $vsvr) {
-        if (isset($vsvr['vsvrName'])) {
-            $vsvr_exist[$vsvr['vsvrName']] = 1;
-            $rrd_name  = 'netscaler-vsvr-'.$vsvr['vsvrName'];
+        if (isset($vsvr['vsvrFullName'])) {
+            $vsvr_exist[$vsvr['vsvrFullName']] = 1;
+            $rrd_name  = 'netscaler-vsvr-'.$vsvr['vsvrFullName'];
 
             $fields = array();
             foreach ($oids as $oid) {
@@ -90,13 +90,13 @@ if ($device['os'] == 'netscaler') {
             }
 
             $tags = array(
-                'vsvrName' => $vsvr['vsvrName'],
+                'vsvrFullName' => $vsvr['vsvrFullName'],
                 'rrd_name' => $rrd_name,
                 'rrd_def' => $rrd_def
             );
             data_update($device, 'netscaler-vsvr', $tags, $fields);
 
-            echo str_pad($vsvr['vsvrName'], 25).' | '.str_pad($vsvr['vsvrType'], 5).' | '.str_pad($vsvr['vsvrState'], 6).' | '.str_pad($vsvr['vsvrIpAddress'], 16).' | '.str_pad($vsvr['vsvrPort'], 5);
+            echo str_pad($vsvr['vsvrFullName'], 25).' | '.str_pad($vsvr['vsvrType'], 5).' | '.str_pad($vsvr['vsvrState'], 6).' | '.str_pad($vsvr['vsvrIpAddress'], 16).' | '.str_pad($vsvr['vsvrPort'], 5);
             echo ' | '.str_pad($vsvr['vsvrRequestRate'], 8).' | '.str_pad($vsvr['vsvrRxBytesRate'].'B/s', 8).' | '.str_pad($vsvr['vsvrTxBytesRate'].'B/s', 8);
 
             $db_update = array(
@@ -109,12 +109,12 @@ if ($device['os'] == 'netscaler') {
                           'vsvr_bps_out'  => $vsvr['vsvrTxBytesRate'],
                          );
 
-            if (!is_array($vsvrs[$vsvr['vsvrName']])) {
-                $db_insert = array_merge(array('device_id' => $device['device_id'], 'vsvr_name' => $vsvr['vsvrName']), $db_update);
+            if (!is_array($vsvrs[$vsvr['vsvrFullName']])) {
+                $db_insert = array_merge(array('device_id' => $device['device_id'], 'vsvr_name' => $vsvr['vsvrFullName']), $db_update);
                 $vsvr_id   = dbInsert($db_insert, 'netscaler_vservers');
                 echo ' +';
             } else {
-                $updated = dbUpdate($db_update, 'netscaler_vservers', '`vsvr_id` = ?', array($vsvrs[$vsvr['vsvrName']]['vsvr_id']));
+                $updated = dbUpdate($db_update, 'netscaler_vservers', '`vsvr_id` = ?', array($vsvrs[$vsvr['vsvrFullName']]['vsvr_id']));
                 echo ' U';
             }
 


### PR DESCRIPTION
Netscaler vserver names can be up to 127 chars long.  The current db schema supports that but the actual polling was using `vsvrName` instead of `vsvrFullName`, therefore producing some random string names for vserver names longer than 30 chars (based on my observations).

Querying the SNMP agent with the Citrix MIB with something like:

```
snmptable -v2c -c READONLY123  -m "/srv/nms/librenms/mibs/citrix/NS-MIB-SMIV2-MIB" 10.11.12.13 vserverTable | awk '$0 !~ /^(SNMP|NS-ROOT)/ {print $1,$47;}' | column -t
```
Show the `vsvrName` vs `vsvrFullName` OID content:

```
vsvrName                           vsvrFullName
"v1test.example.dn-ssl"            "v1test.example.dn-ssl"
"v4test.example.dn-ssl"            "v4test.example.dn-ssl"
"IN5x1b508recfdlda1aghwbqrzfijap"  "v4test10-staging-intvserver-http"
"INrnvioacb39ujklzkl1fxdlz5v4wdb"  "test1.staging.example.dn-http-gslb"
"INnjxa2gd5mg54s9plgfchyapetvddp"  "testfeature-staging-intvserver-http"
```
As shown, longer vserver `vsvrName` are sent encoded (in something) but the `vsvrFullName` is always representative of the original configured vserver name.

With the proposed change, the `vsvrFullName` is used everywhere, including the RRD data files.

After some Googling, I found some references that this `vsvrFullName` OID was added in version 9 of the Netscaler.  Considering that v9.x was EOL in 2015, it should be safe to use that OID without exception.

I also just found this:

https://gitlab.ctwug.za.net/librenms/librenms/commits/4edd835d0e03b3790e9ee9c947f597fe5752b8cb/includes/polling/netscaler-vsvr.inc.php

Looks like this exact change was attempted in 2012, but reverted the next day.  I can't find the reason as to why, but possibly this was because the `vsvrFullName` was not available in all versions at that time.

Note that this change works without issue in our installation, but I am far from an expert in the polling code / SNMP in general.

Thanks,
Math.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7279)
<!-- Reviewable:end -->
