### PR TITLE
Update Interface-Description-Parsing.md

### DIFF
--- a/doc/Extensions/Interface-Description-Parsing.md
+++ b/doc/Extensions/Interface-Description-Parsing.md
@@ -45,11 +45,11 @@ Unix / Linux:
 
 The following config options can be set to enable more custom types:
 ```php
-$config['customers_descr'][]         = 'cust';
-$config['transit_descr'][]           = "transit";
-$config['peering_descr'][]           = "peering";
-$config['core_descr'][]              = "core";
-$config['custom_descr'][]            = "something_made_up";
+$config['customers_descr']         = 'cust';
+$config['transit_descr']           = "transit";
+$config['peering_descr']           = "peering";
+$config['core_descr']              = "core";
+$config['custom_descr']            = "something_made_up";
 ```
 
 ## Custom interface parser


### PR DESCRIPTION
When I add '$config['core_descr'][]              = "core";' to my config.php I get a fatal error:

removing the second [] fixes the issue.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
