### PR TITLE
fix: improve accuracy of is_valid_hostname()

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -628,6 +628,7 @@ function is_valid_hostname($hostname)
     // such as the underscore character (_), other DNS names may contain the underscore
     // maximum length is 253 characters, maximum segment size is 63
 
+    return (
         preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*\.?$/i", $hostname) //valid chars check
         && preg_match("/^.{1,253}$/", $hostname) //overall length check
         && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*\.?$/", $hostname)

--- a/includes/common.php
+++ b/includes/common.php
@@ -626,8 +626,12 @@ function is_valid_hostname($hostname)
     // labels to start with digits. No other symbols, punctuation characters, or
     // white space are permitted. While a hostname may not contain other characters,
     // such as the underscore character (_), other DNS names may contain the underscore
+    // maximum length is 253 characters, maximum segment size is 63
 
-    return ctype_alnum(str_replace(array('_', '-', '.'), '', $hostname));
+        preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*\.?$/i", $hostname) //valid chars check
+        && preg_match("/^.{1,253}$/", $hostname) //overall length check
+        && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*\.?$/", $hostname)
+    );
 }
 
 /*

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -25,10 +25,6 @@
 
 namespace LibreNMS\Tests;
 
-use LibreNMS\Util\IP;
-use LibreNMS\Util\IPv4;
-use LibreNMS\Util\IPv6;
-
 class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
 {
     public function testStrContains()
@@ -121,5 +117,29 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('DashName', str_to_class('dash-name'));
         $this->assertSame('UnderscoreName', str_to_class('underscore_name'));
         $this->assertSame('LibreNMS\\AllOfThemName', str_to_class('all OF-thEm_NaMe', 'LibreNMS\\'));
+    }
+
+    public function testIsValidHostname()
+    {
+        $this->assertTrue(is_valid_hostname('a'), 'a');
+        $this->assertTrue(is_valid_hostname('a.'), 'a.');
+        $this->assertTrue(is_valid_hostname('0'), '0');
+        $this->assertTrue(is_valid_hostname('a.b'), 'a.b');
+        $this->assertTrue(is_valid_hostname('localhost'), 'localhost');
+        $this->assertTrue(is_valid_hostname('google.com'), 'google.com');
+        $this->assertTrue(is_valid_hostname('news.google.co.uk'), 'news.google.co.uk');
+        $this->assertTrue(is_valid_hostname('xn--fsqu00a.xn--0zwm56d'), 'xn--fsqu00a.xn--0zwm56d');
+        $this->assertFalse(is_valid_hostname('goo gle.com'), 'goo gle.com');
+        $this->assertFalse(is_valid_hostname('google..com'), 'google..com');
+        $this->assertFalse(is_valid_hostname('google.com '), 'google.com ');
+        $this->assertFalse(is_valid_hostname('google-.com'), 'google-.com');
+        $this->assertFalse(is_valid_hostname('.google.com'), '.google.com');
+        $this->assertFalse(is_valid_hostname('<script'), '<script');
+        $this->assertFalse(is_valid_hostname('alert('), 'alert(');
+        $this->assertFalse(is_valid_hostname('.'), '.');
+        $this->assertFalse(is_valid_hostname('..'), '..');
+        $this->assertFalse(is_valid_hostname(' '), 'Just a space');
+        $this->assertFalse(is_valid_hostname('-'), '-');
+        $this->assertFalse(is_valid_hostname(''), 'Empty string');
     }
 }


### PR DESCRIPTION
fixes discovery code attempting to add invalid dns names
the old code allowed some invalid hostnames, this is more thorough
add tests

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
