### PR TITLE
Fail isPingable() if fping fails, take 2

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -612,15 +612,15 @@ function isPingable($hostname, $address_family = AF_INET, $attribs = array())
             $fping_params .= ' -p ' . $config['fping_options']['millisec'];
         }
         $status = fping($hostname, $fping_params, $address_family);
-        if ($status['exitcode'] > 0 || $status['db']['loss'] == 100) {
+        if ($status['exitcode'] > 0 || $status['loss'] == 100) {
             $response['result'] = false;
         } else {
             $response['result'] = true;
         }
-        if (is_numeric($status['db']['avg'])) {
-            $response['last_ping_timetaken'] = $status['db']['avg'];
+        if (is_numeric($status['avg'])) {
+            $response['last_ping_timetaken'] = $status['avg'];
         }
-        $response['db'] = $status['db'];
+        $response['db'] = array_intersect_key($status, array_flip(array('xmt','rcv','loss','min','max','avg')));
     } else {
         $response['result'] = true;
         $response['last_ping_timetaken'] = 0;
@@ -1398,7 +1398,7 @@ function fping($host, $params, $address_family = AF_INET)
     $min      = set_numeric($min);
     $max      = set_numeric($max);
     $avg      = set_numeric($avg);
-    $response = array('db' => array('xmt'=>$xmt,'rcv'=>$rcv,'loss'=>$loss,'min'=>$min,'max'=>$max,'avg'=>$avg), 'exitcode'=>$proc_status['exitcode']);
+    $response = array('xmt'=>$xmt,'rcv'=>$rcv,'loss'=>$loss,'min'=>$min,'max'=>$max,'avg'=>$avg,'exitcode'=>$proc_status['exitcode']);
     return $response;
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1370,6 +1370,7 @@ function fping($host, $params, $address_family = AF_INET)
     $process = proc_open($fping_path . ' -e -q ' .$params . ' ' .$host.' 2>&1', $descriptorspec, $pipes);
     $read = '';
 
+    $proc_status = 0;
     if (is_resource($process)) {
         fclose($pipes[0]);
 
@@ -1397,7 +1398,6 @@ function fping($host, $params, $address_family = AF_INET)
     $min      = set_numeric($min);
     $max      = set_numeric($max);
     $avg      = set_numeric($avg);
-    $response = array('xmt'=>$xmt,'rcv'=>$rcv,'loss'=>$loss,'min'=>$min,'max'=>$max,'avg'=>$avg);
     $response = array('db' => array('xmt'=>$xmt,'rcv'=>$rcv,'loss'=>$loss,'min'=>$min,'max'=>$max,'avg'=>$avg), 'exitcode'=>$proc_status['exitcode']);
     return $response;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -612,15 +612,15 @@ function isPingable($hostname, $address_family = AF_INET, $attribs = array())
             $fping_params .= ' -p ' . $config['fping_options']['millisec'];
         }
         $status = fping($hostname, $fping_params, $address_family);
-        if ($status['loss'] == 100) {
+        if ($status['exitcode'] > 0 || $status['db']['loss'] == 100) {
             $response['result'] = false;
         } else {
             $response['result'] = true;
         }
-        if (is_numeric($status['avg'])) {
-            $response['last_ping_timetaken'] = $status['avg'];
+        if (is_numeric($status['db']['avg'])) {
+            $response['last_ping_timetaken'] = $status['db']['avg'];
         }
-        $response['db'] = $status;
+        $response['db'] = $status['db'];
     } else {
         $response['result'] = true;
         $response['last_ping_timetaken'] = 0;
@@ -1377,6 +1377,7 @@ function fping($host, $params, $address_family = AF_INET)
             $read .= fgets($pipes[1], 1024);
         }
         fclose($pipes[1]);
+        $proc_status = proc_get_status($process);
         proc_close($process);
     }
 
@@ -1397,6 +1398,7 @@ function fping($host, $params, $address_family = AF_INET)
     $max      = set_numeric($max);
     $avg      = set_numeric($avg);
     $response = array('xmt'=>$xmt,'rcv'=>$rcv,'loss'=>$loss,'min'=>$min,'max'=>$max,'avg'=>$avg);
+    $response = array('db' => array('xmt'=>$xmt,'rcv'=>$rcv,'loss'=>$loss,'min'=>$min,'max'=>$max,'avg'=>$avg), 'exitcode'=>$proc_status['exitcode']);
     return $response;
 }
 


### PR DESCRIPTION
Another take on https://github.com/librenms/librenms/pull/7426.
If the command fping fails, the function isPingable() should fail too, for example for invalid hostnames.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
