### PR TITLE
fix: snmpwalk_group tables not using entries.

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -552,6 +552,11 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = array())
         $parts = $parts[1];
         array_splice($parts, $depth, 0, array_shift($parts)); // move the oid name to the correct depth
 
+        // some tables don't use entries so they end with .0
+        if (end($parts) == '.0') {
+            array_pop($parts);
+        }
+
         $line = strtok("\n"); // get the next line and concatenate multi-line values
         while ($line !== false && !str_contains($line, '=')) {
             $value .= $line . PHP_EOL;
@@ -561,7 +566,7 @@ function snmpwalk_group($device, $oid, $mib = '', $depth = 1, $array = array())
         // merge the parts into an array, creating keys if they don't exist
         $tmp = &$array;
         foreach ($parts as $part) {
-            $tmp = &$tmp[trim($part, '"')];
+            $tmp = &$tmp[trim($part, '".')];
         }
         $tmp = trim($value, "\" \n\r"); // assign the value as the leaf
     }


### PR DESCRIPTION
When walking an arbitrary oid, it may not be grouped properly if the address ends with .0

For example: channelInternalTxAborted[11].0

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
