### PR TITLE
docs: re-organize install docs

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -1,17 +1,32 @@
 source: Installation/Installation-CentOS-7-Apache.md
-> NOTE: These instructions assume you are the root user.  If you are not, prepend `sudo` to the shell commands (the ones that aren't at `mysql>` prompts) or temporarily become a user with root privileges with `sudo -s` or `sudo -i`.
+> NOTE: These instructions assume you are the **root** user.  If you are not, prepend `sudo` to the shell commands (the ones that aren't at `mysql>` prompts) or temporarily become a user with root privileges with `sudo -s` or `sudo -i`.
 
-### DB Server ###
+## Install Required Packages ##
 
-> NOTE: Whilst we are working on ensuring LibreNMS is compatible with MySQL strict mode, for now, please disable this after mysql is installed.
+    yum install epel-release
+    
+    rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
 
-#### Install / Configure MySQL
-```bash
-yum install mariadb-server mariadb
-systemctl restart mariadb
-mysql -uroot
-```
+    yum install composer cronie fping git httpd ImageMagick jwhois mariadb mariadb-server mtr MySQL-python net-snmp net-snmp-utils nmap php71w php71w-cli php71w-common php71w-curl php71w-gd php71w-mcrypt php71w-mysql php71w-snmp php70w-xml php71w-zip python-memcached rrdtool
 
+#### Add librenms user
+
+    useradd librenms -d /opt/librenms -M -r
+    usermod -a -G librenms apache
+
+#### Install LibreNMS
+
+    cd /opt
+    git clone https://github.com/librenms/librenms.git librenms
+
+## DB Server ##
+
+#### Configure MySQL
+
+    systemctl restart mariadb
+    mysql -uroot
+
+> NOTE: Please change the 'password' below to something secure.
 ```sql
 CREATE DATABASE librenms CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 CREATE USER 'librenms'@'localhost' IDENTIFIED BY 'password';
@@ -20,66 +35,39 @@ FLUSH PRIVILEGES;
 exit
 ```
 
-`vim /etc/my.cnf.d/server.cnf`
+    vi /etc/my.cnf
 
-Within the [mysqld] section please add:
+> NOTE: Whilst we are working on ensuring LibreNMS is compatible with MySQL strict mode, for now, please disable this after mysql is installed.
+
+Within the `[mysqld]` section please add:
 
 ```bash
 innodb_file_per_table=1
 sql-mode=""
 lower_case_table_names=0
 ```
+    systemctl enable mariadb
+    systemctl restart mariadb
 
-```
-systemctl enable mariadb  
-systemctl restart mariadb
-```
+## Web Server ##
 
-### Web Server ###
+### Configure PHP
 
-#### Install / Configure Apache
+Ensure date.timezone is set in php.ini to your preferred time zone.  See http://php.net/manual/en/timezones.php for a list of supported timezones.  Valid examples are: "America/New_York", "Australia/Brisbane", "Etc/UTC".
 
-```bash
-yum install epel-release
-rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
+    vi  /etc/php.ini
 
-yum install php70w php70w-cli php70w-gd php70w-mysql php70w-snmp php70w-curl php70w-common php70w-xml httpd net-snmp mariadb ImageMagick jwhois nmap mtr rrdtool MySQL-python net-snmp-utils cronie php70w-mcrypt fping git
-```
+### Configure Apache
 
-In `/etc/php.ini` ensure date.timezone is set to your preferred time zone.  See http://php.net/manual/en/timezones.php for a list of supported timezones.  Valid examples are: "America/New_York", "Australia/Brisbane", "Etc/UTC".
+    vi /etc/httpd/conf.d/librenms.conf
 
-#### Add librenms user
-
-```bash
-useradd librenms -d /opt/librenms -M -r
-usermod -a -G librenms apache
-```
-
-#### Clone repo
-
-```bash
-cd /opt
-git clone https://github.com/librenms/librenms.git librenms
-```
-
-#### Web interface
-
-```bash
-cd /opt/librenms
-mkdir rrd logs
-chmod 775 rrd
-vim /etc/httpd/conf.d/librenms.conf
-```
-
-Add the following config:
+Add the following config, edit `ServerName` as required:
 
 ```apache
 <VirtualHost *:80>
   DocumentRoot /opt/librenms/html/
   ServerName  librenms.example.com
-  CustomLog /opt/librenms/logs/access_log combined
-  ErrorLog /opt/librenms/logs/error_log
+
   AllowEncodedSlashes NoDecode
   <Directory "/opt/librenms/html/">
     Require all granted
@@ -90,81 +78,72 @@ Add the following config:
 ```
 
 > NOTE: If this is the only site you are hosting on this server (it should be :)) then you will need to disable the default site.
-
 `rm -f /etc/httpd/conf.d/welcome.conf`
+
+    systemctl enable httpd
+    systemctl restart httpd
 
 #### SELinux
 
-```bash
     yum install policycoreutils-python
+
     semanage fcontext -a -t httpd_sys_content_t '/opt/librenms/logs(/.*)?'
     semanage fcontext -a -t httpd_sys_rw_content_t '/opt/librenms/logs(/.*)?'
-    semanage fcontext -a -t httpd_sys_rw_content_t '/opt/librenms/rrd(/.*)?'
-    semanage fcontext -a -t httpd_sys_content_t '/opt/librenms/rrd(/.*)?'
     restorecon -RFvv /opt/librenms/logs/
+    semanage fcontext -a -t httpd_sys_content_t '/opt/librenms/rrd(/.*)?'
+    semanage fcontext -a -t httpd_sys_rw_content_t '/opt/librenms/rrd(/.*)?'
+    restorecon -RFvv /opt/librenms/rrd/
     setsebool -P httpd_can_sendmail=1
-    setsebool -P httpd_can_network_connect=1
-```
 
 #### Allow access through firewall
 
-```bash
-firewall-cmd --zone public --add-service http
-firewall-cmd --permanent --zone public --add-service http
-```
-
-#### Restart Web server
-
-```bash
-systemctl restart httpd
-```
-
-#### Web installer
-
-Now head to: http://librenms.example.com/install.php and follow the on-screen instructions.
-
-Once you have completed the web installer steps. Please add the following to `config.php`
-
-`$config['fping'] = "/usr/sbin/fping";`
+    firewall-cmd --zone public --add-service http
+    firewall-cmd --permanent --zone public --add-service http
+    firewall-cmd --zone public --add-service https
+    firewall-cmd --permanent --zone public --add-service https
 
 #### Configure snmpd
 
-```bash
-cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
-vim /etc/snmp/snmpd.conf
-```
+    cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
+
+    vi /etc/snmp/snmpd.conf
 
 Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community string.
 
-```bash
-curl -o /usr/bin/distro https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/distro
-chmod +x /usr/bin/distro
-systemctl restart snmpd
-```
+    curl -o /usr/bin/distro https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/distro
+    chmod +x /usr/bin/distro
+    systemctl enable snmpd
+    systemctl restart snmpd
 
-#### Cron job
+### Cron job
 
-`cp librenms.nonroot.cron /etc/cron.d/librenms`
+    cp /opt/librenms/librenms.nonroot.cron /etc/cron.d/librenms
 
 #### Copy logrotate config
 
 LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
 
-    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+    cp /opt/librenms/misc/librenms.logrotate /etc/logrotate.d/librenms
 
-#### Final steps
+### Set permissions
 
-```bash
-chown -R librenms:librenms /opt/librenms
-systemctl enable httpd mariadb
-```
+    chown -R librenms:librenms /opt/librenms
+    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs
+    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs
+
+## Web installer ##
+
+Now head to the web installer and follow the on-screen instructions.
+
+    http://librenms.example.com/install.php
+
+
+### Final steps
 
 Run validate.php as root in the librenms directory:
 
-```bash
-cd /opt/librenms
-./validate.php
-```
+    cd /opt/librenms
+    ./validate.php
 
 That's it!  You now should be able to log in to http://librenms.example.com/.  Please note that we have not covered HTTPS setup in this example, so your LibreNMS install is not secure by default.  Please do not expose it to the public Internet unless you have configured HTTPS and taken appropriate web server hardening steps.
 
@@ -172,7 +151,7 @@ That's it!  You now should be able to log in to http://librenms.example.com/.  P
 
 We now suggest that you add localhost as your first device from within the WebUI.
 
-#### What next?
+### What next?
 
 Now that you've installed LibreNMS, we'd suggest that you have a read of a few other docs to get you going:
 
@@ -181,6 +160,8 @@ Now that you've installed LibreNMS, we'd suggest that you have a read of a few o
  - [Device Groups](http://docs.librenms.org/Extensions/Device-Groups/)
  - [Auto discovery](http://docs.librenms.org/Extensions/Auto-Discovery/)
 
-#### Closing
+### Closing
 
 We hope you enjoy using LibreNMS. If you do, it would be great if you would consider opting into the stats system we have, please see [this page](http://docs.librenms.org/General/Callback-Stats-and-Privacy/) on what it is and how to enable it.
+
+If you would like to help make LibreNMS better there are [many ways to help](http://docs.librenms.org/Support/FAQ/#what-can-i-do-to-help). You can also [support our Collective](https://t.libren.ms/donations). 

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -1,17 +1,28 @@
 source: Installation/Installation-Ubuntu-1604-Nginx.md
-> NOTE: These instructions assume you are the root user.  If you are not, prepend `sudo` to the shell commands (the ones that aren't at `mysql>` prompts) or temporarily become a user with root privileges with `sudo -s` or `sudo -i`.
+> NOTE: These instructions assume you are the **root** user.  If you are not, prepend `sudo` to the shell commands (the ones that aren't at `mysql>` prompts) or temporarily become a user with root privileges with `sudo -s` or `sudo -i`.
 
-### DB Server ###
+## Install Required Packages ##
 
-> NOTE: Whilst we are working on ensuring LibreNMS is compatible with MySQL strict mode, for now, please disable this after mysql is installed.
+    apt install composer fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php7.0-cli php7.0-curl php7.0-fpm php7.0-gd php7.0-mcrypt php7.0-mysql php7.0-snmp php7.0-xml php7.0-zip python-memcache python-mysqldb rrdtool snmp snmpd whois
 
-#### Install / Configure MySQL
-```bash
-apt-get install mariadb-server mariadb-client
-systemctl restart mysql
-mysql -uroot -p
-```
+#### Add librenms user
 
+    useradd librenms -d /opt/librenms -M -r
+    usermod -a -G librenms www-data
+
+#### Install LibreNMS
+
+    cd /opt
+    git clone https://github.com/librenms/librenms.git librenms
+
+
+## DB Server ##
+
+#### Configure MySQL
+    systemctl restart mysql
+    mysql -uroot -p
+
+> NOTE: Please change the 'password' below to something secure.
 ```sql
 CREATE DATABASE librenms CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 CREATE USER 'librenms'@'localhost' IDENTIFIED BY 'password';
@@ -20,55 +31,35 @@ FLUSH PRIVILEGES;
 exit
 ```
 
-`vim /etc/mysql/mariadb.conf.d/50-server.cnf`
+    vim /etc/mysql/mariadb.conf.d/50-server.cnf
 
-Within the [mysqld] section please add:
+> NOTE: Whilst we are working on ensuring LibreNMS is compatible with MySQL strict mode, for now, please disable this after mysql is installed.
+
+Within the `[mysqld]` section please add:
 
 ```bash
 innodb_file_per_table=1
 sql-mode=""
 lower_case_table_names=0
 ```
+    systemctl restart mysql
 
-```systemctl restart mysql```
+## Web Server ##
 
-### Web Server ###
+### Configure and Start PHP-FPM
+Ensure date.timezone is set in php.ini to your preferred time zone.  See http://php.net/manual/en/timezones.php for a list of supported timezones.  Valid examples are: "America/New_York", "Australia/Brisbane", "Etc/UTC".
 
-#### Install / Configure Nginx
+    vim /etc/php/7.0/fpm/php.ini
+    vim /etc/php/7.0/cli/php.ini
 
-`apt-get install php7.0-cli php7.0-mysql php7.0-gd php7.0-snmp php7.0-curl php7.0-fpm php7.0-xml snmp graphviz php7.0-mcrypt php7.0-json nginx-full fping imagemagick whois mtr-tiny nmap python-mysqldb snmpd rrdtool git`
+    phpenmod mcrypt
+    systemctl restart php7.0-fpm
 
-In `/etc/php/7.0/fpm/php.ini` and `/etc/php/7.0/cli/php.ini`, ensure date.timezone is set to your preferred time zone.  See http://php.net/manual/en/timezones.php for a list of supported timezones.  Valid examples are: "America/New_York", "Australia/Brisbane", "Etc/UTC".
+#### Configure NGINX
 
-```bash
-systemctl restart php7.0-fpm
-phpenmod mcrypt
-```
+    vim /etc/nginx/conf.d/librenms.conf
 
-#### Add librenms user
-
-```bash
-useradd librenms -d /opt/librenms -M -r
-usermod -a -G librenms www-data
-```
-
-#### Clone repo
-
-```bash
-cd /opt
-git clone https://github.com/librenms/librenms.git librenms
-```
-
-#### Web interface
-
-```bash
-cd /opt/librenms
-mkdir rrd logs
-chmod 775 rrd
-vim /etc/nginx/conf.d/librenms.conf
-```
-
-Add the following config:
+Add the following config, edit `server_name` as required:
 
 ```nginx
 server {
@@ -76,8 +67,7 @@ server {
  server_name librenms.example.com;
  root        /opt/librenms/html;
  index       index.php;
- access_log  /opt/librenms/logs/access_log;
- error_log   /opt/librenms/logs/error_log;
+
  charset utf-8;
  gzip on;
  gzip_types text/css application/javascript text/javascript application/x-javascript image/svg+xml text/plain text/xsd text/xsl text/xml image/x-icon;
@@ -98,52 +88,48 @@ server {
 }
 ```
 
-```bash
-rm /etc/nginx/sites-enabled/default
-systemctl restart nginx
-```
-
-#### Web installer
-
-Now head to: `http://librenms.example.com/install.php` and follow the on-screen instructions.
+    rm /etc/nginx/sites-enabled/default
+    systemctl restart nginx
 
 #### Configure snmpd
 
-```bash
-cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
-vim /etc/snmp/snmpd.conf
-```
+    cp /opt/librenms/snmpd.conf.example /etc/snmp/snmpd.conf
+    vim /etc/snmp/snmpd.conf
 
 Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community string.
 
-```bash
-curl -o /usr/bin/distro https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/distro
-chmod +x /usr/bin/distro
-systemctl restart snmpd
-```
+    curl -o /usr/bin/distro https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/distro
+    chmod +x /usr/bin/distro
+    systemctl restart snmpd
 
-#### Cron job
+### Cron job
 
-`cp librenms.nonroot.cron /etc/cron.d/librenms`
+    cp /opt/librenms/librenms.nonroot.cron /etc/cron.d/librenms
 
 #### Copy logrotate config
 
 LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
 
-    cp misc/librenms.logrotate /etc/logrotate.d/librenms
+    cp /opt/librenms/misc/librenms.logrotate /etc/logrotate.d/librenms
 
-#### Final steps
+### Set permissions
 
-```bash
-chown -R librenms:librenms /opt/librenms
-```
+    chown -R librenms:librenms /opt/librenms
+    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs
+    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs
+
+## Web installer ##
+
+Now head to the web installer and follow the on-screen instructions.
+
+    http://librenms.example.com/install.php
+
+### Final steps
 
 Run validate.php as root in the librenms directory:
 
-```bash
-cd /opt/librenms
-./validate.php
-```
+    cd /opt/librenms
+    ./validate.php
 
 That's it!  You now should be able to log in to http://librenms.example.com/.  Please note that we have not covered HTTPS setup in this example, so your LibreNMS install is not secure by default.  Please do not expose it to the public Internet unless you have configured HTTPS and taken appropriate web server hardening steps.
 
@@ -151,7 +137,7 @@ That's it!  You now should be able to log in to http://librenms.example.com/.  P
 
 We now suggest that you add localhost as your first device from within the WebUI.
 
-#### What next?
+### What next?
 
 Now that you've installed LibreNMS, we'd suggest that you have a read of a few other docs to get you going:
 
@@ -160,6 +146,8 @@ Now that you've installed LibreNMS, we'd suggest that you have a read of a few o
  - [Device Groups](http://docs.librenms.org/Extensions/Device-Groups/)
  - [Auto discovery](http://docs.librenms.org/Extensions/Auto-Discovery/)
 
-#### Closing
+### Closing
 
 We hope you enjoy using LibreNMS. If you do, it would be great if you would consider opting into the stats system we have, please see [this page](http://docs.librenms.org/General/Callback-Stats-and-Privacy/) on what it is and how to enable it.
+
+If you would like to help make LibreNMS better there are [many ways to help](http://docs.librenms.org/Support/FAQ/#what-can-i-do-to-help). You can also [support our Collective](https://t.libren.ms/donations). 


### PR DESCRIPTION
Try to group things that go together
prevent repeat actions such as running yum/apt
The only reason to return to command line after install.php is to check validate.php.
(The future is to move most validation to the web ui)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Extracted from: #6920
