### PR TITLE
Fix Services container alignment

### DIFF
--- a/html/pages/device/overview/services.inc.php
+++ b/html/pages/device/overview/services.inc.php
@@ -21,22 +21,24 @@ if ($services['total']) {
     }
     ?>
     <div class="container-fluid">
-        <div class="row col-md-12">
-            <div class="panel panel-default panel-condensed">
-                <div class="panel-heading">
-                <i class="fa fa-cogs fa-lg icon-theme" aria-hidden="true"></i> <strong>Services</strong>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="panel panel-default panel-condensed">
+                    <div class="panel-heading">
+                    <i class="fa fa-cogs fa-lg icon-theme" aria-hidden="true"></i> <strong>Services</strong>
+                    </div>
+                    <table class="table table-hover table-condensed table-striped">
+                        <tr>
+                            <td title="Total"><i class="fa fa-cog" style="color:#0080FF" aria-hidden="true"></i> <?php echo $services['total']?></td>
+                            <td title="Status - Ok"><i class="fa fa-cog" style="color:green" aria-hidden="true"></i> <?php echo $services[0]?></td>
+                            <td title="Status - Warning"><i class="fa fa-cog" style="color:orange" aria-hidden="true"></i> <?php echo $services[1]?></td>
+                            <td title="Status - Critical"><i class="fa fa-cog" style="color:red" aria-hidden="true"></i> <?php echo $services[2]?></td>
+                        </tr>
+                        <tr>
+                            <td colspan='4'><?php echo $string?></td>
+                        </tr>
+                    </table>
                 </div>
-                <table class="table table-hover table-condensed table-striped">
-                    <tr>
-                        <td title="Total"><i class="fa fa-cog" style="color:#0080FF" aria-hidden="true"></i> <?php echo $services['total']?></td>
-                        <td title="Status - Ok"><i class="fa fa-cog" style="color:green" aria-hidden="true"></i> <?php echo $services[0]?></td>
-                        <td title="Status - Warning"><i class="fa fa-cog" style="color:orange" aria-hidden="true"></i> <?php echo $services[1]?></td>
-                        <td title="Status - Critical"><i class="fa fa-cog" style="color:red" aria-hidden="true"></i> <?php echo $services[2]?></td>
-                    </tr>
-                    <tr>
-                        <td colspan='4'><?php echo $string?></td>
-                    </tr>
-                </table>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This has been bugging me for a while... ;)
The services container wasn't properly aligned with the rest of the boxes (e.g. Events, Syslog etc.). This small HTML change fixes that.


- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
