### PR TITLE
feature: issue warning notification if php version is less than 5.6.4

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -30,6 +30,14 @@ if ($options['f'] === 'update') {
     exit(0);
 }
 
+if ($options['f'] === 'check_php_ver') {
+    $min_version = '5.6.4';
+    if (version_compare(PHP_VERSION, $min_version, '>=')) {
+        exit(0);
+    }
+    exit(1);
+}
+
 if ($options['f'] === 'rrd_purge') {
     if (is_numeric($config['rrd_purge']) && $config['rrd_purge'] > 0) {
         $cmd = "find ".$config['rrd_dir']." -type f -mtime +".$config['rrd_purge']." -print -exec rm -f {} +";
@@ -98,18 +106,34 @@ if ($options['f'] === 'device_perf') {
     }
 }
 
-if ($options['f'] === 'set_notification') {
+if ($options['f'] === 'handle_notification') {
     if ($options['t'] === 'update') {
         $title = 'Error: Daily update failed';
 
         if ($options['r']) {
+            // result was a success, remove the notification
             remove_notification($title);
         } else {
+            // result was a failure, create the notification
             new_notification(
                 $title,
                 'The daily update script (daily.sh) has failed. Please check output by hand. If you need assistance, '
                 . 'visit the <a href="https://www.librenms.org/#support">LibreNMS Website</a> to find out how.',
                 2,
+                'daily.sh'
+            );
+        }
+    } elseif ($options['t'] === 'php_ver') {
+        $title = 'Warning: PHP version too low';
+        if ($options['r']) {
+            // result was a success, remove the notification
+            remove_notification($title);
+        } else {
+            // result was a failure, create the notification
+            new_notification(
+                $title,
+                'PHP version 5.6 will soon be the minimum supported version.  We suggest you update to PHP the latest version of PHP (7.1 at this time) to continue to receive updates.  If you do not update, LibreNMS will continue to function but stop receiving bug fixes and updates.',
+                1,
                 'daily.sh'
             );
         }

--- a/daily.php
+++ b/daily.php
@@ -132,7 +132,7 @@ if ($options['f'] === 'handle_notifiable') {
             // result was a failure (0), create the notification
             new_notification(
                 $title,
-                'PHP version 5.6 will soon be the minimum supported version.  We suggest you update to PHP the latest version of PHP (7.1 at this time) to continue to receive updates.  If you do not update, LibreNMS will continue to function but stop receiving bug fixes and updates.',
+                'PHP version 5.6.4 will be the minimum supported version on January 10, 2018.  We suggest you update to PHP a supported version of PHP (7.1 suggested) to continue to receive updates.  If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.',
                 1,
                 'daily.sh'
             );

--- a/daily.php
+++ b/daily.php
@@ -6,6 +6,8 @@
  * (c) 2013 LibreNMS Contributors
  */
 
+use LibreNMS\Config;
+
 $init_modules = array('alerts');
 require __DIR__ . '/includes/init.php';
 include_once __DIR__ . '/includes/notifications.php';
@@ -32,10 +34,21 @@ if ($options['f'] === 'update') {
 
 if ($options['f'] === 'check_php_ver') {
     $min_version = '5.6.4';
-    if (version_compare(PHP_VERSION, $min_version, '>=')) {
-        exit(0);
+    $warn_title = 'Warning: PHP version too low';
+
+    // if update is not set to false and version is min or newer
+    if (Config::get('update') && version_compare(PHP_VERSION, $min_version, '<')) {
+        new_notification(
+            $warn_title,
+            'PHP version 5.6.4 will be the minimum supported version on January 10, 2018.  We recommend you update to PHP a supported version of PHP (7.1 suggested) to continue to receive updates.  If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.',
+            1,
+            'daily.sh'
+        );
+        exit(1);
     }
-    exit(1);
+
+    remove_notification($warn_title);
+    exit(0);
 }
 
 if ($options['f'] === 'rrd_purge') {
@@ -120,20 +133,6 @@ if ($options['f'] === 'handle_notifiable') {
                 'The daily update script (daily.sh) has failed. Please check output by hand. If you need assistance, '
                 . 'visit the <a href="https://www.librenms.org/#support">LibreNMS Website</a> to find out how.',
                 2,
-                'daily.sh'
-            );
-        }
-    } elseif ($options['t'] === 'php_ver') {
-        $title = 'Warning: PHP version too low';
-        if ($options['r']) {
-            // result was a success (1), remove the notification
-            remove_notification($title);
-        } else {
-            // result was a failure (0), create the notification
-            new_notification(
-                $title,
-                'PHP version 5.6.4 will be the minimum supported version on January 10, 2018.  We suggest you update to PHP a supported version of PHP (7.1 suggested) to continue to receive updates.  If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.',
-                1,
                 'daily.sh'
             );
         }

--- a/daily.php
+++ b/daily.php
@@ -106,15 +106,15 @@ if ($options['f'] === 'device_perf') {
     }
 }
 
-if ($options['f'] === 'handle_notification') {
+if ($options['f'] === 'handle_notifiable') {
     if ($options['t'] === 'update') {
         $title = 'Error: Daily update failed';
 
         if ($options['r']) {
-            // result was a success, remove the notification
+            // result was a success (1), remove the notification
             remove_notification($title);
         } else {
-            // result was a failure, create the notification
+            // result was a failure (0), create the notification
             new_notification(
                 $title,
                 'The daily update script (daily.sh) has failed. Please check output by hand. If you need assistance, '
@@ -126,10 +126,10 @@ if ($options['f'] === 'handle_notification') {
     } elseif ($options['t'] === 'php_ver') {
         $title = 'Warning: PHP version too low';
         if ($options['r']) {
-            // result was a success, remove the notification
+            // result was a success (1), remove the notification
             remove_notification($title);
         } else {
-            // result was a failure, create the notification
+            // result was a failure (0), create the notification
             new_notification(
                 $title,
                 'PHP version 5.6 will soon be the minimum supported version.  We suggest you update to PHP the latest version of PHP (7.1 at this time) to continue to receive updates.  If you do not update, LibreNMS will continue to function but stop receiving bug fixes and updates.',

--- a/daily.sh
+++ b/daily.sh
@@ -64,7 +64,7 @@ status_run() {
     echo "${tmp}" >> ${log_file}
     echo "Returned: ${exit_code}" >> ${log_file}
 
-    # print OK if the command ran succesfully
+    # print OK if the command ran successfully
     # or FAIL otherwise (non-zero exit code)
     if [[ "${exit_code}" == "0" ]]; then
         printf " \033[0;32mOK\033[0m\n";
@@ -72,6 +72,10 @@ status_run() {
         printf " \033[0;31mFAIL\033[0m\n";
         if [[ "${arg_option}" == "update" ]]; then
             php "${LIBRENMS_DIR}/daily.php" -f notify -o "${tmp}"
+        fi
+        if [[ ! -z "${tmp}" ]]; then
+            # print output in case of failure
+            echo "${tmp}"
         fi
     fi
     return ${exit_code}
@@ -97,7 +101,7 @@ call_daily_php() {
 }
 
 #######################################
-# Set critical notifications for the user
+# Send result of a notifiable process to php code for processing
 # Globals:
 #   LIBRENMS_DIR
 # Arguments:
@@ -107,12 +111,12 @@ call_daily_php() {
 # Returns:
 #   Exit-Code of Command
 #######################################
-set_notification() {
+set_notifiable_result() {
     local args="$@";
     local arg_type=$1;
     local arg_result=$2;
 
-    php "${LIBRENMS_DIR}/daily.php" -f set_notification -t ${arg_type} -r ${arg_result};
+    php "${LIBRENMS_DIR}/daily.php" -f handle_notification -t ${arg_type} -r ${arg_result};
 }
 
 #######################################
@@ -151,8 +155,17 @@ main () {
         up=$(php daily.php -f update >&2; echo $?)
         if [[ "$up" == "0" ]]; then
             ${DAILY_SCRIPT} no-code-update
-            set_notification update 1  # make sure there are no update notifications if update is disabled
+            set_notifiable_result update 1  # make sure there are no update notifications if update is disabled
             exit
+        fi
+
+        status_run 'Checking PHP version' "php ${LIBRENMS_DIR}/daily.php -f check_php_ver" 'check_php_ver'
+        if [[ $? -ne 0 && ${up} -ne 0 ]]; then
+            # php version too low
+            set_notifiable_result php_ver 0
+            # up=0
+        else
+            set_notifiable_result php_ver 1
         fi
 
         # make sure the vendor directory is clean
@@ -174,7 +187,7 @@ main () {
         fi
 
         if (( $update_res > 0 )); then
-            set_notification update 0
+            set_notifiable_result update 0
         fi
 
         if [[ "$old_ver" != "$new_ver" ]]; then
@@ -183,10 +196,10 @@ main () {
             # Run post update checks
             if [ ! -f "${LIBRENMS_DIR}/vendor/autoload.php" ]; then
                 status_run "Reverting update, check the output of composer diagnose" "git checkout $old_ver" 'update'
-                set_notification update 0
+                set_notifiable_result update 0
             else
                 status_run "Updated from $old_ver to $new_ver" ''
-                set_notification update 1  # only clear the error if update was a success
+                set_notifiable_result update 1  # only clear the error if update was a success
             fi
         fi
 

--- a/daily.sh
+++ b/daily.sh
@@ -152,20 +152,13 @@ main () {
     fi
 
     if [[ -z "$arg" ]]; then
+        status_run 'Checking PHP version' "php ${LIBRENMS_DIR}/daily.php -f check_php_ver" 'check_php_ver'
+
         up=$(php daily.php -f update >&2; echo $?)
         if [[ "$up" == "0" ]]; then
             ${DAILY_SCRIPT} no-code-update
             set_notifiable_result update 1  # make sure there are no update notifications if update is disabled
             exit
-        fi
-
-        status_run 'Checking PHP version' "php ${LIBRENMS_DIR}/daily.php -f check_php_ver" 'check_php_ver'
-        if [[ $? -ne 0 && ${up} -ne 0 ]]; then
-            # php version too low
-            set_notifiable_result php_ver 0
-            # up=0
-        else
-            set_notifiable_result php_ver 1
         fi
 
         # make sure the vendor directory is clean

--- a/daily.sh
+++ b/daily.sh
@@ -116,7 +116,7 @@ set_notifiable_result() {
     local arg_type=$1;
     local arg_result=$2;
 
-    php "${LIBRENMS_DIR}/daily.php" -f handle_notification -t ${arg_type} -r ${arg_result};
+    php "${LIBRENMS_DIR}/daily.php" -f handle_notifiable -t ${arg_type} -r ${arg_result};
 }
 
 #######################################


### PR DESCRIPTION
rename set_notification function in daily.sh to set_notifiable_result
print output when a daily.sh process fails

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/librenms/librenms/7418)
<!-- Reviewable:end -->
