### PR TITLE
fix: improve poller validation

### DIFF
--- a/LibreNMS/Validator.php
+++ b/LibreNMS/Validator.php
@@ -267,7 +267,7 @@ class Validator
      */
     public function getBaseURL()
     {
-        $url = Config::get('base_url', get_url());
-        return rtrim(str_replace('validate', '', $url), '/');
+        $url = function_exists('get_url') ? get_url() : Config::get('base_url');
+        return rtrim(str_replace('validate', '', $url), '/');  // get base_url from current url
     }
 }

--- a/sql-schema/214.sql
+++ b/sql-schema/214.sql
@@ -1,0 +1,1 @@
+DELETE FROM `pollers` WHERE `poller_name` LIKE '%\n';


### PR DESCRIPTION
remove failures when there are duplicate poller entries
add warning that there are duplicate poller entries
link to the poller log in the webui
small fix to getBaseURL() to avoid exception when run from cli.
extract poller validations to private methods for better readability

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
