### PR TITLE
fix: Extra fping checks in validation

### DIFF
--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -54,7 +54,8 @@ class Programs implements ValidationGroup
         }
     }
 
-    public function extraFpingChecks(Validator $validator, $bin, $cmd) {
+    public function extraFpingChecks(Validator $validator, $bin, $cmd)
+    {
         $target = ($bin == 'fping' ? '127.0.0.1' : '::1');
         $validator->execAsUser("$cmd $target 2>&1", $output, $return);
         $output = implode(" ", $output);

--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -63,14 +63,14 @@ class Programs implements ValidationGroup
         if ($return !== 0 || $output != "$target is alive") {
             $validator->fail(
                 "$bin could not be executed. ($output)",
-                "$bin must have CAP_NET_RAW capability (getcap) or be suid and exclusions with selinux if applicable."
+                "$bin must have CAP_NET_RAW capability (getcap) or suid. Selinux exlusions may be required."
             );
 
             if ($validator->getUsername() == 'root' && ($getcap = $this->findExecutable('getcap'))) {
                 if (!str_contains(shell_exec("$getcap $cmd"), "$cmd = cap_net_raw+ep")) {
                     $validator->fail(
                         "$bin should have CAP_NET_RAW!",
-                        "getcap c $cmd"
+                        "setcap CAP_NET_RAW $cmd"
                     );
                 }
             } elseif (!(fileperms($cmd) & 2048)) {

--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -75,8 +75,8 @@ class Programs implements ValidationGroup
             } elseif (!(fileperms($cmd) & 2048)) {
                 $msg = "$bin should be suid!";
                 $fix = "chmod u+s $cmd";
-                if ($validator->getUsername() == 'root') {
-                    $msg .= ' (Note: suid may not be needed if CAP_NET_RAW is set, which requires root to check)';
+                if ($validator->getUsername() != 'root') {
+                    $msg .= ' (Note: suid may not be needed if CAP_NET_RAW is set, getcap requires root to check)';
                     $validator->warn($msg, $fix);
                 } else {
                     $validator->fail($msg, $fix);


### PR DESCRIPTION
Don't check suid or getcap if we can execute fping (as librenms or webserver user)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
