### PR TITLE
fix: fix a couple of OS cache invalidation issues

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -216,3 +216,8 @@ if ($options['f'] === 'notify') {
 if ($options['f'] === 'peeringdb') {
     cache_peeringdb();
 }
+
+if ($options['f'] === 'refresh_os_cache') {
+    echo 'Refreshing OS cache' . PHP_EOL;
+    update_os_cache(true);
+}

--- a/daily.sh
+++ b/daily.sh
@@ -226,6 +226,7 @@ main () {
             cleanup)
                 # Cleanups
                 local options=("refresh_alert_rules"
+                               "refresh_os_cache"
                                "syslog"
                                "eventlog"
                                "authlog"

--- a/includes/common.php
+++ b/includes/common.php
@@ -1665,8 +1665,9 @@ function update_os_cache($force = false)
         d_echo('Updating os_def.cache... ');
 
         // remove previously cached os settings and replace with user settings
-        $user_config = json_decode(`$install_dir/config_to_json.php`, true);
-        Config::set('os', $user_config['os']);
+        $config = array('os' => array()); // local $config variable, not global
+        include "$install_dir/config.php";
+        Config::set('os', $config['os']);
 
         // load the os defs fresh from cache (merges with existing OS settings)
         load_all_os(false, false);

--- a/includes/common.php
+++ b/includes/common.php
@@ -1657,21 +1657,21 @@ function load_all_os($existing = false, $cached = true)
  */
 function update_os_cache($force = false)
 {
-    global $config;
-    $cache_file = $config['install_dir'] . '/cache/os_defs.cache';
-    $cache_keep_time = $config['os_def_cache_time'] - 7200; // 2hr buffer
+    $install_dir = Config::get('install_dir');
+    $cache_file = "$install_dir/cache/os_defs.cache";
+    $cache_keep_time = Config::get('os_def_cache_time', 86400) - 7200; // 2hr buffer
 
     if ($force === true || !is_file($cache_file) || time() - filemtime($cache_file) > $cache_keep_time) {
         d_echo('Updating os_def.cache... ');
 
-        // remove pre-loaded os and pull in user settings
-        $user_config = json_decode(`${config['install_dir']}/config_to_json.php`, true);
-        $config['os'] = $user_config['os'];
+        // remove previously cached os settings and replace with user settings
+        $user_config = json_decode(`$install_dir/config_to_json.php`, true);
+        Config::set('os', $user_config['os']);
 
-        // load the os defs fresh from cache (merges with existing $config['os'])
+        // load the os defs fresh from cache (merges with existing OS settings)
         load_all_os(false, false);
 
-        file_put_contents($cache_file, serialize($config['os']));
+        file_put_contents($cache_file, serialize(Config::get('os')));
         d_echo("Done\n");
     }
 }

--- a/includes/common.php
+++ b/includes/common.php
@@ -1663,7 +1663,14 @@ function update_os_cache($force = false)
 
     if ($force === true || !is_file($cache_file) || time() - filemtime($cache_file) > $cache_keep_time) {
         d_echo('Updating os_def.cache... ');
+
+        // remove pre-loaded os and pull in user settings
+        $user_config = json_decode(`${config['install_dir']}/config_to_json.php`, true);
+        $config['os'] = $user_config['os'];
+
+        // load the os defs fresh from cache (merges with existing $config['os'])
         load_all_os(false, false);
+
         file_put_contents($cache_file, serialize($config['os']));
         d_echo("Done\n");
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,7 +48,6 @@ ini_set('display_errors', 1);
 error_reporting(E_ALL & ~E_WARNING);
 
 update_os_cache(true); // Force update of OS Cache
-load_all_os();  // pre-load OS so we don't keep loading them
 
 if (getenv('DBTEST')) {
     global $schema, $sql_mode;


### PR DESCRIPTION
Fixes issues where we might be using outdated os definitions.

Core issue was we had already loaded the os definitions from the cache before we call load_all_os().
We need to remove the previous definitions, (but keep user settings).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
