### PR TITLE
fix: reduce chance of incorrect os detection

### DIFF
--- a/includes/definitions/ddnos.yaml
+++ b/includes/definitions/ddnos.yaml
@@ -11,5 +11,5 @@ discovery:
       sysObjectId: .1.3.6.1.4.1.8072.3.2.10
       snmpget:
           oid: SFA-INFO::systemName.0
-          op: '!=='
+          op: '!='
           value: false

--- a/includes/definitions/dsm.yaml
+++ b/includes/definitions/dsm.yaml
@@ -17,7 +17,7 @@ discovery:
           oid: systemStatus.0
           mib: SYNOLOGY-SYSTEM-MIB
           mib_dir: synology
-          op: '!=='
+          op: '!='
           value: false
     -
       sysDescr_regex: '/^Linux /'

--- a/includes/definitions/extrahop.yaml
+++ b/includes/definitions/extrahop.yaml
@@ -16,5 +16,5 @@ discovery:
           oid: extrahopInfoVersionString
           mib: EXTRAHOP-MIB
           mib_dir: extrahop
-          op: '!=='
+          op: '!='
           value: false

--- a/includes/definitions/pcoweb.yaml
+++ b/includes/definitions/pcoweb.yaml
@@ -17,5 +17,5 @@ discovery:
           oid: roomTemp.0
           mib: CAREL-ug40cdz-MIB
           mib_dir: carel
-          op: '!=='
+          op: '!='
           value: false

--- a/includes/definitions/pktj.yaml
+++ b/includes/definitions/pktj.yaml
@@ -13,5 +13,5 @@ discovery:
       sysDescr_regex: '/^Linux/'
       snmpget:
           oid: GANDI-MIB::rxCounter.0
-          op: '!=='
+          op: '!='
           value: false


### PR DESCRIPTION
I think using the strict check was causing some of our odd incorrect os detection.  The previous php code was not using a strict check, so revert to that.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
