### PR TITLE
feature: save application metrics to db for alerting

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1353,7 +1353,7 @@ function get_port_id($ports_mapped, $port, $port_association_mode)
  * @param int $x Recursion Anchor
  * @param array $hist History of processed tables
  * @param array $last Glues on the fringe
- * @return array|false
+ * @return string|boolean
  */
 function ResolveGlues($tables, $target, $x = 0, $hist = array(), $last = array())
 {
@@ -1370,16 +1370,6 @@ function ResolveGlues($tables, $target, $x = 0, $hist = array(), $last = array()
             return false;
         }
         foreach ($tables as $table) {
-            if ($table == 'state_translations' && ($target == 'device_id' || $target == 'sensor_id')) {
-                // workaround for state_translations
-                $st_tables = array(
-                    'state_translations.state_index_id',
-                    'sensors_to_state_indexes.sensor_id',
-                    "sensors.$target",
-                );
-                return array_merge($last, $st_tables);
-            }
-
             $glues = dbFetchRows('SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_NAME = ? && COLUMN_NAME LIKE "%\_id"', array($table));
             if (sizeof($glues) == 1 && $glues[0]['COLUMN_NAME'] != $target) {
                 //Search for new candidates to expand

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -292,6 +292,33 @@ function dbDelete($table, $where = null, $parameters = array())
 }//end dbDelete()
 
 
+/**
+ * Delete orphaned entries from a table that no longer have a parent in parent_table
+ *
+ * @param string $parent_table
+ * @param string $child_table
+ * @param string $id_column
+ * @return bool|int
+ */
+function dbDeleteOrphans($parent_table, $child_table, $id_column)
+{
+    global $database_link;
+    $time_start = microtime(true);
+
+    $sql = "DELETE C FROM `$child_table` C";
+    $sql .= " LEFT JOIN `$parent_table` P USING (`$id_column`)";
+    $sql .= " WHERE P.`$id_column` IS NULL";
+
+    $result = dbQuery($sql, array());
+
+    recordDbStatistic('delete', $time_start);
+    if ($result) {
+        return mysqli_affected_rows($database_link);
+    } else {
+        return false;
+    }
+}
+
 /*
  * Fetches all of the rows (associatively) from the last performed query.
  * Most other retrieval functions build off this

--- a/includes/discovery/applications.inc.php
+++ b/includes/discovery/applications.inc.php
@@ -105,6 +105,9 @@ if ($num > 0) {
     }
 }
 
+// clean application_metrics
+dbDeleteOrphans('applications', 'application_metrics', 'app_id');
+
 echo PHP_EOL;
 
 unset(

--- a/includes/polling/applications/nginx.inc.php
+++ b/includes/polling/applications/nginx.inc.php
@@ -11,7 +11,6 @@ if (!empty($agent_data['app'][$name])) {
     $nginx = snmp_get($device, '.1.3.6.1.4.1.8072.1.3.2.3.1.2.5.110.103.105.110.120', '-Ovq');
 }
 $nginx = trim($nginx, '"');
-update_application($app, $nginx);
 
 echo ' nginx';
 
@@ -36,6 +35,7 @@ $fields = array(
 
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
 data_update($device, 'app', $tags, $fields);
+update_application($app, $nginx, '', $fields);
 
 // Unset the variables we set here
 unset($nginx, $active, $reading, $writing, $waiting, $req, $rrd_name, $rrd_def, $tags);

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -574,9 +574,10 @@ function location_to_latlng($device)
  *
  * @param array $app app from the db, including app_id
  * @param string $response This should be the full output
- * @param string $current This is the current value we store in rrd for graphing
+ * @param string $status This is the current value for alerting
+ * @param array $metrics an array of additional metrics to store in the database for alerting
  */
-function update_application($app, $response, $current = '')
+function update_application($app, $response, $status = '', $metrics = array())
 {
     if (!is_numeric($app['app_id'])) {
         d_echo('$app does not contain app_id, could not update');
@@ -585,7 +586,7 @@ function update_application($app, $response, $current = '')
 
     $data = array(
         'app_state'  => 'UNKNOWN',
-        'app_status' => $current,
+        'app_status' => $status,
         'timestamp'  => array('NOW()'),
     );
 
@@ -603,6 +604,53 @@ function update_application($app, $response, $current = '')
         $data['app_state_prev'] = $app['app_state'];
     }
     dbUpdate($data, 'applications', '`app_id` = ?', array($app['app_id']));
+
+    // update metrics
+    if (!empty($metrics)) {
+        $db_metrics = dbFetchRows('SELECT * FROM `application_metrics` WHERE app_id=?', array($app['app_id']));
+        $db_metrics = array_by_column($db_metrics, 'metric');
+
+        echo ': ';
+        foreach ($metrics as $metric_name => $value) {
+            if (!isset($db_metrics[$metric_name])) {
+                // insert new metric
+                dbInsert(
+                    array(
+                        'app_id' => $app['app_id'],
+                        'metric' => $metric_name,
+                        'value' => $value,
+                    ),
+                    'application_metrics'
+                );
+                echo '+';
+            } elseif ($value != $db_metrics[$metric_name]['value']) {
+                dbUpdate(
+                    array(
+                        'value' => $value,
+                        'value_prev' => $db_metrics[$metric_name]['value'],
+                    ),
+                    'application_metrics',
+                    'app_id=? && metric=?',
+                    array($app['app_id'], $metric_name)
+                );
+                echo 'U';
+            } else {
+                echo '.';
+            }
+
+            unset($db_metrics[$metric_name]);
+        }
+
+        // remove no longer existing metrics (generally should not happen
+        foreach ($db_metrics as $db_metric) {
+            dbDelete(
+                'application_metrics',
+                'app_id=? && metric=?',
+                array($app['app_id'], $db_metric['metric'])
+            );
+            echo '-';
+        }
+    }
 }
 
 function convert_to_celsius($value)

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -133,6 +133,14 @@ applications:
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [app_id], Unique: true, Type: BTREE }
     unique_index: { Name: unique_index, Columns: [device_id, app_type], Unique: true, Type: BTREE }
+application_metrics:
+  Columns:
+    - { Field: app_id, Type: int(11), 'Null': false, Extra: '' }
+    - { Field: metric, Type: varchar(18), 'Null': false, Extra: '' }
+    - { Field: value, Type: int(11), 'Null': true, Extra: '' }
+    - { Field: value_prev, Type: int(11), 'Null': true, Extra: '' }
+  Indexes:
+    application_metrics_app_id_metric_uindex: { Name: application_metrics_app_id_metric_uindex, Columns: [app_id, metric], Unique: true, Type: BTREE }
 authlog:
   Columns:
     - { Field: id, Type: int(11), 'Null': false, Extra: auto_increment }

--- a/sql-schema/219.sql
+++ b/sql-schema/219.sql
@@ -1,0 +1,2 @@
+CREATE TABLE application_metrics (app_id INT(11) NOT NULL, metric VARCHAR(18) NOT NULL, value INT(11), value_prev INT(11));
+CREATE UNIQUE INDEX application_metrics_app_id_metric_uindex ON application_metrics (app_id, metric);


### PR DESCRIPTION
However, alerting will not work because ResolveGlues() is broken.
Can add workaround after state_translations alerting is merged

Does not update all applications yet, not sure if that should be done here or in another PR. Most are simple, some are complex.

Introduces two handy functions dbDeleteOrphans() and array_by_column().  Will replace those in other locations after this is merged or separate them out if this is not merged.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
