### PR TITLE
refactor: Switch to using discovery-wrapper.py by default

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -6,7 +6,7 @@ source: Extensions/Auto-Discovery.md
 LibreNMS provides the ability to automatically add devices on your network, we can do this via
 a few methods which will be explained below and also indicate if they are enabled by default.
 
-All discovery methods run when discovery.php runs (every 6 hours by default and within 5 minutes for new devices).
+All discovery methods run when discovery runs (every 6 hours by default and within 5 minutes for new devices).
 
 > Please note that you need at least ONE device added before auto-discovery will work.
 

--- a/doc/Extensions/Distributed-Poller.md
+++ b/doc/Extensions/Distributed-Poller.md
@@ -137,11 +137,11 @@ $config['update']                            = 0;
 `/etc/cron.d/librenms`
 Runs discovery and polling for group 0, daily.sh to deal with notifications and DB cleanup and alerts.
 ```conf
-33  */6 * * * librenms /opt/librenms/discovery.php -h all >> /dev/null 2>&1
-*/5 *   * * * librenms /opt/librenms/discovery.php -h new >> /dev/null 2>&1
-*/5 *   * * * librenms /opt/librenms/poller-wrapper.py 24 >> /opt/librenms/logs/wrapper.log
-15  0   * * * librenms /opt/librenms/daily.sh >> /dev/null 2>&1
-*   *   * * * librenms /opt/librenms/alerts.php >> /dev/null 2>&1
+33   */6  * * *   librenms    /opt/librenms/cronic /opt/librenms/discovery-wrapper.py 1
+*/5  *    * * *   librenms    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
+*/5  *    * * *   librenms    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
+15   0    * * *   librenms    /opt/librenms/daily.sh >> /dev/null 2>&1
+*    *    * * *   librenms    /opt/librenms/alerts.php >> /dev/null 2>&1
 ```
 
 Poller 2:
@@ -161,7 +161,7 @@ $config['update']                            = 0;
 `/etc/cron.d/librenms`
 Runs billing as well as polling for group 0.
 ```conf
-*/5 * * * * librenms /opt/librenms/poller-wrapper.py 24 >> /opt/librenms/logs/wrapper.log
+*/5 * * * * librenms /opt/librenms/poller-wrapper.py 16 >> /opt/librenms/logs/wrapper.log
 */5 * * * * librenms /opt/librenms/poll-billing.php >> /dev/null 2>&1
 01  * * * * librenms /opt/librenms/billing-calculate.php >> /dev/null 2>&1
 ```
@@ -183,7 +183,7 @@ $config['update']                            = 0;
 `/etc/cron.d/librenms`
 Runs discovery and polling for groups 2 and 3.
 ```conf
-33  */6 * * * librenms /opt/librenms/discovery.php -h all >> /dev/null 2>&1
-*/5 *   * * * librenms /opt/librenms/discovery.php -h new >> /dev/null 2>&1
-*/5 *   * * * librenms /opt/librenms/poller-wrapper.py 16 >> /opt/librenms/logs/wrapper.log
+33   */6  * * *   librenms    /opt/librenms/cronic /opt/librenms/discovery-wrapper.py 1
+*/5  *    * * *   librenms    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
+*/5  *    * * *   librenms    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
 ```

--- a/doc/Support/Discovery Support.md
+++ b/doc/Support/Discovery Support.md
@@ -37,18 +37,15 @@ new will poll only those devices that have recently been added or have been sele
 
 #### Discovery wrapper
 
-We have a `discovery-wrapper.py` script which is based on `poller-wrapper.py` by [Job Snijders](https://github.com/job).
-You can enable support for this within cron by replacing:
+We have a `discovery-wrapper.py` script which is based on `poller-wrapper.py` by [Job Snijders](https://github.com/job). This script is currently the default.
 
-`33  */6   * * *   librenms    /opt/librenms/discovery.php -h all >> /dev/null 2>&1`
-
-With:
+If you want to switch back to discovery.php then you can replace:
 
 `33  */6   * * *   librenms    /opt/librenms/discovery-wrapper.py 1 >> /dev/null 2>&1`
 
-The default is for discovery wrapper to only use 1 thread so that it mimics the current behaviour. However if your
-system is powerful enough and the devices can cope then you can increase the thread count from 1 to a value of your
-choosing.
+With:
+
+`33  */6   * * *   librenms    /opt/librenms/discovery.php -h all >> /dev/null 2>&1`
 
 #### Discovery config
 

--- a/librenms.nonroot.cron
+++ b/librenms.nonroot.cron
@@ -1,6 +1,6 @@
 # Using this cron file requires an additional user on your system, please see install docs.
 
-33  */6   * * *   librenms    /opt/librenms/discovery.php -h all >> /dev/null 2>&1
+33   */6  * * *   librenms    /opt/librenms/cronic /opt/librenms/discovery-wrapper.py 1
 */5  *    * * *   librenms    /opt/librenms/discovery.php -h new >> /dev/null 2>&1
 */5  *    * * *   librenms    /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
 15   0    * * *   librenms    /opt/librenms/daily.sh >> /dev/null 2>&1
@@ -8,4 +8,3 @@
 */5  *    * * *   librenms    /opt/librenms/poll-billing.php >> /dev/null 2>&1
 01   *    * * *   librenms    /opt/librenms/billing-calculate.php >> /dev/null 2>&1
 */5  *    * * *   librenms    /opt/librenms/check-services.php >> /dev/null 2>&1
-


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Seems sensible to run like this now. Won't effect new installs.