### PR TITLE
Add sysname as filtering group for oxidized

### DIFF
--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -81,11 +81,12 @@ $config['oxidized']['reload_nodes'] = true;
 
 ### Working with groups
 
-To return a group to Oxidized you can do this by matching a regex for either `hostname`, `os` or `location`. The order is `hostname` is matched first, if nothing is found then `os` is tried and then `location` is attempted.
-The first match found will be used. To match on the device hostnames that contain 'lon-sw' or if the location contains 'London' then you would place the following within config.php:
+To return a group to Oxidized you can do this by matching a regex for either `hostname`, `sysname`, `os` or `location`. The order is `hostname` is matched first, if nothing is found then `sysname` is tried, then `os`, and finally `location` is attempted.
+The first match found will be used. To match on the device hostnames or sysnames that contain 'lon-sw' or if the location contains 'London' then you would place the following within config.php:
 
 ```php
 $config['oxidized']['group']['hostname'][] = array('regex' => '/^lon-sw/', 'group' => 'london-switches');
+$config['oxidized']['group']['sysname'][] = array('regex' => '/^lon-sw/', 'group' => 'london-switches');
 $config['oxidized']['group']['location'][] = array('regex' => '/london/', 'group' => 'london-switches');
 ```
 

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1234,12 +1234,20 @@ function list_oxidized()
     $devices = array();
     $device_types = "'".implode("','", $config['oxidized']['ignore_types'])."'";
     $device_os    = "'".implode("','", $config['oxidized']['ignore_os'])."'";
-    foreach (dbFetchRows("SELECT hostname,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
+    foreach (dbFetchRows("SELECT hostname,sysname,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os))") as $device) {
         if ($config['oxidized']['group_support'] == "true") {
             foreach ($config['oxidized']['group']['hostname'] as $host_group) {
                 if (preg_match($host_group['regex'].'i', $device['hostname'])) {
                     $device['group'] = $host_group['group'];
                     break;
+                }
+            }
+            if (empty($device['group'])) {
+                foreach ($config['oxidized']['group']['sysname'] as $host_group) {
+                    if (preg_match($host_group['regex'].'i', $device['sysname'])) {
+                        $device['group'] = $host_group['group'];
+                        break;
+                    }
                 }
             }
             if (empty($device['group'])) {
@@ -1263,6 +1271,7 @@ function list_oxidized()
             }
         }
         unset($device['location']);
+        unset($device['sysname']);
         $devices[] = $device;
     }
 


### PR DESCRIPTION
For networks without DNS names for their devices, it may be useful to have the ability to create oxidized groups based on the SNMP sysname as that is usually more descriptive than the IP address.

This pull request adds the ability to match groups on the sysname and still returns the standard three hostname, os and group attributes to oxidized.


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
