### PR TITLE
webui: Show how long a device has been down if it is down

### DIFF
--- a/html/includes/dev-overview-data.inc.php
+++ b/html/includes/dev-overview-data.inc.php
@@ -16,7 +16,13 @@ if ($config['overview_show_sysDescr']) {
 echo '</div>
       <table class="table table-hover table-condensed table-striped">';
 
-$uptime = $device['uptime'];
+$uptime = formatUptime($device['uptime']);
+$uptime_text = 'Uptime';
+if ($device['status'] == 0) {
+    // Rewrite $uptime to be downtime if device is down
+    $uptime = formatUptime(time() - strtotime($device['last_polled']));
+    $uptime_text = 'Downtime';
+}
 
 if ($device['os'] == 'ios') {
     formatCiscoHardware($device);
@@ -111,10 +117,10 @@ if (is_array($loc)) {
 }
 
 if ($uptime) {
-    echo '<tr>
-        <td>Uptime</td>
-        <td>'.formatUptime($uptime).'</td>
-      </tr>';
+    echo "<tr>
+        <td>$uptime_text</td>
+        <td>".$uptime."</td>
+      </tr>";
 }
 
 echo '</table>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I've only done it on the overview page as I felt showing it in the device list will be confusing as the column is titled uptime.

https://community.librenms.org/t/down-devices-shows-up-time/2073

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7336)
<!-- Reviewable:end -->
