### PR TITLE
Allow sysname to be used as the hostname in oxidized API call

### DIFF
--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -95,6 +95,12 @@ To match on a device os of edgeos then please use the following:
 $config['oxidized']['group']['os'][] = array('match' => 'edgeos', 'group' => 'wireless');
 ```
 
+If you do not have good hostnames in Librenms (i.e. you added devices by IP), you can add the following to your config.php to use the sysname instead.
+
+```php
+$config['oxidized']['sysname_as_hostname'] = true;
+```
+
 Verify the return of groups by querying the API:
 
 ```

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1231,10 +1231,11 @@ function list_oxidized()
     $app = \Slim\Slim::getInstance();
     $app->response->headers->set('Content-Type', 'application/json');
 
+    $hostname = $config['oxidized']['sysname_as_hostname'] ? 'sysname' : 'hostname';
     $devices = array();
     $device_types = "'".implode("','", $config['oxidized']['ignore_types'])."'";
     $device_os    = "'".implode("','", $config['oxidized']['ignore_os'])."'";
-    foreach (dbFetchRows("SELECT hostname,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
+    foreach (dbFetchRows("SELECT $hostname AS `hostname`,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
         if ($config['oxidized']['group_support'] == "true") {
             foreach ($config['oxidized']['group']['hostname'] as $host_group) {
                 if (preg_match($host_group['regex'].'i', $device['hostname'])) {


### PR DESCRIPTION
We are monitoring our network with Librenms and are evaluating oxidized as a possible config management tool. We do not currently have DNS names for our network devices but we have good sysnames in their SNMP configurations. It would be great if we could use those sysnames instead of the hostnames (IPs) when defining regular expressions to use with the librenms oxidized group mapping settings.

This pull request adds a config option `$config['oxidized']['sysname_as_hostname']` that lets the Oxidized API endpoint return the sysname as the hostname for devices when set to `true`.


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

