### PR TITLE
Use ignore_storage function for NetApp storage discovery

### DIFF
--- a/includes/discovery/storage/netapp-storage.inc.php
+++ b/includes/discovery/storage/netapp-storage.inc.php
@@ -18,28 +18,7 @@ if (is_array($netapp_storage)) {
             $used = ($storage['dfKBytesUsed'] * $units);
         }
 
-        foreach (Config::get('ignore_mount', array()) as $bi) {
-            if ($bi == $descr) {
-                d_echo("$bi == $descr \n");
-                continue;
-            }
-        }
-
-        foreach (Config::get('ignore_mount_string', array()) as $bi) {
-            if (strpos($descr, $bi) !== false) {
-                d_echo("strpos: $descr, $bi \n");
-                continue;
-            }
-        }
-
-        foreach (Config::get('ignore_mount_regexp', array()) as $bi) {
-            if (preg_match($bi, $descr) > '0') {
-                d_echo("preg_match $bi, $descr \n");
-                continue;
-            }
-        }
-
-        if (is_numeric($index)) {
+        if (is_numeric($index) and ignore_storage($device['os'], $descr) != 1) {
             discover_storage($valid_storage, $device, $index, $fstype, 'netapp-storage', $descr, $size, $units, $used);
         }
 


### PR DESCRIPTION
The previous discovery was not honoring the ignore_mount_* configs for me, and whilst investigating I noticed the ignore_storage function. I've updated the discovery to use this instead and the ignore options now appear to be working as expected.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
