### PR TITLE
Added DHCP Leases Graph for Mikrotik

### DIFF
--- a/html/includes/graphs/device/routeros_leases.inc.php
+++ b/html/includes/graphs/device/routeros_leases.inc.php
@@ -1,0 +1,19 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'routeros_leases');
+
+require 'includes/graphs/common.inc.php';
+
+$ds = 'leases';
+
+$colour_area = '9999cc';
+$colour_line = '0000cc';
+
+$colour_area_max = '9999cc';
+$scale_min = '0';
+$graph_max = 1;
+$graph_min = 0;
+
+$unit_text = 'Leases';
+
+require 'includes/graphs/generic_simplex.inc.php';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -600,6 +600,11 @@ $config['graph_types']['device']['riverbed_passthrough']['section'] = 'network';
 $config['graph_types']['device']['riverbed_passthrough']['order'] = 3;
 $config['graph_types']['device']['riverbed_passthrough']['descr'] = 'Bandwidth Passthrough';
 
+//mikrotik specific graphs
+$config['graph_types']['device']['routeros_leases']['section'] = 'network';
+$config['graph_types']['device']['routeros_leases']['order'] = 0;
+$config['graph_types']['device']['routeros_leases']['descr'] = 'DHCP Lease Count';
+
 // Device Types
 $i = 0;
 $config['device_types'][$i]['text'] = 'Servers';

--- a/includes/polling/os/routeros.inc.php
+++ b/includes/polling/os/routeros.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\RRD\RrdDefinition;
+
 $version = trim(snmp_get($device, '1.3.6.1.4.1.14988.1.1.4.4.0', '-OQv', '', ''), '"');
 if (strstr($poll_device['sysDescr'], 'RouterOS')) {
     $hardware = substr($poll_device['sysDescr'], 9);
@@ -7,3 +9,20 @@ if (strstr($poll_device['sysDescr'], 'RouterOS')) {
 
 $features = 'Level '.trim(snmp_get($device, '1.3.6.1.4.1.14988.1.1.4.3.0', '-OQv', '', ''), '"');
 $serial = trim(snmp_get($device, '1.3.6.1.4.1.14988.1.1.7.3.0', '-OQv', '', ''), '"');
+
+
+$leases = snmp_get($device, 'mtxrDHCPLeaseCount.0', '-OQv', 'MIKROTIK-MIB');
+
+if (is_numeric($leases)) {
+    $rrd_def = RrdDefinition::make()->addDataset('leases', 'GAUGE', 0);
+
+    $fields = array(
+        'leases' => $leases,
+    );
+
+    $tags = compact('rrd_def');
+    data_update($device, 'routeros_leases', $tags, $fields);
+    $graphs['routeros_leases'] = true;
+}
+
+unset($leases);


### PR DESCRIPTION
Added basic graph for DHCP leases for mikrotik. 

I didn't see an option to add this via the yaml, if there is let me know and I can refactor.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7333)
<!-- Reviewable:end -->
