### PR TITLE
fix: enexus do not disable the os discovery module

### DIFF
--- a/includes/definitions/enexus.yaml
+++ b/includes/definitions/enexus.yaml
@@ -6,30 +6,17 @@ nobulk: 1
 mib_dir:
     - eltek
 discovery:
-    -
-      snmpget:
+    - snmpget:
           oid: .1.3.6.1.4.1.12148.10.2.6.0
-          value:
-            - 'Micropack System'
+          value: 'Micropack System'
 poller_modules:
-    applications: 0
-    bgp-peers: 0
     entity-physical: 0
     hr-mib: 0
     ipSystemStats: 0
-    ipmi: 0
-    mempools: 0
     netstats: 0
-    ntp: 0
     ospf: 0
-    processors: 0
-    services: 0
-    storage: 0
-    ucd-diskio: 0
     ucd-mib: 0
-    wireless: 0
     ports: 0
-    wifi: 0
     stp: 0
 discovery_modules:
     ports-stack: 0
@@ -45,12 +32,8 @@ discovery_modules:
     arp-table: 0
     bgp-peers: 0
     ucd-diskio: 0
-    services: 0
-    ntp: 0
-    wireless: 0
-    charge: 0
     fdb-table: 0
     stp: 0
     vlans: 0
     ports: 0
-    os: 0
+


### PR DESCRIPTION
and other modules it is pointless to disable

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
