### PR TITLE
fix: if session save path is "", php will use /tmp

### DIFF
--- a/html/install.php
+++ b/html/install.php
@@ -183,7 +183,7 @@ foreach ($modules as $extension) {
     echo "<tr class='$row_class'><td>PHP module <strong>$extension</strong></td><td>$status</td><td></td></tr>";
 }
 
-if (is_writable(session_save_path())) {
+if (is_writable(session_save_path() === '' ? '/tmp' : session_save_path())) {
     $status = 'yes';
     $row_class = 'success';
 } else {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7359)
<!-- Reviewable:end -->
