### PR TITLE
Fixed and added details presented to Pagerduty

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -42,15 +42,12 @@ class Pagerduty implements Transport
         } else {
             $protocol['event_type'] = 'trigger';
         }
+        $details = array();
         foreach ($obj['faults'] as $fault => $data) {
-            $rough_details = array_filter(explode('; ', $data['string']));
-            $details = array();
-            foreach ($rough_details as $r) {
-                $kv_pair = explode(' => ', $r);
-                $details[$kv_pair[0]] = $kv_pair[1];
-            }
-            $protocol['details'] = $details;
+            $details = $data;
+            unset($details['string']);
         }
+        $protocol['details'] = $details;
         $curl = curl_init();
         set_curl_proxy($curl);
         curl_setopt($curl, CURLOPT_URL, 'https://events.pagerduty.com/generic/2010-04-15/create_event.json');

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -42,12 +42,8 @@ class Pagerduty implements Transport
         } else {
             $protocol['event_type'] = 'trigger';
         }
-        $details = array();
-        foreach ($obj['faults'] as $fault => $data) {
-            $details = $data;
-            unset($details['string']);
-        }
-        $protocol['details'] = $details;
+        $protocol['details'] = end($obj['faults']);
+        unset($protocol['details']['string']);
         $curl = curl_init();
         set_curl_proxy($curl);
         curl_setopt($curl, CURLOPT_URL, 'https://events.pagerduty.com/generic/2010-04-15/create_event.json');

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -43,7 +43,13 @@ class Pagerduty implements Transport
             $protocol['event_type'] = 'trigger';
         }
         foreach ($obj['faults'] as $fault => $data) {
-            $protocol['details'][] = $data['string'];
+            $rough_details = array_filter(explode('; ', $data['string']));
+            $details = array();
+            foreach ($rough_details as $r) {
+                $kv_pair = explode(' => ', $r);
+                $details[$kv_pair[0]] = $kv_pair[1];
+            }
+            $protocol['details'] = $details;
         }
         $curl = curl_init();
         set_curl_proxy($curl);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

---

The JSON generated for presentation to PagerDuty was not correct so the 'custom details' were not being parsed correctly by PD.  This method fixes that and additionally presents many more details to PagerDuty.  In the case of an interface alarm, things like interface stats, attributes, etc.

## The message as received by PD BEFORE:
```
{
  "client": "LibreNMS",
  "description": "some event title",
  "details": [
    "port_id => 6; ifDescr => GigabitEthernet1/0/4; "
  ],
  "event_type": "trigger",
  "incident_key": "12345",
  "service_key": "12345abcdef"
}
```

## Message as received by PD AFTER:
```
{
  "client": "LibreNMS",
  "description": "some event title",
  "details": {
    "port_id": "6",
    "ifDescr": "GigabitEthernet1/0/4",
    "port_descr_descr": "CORE-1_GI1/0/1",
    <TRUNCATED, MANY MORE DETAILS>
  },
  "event_type": "trigger",
  "incident_key": "12345",
  "service_key": "12345abcdef"
}
```