### PR TITLE
Allow user to display ok/warning/critical alerts only

### DIFF
--- a/html/includes/common/alerts.inc.php
+++ b/html/includes/common/alerts.inc.php
@@ -17,7 +17,10 @@ $alert_severities = array(
     // alert_rules.status is enum('ok','warning','critical')
     'ok' => 1,
     'warning' => 2,
-    'critical' => 3
+    'critical' => 3,
+    'ok only' => 4,
+    'warning only' => 5,
+    'critical only' => 6
 );
 
 //if( defined('SHOW_SETTINGS') || empty($widget_settings) ) {
@@ -47,14 +50,14 @@ if (defined('SHOW_SETTINGS')) {
   </div>
   <div class="form-group row">
     <div class="col-sm-4">
-      <label for="min_severity" class="control-label">Minimum displayed severity:</label>
+      <label for="min_severity" class="control-label">Displayed severity:</label>
     </div>
     <div class="col-sm-8">
       <select class="form-control" name="min_severity">
         <option value="">any severity</option>';
 
     foreach ($alert_severities as $name => $val) {
-        $common_output[] = "<option value=\"$val\"".($current_severity == $name || $current_severity == $val ? ' selected' : '').">$name or higher</option>";
+        $common_output[] = "<option value=\"$val\"".($current_severity == $name || $current_severity == $val ? ' selected' : '').">$name".($val > 3 ? "" : " or higher")."</option>";
     }
 
     $common_output[] = '
@@ -154,7 +157,7 @@ if (defined('SHOW_SETTINGS')) {
         $sev_name = $min_severity;
         if (is_numeric($min_severity)) {
             $sev_name = array_search($min_severity, $alert_severities);
-            $title = "$title >=$sev_name";
+            $title = "$title ".($min_severity > 3 ? "" :">")."=$sev_name";
         }
     }
 

--- a/html/includes/common/alerts.inc.php
+++ b/html/includes/common/alerts.inc.php
@@ -10,7 +10,7 @@ $alert_states = array(
     'alerted' => 1,
     'acknowledged' => 2,
     'worse' => 3,
-    'better' => 4
+    'better' => 4,
 );
 
 $alert_severities = array(
@@ -20,7 +20,7 @@ $alert_severities = array(
     'critical' => 3,
     'ok only' => 4,
     'warning only' => 5,
-    'critical only' => 6
+    'critical only' => 6,
 );
 
 //if( defined('SHOW_SETTINGS') || empty($widget_settings) ) {

--- a/html/includes/table/alerts.inc.php
+++ b/html/includes/table/alerts.inc.php
@@ -17,7 +17,10 @@ $alert_severities = array(
     // alert_rules.status is enum('ok','warning','critical')
     'ok' => 1,
     'warning' => 2,
-    'critical' => 3
+    'critical' => 3,
+    'ok only' => 4,
+    'warning only' => 5,
+    'critical only' => 6
 );
 
 $show_recovered = false;
@@ -45,7 +48,7 @@ if (isset($_POST['min_severity'])) {
         $min_severity_id = $alert_severities[$_POST['min_severity']];
     }
     if (isset($min_severity_id)) {
-        $where .= " AND `alert_rules`.`severity` >= ".$min_severity_id;
+        $where .= " AND `alert_rules`.`severity` ".($min_severity_id > 3 ? "" :">")."= ".($min_severity_id > 3 ? $min_severity_id - 3 : $min_severity_id);
     }
 }
 

--- a/html/includes/table/alerts.inc.php
+++ b/html/includes/table/alerts.inc.php
@@ -10,7 +10,7 @@ $alert_states = array(
     'alerted' => 1,
     'acknowledged' => 2,
     'worse' => 3,
-    'better' => 4
+    'better' => 4,
 );
 
 $alert_severities = array(
@@ -20,7 +20,7 @@ $alert_severities = array(
     'critical' => 3,
     'ok only' => 4,
     'warning only' => 5,
-    'critical only' => 6
+    'critical only' => 6,
 );
 
 $show_recovered = false;


### PR DESCRIPTION
Adds options to the alert widget to allow users to display alerts by specific severity in addition to displaying alerts above a severity threshold.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
