### PR TITLE
Add Permission checks to API

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -119,7 +119,7 @@ function check_is_admin()
 
 function check_is_read()
 {
-    if (!is_admin && !is_read()) {
+    if (!is_admin() && !is_read()) {
         api_error(403, 'Insufficient privileges');
     }
 }
@@ -1122,15 +1122,15 @@ function list_bills()
         $sql    .= '`bill_ref` = ?';
         $param[] = $bill_ref;
     } elseif (is_numeric($bill_id)) {
-        $sql    .= '`bills`.`bill_id` = ?';
+        $sql    .= '`bill_id` = ?';
         $param[] = $bill_id;
     }
     if (!is_admin() && !is_read()) {
-        $sql    .= ' AND `bills`.`bill_id` IN (SELECT `bill_id` FROM `bills_perms` WHERE `user_id` = ?)';
+        $sql    .= ' AND `bill_id` IN (SELECT `bill_id` FROM `bill_perms` WHERE `user_id` = ?)';
         $param[] = $_SESSION['user_id'];
     }
 
-    foreach (dbFetchRows("SELECT `bills`.*,COUNT(port_id) AS `ports_total` FROM `bills` LEFT JOIN `bill_ports` ON `bill_ports`.`bill_id`=`bills`.`bill_id` WHERE $sql GROUP BY `bill_name`,`bill_ref` ORDER BY `bill_name`", $param) as $bill) {
+    foreach (dbFetchRows("SELECT * FROM `bills` WHERE $sql ORDER BY `bill_name`", $param) as $bill) {
         $rate_data    = $bill;
         $allowed = '';
         $used = '';
@@ -1206,7 +1206,6 @@ function update_device()
 
 function get_device_groups()
 {
-    check_is_read();
     $app = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     $status   = 'error';

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -135,6 +135,7 @@ function check_not_demo()
 function get_graph_by_port_hostname()
 {
     // This will return a graph for a given port by the ifName
+    global $config;
     $app          = \Slim\Slim::getInstance();
     $router       = $app->router()->getCurrentRoute()->getParams();
     $hostname     = $router['hostname'];
@@ -207,6 +208,7 @@ function get_port_stats_by_port_hostname()
 function get_graph_generic_by_hostname()
 {
     // This will return a graph type given a device id.
+    global $config;
     $app          = \Slim\Slim::getInstance();
     $router       = $app->router()->getCurrentRoute()->getParams();
     $hostname     = $router['hostname'];
@@ -531,6 +533,7 @@ function list_ospf()
 function get_graph_by_portgroup()
 {
     check_is_read();
+    global $config;
     $app    = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     $group  = $router['group'] ?: '';

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -48,11 +48,46 @@ function authToken(\Slim\Route $route)
     }
 }
 
+function api_success($result, $result_name, $message = null, $code = 200, $count = null, $extra = null)
+{
+    if (isset($result) && !isset($result_name)) {
+        api_error(500, 'Result name not specified');
+    }
+    
+    $app  = \Slim\Slim::getInstance();
+    $app->response->setStatus($code);
+    $app->response->headers->set('Content-Type', 'application/json');
+    $output = array('status'  => 'ok');
+    
+    if (isset($result)) {
+        $output[$result_name] = $result;
+    }
+    if (isset($message) && $message != '') {
+        $output['message'] = $message;
+    }
+    if (!isset($count) && is_array($result)) {
+        $count = count($result);
+    }
+    if (isset($count)) {
+        $output['count'] = $count;
+    }
+    if (isset($extra)) {
+        $output = array_merge($output, $extra);
+    }
+    echo _json_encode($output);
+    $app->stop();
+} // end api_success()
+
+function api_success_noresult($code, $message = null)
+{
+    api_success(null, null, $message, $code);
+} // end api_success_noresult
+
 function api_error($statusCode, $message)
 {
     $app  = \Slim\Slim::getInstance();
-    $app->response->headers->set('Content-Type', 'application/json');
     $app->response->setStatus($statusCode);
+    $app->response->headers->set('Content-Type', 'application/json');
     $output = array(
         'status'  => 'error',
         'message' => $message
@@ -82,10 +117,24 @@ function check_is_admin()
     }
 }
 
+function check_is_read()
+{
+    if (!is_admin && !is_read()) {
+        api_error(403, 'Insufficient privileges');
+    }
+}
+
+function check_not_demo()
+{
+    global $config;
+    if ($config['api_demo'] == 1) {
+        api_error(500, 'This feature isn\'t available in the demo');
+    }
+}
+
 function get_graph_by_port_hostname()
 {
     // This will return a graph for a given port by the ifName
-    global $config;
     $app          = \Slim\Slim::getInstance();
     $router       = $app->router()->getCurrentRoute()->getParams();
     $hostname     = $router['hostname'];
@@ -123,7 +172,6 @@ function get_graph_by_port_hostname()
 function get_port_stats_by_port_hostname()
 {
     // This will return port stats based on a devices hostname and ifName
-    global $config;
     $app       = \Slim\Slim::getInstance();
     $router    = $app->router()->getCurrentRoute()->getParams();
     $hostname  = $router['hostname'];
@@ -152,19 +200,13 @@ function get_port_stats_by_port_hostname()
         }
     }
 
-    $output    = array(
-        'status' => 'ok',
-        'port'   => $port,
-    );
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($port, 'port');
 }
 
 
 function get_graph_generic_by_hostname()
 {
     // This will return a graph type given a device id.
-    global $config;
     $app          = \Slim\Slim::getInstance();
     $router       = $app->router()->getCurrentRoute()->getParams();
     $hostname     = $router['hostname'];
@@ -200,12 +242,10 @@ function get_graph_generic_by_hostname()
     rrdtool_close();
 }
 
-
 function get_device()
 {
     // return details of a single device
     $app = \Slim\Slim::getInstance();
-    $app->response->headers->set('Content-Type', 'application/json');
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
 
@@ -216,26 +256,19 @@ function get_device()
     $device = device_by_id_cache($device_id);
     if (!$device) {
         api_error(404, "Device $hostname does not exist");
-    } else {
-        check_device_permission($device_id);
-        
-        $host_id = get_vm_parent_id($device);
-        if (is_numeric($host_id)) {
-            $device = array_merge($device, array('parent_id' => $host_id));
-        }
-        $output = array(
-            'status'  => 'ok',
-            'devices' => array($device),
-        );
-        echo _json_encode($output);
     }
+
+    check_device_permission($device_id);
+    $host_id = get_vm_parent_id($device);
+    if (is_numeric($host_id)) {
+        $device = array_merge($device, array('parent_id' => $host_id));
+    }
+    api_success(array($device), 'devices');
 }
 
 function list_devices()
 {
     // This will return a list of devices
-    global $config;
-    $app   = \Slim\Slim::getInstance();
     $order = $_GET['order'];
     $type  = $_GET['type'];
     $query = mres($_GET['query']);
@@ -279,12 +312,12 @@ function list_devices()
     } else {
         $sql = '1';
     }
+    if (!is_admin() && !is_read()) {
+        $sql .= " AND `device_id` IN (SELECT device_id FROM devices_perms WHERE user_id = ?)";
+        $param[] = $_SESSION['user_id'];
+    }
     $devices = array();
     foreach (dbFetchRows("SELECT * FROM `devices` $join WHERE $sql ORDER by $order", $param) as $device) {
-        if (!device_permitted($device['device_id'])) {
-            continue;
-        }
-
         $host_id = get_vm_parent_id($device);
         $device['ip'] = inet6_ntop($device['ip']);
         if (is_numeric($host_id)) {
@@ -293,15 +326,7 @@ function list_devices()
         $devices[] = $device;
     }
 
-    $count = count($devices);
-
-    $output = array(
-        'status'  => 'ok',
-        'count'   => $count,
-        'devices' => $devices,
-    );
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($devices, 'devices');
 }
 
 
@@ -312,18 +337,16 @@ function add_device()
     // This will add a device using the data passed encoded with json
     // FIXME: Execution flow through this function could be improved
     global $config;
-    $app  = \Slim\Slim::getInstance();
     $data = json_decode(file_get_contents('php://input'), true);
-    // Default status & code to error and change it if we need to.
-    $status = 'error';
-    $code   = 500;
+
     $additional = array();
     // keep scrutinizer from complaining about snmpver not being set for all execution paths
     $snmpver = 'v2c';
     if (empty($data)) {
-        $message = 'No information has been provided to add this new device';
-    } elseif (empty($data['hostname'])) {
-        $message = 'Missing the device hostname';
+        api_error(400, 'No information has been provided to add this new device');
+    }
+    if (empty($data['hostname'])) {
+        api_error(400, 'Missing the device hostname');
     }
 
     $hostname     = $data['hostname'];
@@ -357,28 +380,15 @@ function add_device()
         array_push($config['snmp']['v3'], $v3);
         $snmpver = 'v3';
     } else {
-        $code    = 400;
-        $status  = 'error';
-        $message = "You haven't specified an SNMP version to use";
+        api_error(400, 'You haven\'t specified an SNMP version to use');
     }
-    if (empty($message)) {
-        try {
-            $device_id = addHost($hostname, $snmpver, $port, $transport, $poller_group, $force_add, 'ifIndex', $additional);
-            $code    = 201;
-            $status  = 'ok';
-            $message = "Device $hostname ($device_id) has been added successfully";
-        } catch (Exception $e) {
-            $message = $e->getMessage();
-        }
+    try {
+        $device_id = addHost($hostname, $snmpver, $port, $transport, $poller_group, $force_add, 'ifIndex', $additional);
+    } catch (Exception $e) {
+        api_error(500, $e->getMessage());
     }
 
-    $app->response->setStatus($code);
-    $output = array(
-        'status'  => $status,
-        'message' => $message,
-    );
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success_noresult(201, "Device $hostname ($device_id) has been added successfully");
 }
 
 
@@ -391,106 +401,60 @@ function del_device()
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
-    // Default status to error and change it if we need to.
-    $status = 'error';
-    $code   = 500;
-    if (empty($hostname) || $config['api_demo'] == 1) {
-        $message = 'No hostname has been provided to delete';
-        if ($config['api_demo'] == 1) {
-            $message = "This feature isn\'t available in the demo";
-        }
 
-        $output = array(
-            'status'  => $status,
-            'message' => $message,
-        );
-    } else {
-        // allow deleting by device_id or hostname
-        $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
-        $device    = null;
-        if ($device_id) {
-            // save the current details for returning to the client on successful delete
-            $device = device_by_id_cache($device_id);
-        }
-
-        if ($device) {
-            $response = delete_device($device_id);
-            if (empty($response)) {
-                // FIXME: Need to provide better diagnostics out of delete_device
-                $output = array(
-                    'status'  => $status,
-                    'message' => 'Device deletion failed',
-                );
-            } else {
-                // deletion succeeded - include old device details in response
-                $code   = 200;
-                $status = 'ok';
-                $output = array(
-                    'status'  => $status,
-                    'message' => $response,
-                    'devices' => array($device),
-                );
-            }
-        } else {
-            // no device matching the name
-            $code   = 404;
-            $output = array(
-                'status'  => $status,
-                'message' => "Device $hostname not found",
-            );
-        }
+    check_not_demo();
+    if (empty($hostname)) {
+        api_error(400, 'No hostname has been provided to delete');
     }
 
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    // allow deleting by device_id or hostname
+    $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+    $device    = null;
+    if ($device_id) {
+        // save the current details for returning to the client on successful delete
+        $device = device_by_id_cache($device_id);
+    }
+
+    if (!device) {
+        api_error(404, "Device $hostname not found");
+    }
+
+    $response = delete_device($device_id);
+    if (empty($response)) {
+        // FIXME: Need to provide better diagnostics out of delete_device
+        api_error(500, 'Device deletion failed');
+    }
+
+    // deletion succeeded - include old device details in response
+    api_success(array($device), 'devices', $response);
 }
 
 
 function get_vlans()
 {
     // This will list all vlans for a given device
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
-    $code     = 500;
-    if (empty($hostname)) {
-        $output = $output = array(
-            'status'  => 'error',
-            'message' => 'No hostname has been provided',
-        );
-    } else {
-        include_once '../includes/functions.php';
-        $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
-        $device    = null;
-        if ($device_id) {
-            // save the current details for returning to the client on successful delete
-            $device = device_by_id_cache($device_id);
-        }
 
-        if ($device) {
-            check_device_permission($device_id);
-            
-            $vlans       = dbFetchRows('SELECT vlan_vlan,vlan_domain,vlan_name,vlan_type,vlan_mtu FROM vlans WHERE `device_id` = ?', array($device_id));
-            $total_vlans = count($vlans);
-            $code        = 200;
-            $output      = array(
-                'status' => 'ok',
-                'count'  => $total_vlans,
-                'vlans'  => $vlans,
-            );
-        } else {
-            $code   = 404;
-            $output = array(
-                'status' => 'error', "Device $hostname not found"
-            );
-        }
+    if (empty($hostname)) {
+        api_error(500, 'No hostname has been provided');
     }
 
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+    $device    = null;
+    if ($device_id) {
+        // save the current details for returning to the client on successful delete
+        $device = device_by_id_cache($device_id);
+    }
+
+    if (!$device) {
+        api_error(404, "Device $hostname not found");
+    }
+    check_device_permission($device_id);
+
+    $vlans       = dbFetchRows('SELECT vlan_vlan,vlan_domain,vlan_name,vlan_type,vlan_mtu FROM vlans WHERE `device_id` = ?', array($device_id));
+    api_success($vlans, 'vlans');
 }
 
 
@@ -512,13 +476,10 @@ function show_endpoints()
 
 function list_bgp()
 {
-    check_is_admin();
+    check_is_read();
 
-    global $config;
     $app        = \Slim\Slim::getInstance();
-    $code       = 500;
-    $status     = 'error';
-    $message    = 'Error retrieving bgpPeers';
+
     $sql        = '';
     $sql_params = array();
     $hostname   = $_GET['hostname'] ?: '';
@@ -535,29 +496,18 @@ function list_bgp()
 
     $bgp_sessions       = dbFetchRows("SELECT `bgpPeers`.* FROM `bgpPeers` LEFT JOIN `devices` ON `bgpPeers`.`device_id` = `devices`.`device_id` WHERE `bgpPeerState` IS NOT NULL AND `bgpPeerState` != '' $sql", $sql_params);
     $total_bgp_sessions = count($bgp_sessions);
-    if (is_numeric($total_bgp_sessions)) {
-        $code    = 200;
-        $status  = 'ok';
-        $message = '';
+    if (!is_numeric($total_bgp_sessions)) {
+        api_error(500, 'Error retrieving bgpPeers');
     }
 
-    $output = array(
-        'status'       => "$status",
-        'err-msg'      => $message,
-        'count'        => $total_bgp_sessions,
-        'bgp_sessions' => $bgp_sessions,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($bgp_sessions, 'bgp_sessions');
 }
 
 
 function list_ospf()
 {
-    check_is_admin();
+    check_is_read();
 
-    global $config;
     $app        = \Slim\Slim::getInstance();
     $code       = 500;
     $status     = 'error';
@@ -573,28 +523,17 @@ function list_ospf()
 
     $ospf_neighbours       = dbFetchRows("SELECT * FROM ospf_nbrs WHERE `ospfNbrState` IS NOT NULL AND `ospfNbrState` != '' $sql", $sql_params);
     $total_ospf_neighbours = count($ospf_neighbours);
-    if (is_numeric($total_ospf_neighbours)) {
-        $code    = 200;
-        $status  = 'ok';
-        $message = '';
+    if (!is_numeric($total_ospf_neighbours)) {
+        api_error(500, 'Error retrieving ospf_nbrs');
     }
 
-    $output = array(
-        'status'       => "$status",
-        'err-msg'      => $message,
-        'count'        => $total_ospf_neighbours,
-        'ospf_neighbours' => $ospf_neighbours,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($ospf_neighbours, 'ospf_neighbours');
 }
 
 
 function get_graph_by_portgroup()
 {
-    check_is_admin();
-    global $config;
+    check_is_read();
     $app    = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     $group  = $router['group'] ?: '';
@@ -639,10 +578,6 @@ function get_graph_by_portgroup()
 
 function get_components()
 {
-    global $config;
-    $code     = 200;
-    $status   = 'ok';
-    $message  = '';
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -666,15 +601,7 @@ function get_components()
     $COMPONENT = new LibreNMS\Component();
     $components = $COMPONENT->getComponents($device_id, $options);
 
-    $output       = array(
-        'status'  => "$status",
-        'err-msg' => $message,
-        'count'   => count($components[$device_id]),
-        'components'  => $components[$device_id],
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($components[$device_id], 'components');
 }
 
 
@@ -682,10 +609,6 @@ function add_components()
 {
     check_is_admin();
 
-    global $config;
-    $code     = 200;
-    $status   = 'ok';
-    $message  = '';
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -696,15 +619,7 @@ function add_components()
     $COMPONENT = new LibreNMS\Component();
     $component = $COMPONENT->createComponent($device_id, $ctype);
 
-    $output       = array(
-        'status'  => "$status",
-        'err-msg' => $message,
-        'count'   => count($component),
-        'components'  => $component,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($component, 'components');
 }
 
 
@@ -712,7 +627,6 @@ function edit_components()
 {
     check_is_admin();
 
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -722,27 +636,11 @@ function edit_components()
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     $COMPONENT = new LibreNMS\Component();
 
-    if ($COMPONENT->setComponentPrefs($device_id, $data)) {
-        // Edit Success.
-        $code     = 200;
-        $status   = 'ok';
-        $message  = '';
-    } else {
-        // Edit Failure.
-        $code     = 500;
-        $status   = 'error';
-        $message  = 'Components could not be edited.';
+    if (!$COMPONENT->setComponentPrefs($device_id, $data)) {
+        api_error(500, 'Components could not be edited.');
     }
 
-    $output       = array(
-        'status'  => "$status",
-        'err-msg' => $message,
-        'count'   => count($data),
-    );
-
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success_noresult(200);
 }
 
 
@@ -750,41 +648,22 @@ function delete_components()
 {
     check_is_admin();
 
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $cid = $router['component'];
 
     $COMPONENT = new LibreNMS\Component();
-    if ($COMPONENT->deleteComponent($cid)) {
-        // Edit Success.
-        $code     = 200;
-        $status   = 'ok';
-        $message  = '';
-    } else {
-        // Edit Failure.
-        $code     = 500;
-        $status   = 'error';
-        $message  = 'Components could not be deleted.';
+    if (!$COMPONENT->deleteComponent($cid)) {
+        api_error(500, 'Components could not be deleted.');
     }
-
-    $output       = array(
-        'status'  => "$status",
-        'err-msg' => $message,
-    );
-
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    
+    api_success_noresult(200);
 }
 
 
 function get_graphs()
 {
     global $config;
-    $code     = 200;
-    $status   = 'ok';
-    $message  = '';
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -810,24 +689,11 @@ function get_graphs()
         );
     }
 
-    $total_graphs = count($graphs);
-    $output       = array(
-        'status'  => "$status",
-        'err-msg' => $message,
-        'count'   => $total_graphs,
-        'graphs'  => $graphs,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    return api_success($graphs, 'graphs');
 }
 
 function list_available_health_graphs()
 {
-    global $config;
-    $code     = 200;
-    $status   = 'ok';
-    $message  = '';
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -859,21 +725,11 @@ function list_available_health_graphs()
         }
     }
 
-    $total_graphs = count($graphs);
-    $output       = array(
-        'status'  => "$status",
-        'err-msg' => $message,
-        'count'   => $total_graphs,
-        'graphs'  => $graphs,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    return api_success($graphs, 'graphs');
 }
 
 function get_port_graphs()
 {
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -894,21 +750,11 @@ function get_port_graphs()
     }
     
     $ports       = dbFetchRows("SELECT $columns FROM `ports` WHERE `device_id` = ? AND `deleted` = '0' $sql ORDER BY `ifIndex` ASC", $params);
-    $total_ports = count($ports);
-    $output      = array(
-        'status'  => 'ok',
-        'err-msg' => '',
-        'count'   => $total_ports,
-        'ports'   => $ports,
-    );
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($ports, 'ports');
 }
 
 function get_ip_addresses()
 {
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     if (isset($router['hostname'])) {
@@ -925,20 +771,11 @@ function get_ip_addresses()
         $ipv6   = dbFetchRows("SELECT * FROM `ipv6_addresses` WHERE `port_id` = ?", array($port_id));
     }
 
-    $output = array(
-        'status'    => 'ok',
-        'err-msg'   => '',
-        'addresses' => array_merge($ipv4, $ipv6),
-    );
-
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success(array_merge($ipv4, $ipv6), 'addresses');
 }
 
 function get_port_info()
 {
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $port_id  = urldecode($router['portid']);
@@ -946,19 +783,11 @@ function get_port_info()
 
     // use hostname as device_id if it's all digits
     $port   = dbFetchRows("SELECT * FROM `ports` WHERE `port_id` = ? AND `deleted` = 0", array($port_id));
-    $output = array(
-        'status'  => 'ok',
-        'err-msg' => '',
-        'port'    => $port,
-    );
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($port, 'port');
 }
 
 function get_all_ports()
 {
-    global $config;
     $app = \Slim\Slim::getInstance();
     if (isset($_GET['columns'])) {
         $columns = $_GET['columns'];
@@ -968,26 +797,18 @@ function get_all_ports()
     validate_column_list($columns, 'ports');
     $params = array();
     $sql = '';
-    if (!is_admin()) {
+    if (!is_read()) {
         $sql = ' AND (device_id IN (SELECT device_id FROM devices_perms WHERE user_id = ?) OR port_id IN (SELECT port_id FROM ports_perms WHERE user_id = ?))';
         array_push($params, $_SESSION['user_id']);
         array_push($params, $_SESSION['user_id']);
     }
     $ports = dbFetchRows("SELECT $columns FROM `ports` WHERE `deleted` = 0 $sql", $params);
 
-    $output = array(
-        'status'  => 'ok',
-        'err-msg' => '',
-        'ports'   => $ports,
-    );
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($ports, 'ports');
 }
 
 function get_port_stack()
 {
-    global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $hostname = $router['hostname'];
@@ -1001,22 +822,12 @@ function get_port_stack()
         $mappings       = dbFetchRows("SELECT * FROM `ports_stack` WHERE `device_id` = ? AND `ifStackStatus` = 'active' ORDER BY `port_id_high` ASC", array($device_id));
     }
 
-    $total_mappings = count($mappings);
-    $output         = array(
-        'status'  => 'ok',
-        'err-msg' => '',
-        'count'   => $total_mappings,
-        'mappings'   => $mappings,
-    );
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($mappings, 'mappings');
 }
 
 function list_alert_rules()
 {
-    check_is_admin();
-    global $config;
+    check_is_read();
     $app    = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     $sql    = '';
@@ -1028,23 +839,13 @@ function list_alert_rules()
     }
 
     $rules       = dbFetchRows("SELECT * FROM `alert_rules` $sql", $param);
-    $total_rules = count($rules);
-    $output      = array(
-        'status'  => 'ok',
-        'err-msg' => '',
-        'count'   => $total_rules,
-        'rules'   => $rules,
-    );
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($rules, 'rules');
 }
 
 
 function list_alerts()
 {
-    check_is_admin();
-    global $config;
+    check_is_read();
     $app    = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     if (isset($_GET['state'])) {
@@ -1061,47 +862,34 @@ function list_alerts()
     }
 
     $alerts       = dbFetchRows("SELECT `D`.`hostname`, `A`.*, `R`.`severity` FROM `alerts` AS `A`, `devices` AS `D`, `alert_rules` AS `R` WHERE `D`.`device_id` = `A`.`device_id` AND `A`.`rule_id` = `R`.`id` AND `A`.`state` IN (?) $sql", $param);
-    $total_alerts = count($alerts);
-    $output       = array(
-        'status'  => 'ok',
-        'err-msg' => '',
-        'count'   => $total_alerts,
-        'alerts'  => $alerts,
-    );
-    $app->response->setStatus('200');
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($alerts, 'alerts');
 }
 
 
 function add_edit_rule()
 {
     check_is_admin();
-    global $config;
     $app  = \Slim\Slim::getInstance();
     $data = json_decode(file_get_contents('php://input'), true);
 
-    $status  = 'error';
-    $message = '';
-    $code    = 500;
-
     $rule_id = mres($data['rule_id']);
-
     $device_id = mres($data['device_id']);
     if (empty($device_id) && !isset($rule_id)) {
-        $message = 'Missing the device id or global device id (-1)';
-    } elseif ($device_id == 0) {
+        api_error(400, 'Missing the device id or global device id (-1)');
+    }
+    
+    if ($device_id == 0) {
         $device_id = '-1';
     }
 
     $rule = $data['rule'];
     if (empty($rule)) {
-        $message = 'Missing the alert rule';
+        api_error(400, 'Missing the alert rule');
     }
 
     $name = mres($data['name']);
     if (empty($name)) {
-        $message = 'Missing the alert rule name';
+        api_error(400, 'Missing the alert rule name');
     }
 
     $severity = mres($data['severity']);
@@ -1111,7 +899,7 @@ function add_edit_rule()
         'critical',
     );
     if (!in_array($severity, $sevs)) {
-        $message = 'Missing the severity';
+        api_error(400, 'Missing the severity');
     }
 
     $disabled = mres($data['disabled']);
@@ -1138,71 +926,41 @@ function add_edit_rule()
 
     if (!isset($rule_id)) {
         if (dbFetchCell('SELECT `name` FROM `alert_rules` WHERE `name`=?', array($name)) == $name) {
-            $message = 'Addition failed : Name has already been used';
+            api_error(500, 'Addition failed : Name has already been used');
         }
     } else {
         if (dbFetchCell("SELECT name FROM alert_rules WHERE name=? AND id !=? ", array($name, $rule_id)) == $name) {
-            $message = 'Edition failed : Name has already been used';
+            api_error(500, 'Addition failed : Name has already been used');
         }
     }
 
-    if (empty($message)) {
-        if (is_numeric($rule_id)) {
-            if (dbUpdate(array('name' => $name, 'rule' => $rule, 'severity' => $severity, 'disabled' => $disabled, 'extra' => $extra_json), 'alert_rules', 'id=?', array($rule_id)) >= 0) {
-                $status = 'ok';
-                $code   = 200;
-            } else {
-                $message = 'Failed to update existing alert rule';
-            }
-        } elseif (dbInsert(array('name' => $name, 'device_id' => $device_id, 'rule' => $rule, 'severity' => $severity, 'disabled' => $disabled, 'extra' => $extra_json), 'alert_rules')) {
-            $status = 'ok';
-            $code   = 200;
-        } else {
-            $message = 'Failed to create new alert rule';
+    if (is_numeric($rule_id)) {
+        if (!(dbUpdate(array('name' => $name, 'rule' => $rule, 'severity' => $severity, 'disabled' => $disabled, 'extra' => $extra_json), 'alert_rules', 'id=?', array($rule_id)) >= 0)) {
+            api_error(500, 'Failed to update existing alert rule');
         }
+    } elseif (!dbInsert(array('name' => $name, 'device_id' => $device_id, 'rule' => $rule, 'severity' => $severity, 'disabled' => $disabled, 'extra' => $extra_json), 'alert_rules')) {
+        api_error(500, 'Failed to create new alert rule');
     }
 
-    $output = array(
-        'status'  => $status,
-        'err-msg' => $message,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success_noresult(200);
 }
 
 
 function delete_rule()
 {
     check_is_admin();
-    global $config;
     $app     = \Slim\Slim::getInstance();
     $router  = $app->router()->getCurrentRoute()->getParams();
     $rule_id = mres($router['id']);
-    $status  = 'error';
-    $err_msg = '';
-    $message = '';
-    $code    = 500;
     if (is_numeric($rule_id)) {
-        $status = 'ok';
-        $code   = 200;
         if (dbDelete('alert_rules', '`id` =  ? LIMIT 1', array($rule_id))) {
-            $message = 'Alert rule has been removed';
+            api_success_noresult(200, 'Alert rule has been removed');
         } else {
-            $message = 'No alert rule by that ID';
+            api_success_noresult(200, 'No alert rule by that ID');
         }
     } else {
-        $err_msg = 'Invalid rule id has been provided';
+        api_error(400, 'Invalid rule id has been provided');
     }
-
-    $output = array(
-        'status'  => $status,
-        'err-msg' => $err_msg,
-        'message' => $message,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
 }
 
 
@@ -1213,30 +971,15 @@ function ack_alert()
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $alert_id = mres($router['id']);
-    $status   = 'error';
-    $err_msg  = '';
-    $message  = '';
-    $code     = 500;
-    if (is_numeric($alert_id)) {
-        $status = 'ok';
-        $code   = 200;
-        if (dbUpdate(array('state' => 2), 'alerts', '`id` = ? LIMIT 1', array($alert_id))) {
-            $message = 'Alert has been acknowledged';
-        } else {
-            $message = 'No alert by that ID';
-        }
-    } else {
-        $err_msg = 'Invalid alert has been provided';
-    }
 
-    $output = array(
-        'status'  => $status,
-        'err-msg' => $err_msg,
-        'message' => $message,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    if (!is_numeric($alert_id)) {
+        api_error(400, 'Invalid alert has been provided');
+    }
+    if (dbUpdate(array('state' => 2), 'alerts', '`id` = ? LIMIT 1', array($alert_id))) {
+        api_success_noresult(200, 'Alert has been acknowledged');
+    } else {
+        api_success_noresult(200, 'No Alert by that ID');
+    }
 }
 
 function unmute_alert()
@@ -1246,30 +989,16 @@ function unmute_alert()
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
     $alert_id = mres($router['id']);
-    $status   = 'error';
-    $err_msg  = '';
-    $message  = '';
-    $code     = 500;
-    if (is_numeric($alert_id)) {
-        $status = 'ok';
-        $code   = 200;
-        if (dbUpdate(array('state' => 1), 'alerts', '`id` = ? LIMIT 1', array($alert_id))) {
-            $message = 'Alert has been unmuted';
-        } else {
-            $message = 'No alert by that ID';
-        }
-    } else {
-        $err_msg = 'Invalid alert has been provided';
+
+    if (!is_numeric($alert_id)) {
+        api_success_noresult(200, 'Alert has been acknowledged');
     }
 
-    $output = array(
-        'status'  => $status,
-        'err-msg' => $err_msg,
-        'message' => $message,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    if (dbUpdate(array('state' => 1), 'alerts', '`id` = ? LIMIT 1', array($alert_id))) {
+        api_success_noresult(200, 'Alert has been unmuted');
+    } else {
+        api_success_noresult(200, 'No alert by that ID');
+    }
 }
 
 
@@ -1278,9 +1007,7 @@ function get_inventory()
     global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
-    $status   = 'error';
-    $err_msg  = '';
-    $code     = 500;
+
     $hostname = $router['hostname'];
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
@@ -1300,33 +1027,19 @@ function get_inventory()
     }
 
     if (!is_numeric($device_id)) {
-        $err_msg   = 'Invalid device provided';
-        $total_inv = 0;
-        $inventory = array();
-    } else {
-        $sql .= ' AND `device_id`=?';
-        $params[] = $device_id;
-        $inventory = dbFetchRows("SELECT * FROM `entPhysical` WHERE 1 $sql", $params);
-        $code      = 200;
-        $status    = 'ok';
-        $total_inv = count($inventory);
+        api_error(400, 'Invalid device provided');
     }
+    $sql .= ' AND `device_id`=?';
+    $params[] = $device_id;
+    $inventory = dbFetchRows("SELECT * FROM `entPhysical` WHERE 1 $sql", $params);
 
-    $output = array(
-        'status'    => $status,
-        'err-msg'   => $err_msg,
-        'count'     => $total_inv,
-        'inventory' => $inventory,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($inventory, 'inventory');
 }
 
 
 function list_oxidized()
 {
-    check_is_admin();
+    check_is_read();
     global $config;
     $app = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
@@ -1393,37 +1106,29 @@ function list_bills()
     global $config;
     $app = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
-    $status = 'ok';
-    $err_msg = '';
-    $message = '';
-    $code = 200;
+
     $bills = array();
     $bill_id = mres($router['bill_id']);
     $bill_ref = mres($_GET['ref']);
     $bill_custid = mres($_GET['custid']);
+    $param = array();
+    $sql = '1';
     if (!empty($bill_custid)) {
-        $sql   = '`bill_custid` = ?';
-        $param = array($bill_custid);
+        $sql    .= '`bill_custid` = ?';
+        $param[] = $bill_custid;
     } elseif (!empty($bill_ref)) {
-        $sql   = '`bill_ref` = ?';
-        $param = array($bill_ref);
+        $sql    .= '`bill_ref` = ?';
+        $param[] = $bill_ref;
     } elseif (is_numeric($bill_id)) {
-        $sql   = '`bills`.`bill_id` = ?';
-        $param = array($bill_id);
-    } else {
-        $sql   = '';
-        $param = array();
+        $sql    .= '`bills`.`bill_id` = ?';
+        $param[] = $bill_id;
+    }
+    if (!is_admin() && !is_read()) {
+        $sql    .= ' AND `bills`.`bill_id` IN (SELECT `bill_id` FROM `bills_perms` WHERE `user_id` = ?)';
+        $param[] = $_SESSION['user_id'];
     }
 
-    if (count($param) >= 1) {
-        $sql = "WHERE $sql";
-    }
-
-    foreach (dbFetchRows("SELECT `bills`.*,COUNT(port_id) AS `ports_total` FROM `bills` LEFT JOIN `bill_ports` ON `bill_ports`.`bill_id`=`bills`.`bill_id` $sql GROUP BY `bill_name`,`bill_ref` ORDER BY `bill_name`", $param) as $bill) {
-        if (!bill_permitted($bill['bill_id'])) {
-            continue;
-        }
-
+    foreach (dbFetchRows("SELECT `bills`.*,COUNT(port_id) AS `ports_total` FROM `bills` LEFT JOIN `bill_ports` ON `bill_ports`.`bill_id`=`bills`.`bill_id` WHERE $sql GROUP BY `bill_name`,`bill_ref` ORDER BY `bill_name`", $param) as $bill) {
         $rate_data    = $bill;
         $allowed = '';
         $used = '';
@@ -1452,17 +1157,7 @@ function list_bills()
 
         $bills[] = $bill;
     }
-    $count = count($bills);
-    $output = array(
-        'status' => $status,
-        'message' => $message,
-        'err-msg' => $err_msg,
-        'count' => $count,
-        'bills' => $bills
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($bills, 'bills');
 }
 
 function update_device()
@@ -1471,58 +1166,45 @@ function update_device()
     global $config;
     $app = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
-    $status   = 'error';
-    $code     = 500;
     $hostname = $router['hostname'];
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     $data = json_decode(file_get_contents('php://input'), true);
     $bad_fields = array('device_id','hostname');
     if (empty($data['field'])) {
-        $message = 'Device field to patch has not been supplied';
+        api_error(400, 'Device field to patch has not been supplied');
     } elseif (in_array($data['field'], $bad_fields)) {
-        $message = 'Device field is not allowed to be updated';
-    } else {
-        if (is_array($data['field']) && is_array($data['data'])) {
-            foreach ($data['field'] as $tmp_field) {
-                if (in_array($tmp_field, $bad_fields)) {
-                    $message = 'Device field is not allowed to be updated';
-                }
-            }
-            if ($message == '' && count($data['field']) == count($data['data'])) {
-                for ($x=0; $x<count($data['field']); $x++) {
-                    $update[mres($data['field'][$x])] = mres($data['data'][$x]);
-                }
-                if (dbUpdate($update, 'devices', '`device_id`=?', array($device_id)) >= 0) {
-                    $status = 'ok';
-                    $code = 200;
-                    $message = 'Device fields have been updated';
-                } else {
-                    $message = 'Device fields failed to be updated';
-                }
-            } elseif ($message == '') {
-                $message = 'Device fields failed to be updated as the number of fields ('.count($data['field']).') does not match the supplied data ('.count($data['data']).')';
-            }
-        } elseif (dbUpdate(array(mres($data['field']) => mres($data['data'])), 'devices', '`device_id`=?', array($device_id)) >= 0) {
-            $status = 'ok';
-            $message = 'Device ' . mres($data['field']) . ' field has been updated';
-            $code = 200;
-        } else {
-            $message = 'Device ' . mres($data['field']) . ' field failed to be updated';
-        }
+        api_error(500, 'Device field is not allowed to be updated');
     }
-    $output = array(
-        'status'  => $status,
-        'message' => $message,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+
+    if (is_array($data['field']) && is_array($data['data'])) {
+        foreach ($data['field'] as $tmp_field) {
+            if (in_array($tmp_field, $bad_fields)) {
+                api_error(500, 'Device field is not allowed to be updated');
+            }
+        }
+        if ($message == '' && count($data['field']) == count($data['data'])) {
+            for ($x=0; $x<count($data['field']); $x++) {
+                $update[mres($data['field'][$x])] = mres($data['data'][$x]);
+            }
+            if (dbUpdate($update, 'devices', '`device_id`=?', array($device_id)) >= 0) {
+                api_success_noresult(200, 'Device fields have been updated');
+            } else {
+                api_error(500, 'Device fields failed to be updated');
+            }
+        } elseif ($message == '') {
+            api_error(500, 'Device fields failed to be updated as the number of fields ('.count($data['field']).') does not match the supplied data ('.count($data['data']).')');
+        }
+    } elseif (dbUpdate(array(mres($data['field']) => mres($data['data'])), 'devices', '`device_id`=?', array($device_id)) >= 0) {
+        api_success_noresult(200, 'Device ' . mres($data['field']) . ' field has been updated');
+    } else {
+        api_error(500, 'Device ' . mres($data['field']) . ' field failed to be updated');
+    }
 }
 
 function get_device_groups()
 {
-    check_is_admin();
+    check_is_read();
     $app = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     $status   = 'error';
@@ -1536,145 +1218,83 @@ function get_device_groups()
         $groups = GetDeviceGroups();
     }
     if (empty($groups)) {
-        $message = 'No device groups found';
-    } else {
-        $status = 'ok';
-        $code = 200;
-        $message = 'Found ' . count($groups) . ' device groups';
+        api_error(404, 'No device groups found');
     }
 
-    $output = array(
-        'status'  => $status,
-        'message' => $message,
-        'count'   => count($groups),
-        'groups'  => $groups,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($groups, 'groups', 'Found ' . count($groups) . ' device groups');
 }
 
 function get_devices_by_group()
 {
-    check_is_admin();
+    check_is_read();
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
-    $status   = 'error';
-    $code     = 404;
-    $count    = 0;
     $name     = urldecode($router['name']);
     $devices  = array();
     $full     = $_GET['full'];
     if (empty($name)) {
-        $message = 'No device group name provided';
-    } else {
-        $group_id = dbFetchCell("SELECT `id` FROM `device_groups` WHERE `name`=?", array($name));
-        $devices = GetDevicesFromGroup($group_id, true, $full);
-        $count = count($devices);
-        if (empty($devices)) {
-            $message = 'No devices found in group ' . $name;
-        } else {
-            $message = "Found $count in group $name";
-            $status = 'ok';
-            $code = 200;
-        }
+        api_error(400, 'No device group name provided');
     }
-    $output = array(
-        'status'  => $status,
-        'message' => $message,
-        'count'   => $count,
-        'devices' => $devices,
-    );
+    $group_id = dbFetchCell("SELECT `id` FROM `device_groups` WHERE `name`=?", array($name));
+    $devices = GetDevicesFromGroup($group_id, true, $full);
+    if (empty($devices)) {
+        api_error(404, 'No devices found in group ' . $name);
+    }
 
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($devices, 'devices');
 }
 
 function list_ipsec()
 {
-    check_is_admin();
+    check_is_read();
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
-    $status   = 'error';
-    $code     = 404;
-    $message  = '';
     $hostname = $router['hostname'];
-    $total    = 0;
     // use hostname as device_id if it's all digits
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     if (!is_numeric($device_id)) {
-        $message = "No valid hostname or device ID provided";
-    } else {
-        $ipsec  = dbFetchRows("SELECT `D`.`hostname`, `I`.* FROM `ipsec_tunnels` AS `I`, `devices` AS `D` WHERE `I`.`device_id`=? AND `D`.`device_id` = `I`.`device_id`", array($device_id));
-        $total  = count($ipsec);
-        $status = 'ok';
-        $code   = 200;
+        api_error(400, "No valid hostname or device ID provided");
     }
 
-    $output  = array(
-        'status'  => $status,
-        'err-msg' => $message,
-        'count'   => $total,
-        'ipsec'  => $ipsec,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    $ipsec  = dbFetchRows("SELECT `D`.`hostname`, `I`.* FROM `ipsec_tunnels` AS `I`, `devices` AS `D` WHERE `I`.`device_id`=? AND `D`.`device_id` = `I`.`device_id`", array($device_id));
+    api_success($ipsec, 'ipsec');
 }
 
 function list_arp()
 {
-    check_is_admin();
+    check_is_read();
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
-    $status   = 'error';
-    $code     = 404;
-    $message  = '';
     $ip       = $router['ip'];
     $hostname = mres($_GET['device']);
     $total    = 0;
     if (empty($ip)) {
-        $message = "No valid IP provided";
+        api_error(400, "No valid IP provided");
     } elseif ($ip === "all" && empty($hostname)) {
-        $message = "Device argument is required when requesting all entries";
-    } else {
-        $code = 200;
-        $status = 'ok';
-        if ($ip === "all") {
-            $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
-            $arp = dbFetchRows("SELECT `ipv4_mac`.* FROM `ipv4_mac` LEFT JOIN `ports` ON `ipv4_mac`.`port_id` = `ports`.`port_id` WHERE `ports`.`device_id` = ?", array($device_id));
-        } elseif (str_contains($ip, '/')) {
-            list($net, $cidr) = explode('/', $ip, 2);
-            $arp = dbFetchRows(
-                'SELECT * FROM `ipv4_mac` WHERE (inet_aton(`ipv4_address`) & ?) = ?',
-                array(cidr2long($cidr), ip2long($net))
-            );
-        } else {
-            $arp = dbFetchRows("SELECT * FROM `ipv4_mac` WHERE `ipv4_address`=?", array($ip));
-        }
-        $total = count($arp);
+        api_error(400, "Device argument is required when requesting all entries");
     }
-    $output  = array(
-        'status'  => $status,
-        'err-msg' => $message,
-        'count'   => $total,
-        'arp'     => $arp,
-    );
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+
+    if ($ip === "all") {
+        $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+        $arp = dbFetchRows("SELECT `ipv4_mac`.* FROM `ipv4_mac` LEFT JOIN `ports` ON `ipv4_mac`.`port_id` = `ports`.`port_id` WHERE `ports`.`device_id` = ?", array($device_id));
+    } elseif (str_contains($ip, '/')) {
+        list($net, $cidr) = explode('/', $ip, 2);
+        $arp = dbFetchRows(
+            'SELECT * FROM `ipv4_mac` WHERE (inet_aton(`ipv4_address`) & ?) = ?',
+            array(cidr2long($cidr), ip2long($net))
+        );
+    } else {
+        $arp = dbFetchRows("SELECT * FROM `ipv4_mac` WHERE `ipv4_address`=?", array($ip));
+    }
+    api_success($arp, 'arp');
 }
 
 function list_services()
 {
-    check_is_admin();
+    check_is_read();
     global $config;
     $app      = \Slim\Slim::getInstance();
     $router   = $app->router()->getCurrentRoute()->getParams();
-    $status   = 'ok';
-    $code     = 200;
-    $message  = '';
     $services = array();
     $where    = array();
     $params   = array();
@@ -1706,8 +1326,7 @@ function list_services()
         $params[] = $device_id;
 
         if (!is_numeric($device_id)) {
-            $status   = 'error';
-            $message = "No valid hostname or device id provided";
+            api_error(500, "No valid hostname or device id provided");
         }
     }
 
@@ -1719,22 +1338,12 @@ function list_services()
     $query .= ' ORDER BY `service_ip`';
     $services = array(dbFetchRows($query, $params)); // double array for backwards compat :(
 
-    $count = count($services);
-    $output = array(
-        'status'  => $status,
-        'err-msg' => $message,
-        'count'   => $count,
-        'services' => $services,
-    );
-
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($services, 'services');
 }
 
 function list_logs()
 {
-    check_is_admin();
+    check_is_read();
     global $config;
     $app = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
@@ -1758,9 +1367,6 @@ function list_logs()
         $timestamp = 'datetime';
     }
 
-    $message = '';
-    $status = 'ok';
-    $code = 200;
     $start = mres($_GET['start']) ?: 0;
     $limit = mres($_GET['limit']) ?: 50;
     $from = mres($_GET['from']);
@@ -1792,18 +1398,7 @@ function list_logs()
     $full_query = $full_query . $query . " ORDER BY $timestamp ASC LIMIT $start,$limit";
     $logs = dbFetchRows($full_query, $param);
 
-    $limited_count = count($logs);
-    $output = array(
-        'status' => $status,
-        'err-msg' => $message,
-        'count' => $limited_count,
-        'total' => $count,
-        'logs' => $logs,
-    );
-
-    $app->response->setStatus($code);
-    $app->response->headers->set('Content-Type', 'application/json');
-    echo _json_encode($output);
+    api_success($logs, 'logs', null, 200, null, array('total' => $count));
 }
 
 function validate_column_list($columns, $tableName)


### PR DESCRIPTION
The API functions do not contain any authorisation checks - as long as a valid API key is given, all functions are allowed, bypassing device/port/bill permissions.  Non-admin users cannot create their own key, but an admin can create a key for them.

This PR adds basic authorisation checks in.  Initially by adding fake $_SESSION variables, which mean that the standard is_admin/device_permitted/port_permitted/bill_permitted functions all work as expected.

I've also been through the API functions adding in the authorisation checks.  Anything I wasn't 100% sure about now has a is_admin requirement, as does any action function (add/edit/delete).  List devices/ports/bills respect user permissions.

Also added shortcut function for returning an error and finishing - api_error.

I've got no way to test alternate authentication mechanisms, but any auth code has been based  on includes/authentication.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
