### PR TITLE
Fix: discovery.php -h all stops working after ping only device

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -144,22 +144,23 @@ function discover_device(&$device, $options = null)
 
     echo "\n";
 
+    $discovery_modules = Config::get('discovery_modules', array());
     $force_module = false;
     if ($device['snmp_disable'] != '1') {
         // If we've specified modules, use them, else walk the modules array
         if ($options['m']) {
-            Config::set('discovery_modules', array());
+            $discovery_modules = array();
             foreach (explode(',', $options['m']) as $module) {
                 if (is_file("includes/discovery/$module.inc.php")) {
-                    Config::set("discovery_modules.$module", 1);
+                    $discovery_modules[$module] = 1;
                     $force_module = true;
                 }
             }
         }
     } else {
-        Config::set('discovery_modules', array());
+        $discovery_modules = array();
     }
-    foreach (Config::get('discovery_modules', array()) as $module => $module_status) {
+    foreach ($discovery_modules as $module => $module_status) {
         $os_module_status = Config::getOsSetting($device['os'], "discovery_modules.$module");
         d_echo("Modules status: Global" . (isset($module_status) ? ($module_status ? '+ ' : '- ') : '  '));
         d_echo("OS" . (isset($os_module_status) ? ($os_module_status ? '+ ' : '- ') : '  '));

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -110,6 +110,10 @@ function load_discovery(&$device)
 
 function discover_device(&$device, $options = null)
 {
+    if ($device['snmp_disable'] == '1') {
+        return;
+    }
+
     global $valid;
 
     $valid = array();
@@ -144,23 +148,18 @@ function discover_device(&$device, $options = null)
 
     echo "\n";
 
-    $discovery_modules = Config::get('discovery_modules', array());
     $force_module = false;
-    if ($device['snmp_disable'] != '1') {
-        // If we've specified modules, use them, else walk the modules array
-        if ($options['m']) {
-            $discovery_modules = array();
-            foreach (explode(',', $options['m']) as $module) {
-                if (is_file("includes/discovery/$module.inc.php")) {
-                    $discovery_modules[$module] = 1;
-                    $force_module = true;
-                }
+    // If we've specified modules, use them, else walk the modules array
+    if ($options['m']) {
+        Config::set('discovery_modules', array());
+        foreach (explode(',', $options['m']) as $module) {
+            if (is_file("includes/discovery/$module.inc.php")) {
+                Config::set("discovery_modules.$module", 1);
+                $force_module = true;
             }
         }
-    } else {
-        $discovery_modules = array();
     }
-    foreach ($discovery_modules as $module => $module_status) {
+    foreach (Config::get('discovery_modules', array()) as $module => $module_status) {
         $os_module_status = Config::getOsSetting($device['os'], "discovery_modules.$module");
         d_echo("Modules status: Global" . (isset($module_status) ? ($module_status ? '+ ' : '- ') : '  '));
         d_echo("OS" . (isset($os_module_status) ? ($os_module_status ? '+ ' : '- ') : '  '));


### PR DESCRIPTION
If a ping only device is discovered before any other device, the discovery_modules config variable was emptied for the rest of them.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
