### PR TITLE
fix: Fixed clickatell alert transport

### DIFF
--- a/includes/alerts/transport.clickatell.php
+++ b/includes/alerts/transport.clickatell.php
@@ -22,9 +22,7 @@
  */
 
 $url  = 'https://platform.clickatell.com/messages/http/send?apiKey='.$opts['token'].'&to='.implode(',',$opts['to']).'&content='.urlencode($obj['title']);
-if (!empty($opts['from'])) {
-   $url .= '&from='.$opts['from'];
-}
+
 $curl = curl_init($url);
 set_curl_proxy($curl);
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");

--- a/includes/alerts/transport.clickatell.php
+++ b/includes/alerts/transport.clickatell.php
@@ -21,14 +21,13 @@
  * @subpackage Alerts
  */
 
-$data = array("api_id" => $opts['api_id'], "user" => $opts['user'], "password" => $opts['password'], "to" => implode(',',$opts['to']), "text" => $obj['title']);
+$url  = 'https://platform.clickatell.com/messages/http/send?apiKey='.$opts['token'].'&to='.implode(',',$opts['to']).'&content='.urlencode($obj['title']);
 if (!empty($opts['from'])) {
-    $data['from'] = $opts['from'];
+   $url .= '&from='.$opts['from'];
 }
-$url  = 'https://api.clickatell.com/http/sendmsg?'.http_build_query($data);
 $curl = curl_init($url);
 set_curl_proxy($curl);
-curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "POST");
+curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
 $ret  = curl_exec($curl);

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -414,7 +414,6 @@ devices:
     notes: { Field: notes, Type: text, 'Null': true, Default: 'NULL', Extra: '' }
     os: { Field: os, Type: varchar(32), 'Null': true, Default: 'NULL', Extra: '' }
     override_sysLocation: { Field: override_sysLocation, Type: tinyint(1), 'Null': true, Default: '0', Extra: '' }
-    parent_id: { Field: parent_id, Type: 'int(11) unsigned', 'Null': true, Default: 'NULL', Extra: '' }
     poller_group: { Field: poller_group, Type: int(11), 'Null': false, Default: '0', Extra: '' }
     port: { Field: port, Type: 'smallint(5) unsigned', 'Null': false, Default: '161', Extra: '' }
     port_association_mode: { Field: port_association_mode, Type: int(11), 'Null': false, Default: '1', Extra: '' }
@@ -422,7 +421,6 @@ devices:
     retries: { Field: retries, Type: int(11), 'Null': true, Default: 'NULL', Extra: '' }
     serial: { Field: serial, Type: text, 'Null': true, Default: 'NULL', Extra: '' }
     snmpver: { Field: snmpver, Type: varchar(4), 'Null': false, Default: v2c, Extra: '' }
-    snmp_disable: { Field: snmp_disable, Type: tinyint(1), 'Null': false, Default: '0', Extra: '' }
     status: { Field: status, Type: tinyint(4), 'Null': false, Default: '0', Extra: '' }
     status_reason: { Field: status_reason, Type: varchar(50), 'Null': false, Default: 'NULL', Extra: '' }
     sysContact: { Field: sysContact, Type: text, 'Null': true, Default: 'NULL', Extra: '' }
@@ -442,7 +440,6 @@ devices:
     os: { Name: os, Columns: [os], Unique: false, Type: BTREE }
     last_polled: { Name: last_polled, Columns: [last_polled], Unique: false, Type: BTREE }
     last_poll_attempted: { Name: last_poll_attempted, Columns: [last_poll_attempted], Unique: false, Type: BTREE }
-    parent_id_idx: { Name: parent_id_idx, Columns: [parent_id], Unique: false, Type: BTREE }
 devices_attribs:
   Columns:
     attrib_id: { Field: attrib_id, Type: int(11), 'Null': false, Default: 'NULL', Extra: auto_increment }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -351,12 +351,12 @@ config:
     config_descr: { Field: config_descr, Type: varchar(100), 'Null': false, Default: 'NULL', Extra: '' }
     config_disabled: { Field: config_disabled, Type: 'enum(''0'',''1'')', 'Null': false, Default: '0', Extra: '' }
     config_group: { Field: config_group, Type: varchar(50), 'Null': false, Default: 'NULL', Extra: '' }
