### PR TITLE
fix: Use correct entity columns for sensors

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -206,7 +206,7 @@ function discover_device(&$device, $options = null)
 //end discover_device()
 
 // Discover sensors
-function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, $divisor = 1, $multiplier = 1, $low_limit = null, $low_warn_limit = null, $warn_limit = null, $high_limit = null, $current = null, $poller_type = 'snmp', $entPhysicalIndex = null, $entPhysicalIndex_measured = null, $user_func = null, $entity_link_type = null, $entity_link_index = 0)
+function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, $divisor = 1, $multiplier = 1, $low_limit = null, $low_warn_limit = null, $warn_limit = null, $high_limit = null, $current = null, $poller_type = 'snmp', $entPhysicalIndex = null, $entPhysicalIndex_measured = null, $user_func = null)
 {
     $low_limit      = set_null($low_limit);
     $low_warn_limit = set_null($low_warn_limit);
@@ -260,8 +260,6 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             'entPhysicalIndex' => $entPhysicalIndex,
             'entPhysicalIndex_measured' => $entPhysicalIndex_measured,
             'user_func' => $user_func,
-            'entity_link_type' => $entity_link_type,
-            'entity_link_index' => $entity_link_index,
         );
 
         foreach ($insert as $key => $val_check) {
@@ -346,9 +344,7 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
             $divisor == $sensor_entry['sensor_divisor'] &&
             $entPhysicalIndex_measured == $sensor_entry['entPhysicalIndex_measured'] &&
             $entPhysicalIndex == $sensor_entry['entPhysicalIndex'] &&
-            $user_func == $sensor_entry['user_func'] &&
-            $entity_link_type == $sensor_entry['entity_link_type'] &&
-            $entity_link_index == $sensor_entry['entity_link_index']
+            $user_func == $sensor_entry['user_func']
 
         ) {
             echo '.';
@@ -361,8 +357,6 @@ function discover_sensor(&$valid, $class, $device, $oid, $index, $type, $descr, 
                 'entPhysicalIndex' => $entPhysicalIndex,
                 'entPhysicalIndex_measured' => $entPhysicalIndex_measured,
                 'user_func' => $user_func,
-                'entity_link_type' => $entity_link_type,
-                'entity_link_index' => $entity_link_index,
             );
             $updated = dbUpdate($update, 'sensors', '`sensor_id` = ?', array($sensor_entry['sensor_id']));
             echo 'U';

--- a/includes/discovery/sensors/cisco-entity-sensor.inc.php
+++ b/includes/discovery/sensors/cisco-entity-sensor.inc.php
@@ -168,8 +168,8 @@ if ($device['os_group'] == 'cisco') {
                                 list(, $tmp_ifindex) = explode(".", $entity_array[$phys_index][0]['entAliasMappingIdentifier']);
                                 $tmp_port = get_port_by_index_cache($device['device_id'], $tmp_ifindex);
                                 if (is_array($tmp_port)) {
-                                    $entity_link_type = 'port';
-                                    $entity_link_index = $tmp_ifindex;
+                                    $entPhysicalIndex                 = $tmp_ifindex;
+                                    $entry['entSensorMeasuredEntity'] = 'ports';
                                 }
                             }
                             break;
@@ -177,7 +177,7 @@ if ($device['os_group'] == 'cisco') {
                             $phys_index = $entity_array[$phys_index]['entPhysicalContainedIn'];
                         }
                     }
