### PR TITLE
Fix: availability-map showed ping devices as warning.

### DIFF
--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -209,7 +209,7 @@ if (defined('SHOW_SETTINGS')) {
                 $deviceLabel = "label-default";
                 $host_ignored_count++;
             } elseif ($device['status'] == '1') {
-                if (($device['uptime'] < $config['uptime_warning']) && ($device['uptime'] != '0')) {
+                if (($device['uptime'] < $config['uptime_warning']) && ($device['uptime'] != 0)) {
                     $deviceState = 'warn';
                     $deviceLabel = 'label-warning';
                     $deviceLabelOld = 'availability-map-oldview-box-warn';


### PR DESCRIPTION
The availability-map dashboard show devices with `NULL` in the uptime column as warning. There was a check for 0 uptime, but `NULL != '0'`. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
