### PR TITLE
Better default temperature sensor limits

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -381,7 +381,7 @@ function sensor_low_limit($class, $current)
 
     switch ($class) {
         case 'temperature':
-            $limit = ($current * 0.7);
+            $limit = $current - 10;
             break;
         case 'voltage':
             if ($current < 0) {
@@ -426,7 +426,7 @@ function sensor_limit($class, $current)
 
     switch ($class) {
         case 'temperature':
-            $limit = ($current * 1.60);
+            $limit = $current + 20;
             break;
         case 'voltage':
             if ($current < 0) {

--- a/includes/discovery/sensors/temperature/routeros.inc.php
+++ b/includes/discovery/sensors/temperature/routeros.inc.php
@@ -18,7 +18,7 @@ foreach (explode("\n", $oids) as $data) {
         $oid              = '.1.3.6.1.4.1.14988.1.1.3.10.'.$index;
         $temperature      = (snmp_get($device, $oid, '-Oqv') / $divisor);
 
-        discover_sensor($valid['sensor'], 'temperature', $device, $oid, $insert_index, $type, $descr, $divisor, '1', null, null, null, null, $temperature);
+        discover_sensor($valid['sensor'], 'temperature', $device, $oid, $insert_index, $type, $descr, $divisor, '1', -40, -35, 65, 70, $temperature);
         $insert_index++;
     }
 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This pull request contains two patches to improve temperature sensor discovery.

One changes the default temperature sensor limits from scaled to static. Before this patch, the default temperature sensor limits were 70% through 160% of the current value at time of discovery. At 20C this resulted in a pretty useful range of 14-32C. However, for devices in spaces with lower temperatures, 3C for example, it set default temperature limits of 2.1-4.8C. At negative temperatures, the limits flip flop! This has nothing to do with the temperature specification of the device and for values near zero it causes alert flapping. My solution is to make the defaults static (yet relative), rather than scaled, so that single digit temperatures have ranges just as broad as double digit temperatures: `$current - 10` through `$current + 20`. At a typical temperature of 20C, this is roughly equivalent to the limits set by the old scaling.

The other patch adds defaults for Mikrotik RouterOS hardware. A quick survey of Mikrotik hardware shows that most devices are rated for or close to -40C through 70C.

* https://mikrotik.com/product/RB922UAGS-5HPacT-NM
* https://mikrotik.com/product/RB2011UiAS-2HnD-IN
* https://mikrotik.com/product/CRS125-24G-1S-IN

Rather than let LibreNMS choose defaults for these based on the temperature at the time of discovery, I've hardcoded the operating temperatures specified in the Mikrotik data sheets.