### PR TITLE
fix: Cisco-vrf discovery for device os junos

### DIFF
--- a/includes/discovery/cisco-vrf.inc.php
+++ b/includes/discovery/cisco-vrf.inc.php
@@ -3,7 +3,7 @@
 use LibreNMS\Config;
 
 if (Config::get('enable_vrfs')) {
-    if ($device['os_group'] == 'cisco' || $device['os_group'] == 'junos' || $device['os'] == 'ironware') {
+    if ($device['os_group'] == 'cisco' || $device['os'] == 'junos' || $device['os'] == 'ironware') {
         unset($vrf_count);
 
         /*


### PR DESCRIPTION
Fix vrf discovery for junos devices because there is no
os_group junos right now and no need to create it as
other junos variant probably doesn't support mpls l3vpn.
This PR superseeds #8003 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
