### PR TITLE
Features: Add alert rules for RFC1628 UPS to the collection

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -114,19 +114,19 @@
     "rule": "%services.service_status = \"2\"",
     "name": "Service critical"
   },
-   {
+  {
     "rule": "%syslog.timestamp >= %macros.past_5m && %syslog.priority ~ \"alert\"",
     "name": "Syslog, received Alert Priority Message"
   },
-    {
+  {
     "rule": "%syslog.timestamp >= %macros.past_5m && %syslog.priority ~ \"emergency\"",
     "name": "Syslog, received Emergency Priority Message"
   },
-     {
+  {
     "rule": "%syslog.timestamp = %macros.past_5m && %syslog.msg ~ \"@arp table is full@\"",
     "name": "Syslog, ARP table is full check on device "
   },
-   {
+  {
     "rule": "%sensors.sensor_type = \"upsAdvBatteryReplaceIndicator\" && %sensors.sensor_current = \"2\"",
     "name": "APC UPS Battery Needs Replacement"
   },
@@ -146,11 +146,11 @@
     "rule": "%sensors.sensor_current = \"12\" && %sensors.sensor_type = \"upsBasicOutputStatus\"",
     "name": "APC UPS in Smart Trim Mode"
   },
-   {
+  {
     "rule": "%sensors.sensor_oid ~ \".1.3.6.1.4.1.11.2.14.11.1.2.6.1.4.[2-5]\" && %sensors.sensor_current = \"2\"",
     "name": "HP Procurve Bad Power Supply"
   },
-    {
+  {
     "rule": "%sensors.sensor_oid = \".1.3.6.1.4.1.11.2.14.11.1.2.6.1.4.1\" && %sensors.sensor_current = \"2\"",
     "name": "HP Procurve Fan Fault"
   },
@@ -161,5 +161,25 @@
   {
     "rule": "%sensors.sensor_current < %sensors.sensor_limit_low && %sensors.sensor_alert = \"1\" && %macros.device_up = \"1\" && %macros.sensor_port_link = \"1\"",
     "name": "Sensor under limit with linked port"
+  },
+  {
+    "rule": "%sensors.sensor_current = \"4\" && %sensors.sensor_type = \"upsOutputSourceState\"",
+    "name": "UPS is running on the bypass"
+  },
+  {
+    "rule": "%sensors.sensor_current = \"5\" && %sensors.sensor_type = \"upsOutputSourceState\"",
+    "name": "UPS is running on the battery"
+  },
+  {
+    "rule": "%sensors.sensor_current = \"3\" && %sensors.sensor_type = \"upsBatteryStatusState\"",
+    "name": "UPS has a low battery"
+  },
+  {
+    "rule": "%sensors.sensor_current = \"4\" && %sensors.sensor_type = \"upsBatteryStatusState\"",
+    "name": "UPS has a depleted battery"
+  },
+  {
+    "rule": "%sensors.sensor_descr ~ \"Percentage load\" && %sensors.sensor_current >= \"90\" && %sensors.sensor_type = \"rfc1628\"",
+    "name": "UPS has a heavy load"
   }
 ]


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


----------------------

- Added some rules for RFC 1628 UPS, tested on APC Galaxy and Generex SNMP card
- Corrected some indentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7415)
<!-- Reviewable:end -->
