### PR TITLE
fix: Updated graph_types table so graph_subtype has no default value

### DIFF
--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -571,7 +571,7 @@ graph_types:
     graph_descr: { Field: graph_descr, Type: varchar(255), 'Null': true, Default: 'NULL', Extra: '' }
     graph_order: { Field: graph_order, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
     graph_section: { Field: graph_section, Type: varchar(32), 'Null': false, Default: 'NULL', Extra: '' }
-    graph_subtype: { Field: graph_subtype, Type: varchar(64), 'Null': false, Default: '', Extra: '' }
+    graph_subtype: { Field: graph_subtype, Type: varchar(64), 'Null': false, Default: 'NULL', Extra: '' }
     graph_type: { Field: graph_type, Type: varchar(32), 'Null': false, Default: 'NULL', Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [graph_type, graph_subtype, graph_section], Unique: true, Type: BTREE }

--- a/sql-schema/206.sql
+++ b/sql-schema/206.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `graph_types` CHANGE `graph_subtype` `graph_subtype` varchar(64) NOT NULL;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This should fix the validate issues. We insert a value into this column so it makes sense to just have it set as NOT NULL with no default value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7285)
<!-- Reviewable:end -->
