### PR TITLE
Update Installation-Ubuntu-1604-Nginx.md

### DIFF
--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -3,7 +3,7 @@ source: Installation/Installation-Ubuntu-1604-Nginx.md
 
 ## Install Required Packages ##
 
-    apt install composer fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php7.0-cli php7.0-curl php7.0-fpm php7.0-gd php7.0-mcrypt php7.0-mysql php7.0-snmp php7.0-xml php7.0-zip python-memcache python-mysqldb rrdtool snmp snmpd whois
+    apt install composer fping git graphviz imagemagick mariadb-client mariadb-server mtr-tiny nginx-full nmap php7.0-cli php7.0-curl php7.0-fpm php7.0-gd php7.0-mcrypt php7.0-mysql php7.0-snmp php7.0-xml php7.0-zip python-memcache python-mysqldb rrdtool snmp snmpd whois php-net-ipv4 php-net-ipv6
 
 #### Add librenms user
 


### PR DESCRIPTION
Missed php-net-ipv4 and php-net-ipv6 in #7597 (Not sure how to edit a submitted PR).

These were needed on Vanilla Ubuntu 16.04, otherwise you would get these errors when running ./validate.php:

```
PHP Warning:  include_once(Net/IPv4.php): failed to open stream: No such file or directory in /opt/librenms/includes/init.php on line 37
PHP Warning:  include_once(): Failed opening 'Net/IPv4.php' for inclusion (include_path='.:/usr/share/php') in /opt/librenms/includes/init.php on line 37
PHP Warning:  include_once(Net/IPv6.php): failed to open stream: No such file or directory in /opt/librenms/includes/init.php on line 38
PHP Warning:  include_once(): Failed opening 'Net/IPv6.php' for inclusion (include_path='.:/usr/share/php') in /opt/librenms/includes/init.php on line 38
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
