### PR TITLE
Fix: Disable the dependency delete button when it should be.

### DIFF
--- a/html/pages/device-dependencies.inc.php
+++ b/html/pages/device-dependencies.inc.php
@@ -70,14 +70,12 @@ var grid = $("#hostdeps").bootgrid({
     },
     formatters: {
         "actions": function(column, row) {
-            var buttonClass = '';
+            var buttonDisabled = '';
             var response =  "<button type='button' class='btn btn-primary btn-sm command-edit' aria-label='Edit' data-toggle='modal' data-target='#edit-dependency' data-device_id='"+row.deviceid+"' data-host_name='"+row.hostname+"' data-parent_id='"+row.parentid+"' name='edit-host-dependency'><i class='fa fa-pencil' aria-hidden='true'></i></button> ";
             if (row.parent == 'None') {
-                buttonClass = 'command-delete btn btn-danger btn-sm disabled';
-            } else {
-                buttonClass = 'command-delete btn btn-danger btn-sm';
+                buttonDisabled = ' disabled';
             }
-            response += "<button type='button' class='"+buttonClass+"' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-device_id='"+row.deviceid+"' data-device_parent ='"+row.parentid+"' data-host_name='"+row.hostname+"' name='delete-host-dependency'><i class='fa fa-trash' aria-hidden='true'></i></button>";
+            response += "<button type='button' class='command-delete btn btn-danger btn-sm"+buttonDisabled+"' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-device_id='"+row.deviceid+"' data-device_parent ='"+row.parentid+"' data-host_name='"+row.hostname+"' name='delete-host-dependency'"+buttonDisabled+"><i class='fa fa-trash' aria-hidden='true'></i></button>";
             return response;
         },
         "hostname": function(column, row) {


### PR DESCRIPTION
The delete dependency button is dim when there is no dependency, but if you click it anyway it still works.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
