### PR TITLE
device: Removed unused poller/discovery modules for Arista EOS

### DIFF
--- a/includes/definitions/arista_eos.yaml
+++ b/includes/definitions/arista_eos.yaml
@@ -10,3 +10,14 @@ over:
 discovery:
     - sysDescr:
         - Arista Networks EOS
+poller_modules:
+    wireless: 0
+    ipmi: 0
+    applications: 0
+    services: 0
+    ntp: 0
+discovery_modules:
+    cisco-vrf-lite: 0
+    services: 0
+    ntp: 0
+    wireless: 0


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Disabling some unused poller/discovery modules for Arista EOS.