### PR TITLE
fix: escape sql credentials during install

### DIFF
--- a/html/includes/output/db-update.inc.php
+++ b/html/includes/output/db-update.inc.php
@@ -44,7 +44,7 @@ $cmd = $config['install_dir'] . '/build-base.php -l';
 
 foreach ($db_vars as $var => $opt) {
     if ($_SESSION[$var]) {
-        $cmd .= " -$opt {$_SESSION[$var]}";
+        $cmd .= " -$opt " . escapeshellarg($_SESSION[$var]);
     }
 }
 


### PR DESCRIPTION
Fixes https://community.librenms.org/t/problem-with-starting-install/2363 also, probably a security vulnerability.



DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
