### PR TITLE
feature: Clear OS defs cache on poller/discovery debug

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -84,6 +84,7 @@ EOH;
         $vdebug = true;
     }
     $debug = true;
+    update_os_cache(true); // Force update of OS Cache
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);
     ini_set('log_errors', 1);

--- a/poller.php
+++ b/poller.php
@@ -94,6 +94,7 @@ EOH;
         $vdebug = true;
     }
     $debug = true;
+    update_os_cache(true); // Force update of OS Cache
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);
     ini_set('log_errors', 1);


### PR DESCRIPTION
Can't see any draw back to this unless someone has -d or -v set in poller/discovery-wrapper.py!

Will aid people adding new support + for us getting fresh data when asking for debug.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
