### PR TITLE
Set ifIndex to null if there is no dot1dBasePortIfIndex

### DIFF
--- a/includes/discovery/discovery-protocols.inc.php
+++ b/includes/discovery/discovery-protocols.inc.php
@@ -126,7 +126,7 @@ if (($device['os'] == 'pbn' || $device['os'] == 'bdcom') && Config::get('autodis
             if (is_numeric($dot1d_array[$entry_key]['dot1dBasePortIfIndex'])) {
                 $ifIndex = $dot1d_array[$entry_key]['dot1dBasePortIfIndex'];
             } else {
-                $ifIndex = $entry_key;
+                $ifIndex = null;
             }
 
             $local_port_id = find_port_id($lldp_ports[$entry_key]['lldpLocPortId'], $ifIndex, $device['device_id']);


### PR DESCRIPTION
The ifIndex here is only being used to query for $local_port_id, and when there is no dot1dBasePortIfIndex, the default value is set to the index of the array. This is problematic because the index for interfaces in SNMP for devices do not start from 1. 

ifIndex = 1 is set for VLAN1,
ifIndex = 2 is set for VLAN2, and so forth.....


This results in librenms wrongly attaching the local_port_id to VLan1. 

Setting this to null should not be a problem. The reason for this is that $local_port_id should be totally resolvable from lldpLocPortId.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
