### PR TITLE
API - Validate columns parameter against fields in table

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1702,7 +1702,11 @@ function validate_column_list($columns, $tableName)
     $app = \Slim\Slim::getInstance();
 
     $column_names = explode(',', $columns);
-    $valid_columns = dbFetchColumn("SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '{$config['db_name']}' AND TABLE_NAME=?", array($tableName));
+    $db_schema = Symfony\Component\Yaml\Yaml::parse(file_get_contents($config['install_dir'] . '/misc/db_schema.yaml'));
+    $valid_columns = array();
+    foreach ($db_schema[$tableName]['Columns'] as $col) {
+        $valid_columns[] = $col['Field'];
+    }
     $invalid_columns = array();
 
     foreach ($column_names as $col) {

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1699,27 +1699,18 @@ function list_logs()
 function validate_column_list($columns, $tableName)
 {
     global $config;
-    $app = \Slim\Slim::getInstance();
 
     $column_names = explode(',', $columns);
     $db_schema = Symfony\Component\Yaml\Yaml::parse(file_get_contents($config['install_dir'] . '/misc/db_schema.yaml'));
-    $valid_columns = array();
-    foreach ($db_schema[$tableName]['Columns'] as $col) {
-        $valid_columns[] = $col['Field'];
-    }
-    $invalid_columns = array();
+    $valid_columns = array_column($db_schema[$tableName]['Columns'], 'Field');
+    $invalid_columns = array_diff(array_map('trim', $column_names), $valid_columns);
 
-    foreach ($column_names as $col) {
-        $col = trim($col);
-        if (!in_array($col, $valid_columns)) {
-            $invalid_columns[] = $col;
-        }
-    }
     if (count($invalid_columns) > 0) {
         $output = array(
             'status'  => 'error',
             'message' => 'Invalid columns: ' . join(',', $invalid_columns),
         );
+        $app = \Slim\Slim::getInstance();
         $app->response->setStatus(400);     // Bad request
         $app->response->headers->set('Content-Type', 'application/json');
         echo _json_encode($output);

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1714,8 +1714,7 @@ function validate_column_list($columns, $tableName)
     if (count($invalid_columns) > 0) {
         $output = array(
             'status'  => 'error',
-            'err-msg' => 'Invalid columns: ' . join(',', $invalid_columns),
-            'ports'   => $ports,
+            'message' => 'Invalid columns: ' . join(',', $invalid_columns),
         );
         $app->response->setStatus(400);     // Bad request
         $app->response->headers->set('Content-Type', 'application/json');


### PR DESCRIPTION
API functions get_all_ports and get_port_graphs had an SQL injection vulnerability as they take a list of columns to include and do not validate this.  This PR adds that validation in.

Example URL: `/api/v0/devices/1/ports?columns=VERSION()--`

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