-                    discover_sensor($valid['sensor'], $type, $device, $oid, $index, 'cisco-entity-sensor', ucwords($descr), $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entry['entSensorMeasuredEntity'], null, $entity_link_type, $entity_link_index);
+                    discover_sensor($valid['sensor'], $type, $device, $oid, $index, 'cisco-entity-sensor', ucwords($descr), $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entry['entSensorMeasuredEntity'], null);
                     #Cisco IOS-XR : add a fake sensor to graph as dbm
                     if ($type == "power" and $device['os'] == "iosxr" and (preg_match("/power (R|T)x/i", $descr) or preg_match("/(R|T)x Power/i", $descr))) {
                             // convert Watts to dbm
@@ -190,7 +190,7 @@ if ($device['os_group'] == 'cisco') {
                             $multiplier = 1;
                             $divisor = 1;
                             //echo("\n".$valid['sensor'].", $type, $device, $oid, $index, 'cisco-entity-sensor', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current");
-                            discover_sensor($valid['sensor'], $type, $device, $oid, $index, 'cisco-entity-sensor', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entry['entSensorMeasuredEntity'], null, $entity_link_type, $entity_link_index);
+                            discover_sensor($valid['sensor'], $type, $device, $oid, $index, 'cisco-entity-sensor', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entry['entSensorMeasuredEntity'], null);
                     }
                 }
 

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1337,8 +1337,6 @@ sensors:
     - { Field: lastupdate, Type: timestamp, 'Null': false, Extra: 'on update CURRENT_TIMESTAMP', Default: CURRENT_TIMESTAMP }
     - { Field: sensor_prev, Type: float, 'Null': true, Extra: '' }
     - { Field: user_func, Type: varchar(100), 'Null': true, Extra: '' }
-    - { Field: entity_link_type, Type: varchar(32), 'Null': true, Extra: '' }
-    - { Field: entity_link_index, Type: 'int(11) unsigned', 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sensor_id], Unique: true, Type: BTREE }
     sensor_host: { Name: sensor_host, Columns: [device_id], Unique: false, Type: BTREE }

--- a/sql-schema/216.sql
+++ b/sql-schema/216.sql
@@ -1,0 +1,5 @@
+UPDATE `sensors` SET `entPhysicalIndex_measured` = 'ports', `entPhysicalIndex` = entity_link_index WHERE entity_link_type='port';
+UPDATE `config` SET `config_value` = "(%sensors.entPhysicalIndex_measured = 'ports' && %sensors.entPhysicalIndex = %ports.ifIndex && %macros.port_up)", `config_default`  = "(%sensors.entPhysicalIndex_measured = 'ports' && %sensors.entPhysicalIndex = %ports.ifIndex && %macros.port_up)" WHERE `config_name` = 'alert.macros.rule.sensor_port_link';
+UPDATE `alert_rules` SET `query` = REPLACE(query, 'entity_link_type', 'entPhysicalIndex_measured');
+UPDATE `alert_rules` SET `query` = REPLACE(query, 'entity_link_index', 'entPhysicalIndex');
+ALTER TABLE `sensors` DROP `entity_link_type` , DROP `entity_link_index`;

--- a/sql-schema/216.sql
+++ b/sql-schema/216.sql
@@ -2,4 +2,6 @@ UPDATE `sensors` SET `entPhysicalIndex_measured` = 'ports', `entPhysicalIndex` =
 UPDATE `config` SET `config_value` = "(%sensors.entPhysicalIndex_measured = 'ports' && %sensors.entPhysicalIndex = %ports.ifIndex && %macros.port_up)", `config_default`  = "(%sensors.entPhysicalIndex_measured = 'ports' && %sensors.entPhysicalIndex = %ports.ifIndex && %macros.port_up)" WHERE `config_name` = 'alert.macros.rule.sensor_port_link';
 UPDATE `alert_rules` SET `query` = REPLACE(query, 'entity_link_type', 'entPhysicalIndex_measured');
 UPDATE `alert_rules` SET `query` = REPLACE(query, 'entity_link_index', 'entPhysicalIndex');
+UPDATE `alert_rules` SET `rule` = REPLACE(rule, 'entity_link_type', 'entPhysicalIndex_measured');
+UPDATE `alert_rules` SET `rule` = REPLACE(rule, 'entity_link_index', 'entPhysicalIndex');
 ALTER TABLE `sensors` DROP `entity_link_type` , DROP `entity_link_index`;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Shouldn't have created these two columns in the first place.

This fixes that, updates the config macro, updates the existing alert rules, updates the sensors tables and then drops the old columns.

Only port was used in this regards so these queries are safe and we don't lose any other data.