### PR TITLE
refactor: discovery protocols re-write

### DIFF
--- a/LibreNMS/Util/IP.php
+++ b/LibreNMS/Util/IP.php
@@ -139,6 +139,23 @@ abstract class IP
     abstract public function inNetwork($network);
 
     /**
+     * Check if this IP is in one of multiple networks
+     *
+     * @param array $networks
+     * @return bool
+     */
+    public function inNetworks($networks)
+    {
+        foreach ((array)$networks as $network) {
+            if ($this->inNetwork($network)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Check if this IP is in the reserved range.
      * @return bool
      */
@@ -165,6 +182,16 @@ abstract class IP
     public function uncompressed()
     {
         return (string)$this->ip;
+    }
+
+    /**
+     * Packed address for storage in database
+     *
+     * return string
+     */
+    public function packed()
+    {
+        return inet_pton((string)$this->ip);
     }
 
     /**

--- a/includes/common.php
+++ b/includes/common.php
@@ -627,7 +627,7 @@ function is_valid_hostname($hostname)
     // white space are permitted. While a hostname may not contain other characters,
     // such as the underscore character (_), other DNS names may contain the underscore
 
-    return ctype_alnum(str_replace('_', '', str_replace('-', '', str_replace('.', '', $hostname))));
+    return ctype_alnum(str_replace(array('_', '-', '.'), '', $hostname));
 }
 
 /*

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -22,20 +22,18 @@ if ($device['os'] == 'ironware' && Config::get('autodiscovery.xdp') === true) {
                 $remote_device_id = discover_new_device($fdp['snFdpCacheDeviceId'], $device, 'FDP', $interface);
             }
 
-            if ($remote_device_id) {
-                $remote_port_id = find_port_id($fdp['snFdpCacheDevicePort'], '', $remote_device_id);
-                discover_link(
-                    $interface['port_id'],
-                    $fdp['snFdpCacheVendorId'],
-                    $remote_port_id,
-                    $fdp['snFdpCacheDeviceId'],
-                    $fdp['snFdpCacheDevicePort'],
-                    $fdp['snFdpCachePlatform'],
-                    $fdp['snFdpCacheVersion'],
-                    $device['device_id'],
-                    $remote_device_id
-                );
-            }
+            $remote_port_id = find_port_id($fdp['snFdpCacheDevicePort'], '', $remote_device_id);
+            discover_link(
+                $interface['port_id'],
+                $fdp['snFdpCacheVendorId'],
+                $remote_port_id,
+                $fdp['snFdpCacheDeviceId'],
+                $fdp['snFdpCacheDevicePort'],
+                $fdp['snFdpCachePlatform'],
+                $fdp['snFdpCacheVersion'],
+                $device['device_id'],
+                $remote_device_id
+            );
         }
     }//end foreach
     echo PHP_EOL;
@@ -64,7 +62,7 @@ if (Config::get('autodiscovery.xdp') === true) {
                 }
             }
 
-            if ($remote_device_id && $interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
+            if ($interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
                 $remote_port_id = find_port_id($cdp['cdpCacheDevicePort'], '', $remote_device_id);
                 discover_link(
                     $interface['port_id'],
@@ -99,7 +97,7 @@ if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
             $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
         }
 
-        if ($remote_device_id && $interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
+        if ($interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
             $remote_port_id = find_port_id($lldp['lldpRemPortDesc'], $lldp['lldpRemPortId'], $remote_device_id);
             discover_link(
                 $interface['port_id'],
@@ -159,33 +157,32 @@ if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
                     }
                 }
 
-                if ($remote_device_id) {
-                    $remote_port_id = find_port_id(
-                        $lldp['lldpRemPortDesc'],
-                        $lldp['lldpRemPortId'],
-                        $remote_device_id,
-                        $remote_port_mac
-                    );
+                $remote_port_id = find_port_id(
+                    $lldp['lldpRemPortDesc'],
+                    $lldp['lldpRemPortId'],
+                    $remote_device_id,
+                    $remote_port_mac
+                );
 
-                    if (empty($lldp['lldpRemSysName'])) {
-                        $remote_device = device_by_id_cache($remote_device_id);
-                        $lldp['lldpRemSysName'] = $remote_device['sysName'] ?: $remote_device['hostname'];
-                    }
-
-                    if ($interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
-                        discover_link(
-                            $interface['port_id'],
-                            'lldp',
-                            $remote_port_id,
-                            $lldp['lldpRemSysName'],
-                            $lldp['lldpRemPortId'],
-                            null,
-                            $lldp['lldpRemSysDesc'],
-                            $device['device_id'],
-                            $remote_device_id
-                        );
-                    }
+                if (empty($lldp['lldpRemSysName'])) {
+                    $remote_device = device_by_id_cache($remote_device_id);
+                    $lldp['lldpRemSysName'] = $remote_device['sysName'] ?: $remote_device['hostname'];
                 }
+
+                if ($interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
+                    discover_link(
+                        $interface['port_id'],
+                        'lldp',
+                        $remote_port_id,
+                        $lldp['lldpRemSysName'],
+                        $lldp['lldpRemPortId'],
+                        null,
+                        $lldp['lldpRemSysDesc'],
+                        $device['device_id'],
+                        $remote_device_id
+                    );
+                }
+
             }//end foreach
         }//end foreach
     }//end foreach

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -234,6 +234,11 @@ foreach (dbFetchRows($sql, array($device['device_id'])) as $test) {
     }
 }
 
+// remove orphaned links
+$deleted = dbQuery('DELETE `l` FROM `links` `l` LEFT JOIN `devices` `d` ON `d`.`device_id` = `l`.`local_device_id` WHERE `d`.`device_id` IS NULL');
+echo str_repeat('-', $deleted);
+d_echo(" $deleted orphaned links deleted\n");
+
 unset(
     $link_exists,
     $sql,

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -1,236 +1,231 @@
 <?php
 
-global $link_exists;
-
 use LibreNMS\Config;
 use LibreNMS\Util\IP;
 
-$community = $device['community'];
+global $link_exists;
 
 if ($device['os'] == 'ironware' && Config::get('autodiscovery.xdp') === true) {
     echo ' Brocade FDP: ';
-    $fdp_array = snmpwalk_cache_twopart_oid($device, 'snFdpCacheEntry', array(), 'FOUNDRY-SN-SWITCH-GROUP-MIB');
-    d_echo($fdp_array);
-    if ($fdp_array) {
-        unset($fdp_links);
-        foreach ($fdp_array as $key => $fdp_if_array) {
-            $interface = get_port_by_ifIndex($device['device_id'], $key);
-            d_echo($fdp_if_array);
-            foreach ($fdp_if_array as $entry_key => $fdp) {
-                $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']));
+    $fdp_array = snmpwalk_group($device, 'snFdpCacheEntry', 'FOUNDRY-SN-SWITCH-GROUP-MIB', 2);
 
-                if (!$remote_device_id &&
-                    !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysname_regexp'), $fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDeviceId']) &&
-                    !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysdesc_regexp'), $fdp['snFdpCacheVersion'], $fdp['snFdpCacheDeviceId'])
-                ) {
-                    $remote_device_id = discover_new_device($fdp['snFdpCacheDeviceId'], $device, 'FDP', $interface);
-                }
+    foreach ($fdp_array as $key => $fdp_if_array) {
+        $interface = get_port_by_ifIndex($device['device_id'], $key);
+        d_echo($fdp_if_array);
 
-                if ($remote_device_id) {
-                    $if             = $fdp['snFdpCacheDevicePort'];
-                    $remote_port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $remote_device_id));
-                } else {
-                    $remote_port_id = '0';
-                }
-
-                discover_link($interface['port_id'], $fdp['snFdpCacheVendorId'], $remote_port_id, $fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheDevicePort'], $fdp['snFdpCachePlatform'], $fdp['snFdpCacheVersion'], $device['device_id'], $remote_device_id);
-            }
-        }//end foreach
-    }//end if
-}//end if
-
-echo ' CISCO-CDP-MIB: ';
-unset($cdp_array);
-if (Config::get('autodiscovery.xdp') === true) {
-    $cdp_array = snmpwalk_cache_twopart_oid($device, 'cdpCache', array(), 'CISCO-CDP-MIB');
-    d_echo($cdp_array);
-    if ($cdp_array) {
-        unset($cdp_links);
-        foreach ($cdp_array as $key => $cdp_if_array) {
-            $interface = get_port_by_ifIndex($device['device_id'], $key);
-            d_echo($cdp_if_array);
-            foreach ($cdp_if_array as $entry_key => $cdp) {
-                if (is_valid_hostname($cdp['cdpCacheDeviceId']) || Config::get('discovery_by_ip', false)) {
-                    $cdp_ip = IP::fromHexString($cdp['cdpCacheAddress'], true);
-                    $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ? OR `hostname` = ?', array($cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId'], $cdp_ip));
-
-                    if (!$remote_device_id &&
-                        !can_skip_discovery(Config::get('autodiscovery.cdp_exclude.platform_regexp'), $cdp['cdpCachePlatform'], $cdp['cdpCacheDeviceId']) &&
-                        !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysname_regexp'), $cdp['cdpCacheDeviceId'], $cdp['cdpCacheDeviceId']) &&
-                        !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysdesc_regexp'), $cdp['cdpCacheVersion'], $cdp['cdpCacheDeviceId'])
-                    ) {
-                        if (Config::get('discovery_by_ip', false)) {
-                            $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
-                        } else {
-                            $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
-                        }
-                    }
-
-                    if ($remote_device_id) {
-                        $if             = $cdp['cdpCacheDevicePort'];
-                        $remote_port_id = dbFetchCell('SELECT port_id FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $remote_device_id));
-                    } else {
-                        $remote_port_id = '0';
-                    }
-
-                    if ($interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
-                        discover_link($interface['port_id'], 'cdp', $remote_port_id, $cdp['cdpCacheDeviceId'], $cdp['cdpCacheDevicePort'], $cdp['cdpCachePlatform'], $cdp['cdpCacheVersion'], $device['device_id'], $remote_device_id);
-                    }
-                } else {
-                    echo 'X';
-                }//end if
-            }//end foreach
-        }//end foreach
-    }//end if
-}//end if
-
-unset(
-    $lldp_array,
-    $cdp_array
-);
-
-if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
-    echo ' NMS-LLDP-MIB: ';
-    $lldp_array  = snmpwalk_cache_oid($device, 'lldpRemoteSystemsData', array(), 'NMS-LLDP-MIB', 'pbn');
-    d_echo($lldp_array);
-    if ($lldp_array) {
-        unset($lldp_links);
-        foreach ($lldp_array as $key => $lldp) {
-            d_echo($lldp);
-            $interface = get_port_by_ifIndex($device['device_id'], $lldp['lldpRemLocalPortNum']);
-            $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
+        foreach ($fdp_if_array as $entry_key => $fdp) {
+            $remote_device_id = find_device_id($fdp['snFdpCacheDeviceId']);
 
             if (!$remote_device_id &&
-                is_valid_hostname($lldp['lldpRemSysName']) &&
-                !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysname_regexp'), $lldp['lldpRemSysName'], $lldp['lldpRemSysName']) &&
-                !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysdesc_regexp'), $lldp['lldpRemSysDesc'], $lldp['lldpRemSysName'])
+                !can_skip_discovery($fdp['snFdpCacheDeviceId'], $fdp['snFdpCacheVersion'])
             ) {
-                $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+                $remote_device_id = discover_new_device($fdp['snFdpCacheDeviceId'], $device, 'FDP', $interface);
             }
 
             if ($remote_device_id) {
-                $if             = $lldp['lldpRemPortDesc'];
-                $id             = $lldp['lldpRemPortId'];
-                $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_device_id));
-            } else {
-                $remote_port_id = '0';
+                $remote_port_id = find_port_id($fdp['snFdpCacheDevicePort'], '', $remote_device_id);
+                discover_link(
+                    $interface['port_id'],
+                    $fdp['snFdpCacheVendorId'],
+                    $remote_port_id,
+                    $fdp['snFdpCacheDeviceId'],
+                    $fdp['snFdpCacheDevicePort'],
+                    $fdp['snFdpCachePlatform'],
+                    $fdp['snFdpCacheVersion'],
+                    $device['device_id'],
+                    $remote_device_id
+                );
+            }
+        }
+    }//end foreach
+    echo PHP_EOL;
+}//end if
+
+echo ' CISCO-CDP-MIB: ';
+if (Config::get('autodiscovery.xdp') === true) {
+    $cdp_array = snmpwalk_group($device, 'cdpCache', 'CISCO-CDP-MIB', 2);
+
+    foreach ($cdp_array as $key => $cdp_if_array) {
+        $interface = get_port_by_ifIndex($device['device_id'], $key);
+
+        foreach ($cdp_if_array as $entry_key => $cdp) {
+            d_echo($cdp);
+
+            $cdp_ip = IP::fromHexString($cdp['cdpCacheAddress'], true);
+            $remote_device_id = find_device_id($cdp['cdpCacheDeviceId'], $cdp_ip);
+
+            if (!$remote_device_id &&
+                !can_skip_discovery($cdp['cdpCacheDeviceId'], $cdp['cdpCacheVersion'], $cdp['cdpCachePlatform'])
+            ) {
+                $remote_device_id = discover_new_device($cdp['cdpCacheDeviceId'], $device, 'CDP', $interface);
+
+                if (!$remote_device_id && Config::get('discovery_by_ip', false)) {
+                    $remote_device_id = discover_new_device($cdp_ip, $device, 'CDP', $interface);
+                }
             }
 
-            if (is_numeric($interface['port_id']) && isset($lldp['lldpRemSysName']) && isset($lldp['lldpRemPortId'])) {
-                discover_link($interface['port_id'], 'lldp', $remote_port_id, $lldp['lldpRemSysName'], $lldp['lldpRemPortId'], null, $lldp['lldpRemSysDesc'], $device['device_id'], $remote_device_id);
+            if ($remote_device_id && $interface['port_id'] && $cdp['cdpCacheDeviceId'] && $cdp['cdpCacheDevicePort']) {
+                $remote_port_id = find_port_id($cdp['cdpCacheDevicePort'], '', $remote_device_id);
+                discover_link(
+                    $interface['port_id'],
+                    'cdp',
+                    $remote_port_id,
+                    $cdp['cdpCacheDeviceId'],
+                    $cdp['cdpCacheDevicePort'],
+                    $cdp['cdpCachePlatform'],
+                    $cdp['cdpCacheVersion'],
+                    $device['device_id'],
+                    $remote_device_id
+                );
             }
         }//end foreach
-    }//end if
+    }//end foreach
+    echo PHP_EOL;
+}//end if
+
+if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
+    echo ' NMS-LLDP-MIB: ';
+    $lldp_array  = snmpwalk_group($device, 'lldpRemoteSystemsData', 'NMS-LLDP-MIB');
+
+    foreach ($lldp_array as $key => $lldp) {
+        d_echo($lldp);
+        $interface = get_port_by_ifIndex($device['device_id'], $lldp['lldpRemLocalPortNum']);
+        $remote_device_id = find_device_id($lldp['lldpRemSysName']);
+
+        if (!$remote_device_id &&
+            is_valid_hostname($lldp['lldpRemSysName']) &&
+            !can_skip_discovery($lldp['lldpRemSysName'], $lldp['lldpRemSysDesc'])
+        ) {
+            $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+        }
+
+        if ($remote_device_id && $interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
+            $remote_port_id = find_port_id($lldp['lldpRemPortDesc'], $lldp['lldpRemPortId'], $remote_device_id);
+            discover_link(
+                $interface['port_id'],
+                'lldp',
+                $remote_port_id,
+                $lldp['lldpRemSysName'],
+                $lldp['lldpRemPortId'],
+                null,
+                $lldp['lldpRemSysDesc'],
+                $device['device_id'],
+                $remote_device_id
+            );
+        }
+    }//end foreach
+    echo PHP_EOL;
 } elseif (Config::get('autodiscovery.xdp') === true) {
     echo ' LLDP-MIB: ';
-    $lldp_array  = snmpwalk_cache_threepart_oid($device, 'lldpRemoteSystemsData', array(), 'LLDP-MIB');
-    d_echo($lldp_array);
-    $dot1d_array = snmpwalk_cache_oid($device, 'dot1dBasePortIfIndex', array(), 'BRIDGE-MIB');
-    d_echo($dot1d_array);
-    if ($lldp_array) {
-        $lldp_links = '';
-        foreach ($lldp_array as $key => $lldp_if_array) {
-            d_echo($lldp_if_array);
-            foreach ($lldp_if_array as $entry_key => $lldp_instance) {
-                if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
-                    $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
-                } else {
-                    $ifIndex = $entry_key;
+    $lldp_array  = snmpwalk_group($device, 'lldpRemTable', 'LLDP-MIB', 3);
+    if (!empty($lldp_array)) {
+        $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+    }
+
+    foreach ($lldp_array as $key => $lldp_if_array) {
+        foreach ($lldp_if_array as $entry_key => $lldp_instance) {
+            if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
+                $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
+            } else {
+                $ifIndex = $entry_key;
+            }
+            $interface = get_port_by_ifIndex($device['device_id'], $ifIndex);
+            d_echo($lldp_instance);
+
+            foreach ($lldp_instance as $entry_instance => $lldp) {
+                // normalize MAC address if present
+                $remote_port_mac = '';
+                if ($lldp['lldpRemPortIdSubtype'] == 3) { // 3 = macaddress
+                    $remote_port_mac = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemPortId']));
                 }
-                $interface = get_port_by_ifIndex($device['device_id'], $ifIndex);
 
-                d_echo($lldp_instance);
-                foreach ($lldp_instance as $entry_instance => $lldp) {
-                    $remote_device_id = dbFetchCell('SELECT `device_id` FROM `devices` WHERE `sysName` = ? OR `hostname` = ?', array($lldp['lldpRemSysName'], $lldp['lldpRemSysName']));
+                $remote_device_id = find_device_id($lldp['lldpRemSysName'], $lldp['lldpRemManAddr'], $remote_port_mac);
 
-                    if (!$remote_device_id && is_valid_hostname($lldp['lldpRemSysName'])) {
-                        if (!can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysname_regexp'), $lldp['lldpRemSysName'], $lldp['lldpRemSysName']) &&
-                            !can_skip_discovery(Config::get('autodiscovery.xdp_exclude.sysdesc_regexp'), $lldp['lldpRemSysDesc'], $lldp['lldpRemSysName'])
-                        ) {
-                            $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
-                            if (is_numeric($remote_device_id) === false) {
-                                $ptopo_array = snmpwalk_cache_oid($device, 'ptopoConnEntry', array(), 'PTOPO-MIB');
-                                d_echo($ptopo_array);
-                                foreach ($ptopo_array as $ptopo) {
-                                    if (strcmp(trim($ptopo['ptopoConnRemoteChassis']), trim($lldp['lldpRemChassisId'])) == 0) {
-                                        $discover_hostname = IP::fromHexString($ptopo['ptopoConnAgentNetAddr'], true);
-                                        break;
-                                    }
-                                }
-                                unset(
-                                    $ptopo_array,
-                                    $ip_arr
-                                );
+                // add device if configured to do so
+                if (!$remote_device_id && !can_skip_discovery($lldp['lldpRemSysName'], $lldp['lldpRemSysDesc'])) {
+                    $remote_device_id = discover_new_device($lldp['lldpRemSysName'], $device, 'LLDP', $interface);
+
+                    if (!$remote_device_id && Config::get('discovery_by_ip', false)) {
+                        $ptopo_array = snmpwalk_group($device, 'ptopoConnEntry', 'PTOPO-MIB');
+                        d_echo($ptopo_array);
+                        foreach ($ptopo_array as $ptopo) {
+                            if (strcmp(trim($ptopo['ptopoConnRemoteChassis']), trim($lldp['lldpRemChassisId'])) == 0) {
+                                $ip = IP::fromHexString($ptopo['ptopoConnAgentNetAddr'], true);
+                                $remote_device_id = discover_new_device($ip, $device, 'LLDP', $interface);
+                                break;
                             }
-                            d_echo("Discovering $discover_hostname\n");
-                            $remote_device_id = discover_new_device($discover_hostname, $device, 'LLDP', $interface);
                         }
+                        unset($ptopo_array);
                     }
-                    // normalize MAC address if present
-                    $remote_port_mac_address = '';
-                    if ($lldp['lldpRemPortIdSubtype'] == 'macAddress') {
-                        $remote_port_mac_address = str_replace(array(' ', ':', '-'), '', strtolower($lldp['lldpRemPortId']));
+                }
+
+                if ($remote_device_id) {
+                    $remote_port_id = find_port_id(
+                        $lldp['lldpRemPortDesc'],
+                        $lldp['lldpRemPortId'],
+                        $remote_device_id,
+                        $remote_port_mac
+                    );
+
+                    if (empty($lldp['lldpRemSysName'])) {
+                        $remote_device = device_by_id_cache($remote_device_id);
+                        $lldp['lldpRemSysName'] = $remote_device['sysName'] ?: $remote_device['hostname'];
                     }
-                    // get remote device hostname from db by MAC address and replace lldpRemSysName if absent
-                    if (!$remote_device_id && $remote_port_mac_address) {
-                        $remote_device_id = dbFetchCell('SELECT `device_id` FROM `ports` WHERE ifPhysAddress = ? AND `deleted` = ?', array($remote_port_mac_address, '0'));
-                        if ($remote_device_id) {
-                            $remote_device_hostname = dbFetchRow('SELECT `hostname` FROM `devices` WHERE `device_id` = ?', array($remote_device_id));
-                        }
-                        if ($remote_device_hostname['hostname']) {
-                            $lldp['lldpRemSysName'] = $remote_device_hostname['hostname'];
-                        }
+
+                    if ($interface['port_id'] && $lldp['lldpRemSysName'] && $lldp['lldpRemPortId']) {
+                        discover_link(
+                            $interface['port_id'],
+                            'lldp',
+                            $remote_port_id,
+                            $lldp['lldpRemSysName'],
+                            $lldp['lldpRemPortId'],
+                            null,
+                            $lldp['lldpRemSysDesc'],
+                            $device['device_id'],
+                            $remote_device_id
+                        );
                     }
-                    if ($remote_device_id) {
-                        $if             = $lldp['lldpRemPortDesc'];
-                        $id             = $lldp['lldpRemPortId'];
-                        $remote_port_id = dbFetchCell('SELECT `port_id` FROM `ports` WHERE (`ifDescr` = ? OR `ifName` = ? OR `ifDescr` = ? OR `ifName` = ? OR `ifPhysAddress` = ?) AND `device_id` = ?', array($if, $if, $id, $id, $remote_port_mac_address, $remote_device_id));
-                    } else {
-                        $remote_port_id = '0';
-                    }
-                    if (is_numeric($interface['port_id']) && isset($lldp['lldpRemSysName']) && isset($lldp['lldpRemPortId'])) {
-                        discover_link($interface['port_id'], 'lldp', $remote_port_id, $lldp['lldpRemSysName'], $lldp['lldpRemPortId'], null, $lldp['lldpRemSysDesc'], $device['device_id'], $remote_device_id);
-                    }
-                }//end foreach
+                }
             }//end foreach
         }//end foreach
-    }//end if
+    }//end foreach
+
     unset(
         $dot1d_array
     );
+    echo PHP_EOL;
 }//end elseif
 
-unset(
-    $lldp_array
-);
-
-echo ' OSPF Discovery: ';
-
 if (Config::get('autodiscovery.ospf') === true) {
-    echo "enabled\n";
-    foreach (dbFetchRows('SELECT DISTINCT(`ospfNbrIpAddr`),`device_id` FROM `ospf_nbrs` WHERE `device_id`=?', array($device['device_id'])) as $nbr) {
-        $ip = $nbr['ospfNbrIpAddr'];
-        if (match_network(Config::get('autodiscovery.nets-exclude'), $ip)) {
-            echo 'x';
-            continue;
-        }
+    echo ' OSPF Discovery: ';
+    $sql = 'SELECT DISTINCT(`ospfNbrIpAddr`),`device_id` FROM `ospf_nbrs` WHERE `device_id`=?';
+    foreach (dbFetchRows($sql, array($device['device_id'])) as $nbr) {
+        try {
+            $ip = IP::parse($nbr['ospfNbrIpAddr']);
 
-        if (!match_network(Config::get('nets'), $ip)) {
-            echo 'i';
-            continue;
-        }
+            if ($ip->inNetworks(Config::get('autodiscovery.nets-exclude'))) {
+                echo 'x';
+                continue;
+            }
 
-        $name             = gethostbyaddr($ip);
-        $remote_device_id = discover_new_device($name, $device, 'OSPF');
+            if (!$ip->inNetworks(Config::get('nets'))) {
+                echo 'i';
+                continue;
+            }
+
+            $name = gethostbyaddr($ip);
+            $remote_device_id = discover_new_device($name, $device, 'OSPF');
+        } catch (\LibreNMS\Exceptions\InvalidIpException $e) {
+            //
+        }
     }
-} else {
-    echo "disabled\n";
+    echo PHP_EOL;
 }
 
 d_echo($link_exists);
 
-$sql = "SELECT * FROM `links` AS L, `ports` AS I WHERE L.local_port_id = I.port_id AND I.device_id = '".$device['device_id']."'";
-foreach (dbFetchRows($sql) as $test) {
+$sql = "SELECT * FROM `links` AS L, `ports` AS I WHERE L.local_port_id = I.port_id AND I.device_id = ?";
+foreach (dbFetchRows($sql, array($device['device_id'])) as $test) {
     $local_port_id   = $test['local_port_id'];
     $remote_hostname = $test['remote_hostname'];
     $remote_port     = $test['remote_port'];
@@ -245,6 +240,8 @@ foreach (dbFetchRows($sql) as $test) {
 
 unset(
     $link_exists,
-    $sql
+    $sql,
+    $fdp_array,
+    $cdp_array,
+    $lldp_array
 );
-echo "\n";

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -182,7 +182,6 @@ if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
                         $remote_device_id
                     );
                 }
-
             }//end foreach
         }//end foreach
     }//end foreach

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -14,77 +14,83 @@
 
 use LibreNMS\Config;
 use LibreNMS\Exceptions\HostExistsException;
+use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\IPv6;
 
 function discover_new_device($hostname, $device = '', $method = '', $interface = '')
 {
-    if (Config::has('mydomain')) {
-        $full_host = rtrim($hostname, '.') . '.' . Config::get('mydomain');
-        if (isDomainResolves($full_host)) {
-            $hostname = $full_host;
-        }
-    }
-
     d_echo("discovering $hostname\n");
 
-    $ip = gethostbyname($hostname);
-    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false && filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
-        // $ip isn't a valid IP so it must be a name.
-        if ($ip == $hostname) {
-            d_echo("name lookup of $hostname failed\n");
-            log_event("$method discovery of " . $hostname . " failed - Check name lookup", $device['device_id'], 'discovery', 5);
-
-            return false;
-        }
-    } elseif (filter_var($hostname, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === true || filter_var($hostname, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === true) {
-        // gethostbyname returned a valid $ip, was $dst_host an IP?
+    if (IP::isValid($hostname)) {
+        $ip = $hostname;
         if (!Config::get('discovery_by_ip', false)) {
             d_echo('Discovery by IP disabled, skipping ' . $hostname);
             log_event("$method discovery of " . $hostname . " failed - Discovery by IP disabled", $device['device_id'], 'discovery', 4);
 
             return false;
         }
+    } elseif (is_valid_hostname($hostname)) {
+        if ($mydomain = Config::get('mydomain')) {
+            $full_host = rtrim($hostname, '.') . '.' . $mydomain;
+            if (isDomainResolves($full_host)) {
+                $hostname = $full_host;
+            }
+        }
+
+        $ip = gethostbyname($hostname);
+        if ($ip == $hostname) {
+            d_echo("name lookup of $hostname failed\n");
+            log_event("$method discovery of " . $hostname . " failed - Check name lookup", $device['device_id'], 'discovery', 5);
+
+            return false;
+        }
+    } else {
+        d_echo("Discovery failed: '$hostname' is not a valid ip or dns name\n");
+        return false;
     }
 
     d_echo("ip lookup result: $ip\n");
 
-    $hostname = rtrim($hostname, '.');
-    // remove trailing dot
-    if (match_network(Config::get('autodiscovery.nets-exclude'), $ip)) {
-        d_echo("$ip in an excluded network - skipping\n");
+    $hostname = rtrim($hostname, '.'); // remove trailing dot
 
+    $ip = IP::parse($ip, true);
+    if ($ip->inNetworks(Config::get('autodiscovery.nets-exclude'))) {
+        d_echo("$ip in an excluded network - skipping\n");
         return false;
     }
 
-    if (match_network(Config::get('nets'), $ip)) {
-        try {
-            $remote_device_id = addHost($hostname, '', '161', 'udp', Config::get('distributed_poller_group'));
-            $remote_device = device_by_id_cache($remote_device_id, 1);
-            echo '+[' . $remote_device['hostname'] . '(' . $remote_device['device_id'] . ')]';
-            discover_device($remote_device);
-            device_by_id_cache($remote_device_id, 1);
-            if ($remote_device_id && is_array($device) && !empty($method)) {
-                $extra_log = '';
-                $int = cleanPort($interface);
-                if (is_array($int)) {
-                    $extra_log = ' (port ' . $int['label'] . ') ';
-                }
+    if (!$ip->inNetworks(Config::get('nets'))) {
+        d_echo("$ip not in a matched network - skipping\n");
+        return false;
+    }
 
-                log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery', 1);
-            } else {
-                log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check ping and SNMP access", $device['device_id'], 'discovery', 5);
+    try {
+        $remote_device_id = addHost($hostname, '', '161', 'udp', Config::get('distributed_poller_group'));
+        $remote_device = device_by_id_cache($remote_device_id, 1);
+        echo '+[' . $remote_device['hostname'] . '(' . $remote_device['device_id'] . ')]';
+        discover_device($remote_device);
+        device_by_id_cache($remote_device_id, 1);
+        if ($remote_device_id && is_array($device) && !empty($method)) {
+            $extra_log = '';
+            $int = cleanPort($interface);
+            if (is_array($int)) {
+                $extra_log = ' (port ' . $int['label'] . ') ';
             }
 
-            return $remote_device_id;
-        } catch (HostExistsException $e) {
-            // already have this device
-        } catch (Exception $e) {
-            log_event("$method discovery of " . $hostname . " ($ip) failed - " . $e->getMessage(), $device['device_id'], 'discovery', 5);
+            log_event('Device ' . $remote_device['hostname'] . " ($ip) $extra_log autodiscovered through $method on " . $device['hostname'], $remote_device_id, 'discovery', 1);
+        } else {
+            log_event("$method discovery of " . $remote_device['hostname'] . " ($ip) failed - Check ping and SNMP access", $device['device_id'], 'discovery', 5);
         }
-    } else {
-        d_echo("$ip not in a matched network - skipping\n");
-    }//end if
+
+        return $remote_device_id;
+    } catch (HostExistsException $e) {
+        // already have this device
+    } catch (Exception $e) {
+        log_event("$method discovery of " . $hostname . " ($ip) failed - " . $e->getMessage(), $device['device_id'], 'discovery', 5);
+    }
+
+    return false;
 }
 //end discover_new_device()
 
@@ -1309,4 +1315,133 @@ function add_cbgp_peer($device, $peer, $afi, $safi)
         );
         dbInsert($cbgp, 'bgpPeers_cbgp');
     }
+}
+
+/**
+ * check if we should skip this device from discovery
+ * @param string $sysName
+ * @param string $sysDescr
+ * @param string $platform
+ * @return bool
+ */
+function can_skip_discovery($sysName, $sysDescr = '', $platform = '')
+{
+    if ($sysName) {
+        foreach ((array)Config::get('autodiscovery.xdp_exclude.sysname_regexp') as $needle) {
+            if (preg_match($needle .'i', $sysName)) {
+                d_echo("$sysName - regexp '$needle' matches '$sysName' - skipping device discovery \n");
+                return true;
+            }
+        }
+    }
+
+    if ($sysDescr) {
+        foreach ((array)Config::get('autodiscovery.xdp_exclude.sysdesc_regexp') as $needle) {
+            if (preg_match($needle .'i', $sysDescr)) {
+                d_echo("$sysName - regexp '$needle' matches '$sysDescr' - skipping device discovery \n");
+                return true;
+            }
+        }
+    }
+
+    if ($platform) {
+        foreach ((array)Config::get('autodiscovery.cdp_exclude.platform_regexp') as $needle) {
+            if (preg_match($needle .'i', $platform)) {
+                d_echo("$sysName - regexp '$needle' matches '$platform' - skipping device discovery \n");
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Try to find a device by sysName, hostname, ip, or mac_address
+ * If a device cannot be found, returns 0
+ *
+ * @param string $name sysName or hostname
+ * @param string $ip May be an IP or hex string
+ * @param string $mac_address
+ * @return int the device_id or 0
+ */
+function find_device_id($name='', $ip='', $mac_address='')
+{
+    $where = array();
+    $params = array();
+
+    if ($name && is_valid_hostname($name)) {
+        $where[] = '`sysName`=?';
+        $params[] = $name;
+
+        $where[] = '`hostname`=?';
+        $params[] = $name;
+
+        if ($mydomain = Config::get('mydomain')) {
+            $where[] = '`hostname`=?';
+            $params[] = "$name.$mydomain";
+        }
+    }
+
+    if ($ip) {
+        $where[] = '`hostname`=?';
+        $params[] = $ip;
+
+        try {
+            $params[] = IP::fromHexString($ip)->packed();
+            $where[] = '`ip`=?';
+        } catch (InvalidIpException $e) {
+            //
+        }
+    }
+
+    if (!empty($where)) {
+        $sql = 'SELECT `device_id` FROM `devices` WHERE ' . implode(' OR ', $where);
+        if ($device_id = dbFetchCell($sql, $params)) {
+            return (int)$device_id;
+        }
+    }
+
+    if ($mac_address && $mac_address != '000000000000') {
+        if ($device_id = dbFetchCell('SELECT `device_id` FROM `ports` WHERE `ifPhysAddress`=?', array($mac_address))) {
+            return (int)$device_id;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Try to find a port by ifDescr, ifName, or MAC
+ *
+ * @param string $description matched against ifDescr and ifName
+ * @param string $identifier matched against ifDescr and ifName
+ * @param int $device_id restrict search to ports on a specific device
+ * @param string $mac_address check against ifPysAddress (should be in lowercase hexadecimal)
+ * @return int
+ */
+function find_port_id($description, $identifier='', $device_id = 0, $mac_address = null)
+{
+    $sql = 'SELECT `port_id` FROM `ports` WHERE (`ifDescr`=? OR `ifName`=?';
+    $params = array($description, $description);
+
+    if ($identifier) {
+        $sql .= ' OR `ifDescr`=? OR `ifName`=?';
+        $params[] = $identifier;
+        $params[] = $identifier;
+    }
+
+    if ($mac_address) {
+        $sql .= ' OR `ifPhysAddress`=?';
+        $params[] = $mac_address;
+    }
+
+    $sql .= ')';
+
+    if ($device_id) {
+        $sql .= ' AND `device_id`=?';
+        $params = $device_id;
+    }
+
+    return (int)dbFetchCell($sql, $params);
 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1365,7 +1365,7 @@ function can_skip_discovery($sysName, $sysDescr = '', $platform = '')
  * @param string $mac_address
  * @return int the device_id or 0
  */
-function find_device_id($name='', $ip='', $mac_address='')
+function find_device_id($name = '', $ip = '', $mac_address = '')
 {
     $where = array();
     $params = array();
@@ -1420,7 +1420,7 @@ function find_device_id($name='', $ip='', $mac_address='')
  * @param string $mac_address check against ifPysAddress (should be in lowercase hexadecimal)
  * @return int
  */
-function find_port_id($description, $identifier='', $device_id = 0, $mac_address = null)
+function find_port_id($description, $identifier = '', $device_id = 0, $mac_address = null)
 {
     $sql = 'SELECT `port_id` FROM `ports` WHERE (`ifDescr`=? OR `ifName`=?';
     $params = array($description, $description);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -544,7 +544,7 @@ function discover_link($local_port_id, $protocol, $remote_port_id, $remote_hostn
         echo '+';
         d_echo("( $inserted inserted )");
     } else {
-        $sql = 'SELECT `local_device_id`,`remote_platform`,`remote_version`,`remote_device_id`,`remote_port_id` FROM `links`';
+        $sql = 'SELECT `id`,`local_device_id`,`remote_platform`,`remote_version`,`remote_device_id`,`remote_port_id` FROM `links`';
         $sql .= ' WHERE `remote_hostname` = ? AND `local_port_id` = ? AND `protocol` = ? AND `remote_port` = ?';
         $data = dbFetchRow($sql, array($remote_hostname, $local_port_id, $protocol, $remote_port));
 
@@ -556,10 +556,12 @@ function discover_link($local_port_id, $protocol, $remote_port_id, $remote_hostn
             'remote_port_id' => $remote_port_id
         );
 
+        $id = $data['id'];
+        unset($data['id']);
         if ($data == $update_data) {
             echo '.';
         } else {
-            $updated = dbUpdate($update_data, 'links', '`id` = ?', array($data['id']));
+            $updated = dbUpdate($update_data, 'links', '`id` = ?', array($id));
             echo 'U';
             d_echo("( $updated updated )");
         }//end if

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -544,21 +544,21 @@ function discover_link($local_port_id, $protocol, $remote_port_id, $remote_hostn
         echo '+';
         d_echo("( $inserted inserted )");
     } else {
-        $data = dbFetchRow('SELECT * FROM `links` WHERE `remote_hostname` = ? AND `local_port_id` = ? AND `protocol` = ? AND `remote_port` = ?', array($remote_hostname, $local_port_id, $protocol, $remote_port));
-        if ($data['remote_port_id'] == $remote_port_id && $data['remote_platform'] == $remote_platform && $remote_version == $remote_version && $data['local_device_id'] > 0 && $data['remote_device_id'] > 0) {
+        $sql = 'SELECT `local_device_id`,`remote_platform`,`remote_version`,`remote_device_id`,`remote_port_id` FROM `links`';
+        $sql .= ' WHERE `remote_hostname` = ? AND `local_port_id` = ? AND `protocol` = ? AND `remote_port` = ?';
+        $data = dbFetchRow($sql, array($remote_hostname, $local_port_id, $protocol, $remote_port));
+
+        $update_data = array(
+            'local_device_id' => $local_device_id,
+            'remote_platform' => $remote_platform,
+            'remote_version' => $remote_version,
+            'remote_device_id' => $remote_device_id,
+            'remote_port_id' => $remote_port_id
+        );
+
+        if ($data == $update_data) {
             echo '.';
         } else {
-            $update_data = array(
-                'remote_platform' => $remote_platform,
-                'remote_version' => $remote_version,
-                'local_device_id' => $local_device_id,
-                'remote_device_id' => $remote_device_id,
-            );
-
-            if (!empty($remote_port_id)) {
-                $update_data['remote_port_id'] = $remote_port_id;
-            }
-
             $updated = dbUpdate($update_data, 'links', '`id` = ?', array($data['id']));
             echo 'U';
             d_echo("( $updated updated )");

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1920,25 +1920,6 @@ function get_toner_levels($device, $raw_value, $capacity)
 }
 
 /**
- * check if we should skip this device from discovery
- * @param $needles
- * @param $haystack
- * @param $name
- * @return bool
- */
-function can_skip_discovery($needles, $haystack, $name)
-{
-    foreach ((array)$needles as $needle) {
-        if (preg_match($needle ."i", $haystack)) {
-            d_echo("{$name} - regexp '{$needle}' matches '{$haystack}' - skipping device discovery \n");
-            return true;
-        }
-    }
-    return false;
-}
-
-
-/**
  * Intialize global stat arrays
  */
 function initStats()

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -682,7 +682,7 @@ links:
     protocol: { Field: protocol, Type: varchar(11), 'Null': true, Default: 'NULL', Extra: '' }
     remote_device_id: { Field: remote_device_id, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
     remote_hostname: { Field: remote_hostname, Type: varchar(128), 'Null': false, Default: 'NULL', Extra: '' }
-    remote_platform: { Field: remote_platform, Type: varchar(128), 'Null': false, Default: 'NULL', Extra: '' }
+    remote_platform: { Field: remote_platform, Type: varchar(256), 'Null': true, Default: 'NULL', Extra: '' }
     remote_port: { Field: remote_port, Type: varchar(128), 'Null': false, Default: 'NULL', Extra: '' }
     remote_port_id: { Field: remote_port_id, Type: int(11), 'Null': true, Default: 'NULL', Extra: '' }
     remote_version: { Field: remote_version, Type: varchar(256), 'Null': false, Default: 'NULL', Extra: '' }

--- a/sql-schema/210.sql
+++ b/sql-schema/210.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `links` MODIFY `remote_platform` VARCHAR(256);


### PR DESCRIPTION
extract more code to make it easier to read
use snmpwalk_group
walk lldpRemTable instead of lldpRemoteSystemsData
Optimize discover_device to reduce dns lookups of bad dns names
Make discovery_by_ip behavior consistent between cdp and lldp
move can_skip_discovery to discovery functions

Tested lldp, cdp, and ospf.

discovery-protocols went from 50s to 1.5s on one test device

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7380)
<!-- Reviewable:end -->
