### PR TITLE
Fail2ban polling update and dropping of the FW checking

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -215,21 +215,36 @@ snmp ALL=(ALL) NOPASSWD: /etc/snmp/exim-stats.sh, /usr/bin/exim*
 extend fail2ban /etc/snmp/fail2ban
 ```
 
-4: Edit /etc/snmp/fail2ban to match the firewall table you are using on your system. You should be good if you are using the defaults. Also make sure that the cache variable is properly set if you wish to use caching. The directory it exists in, needs to exist as well. To make sure it is working with out issue, run '/etc/snmp/fail2ban -u' and make sure it runs with out producing any errors.
+If you want to use the cache, it is as below, by using the -c switch.
+```
+extend fail2ban /etc/snmp/fail2ban -c
+```
+
+If you want to use the cache and update it if needed, this can by using the -c and -U switches.
+```
+extend fail2ban /etc/snmp/fail2ban -c -U
+```
+
+If you need to specify a custom location for the fail2ban-client, that can be done via the -f switch.
+
+If not specified, "/usr/bin/env fail2ban-client" is used.
+
+```
+extend fail2ban /etc/snmp/fail2ban -f /foo/bin/fail2ban-client
+```
 
 5: Restart snmpd on your host
 
-6: If you wish to use caching, add the following to /etc/crontab and restart cron.
+6: If you wish to use caching, add the following to /etc/crontab and restart cron. 
 ```
 */3    *    *    *    *    root    /etc/snmp/fail2ban -u 
 ```
 
 7: Restart or reload cron on your system.
 
-In regards to the totals graphed there are two variables banned and firewalled. Firewalled is a count of banned entries the firewall for fail2ban and banned is the currently banned total from fail2ban-client. Both are graphed as the total will diverge with some configurations when fail2ban fails to see if a IP is in more than one jail when unbanning it. This is most likely to happen when the recidive is in use.
-
 If you have more than a few jails configured, you may need to use caching as each jail needs to be polled and fail2ban-client can't do so in a timely manner for than a few. This can result in failure of other SNMP information being polled.
 
+For additional details of the switches, please see the POD in the script it self at the top.
 
 ### FreeBSD NFS Client
 #### SNMP Extend

--- a/html/includes/graphs/application/fail2ban_banned.inc.php
+++ b/html/includes/graphs/application/fail2ban_banned.inc.php
@@ -21,12 +21,6 @@ if (is_file($rrd_filename)) {
             'ds'       => 'banned',
             'colour'   => '582A72'
         ),
-        array(
-            'filename' => $rrd_filename,
-            'descr'    => 'Firewalled',
-            'ds'       => 'firewalled',
-            'colour'   => '28774F'
-        )
     );
 } else {
     echo "file missing: $rrd_filename";

--- a/html/includes/graphs/application/fail2ban_banned.inc.php
+++ b/html/includes/graphs/application/fail2ban_banned.inc.php
@@ -11,7 +11,7 @@ $printtotal    = 0;
 $addarea       = 1;
 $transparency  = 15;
 
-$rrd_filename = rrd_name($device['hostname'], array('app', $app['app_type'], $app['app_id']));
+$rrd_filename = rrd_name($device['hostname'], array('app', $app['app_type'], $app['app_id'], 'totalbanned'));
 
 if (is_file($rrd_filename)) {
     $rrd_list = array(

--- a/html/includes/graphs/application/fail2ban_banned.inc.php
+++ b/html/includes/graphs/application/fail2ban_banned.inc.php
@@ -11,7 +11,7 @@ $printtotal    = 0;
 $addarea       = 1;
 $transparency  = 15;
 
-$rrd_filename = rrd_name($device['hostname'], array('app', $app['app_type'], $app['app_id'], 'totalbanned'));
+$rrd_filename = rrd_name($device['hostname'], array('app', $app['app_type'], $app['app_id']));
 
 if (is_file($rrd_filename)) {
     $rrd_list = array(

--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -17,12 +17,15 @@ $bannedStuff = explode("\n", $f2b);
 
 $total_banned=$bannedStuff[0];
 
-$rrd_name = array('app', $name, $app_id, 'totalbanned');
+$rrd_name = array('app', $name, $app_id);
 $rrd_def = RrdDefinition::make()
-    ->addDataset('banned', 'GAUGE', 0);
+    ->addDataset('banned', 'GAUGE', 0)
+    ->addDataset('firewalled', 'GAUGE', 0);
+
 
 $fields = array(
     'banned' =>$total_banned,
+    'firewalled'=>'U',
 );
 $metrics['total'] = $fields;
 

--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -16,23 +16,20 @@ $metrics = array();
 $bannedStuff = explode("\n", $f2b);
 
 $total_banned=$bannedStuff[0];
-$firewalled=$bannedStuff[1];
 
 $rrd_name = array('app', $name, $app_id);
 $rrd_def = RrdDefinition::make()
-    ->addDataset('banned', 'GAUGE', 0)
-    ->addDataset('firewalled', 'GAUGE', 0);
+    ->addDataset('banned', 'GAUGE', 0);
 
 $fields = array(
     'banned' =>$total_banned,
-    'firewalled' => $firewalled,
 );
 $metrics['total'] = $fields;
 
 $tags = array('name' => $name, 'app_id' => $app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name);
 data_update($device, 'app', $tags, $fields);
 
-$int=2;
+$int=1;
 $jails=array();
 
 while (isset($bannedStuff[$int])) {

--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -17,7 +17,7 @@ $bannedStuff = explode("\n", $f2b);
 
 $total_banned=$bannedStuff[0];
 
-$rrd_name = array('app', $name, $app_id);
+$rrd_name = array('app', $name, $app_id, 'totalbanned');
 $rrd_def = RrdDefinition::make()
     ->addDataset('banned', 'GAUGE', 0);
 


### PR DESCRIPTION
Since fail2ban on FreeBSD has moved to using anchors, the previous
issue of it dreking all over its self is no longer a problem.

And AFAIK it has never been an issue on Linux.

This also makes this script more cross platform as well instead.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


Dropping the firewall stuff as since Fail2ban as updated to using anchors(while esoteric as drek, are uber awesome it turns out) in PF instead of tables it means it is a lot more reliable on those systems and I can't seem to find any references to issues with IPFW.

https://github.com/librenms/librenms-agent/pull/155

That update is also needed for this. The polling is not really backwards compatible. The poller is also massively cleaned up and better documented.

Also RRDs are backwards compatible. Any one with the old totals RRD will now just have a RRD with a unused field in it.