### PR TITLE
Improve Freeswitch agent: add ability to get data via snmp and graph more data

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -208,6 +208,7 @@ LibreNMS contributors:
 - Mike Williams <mike@mgww.net> (network-guy)
 - Rob J. Epping <librenms@renf.us> (robje)
 - Frank Petrilli <frank@petril.li> (frankpetrilli)
+- Joel Kociolek <joel@kociolek.org> (lejoko)
 
 Observium was written by:
 - Adam Armstrong

--- a/html/includes/graphs/application/freeswitch_calls.inc.php
+++ b/html/includes/graphs/application/freeswitch_calls.inc.php
@@ -1,0 +1,14 @@
+<?php
+
+require 'includes/graphs/common.inc.php';
+
+$scale_min       = 0;
+$ds              = 'calls';
+$colour_area     = '9DDA52';
+$colour_line     = '2EAC6D';
+$colour_area_max = 'FFEE99';
+$graph_max       = 10000;
+$unit_text       = 'Calls';
+$rrd_filename = rrd_name($device['hostname'], array('app', 'freeswitch', 'stats', $app['app_id']));
+
+require 'includes/graphs/generic_simplex.inc.php';

--- a/html/includes/graphs/application/freeswitch_channels.inc.php
+++ b/html/includes/graphs/application/freeswitch_channels.inc.php
@@ -1,0 +1,14 @@
+<?php
+
+require 'includes/graphs/common.inc.php';
+
+$scale_min       = 0;
+$ds              = 'channels';
+$colour_area     = '9DDA52';
+$colour_line     = '2EAC6D';
+$colour_area_max = 'FFEE99';
+$graph_max       = 10000;
+$unit_text       = 'Channels';
+$rrd_filename = rrd_name($device['hostname'], array('app', 'freeswitch', 'stats', $app['app_id']));
+
+require 'includes/graphs/generic_simplex.inc.php';

--- a/html/pages/apps.inc.php
+++ b/html/pages/apps.inc.php
@@ -129,6 +129,8 @@ $graphs['fail2ban'] = array(
 
 $graphs['freeswitch'] = array(
     'peak',
+    'calls',
+    'channels',
     'callsIn',
     'callsOut',
 );

--- a/html/pages/device/apps/freeswitch.inc.php
+++ b/html/pages/device/apps/freeswitch.inc.php
@@ -4,6 +4,8 @@ global $config;
 
 $graphs = array(
         'freeswitch_peak' => 'Freeswitch - Peak Calls',
+        'freeswitch_calls' => 'Freeswitch - Calls',
+        'freeswitch_channels' => 'Freeswitch - Channels',
         'freeswitch_callsIn' => 'Freeswitch - Inbound Calls',
         'freeswitch_callsOut' => 'Freeswitch - Outbound Calls'
     );

--- a/includes/polling/applications/freeswitch.inc.php
+++ b/includes/polling/applications/freeswitch.inc.php
@@ -13,8 +13,6 @@ if (!empty($agent_data[$name])) {
     $rawdata = snmp_walk($device, $oid, $options);
     $rawdata  = str_replace("<<<freeswitch>>>\n", '', $rawdata);
     update_application($app, $rawdata);
-    //echo "Freeswitch Missing";
-    //return;
 }
 # Format Data
 $lines = explode("\n", $rawdata);

--- a/includes/polling/applications/freeswitch.inc.php
+++ b/includes/polling/applications/freeswitch.inc.php
@@ -8,8 +8,13 @@ if (!empty($agent_data[$name])) {
     $rawdata = $agent_data[$name];
     update_application($app, $rawdata);
 } else {
-    echo "Freeswitch Missing";
-    return;
+    $options = '-O qv';
+    $oid = '.1.3.6.1.4.1.8072.1.3.2.4.1.2.10.102.114.101.101.115.119.105.116.99.104';
+    $rawdata = snmp_walk($device, $oid, $options);
+    $rawdata  = str_replace("<<<freeswitch>>>\n", '', $rawdata);
+    update_application($app, $rawdata);
+    //echo "Freeswitch Missing";
+    //return;
 }
 # Format Data
 $lines = explode("\n", $rawdata);


### PR DESCRIPTION
This request:
- adds the possibility to use the freeswitch script from librenms-agent as an snmp extension
- adds graphs for freeswitch data that was already sent by the librenms-agent script and kept by librenms but was not graphed

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
