### PR TITLE
Fix ".status services" to show properly possible status codes

### DIFF
--- a/LibreNMS/IRCBot.php
+++ b/LibreNMS/IRCBot.php
@@ -849,21 +849,36 @@ class IRCBot
             case 'services':
             case 'service':
             case 'srv':
-                $srvcount = array_pop(dbFetchRow('SELECT count(service_id) FROM services'.$d_w));
-                $srvup    = array_pop(dbFetchRow("SELECT count(service_id) FROM services  WHERE service_status = '0' AND service_ignore ='0'".$d_a));
-                $srvdown  = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_status = '1' AND service_ignore = '0'".$d_a));
-                $srvign   = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_ignore = '1'".$d_a));
-                $srvdis   = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_disabled = '1'".$d_a));
-                if ($srvup > 0) {
-                    $srvup = $this->_color($srvup, 'green');
-                }
-                if ($srvdown > 0) {
-                    $srvdown = $this->_color($srvdown, 'red');
-                    $srvcount = $this->_color($srvcount, 'yellow', null, 'bold');
-                } else {
-                    $srvcount = $this->_color($srvcount, 'green', null, 'bold');
-                }
-                $msg      = 'Services: '.$srvcount.' ('.$srvup.' up, '.$srvdown.' down, '.$srvign.' ignored, '.$srvdis.' disabled'.')';
+				$srvcount = array_pop(dbFetchRow('SELECT count(service_id) FROM services'.$d_w));
+				$srvup    = array_pop(dbFetchRow("SELECT count(service_id) FROM services  WHERE service_status = '0' AND service_ignore ='0'".$d_a));
+				$srvdown  = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_status = '2' AND service_ignore = '0'".$d_a));
+				$srvwarn  = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_status = '1' AND service_ignore = '0'".$d_a));
+				$srvunknown = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_status = '3' AND service_ignore = '0'".$d_a));
+				$srvign   = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_ignore = '1'".$d_a));
+				$srvdis   = array_pop(dbFetchRow("SELECT count(service_id) FROM services WHERE service_disabled = '1'".$d_a));
+				$srvcountcolor = array($srvdown, $srvwarn, $srvunknown);
+				if ($srvup > 0) {
+					$srvup = $this->_color($srvup, 'green');
+				}
+				if ($srvdown > 0) {
+					$srvdown = $this->_color($srvdown, 'red');
+				}
+				if ($srvwarn > 0) {
+					$srvwarn = $this->_color($srvwarn, 'yellow');
+				}
+				if ($srvunknown > 0) {
+					$srvunknown = $this->_color($srvunknown, 'lightblue');
+				}
+				if ($srvcountcolor[0] > 0) {
+					$srvcount = $this->_color($srvcount, 'red', null, 'bold');
+				} elseif ($srvcountcolor[1] > 0) {
+					$srvcount = $this->_color($srvcount, 'yellow', null, 'bold');
+				} elseif ($srvcountcolor[2] > 0) {
+					$srvcount = $this->_color($srvcount, 'lightblue', null, 'bold');
+				} else {
+					$srvcount = $this->_color($srvcount, 'green', null, 'bold');
+				}
+				$msg      = 'Services: '.$srvcount.' ('.$srvup.' up, '.$srvdown.' down, '.$srvwarn.' warning, '.$srvunknown.' unknown, '.$srvign.' ignored, '.$srvdis.' disabled'.')';
                 break;
 
             default:


### PR DESCRIPTION
Nagios plugins return 0-3 as the status-code for a check. This adds "warning" and "unknown" to the output as well as hierarchical color for the total.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
