### PR TITLE
Fix: Better sanity checks of fping options.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -661,16 +661,28 @@ function isPingable($hostname, $address_family = AF_INET, $attribs = array())
     $response = array();
     if (can_ping_device($attribs) === true) {
         $fping_params = '';
-        if (is_numeric($config['fping_options']['retries']) && $config['fping_options']['retries'] > 0 && $config['fping_options']['retries'] <= 20) {
+        if (is_numeric($config['fping_options']['retries']) && $config['fping_options']['retries'] > 0) {
+            if ($config['fping_options']['retries'] > 20) {
+                $config['fping_options']['retries'] = 20;
+            }
             $fping_params .= ' -r ' . $config['fping_options']['retries'];
         }
-        if (is_numeric($config['fping_options']['timeout']) && $config['fping_options']['timeout'] > 50) {
+        if (is_numeric($config['fping_options']['timeout'])) {
+            if ($config['fping_options']['timeout'] < 50) {
+                $config['fping_options']['timeout'] = 50;
+            }
+            if ($config['fping_options']['millisec'] < $config['fping_options']['timeout']) {
+                $config['fping_options']['millisec'] = $config['fping_options']['timeout'];
+            }
             $fping_params .= ' -t ' . $config['fping_options']['timeout'];
         }
         if (is_numeric($config['fping_options']['count']) && $config['fping_options']['count'] > 0) {
             $fping_params .= ' -c ' . $config['fping_options']['count'];
         }
-        if (is_numeric($config['fping_options']['millisec']) && $config['fping_options']['millisec'] > 20) {
+        if (is_numeric($config['fping_options']['millisec'])) {
+            if ($config['fping_options']['millisec'] < 20) {
+                $config['fping_options']['millisec'] = 20;
+            }
             $fping_params .= ' -p ' . $config['fping_options']['millisec'];
         }
         $status = fping($hostname, $fping_params, $address_family);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -661,16 +661,16 @@ function isPingable($hostname, $address_family = AF_INET, $attribs = array())
     $response = array();
     if (can_ping_device($attribs) === true) {
         $fping_params = '';
-        if (is_numeric($config['fping_options']['retries']) || $config['fping_options']['retries'] > 1) {
+        if (is_numeric($config['fping_options']['retries']) && $config['fping_options']['retries'] > 0 && $config['fping_options']['retries'] <= 20) {
             $fping_params .= ' -r ' . $config['fping_options']['retries'];
         }
-        if (is_numeric($config['fping_options']['timeout']) || $config['fping_options']['timeout'] > 1) {
+        if (is_numeric($config['fping_options']['timeout']) && $config['fping_options']['timeout'] > 50) {
             $fping_params .= ' -t ' . $config['fping_options']['timeout'];
         }
-        if (is_numeric($config['fping_options']['count']) || $config['fping_options']['count'] > 0) {
+        if (is_numeric($config['fping_options']['count']) && $config['fping_options']['count'] > 0) {
             $fping_params .= ' -c ' . $config['fping_options']['count'];
         }
-        if (is_numeric($config['fping_options']['millisec']) || $config['fping_options']['millisec'] > 0) {
+        if (is_numeric($config['fping_options']['millisec']) && $config['fping_options']['millisec'] > 20) {
             $fping_params .= ' -p ' . $config['fping_options']['millisec'];
         }
         $status = fping($hostname, $fping_params, $address_family);


### PR DESCRIPTION
If someone specifies too aggressive fping options, the fping command fails and all devices fail the ping check.

Should we mention this in the docs?

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
