### PR TITLE
fix incorrect getOsSetting arguments

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -134,7 +134,7 @@ function discover_device(&$device, $options = null)
 
     load_os($device);
     load_discovery($device);
-    register_mibs($device, Config::getOsSetting($device, 'register_mibs', array()), 'includes/discovery/os/' . $device['os'] . '.inc.php');
+    register_mibs($device, Config::getOsSetting($device['os'], 'register_mibs', array()), 'includes/discovery/os/' . $device['os'] . '.inc.php');
 
     echo "\n";
 
@@ -150,7 +150,7 @@ function discover_device(&$device, $options = null)
         }
     }
     foreach (Config::get('discovery_modules', array()) as $module => $module_status) {
-        $os_module_status = Config::getOsSetting($device, "discovery_modules.$module");
+        $os_module_status = Config::getOsSetting($device['os'], "discovery_modules.$module");
         d_echo("Modules status: Global" . (isset($module_status) ? ($module_status ? '+ ' : '- ') : '  '));
         d_echo("OS" . (isset($os_module_status) ? ($os_module_status ? '+ ' : '- ') : '  '));
         d_echo("Device" . (isset($attribs['discover_' . $module]) ? ($attribs['discover_' . $module] ? '+ ' : '- ') : '  '));
@@ -798,7 +798,7 @@ function discover_process_ipv6(&$valid, $ifIndex, $ipv6_address, $ipv6_prefixlen
 */
 function check_entity_sensor($string, $device)
 {
-    $fringe = array_merge(Config::get('bad_entity_sensor_regex', array()), Config::getOsSetting($device, 'bad_entity_sensor_regex', array()));
+    $fringe = array_merge(Config::get('bad_entity_sensor_regex', array()), Config::getOsSetting($device['os'], 'bad_entity_sensor_regex', array()));
 
     foreach ($fringe as $bad) {
         if (preg_match($bad . "i", $string)) {
@@ -1166,7 +1166,7 @@ function sensors($types, $device, $valid, $pre_cache = array())
         if (is_file($dir . $device['os'] . '.inc.php')) {
             include $dir . $device['os'] . '.inc.php';
         }
-        if (Config::getOsSetting($device, 'rfc1628_compat', false)) {
+        if (Config::getOsSetting($device['os'], 'rfc1628_compat', false)) {
             if (is_file($dir  . '/rfc1628.inc.php')) {
                 include $dir . '/rfc1628.inc.php';
             }

--- a/includes/discovery/sensors/runtime/rfc1628.inc.php
+++ b/includes/discovery/sensors/runtime/rfc1628.inc.php
@@ -2,7 +2,7 @@
 
 echo 'RFC1628 ';
 
-// UPS-MIB::upsSeconsOnBattery
+// UPS-MIB::upsSecondsOnBattery
 $secs_on_battery_oid = '.1.3.6.1.2.1.33.1.2.2.0';
 $secs_on_battery = snmp_get($device, $secs_on_battery_oid, '-Oqv');
 


### PR DESCRIPTION
Missed calls when the function definition changed.
and a comment typo fix

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7339)
<!-- Reviewable:end -->
