### PR TITLE
Proposal: ignore loopback interfaces by default

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -560,6 +560,7 @@ $config['bad_iftype'][] = 'aal5';
 $config['bad_iftype'][] = 'shdsl';
 $config['bad_iftype'][] = 'mpls';
 
+$config['bad_if_regexp'][] = '/^lo[0-9]*.*/';
 $config['bad_if_regexp'][] = '/^ng[0-9]+$/';
 $config['bad_if_regexp'][] = '/^sl[0-9]/';
 


### PR DESCRIPTION
Adding server & network device loopbacks to default ignored ports.

Monitoring loopback doesn't add any value IMHO and could even trigger confusing alerts for new users: https://community.librenms.org/t/port-utilisation-over-threshold-for-lo-interface/2041

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7303)
<!-- Reviewable:end -->
