### PR TITLE
webui: Added device description to overview page

### DIFF
--- a/html/includes/dev-overview-data.inc.php
+++ b/html/includes/dev-overview-data.inc.php
@@ -44,6 +44,13 @@ if (!empty($device['ip'])) {
     }
 }
 
+if ($device['purpose']) {
+    echo '<tr>
+        <td>Description</td>
+        <td>'.display($device['purpose']).'</td>
+      </tr>';
+}
+
 if ($device['hardware']) {
     echo '<tr>
         <td>Hardware</td>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Added device description to the overview page. Requested: https://community.librenms.org/t/missing-custom-device-settings-description-field-in-device-overview/2071 Seems sensible as we don't use it anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7328)
<!-- Reviewable:end -->
