### PR TITLE
webui: Make left and right texts on percentage bar look better.

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -603,8 +603,8 @@ function print_percentage_bar($width, $height, $percent, $left_text, $left_colou
         <div class="progress-bar" role="progressbar" aria-valuenow="'.$size_percent.'" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width:'.$size_percent.'%; background-color: #'.$left_background.';">
         </div>
         </div>
-        <b style="padding-left: 10%; position: absolute; top: 0px; left: 0px;color:#'.$left_colour.';">'.$left_text.'</b>
-        <b style="padding-right: 10%; position: absolute; top: 0px; right: 0px;color:#'.$right_colour.';">'.$right_text.'</b>
+        <b style="padding-left: 2%; position: absolute; top: 0px; left: 0px;color:#'.$left_colour.';">'.$left_text.'</b>
+        <b style="padding-right: 2%; position: absolute; top: 0px; right: 0px;color:#'.$right_colour.';">'.$right_text.'</b>
         </div>
         ';
 


### PR DESCRIPTION
In the screenshot, top one is 2% and the one below is 10%. With last css updates, the text moved further towards the centre.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

![screen shot 2017-12-26 at 14 18 38](https://user-images.githubusercontent.com/1029270/34355653-2829464c-ea48-11e7-96eb-394f62476d67.png)