### PR TITLE
Update RFC1123 Hostname Check

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -629,7 +629,7 @@ function is_valid_hostname($hostname)
     // maximum length is 253 characters, maximum segment size is 63
 
     return (
-        preg_match("/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/", $hostname) //valid chars check
+        preg_match("/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?$/", $hostname) //valid chars check
         && preg_match("/^.{1,253}$/", $hostname) //overall length check
         && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*\.?$/", $hostname) //segment length check
     );

--- a/includes/common.php
+++ b/includes/common.php
@@ -629,9 +629,9 @@ function is_valid_hostname($hostname)
     // maximum length is 253 characters, maximum segment size is 63
 
     return (
-        preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*\.?$/i", $hostname) //valid chars check
+        preg_match("/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/", $hostname) //valid chars check
         && preg_match("/^.{1,253}$/", $hostname) //overall length check
-        && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*\.?$/", $hostname)
+        && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*\.?$/", $hostname) //segment length check
     );
 }
 

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -122,12 +122,15 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
     public function testIsValidHostname()
     {
         $this->assertTrue(is_valid_hostname('a'), 'a');
+        $this->assertTrue(is_valid_hostname('a.'), 'a.');
         $this->assertTrue(is_valid_hostname('0'), '0');
         $this->assertTrue(is_valid_hostname('a.b'), 'a.b');
         $this->assertTrue(is_valid_hostname('localhost'), 'localhost');
         $this->assertTrue(is_valid_hostname('google.com'), 'google.com');
         $this->assertTrue(is_valid_hostname('news.google.co.uk'), 'news.google.co.uk');
         $this->assertTrue(is_valid_hostname('xn--fsqu00a.xn--0zwm56d'), 'xn--fsqu00a.xn--0zwm56d');
+        $this->assertTrue(is_valid_hostname('www.averylargedomainthatdoesnotreallyexist.com'), 'www.averylargedomainthatdoesnotreallyexist.com');
+        $this->assertTrue(is_valid_hostname('cont-ains.h-yph-en-s.com'), 'cont-ains.h-yph-en-s.com');
         $this->assertTrue(is_valid_hostname('cisco-3750x'), 'cisco-3750x');
         $this->assertFalse(is_valid_hostname('cisco_3750x'), 'cisco_3750x');
         $this->assertFalse(is_valid_hostname('goo gle.com'), 'goo gle.com');
@@ -135,6 +138,7 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(is_valid_hostname('google.com '), 'google.com ');
         $this->assertFalse(is_valid_hostname('google-.com'), 'google-.com');
         $this->assertFalse(is_valid_hostname('.google.com'), '.google.com');
+        $this->assertFalse(is_valid_hostname('..google.com'), '..google.com');
         $this->assertFalse(is_valid_hostname('<script'), '<script');
         $this->assertFalse(is_valid_hostname('alert('), 'alert(');
         $this->assertFalse(is_valid_hostname('.'), '.');

--- a/tests/CommonFunctionsTest.php
+++ b/tests/CommonFunctionsTest.php
@@ -122,13 +122,14 @@ class CommonFunctionsTest extends \PHPUnit_Framework_TestCase
     public function testIsValidHostname()
     {
         $this->assertTrue(is_valid_hostname('a'), 'a');
-        $this->assertTrue(is_valid_hostname('a.'), 'a.');
         $this->assertTrue(is_valid_hostname('0'), '0');
         $this->assertTrue(is_valid_hostname('a.b'), 'a.b');
         $this->assertTrue(is_valid_hostname('localhost'), 'localhost');
         $this->assertTrue(is_valid_hostname('google.com'), 'google.com');
         $this->assertTrue(is_valid_hostname('news.google.co.uk'), 'news.google.co.uk');
         $this->assertTrue(is_valid_hostname('xn--fsqu00a.xn--0zwm56d'), 'xn--fsqu00a.xn--0zwm56d');
+        $this->assertTrue(is_valid_hostname('cisco-3750x'), 'cisco-3750x');
+        $this->assertFalse(is_valid_hostname('cisco_3750x'), 'cisco_3750x');
         $this->assertFalse(is_valid_hostname('goo gle.com'), 'goo gle.com');
         $this->assertFalse(is_valid_hostname('google..com'), 'google..com');
         $this->assertFalse(is_valid_hostname('google.com '), 'google.com ');


### PR DESCRIPTION
The regex was wrong. It failed to match devices like `cisco-3750x` even though it is a valid hostname. 
I picked this regex from the RFC1123 documentation, and updated it.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
