### PR TITLE
Fix: Load device attributes before load_os() in device_by_id_cache().

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -360,6 +360,7 @@ function device_by_id_cache($device_id, $refresh = false)
         $device = $cache['devices']['id'][$device_id];
     } else {
         $device = dbFetchRow("SELECT * FROM `devices` WHERE `device_id` = ?", array($device_id));
+        $device['attribs'] = get_dev_attribs($device['device_id']);
         load_os($device);
 
         //order vrf_lite_cisco with context, this will help to get the vrf_name and instance_name all the time


### PR DESCRIPTION
Not sure this is the best place to do this of if this is the only place it's needed, please let me know if you have any suggestions.

`device_by_id_cache()` calls `load_os()` right after fetching the device row from the database. `load_os()` checks if the device attribute `override_device_type` is set, otherwise it will update the device type. The attributes aren't loaded yet, so this always fails and the type is always updated, even when the user has tried to override it.

This fixes #8027.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
