### PR TITLE
Add runtime divisor to fxm

### DIFF
--- a/includes/definitions/discovery/fxm.yaml
+++ b/includes/definitions/discovery/fxm.yaml
@@ -75,6 +75,8 @@ modules:
                     index: 'upsBatteryTemperature.{{ $index }}'
                     descr: Battery
         runtime:
+            options:
+              divisor: 60
             data:
                 -
                     oid: upsMinutesOnBattery

--- a/includes/definitions/discovery/fxm.yaml
+++ b/includes/definitions/discovery/fxm.yaml
@@ -1,4 +1,4 @@
-mib: mibs/alpha/Argus-Power-System-MIB
+mib: Argus-Power-System-MIB
 modules:
     sensors:
         voltage:


### PR DESCRIPTION
Runtime was returning in seconds for the Alpha FXM so a 60 divisor was added to reduce to minutes

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
