### PR TITLE
Add Oxidized API URL protocol

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2174,3 +2174,8 @@ label {
   vertical-align: middle;
   padding: 15px;
 }
+
+.validation:invalid {
+    border-color: red;
+}
+

--- a/html/includes/forms/update-config-item.inc.php
+++ b/html/includes/forms/update-config-item.inc.php
@@ -83,6 +83,9 @@ if (!is_numeric($config_id)) {
     $status  = 'ok';
 } else {
     $state  = mres($_POST['config_value']);
+    if ($_POST['item_name'] == "oxidized.url" && !preg_match("#^[a-zA-Z0-9]{1,5}://#", $state)) {
+        $state = "http://" . $state;
+    }
     $update = dbUpdate(array('config_value' => $state), 'config', '`config_id`=?', array($config_id));
     if (!empty($update) || $update == '0') {
         $message = 'Alert rule has been updated.';

--- a/html/includes/forms/update-config-item.inc.php
+++ b/html/includes/forms/update-config-item.inc.php
@@ -83,9 +83,6 @@ if (!is_numeric($config_id)) {
     $status  = 'ok';
 } else {
     $state  = mres($_POST['config_value']);
-    if ($_POST['item_name'] == "oxidized.url" && !preg_match("#^[a-zA-Z0-9]{1,5}://#", $state)) {
-        $state = "http://" . $state;
-    }
     $update = dbUpdate(array('config_value' => $state), 'config', '`config_id`=?', array($config_id));
     if (!empty($update) || $update == '0') {
         $message = 'Alert rule has been updated.';

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1257,8 +1257,9 @@ function generate_dynamic_config_panel($title, $config_groups, $items = array(),
             if ($item['type'] == 'checkbox') {
                 $output .= '<input id="' . $item['name'] . '" type="checkbox" name="global-config-check" ' . $config_groups[$item['name']]['config_checked'] . ' data-on-text="Yes" data-off-text="No" data-size="small" data-config_id="' . $config_groups[$item['name']]['config_id'] . '">';
             } elseif ($item['type'] == 'text') {
+                $pattern = isset($item['pattern']) ? ' pattern="' . $item['pattern'] . '"' : "";
                 $output .= '
-                <input id="' . $item['name'] . '" class="form-control" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . '" data-item_name="' . $item['name'] . '">
+                <input id="' . $item['name'] . '" class="form-control validation" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . '"' . $pattern . '>
                 <span class="form-control-feedback"><i class="fa" aria-hidden="true"></i></span>
                 ';
             } elseif ($item['type'] == 'password') {

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1258,7 +1258,7 @@ function generate_dynamic_config_panel($title, $config_groups, $items = array(),
                 $output .= '<input id="' . $item['name'] . '" type="checkbox" name="global-config-check" ' . $config_groups[$item['name']]['config_checked'] . ' data-on-text="Yes" data-off-text="No" data-size="small" data-config_id="' . $config_groups[$item['name']]['config_id'] . '">';
             } elseif ($item['type'] == 'text') {
                 $output .= '
-                <input id="' . $item['name'] . '" class="form-control" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . ' data-item_name="' . $item['name'] . '">
+                <input id="' . $item['name'] . '" class="form-control" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . '" data-item_name="' . $item['name'] . '">
                 <span class="form-control-feedback"><i class="fa" aria-hidden="true"></i></span>
                 ';
             } elseif ($item['type'] == 'password') {

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1257,7 +1257,7 @@ function generate_dynamic_config_panel($title, $config_groups, $items = array(),
             if ($item['type'] == 'checkbox') {
                 $output .= '<input id="' . $item['name'] . '" type="checkbox" name="global-config-check" ' . $config_groups[$item['name']]['config_checked'] . ' data-on-text="Yes" data-off-text="No" data-size="small" data-config_id="' . $config_groups[$item['name']]['config_id'] . '">';
             } elseif ($item['type'] == 'text') {
-                $pattern = isset($item['pattern']) ? ' pattern="' . $item['pattern'] . '"' : "";
+                $pattern = isset($item['pattern']) ? ' required pattern="' . $item['pattern'] . '"' : "";
                 $output .= '
                 <input id="' . $item['name'] . '" class="form-control validation" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . '"' . $pattern . '>
                 <span class="form-control-feedback"><i class="fa" aria-hidden="true"></i></span>

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1258,7 +1258,7 @@ function generate_dynamic_config_panel($title, $config_groups, $items = array(),
                 $output .= '<input id="' . $item['name'] . '" type="checkbox" name="global-config-check" ' . $config_groups[$item['name']]['config_checked'] . ' data-on-text="Yes" data-off-text="No" data-size="small" data-config_id="' . $config_groups[$item['name']]['config_id'] . '">';
             } elseif ($item['type'] == 'text') {
                 $output .= '
-                <input id="' . $item['name'] . '" class="form-control" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . '">
+                <input id="' . $item['name'] . '" class="form-control" type="text" name="global-config-input" value="' . $config_groups[$item['name']]['config_value'] . '" data-config_id="' . $config_groups[$item['name']]['config_id'] . ' data-item_name="' . $item['name'] . '">
                 <span class="form-control-feedback"><i class="fa" aria-hidden="true"></i></span>
                 ';
             } elseif ($item['type'] == 'password') {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -87,22 +87,25 @@ $(document).ready(function() {
         var $this = $(this);
         var config_id = $this.data("config_id");
         var config_value = $this.val();
-        $.ajax({
-            type: 'POST',
-            url: 'ajax_form.php',
-            data: {type: "update-config-item", config_id: config_id, config_value: config_value},
-            dataType: "json",
-            success: function (data) {
-                if (data.status == 'ok') {
-                    toastr.success('Config updated');
-                } else {
+        var required = $this.prop('required');
+        if (required == false) {
+            $.ajax({
+                type: 'POST',
+                url: 'ajax_form.php',
+                data: {type: "update-config-item", config_id: config_id, config_value: config_value},
+                dataType: "json",
+                success: function (data) {
+                    if (data.status == 'ok') {
+                        toastr.success('Config updated');
+                    } else {
+                        toastr.error(data.message);
+                    }
+                },
+                error: function () {
                     toastr.error(data.message);
                 }
-            },
-            error: function () {
-                toastr.error(data.message);
-            }
-        });
+            });
+        }
     });
 
     // Select config ajax calls

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -87,10 +87,11 @@ $(document).ready(function() {
         var $this = $(this);
         var config_id = $this.data("config_id");
         var config_value = $this.val();
+        var item_name = $this.data("item_name");
         $.ajax({
             type: 'POST',
             url: 'ajax_form.php',
-            data: {type: "update-config-item", config_id: config_id, config_value: config_value},
+            data: {type: "update-config-item", config_id: config_id, config_value: config_value, item_name: item_name},
             dataType: "json",
             success: function (data) {
                 if (data.status == 'ok') {

--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -87,11 +87,10 @@ $(document).ready(function() {
         var $this = $(this);
         var config_id = $this.data("config_id");
         var config_value = $this.val();
-        var item_name = $this.data("item_name");
         $.ajax({
             type: 'POST',
             url: 'ajax_form.php',
-            data: {type: "update-config-item", config_id: config_id, config_value: config_value, item_name: item_name},
+            data: {type: "update-config-item", config_id: config_id, config_value: config_value},
             dataType: "json",
             success: function (data) {
                 if (data.status == 'ok') {

--- a/html/pages/settings/external.inc.php
+++ b/html/pages/settings/external.inc.php
@@ -12,6 +12,7 @@ $oxidized_conf = array(
     array('name'               => 'oxidized.url',
           'descr'              => 'URL to your Oxidized API',
           'type'               => 'text',
+          'pattern'            => '[a-zA-Z0-9]{1,5}://.*',
     ),
     array('name'               => 'oxidized.features.versioning',
           'descr'              => 'Enable config versioning access',


### PR DESCRIPTION
file_get_contents() need the protocol ("http://" or similar) when fetching remote files, add it to the oxidized API URL config if the user forgot it.

From: https://www.reddit.com/r/LibreNMS/comments/7mrufq/i_am_a_moron_oxidized_config/

I'm not sure this is the best place to add this check, if you have any suggestion, please let me know.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
