### PR TITLE
fix: readd PA GP Active Session graph

### DIFF
--- a/includes/polling/os/panos.inc.php
+++ b/includes/polling/os/panos.inc.php
@@ -2,7 +2,7 @@
 
 use LibreNMS\RRD\RrdDefinition;
 
-$oids = snmp_get_multi($device, 'panChassisType.0 panSysSwVersion.0 panSysSerialNumber.0 panSessionActive.0 panSessionActiveTcp.0 panSessionActiveUdp.0 panSessionActiveICMP.0 panSessionActiveSslProxy.0 panSessionSslProxyUtilization.0', '-OQUs', 'PAN-COMMON-MIB');
+$oids = snmp_get_multi($device, 'panChassisType.0 panSysSwVersion.0 panSysSerialNumber.0 panSessionActive.0 panSessionActiveTcp.0 panSessionActiveUdp.0 panSessionActiveICMP.0 panSessionActiveSslProxy.0 panSessionSslProxyUtilization.0 panGPGWUtilizationActiveTunnels.0', '-OQUs', 'PAN-COMMON-MIB');
 
 $hardware = $oids[0]['panChassisType'];
 $version  = $oids[0]['panSysSwVersion'];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

-------------------

- Missed the Global Protect Active Session graph when refactoring to snmp_get_multi