### PR TITLE
fix: lldp find_port_id does not the correct port

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1437,36 +1437,48 @@ function find_port_id($description, $identifier = '', $device_id = 0, $mac_addre
         return 0;
     }
 
-    $sql = 'SELECT `port_id` FROM `ports` WHERE (0';
+    $statements = array();
     $params = array();
 
-    if ($description) {
-        $sql .= ' OR `ifDescr`=? OR `ifName`=?';
-        $params[] = $description;
-        $params[] = $description;
-    }
+    if ($device_id) {
+        if ($description) {
+            $statements[] = "SELECT `port_id` FROM `ports` WHERE `device_id`=? AND (`ifDescr`=? OR `ifName`=?)";
 
-    if ($identifier) {
-        if (is_numeric($identifier)) {
-            $sql .= ' OR `ifIndex`=? OR `ifAlias`=?';
-        } else {
-            $sql .= ' OR `ifDescr`=? OR `ifName`=?';
+            $params[] = $device_id;
+            $params[] = $description;
+            $params[] = $description;
         }
-        $params[] = $identifier;
-        $params[] = $identifier;
+
+        if ($identifier) {
+            if (is_numeric($identifier)) {
+                $statements[] = 'SELECT `port_id` FROM `ports` WHERE `device_id`=? AND (`ifIndex`=? OR `ifAlias`=?)';
+            } else {
+                $statements[] = 'SELECT `port_id` FROM `ports` WHERE `device_id`=? AND (`ifDescr`=? OR `ifName`=?)';
+            }
+            $params[] = $device_id;
+            $params[] = $identifier;
+            $params[] = $identifier;
+        }
     }
 
     if ($mac_address) {
-        $sql .= ' OR `ifPhysAddress`=?';
+        $mac_statement = 'SELECT `port_id` FROM `ports` WHERE ';
+        if ($device_id) {
+            $mac_statement .= '`device_id`=? AND ';
+            $params[] = $device_id;
+        }
+        $mac_statement .= '`ifPhysAddress`=?';
+
+        $statements[] = $mac_statement;
         $params[] = $mac_address;
     }
 
-    $sql .= ')';
-
-    if ($device_id) {
-        $sql .= ' AND `device_id`=?';
-        $params[] = $device_id;
+    if (empty($statements)) {
+        return 0;
     }
+
+    $queries = implode(' UNION ', $statements);
+    $sql = "SELECT * FROM ($queries LIMIT 1) p";
 
     return (int)dbFetchCell($sql, $params);
 }


### PR DESCRIPTION
Order statements to give some results precedence over others.
Union the results but limit 1 so we can stop when we get the first result.
Checking if variables doesn't work very well without the device_id

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
