### PR TITLE
fix: Bgp-peers add missing os junos safi values

### DIFF
--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -83,7 +83,7 @@ if (Config::get('enable_bgp')) {
                     $safis[2] = 'multicast';
                     $safis[3] = 'unicastAndMulticast';
                     $safis[4] = 'labeledUnicast';
-                    $safix[128] = 'vpn';
+                    $safis[128] = 'vpn';
 
                     if (!isset($j_peerIndexes)) {
                         $j_bgp = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PeerEntry', $jbgp, 'BGP4-V2-MIB-JUNIPER', 'junos');

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -81,8 +81,9 @@ if (Config::get('enable_bgp')) {
                 if ($device['os'] == 'junos') {
                     $safis[1] = 'unicast';
                     $safis[2] = 'multicast';
-                    $safis[4] = 'mpls-label';
-                    $safix[128] = 'mpls-labled-vpn';
+                    $safis[3] = 'unicastAndMulticast';
+                    $safis[4] = 'labeledUnicast';
+                    $safix[128] = 'vpn';
 
                     if (!isset($j_peerIndexes)) {
                         $j_bgp = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PeerEntry', $jbgp, 'BGP4-V2-MIB-JUNIPER', 'junos');

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -81,6 +81,8 @@ if (Config::get('enable_bgp')) {
                 if ($device['os'] == 'junos') {
                     $safis[1] = 'unicast';
                     $safis[2] = 'multicast';
+                    $safis[4] = 'mpls-label';
+                    $safix[128] = 'mpls-labled-vpn';
 
                     if (!isset($j_peerIndexes)) {
                         $j_bgp = snmpwalk_cache_multi_oid($device, 'jnxBgpM2PeerEntry', $jbgp, 'BGP4-V2-MIB-JUNIPER', 'junos');


### PR DESCRIPTION
This fixes missing safi for Junos bgp peer sessions

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
