### PR TITLE
Fixes query selector scope for bootgrid destroy

### DIFF
--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -591,7 +591,7 @@ if (strpos($dash_config, 'globe') !== false) {
     }
 
     function widget_reload(id,data_type) {
-        $(".bootgrid-table").bootgrid("destroy");
+        $("#widget_body_"+id+" .bootgrid-table").bootgrid("destroy");
         $("#widget_body_"+id+" *").off();
         $("#widget_body_"+id).empty();
         if( $("#widget_body_"+id).parent().data('settings') == 1 ) {


### PR DESCRIPTION
I realized that I did not scope this selector and that was causing issues when displaying multiple alert tables on a dashboard.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7379)
<!-- Reviewable:end -->
