### PR TITLE
added poller modules to ceraos.yaml

### DIFF
--- a/includes/definitions/ceraos.yaml
+++ b/includes/definitions/ceraos.yaml
@@ -10,22 +10,71 @@ discovery:
     - sysObjectId:
         - .1.3.6.1.4.1.2281
 poller_modules:
-    applications: 1
+    applications: 0
+    aruba-controller: 0
+    bgp-peers: 0
+    cisco-ipsec-flow-monitor: 0
+    cisco-remote-access-monitor: 0
+    cisco-cef: 0
+    cisco-sla: 0
+    cisco-mac-accounting: 0
+    cipsec-tunnels: 0
+    cisco-ace-loadbalancer : 0
+    cisco-ace-serverfarms: 0
+    cisco-asa-firewall: 0
+    cisco-voice: 0
+    cisco-cbqos: 0
+    cisco-otv: 0
+    cisco-vpdn: 0
+    entity-physical: 0
     hr-mib: 0
     ipSystemStats: 0
     ipmi: 0
+    junose-atm-vp: 0
+    loadbalancers: 0
+    mef: 0
     mempools: 0
-    netstats: 1
+    netscaler-vsvr: 0
+    netstats: 0
     ntp: 0
-    os: 1
     ospf: 0
-    ports: 1
     processors: 0
-    sensors: 1
     services: 0
     storage: 0
-    stp: 0
+    tnms-nbi: 0
+    toner: 0
     ucd-diskio: 0
     ucd-mib: 0
-    wifi: 1
     wireless: 0
+discovery_modules:
+    ports-stack: 0
+    entity-physical: 0
+    processors: 0
+    mempools: 0
+    cisco-vrf-lite: 0
+    cisco-mac-accounting: 0
+    cisco-pw: 0
+    cisco-vrf: 0
+    cisco-cef: 0
+    cisco-sla: 0
+    cisco-cbqos: 0
+    cisco-otv: 0
+    ipv4-addresses: 0
+    ipv6-addresses: 0
+    storage: 0
+    hr-device: 0
+    discovery-protocols: 0
+    arp-table: 0
+    junose-atm-vp: 0
+    bgp-peers: 0
+    vmware-vminfo: 0
+    libvirt-vminfo: 0
+    toner: 0
+    ucd-diskio: 0
+    applications: 0
+    services: 0
+    ntp: 0
+    loadbalancers: 0
+    mef: 0
+    wireless: 0
+    charge: 0

--- a/includes/definitions/ceraos.yaml
+++ b/includes/definitions/ceraos.yaml
@@ -11,38 +11,18 @@ discovery:
         - .1.3.6.1.4.1.2281
 poller_modules:
     applications: 0
-    aruba-controller: 0
     bgp-peers: 0
-    cisco-ipsec-flow-monitor: 0
-    cisco-remote-access-monitor: 0
-    cisco-cef: 0
-    cisco-sla: 0
-    cisco-mac-accounting: 0
-    cipsec-tunnels: 0
-    cisco-ace-loadbalancer : 0
-    cisco-ace-serverfarms: 0
-    cisco-asa-firewall: 0
-    cisco-voice: 0
-    cisco-cbqos: 0
-    cisco-otv: 0
-    cisco-vpdn: 0
     entity-physical: 0
     hr-mib: 0
     ipSystemStats: 0
     ipmi: 0
-    junose-atm-vp: 0
-    loadbalancers: 0
-    mef: 0
     mempools: 0
-    netscaler-vsvr: 0
     netstats: 0
     ntp: 0
     ospf: 0
     processors: 0
     services: 0
     storage: 0
-    tnms-nbi: 0
-    toner: 0
     ucd-diskio: 0
     ucd-mib: 0
     wireless: 0
@@ -52,29 +32,15 @@ discovery_modules:
     processors: 0
     mempools: 0
     cisco-vrf-lite: 0
-    cisco-mac-accounting: 0
-    cisco-pw: 0
-    cisco-vrf: 0
-    cisco-cef: 0
-    cisco-sla: 0
-    cisco-cbqos: 0
-    cisco-otv: 0
     ipv4-addresses: 0
     ipv6-addresses: 0
     storage: 0
     hr-device: 0
     discovery-protocols: 0
     arp-table: 0
-    junose-atm-vp: 0
     bgp-peers: 0
-    vmware-vminfo: 0
-    libvirt-vminfo: 0
-    toner: 0
     ucd-diskio: 0
-    applications: 0
     services: 0
     ntp: 0
-    loadbalancers: 0
-    mef: 0
     wireless: 0
     charge: 0

--- a/includes/definitions/ceraos.yaml
+++ b/includes/definitions/ceraos.yaml
@@ -10,4 +10,22 @@ discovery:
     - sysObjectId:
         - .1.3.6.1.4.1.2281
 poller_modules:
+    applications: 1
+    hr-mib: 0
+    ipSystemStats: 0
+    ipmi: 0
+    mempools: 0
+    netstats: 1
+    ntp: 0
+    os: 1
+    ospf: 0
+    ports: 1
+    processors: 0
+    sensors: 1
+    services: 0
+    storage: 0
+    stp: 0
+    ucd-diskio: 0
+    ucd-mib: 0
     wifi: 1
+    wireless: 0


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


Disabled most poller modules in ceraos.yaml definition file.
None of the disabled modules apply to Ceragon radios and on some firmwares the repeated extra SNMP queries can cause the SNMP daemon to hang requiring a power cycle to restore functionality.
The polling time reduces from >150 seconds in many cases and >300 in some to ~40 seconds.

