### PR TITLE
Add snmp_getnext_multi() function

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -335,13 +335,10 @@ function snmp_getnext_multi($device, $oids, $options = '-OQUs', $mib = null, $mi
         $value             = trim($value, "\" \n\r");
         list($oid, $index) = explode('.', $oid, 2);
         if (!str_contains($value, 'at this OID')) {
-            if (is_null($index)) {
-                if (empty($oid)) {
-                    continue; // no index or oid
-                }
-                $array[$oid] = $value;
+            if (empty($oid)) {
+                continue; // no index or oid
             } else {
-                $array[$index][$oid] = $value;
+                $array[$oid] = $value;
             }
         }
     }

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -342,7 +342,7 @@ function snmp_getnext_multi($device, $oids, $options = '-OQUs', $mib = null, $mi
             }
         }
     }
-    recordSnmpStatistic('snmpget', $time_start);
+    recordSnmpStatistic('snmpgetnext', $time_start);
     return $array;
 }//end snmp_getnext_multi()
 

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1,3 +1,4 @@
+
 <?php
 /*
  * LibreNMS - SNMP Functions
@@ -306,6 +307,48 @@ function snmp_getnext($device, $oid, $options = null, $mib = null, $mibdir = nul
 
     return false;
 }
+
+/**
+ * Calls snmpgetnext for multiple OIDs.  Getnext returns the next oid after the specified oid.
+ * For example instead of get sysName.0, you can getnext sysName to get the .0 value.
+ *
+ * @param array $device Target device
+ * @param string $oid The oids to getnext
+ * @param string $options Options to pass to snmpgetnext (-OQUs for example)
+ * @param string $mib The MIB to use
+ * @param string $mibdir Optional mib directory to search
+ * @return array|false the output or false if the data could not be fetched
+ */
+
+function snmp_getnext_multi($device, $oids, $options = '-OQUs', $mib = null, $mibdir = null, $array = array())
+{
+    $time_start = microtime(true);
+    if (is_array($oids)) {
+        $oids = implode(' ', $oids);
+    }
+    $snmpcmd  = Config::get('snmpgetnext', 'snmpgetnext');
+    $cmd = gen_snmp_cmd($snmpcmd, $device, $oids, $options, $mib, $mibdir);
+    $data = trim(external_exec($cmd), "\" \n\r");
+
+    foreach (explode("\n", $data) as $entry) {
+        list($oid,$value)  = explode('=', $entry, 2);
+        $oid               = trim($oid);
+        $value             = trim($value, "\" \n\r");
+        list($oid, $index) = explode('.', $oid, 2);
+        if (!str_contains($value, 'at this OID')) {
+            if (is_null($index)) {
+                if (empty($oid)) {
+                    continue; // no index or oid
+                }
+                $array[$oid] = $value;
+            } else {
+                $array[$index][$oid] = $value;
+            }
+        }
+    }
+    recordSnmpStatistic('snmpget', $time_start);
+    return $array;
+}//end snmp_getnext_multi()
 
 /**
  * @param $device

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -1,4 +1,3 @@
-
 <?php
 /*
  * LibreNMS - SNMP Functions
@@ -313,7 +312,7 @@ function snmp_getnext($device, $oid, $options = null, $mib = null, $mibdir = nul
  * For example instead of get sysName.0, you can getnext sysName to get the .0 value.
  *
  * @param array $device Target device
- * @param string $oid The oids to getnext
+ * @param string $oids The oids to getnext
  * @param string $options Options to pass to snmpgetnext (-OQUs for example)
  * @param string $mib The MIB to use
  * @param string $mibdir Optional mib directory to search


### PR DESCRIPTION
Added snmp_getnext_multi() function using syntax of existing snmp_get_multi() function.

This replicates the snmp_get_multi() function but calls snmpgetnext instead, returning an array like so;

```
array(1) {
  [4]=>
  array(2) {
    ["dot11manufacturerProductName"]=>
    string(15) "UAP-AC-Pro-Gen2"
    ["dot11manufacturerProductVersion"]=>
    string(35) "BZ.qca956x.v3.7.37.6065.170118.0908"
  }
}
```

This replicates the output of snmp_get_multi() - we won't know the index in advance, but consistency of outputs seems worth doing.

See #8005 for further details :)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
