### PR TITLE
Feature: selected_ports per OS. Fixed layout of example MySQL table.

### DIFF
--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -82,10 +82,11 @@ LibreNMS server. Something like pdns-recursor can be used and then configure `/e
 By default the polling ports module will walk ifXEntry + some items from ifEntry regardless of the port. So if a port is marked as deleted because you don't want to see them 
 or it's disabled then we still collect data. For the most part this is fine as the walks are quite quick. However for devices with a lot of ports and good % of those are 
 either deleted or disabled then this approach isn't optimal. So to counter this you can enable 'selected port polling' per device within the edit device -> misc section or by
-globally enabling it (not recommended): `$config['polling']['selected_ports'] = true;`.
+globally enabling it (not recommended): `$config['polling']['selected_ports'] = true;`. You can also set it for a specific OS: `$config['os']['ios']['polling']['selected_ports'] = true;`. 
 
 If you would like to see if you should turn this on then run this query in MySQL: `select device_id, count(*) as total from ports where deleted=1 group by device_id order by total desc;`. You will see output like the following:
 
+```
 +-----------+-------+
 | device_id | total |
 +-----------+-------+
@@ -94,6 +95,8 @@ If you would like to see if you should turn this on then run this query in MySQL
 |        41 |    41 |
 |        38 |     3 |
 |        81 |     2 |
++-----------+-------+
+```
 
 Here device id 128 and potentially 92 and 41 are likely candidates for this feature to be enabled on. Turn it on and then closely monitor the device for the next 15-30 minutes.
 

--- a/doc/Support/Performance.md
+++ b/doc/Support/Performance.md
@@ -86,17 +86,13 @@ globally enabling it (not recommended): `$config['polling']['selected_ports'] = 
 
 If you would like to see if you should turn this on then run this query in MySQL: `select device_id, count(*) as total from ports where deleted=1 group by device_id order by total desc;`. You will see output like the following:
 
-```
-+-----------+-------+
 | device_id | total |
-+-----------+-------+
+| --------: | ----: |
 |       128 |   339 |
 |        92 |    56 |
 |        41 |    41 |
 |        38 |     3 |
 |        81 |     2 |
-+-----------+-------+
-```
 
 Here device id 128 and potentially 92 and 41 are likely candidates for this feature to be enabled on. Turn it on and then closely monitor the device for the next 15-30 minutes.
 

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -176,7 +176,7 @@ $data       = array();
 if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=') && version_compare($device['version'], '11.7', '<'))) {
     require_once 'ports/f5.inc.php';
 } else {
-    if ($config['polling']['selected_ports'] === true || $device['attribs']['selected_ports'] == 'true') {
+    if ($config['polling']['selected_ports'] === true || $config['os'][$device['os']]['polling']['selected_ports'] === true || $device['attribs']['selected_ports'] == 'true') {
         echo('Select ports polling');
         $lports = dbFetchRows("SELECT * FROM `ports` where `device_id` = ? AND `deleted` = 0 AND `disabled` = 0", array($device['device_id']));
         foreach ($lports as $lport) {


### PR DESCRIPTION
Allow users to set selected_ports polling on an OS level.
Fixed the layout of the MySQL example output table.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
