### PR TITLE
fix: issues with recent discovery refactor

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -235,7 +235,8 @@ foreach (dbFetchRows($sql, array($device['device_id'])) as $test) {
 }
 
 // remove orphaned links
-$deleted = dbQuery('DELETE `l` FROM `links` `l` LEFT JOIN `devices` `d` ON `d`.`device_id` = `l`.`local_device_id` WHERE `d`.`device_id` IS NULL');
+$del_result = dbQuery('DELETE `l` FROM `links` `l` LEFT JOIN `devices` `d` ON `d`.`device_id` = `l`.`local_device_id` WHERE `d`.`device_id` IS NULL');
+$deleted = mysqli_affected_rows($del_result);
 echo str_repeat('-', $deleted);
 d_echo(" $deleted orphaned links deleted\n");
 
@@ -244,5 +245,7 @@ unset(
     $sql,
     $fdp_array,
     $cdp_array,
-    $lldp_array
+    $lldp_array,
+    $del_result,
+    $deleted
 );


### PR DESCRIPTION
fix find_port_id() deleting all variables when device_id was given
improve find_port_id() to find ports where only a number is given
fix orphan deletion count
fix insert and update of links with strings where int are required

This should fix map issues, because previously it would never have remote_port_id.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

fixes: #7439