### PR TITLE
docs: Moved ARP function docs from Bills section

### DIFF
--- a/doc/API/index.md
+++ b/doc/API/index.md
@@ -1763,6 +1763,8 @@ Output:
 }
 ```
 
+## ARP
+
 ### Function: `list_arp`
 
 Retrieve a specific ARP entry or all ARP enties for a device


### PR DESCRIPTION
Minor change, the list ARP function was nested under the bills section of the API docs.  Moved to its own section, I presume some tool builds the index on the docs site.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
