### PR TITLE
Move ignore_storage call to discover_storage

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -577,37 +577,39 @@ function discover_link($local_port_id, $protocol, $remote_port_id, $remote_hostn
 
 function discover_storage(&$valid, $device, $index, $type, $mib, $descr, $size, $units, $used = null)
 {
-    d_echo("Discover Storage: $index, $type, $mib, $descr, $size, $units, $used\n");
+    if (ignore_storage($device['os'], $descr) != 1) {
+        d_echo("Discover Storage: $index, $type, $mib, $descr, $size, $units, $used\n");
 
-    if ($descr && $size > '0') {
-        $storage = dbFetchRow('SELECT * FROM `storage` WHERE `storage_index` = ? AND `device_id` = ? AND `storage_mib` = ?', array($index, $device['device_id'], $mib));
-        if ($storage === false || !count($storage)) {
-            $insert = dbInsert(
-                array(
-                    'device_id' => $device['device_id'],
-                    'storage_descr' => $descr,
-                    'storage_index' => $index,
-                    'storage_mib' => $mib,
-                    'storage_type' => $type,
-                    'storage_units' => $units,
-                    'storage_size' => $size,
-                    'storage_used' => $used,
-                ),
-                'storage'
-            );
+        if ($descr && $size > '0') {
+            $storage = dbFetchRow('SELECT * FROM `storage` WHERE `storage_index` = ? AND `device_id` = ? AND `storage_mib` = ?', array($index, $device['device_id'], $mib));
+            if ($storage === false || !count($storage)) {
+                $insert = dbInsert(
+                    array(
+                        'device_id' => $device['device_id'],
+                        'storage_descr' => $descr,
+                        'storage_index' => $index,
+                        'storage_mib' => $mib,
+                        'storage_type' => $type,
+                        'storage_units' => $units,
+                        'storage_size' => $size,
+                        'storage_used' => $used,
+                    ),
+                    'storage'
+                );
 
-            echo '+';
-        } else {
-            $updated = dbUpdate(array('storage_descr' => $descr, 'storage_type' => $type, 'storage_units' => $units, 'storage_size' => $size), 'storage', '`device_id` = ? AND `storage_index` = ? AND `storage_mib` = ?', array($device['device_id'], $index, $mib));
-            if ($updated) {
-                echo 'U';
+                echo '+';
             } else {
-                echo '.';
-            }
-        }//end if
+                $updated = dbUpdate(array('storage_descr' => $descr, 'storage_type' => $type, 'storage_units' => $units, 'storage_size' => $size), 'storage', '`device_id` = ? AND `storage_index` = ? AND `storage_mib` = ?', array($device['device_id'], $index, $mib));
+                if ($updated) {
+                    echo 'U';
+                } else {
+                    echo '.';
+                }
+            }//end if
 
-        $valid[$mib][$index] = 1;
-    }//end if
+            $valid[$mib][$index] = 1;
+        }//end if
+    }//
 }
 
 //end discover_storage()

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -577,39 +577,40 @@ function discover_link($local_port_id, $protocol, $remote_port_id, $remote_hostn
 
 function discover_storage(&$valid, $device, $index, $type, $mib, $descr, $size, $units, $used = null)
 {
-    if (ignore_storage($device['os'], $descr) != 1) {
-        d_echo("Discover Storage: $index, $type, $mib, $descr, $size, $units, $used\n");
+    if (ignore_storage($device['os'], $descr)) {
+        return;
+    }
+    d_echo("Discover Storage: $index, $type, $mib, $descr, $size, $units, $used\n");
 
-        if ($descr && $size > '0') {
-            $storage = dbFetchRow('SELECT * FROM `storage` WHERE `storage_index` = ? AND `device_id` = ? AND `storage_mib` = ?', array($index, $device['device_id'], $mib));
-            if ($storage === false || !count($storage)) {
-                $insert = dbInsert(
-                    array(
-                        'device_id' => $device['device_id'],
-                        'storage_descr' => $descr,
-                        'storage_index' => $index,
-                        'storage_mib' => $mib,
-                        'storage_type' => $type,
-                        'storage_units' => $units,
-                        'storage_size' => $size,
-                        'storage_used' => $used,
-                    ),
-                    'storage'
-                );
+    if ($descr && $size > '0') {
+        $storage = dbFetchRow('SELECT * FROM `storage` WHERE `storage_index` = ? AND `device_id` = ? AND `storage_mib` = ?', array($index, $device['device_id'], $mib));
+        if ($storage === false || !count($storage)) {
+            $insert = dbInsert(
+                array(
+                    'device_id' => $device['device_id'],
+                    'storage_descr' => $descr,
+                    'storage_index' => $index,
+                    'storage_mib' => $mib,
+                    'storage_type' => $type,
+                    'storage_units' => $units,
+                    'storage_size' => $size,
+                    'storage_used' => $used,
+                ),
+                'storage'
+            );
 
-                echo '+';
+            echo '+';
+        } else {
+            $updated = dbUpdate(array('storage_descr' => $descr, 'storage_type' => $type, 'storage_units' => $units, 'storage_size' => $size), 'storage', '`device_id` = ? AND `storage_index` = ? AND `storage_mib` = ?', array($device['device_id'], $index, $mib));
+            if ($updated) {
+                echo 'U';
             } else {
-                $updated = dbUpdate(array('storage_descr' => $descr, 'storage_type' => $type, 'storage_units' => $units, 'storage_size' => $size), 'storage', '`device_id` = ? AND `storage_index` = ? AND `storage_mib` = ?', array($device['device_id'], $index, $mib));
-                if ($updated) {
-                    echo 'U';
-                } else {
-                    echo '.';
-                }
-            }//end if
-
-            $valid[$mib][$index] = 1;
+                echo '.';
+            }
         }//end if
-    }//
+
+        $valid[$mib][$index] = 1;
+    }//end if
 }
 
 //end discover_storage()

--- a/includes/discovery/storage/netapp-storage.inc.php
+++ b/includes/discovery/storage/netapp-storage.inc.php
@@ -18,27 +18,6 @@ if (is_array($netapp_storage)) {
             $used = ($storage['dfKBytesUsed'] * $units);
         }
 
-        foreach (Config::get('ignore_mount', array()) as $bi) {
-            if ($bi == $descr) {
-                d_echo("$bi == $descr \n");
-                continue;
-            }
-        }
-
-        foreach (Config::get('ignore_mount_string', array()) as $bi) {
-            if (strpos($descr, $bi) !== false) {
-                d_echo("strpos: $descr, $bi \n");
-                continue;
-            }
-        }
-
-        foreach (Config::get('ignore_mount_regexp', array()) as $bi) {
-            if (preg_match($bi, $descr) > '0') {
-                d_echo("preg_match $bi, $descr \n");
-                continue;
-            }
-        }
-
         if (is_numeric($index)) {
             discover_storage($valid_storage, $device, $index, $fstype, 'netapp-storage', $descr, $size, $units, $used);
         }

--- a/includes/discovery/storage/ucd-dsktable.inc.php
+++ b/includes/discovery/storage/ucd-dsktable.inc.php
@@ -13,9 +13,7 @@ if (is_array($dsktable_array)) {
                 $dsk['dskAvail'] = ($entry['dskAvail'] * 1024);
                 $dsk['dskUsed'] = $dsk['dskTotal'] - $dsk['dskAvail'];
 
-                if (ignore_storage($device['os'], $dsk['dskPath']) != 1) {
-                    discover_storage($valid_storage, $device, $dsk['dskIndex'], 'dsk', 'ucd-dsktable', $dsk['dskPath'], $dsk['dskTotal'], 1024, $dsk['dskUsed']);
-                }
+                discover_storage($valid_storage, $device, $dsk['dskIndex'], 'dsk', 'ucd-dsktable', $dsk['dskPath'], $dsk['dskTotal'], 1024, $dsk['dskUsed']);
             }
         }
     }


### PR DESCRIPTION
Calling ignore_storage as part of discover_storage to ignore based on description. Also updated NetApp and ucd-dsktable to remove calls to ignore_storage in these discovery includes.

Tested the NetApp discovery and works as expected.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
