### PR TITLE
fix: number comparisons in alerts and device groups

### DIFF
--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -357,7 +357,7 @@ $('#and').click('', function(e) {
            strategy: 'array',
            tagFieldName: 'rules[]'
         });
-        if(value.indexOf("%") < 0) {
+        if(value.indexOf("%") < 0 && isNaN(value)) {
           value = '"'+value+'"';
         }
         if(entity.indexOf("%") < 0) {

--- a/html/includes/modal/new_device_group.inc.php
+++ b/html/includes/modal/new_device_group.inc.php
@@ -181,11 +181,13 @@ $('#and, #or').click('', function(e) {
            strategy: 'array',
            tagFieldName: 'patterns[]'
         });
-        if(entity.indexOf("%") >= 0) {
-            $('#response').data('tagmanager').populate([ entity+' '+condition+' '+value+' '+glue ]);
-        } else {
-            $('#response').data('tagmanager').populate([ '%'+entity+' '+condition+' "'+value+'" '+glue ]);
+        if(value.indexOf("%") < 0 && isNaN(value)) {
+            value = '"'+value+'"';
         }
+        if(entity.indexOf("%") < 0) {
+            entity = '%'+entity;
+        }
+        $('#response').data('tagmanager').populate([ entity+' '+condition+' '+value+' '+glue ]);
     }
 });
 


### PR DESCRIPTION
Remove quotes so if the field we are comparing against is a string type, we still do a number comparison.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
