### PR TITLE
fix: cdp matching incorrect ports

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1424,6 +1424,10 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
  */
 function find_port_id($description, $identifier = '', $device_id = 0, $mac_address = null)
 {
+    if (!($device_id || $mac_address)) {
+        return 0;
+    }
+
     $sql = 'SELECT `port_id` FROM `ports` WHERE (0';
     $params = array();
 


### PR DESCRIPTION
Need either remote device_id or mac_address to find a port, otherwise, we might match an incorrect port.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
