### PR TITLE
Syslog future entries cleanup

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -57,8 +57,23 @@ if ($options['f'] === 'syslog') {
                 break;
             }
         }
-
         dbDelete('syslog', 'seq >= ? AND timestamp < DATE_SUB(NOW(), INTERVAL ? DAY)', array($rows, $config['syslog_purge']));
+
+        $rows = (int)dbFetchCell('SELECT MIN(seq) FROM syslog');
+        while (true) {
+            $limit = dbFetchRow('SELECT seq FROM syslog WHERE seq >= ? ORDER BY seq LIMIT 1000,1', array($rows));
+            if (empty($limit)) {
+                break;
+            }
+
+            if (dbDelete('syslog', 'seq >= ? AND seq < ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows, $limit)) > 0) {
+                $rows = $limit;
+                echo "Syslog cleared for entries from more than 7 days in the future 1000 limit\n";
+            } else {
+                break;
+            }
+        }
+        dbDelete('syslog', 'seq >= ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows));
     }
 }
 

--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -180,7 +180,12 @@ Trigger external scripts based on specific syslog patterns being matched with sy
 $config['enable_syslog_hooks'] = 1;
 ```
 
-The below are some example hooks to call an external script in the event of a configuration change on Cisco IOS, IOS-XR and NX-OS devices. Add to your `config.php` file to enable.
+The below are some example hooks to call an external script in the event of a configuration change on Cisco ASA, IOS, NX-OS and IOS-XR devices. Add to your `config.php` file to enable.
+
+#### Cisco ASA
+```ssh
+$config['os']['asa']['syslog_hook'][] = Array('regex' => '/%ASA-5-111005/', 'script' => '/opt/librenms/scripts/syslog-notify-oxidized.php');
+```
 
 #### Cisco IOS
 ```ssh

--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -184,7 +184,7 @@ The below are some example hooks to call an external script in the event of a co
 
 #### Cisco ASA
 ```ssh
-$config['os']['asa']['syslog_hook'][] = Array('regex' => '/%ASA-5-111005/', 'script' => '/opt/librenms/scripts/syslog-notify-oxidized.php');
+$config['os']['asa']['syslog_hook'][] = Array('regex' => '/%ASA-(config-)?5-111005/', 'script' => '/opt/librenms/scripts/syslog-notify-oxidized.php');
 ```
 
 #### Cisco IOS

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -64,8 +64,9 @@ function process_syslog($entry, $update)
 
         if ((isset($config['enable_syslog_hooks'])) && ($config['enable_syslog_hooks']) && (isset($config['os'][$os]['syslog_hook'])) && (is_array($config['os'][$os]['syslog_hook']))) {
             foreach ($config['os'][$os]['syslog_hook'] as $k => $v) {
-                if ((isset($v['script'])) && (isset($v['regex'])) && (preg_match($v['regex'], $entry['msg']))) {
-                    shell_exec(escapeshellcmd($v['script']).' '.escapeshellarg($hostname).' '.escapeshellarg($os).' '.escapeshellarg($entry['msg']).' >/dev/null 2>&1 &');
+                $syslogmsg = $entry['program'].": ".$entry['msg'];
+                if ((isset($v['script'])) && (isset($v['regex'])) && ((preg_match($v['regex'], $syslogmsg)))) {
+                    shell_exec(escapeshellcmd($v['script']).' '.escapeshellarg($hostname).' '.escapeshellarg($os).' '.escapeshellarg($syslogmsg).' >/dev/null 2>&1 &');
                 }
             }
         }

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -64,9 +64,9 @@ function process_syslog($entry, $update)
 
         if ((isset($config['enable_syslog_hooks'])) && ($config['enable_syslog_hooks']) && (isset($config['os'][$os]['syslog_hook'])) && (is_array($config['os'][$os]['syslog_hook']))) {
             foreach ($config['os'][$os]['syslog_hook'] as $k => $v) {
-                $syslogmsg = $entry['program'].": ".$entry['msg'];
-                if ((isset($v['script'])) && (isset($v['regex'])) && ((preg_match($v['regex'], $syslogmsg)))) {
-                    shell_exec(escapeshellcmd($v['script']).' '.escapeshellarg($hostname).' '.escapeshellarg($os).' '.escapeshellarg($syslogmsg).' >/dev/null 2>&1 &');
+                $syslogprogmsg = $entry['program'].": ".$entry['msg'];
+                if ((isset($v['script'])) && (isset($v['regex'])) && ((preg_match($v['regex'], $syslogprogmsg)))) {
+                    shell_exec(escapeshellcmd($v['script']).' '.escapeshellarg($hostname).' '.escapeshellarg($os).' '.escapeshellarg($syslogprogmsg).' >/dev/null 2>&1 &');
                 }
             }
         }

--- a/scripts/syslog-notify-oxidized.php
+++ b/scripts/syslog-notify-oxidized.php
@@ -35,4 +35,8 @@ if (preg_match('/(SYS-(SW[0-9]+-)?5-CONFIG_I|VSHD-5-VSHD_SYSLOG_CONFIG_I): Confi
 } elseif (preg_match('/GBL-CONFIG-6-DB_COMMIT : Configuration committed by user \\\\\'(?P<user>.+?)\\\\\'..*/', $msg, $matches)) {
     $username = $matches['user'];
     oxidized_node_update($hostname, $username, $msg);
+} elseif (preg_match('/ASA-config-5-111005: (?P<user>.+) end configuration: OK/', $msg, $matches)) {
+    echo "matched\n";
+    $username = $matches['user'];
+    oxidized_node_update($hostname, $username, $msg);
 }

--- a/scripts/syslog-notify-oxidized.php
+++ b/scripts/syslog-notify-oxidized.php
@@ -35,7 +35,7 @@ if (preg_match('/(SYS-(SW[0-9]+-)?5-CONFIG_I|VSHD-5-VSHD_SYSLOG_CONFIG_I): Confi
 } elseif (preg_match('/GBL-CONFIG-6-DB_COMMIT : Configuration committed by user \\\\\'(?P<user>.+?)\\\\\'..*/', $msg, $matches)) {
     $username = $matches['user'];
     oxidized_node_update($hostname, $username, $msg);
-} elseif (preg_match('/ASA-config-5-111005: (?P<user>.+) end configuration: OK/', $msg, $matches)) {
+} elseif (preg_match('/ASA-(config-)?5-111005: (?P<user>.+) end configuration: OK/', $msg, $matches)) {
     echo "matched\n";
     $username = $matches['user'];
     oxidized_node_update($hostname, $username, $msg);


### PR DESCRIPTION
When switches reload, often we end up with entries in the database that show timestamps from the future. These entries then remain until the future date gets reached, which is undesirable.

This patch deletes any entries that are more than 7 days into the future. This accounts for the majority of clock skew, where devices can be hours or days ahead "legitimately" while solving for others.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7280)
<!-- Reviewable:end -->
