### PR TITLE
Support a wider range of link speeds in network maps

### DIFF
--- a/html/includes/print-map.inc.php
+++ b/html/includes/print-map.inc.php
@@ -158,18 +158,10 @@ foreach ($list as $items) {
     }
 
     $speed = $items['local_ifspeed']/1000/1000;
-    if ($speed == 100) {
-        $width = 3;
-    } elseif ($speed == 1000) {
-        $width = 5;
-    } elseif ($speed == 10000) {
-        $width = 10;
-    } elseif ($speed == 40000) {
-        $width = 15;
-    } elseif ($speed == 100000) {
+    if ($speed > 500000) {
         $width = 20;
     } else {
-        $width = 1;
+        $width = round(0.77 * pow($speed, 0.25));
     }
     $link_in_used = ($items['local_ifinoctets_rate'] * 8) / $items['local_ifspeed'] * 100;
     $link_out_used = ($items['local_ifoutoctets_rate'] * 8) / $items['local_ifspeed'] * 100;


### PR DESCRIPTION
Add support for links at 25Gbps, 56Gbps, and those faster than 100Gbps.
Will likely need adjusted down as links higher than 100Gbps become common, as 20 width looks a bit silly.

If people would prefer, I could swap those matched to be <= matches, to catch odd link speeds.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
