### PR TITLE
fix: Validate ifHighSpeed is > 0 in selected port polling

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -190,7 +190,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
                     echo 'port is still down';
                 } else {
                     echo 'valid';
-                    if (is_numeric($data[$i]['ifHighSpeed'])) {
+                    if (is_numeric($data[$i]['ifHighSpeed']) && $data[$i]['ifHighSpeed'] > 0) {
                         $full_oids = array_merge($hc_oids, $shared_oids);
                     } else {
                         $full_oids = array_merge($nonhc_oids, $shared_oids);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Used in two forum threads:

https://community.librenms.org/t/pfsense-openvpn-traffic-not-populating-graphs-in-librenms/2710/25

https://community.librenms.org/t/add-support-for-technicolor-tg670/2480/21

It shouldn't break legit devices but obviously can't be sure it wont break devices with bad snmp implementation where they report ifHighSpeed as 0 but have HC counters.