### PR TITLE
fix: Do not add invalid Cisco senors seen in IOS 15.6(3)M1

### DIFF
--- a/includes/discovery/sensors/state/cisco.inc.php
+++ b/includes/discovery/sensors/state/cisco.inc.php
@@ -28,7 +28,6 @@ $tables = array(
 foreach ($tables as $tablevalue) {
     $temp = snmpwalk_cache_multi_oid($device, $tablevalue[0], array(), $tablevalue[4]);
     $cur_oid = $tablevalue[1];
-    $process_sensor = true;
 
     if (is_array($temp)) {
         if ($temp[0][$tablevalue[2]] == 'nonRedundant' || $temp[0]['cswMaxSwitchNum'] == '1') {
@@ -137,9 +136,8 @@ foreach ($tables as $tablevalue) {
 
         foreach ($temp as $index => $entry) {
             if ($tablevalue[2] == 'ciscoEnvMonTemperatureState' && (empty($temp[$index][$tablevalue[3]]))) {
-                $process_sensor = false;
-            }
-            if ($process_sensor == true) {
+                d_echo('Invalid sensor, skipping..');
+            } else {
                 //Discover Sensors
                 $descr = ucwords($temp[$index][$tablevalue[3]]);
                 if ($state_name == 'cRFStatusUnitState' || $state_name == 'cRFStatusPeerUnitState' || $state_name == 'cRFCfgRedundancyOperMode' || $state_name == 'cswRingRedundant') {

--- a/includes/discovery/sensors/state/cisco.inc.php
+++ b/includes/discovery/sensors/state/cisco.inc.php
@@ -136,7 +136,7 @@ foreach ($tables as $tablevalue) {
         }
 
         foreach ($temp as $index => $entry) {
-            if ($tablevalue[2] == 'ciscoEnvMonTemperatureState' && (is_null($temp[$index][$tablevalue[3]]) or empty($temp[$index][$tablevalue[3]]))) {
+            if ($tablevalue[2] == 'ciscoEnvMonTemperatureState' && (empty($temp[$index][$tablevalue[3]]))) {
                 $process_sensor = false;
             }
             if ($process_sensor == true) {

--- a/includes/discovery/sensors/temperature/cisco.inc.php
+++ b/includes/discovery/sensors/temperature/cisco.inc.php
@@ -2,7 +2,7 @@
 /*
  * LibreNMS
  *
- * Copyright (c) 2016 Søren Friis Rosiak <sorenrosiak@gmail.com> 
+ * Copyright (c) 2016 Søren Friis Rosiak <sorenrosiak@gmail.com>
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation, either version 3 of the License, or (at your
@@ -14,7 +14,7 @@ $temp = snmpwalk_cache_multi_oid($device, 'ciscoEnvMonTemperatureStatusTable', a
 if (is_array($temp)) {
     $cur_oid = '.1.3.6.1.4.1.9.9.13.1.3.1.3.';
     foreach ($temp as $index => $entry) {
-        if ($temp[$index]['ciscoEnvMonTemperatureState'] != 'notPresent') {
+        if ($temp[$index]['ciscoEnvMonTemperatureState'] != 'notPresent' && !empty($temp[$index]['ciscoEnvMonTemperatureStatusDescr'])) {
             $descr = ucwords($temp[$index]['ciscoEnvMonTemperatureStatusDescr']);
             discover_sensor($valid['sensor'], 'temperature', $device, $cur_oid.$index, $index, 'cisco', $descr, '1', '1', null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'], null, $temp[$index]['ciscoEnvMonTemperatureStatusValue'], 'snmp', $index);
         }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Cisco introduced invalid sensors into IOS 15.6(3)M1, this fix makes sure we do not add these sensors. 
