### PR TITLE
edgeos bad_if_regexp

### DIFF
--- a/includes/definitions/edgeos.yaml
+++ b/includes/definitions/edgeos.yaml
@@ -11,3 +11,8 @@ discovery:
     - sysDescr_regex:
         - '/^EdgeOS/'
         - '/^EdgeRouter/'
+bad_if_regexp:
+    - '/^npi[0-9]/'
+    - '/^loop[0-9]/'
+    - '/^gre[0-9]/'
+    - '/^gretap[0-9]/'


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

added bad_if_regexp to filter out some interfaces that are always down in edgeos hardware.
tested on er 8 pro with 1.9.7 fix 4