### PR TITLE
Allow Options in .htaccess to be merged

### DIFF
--- a/html/.htaccess
+++ b/html/.htaccess
@@ -1,7 +1,7 @@
 #  DO NOT CHANGE THIS FILE
 #  If you need to change this file, you are doing something wrong.
 
-Options FollowSymlinks Multiviews
+Options +FollowSymlinks +Multiviews
 
 AddType image/svg+xml .svg
 <IfModule mod_filter.c>


### PR DESCRIPTION
When the webserver is running php under fcgid, the current `.htaccess` removes `+ExecCGI` from the `Options` directive. This PR allows some options to be set in the server configuration without needing to change the default `.htaccess`.

[Apache docs](http://httpd.apache.org/docs/2.4/mod/core.html#Options):

> Normally, if multiple Options could apply to a directory, then the most specific one is used and others are ignored; the options are not merged. (See how sections are merged.) However if all the options on the Options directive are preceded by a + or - symbol, the options are merged. Any options preceded by a + are added to the options currently in force, and any options preceded by a - are removed from the options currently in force. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
