### PR TITLE
device: Change Ironware mempools NetIron checking logic from sysObjectID to sysDescr

### DIFF
--- a/includes/discovery/mempools/ironware-dyn.inc.php
+++ b/includes/discovery/mempools/ironware-dyn.inc.php
@@ -1,9 +1,8 @@
 <?php
 
 if ($device['os'] == 'ironware' || $device['os_type'] == 'ironware') {
-    $is_netiron = $poll_device['sysDescr'];
 
-    if (strpos($is_netiron, 'NetIron') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'CER') === false) {
+    if (str_contains($device['sysDescr'], array('NetIron', 'MLX', 'CER')) === false) {
         echo 'Ironware Dynamic: ';
 
         $percent = snmp_get($device, 'snAgGblDynMemUtil.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');

--- a/includes/discovery/mempools/ironware-dyn.inc.php
+++ b/includes/discovery/mempools/ironware-dyn.inc.php
@@ -1,9 +1,9 @@
 <?php
 
 if ($device['os'] == 'ironware' || $device['os_type'] == 'ironware') {
-    $is_netiron = snmp_get($device, 'sysObjectID.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+    $is_netiron = $poll_device['sysDescr'];
 
-    if (strpos($is_netiron, 'NI') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'Cer') === false) {
+    if (strpos($is_netiron, 'NetIron') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'CER') === false) {
         echo 'Ironware Dynamic: ';
 
         $percent = snmp_get($device, 'snAgGblDynMemUtil.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');

--- a/includes/discovery/mempools/ironware-dyn.inc.php
+++ b/includes/discovery/mempools/ironware-dyn.inc.php
@@ -1,7 +1,6 @@
 <?php
 
 if ($device['os'] == 'ironware' || $device['os_type'] == 'ironware') {
-
     if (str_contains($device['sysDescr'], array('NetIron', 'MLX', 'CER')) === false) {
         echo 'Ironware Dynamic: ';
 

--- a/includes/polling/mempools/ironware-dyn.inc.php
+++ b/includes/polling/mempools/ironware-dyn.inc.php
@@ -4,9 +4,9 @@ $oid = $mempool['mempool_index'];
 
 d_echo('Ironware Mempool'."\n");
 
-$is_netiron = snmp_get($device, 'sysObjectID.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
+$is_netiron = $poll_device['sysDescr'];
 
-if (strpos($is_netiron, 'NI') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'Cer') === false) {
+if (strpos($is_netiron, 'NetIron') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'CER') === false) {
     $mempool['total'] = snmp_get($device, 'snAgGblDynMemTotal.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
     $mempool['free']  = snmp_get($device, 'snAgGblDynMemFree.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
     $mempool['used']  = ($mempool['total'] - $mempool['free']);

--- a/includes/polling/mempools/ironware-dyn.inc.php
+++ b/includes/polling/mempools/ironware-dyn.inc.php
@@ -4,9 +4,7 @@ $oid = $mempool['mempool_index'];
 
 d_echo('Ironware Mempool'."\n");
 
-$is_netiron = $poll_device['sysDescr'];
-
-if (strpos($is_netiron, 'NetIron') === false && strpos($is_netiron, 'MLX') === false && strpos($is_netiron, 'CER') === false) {
+if (str_contains($device['sysDescr'], array('NetIron', 'MLX', 'CER'))) {
     $mempool['total'] = snmp_get($device, 'snAgGblDynMemTotal.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
     $mempool['free']  = snmp_get($device, 'snAgGblDynMemFree.0', '-OvQ', 'FOUNDRY-SN-AGENT-MIB');
     $mempool['used']  = ($mempool['total'] - $mempool['free']);


### PR DESCRIPTION
#### Context

The current mempool logic checks if a Brocade IronWare device is running NetIron code by doing a string match for "NI", "MLX", and "Cer" against sysObjectID. While this works for some devices, it doesn't for others.

Example:

Device 1
```shell
SNMPv2-MIB::sysDescr.0 = STRING: Brocade NetIron XMR (System Mode: XMR), IronWare Version V5.6.0fT163 Compiled on Mar 27 2015 at 01:56:34 labeled as V5.6.00fb
SNMPv2-MIB::sysObjectID.0 = OID: FOUNDRY-SN-ROOT-MIB::snNIXMR8000Router
```

Device 1
```shell
SNMPv2-MIB::sysDescr.0 = STRING: Brocade MLXe (System Mode: XMR), IronWare Version V5.6.0hT163 Compiled on Apr 27 2016 at 07:33:38 labeled as V5.6.00h
SNMPv2-MIB::sysObjectID.0 = OID: FOUNDRY-SN-ROOT-MIB::registration.55.2.2
```
This results in some chassis's using the "Dynamic Memory" option, which is not applicable to them and reports the memory at something crazy like -817381376.

 sysDescr seems to be a more consistent method, so I am proposing we change the logic to that.


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

