### PR TITLE
fix: github-apply sometimes fails on PRs with lots of commits

### DIFF
--- a/scripts/github-apply
+++ b/scripts/github-apply
@@ -5,5 +5,5 @@ cd $LIBRENMS_DIR
 
 case $1 in
     ''|*[!0-9]*) echo "You must specify a PR number to apply a patch" ;;
-    *) curl -s https://patch-diff.githubusercontent.com/raw/librenms/librenms/pull/${1}.patch | git apply -v ${2} ;;
+    *) curl -s https://patch-diff.githubusercontent.com/raw/librenms/librenms/pull/${1}.diff | git apply -v ${2} ;;
 esac


### PR DESCRIPTION
.patch is all commits individually, .diff is all commits merged

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
