### PR TITLE
fix: fallback to snmpgetnext if db is unavailable

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -293,7 +293,7 @@ function snmp_getnext($device, $oid, $options = null, $mib = null, $mibdir = nul
 {
     $time_start = microtime(true);
 
-    $snmpcmd  = Config::get('snmpgetnext');
+    $snmpcmd  = Config::get('snmpgetnext', 'snmpgetnext');
     $cmd = gen_snmp_cmd($snmpcmd, $device, $oid, $options, $mib, $mibdir);
     $data = trim(external_exec($cmd), "\" \n\r");
 


### PR DESCRIPTION
running tests without DBTEST=1 for example.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
