### PR TITLE
refactor fix php codesniffer 3.x issues

### DIFF
--- a/LibreNMS/Component.php
+++ b/LibreNMS/Component.php
@@ -302,7 +302,7 @@ class Component
             }
 
             // Ignore type, we cant change that.
-            unset($AVP['type'],$OLD[$device_id][$COMPONENT]['type']);
+            unset($AVP['type'], $OLD[$device_id][$COMPONENT]['type']);
 
             // If the Status has changed we need to add a log entry
             if ($AVP['status'] != $OLD[$device_id][$COMPONENT]['status']) {
@@ -322,7 +322,7 @@ class Component
                     }
 
                     // Unset the reserved field. We don't want to insert it below.
-                    unset($AVP[$k],$OLD[$device_id][$COMPONENT][$k]);
+                    unset($AVP[$k], $OLD[$device_id][$COMPONENT][$k]);
                 }
             }
 

--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -163,7 +163,7 @@ class Config
      * @param string $group webui group (only set when initially created)
      * @param string $sub_group webui subgroup (only set when initially created)
      */
-    public static function set($key, $value, $persist = false, $default ='', $descr='', $group='', $sub_group='')
+    public static function set($key, $value, $persist = false, $default = '', $descr = '', $group = '', $sub_group = '')
     {
         global $config;
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "palanik/corsslim": "^1.1"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "2.6.*",
+        "squizlabs/php_codesniffer": "^2.9.1",
         "phpunit/phpunit": "4.*",
         "jakub-onderka/php-parallel-lint": "*",
         "jakub-onderka/php-console-highlighter": "*",

--- a/html/ajax_rulesuggest.php
+++ b/html/ajax_rulesuggest.php
@@ -63,7 +63,7 @@ header('Content-type: application/json');
 $obj     = array(array('name' => 'Error: No suggestions found.'));
 $term    = array();
 $current = false;
-if (isset($_GET['term'],$_GET['device_id'])) {
+if (isset($_GET['term'], $_GET['device_id'])) {
     $chk               = array();
     $_GET['term']      = mres($_GET['term']);
     $_GET['device_id'] = mres($_GET['device_id']);

--- a/html/includes/forms/create-alert-item.inc.php
+++ b/html/includes/forms/create-alert-item.inc.php
@@ -80,7 +80,7 @@ if (empty($rule)) {
                     $_POST['target'] = $target;
                     $_POST['map_id'] = '';
                     include 'create-map-item.inc.php';
-                    unset($ret,$target,$raw,$rule,$msg,$map_id);
+                    unset($ret, $target, $raw, $rule, $msg, $map_id);
                 }
             }
         } else {

--- a/html/includes/forms/test-transport.inc.php
+++ b/html/includes/forms/test-transport.inc.php
@@ -50,7 +50,7 @@ if (file_exists($config['install_dir']."/includes/alerts/transport.".$transport.
     $opts = $config['alert']['transports'][$transport];
     if ($opts) {
         eval('$tmp = function($obj,$opts) { global $config; '.file_get_contents($config['install_dir'].'/includes/alerts/transport.'.$transport.'.php').' return false; };');
-        $tmp = $tmp($obj,$opts);
+        $tmp = $tmp($obj, $opts);
         if ($tmp) {
             $status = 'ok';
         }

--- a/html/includes/modal/new_bill.inc.php
+++ b/html/includes/modal/new_bill.inc.php
@@ -12,7 +12,7 @@
  */
 if (is_admin() !== false) {
     require 'includes/javascript-interfacepicker.inc.php';
-    
+
     $port_device_id = -1;
     if (is_numeric($vars['port'])) {
         $port = dbFetchRow('SELECT * FROM `ports` AS P, `devices` AS D WHERE `port_id` = ? AND D.device_id = P.device_id', array($vars['port']));
@@ -53,7 +53,8 @@ if (is_admin() !== false) {
                     <label class="col-sm-4 control-label" for="port_id">Port</label>
                     <div class="col-sm-8">
                         <select class="form-control input-sm" id="port_id" name="port_id">
-                        <?php if (is_array($port)) {
+                        <?php
+                        if (is_array($port)) {
                             // Need to pre-populate port as we've got a port pre-selected
                             foreach (dbFetch('SELECT * FROM ports WHERE device_id = ?', array($port_device_id)) as $interface) {
                                 $interface  = cleanPort($interface);
@@ -61,11 +62,12 @@ if (is_admin() !== false) {
                                 $selected = $interface['port_id'] === $port['port_id'] ? " selected" : "";
                                 echo "<option value='${interface['port_id']}' $selected>$string</option>\n";
                             }
-}   ?>
+                        }
+                        ?>
                         </select>
                     </div>
-                </div>                
-                
+                </div>
+
 <?php
 
     $bill_data['bill_type'] = 'cdr';

--- a/html/install.php
+++ b/html/install.php
@@ -221,9 +221,12 @@ echo "</td></tr>";
       <div class="col-md-6 col-md-offset-3">
         <form class="form-inline" role="form" method="post">
           <input type="hidden" name="stage" value="1">
-          <button type="submit" class="btn btn-success pull-right" <?php if (!$complete) {
+          <button type="submit" class="btn btn-success pull-right"
+            <?php
+            if (!$complete) {
                 echo "disabled='disabled'";
-} ?>>Next Stage</button>
+            }
+            ?>>Next Stage</button>
         </form>
       </div>
     </div>
@@ -498,9 +501,12 @@ if (Auth::get()->canManageUsers()) {
           <input type="hidden" name="dbpass" value="<?php echo $dbpass; ?>">
           <input type="hidden" name="dbname" value="<?php echo $dbname; ?>">
           <input type="hidden" name="dbsocket" value="<?php echo $dbsocket; ?>">
-          <button type="submit" class="btn btn-success pull-right" <?php if ($proceed == "1") {
+          <button type="submit" class="btn btn-success pull-right"
+            <?php
+            if ($proceed == "1") {
                 echo "disabled='disabled'";
-} ?>>Generate Config</button>
+            }
+            ?>>Generate Config</button>
         </form>
       </div>
       <div class="col-md-3">

--- a/html/pages/bill.inc.php
+++ b/html/pages/bill.inc.php
@@ -99,41 +99,41 @@ if (bill_permitted($bill_id)) {
         'transfer' => 'Transfer Graphs',
         'history' => 'Historical Graphs'
     );
-    if ($_SESSION['userlevel'] >= '10') {
-        $menu_options['edit'] = 'Edit';
-        $menu_options['delete'] = 'Delete';
-        $menu_options['reset'] = 'Reset';
-    }
+if ($_SESSION['userlevel'] >= '10') {
+    $menu_options['edit'] = 'Edit';
+    $menu_options['delete'] = 'Delete';
+    $menu_options['reset'] = 'Reset';
+}
     $sep = '';
-    foreach ($menu_options as $option => $text) {
-        echo $sep;
-        if ($vars['view'] == $option) {
-            echo "<span class='pagemenu-selected'>";
-        }
-
-        echo generate_link($text, $vars, array('view' => $option));
-        if ($vars['view'] == $option) {
-            echo '</span>';
-        }
-
-        $sep = ' | ';
+foreach ($menu_options as $option => $text) {
+    echo $sep;
+    if ($vars['view'] == $option) {
+        echo "<span class='pagemenu-selected'>";
     }
+
+    echo generate_link($text, $vars, array('view' => $option));
+    if ($vars['view'] == $option) {
+        echo '</span>';
+    }
+
+    $sep = ' | ';
+}
     
     echo '<div style="font-weight: bold; float: right;"><a href="'.generate_url(array('page' => 'bills')).'/"><i class="fa fa-arrow-left fa-lg icon-theme" aria-hidden="true"></i> Back to Bills</a></div>';
 
     print_optionbar_end();
 
-    if ($vars['view'] == 'edit' && $_SESSION['userlevel'] >= '10') {
-        include 'pages/bill/edit.inc.php';
-    } elseif ($vars['view'] == 'delete' && $_SESSION['userlevel'] >= '10') {
-        include 'pages/bill/delete.inc.php';
-    } elseif ($vars['view'] == 'reset' && $_SESSION['userlevel'] >= '10') {
-        include 'pages/bill/reset.inc.php';
-    } elseif ($vars['view'] == 'history') {
-        include 'pages/bill/history.inc.php';
-    } elseif ($vars['view'] == 'transfer') {
-        include 'pages/bill/transfer.inc.php';
-    } elseif ($vars['view'] == 'quick' || $vars['view'] == 'accurate') {
+if ($vars['view'] == 'edit' && $_SESSION['userlevel'] >= '10') {
+    include 'pages/bill/edit.inc.php';
+} elseif ($vars['view'] == 'delete' && $_SESSION['userlevel'] >= '10') {
+    include 'pages/bill/delete.inc.php';
+} elseif ($vars['view'] == 'reset' && $_SESSION['userlevel'] >= '10') {
+    include 'pages/bill/reset.inc.php';
+} elseif ($vars['view'] == 'history') {
+    include 'pages/bill/history.inc.php';
+} elseif ($vars['view'] == 'transfer') {
+    include 'pages/bill/transfer.inc.php';
+} elseif ($vars['view'] == 'quick' || $vars['view'] == 'accurate') {
 ?>
 
 <?php   if ($bill_data['bill_type'] == 'quota') { ?>
@@ -147,18 +147,18 @@ if (bill_permitted($bill_id)) {
 <br /><br />
 
 <div class="row">
-    <div class="col-lg-6 col-lg-push-6">
-        <?php print_port_list() ?>
+<div class="col-lg-6 col-lg-push-6">
+    <?php print_port_list() ?>
+</div>
+<div class="col-lg-6 col-lg-pull-6">
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">
+            Bill Summary
+        </h3>
     </div>
-    <div class="col-lg-6 col-lg-pull-6">
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">
-                Bill Summary
-            </h3>
-        </div>
-        <table class="table">
-        <tr>
+    <table class="table">
+    <tr>
 <?php   if ($bill_data['bill_type'] == 'quota') {
             // The Customer is billed based on a pre-paid quota with overage in xB
             $percent    = round((($total_data) / $bill_data['bill_quota'] * 100), 2);
@@ -204,17 +204,17 @@ if (bill_permitted($bill_id)) {
 
 <?php           }//end if
 ?>
-        </tr>
-        </table>
-    </div>
-    </div>
-    </div>
+    </tr>
+    </table>
+</div>
+</div>
+</div>
 
 <?php
 
-        $lastmonth = dbFetchCell('SELECT UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 1 MONTH))');
-        $yesterday = dbFetchCell('SELECT UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 1 DAY))');
-        $rightnow  = date(U);
+    $lastmonth = dbFetchCell('SELECT UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 1 MONTH))');
+    $yesterday = dbFetchCell('SELECT UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 1 DAY))');
+    $rightnow  = date(U);
 
 if ($vars['view'] == 'accurate') {
     $bi  = "<img src='billing-graph.php?bill_id=".$bill_id.'&amp;bill_code='.$_GET['bill_code'];
@@ -255,28 +255,28 @@ if ($vars['view'] == 'accurate') {
 }//end if
 
 ?>
-    <div class="panel panel-default">
-    <div class="panel-heading">
-        <h3 class="panel-title">Billing View</h3>
-    </div>
-    <?php echo $bi ?>
-    </div>
+<div class="panel panel-default">
+<div class="panel-heading">
+    <h3 class="panel-title">Billing View</h3>
+</div>
+<?php echo $bi ?>
+</div>
     
-    <div class="panel panel-default">
-    <div class="panel-heading">
-        <h3 class="panel-title">24 Hour View</h3>
-    </div>
-    <?php echo $di ?>
-    </div>
+<div class="panel panel-default">
+<div class="panel-heading">
+    <h3 class="panel-title">24 Hour View</h3>
+</div>
+<?php echo $di ?>
+</div>
 
-    <div class="panel panel-default">
-    <div class="panel-heading">
-        <h3 class="panel-title">Monthly View</h3>
-    </div>
-    <?php echo $mi ?>
-    </div>    
+<div class="panel panel-default">
+<div class="panel-heading">
+    <h3 class="panel-title">Monthly View</h3>
+</div>
+<?php echo $mi ?>
+</div>    
 <?php
-    } //end if
+} //end if
 } else {
     include 'includes/error-no-perm.inc.php';
 }//end if

--- a/html/pages/bill/addoreditbill.inc.php
+++ b/html/pages/bill/addoreditbill.inc.php
@@ -9,14 +9,20 @@
   <label class="col-sm-4 control-label" for="bill_type">Billing Type</label>
   <div class="col-sm-8">
     <label class="radio-inline">
-      <input type="radio" name="bill_type" id="bill_type_cdr" value="cdr" <?php if ($bill_data['bill_type'] == 'cdr') {
-            echo "checked";
-} ?> onchange="javascript: billType();" /> CDR 95th
+      <input type="radio" name="bill_type" id="bill_type_cdr" value="cdr"
+            <?php
+            if ($bill_data['bill_type'] == 'cdr') {
+                echo "checked";
+            }
+            ?> onchange="javascript: billType();" /> CDR 95th
     </label>
     <label class="radio-inline">
-      <input type="radio" name="bill_type" id="bill_type_quota" value="quota" <?php if ($bill_data['bill_type'] == 'quota') {
-            echo "checked";
-} ?> onchange="javascript: billType();" /> Quota
+      <input type="radio" name="bill_type" id="bill_type_quota" value="quota"
+            <?php
+            if ($bill_data['bill_type'] == 'quota') {
+                echo "checked";
+            }
+            ?> onchange="javascript: billType();" /> Quota
     </label>
   </div>
 </div>
@@ -86,7 +92,7 @@
 <script type="text/javascript">
 function billType() {
     var selected = $('input[name=bill_type]:checked').val();
-    
+
     $('#cdrDiv').toggle(selected === 'cdr');
     $('#quotaDiv').toggle(selected === 'quota');
 }

--- a/html/pages/bill/edit.inc.php
+++ b/html/pages/bill/edit.inc.php
@@ -128,7 +128,7 @@ if ($bill_data['bill_type'] == 'cdr') {
         <?php   }
 if (!$emptyCheck) { ?>
                 <div class="alert alert-info">There are no ports assigned to this bill</alert>
-        <?php                   } ?>
+<?php                   } ?>
             
             </div>
                 

--- a/html/pages/bills.inc.php
+++ b/html/pages/bills.inc.php
@@ -7,7 +7,7 @@ if ($_POST['addbill'] == 'yes') {
         include 'includes/error-no-perm.inc.php';
         exit;
     }
-    
+
     $updated = '1';
 
     if (isset($_POST['bill_quota']) or isset($_POST['bill_cdr'])) {
@@ -78,7 +78,7 @@ if ($_POST['addbill'] == 'yes') {
     if (is_numeric($bill_id) && is_numeric($_POST['port_id'])) {
         dbInsert(array('bill_id' => $bill_id, 'port_id' => $_POST['port_id']), 'bill_ports');
     }
-    
+
     header('Location: ' . generate_url(array('page' => 'bill', 'bill_id' => $bill_id, 'view' => 'edit')));
     exit();
 }
@@ -109,14 +109,14 @@ include 'includes/modal/new_bill.inc.php';
         </table>
     </div>
 </div>
-    
+
 <script type="text/html" id="table-header">
     <div id="{{ctx.id}}" class="{{css.header}}">
         <div class="row">
             <div class="col-sm-4">
             <?php if ($_SESSION['userlevel'] >= 10) {  ?>
                 <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#create-bill"><i class="fa fa-plus"></i> Create Bill</button>
-            <?php } ?>     
+            <?php } ?>
             </div>
             <div class="col-sm-8 actionBar">
                 <span class="form-inline" id="table-filters">
@@ -127,21 +127,33 @@ include 'includes/modal/new_bill.inc.php';
                     </select>
                     <select name='bill_type' id='bill_type' class="form-control input-sm">
                       <option value=''>All Types</option>
-                      <option value='cdr' <?php if ($_GET['bill_type'] === 'cdr') {
-                            echo 'selected';
-} ?>>CDR</option>
-                      <option value='quota' <?php if ($_GET['bill_type'] === 'quota') {
-                            echo 'selected';
-} ?>>Quota</option>
+                      <option value='cdr'
+                            <?php
+                            if ($_GET['bill_type'] === 'cdr') {
+                                echo 'selected';
+                            }
+                            ?>>CDR</option>
+                      <option value='quota'
+                            <?php
+                            if ($_GET['bill_type'] === 'quota') {
+                                echo 'selected';
+                            }
+                            ?>>Quota</option>
                     </select>
                     <select name='state' id='state' class="form-control input-sm">
                       <option value=''>All States</option>
-                      <option value='under' <?php if ($_GET['state'] === 'under') {
-                            echo 'selected';
-} ?>>Under Quota</option>
-                      <option value='over' <?php if ($_GET['state'] === 'over') {
-                            echo 'selected';
-} ?>>Over Quota</option>
+                      <option value='under'
+                            <?php
+                            if ($_GET['state'] === 'under') {
+                                echo 'selected';
+                            }
+                            ?>>Under Quota</option>
+                      <option value='over'
+                            <?php
+                            if ($_GET['state'] === 'over') {
+                                echo 'selected';
+                            }
+                            ?>>Over Quota</option>
                     </select>
                   </fieldset>
                 </span>
@@ -151,7 +163,7 @@ include 'includes/modal/new_bill.inc.php';
         </div>
     </div>
 </script>
-    
+
 <script type="text/javascript">
     var grid = $('#bills-list').bootgrid({
        ajax: true,
@@ -172,12 +184,12 @@ include 'includes/modal/new_bill.inc.php';
     }).on("loaded.rs.jquery.bootgrid", function() {
     });
     $('#table-filters select').on('change', function() { grid.bootgrid('reload'); });
-        
+
 <?php
 if ($vars['view'] == 'add') {
 ?>
 $(function() {
-    $('#create-bill').modal('show');    
+    $('#create-bill').modal('show');
 });
 <?php
 }

--- a/html/pages/device/edit/device.inc.php
+++ b/html/pages/device/edit/device.inc.php
@@ -145,33 +145,45 @@ if ($updated && $update_message) {
 <div class="form-group">
     <label for="sysLocation" class="col-sm-2 control-label">Override sysLocation:</label>
     <div class="col-sm-6">
-      <input onclick="edit.sysLocation.disabled=!edit.override_sysLocation.checked" type="checkbox" name="override_sysLocation"<?php if ($override_sysLocation) {
-            echo(' checked="1"');
-} ?> />
+      <input onclick="edit.sysLocation.disabled=!edit.override_sysLocation.checked" type="checkbox" name="override_sysLocation"
+            <?php
+            if ($override_sysLocation) {
+                echo(' checked="1"');
+            }
+            ?> />
     </div>
 </div>
 <div class="form-group">
     <div class="col-sm-2"></div>
     <div class="col-sm-6">
-      <input id="sysLocation" name="sysLocation" class="form-control" <?php if (!$override_sysLocation) {
-            echo(' disabled="1"');
-} ?> value="<?php echo($override_sysLocation_string); ?>" />
+      <input id="sysLocation" name="sysLocation" class="form-control"
+            <?php
+            if (!$override_sysLocation) {
+                echo(' disabled="1"');
+            }
+            ?> value="<?php echo($override_sysLocation_string); ?>" />
     </div>
 </div>
 <div class="form-group">
     <label for="disabled" class="col-sm-2 control-label">Disable:</label>
     <div class="col-sm-6">
-      <input name="disabled" type="checkbox" id="disabled" value="1" <?php if ($device["disabled"]) {
-            echo("checked=checked");
-} ?> />
+      <input name="disabled" type="checkbox" id="disabled" value="1"
+            <?php
+            if ($device["disabled"]) {
+                echo("checked=checked");
+            }
+            ?> />
     </div>
 </div>
 <div class="form-group">
     <label for="ignore" class="col-sm-2 control-label">Ignore</label>
     <div class="col-sm-6">
-       <input name="ignore" type="checkbox" id="ignore" value="1" <?php if ($device['ignore']) {
-            echo("checked=checked");
-} ?> />
+       <input name="ignore" type="checkbox" id="ignore" value="1"
+            <?php
+            if ($device['ignore']) {
+                echo("checked=checked");
+            }
+            ?> />
     </div>
 </div>
 <div class="row">

--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -114,22 +114,37 @@ foreach ($results as $data) {
 
 ?>
       </select>
-      <input type="text" name="hostname" id="hostname" title="Hostname" class="form-control input-sm" <?php if (strlen($vars['hostname'])) {
-            echo('value="'.$vars['hostname'].'"');
-} ?> placeholder="Hostname" />
+      <input type="text" name="hostname" id="hostname" title="Hostname" class="form-control input-sm"
+            <?php
+            if (strlen($vars['hostname'])) {
+                echo('value="' . $vars['hostname'] . '"');
+            }
+            ?> placeholder="Hostname"/>
     </div>
     <div class="form-group">
       <select name="state" id="state" class="form-control input-sm">
         <option value="">All States</option>
-        <option value="up" <?php if ($vars['state'] == "up") {
-            echo("selected");
-} ?>>Up</option>
-        <option value="down"<?php if ($vars['state'] == "down") {
-            echo("selected");
-} ?>>Down</option>
-        <option value="admindown" <?php if ($vars['state'] == "admindown") {
-            echo("selected");
-} ?>>Shutdown</option>
+        <option value="up"
+            <?php
+            if ($vars['state'] == "up") {
+                echo("selected");
+            }
+            ?>>Up
+        </option>
+        <option value="down"
+            <?php
+            if ($vars['state'] == "down") {
+                echo("selected");
+            }
+            ?>>Down
+        </option>
+        <option value="admindown"
+            <?php
+            if ($vars['state'] == "admindown") {
+                echo("selected");
+            }
+            ?>>Shutdown
+        </option>
       </select>
 
       <select name="ifSpeed" id="ifSpeed" class="form-control input-sm">
@@ -201,9 +216,12 @@ foreach ($ports as $data) {
       </select>
     </div>
     <div class="form-group">
-      <input title="Port Description" type="text" name="ifAlias" id="ifAlias" class="form-control input-sm" <?php if (strlen($vars['ifAlias'])) {
-            echo('value="'.$vars['ifAlias'].'"');
-} ?> placeholder="Port Description"/>
+      <input title="Port Description" type="text" name="ifAlias" id="ifAlias" class="form-control input-sm"
+            <?php
+            if (strlen($vars['ifAlias'])) {
+                echo('value="' . $vars['ifAlias'] . '"');
+            }
+            ?> placeholder="Port Description"/>
         <select title="Location" name="location" id="location" class="form-control input-sm">
           <option value="">All Locations</option>
 <?php
@@ -223,17 +241,26 @@ foreach (getlocations() as $location) {
       </div>
       <div class="form-group">
         <label for="ignore">Ignored</label>
-        <input type=checkbox id="ignore" name="ignore" value="1" <?php if ($vars['ignore']) {
-            echo("checked");
-} ?> >
+        <input type=checkbox id="ignore" name="ignore" value="1"
+            <?php
+            if ($vars['ignore']) {
+                echo("checked");
+            }
+            ?> >
         <label for="disabled">Disabled</label>
-        <input type=checkbox id="disabled" name="disabled" value=1 <?php if ($vars['disabled']) {
-            echo("checked");
-} ?> >
+        <input type=checkbox id="disabled" name="disabled" value=1
+            <?php
+            if ($vars['disabled']) {
+                echo("checked");
+            }
+            ?> >
         <label for="deleted">Deleted</label>
-        <input type=checkbox id="deleted" name="deleted" value=1 <?php if ($vars['deleted']) {
-            echo("checked");
-} ?> >
+        <input type=checkbox id="deleted" name="deleted" value=1
+            <?php
+            if ($vars['deleted']) {
+                echo("checked");
+            }
+            ?> >
       </div>
       <button type="submit" class="btn btn-default btn-sm">Search</button>
       <a class="btn btn-default btn-sm" href="<?php echo(generate_url(array('page' => 'ports', 'section' => $vars['section'], 'bare' => $vars['bare']))); ?>" title="Reset critera to default." >Reset</a>

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -849,7 +849,7 @@ function ExtTransports($obj)
             $obj['msg'] = $msg;
             echo $transport.' => ';
             eval('$tmp = function($obj,$opts) { global $config; '.file_get_contents($config['install_dir'].'/includes/alerts/transport.'.$transport.'.php').' return false; };');
-            $tmp = $tmp($obj,$opts);
+            $tmp = $tmp($obj, $opts);
             $prefix = array( 0=>"recovery", 1=>$obj['severity']." alert", 2=>"acknowledgment" );
             $prefix[3] = &$prefix[0];
             $prefix[4] = &$prefix[0];

--- a/includes/discovery/processors/hrdevice.inc.php
+++ b/includes/discovery/processors/hrdevice.inc.php
@@ -74,7 +74,7 @@ if (is_array($hrDevice_array)) {
                 discover_processor($valid['processor'], $device, $usage_oid, $index, 'hr', $descr, '1', $usage, null, $hrDeviceIndex);
             }
 
-            unset($old_rrd,$new_rrd,$descr,$entry,$usage_oid,$index,$usage,$hrDeviceIndex,$descr_array);
+            unset($old_rrd, $new_rrd, $descr, $entry, $usage_oid, $index, $usage, $hrDeviceIndex, $descr_array);
         }//end if
 
         unset($entry);

--- a/includes/polling/applications/freeswitch.inc.php
+++ b/includes/polling/applications/freeswitch.inc.php
@@ -42,4 +42,4 @@ $fields = array (
     );
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
 data_update($device, 'app', $tags, $fields);
-unset($lines , $freeswitch, $rrd_name, $rrd_def, $fields, $tags);
+unset($lines, $freeswitch, $rrd_name, $rrd_def, $fields, $tags);

--- a/includes/polling/applications/unbound.inc.php
+++ b/includes/polling/applications/unbound.inc.php
@@ -76,4 +76,4 @@ $fields = array (
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
 data_update($device, 'app', $tags, $fields);
 
-unset($lines , $unbound, $rrd_name, $rrd_def, $fields, $tags);
+unset($lines, $unbound, $rrd_name, $rrd_def, $fields, $tags);

--- a/includes/polling/cisco-asa-firewall.inc.php
+++ b/includes/polling/cisco-asa-firewall.inc.php
@@ -43,5 +43,5 @@ if ($device['os_group'] == 'cisco' && $device['os'] == 'asa' && $device['type'] 
         echo ' ASA Connections';
     }
 
-    unset($data,$rrd_def);
+    unset($data, $rrd_def);
 }//end if

--- a/includes/polling/mef.inc.php
+++ b/includes/polling/mef.inc.php
@@ -47,5 +47,5 @@ foreach ($db_info_list as $db_info) {
  * Finished discovering MEF Links information.
  */
 
-unset($db_info_list,$current_mefinfo);
+unset($db_info_list, $current_mefinfo);
 echo PHP_EOL;

--- a/includes/polling/mib/ceraos-mib.inc.php
+++ b/includes/polling/mib/ceraos-mib.inc.php
@@ -93,4 +93,4 @@ if ($num_radios > 1) {
     );
 }
 poll_mib_def($device, "MWRM-RADIO-MIB:ceragon-radio", "ceraos", $mib_oids, $mib_graphs, $graphs);
-unset($feature, $num_radios, $radioNumber, $ifIndex, $ifIndex_array, $ifName, $ifDescr,  $mib_graphs, $mib_oids, $snmp_get_oids);
+unset($feature, $num_radios, $radioNumber, $ifIndex, $ifIndex_array, $ifName, $ifDescr, $mib_graphs, $mib_oids, $snmp_get_oids);

--- a/includes/polling/os/calix.inc.php
+++ b/includes/polling/os/calix.inc.php
@@ -15,9 +15,7 @@
 
 
 if (strstr($sysObjectId, '.6321.1.2.3')) { // E5-1xx Series
-
     if (strpos($device['sysObjectID'], 'enterprises.6321.1.2.3.4') !== false) { // E5-121
-
         $version = snmp_get($device, 'iesSlotModuleFWVersion.0.0', '-Oqv', '+E5-121-IESCOMMON-MIB', 'calix');
         $hardware = snmp_get($device, 'iesSlotModuleDescr.0.0', '-Ovqs', '+E5-121-IESCOMMON-MIB', 'calix');
         $serial   = snmp_get($device, 'iesChassisSerialNumber.0', '-OQv', '+E5-121-IESCOMMON-MIB', 'calix');
@@ -29,7 +27,6 @@ if (strstr($sysObjectId, '.6321.1.2.3')) { // E5-1xx Series
     }
 
     if (strpos($device['sysObjectID'], 'enterprises.6321.1.2.3.3') !== false) { // E5-120
-
         $version = snmp_get($device, 'iesSlotModuleFWVersion.0.0', '-Oqv', '+E5-120-IESCOMMON-MIB', 'calix');
         $hardware = snmp_get($device, 'iesSlotModuleDescr.0.0', '-Ovqs', '+E5-120-IESCOMMON-MIB', 'calix');
         $serial   = snmp_get($device, 'iesChassisSerialNumber.0', '-OQv', '+E5-120-IESCOMMON-MIB', 'calix');
@@ -41,7 +38,6 @@ if (strstr($sysObjectId, '.6321.1.2.3')) { // E5-1xx Series
     }
 
     if (strpos($device['sysObjectID'], 'enterprises.6321.1.2.3.2') !== false) { // E5-111
-
         $version = snmp_get($device, 'iesSlotModuleFWVersion.0.0', '-Oqv', '+E5-111-IESCOMMON-MIB', 'calix');
         $hardware = snmp_get($device, 'iesSlotModuleDescr.0.0', '-Ovqs', '+E5-111-IESCOMMON-MIB', 'calix');
         $serial   = snmp_get($device, 'iesChassisSerialNumber.0', '-OQv', '+E5-111-IESCOMMON-MIB', 'calix');
@@ -53,7 +49,6 @@ if (strstr($sysObjectId, '.6321.1.2.3')) { // E5-1xx Series
     }
 
     if (strpos($device['sysObjectID'], 'enterprises.6321.1.2.3.1') !== false) { // E5-110
-
         $version = snmp_get($device, 'iesSlotModuleFWVersion.0.0', '-Oqv', '+E5-110-IESCOMMON-MIB', 'calix');
         $hardware = snmp_get($device, 'iesSlotModuleDescr.0.0', '-Ovqs', '+E5-110-IESCOMMON-MIB', 'calix');
         $serial   = snmp_get($device, 'iesChassisSerialNumber.0', '-OQv', '+E5-110-IESCOMMON-MIB', 'calix');

--- a/includes/polling/wireless/cambium-generic.inc.php
+++ b/includes/polling/wireless/cambium-generic.inc.php
@@ -54,7 +54,7 @@ if (strstr($hardware, 'CMM') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-signalHV', $tags, $fields);
         $graphs['cambium_generic_signalHV'] = true;
-        unset($rrd_filename,$vertical,$horizontal,$combined);
+        unset($rrd_filename, $vertical, $horizontal, $combined);
     }
 
     $rssi = snmp_get($device, "1.3.6.1.4.1.161.19.3.2.2.2.0", "-Ovqn", "");
@@ -66,7 +66,7 @@ if (strstr($hardware, 'CMM') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-rssi', $tags, $fields);
         $graphs['cambium_generic_rssi'] = true;
-        unset($rrd_filename,$rssi);
+        unset($rrd_filename, $rssi);
     }
 
     $jitter = snmp_get($device, "jitter.0", "-Ovqn", "WHISP-SM-MIB");
@@ -78,7 +78,7 @@ if (strstr($hardware, 'CMM') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-jitter', $tags, $fields);
         $graphs['cambium_generic_jitter'] = true;
-        unset($rrd_filename,$jitter);
+        unset($rrd_filename, $jitter);
     }
 
     $horizontal = str_replace('"', "", snmp_get($device, "radioDbmHorizontal.0", "-Ovqn", "WHISP-SM-MIB"));
@@ -94,7 +94,7 @@ if (strstr($hardware, 'CMM') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-450-slaveHV', $tags, $fields);
         $graphs['cambium_generic_450_slaveHV'] = true;
-        unset($rrd_filename,$horizontal,$vertical);
+        unset($rrd_filename, $horizontal, $vertical);
     }
 
     $ssr = str_replace('"', "", snmp_get($device, "signalStrengthRatio.0", "-Ovqn", "WHISP-SM-MIB"));
@@ -106,7 +106,7 @@ if (strstr($hardware, 'CMM') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-450-slaveSSR', $tags, $fields);
         $graphs['cambium_generic_450_slaveSSR'] = true;
-        unset($rrd_filename,$ssr);
+        unset($rrd_filename, $ssr);
     }
 
     $horizontal = str_replace('"', "", snmp_get($device, "signalToNoiseRatioSMHorizontal.0", "-Ovqn", "WHISP-SM-MIB"));
@@ -122,7 +122,7 @@ if (strstr($hardware, 'CMM') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-450-slaveSNR', $tags, $fields);
         $graphs['cambium_generic_450_slaveSNR'] = true;
-        unset($rrd_filename,$horizontal,$vertical);
+        unset($rrd_filename, $horizontal, $vertical);
     }
 }
 
@@ -143,7 +143,7 @@ if (strstr($hardware, 'AP') || strstr($hardware, 'Master') || strstr($hardware, 
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-whispGPSStats', $tags, $fields);
         $graphs['cambium_generic_whispGPSStats'] = true;
-        unset($rrd_filename,$gpsStatus);
+        unset($rrd_filename, $gpsStatus);
     }
 
     $visible = str_replace('"', "", snmp_get($device, ".1.3.6.1.4.1.161.19.3.4.4.7.0", "-Ovqn", ""));
@@ -159,7 +159,7 @@ if (strstr($hardware, 'AP') || strstr($hardware, 'Master') || strstr($hardware, 
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-gpsStats', $tags, $fields);
         $graphs['cambium_generic_gpsStats'] = true;
-        unset($rrd_filename,$visible,$tracked);
+        unset($rrd_filename, $visible, $tracked);
     }
 }
 //PTP Equipment
@@ -189,7 +189,7 @@ if (strstr($version, 'AP') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-450-linkRadioDbm', $tags, $fields);
         $graphs['cambium_generic_450_linkRadioDbm'] = true;
-        unset($rrd_filename,$horizontal,$horizontal);
+        unset($rrd_filename, $horizontal, $horizontal);
     }
 
     $horizontal = str_replace('"', "", snmp_get($device, "signalToNoiseRatioHorizontal.2", "-Ovqn", "WHISP-APS-MIB"));
@@ -205,7 +205,7 @@ if (strstr($version, 'AP') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-450-ptpSNR', $tags, $fields);
         $graphs['cambium_generic_450_ptpSNR'] = true;
-        unset($rrd_filename,$horizontal,$horizontal);
+        unset($rrd_filename, $horizontal, $horizontal);
     }
 
     $ssr = str_replace('"', "", snmp_get($device, "linkSignalStrengthRatio.2", "-Ovqn", "WHISP-APS-MIB"));
@@ -217,7 +217,7 @@ if (strstr($version, 'AP') == false) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-450-masterSSR', $tags, $fields);
         $graphs['cambium_generic_450_masterSSR'] = true;
-        unset($rrd_filename,$ssr);
+        unset($rrd_filename, $ssr);
     }
 
     if (strstr($hardware, 'PTP 230')) {
@@ -241,7 +241,7 @@ if (strstr($version, 'AP') == false) {
             $tags = compact('rrd_def');
             data_update($device, 'cambium-generic-radioDbm', $tags, $fields);
             $graphs['cambium_generic_radioDbm'] = true;
-            unset($rrd_filename,$dbmRadio,$minRadio,$maxRadio,$avgRadio);
+            unset($rrd_filename, $dbmRadio, $minRadio, $maxRadio, $avgRadio);
         }
     }
 }
@@ -261,7 +261,7 @@ if (strstr($version, 'AP')) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-regCount', $tags, $fields);
         $graphs['cambium_generic_regCount'] = true;
-        unset($rrd_filename,$registered,$failed);
+        unset($rrd_filename, $registered, $failed);
     }
     
     $freq = str_replace('"', "", snmp_get($device, "currentRadioFreqCarrier.0", "-Ovqn", "WHISP-APS-MIB"));
@@ -278,6 +278,6 @@ if (strstr($version, 'AP')) {
         $tags = compact('rrd_def');
         data_update($device, 'cambium-generic-freq', $tags, $fields);
         $graphs['cambium_generic_freq'] = true;
-        unset($rrd_filename,$freq);
+        unset($rrd_filename, $freq);
     }
 }


### PR DESCRIPTION
We cannot use 3.x because it  requires php 5.4, so update to 2.9.1 or newer 2.x release.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
