### PR TITLE
Add config option "api_auth_local" to bypass auth_mechanism for API-requests

### DIFF
--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -232,3 +232,20 @@ $config['auth_ad_binduser']     = "ad_binduser";
 $config['auth_ad_bindpassword'] = "ad_bindpassword";
 $config['auth_ldap_cache_ttl']  = 300;
 ```
+
+### API access 
+
+Config option: `auth_api_local`
+
+The API uses the authentication extension set with `$config['auth_mechanism']` by default. It is possible to have API calls authenticated against the mysql-database with the following config (default value is false):
+
+```php
+$config['auth_api_local'] = true;
+```
+
+It is not possible to add local tokens from the web-interface if `auth_mechanism` is something else than mysql. 
+To add API-tokens/users you will have to either:
+
+- manually alter the database
+
+- temporarily set `$config['auth_mechanism'] = mysql;` and add them from the webinterface

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -12,14 +12,14 @@
  * the source code distribution for details.
  */
 
+use LibreNMS\Config;
+
 function authToken(\Slim\Route $route)
 {
-    global $config;
-
     $app   = \Slim\Slim::getInstance();
     $token = $app->request->headers->get('X-Auth-Token');
     if (isset($token) && !empty($token)) {
-        if (!function_exists('get_user') || $config['api_auth_local'] === true) {
+        if (!function_exists('get_user') || Config::get('api_auth_local', true)) {
             $username = dbFetchCell('SELECT `U`.`username` FROM `api_tokens` AS AT JOIN `users` AS U ON `AT`.`user_id`=`U`.`user_id` WHERE `AT`.`token_hash`=?', array($token));
         } else {
             $username = get_user(dbFetchCell('SELECT `AT`.`user_id` FROM `api_tokens` AS AT WHERE `AT`.`token_hash`=?', array($token)));

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -14,10 +14,12 @@
 
 function authToken(\Slim\Route $route)
 {
+    global $config;
+
     $app   = \Slim\Slim::getInstance();
     $token = $app->request->headers->get('X-Auth-Token');
     if (isset($token) && !empty($token)) {
-        if (!function_exists('get_user')) {
+        if (!function_exists('get_user') || $config['api_auth_local'] === true) {
             $username = dbFetchCell('SELECT `U`.`username` FROM `api_tokens` AS AT JOIN `users` AS U ON `AT`.`user_id`=`U`.`user_id` WHERE `AT`.`token_hash`=?', array($token));
         } else {
             $username = get_user(dbFetchCell('SELECT `AT`.`user_id` FROM `api_tokens` AS AT WHERE `AT`.`token_hash`=?', array($token)));

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -19,7 +19,7 @@ function authToken(\Slim\Route $route)
     $app   = \Slim\Slim::getInstance();
     $token = $app->request->headers->get('X-Auth-Token');
     if (isset($token) && !empty($token)) {
-        if (!function_exists('get_user') || Config::get('api_auth_local', true)) {
+        if (!function_exists('get_user') || Config::get('api_auth_local', false)) {
             $username = dbFetchCell('SELECT `U`.`username` FROM `api_tokens` AS AT JOIN `users` AS U ON `AT`.`user_id`=`U`.`user_id` WHERE `AT`.`token_hash`=?', array($token));
         } else {
             $username = get_user(dbFetchCell('SELECT `AT`.`user_id` FROM `api_tokens` AS AT WHERE `AT`.`token_hash`=?', array($token)));

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -849,6 +849,8 @@ $config['enable_footer'] = 1;
 // Set this to 0 if you want to disable the footer copyright in the web interface
 $config['api_demo'] = 0;
 // Set this to 1 if you want to disable some untrusting features for the API
+$config['api_auth_local'] = false;
+// Set this to true if you have changed auth_mechanism, but want to use mysql database for API-tokens
 // Distributed Poller-Settings
 $config['distributed_poller']                = false;
 $config['distributed_poller_name']           = file_get_contents('/proc/sys/kernel/hostname');

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -849,8 +849,6 @@ $config['enable_footer'] = 1;
 // Set this to 0 if you want to disable the footer copyright in the web interface
 $config['api_demo'] = 0;
 // Set this to 1 if you want to disable some untrusting features for the API
-$config['api_auth_local'] = false;
-// Set this to true if you have changed auth_mechanism, but want to use mysql database for API-tokens
 // Distributed Poller-Settings
 $config['distributed_poller']                = false;
 $config['distributed_poller_name']           = file_get_contents('/proc/sys/kernel/hostname');


### PR DESCRIPTION
Adds an option (api_auth_local) to the config. This can be set to true to force use of local mysql database (token- and user-info) for API-requests. Done in our case to not have it check LDAP-database for API-requests (which was broken). 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7291)
<!-- Reviewable:end -->
