### PR TITLE
Fix: Authentication on CentOS6

### DIFF
--- a/LibreNMS/Authentication/AuthorizerBase.php
+++ b/LibreNMS/Authentication/AuthorizerBase.php
@@ -143,7 +143,7 @@ abstract class AuthorizerBase implements Authorizer
             $db_entry['session_token'] = $token;
             $db_entry['session_auth'] = $auth;
             dbInsert($db_entry, 'session');
-        }\
+        }
 
         setcookie('sess_id', $sess_id, $expiration, '/', null, Config::get('secure_cookies'), true);
         setcookie('token', $token_id, $expiration, '/', null, Config::get('secure_cookies'), true);
@@ -200,9 +200,6 @@ abstract class AuthorizerBase implements Authorizer
         setcookie('auth', '', $time, '/', null, Config::get('secure_cookies'));
     }
 
-
-    abstract public function authenticate($username, $password);
-
     public function reauthenticate($sess_id, $token)
     {
         //not supported by default
@@ -231,21 +228,11 @@ abstract class AuthorizerBase implements Authorizer
         return 0;
     }
 
-    abstract public function userExists($username, $throw_exception = false);
-
-    abstract public function getUserlevel($username);
-
-    abstract public function getUserid($username);
-
-    abstract public function getUser($user_id);
-
     public function deleteUser($userid)
     {
         //not supported by default
         return 0;
     }
-
-    abstract public function getUserlist();
 
     public function canUpdateUsers()
     {


### PR DESCRIPTION
There is no need to redeclare abstract functions if the class is already abstract and they are declared in parent.
For some reason the PHP on CentOS 6 throws an error with this where all other php versions I tested were fine with it.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
