### PR TITLE
refactor remove all old style snmp calls

### DIFF
--- a/includes/discovery/cisco-mac-accounting.inc.php
+++ b/includes/discovery/cisco-mac-accounting.inc.php
@@ -1,9 +1,8 @@
 <?php
 
 if ($device['os_group'] == 'cisco') {
-    $datas = shell_exec($config['snmpbulkwalk'].' -M '.$config['mibdir'].' -m CISCO-IP-STAT-MIB -Oqn '.snmp_gen_auth($device).' '.$device['hostname'].' cipMacSwitchedBytes');
-    // echo("$datas\n");
-    // echo("done\n");
+    $datas = snmp_walk($device, 'cipMacSwitchedBytes', '-Oqn', 'CISCO-IP-STAT-MIB');
+
     foreach (explode("\n", $datas) as $data) {
         list($oid) = explode(' ', $data);
         $oid       = str_replace('.1.3.6.1.4.1.9.9.84.1.2.1.1.4.', '', $oid);

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -82,14 +82,21 @@ if ($config['enable_bgp']) {
                             $peer_data .= "$v\n";
                         }
                     } else {
-                        $peer_cmd  = $config['snmpget'].' -M '.$config['mibdir'].' -m BGP4-MIB -OUvq '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'].' ';
-                        $peer_cmd .= 'bgpPeerState.'.$peer['bgpPeerIdentifier'].' bgpPeerAdminStatus.'.$peer['bgpPeerIdentifier'].' bgpPeerInUpdates.'.$peer['bgpPeerIdentifier'].' bgpPeerOutUpdates.'.$peer['bgpPeerIdentifier'].' bgpPeerInTotalMessages.'.$peer['bgpPeerIdentifier'].' ';
-                        $peer_cmd .= 'bgpPeerOutTotalMessages.'.$peer['bgpPeerIdentifier'].' bgpPeerFsmEstablishedTime.'.$peer['bgpPeerIdentifier'].' bgpPeerInUpdateElapsedTime.'.$peer['bgpPeerIdentifier'].' ';
-                        $peer_cmd .= 'bgpPeerLocalAddr.'.$peer['bgpPeerIdentifier'].'';
-                        $peer_data = trim(`$peer_cmd`);
+                        $oids = array(
+                            'bgpPeerState.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerAdminStatus.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerInUpdates.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerOutUpdates.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerInTotalMessages.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerOutTotalMessages.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerFsmEstablishedTime.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerInUpdateElapsedTime.'.$peer['bgpPeerIdentifier'],
+                            'bgpPeerLocalAddr.'.$peer['bgpPeerIdentifier']
+                        );
+                        $peer_data = snmp_get_multi_oid($device, $oids, '-OUvq', 'BGP4-MIB');
                     }//end if
                     d_echo($peer_data);
-                    list($bgpPeerState, $bgpPeerAdminStatus, $bgpPeerInUpdates, $bgpPeerOutUpdates, $bgpPeerInTotalMessages, $bgpPeerOutTotalMessages, $bgpPeerFsmEstablishedTime, $bgpPeerInUpdateElapsedTime, $bgpLocalAddr) = explode("\n", $peer_data);
+                    list($bgpPeerState, $bgpPeerAdminStatus, $bgpPeerInUpdates, $bgpPeerOutUpdates, $bgpPeerInTotalMessages, $bgpPeerOutTotalMessages, $bgpPeerFsmEstablishedTime, $bgpPeerInUpdateElapsedTime, $bgpLocalAddr) = array_values($peer_data);
                     $bgpLocalAddr = str_replace('"', '', str_replace(' ', '', $bgpLocalAddr));
                 } elseif ($device['os'] == 'junos') {
                     if (!isset($junos)) {
@@ -193,7 +200,7 @@ if ($config['enable_bgp']) {
             );
 
             $peer['update'] = array_diff($bgpPeers_fields, $peer);
-            
+
             if ($peer['update']) {
                 dbUpdate($peer['update'], 'bgpPeers', '`device_id` = ? AND `bgpPeerIdentifier` = ?', array($device['device_id'], $peer['bgpPeerIdentifier']));
             }

--- a/includes/polling/mempools/cemp.inc.php
+++ b/includes/polling/mempools/cemp.inc.php
@@ -2,14 +2,12 @@
 
 $oid = $mempool['mempool_index'];
 
-// FIXME snmp_get
-$pool_cmd  = $config['snmpget'].' -M '.$config['mibdir'].' -m CISCO-ENHANCED-MEMPOOL-MIB -O Uqnv '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'];
-$pool_cmd .= " cempMemPoolUsed.$oid cempMemPoolFree.$oid cempMemPoolLargestFree.$oid";
-$pool_cmd .= " | cut -f 1 -d ' '";
+$oids = array(
+    "cempMemPoolUsed.$oid",
+    "cempMemPoolFree.$oid",
+    "cempMemPoolLargestFree.$oid",
+);
+$data = snmp_get_multi_oid($device, $oids, '-OUqnv', 'CISCO-ENHANCED-MEMPOOL-MIB');
 
-d_echo("SNMP [ $pool_cmd ]\n");
-
-$pool = shell_exec($pool_cmd);
-
-list($mempool['used'], $mempool['free'], $mempool['largestfree']) = explode("\n", $pool);
+list($mempool['used'], $mempool['free'], $mempool['largestfree']) = array_values($data);
 $mempool['total'] = ($mempool['used'] + $mempool['free']);

--- a/includes/polling/mempools/cmp.inc.php
+++ b/includes/polling/mempools/cmp.inc.php
@@ -2,14 +2,12 @@
 
 $oid = $mempool['mempool_index'];
 
-// FIXME snmp_get
-$pool_cmd  = $config['snmpget'].' -M '.$config['mibdir'].' -m CISCO-MEMORY-POOL-MIB -O Uqnv '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'];
-$pool_cmd .= " ciscoMemoryPoolUsed.$oid ciscoMemoryPoolFree.$oid ciscoMemoryPoolLargestFree.$oid";
-$pool_cmd .= " | cut -f 1 -d ' '";
+$oids = array(
+    "ciscoMemoryPoolUsed.$oid",
+    "ciscoMemoryPoolFree.$oid",
+    "ciscoMemoryPoolLargestFree.$oid",
+);
+$data = snmp_get_multi_oid($device, $oids, '-OUqnv', 'CISCO-MEMORY-POOL-MIB');
 
-d_echo("$pool_cmd");
-
-$pool = shell_exec($pool_cmd);
-
-list($mempool['used'], $mempool['free'], $mempool['largestfree']) = explode("\n", $pool);
+list($mempool['used'], $mempool['free'], $mempool['largestfree']) = array_values($data);
 $mempool['total'] = ($mempool['used'] + $mempool['free']);

--- a/includes/polling/os/ironware.inc.php
+++ b/includes/polling/os/ironware.inc.php
@@ -1,21 +1,12 @@
 <?php
 
-// FIXME snmp_ function!
-$hardware = trim(
-    exec(
-        $config['snmpget'].' -M '.$config['mibdir'].' -O vqs -m FOUNDRY-SN-AGENT-MIB:FOUNDRY-SN-ROOT-MIB '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'].' sysObjectID.0'
-    )
-);
+$hardware = snmp_get($device, 'sysObjectID.0', '-Oqvs', 'FOUNDRY-SN-AGENT-MIB:FOUNDRY-SN-ROOT-MIB');
 
 $hardware = rewrite_ironware_hardware($hardware);
 
-$version = trim(
-    exec(
-        $config['snmpget'].' -M '.$config['mibdir'].' -O vqs -m FOUNDRY-SN-AGENT-MIB:FOUNDRY-SN-ROOT-MIB '.snmp_gen_auth($device).' '.$device['hostname'].':'.$device['port'].' snAgBuildVer.0'
-    )
-);
+$version = snmp_get($device, 'snAgBuildVer.0', '-Oqvs', 'FOUNDRY-SN-AGENT-MIB:FOUNDRY-SN-ROOT-MIB');
 
 $version = str_replace('V', '', $version);
 $version = str_replace('"', '', $version);
 
-$serial = trim(snmp_get($device, 'snChasSerNum.0', '-Ovq', 'FOUNDRY-SN-AGENT-MIB'), '"');
+$serial = snmp_get($device, 'snChasSerNum.0', '-Ovq', 'FOUNDRY-SN-AGENT-MIB');

--- a/includes/polling/os/screenos.inc.php
+++ b/includes/polling/os/screenos.inc.php
@@ -5,10 +5,13 @@ use LibreNMS\RRD\RrdDefinition;
 $version = preg_replace('/(.+)\ version\ (.+)\ \(SN:\ (.+)\,\ (.+)\)/', '\\1||\\2||\\3||\\4', $poll_device['sysDescr']);
 list($hardware,$version,$serial,$features) = explode('||', $version);
 
-$sess_cmd  = $config['snmpget'].' -M '.$config['mibdir'].' -O qv '.snmp_gen_auth($device).' '.$device['hostname'];
-$sess_cmd .= ' .1.3.6.1.4.1.3224.16.3.2.0 .1.3.6.1.4.1.3224.16.3.3.0 .1.3.6.1.4.1.3224.16.3.4.0';
-$sess_data = shell_exec($sess_cmd);
-list ($sessalloc, $sessmax, $sessfailed) = explode("\n", $sess_data);
+$oids = array(
+    '.1.3.6.1.4.1.3224.16.3.2.0',
+    '.1.3.6.1.4.1.3224.16.3.3.0',
+    '.1.3.6.1.4.1.3224.16.3.4.0',
+);
+$sess_data = snmp_get_multi_oid($device, $oids, '-Oqv');
+list ($sessalloc, $sessmax, $sessfailed) = array_values($sess_data);
 
 $rrd_def = RrdDefinition::make()
     ->addDataset('allocate', 'GAUGE', 0, 3000000)

--- a/includes/polling/os/speedtouch.inc.php
+++ b/includes/polling/os/speedtouch.inc.php
@@ -7,7 +7,7 @@ $hardware = $poll_device['sysDescr'];
 $features = '';
 
 // Filthy hack to get software version. may not work on anything but 585v7 :)
-$loop = shell_exec($config['snmpget'].' -M '.$config['mibdir'].' -Ovq '.snmp_gen_auth($device).' '.$device['hostname'].' ifDescr.101');
+$loop = snmp_get($device, 'ifDescr.101', '-Oqv');
 
 if ($loop) {
     preg_match('@([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)@i', $loop, $matches);


### PR DESCRIPTION
When calling snmpget (etc) this way it doesn't work with the save-tests-data.php script.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
