### PR TITLE
Support for device credentials and passing to Oxidized via API

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1234,7 +1234,7 @@ function list_oxidized()
     $devices = array();
     $device_types = "'".implode("','", $config['oxidized']['ignore_types'])."'";
     $device_os    = "'".implode("','", $config['oxidized']['ignore_os'])."'";
-    foreach (dbFetchRows("SELECT hostname,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
+    foreach (dbFetchRows("SELECT hostname,os,location,username,password,enable FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
         if ($config['oxidized']['group_support'] == "true") {
             foreach ($config['oxidized']['group']['hostname'] as $host_group) {
                 if (preg_match($host_group['regex'].'i', $device['hostname'])) {

--- a/html/pages/device/edit.inc.php
+++ b/html/pages/device/edit.inc.php
@@ -11,6 +11,7 @@ if ($_SESSION['userlevel'] < '7') {
     print_error("Insufficient Privileges");
 } else {
     $panes['device']   = 'Device Settings';
+	$panes['passwords']   = 'Device Passwords';
     $panes['snmp']     = 'SNMP';
     $panes['ports']    = 'Port Settings';
 

--- a/html/pages/device/edit/passwords.inc.php
+++ b/html/pages/device/edit/passwords.inc.php
@@ -1,0 +1,100 @@
+<?php
+if ($_POST['editing']) {
+    if ($_SESSION['userlevel'] > "7") {
+        $updated = 0;
+
+
+        if ($device['type'] != $vars['type']) {
+            $param['type'] = $vars['type'];
+            $update_type = true;
+        }
+
+        #FIXME needs more sanity checking! and better feedback
+
+        $param['username']  = $vars['username'];
+        $param['password']  = $vars['password'];
+		$param['enable']  = $vars['enable'];
+
+        $rows_updated = dbUpdate($param, 'devices', '`device_id` = ?', array($device['device_id']));
+
+        if ($rows_updated > 0 || $updated) {
+            if ($update_type === true) {
+                set_dev_attrib($device, 'override_device_type', true);
+            }
+            $update_message = "Device record updated.";
+            $updated = 1;
+            $device = dbFetchRow("SELECT * FROM `devices` WHERE `device_id` = ?", array($device['device_id']));
+        } elseif ($rows_updated == 0) {
+            $update_message = "Device record unchanged. No update necessary.";
+            $updated = -1;
+        } else {
+            $update_message = "Device record update error.";
+        }
+        if (isset($_POST['hostname']) && $_POST['hostname'] !== '' && $_POST['hostname'] !== $device['hostname']) {
+            if (is_admin()) {
+                $result = renamehost($device['device_id'], $_POST['hostname'], 'webui');
+                if ($result == "") {
+                    print_message("Hostname updated from {$device['hostname']} to {$_POST['hostname']}");
+                    echo '
+                        <script>
+                            var loc = window.location;
+                            window.location.replace(loc.protocol + "//" + loc.host + loc.pathname + loc.search);
+                        </script>
+                    ';
+                } else {
+                    print_error($result . ".  Does your web server have permission to modify the rrd files?");
+                }
+            } else {
+                print_error('Only administrative users may update the device hostname');
+            }
+        }
+    } else {
+        include 'includes/error-no-perm.inc.php';
+    }
+}
+
+$username  = $device['username'];
+$password  = $device['password'];
+$enable  = $device['enable'];
+
+if ($updated && $update_message) {
+    print_message($update_message);
+} elseif ($update_message) {
+    print_error($update_message);
+}
+
+?>
+<h3> Device Settings </h3>
+<form id="edit" name="edit" method="post" action="" role="form" class="form-horizontal">
+<input type=hidden name="editing" value="yes">
+<div class="row">
+     <div class="form-group">
+        <label for="username" class="col-sm-2 control-label">Username:</label>
+        <div class="col-sm-6">
+            <textarea id="username" name="username" class="form-control"><?php echo(display($device['username'])); ?></textarea>
+        </div>
+    </div>
+     <div class="form-group">
+        <label for="password" class="col-sm-2 control-label">Password:</label>
+        <div class="col-sm-6">
+            <textarea id="password" name="password" class="form-control"><?php echo(display($device['password'])); ?></textarea>
+        </div>
+    </div>
+     <div class="form-group">
+        <label for="enable" class="col-sm-2 control-label">Enable Password:</label>
+        <div class="col-sm-6">
+            <textarea id="enable" name="enable" class="form-control"><?php echo(display($device['enable'])); ?></textarea>
+        </div>
+    </div>	
+    <div class="col-md-1 col-md-offset-2">
+        <button type="submit" name="Submit"  class="btn btn-default"><i class="fa fa-check"></i> Save</button>
+    </div>
+</div>
+</form>
+<br />
+<?php
+print_optionbar_start();
+list($sizeondisk, $numrrds) = foldersize(get_rrd_dir($device['hostname']));
+echo("Size on Disk: <b>" . formatStorage($sizeondisk) . "</b> in <b>" . $numrrds . " RRD files</b>.");
+print_optionbar_end();
+?>

--- a/sql-schema/207.sql
+++ b/sql-schema/207.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `devices` ADD `username` VARCHAR(128) NOT NULL AFTER `enable`, ADD `password` VARCHAR(128) NOT NULL AFTER `username`, ADD `enable` VARCHAR(128) NOT NULL AFTER `password`;


### PR DESCRIPTION
Additional config to enable LibreNMS to add/edit and show username, password & enable-password via API call on /api/v0/oxidized for Oxidized

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7334)
<!-- Reviewable:end -->
