### PR TITLE
api: Added 404 fallback for bad / invalid calls

### DIFF
--- a/html/api_v0.php
+++ b/html/api_v0.php
@@ -33,6 +33,10 @@ if (Config::get('api.cors.enabled') === true) {
 require $config['install_dir'] . '/html/includes/api_functions.inc.php';
 $app->setName('api');
 
+$app->notFound(function () use ($app) {
+    api_error(404, "This API route doesn't exist.");
+});
+
 $app->group(
     '/api',
     function () use ($app) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Before any invalid api calls resulted in the LibreNMS index page being delivered. This now responds with:

```
{
    "status": "error",
    "message": "This API route doesn't exist."
}
```