### PR TITLE
device: RouterOS LTE Modem Signal Data & USB UPS

### DIFF
--- a/includes/definitions/discovery/routeros.yaml
+++ b/includes/definitions/discovery/routeros.yaml
@@ -43,6 +43,32 @@ modules:
                     divisor: 1000
                     descr: '{{ $mtxrOpticalName }} Rx'
                     index: 'mtxrOpticalRxPower.{{ $index }}'
+        signal:
+            data:
+                -
+                    oid: mtxrLTEModemTable
+                    value: mtxrLTEModemSignalRSSI
+                    num_oid: .1.3.6.1.4.1.14988.1.1.16.1.1.2.
+                    descr: 'LTE {{ $mtxrLTEModemInterfaceIndex }} RSSI'
+                    index: 'mtxrLTEModemSignalRSSI.{{ $index }}'
+                -
+                    oid: mtxrLTEModemTable
+                    value: mtxrLTEModemSignalRSRQ
+                    num_oid: .1.3.6.1.4.1.14988.1.1.16.1.1.3.
+                    descr: 'LTE {{ $mtxrLTEModemInterfaceIndex }} RSRQ'
+                    index: 'mtxrLTEModemSignalRSRQ.{{ $index }}'
+                -
+                    oid: mtxrLTEModemTable
+                    value: mtxrLTEModemSignalRSRP
+                    num_oid: .1.3.6.1.4.1.14988.1.1.16.1.1.4.
+                    descr: 'LTE {{ $mtxrLTEModemInterfaceIndex }} RSRP'
+                    index: 'mtxrLTEModemSignalRSRP.{{ $index }}'
+                -
+                    oid: mtxrLTEModemTable
+                    value: mtxrLTEModemSignalSINR
+                    num_oid: .1.3.6.1.4.1.14988.1.1.16.1.1.7.
+                    descr: 'LTE {{ $mtxrLTEModemInterfaceIndex }} SINR'
+                    index: 'mtxrLTEModemSignalSINR.{{ $index }}'
         state:
             data:
                 -
@@ -67,3 +93,20 @@ modules:
                         - { descr: no, graph: 1, value: 0, generic: 0 }
                         - { descr: yes, graph: 1, value: 1, generic: 2 }
                         - { descr: 'null', graph: 1, value: 2, generic: 3 }
+                -
+                    oid: mtxrLTEModemTable
+                    value: mtxrLTEModemAccessTechnology
+                    num_oid: .1.3.6.1.4.1.14988.1.1.16.1.1.6.
+                    descr: 'LTE Modem {{ $mtxrLTEModemInterfaceIndex }} Access Technology'
+                    index: 'mtxrLTEModemAccessTechnology.{{ $index }}'
+                    state_name: mtxrLTEModemAccessTechnology
+                    states:
+                        - { descr: unknown, graph: 1, value: -1, generic: 0 }
+                        - { descr: gsmcompact, graph: 1, value: 0, generic: 2 }
+                        - { descr: gsm, graph: 1, value: 1, generic: 2 }
+                        - { descr: utran, graph: 1, value: 2, generic: 2 }
+                        - { descr: egprs, graph: 1, value: 3, generic: 2 }
+                        - { descr: hsdpa, graph: 1, value: 4, generic: 2 }
+                        - { descr: hsupa, graph: 1, value: 5, generic: 2 }
+                        - { descr: hsdpahsupa, graph: 1, value: 6, generic: 2 }
+                        - { descr: eutran, graph: 1, value: 7, generic: 2 }

--- a/includes/definitions/routeros.yaml
+++ b/includes/definitions/routeros.yaml
@@ -1,6 +1,7 @@
 os: routeros
 text: 'Mikrotik RouterOS'
 type: network
+rfc1628_compat: 1
 nobulk: 1
 mib_dir:
     - mikrotik


### PR DESCRIPTION
Added USB UPS data via `rfc1628_compat` and discovering LTE modem signal data.
Problem with `status` matching was resolved with database update.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7358)
<!-- Reviewable:end -->
