### PR TITLE
docs: Weathermap fix for configs dir

### DIFF
--- a/doc/Extensions/Weathermap.md
+++ b/doc/Extensions/Weathermap.md
@@ -28,6 +28,6 @@ I'd recommend you use the output folder as this is excluded from git updates (i.
 
 Optional: If your install is in another directory than standard, set `$basehref` within `map-poller.php`.
 
-Automatically generate weathermaps from a LibreNMS database [Link](https://github.com/pblasquez/weathermapper)
+Automatically generate weathermaps from a LibreNMS database using WeatherMapper [Link](https://github.com/pblasquez/weathermapper)
 
 ![Example Network Weather Map](/img/network-weather-map.PNG)

--- a/doc/Extensions/Weathermap.md
+++ b/doc/Extensions/Weathermap.md
@@ -8,12 +8,12 @@ Intergarting LibreNMS with Network-Weathermap, allows you to build network maps 
 
 ### Step 1. 
 Extract to your LibreNMS plugins directory `html/plugins` so you should see something like `/opt/librenms/html/plugins/Weathermap/`
-The best way to do this is via git. Go to your install directory and then `html/plugins`.
+The best way to do this is via git. Go to your install directory and then `html/plugins`
 Enter:
     `git clone https://github.com/librenms-plugins/Weathermap.git`
 ### Step 2.
 Inside the librenms/html/plugins directory, change the ownership of the Weathermap directory by typing `chown -R librenms:librenms Weathermap/`
-Make the configs directory writeable `chmod 775 librenms/html/plugins/Weathermap/configs`.
+Make the configs directory writeable `chmod 775 librenms/html/plugins/Weathermap/configs`
 ### Step 3. 
 Enable the cron process by editing your current LibreNMS cron file (typically /etc/cron.d/librenms) and add the following:
 LibreNMS:  `*/5 * * * * librenms /opt/librenms/html/plugins/Weathermap/map-poller.php >> /dev/null 2>&1`

--- a/doc/Extensions/Weathermap.md
+++ b/doc/Extensions/Weathermap.md
@@ -13,8 +13,7 @@ Enter:
     `git clone https://github.com/librenms-plugins/Weathermap.git`
 ### Step 2.
 Inside the librenms/html/plugins directory, change the ownership of the Weathermap directory by typing `chown -R librenms:librenms Weathermap/`
-Make the configs directory writeable by your web server, either `chown apache:apache configs/` or `chmod 777 configs`.
-I'd highly advise you choose the first option, replace `apache:apache` with your web servers user and group this will depend on what OS you are using and Web Server.
+Make the configs directory writeable `chmod 775 librenms/html/plugins/Weathermap/configs`.
 ### Step 3. 
 Enable the cron process by editing your current LibreNMS cron file (typically /etc/cron.d/librenms) and add the following:
 LibreNMS:  `*/5 * * * * librenms /opt/librenms/html/plugins/Weathermap/map-poller.php >> /dev/null 2>&1`

--- a/doc/Extensions/Weathermap.md
+++ b/doc/Extensions/Weathermap.md
@@ -1,7 +1,7 @@
 source: Extensions/Weathermap.md
 
 # Network-WeatherMap with LibreNMS
-Intergarting LibreNMS with Network-Weathermap, allows you to build network maps to visulaize network traffic flow rates.
+Integrating LibreNMS with Network-Weathermap, allows you to build network maps to help visulaize network traffic flow rates.
 [Link](https://network-weathermap.com/) to Network-Wearthermap Offical Website
 
 ### Installing Network-WeatherMap

--- a/doc/Extensions/Weathermap.md
+++ b/doc/Extensions/Weathermap.md
@@ -7,13 +7,13 @@ Integrating LibreNMS with Network-Weathermap, allows you to build network maps t
 ### Installing Network-WeatherMap
 
 ### Step 1. 
-Extract to your LibreNMS plugins directory `html/plugins` so you should see something like `/opt/librenms/html/plugins/Weathermap/`
-The best way to do this is via git. Go to your install directory and then `html/plugins`
+Extract to your LibreNMS plugins directory `/opt/librenms/html/plugins` so you should see something like `/opt/librenms/html/plugins/Weathermap/`
+The best way to do this is via git. Go to your install directory and then `/opt/librenms/html/plugins`
 Enter:
     `git clone https://github.com/librenms-plugins/Weathermap.git`
 ### Step 2.
-Inside the librenms/html/plugins directory, change the ownership of the Weathermap directory by typing `chown -R librenms:librenms Weathermap/`
-Make the configs directory writeable `chmod 775 librenms/html/plugins/Weathermap/configs`
+Inside the html/plugins directory, change the ownership of the Weathermap directory by typing `chown -R librenms:librenms Weathermap/`
+Make the configs directory writeable `chmod 775 /opt/librenms/html/plugins/Weathermap/configs`
 ### Step 3. 
 Enable the cron process by editing your current LibreNMS cron file (typically /etc/cron.d/librenms) and add the following:
 LibreNMS:  `*/5 * * * * librenms /opt/librenms/html/plugins/Weathermap/map-poller.php >> /dev/null 2>&1`


### PR DESCRIPTION
Instead of setting the ownership of the Weathermap/configs directory to apache or www-data, leave it as librenms and chmod 775 librenms/html/plugins/Weathermap/configs
The apache user should already have librenms as a secondary group, so just granting group r/w permissions fixes access for Weathermap and prevents validate.php from complaining. @robje 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
