### PR TITLE
fix: lldp discovery change local port resolution

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -81,7 +81,7 @@ if (Config::get('autodiscovery.xdp') === true) {
     echo PHP_EOL;
 }//end if
 
-if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
+if (($device['os'] == 'pbn' || $device['os'] == 'bdcom') && Config::get('autodiscovery.xdp') === true) {
     echo ' NMS-LLDP-MIB: ';
     $lldp_array  = snmpwalk_group($device, 'lldpRemoteSystemsData', 'NMS-LLDP-MIB');
 

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -117,12 +117,19 @@ if (($device['os'] == 'pbn' || $device['os'] == 'bdcom') && Config::get('autodis
     echo ' LLDP-MIB: ';
     $lldp_array  = snmpwalk_group($device, 'lldpRemTable', 'LLDP-MIB', 3);
     if (!empty($lldp_array)) {
+        $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
         $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
-            $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $entry_key, $device['device_id']);
+            if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
+                $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
+            } else {
+                $ifIndex = $entry_key;
+            }
+
+            $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);
             $interface = get_port_by_id($local_port_id);
 
             d_echo($lldp_instance);

--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -117,17 +117,14 @@ if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
     echo ' LLDP-MIB: ';
     $lldp_array  = snmpwalk_group($device, 'lldpRemTable', 'LLDP-MIB', 3);
     if (!empty($lldp_array)) {
-        $dot1d_array = snmpwalk_group($device, 'dot1dBasePortIfIndex', 'BRIDGE-MIB');
+        $lldp_ports = snmpwalk_group($device, 'lldpLocPortId', 'LLDP-MIB');
     }
 
     foreach ($lldp_array as $key => $lldp_if_array) {
         foreach ($lldp_if_array as $entry_key => $lldp_instance) {
-            if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
-                $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
-            } else {
-                $ifIndex = $entry_key;
-            }
-            $interface = get_port_by_ifIndex($device['device_id'], $ifIndex);
+            $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $entry_key, $device['device_id']);
+            $interface = get_port_by_id($local_port_id);
+
             d_echo($lldp_instance);
 
             foreach ($lldp_instance as $entry_instance => $lldp) {
@@ -157,6 +154,11 @@ if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
                     }
                 }
 
+                $remote_device = device_by_id_cache($remote_device_id);
+                if ($remote_device['os'] == 'calix') {
+                    $lldp['lldpRemPortId'] = 'EthPort ' . $lldp['lldpRemPortId'];
+                }
+
                 $remote_port_id = find_port_id(
                     $lldp['lldpRemPortDesc'],
                     $lldp['lldpRemPortId'],
@@ -165,7 +167,6 @@ if ($device['os'] == 'pbn' && Config::get('autodiscovery.xdp') === true) {
                 );
 
                 if (empty($lldp['lldpRemSysName'])) {
-                    $remote_device = device_by_id_cache($remote_device_id);
                     $lldp['lldpRemSysName'] = $remote_device['sysName'] ?: $remote_device['hostname'];
                 }
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1435,7 +1435,7 @@ function find_port_id($description, $identifier = '', $device_id = 0, $mac_addre
 
     if ($identifier) {
         if (is_numeric($identifier)) {
-            $sql .= ' OR `ifAlias`=? OR `ifIndex`=?';
+            $sql .= ' OR `ifIndex`=? OR `ifAlias`=?';
         } else {
             $sql .= ' OR `ifDescr`=? OR `ifName`=?';
         }


### PR DESCRIPTION
dot1dBasePortIfIndex seems to skip some ports in certain configurations on Cisco devices, use lldpLocPortId instead.
Add quirk for Calix devices that return different port labels than they actually are.
This needs to be tested.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

fixes: #7370