### PR TITLE
fix: Better validation on callback url for Pagerduty integration

### DIFF
--- a/html/pages/settings/alerting.inc.php
+++ b/html/pages/settings/alerting.inc.php
@@ -248,7 +248,7 @@ if (isset($vars['del_pagerduty']) && $vars['del_pagerduty'] == true && is_admin(
 
 $config_groups = get_config_by_group('alerting');
 
-if (isset($config['base_url'])) {
+if (isset($config['base_url']) && filter_var($config['base_url'].'/'.$_SERVER['REQUEST_URI'], FILTER_VALIDATE_URL)) {
     $callback = $config['base_url'].'/'.$_SERVER['REQUEST_URI'].'/';
 } else {
     $callback = get_url().'/';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

If the callback url wasn't a full url then the Pagerduty integration would 404 on the PD side.