### PR TITLE
api: Stop list_logs skipping first row

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1662,7 +1662,7 @@ function list_logs()
     $message = '';
     $status = 'ok';
     $code = 200;
-    $start = mres($_GET['start']) ?: 1;
+    $start = mres($_GET['start']) ?: 0;
     $limit = mres($_GET['limit']) ?: 50;
     $from = mres($_GET['from']);
     $to = mres($_GET['to']);


### PR DESCRIPTION
The list_logs API functions include start and limit parameters, but start defaults to 1 instead of 0, resulting in the first row of the resultset being skipped if start is not specified in the URL params.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
