### PR TITLE
docs: build new Cleanup Options doc

### DIFF
--- a/doc/Support/Cleanup-options.md
+++ b/doc/Support/Cleanup-options.md
@@ -1,0 +1,20 @@
+source: Support/Cleanup-options.md
+
+#  Cleanup Options
+As the number of devices starts to grow in your LibreNMS install, such as the database RRD files, event log, Syslog, system performance and timing logs etc. Your LibreNMS install could become quite large so  it becomes necessary to clean up those entries. With Cleanup Options, you can keep in crontrol. 
+
+Cleanup Options are set in ```config.php```
+
+These options rely on ```daily.sh``` running from cron as per the installation instructions.
+
+```php
+$config['syslog_purge']                                   = 30;
+$config['eventlog_purge']                                 = 30;
+$config['authlog_purge']                                  = 30;
+$config['perf_times_purge']                               = 30;
+$config['device_perf_purge']                              = 7;
+$config['rrd_purge']                                      = 90;// Not set by default
+```
+These options will ensure data within LibreNMS over X days old is automatically purged. You can alter these individually, values are in days.
+
+**NOTE**: Please be aware that ```$config['rrd_purge']``` is NOT set by default. This option will remove any old data within the rrd directory automatically - only enable this if you are comfortable with that happening.

--- a/doc/Support/Cleanup-options.md
+++ b/doc/Support/Cleanup-options.md
@@ -1,11 +1,11 @@
 source: Support/Cleanup-options.md
 
 #  Cleanup Options
-As the number of devices starts to grow in your LibreNMS install, such as the database RRD files, event log, Syslog, system performance and timing logs etc. Your LibreNMS install could become quite large so  it becomes necessary to clean up those entries. With Cleanup Options, you can keep in crontrol. 
-
-Cleanup Options are set in ```config.php```
+As the number of devices starts to grow in your LibreNMS install, such as the database RRD files, event log, Syslog, system performance and timing logs etc. Your LibreNMS install could become quite large so it becomes necessary to clean up those entries. With Cleanup Options, you can keep in crontrol. 
 
 These options rely on ```daily.sh``` running from cron as per the installation instructions.
+
+Cleanup Options are set in ```config.php```
 
 ```php
 $config['syslog_purge']                                   = 30;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ pages:
       - Extensions/IRC-Bot-Extensions.md
       - Extensions/SNMP-Proxy.md
       - Extensions/SNMP-Trap-Handler.md
+      - Support/Cleanup-options.md
   - 6. 3rd Party Integration:
       - Extensions/Graylog.md
       - Nagios Plugins: Extensions/Services.md


### PR DESCRIPTION
Created new clean up options. Found that the Cleanup Options are difficult to find in the configuration doc. 

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
