### PR TITLE
alert rules: added in dell server sensors alert rules to the collection

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -285,5 +285,5 @@
   {
     "%sensors.sensor_current ~ \"[2|5]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
     "name": "Dell Server Disk Array State Failed/Degraded"
-  },
+  }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -271,19 +271,19 @@
     "name": "Palo Alto Networks passive firewall changed to active"
   },
   {
-    "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.15.1.4.1\"",
+    "rule": "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.15.1.4.1\"",
     "name": "Dell Server Raid Battery Failed/Degraded"
   },
   {
-    "%sensors.sensor_current ~ \"2\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.1100.32.1.5\"",
+    "rule": "%sensors.sensor_current ~ \"2\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.1100.32.1.5\"",
     "name": "Dell Server CPU Status Critical"
   },
   {
-    "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.1.1.5\"",
+    "rule": "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.1.1.5\"",
     "name": "Dell Server Controller State Failed/Degraded"
   },
   {
-    "%sensors.sensor_current ~ \"[2|5]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
+    "rule": "%sensors.sensor_current ~ \"[2|5]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
     "name": "Dell Server Disk Array State Failed/Degraded"
   }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -269,5 +269,21 @@
   {
     "rule": "%devices.os = \"panos\" & %sensors.type = \"panSysHAState\" && %sensors.sensor_current = \"1\" && %sensors.sensor_prev = \"2\"",
     "name": "Palo Alto Networks passive firewall changed to active"
-  }
+  },
+  {
+    "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.15.1.4.1\"",
+    "name": "Dell Server Raid Battery Failed/Degraded"
+  },
+  {
+    "%sensors.sensor_current ~ \"2\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.1100.32.1.5\"",
+    "name": "Dell Server CPU Status Critical"
+  },
+  {
+    "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.1.1.5\"",
+    "name": "Dell Server Controller State Failed/Degraded"
+  },
+  {
+    "%sensors.sensor_current ~ \"[2|5]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
+    "name": "Dell Server Disk Array State Failed/Degraded"
+  },
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -275,15 +275,19 @@
     "name": "Dell Server Raid Battery Failed/Degraded"
   },
   {
-    "rule": "%sensors.sensor_current ~ \"2\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.1100.32.1.5\"",
+    "rule": "%sensors.sensor_current = \"2\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10892.1.1100.32.1.5\"",
     "name": "Dell Server CPU Status Critical"
   },
   {
     "rule": "%sensors.sensor_current ~ \"[2|6]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.1.1.5\"",
-    "name": "Dell Server Controller State Failed/Degraded"
+    "name": "Dell Server Disk Controller State Failed/Degraded"
   },
   {
     "rule": "%sensors.sensor_current ~ \"[2|5]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
     "name": "Dell Server Disk Array State Failed/Degraded"
+  },
+  {
+    "rule": "%ipv4_mac.mac_address = \"2c233a756912\"",
+    "name": "Find MAC Address (replace the MAC address whith the MAC you are searching for)"
   }
 ]

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -285,9 +285,8 @@
   {
     "rule": "%sensors.sensor_current ~ \"[2|5]\" && %sensors.sensor_oid = \".1.3.6.1.4.1.674.10893.1.20.130.4.1.4\"",
     "name": "Dell Server Disk Array State Failed/Degraded"
-  },
-  {
-    "rule": "%ipv4_mac.mac_address = \"2c233a756912\"",
-    "name": "Find MAC Address (replace the MAC address whith the MAC you are searching for)"
   }
-]
+  
+  ]
+  
+


### PR DESCRIPTION
Dell server sensors alert rules to the collection. Also added in MAC address alert. This could be useful when searching for missing devices or rogue devices on your network.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
