### PR TITLE
Fixed UniFi AP hardware type and firmware version retrieval

### DIFF
--- a/includes/definitions/unifi.yaml
+++ b/includes/definitions/unifi.yaml
@@ -2,7 +2,6 @@ os: unifi
 text: 'Ubiquiti UniFi'
 type: wireless
 icon: ubiquiti
-nobulk: 1
 group: ubnt
 over:
     - { graph: device_bits, text: 'Device Traffic' }

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -1,27 +1,9 @@
 <?php
-$data = snmp_get_multi($device, 'dot11manufacturerProductName.2 dot11manufacturerProductVersion.2', '-OQUs', 'IEEE802dot11-MIB');
-if (empty($data)) {
-    $data = snmp_get_multi($device, 'dot11manufacturerProductName.3 dot11manufacturerProductVersion.3', '-OQUs', 'IEEE802dot11-MIB');
+
+if ($sysmodel = snmp_get($device, 'unifiApSystemModel.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
+    $hardware = $sysmodel;
 }
 
-if (empty($data)) {
-    $data = snmp_get_multi($device, 'dot11manufacturerProductName.4 dot11manufacturerProductVersion.4', '-OQUs', 'IEEE802dot11-MIB');
-}
-
-if (empty($data)) {
-    $data = snmp_get_multi($device, 'dot11manufacturerProductName.5 dot11manufacturerProductVersion.5', '-OQUs', 'IEEE802dot11-MIB');
-}
-
-if (empty($data)) {
-    $data = snmp_get_multi($device, 'dot11manufacturerProductName.6 dot11manufacturerProductVersion.6', '-OQUs', 'IEEE802dot11-MIB');
-}
-
-foreach ($data as $line) {
-    if (!empty($line['dot11manufacturerProductName'])) {
-        $hardware = $line['dot11manufacturerProductName'];
-    }
-
-    if (preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $line['dot11manufacturerProductVersion'], $matches)) {
-        $version = $matches[0];
-    }
+if ($sysver = snmp_get($device, 'unifiApSystemVersion.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
+    $version = $sysver;
 }

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -1,9 +1,11 @@
 <?php
 
-if ($sysmodel = snmp_get($device, 'unifiApSystemModel.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
-    $hardware = $sysmodel;
-}
-
-if ($sysver = snmp_get($device, 'unifiApSystemVersion.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
-    $version = $sysver;
+if ($data = snmp_get_multi($device, 'unifiApSystemModel unifiApSystemVersion', '-OUQs', 'UBNT-UniFi-MIB')) {
+    $hardware = $data[0]['unifiApSystemModel'];
+    $version = $data[0]['unifiApSystemVersion'];
+} elseif ($data = snmp_get_multi($device, 'dot11manufacturerProductName dot11manufacturerProductVersion', '-OQUs', 'IEEE802dot11-MIB')) {
+    $hardware = $data[0]['dot11manufacturerProductName'];
+    if (preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $data[0]['dot11manufacturerProductVersion'], $matches)) {
+        $version = $matches[0];
+    }
 }

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -3,7 +3,6 @@ if ($data = snmp_get_multi($device, 'unifiApSystemModel unifiApSystemVersion', '
     $hardware = $data['unifiApSystemModel'];
     $version = $data['unifiApSystemVersion'];
 } elseif ($data = snmp_getnext_multi($device, 'dot11manufacturerProductName dot11manufacturerProductVersion', '-OQUs', 'IEEE802dot11-MIB')) {
-    $data = current($data); //strip index
     $hardware = $data['dot11manufacturerProductName'];
     if (preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $data['dot11manufacturerProductVersion'], $matches)) {
         $version = $matches[0];

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -1,9 +1,15 @@
 <?php
 
-if ($sysmodel = snmp_get($device, 'unifiApSystemModel.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
-    $hardware = $sysmodel;
-}
-
-if ($sysver = snmp_get($device, 'unifiApSystemVersion.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
-    $version = $sysver;
+if ($poll_device['sysObjectID'] == 'enterprises.10002.1') {
+    if ($data = snmp_get_multi($device, 'dot11manufacturerProductName.0 dot11manufacturerProductVersion.0', '-OQUs', 'IEEE802dot11-MIB')) {
+        $hardware = $data[0]['dot11manufacturerProductName'];
+        if (preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $data[0]['dot11manufacturerProductVersion'], $matches)) {
+            $version = $matches[0];
+        }
+    }
+} elseif ($poll_device['sysObjectID'] == 'enterprises.8072.3.2.10') {
+    if ($data = snmp_get_multi($device, 'unifiApSystemModel.0 unifiApSystemVersion.0', '-OUQs', 'UBNT-UniFi-MIB')) {
+        $hardware = $data[0]['unifiApSystemModel'];
+        $version = $data[0]['unifiApSystemVersion'];
+    }
 }

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -1,15 +1,9 @@
 <?php
 
-if ($poll_device['sysObjectID'] == 'enterprises.10002.1') {
-    if ($data = snmp_get_multi($device, 'dot11manufacturerProductName.0 dot11manufacturerProductVersion.0', '-OQUs', 'IEEE802dot11-MIB')) {
-        $hardware = $data[0]['dot11manufacturerProductName'];
-        if (preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $data[0]['dot11manufacturerProductVersion'], $matches)) {
-            $version = $matches[0];
-        }
-    }
-} elseif ($poll_device['sysObjectID'] == 'enterprises.8072.3.2.10') {
-    if ($data = snmp_get_multi($device, 'unifiApSystemModel.0 unifiApSystemVersion.0', '-OUQs', 'UBNT-UniFi-MIB')) {
-        $hardware = $data[0]['unifiApSystemModel'];
-        $version = $data[0]['unifiApSystemVersion'];
-    }
+if ($sysmodel = snmp_get($device, 'unifiApSystemModel.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
+    $hardware = $sysmodel;
+}
+
+if ($sysver = snmp_get($device, 'unifiApSystemVersion.0', '-Osqnv', 'UBNT-UniFi-MIB')) {
+    $version = $sysver;
 }

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -5,8 +5,8 @@
  */
 
 if ($data = snmp_get_multi($device, 'unifiApSystemModel unifiApSystemVersion', '-OQUs', 'UBNT-UniFi-MIB')) {
-    $hardware = $data[0]['unifiApSystemModel'];
-    $version = $data[0]['unifiApSystemVersion'];
+    $hardware = $data['unifiApSystemModel'];
+    $version = $data['unifiApSystemVersion'];
 } elseif ($data = snmp_getnext($device, 'dot11manufacturerProductName dot11manufacturerProductVersion', '-Oqs', 'IEEE802dot11-MIB')) {
     foreach (explode("\n", $data) as $entry) {
         $entry = explode(" ", $entry);

--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -1,20 +1,11 @@
 <?php
-
-/**
- * Some of the processing logic below is borrowed from snmp_get_multi() to parse a multi-output snmp_getnext()
- */
-
 if ($data = snmp_get_multi($device, 'unifiApSystemModel unifiApSystemVersion', '-OQUs', 'UBNT-UniFi-MIB')) {
     $hardware = $data['unifiApSystemModel'];
     $version = $data['unifiApSystemVersion'];
-} elseif ($data = snmp_getnext($device, 'dot11manufacturerProductName dot11manufacturerProductVersion', '-Oqs', 'IEEE802dot11-MIB')) {
-    foreach (explode("\n", $data) as $entry) {
-        $entry = explode(" ", $entry);
-        if (str_contains($entry[0], 'dot11manufacturerProductName')) {
-            $hardware = $entry[1];
-        }
-        if (str_contains($entry[0], 'dot11manufacturerProductVersion') && preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $entry[1], $matches)) {
-            $version = $matches[0];
-        }
+} elseif ($data = snmp_getnext_multi($device, 'dot11manufacturerProductName dot11manufacturerProductVersion', '-OQUs', 'IEEE802dot11-MIB')) {
+    $data = current($data); //strip index
+    $hardware = $data['dot11manufacturerProductName'];
+    if (preg_match('/(v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/', $data['dot11manufacturerProductVersion'], $matches)) {
+        $version = $matches[0];
     }
 }


### PR DESCRIPTION
Hi All,

Just a small change here - the existing code to pull hardware/version details from UniFi APs uses a part of IEEE802dot11-MIB which the UniFi APs are... somewhat confused about how to respond to.

Short version; instead of pulling dot11manufacturerName and dot11manufacturerProductVersion from IEEE802dot11-MIB, we pull unifiApSystemModel.0 and unifiApSystemVersion.0 from UBNT-UniFi-MIB. I've also dropped the nobulk flag from the OS definition as it's redundant.

Long version;

In the existing code, we iterate through several possible entity IDs in an attempt to find a valid dot11manufacturerName.x and dot11manufacturerProductVersion.x in IEEE802dot11-MIB. These entities are indexed by vAP interface (SSID/vwire) - in my installation I've seen the index as high as 27 as it increments on config change;

<img width="877" alt="screenshot 2018-01-03 17 40 07" src="https://user-images.githubusercontent.com/4232981/34511057-27f49df0-f0ad-11e7-99e8-4d17fc583893.png">

There's also an issue with the dot11manufacturerProductVersion OID - Ubiquiti released a major UAP firmware upgrade ([3.9.15](https://community.ubnt.com/t5/UniFi-Updates-Blog/FIRMWARE-3-9-15-8011-for-UAP-USW-has-been-released/ba-p/2169339)) a few weeks ago; amongst other things, it replaces tinysnmpd with Net-SNMP & brings v2c/v3 support. Devices on the newer firmware don't respond to dot11manufacturerProductVersion at all; a getnext for the OID skips down the tree to sysDescr.0 without returning any entities. 

Between these two things, model and version detection are broken for UAPs on this firmware and several beta versions. Fortunately, UBNT-UniFi-MIB provides the answer; this MIB is supported by both old and new SNMP daemons, hasn't changed in quite a while, and gives us unifiApSystemModel.0 + unifiApSystemVersion.0. So we just pull those instead, and call it a day. 

While we're at it, I've dropped the nobulk flag from the OS. This doesn't break compatibility with older firmwares; the ubiquiti tinysnmpd implementation only supported SNMPv1, which doesn't do bulkwalks, and snmp.inc.php disables bulkwalks for v1 devices too just for good measure;

https://github.com/librenms/librenms/blob/34ed39c1f9a0aa9c21fe4d0859c7f3ac3678a976/includes/snmp.inc.php#L141-L144

And the change has the desired effect;

<img width="880" alt="screenshot 2018-01-03 18 04 23" src="https://user-images.githubusercontent.com/4232981/34511556-a09c09a2-f0b0-11e7-9bfe-9efc8c724030.png">

Shiny. Works just fine on firmwares as far back as 3.7.37, too.

<img width="686" alt="screenshot 2018-01-03 18 41 20" src="https://user-images.githubusercontent.com/4232981/34512318-c2f268e8-f0b5-11e7-8249-56a501ea4bc5.png">

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Pre-commit says I'm fine! yay.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
