### PR TITLE
Fix: Only add args.ping if it's set.

### DIFF
--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -122,7 +122,7 @@ def scan_host(ip):
 
         try:
             arguments = ['/usr/bin/env', 'php', 'addhost.php', hostname or ip]
-            if args.ping != '':
+            if args.ping:
                 arguments.insert(3, args.ping)
             add_output = check_output(arguments)
             return Result(ip, hostname, Outcome.ADDED, add_output)

--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -121,7 +121,10 @@ def scan_host(ip):
             pass
 
         try:
-            add_output = check_output(['/usr/bin/env', 'php', 'addhost.php', args.ping, hostname or ip])
+            arguments = ['/usr/bin/env', 'php', 'addhost.php', hostname or ip]
+            if args.ping != '':
+                arguments.insert(3, args.ping)
+            add_output = check_output(arguments)
             return Result(ip, hostname, Outcome.ADDED, add_output)
         except CalledProcessError as err:
             output = err.output.decode().rstrip()


### PR DESCRIPTION
snmp-scan.py froze when not using -P for ping only. `check_output()` apparently doesn't ignore empty arguments.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
