### PR TITLE
Syslog future entries cleanup (take 2)

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -67,15 +67,15 @@ if ($options['f'] === 'syslog') {
                 break;
             }
 
-            if (dbDelete('syslog', 'seq >= ? AND seq < ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows, $limit)) > 0) {
+            if (dbDelete('syslog', 'seq >= ? AND seq < ? AND timestamp > DATE_SUB(NOW(), INTERVAL ? DAY)', array($rows, $limit, $config['syslog_future_purge'])) > 0) {
                 $rows = $limit;
-                echo "Syslog cleared for entries from more than 7 days in the future 1000 limit\n";
+                echo "Syslog cleared for entries from more than ".$config['syslog_future_purge']." days in the future 1000 limit\n";
             } else {
                 break;
             }
         }
 
-        dbDelete('syslog', 'seq >= ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows));
+        dbDelete('syslog', 'seq >= ? AND timestamp > DATE_SUB(NOW(), INTERVAL ? DAY)', array($rows, $config['syslog_future_purge']));
     }
 }
 

--- a/daily.php
+++ b/daily.php
@@ -57,8 +57,23 @@ if ($options['f'] === 'syslog') {
                 break;
             }
         }
-
         dbDelete('syslog', 'seq >= ? AND timestamp < DATE_SUB(NOW(), INTERVAL ? DAY)', array($rows, $config['syslog_purge']));
+
+        $rows = (int)dbFetchCell('SELECT MIN(seq) FROM syslog');
+        while (true) {
+            $limit = dbFetchRow('SELECT seq FROM syslog WHERE seq >= ? ORDER BY seq LIMIT 1000,1', array($rows));
+            if (empty($limit)) {
+                break;
+            }
+
+            if (dbDelete('syslog', 'seq >= ? AND seq < ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows, $limit)) > 0) {
+                $rows = $limit;
+                echo "Syslog cleared for entries from more than 7 days in the future 1000 limit\n";
+            } else {
+                break;
+            }
+        }
+        dbDelete('syslog', 'seq >= ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows));
     }
 }
 

--- a/daily.php
+++ b/daily.php
@@ -57,6 +57,7 @@ if ($options['f'] === 'syslog') {
                 break;
             }
         }
+
         dbDelete('syslog', 'seq >= ? AND timestamp < DATE_SUB(NOW(), INTERVAL ? DAY)', array($rows, $config['syslog_purge']));
 
         $rows = (int)dbFetchCell('SELECT MIN(seq) FROM syslog');
@@ -73,6 +74,7 @@ if ($options['f'] === 'syslog') {
                 break;
             }
         }
+
         dbDelete('syslog', 'seq >= ? AND timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)', array($rows));
     }
 }

--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -102,7 +102,7 @@ Create a file called something like `/etc/rsyslog.d/30-librenms.conf` containing
 # Feed syslog messages to librenms
 $ModLoad omprog
 
-$template librenms,"%fromhost%||%syslogfacility%||%syslogpriority%||%syslogseverity%||%syslogtag%||%$year%-%$month%-%$day% %timereported:8:25%||%msg%||%programname%\n"
+$template librenms,"%fromhost%||%syslogfacility%||%syslogpriority%||%syslogseverity%||%syslogtag%||%$year%-%$month%-%$day% %timegenerated:8:25%||%msg%||%programname%\n"
 
 *.* action(type="omprog" binary="/opt/librenms/syslog.php" template="librenms")
 

--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -54,7 +54,7 @@ source s_net {
 # Destinations
 ########################
 destination d_librenms {
-        program("/opt/librenms/syslog.php" template ("$HOST||$FACILITY||$PRIORITY||$LEVEL||$TAG||$YEAR-$MONTH-$DAY $HOUR:$MIN:$SEC||$MSG||$PROGRAM\n") template-escape(yes));
+        program("/opt/librenms/syslog.php" template ("$HOST||$FACILITY||$PRIORITY||$LEVEL||$TAG||$R_YEAR-$R_MONTH-$R_DAY $R_HOUR:$R_MIN:$R_SEC||$MSG||$PROGRAM\n") template-escape(yes));
 };
 
 ########################

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -812,6 +812,8 @@ $config['update'] = 1;
 // Purge syslog and eventlog
 $config['syslog_purge'] = 30;
 // Number in days of how long to keep syslog entries for.
+$config['syslog_future_purge'] = 7;
+// Number in days of how far into the future we should be checking to delete syslog entries.
 $config['eventlog_purge'] = 30;
 // Number in days of how long to keep eventlog entries for.
 $config['authlog_purge'] = 30;


### PR DESCRIPTION
When switches reload, often we end up with entries in the database that show timestamps from the future. These entries then remain until the future date gets reached, which is undesirable.

This patch deletes any entries that are more than 7 days into the future. This accounts for the majority of clock skew, where devices can be hours or days ahead "legitimately" while solving for others.

 DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7282)
<!-- Reviewable:end -->
