### PR TITLE
Fixes #8064 - Use correct array key for uptime value

### DIFF
--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -30,7 +30,7 @@ if (!empty($agent_data['uptime'])) {
     $uptime_data = snmp_get_multi($device, 'snmpEngineTime.0 hrSystemUptime.0', '-OQnUst', 'HOST-RESOURCES-MIB:SNMP-FRAMEWORK-MIB');
 
     $uptime = max(
-        round($poll_device['sysUpTime'] / 100),
+        round($poll_device['sysUptime'] / 100),
         $config['os'][$device['os']]['bad_snmpEngineTime'] ? 0 : $uptime_data[0]['snmpEngineTime'],
         $config['os'][$device['os']]['bad_hrSystemUptime'] ? 0 : round($uptime_data[0]['hrSystemUptime'] / 100)
     );


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: #8064
  