### PR TITLE
Added IOS-XR Bundle-Ether shortened/corrected forms

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1051,6 +1051,7 @@ function shorten_interface_type($string)
             'GigabitEthernet',
             'Port-Channel',
             'Ethernet',
+            'Bundle-Ether',
         ),
         array(
             'Fa',
@@ -1058,6 +1059,7 @@ function shorten_interface_type($string)
             'Gi',
             'Po',
             'Eth',
+            'BE',
         ),
         $string
     );

--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -183,6 +183,7 @@ function makeshortif($if)
         'tunnel'              => 'Tunnel',
         'serviceinstance'     => 'SI',
         'dwdm'                => 'DWDM',
+        'bundle-ether'        => 'BE',
     );
 
     $if = fixifName($if);
@@ -1004,6 +1005,7 @@ function fixifName($inf)
         'hp procurve switch software loopback interface' => 'Loopback Interface',
         'control plane interface'                        => 'Control Plane',
         'loop'                                           => 'Loop',
+        'bundle-ether'                                   => 'Bundle-Ether',
     );
 
     $inf = strtolower($inf);


### PR DESCRIPTION
IOS-XR uses Bundle-Ether (BE) interfaces instead of Port-channel (Po) interfaces.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7283)
<!-- Reviewable:end -->
