### PR TITLE
fix: snmp_get_multi returns no data if the oid doesn't contain a period

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -202,8 +202,16 @@ function snmp_get_multi($device, $oids, $options = '-OQUs', $mib = null, $mibdir
         $oid               = trim($oid);
         $value             = trim($value, "\" \n\r");
         list($oid, $index) = explode('.', $oid, 2);
-        if (!strstr($value, 'at this OID') && isset($oid) && isset($index)) {
-            $array[$index][$oid] = $value;
+
+        if (!str_contains($value, 'at this OID')) {
+            if (is_null($index)) {
+                if (empty($oid)) {
+                    continue; // no index or oid
+                }
+                $array[$oid] = $value;
+            } else {
+                $array[$index][$oid] = $value;
+            }
         }
     }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
