### PR TITLE
fix: Moved sysDescr snmp call to snmp_get_multi_oid() in core poller module

### DIFF
--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -13,14 +13,14 @@
 
 use LibreNMS\RRD\RrdDefinition;
 
-$snmpdata = snmp_get_multi_oid($device, 'sysUpTime.0 sysLocation.0 sysContact.0 sysName.0 sysObjectID.0', '-OQnUt', 'SNMPv2-MIB');
+$snmpdata = snmp_get_multi_oid($device, 'sysUpTime.0 sysLocation.0 sysContact.0 sysName.0 sysObjectID.0 sysDescr.0', '-OQnUt', 'SNMPv2-MIB');
 
 $poll_device['sysUptime']   = $snmpdata['.1.3.6.1.2.1.1.3.0'];
 $poll_device['sysLocation'] = $snmpdata['.1.3.6.1.2.1.1.6.0'];
 $poll_device['sysContact']  = $snmpdata['.1.3.6.1.2.1.1.4.0'];
 $poll_device['sysName']     = strtolower($snmpdata['.1.3.6.1.2.1.1.5.0']);
 $poll_device['sysObjectID'] = $snmpdata['.1.3.6.1.2.1.1.2.0'];
-$poll_device['sysDescr']    = snmp_get($device, 'sysDescr.0', '-OvQ', 'SNMPv2-MIB');
+$poll_device['sysDescr']    = $snmpdata['.1.3.6.1.2.1.1.1.0'];
 
 if (!empty($agent_data['uptime'])) {
     list($uptime) = explode(' ', $agent_data['uptime']);


### PR DESCRIPTION
This fixes the issue where discovery and  poller would try and set sysDescr that varied slightly by a character return (difference between snmp_get and snmp_get_multi_oid) - this was the easier fix.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
