### PR TITLE
Webui: Don't disable the applications check boxes in settings if the …

### DIFF
--- a/html/pages/device/edit/apps.inc.php
+++ b/html/pages/device/edit/apps.inc.php
@@ -1,9 +1,11 @@
 <h3> Applications </h3>
 <?php
 
+use LibreNMS\Config;
+
 // Load our list of available applications
 $applications = array();
-foreach (glob($config['install_dir'] . '/includes/polling/applications/*.inc.php') as $file) {
+foreach (glob(Config::get('install_dir') . '/includes/polling/applications/*.inc.php') as $file) {
     $name = basename($file, '.inc.php');
     $applications[$name] = $name;
 }
@@ -25,7 +27,9 @@ foreach ($applications as $app) {
     // check if the app exists in the enable apps array and check if it was automatically enabled
     if (isset($enabled_apps[$app])) {
         $modifiers = ' checked';
-        if ($enabled_apps[$app]) {
+        if ($enabled_apps[$app]
+            && is_dev_attrib_enabled($device, "poll_applications", Config::getOsSetting($device['os'], "poller_modules.applications"))
+        ) {
             $app_text .= '<span class="text-success"> (Discovered)</span>';
             $modifiers .= ' disabled';
         }


### PR DESCRIPTION
…discovery module is disabled.

It disables the check boxes because it will automatically disabled/enabled based on data returned from the device.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