-    config_group_order: { Field: config_group_order, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
+    config_group_order: { Field: config_group_order, Type: int(11), 'Null': false, Default: '0', Extra: '' }
     config_hidden: { Field: config_hidden, Type: 'enum(''0'',''1'')', 'Null': false, Default: '0', Extra: '' }
     config_id: { Field: config_id, Type: int(11), 'Null': false, Default: 'NULL', Extra: auto_increment }
     config_name: { Field: config_name, Type: varchar(255), 'Null': false, Default: 'NULL', Extra: '' }
     config_sub_group: { Field: config_sub_group, Type: varchar(50), 'Null': false, Default: 'NULL', Extra: '' }
-    config_sub_group_order: { Field: config_sub_group_order, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
+    config_sub_group_order: { Field: config_sub_group_order, Type: int(11), 'Null': false, Default: '0', Extra: '' }
     config_value: { Field: config_value, Type: varchar(512), 'Null': false, Default: 'NULL', Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [config_id], Unique: true, Type: BTREE }
@@ -414,6 +414,7 @@ devices:
     notes: { Field: notes, Type: text, 'Null': true, Default: 'NULL', Extra: '' }
     os: { Field: os, Type: varchar(32), 'Null': true, Default: 'NULL', Extra: '' }
     override_sysLocation: { Field: override_sysLocation, Type: tinyint(1), 'Null': true, Default: '0', Extra: '' }
+    parent_id: { Field: parent_id, Type: 'int(11) unsigned', 'Null': true, Default: 'NULL', Extra: '' }
     poller_group: { Field: poller_group, Type: int(11), 'Null': false, Default: '0', Extra: '' }
     port: { Field: port, Type: 'smallint(5) unsigned', 'Null': false, Default: '161', Extra: '' }
     port_association_mode: { Field: port_association_mode, Type: int(11), 'Null': false, Default: '1', Extra: '' }
@@ -421,6 +422,7 @@ devices:
     retries: { Field: retries, Type: int(11), 'Null': true, Default: 'NULL', Extra: '' }
     serial: { Field: serial, Type: text, 'Null': true, Default: 'NULL', Extra: '' }
     snmpver: { Field: snmpver, Type: varchar(4), 'Null': false, Default: v2c, Extra: '' }
+    snmp_disable: { Field: snmp_disable, Type: tinyint(1), 'Null': false, Default: '0', Extra: '' }
     status: { Field: status, Type: tinyint(4), 'Null': false, Default: '0', Extra: '' }
     status_reason: { Field: status_reason, Type: varchar(50), 'Null': false, Default: 'NULL', Extra: '' }
     sysContact: { Field: sysContact, Type: text, 'Null': true, Default: 'NULL', Extra: '' }
@@ -440,6 +442,7 @@ devices:
     os: { Name: os, Columns: [os], Unique: false, Type: BTREE }
     last_polled: { Name: last_polled, Columns: [last_polled], Unique: false, Type: BTREE }
     last_poll_attempted: { Name: last_poll_attempted, Columns: [last_poll_attempted], Unique: false, Type: BTREE }
+    parent_id_idx: { Name: parent_id_idx, Columns: [parent_id], Unique: false, Type: BTREE }
 devices_attribs:
   Columns:
     attrib_id: { Field: attrib_id, Type: int(11), 'Null': false, Default: 'NULL', Extra: auto_increment }
@@ -999,10 +1002,12 @@ perf_times:
     devices: { Field: devices, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
     doing: { Field: doing, Type: varchar(64), 'Null': false, Default: 'NULL', Extra: '' }
     duration: { Field: duration, Type: 'double(8,2)', 'Null': false, Default: 'NULL', Extra: '' }
+    id: { Field: id, Type: int(11), 'Null': false, Default: 'NULL', Extra: auto_increment }
     poller: { Field: poller, Type: varchar(255), 'Null': false, Default: 'NULL', Extra: '' }
     start: { Field: start, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
     type: { Field: type, Type: varchar(8), 'Null': false, Default: 'NULL', Extra: '' }
   Indexes:
+    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     type: { Name: type, Columns: [type], Unique: false, Type: BTREE }
 plugins:
   Columns:

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -999,12 +999,10 @@ perf_times:
     devices: { Field: devices, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
     doing: { Field: doing, Type: varchar(64), 'Null': false, Default: 'NULL', Extra: '' }
     duration: { Field: duration, Type: 'double(8,2)', 'Null': false, Default: 'NULL', Extra: '' }
-    id: { Field: id, Type: int(11), 'Null': false, Default: 'NULL', Extra: auto_increment }
     poller: { Field: poller, Type: varchar(255), 'Null': false, Default: 'NULL', Extra: '' }
     start: { Field: start, Type: int(11), 'Null': false, Default: 'NULL', Extra: '' }
     type: { Field: type, Type: varchar(8), 'Null': false, Default: 'NULL', Extra: '' }
   Indexes:
-    PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     type: { Name: type, Columns: [type], Unique: false, Type: BTREE }
 plugins:
   Columns:

--- a/sql-schema/211.sql
+++ b/sql-schema/211.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `config` CHANGE `config_group_order` `config_group_order` INT(11) NOT NULL DEFAULT 0;
+ALTER TABLE `config` CHANGE `config_sub_group_order` `config_sub_group_order` INT(11) NOT NULL DEFAULT 0;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #7374 

Not sure how this was supposed to work before, variables that we hadn't documented or were available in the webui were expected. Update based on code from that issue + reference from https://www.clickatell.com/developers/api-documentation/http-api-send-message/