### PR TITLE
fix: ldap-authorization should be considered external

### DIFF
--- a/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
@@ -8,6 +8,7 @@ use LibreNMS\Exceptions\AuthenticationException;
 class ADAuthorizationAuthorizer extends AuthorizerBase
 {
     protected $ldap_connection;
+    protected static $AUTH_IS_EXTERNAL = 1;
 
     public function __construct()
     {

--- a/LibreNMS/Authentication/AuthorizerBase.php
+++ b/LibreNMS/Authentication/AuthorizerBase.php
@@ -252,6 +252,10 @@ abstract class AuthorizerBase implements Authorizer
 
     public function getExternalUsername()
     {
-        return null;
+        if (isset($_SERVER['REMOTE_USER'])) {
+            return clean($_SERVER['REMOTE_USER']);
+        } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
+            return clean($_SERVER['PHP_AUTH_USER']);
+        }
     }
 }

--- a/LibreNMS/Authentication/HttpAuthAuthorizer.php
+++ b/LibreNMS/Authentication/HttpAuthAuthorizer.php
@@ -104,13 +104,4 @@ class HttpAuthAuthorizer extends AuthorizerBase
     {
         dbUpdate(array('realname' => $realname, 'level' => $level, 'can_modify_passwd' => $can_modify_passwd, 'email' => $email), 'users', '`user_id` = ?', array($user_id));
     }
-
-    public function getExternalUsername()
-    {
-        if (isset($_SERVER['REMOTE_USER'])) {
-            return clean($_SERVER['REMOTE_USER']);
-        } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
-            return clean($_SERVER['PHP_AUTH_USER']);
-        }
-    }
 }

--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -221,16 +221,6 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
     }
 
 
-    public function getExternalUsername()
-    {
-        if (isset($_SERVER['REMOTE_USER'])) {
-            return clean($_SERVER['REMOTE_USER']);
-        } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
-            return clean($_SERVER['PHP_AUTH_USER']);
-        }
-    }
-
-
     protected function getMembername($username)
     {
         if (Config::get('auth_ldap_groupmembertype') == 'fulldn') {

--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -45,6 +45,7 @@ use LibreNMS\Exceptions\AuthenticationException;
 class LdapAuthorizationAuthorizer extends AuthorizerBase
 {
     protected $ldap_connection;
+    protected static $AUTH_IS_EXTERNAL = 1;
 
     public function __construct()
     {
@@ -217,6 +218,16 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
             }
         }
         return 0;
+    }
+
+
+    public function getExternalUsername()
+    {
+        if (isset($_SERVER['REMOTE_USER'])) {
+            return clean($_SERVER['REMOTE_USER']);
+        } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
+            return clean($_SERVER['PHP_AUTH_USER']);
+        }
     }
 
 


### PR DESCRIPTION
When sso auth type was added (1c6b7a9), some code for getting a username
was moved into HttpAuthAuthorizer. LdapAuthorizationAuthorizer uses the
same process to get the username and needs to be updated as well.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
