### PR TITLE
Added Dlink MIBS, memory polling and temp polling for some devices

### DIFF
--- a/includes/definitions/discovery/dlink.yaml
+++ b/includes/definitions/discovery/dlink.yaml
@@ -8,5 +8,5 @@ modules:
                     oid: swTemperatureTable
                     value: swTemperatureCurrent
                     num_oid: .1.3.6.1.4.1.171.12.11.1.8.1.2.
-                    descr: Current Sys Temp
-                    index: '{{ $index }}'
+                    descr: 'Current Sys Temp {{ $index }}'
+                    index: 'swTemperatureCurrent.{{ $index }}'

--- a/includes/definitions/discovery/dlink.yaml
+++ b/includes/definitions/discovery/dlink.yaml
@@ -1,0 +1,12 @@
+mib: EQUIPMENT-MIB
+
+modules:
+    sensors:
+        temperature:
+            data:
+                -
+                    oid: swTemperatureTable
+                    value: swTemperatureCurrent
+                    num_oid: .1.3.6.1.4.1.171.12.11.1.8.1.2.
+                    descr: Current Sys Temp
+                    index: '{{ $index }}'

--- a/includes/discovery/mempools/dlink.inc.php
+++ b/includes/discovery/mempools/dlink.inc.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2017 Thomas GAGNIERE
+ * @author     Thomas GAGNIERE <tgagniere@reseau-concept.com>
+ */
+if ($device['os'] == 'dlink') {
+    echo 'D-Link : ';
+    
+    $memory_oid = '.1.3.6.1.4.1.171.12.1.1.9.1.4.1';
+    $usage = snmp_get($device, $memory_oid, '-Ovq');
+    if (is_numeric($usage)) {
+        discover_mempool($valid_mempool, $device, '0', 'dlink', 'Memory', '1', null, null);
+    }
+}

--- a/includes/discovery/mempools/dlink.inc.php
+++ b/includes/discovery/mempools/dlink.inc.php
@@ -10,7 +10,7 @@
  *
  * @package    LibreNMS
  * @link       http://librenms.org
- * @copyright  2017 Thomas GAGNIERE
+ * @copyright  2018 Thomas GAGNIERE
  * @author     Thomas GAGNIERE <tgagniere@reseau-concept.com>
  */
 if ($device['os'] == 'dlink') {

--- a/includes/polling/mempools/dlink.inc.php
+++ b/includes/polling/mempools/dlink.inc.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2017 Thomas GAGNIERE
+ * @author     Thomas GAGNIERE <tgagniere@reseau-concept.com>
+ */
+
+d_echo('Dlink');
+$memory_oid = '.1.3.6.1.4.1.171.12.1.1.9.1.4.1';
+$perc = snmp_get($device, $memory_oid, '-OvQ');
+if (is_numeric($perc)) {
+    $mempool['perc']  = $perc;
+    $mempool['used']  = $perc;
+    $mempool['total'] = 100;
+    $mempool['free']  = 100 - $perc;
+}

--- a/includes/polling/mempools/dlink.inc.php
+++ b/includes/polling/mempools/dlink.inc.php
@@ -18,7 +18,6 @@ d_echo('Dlink');
 $memory_oid = '.1.3.6.1.4.1.171.12.1.1.9.1.4.1';
 $perc = snmp_get($device, $memory_oid, '-OvQ');
 if (is_numeric($perc)) {
-    $mempool['perc']  = $perc;
     $mempool['used']  = $perc;
     $mempool['total'] = 100;
     $mempool['free']  = 100 - $perc;

--- a/includes/polling/os/dlink.inc.php
+++ b/includes/polling/os/dlink.inc.php
@@ -3,5 +3,6 @@
 $Descr_string  = $device['sysDescr'];
 $Descr_chopper = preg_split('/[ ]+/', "$Descr_string");
 
-$version  = 'Firmware '.$Descr_chopper[1];
-$hardware = $Descr_chopper[0].' Rev. '.str_replace('"', '', snmp_get($device, '1.3.6.1.4.1.171.10.76.10.1.2.0', '-Oqv'));
+$hardware = $Descr_chopper[0].' Rev. '.str_replace('"', '', snmp_get($device, '.1.3.6.1.4.1.171.12.11.1.9.4.1.12.1', '-Oqv'));
+$version = snmp_get($device, '.1.3.6.1.4.1.171.12.11.1.9.4.1.11.1', '-Oqv');
+$serial = snmp_get($device, '.1.3.6.1.4.1.171.12.11.1.9.4.1.17.1', '-Oqv');

--- a/mibs/dlink/DLINK-ID-REC-MIB
+++ b/mibs/dlink/DLINK-ID-REC-MIB
@@ -1,0 +1,29 @@
+DLINK-ID-REC-MIB    DEFINITIONS ::= BEGIN
+    IMPORTS
+        enterprises    FROM RFC1155-SMI;
+        
+        
+    AgentNotifyLevel ::= TEXTUAL-CONVENTION
+        STATUS  current
+        DESCRIPTION
+        	"Notification  leveling."
+        SYNTAX  INTEGER {
+        	critical(0),
+        	warning(1),
+        	information(2),
+        	emergency(3),
+        	alert(4),                        	
+        	error(5),
+        	notice(6),
+            	debug(7)                               	
+     }	         
+
+    dlink    				  OBJECT IDENTIFIER ::= { enterprises 171 }
+    dlink-products    		  OBJECT IDENTIFIER ::= { dlink 10 }
+    dlink-mgmt    		   	  OBJECT IDENTIFIER ::= { dlink 11 }
+    dlink-common-mgmt    	  OBJECT IDENTIFIER ::= { dlink 12 }            
+    dlink-broadband-products  OBJECT IDENTIFIER ::= { dlink 30 }   
+    dlink-broadband-mgmt 	  OBJECT IDENTIFIER ::= { dlink 31 }  
+
+
+END

--- a/mibs/dlink/EQUIPMENT-MIB
+++ b/mibs/dlink/EQUIPMENT-MIB
@@ -1,0 +1,1370 @@
+EQUIPMENT-MIB DEFINITIONS ::= BEGIN
+
+     IMPORTS
+        MODULE-IDENTITY, OBJECT-TYPE
+            FROM SNMPv2-SMI
+        DateAndTime, TruthValue ,DisplayString,RowStatus
+            FROM SNMPv2-TC
+        PortList FROM Q-BRIDGE-MIB
+        swTimeRangeMgmtRangeName FROM TIMERANGE-MIB    
+		AgentNotifyLevel, dlink-common-mgmt
+		    FROM DLINK-ID-REC-MIB;
+
+
+     swEquipmentMIB MODULE-IDENTITY
+          LAST-UPDATED "201104200000Z"
+          ORGANIZATION "D-Link Corp."
+          CONTACT-INFO
+            "http://support.dlink.com"
+          DESCRIPTION
+            " equipments MIB."
+          ::= { dlink-common-mgmt 11 }
+
+	MacAddress ::= OCTET STRING (SIZE (6))    -- a 6 octet address
+                                                  -- in the
+                                                  -- "canonical"
+                                                  -- order, copy from RFC1493
+
+
+
+-- -----------------------------------------------------------------------------
+-- OID Tree Allocation
+-- -----------------------------------------------------------------------------
+    swEquipment         OBJECT IDENTIFIER ::= { swEquipmentMIB 1 }
+    swEquipmentNotify   OBJECT IDENTIFIER ::= { swEquipmentMIB 2 }
+
+-- -----------------------------------------------------------------------------
+-- Object Definition
+-- -----------------------------------------------------------------------------
+    swEquipmentCapacity OBJECT-TYPE
+    SYNTAX      BITS {
+                    fanCapable(0),
+                        --
+                    redundantPowerCapable(1),
+                        --
+                    tempteratureDetection(2),
+                    stackingCapable(3),
+                    chassisCapable(4)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates the equipment capability supported in the system."
+
+    ::= { swEquipment 1 }
+
+-- -----------------------------------------------------------------------------
+     swFanTrapState OBJECT-TYPE
+        SYNTAX  INTEGER {
+               enabled(1),
+              disabled(2)
+               }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicate the fan warning event trap state."
+        ::= { swEquipment 4 }    
+        
+     swPowerTrapState OBJECT-TYPE
+        SYNTAX  INTEGER {
+               enabled(1),
+              disabled(2)
+               }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicate the power warning event trap state."
+        ::= { swEquipment 5 }
+        
+    swPowerTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF SwPowerEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "A list of power information values."
+        ::= { swEquipment 6 }
+
+    swPowerEntry OBJECT-TYPE
+        SYNTAX          SwPowerEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "An entry of power information values."
+        INDEX           { swPowerUnitIndex , swPowerID}
+        ::= { swPowerTable 1 }
+ 
+    SwPowerEntry ::= SEQUENCE {
+    			swPowerUnitIndex		      INTEGER,
+                swPowerID	                  INTEGER,
+                swPowerStatus   			  INTEGER
+                }
+
+    swPowerUnitIndex OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the unit ID in the System."
+        ::= { swPowerEntry 1 }
+    swPowerID OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates ID of the power
+            1 : main power
+            2 : redundant power ."
+
+
+        ::= { swPowerEntry 2 }
+
+    swPowerStatus OBJECT-TYPE
+           SYNTAX  INTEGER {
+              other(0),
+              lowVoltage(1),
+              overCurrent(2),
+              working(3),
+              fail(4),
+              connect(5),
+              disconnect(6)
+     }
+
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the current power status.
+             lowVoltage : The voltage of the power unit is too low.
+             overCurrent: The current of the power unit is too high.
+             working    : The power unit is working normally.
+             fail       : The power unit has failed.
+             connect    : The power unit is connected but not powered on.
+             disconnect : The power unit is not connected."
+        ::= { swPowerEntry 3 }
+
+-- -----------------------------------------------------------------------------
+    swFanTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF SwFanEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "A list of fan information values."
+        ::= { swEquipment 7 }
+
+    swFanEntry OBJECT-TYPE
+        SYNTAX          SwFanEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "An entry of fan information values."
+        INDEX           { swFanUnitIndex, swFanID}
+        ::= { swFanTable 1 }
+
+    SwFanEntry ::= SEQUENCE {
+    			swFanUnitIndex		      INTEGER,
+                swFanID	                  INTEGER,
+					swFanStatus				  INTEGER,
+					swFanPostion				INTEGER,
+					swFanNumber					INTEGER,
+					swFanSpeed					INTEGER					
+                }
+
+    swFanUnitIndex OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the unit ID in the System."
+        ::= { swFanEntry 1 }
+    swFanID OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the unit ID."
+        ::= { swFanEntry 2 }
+
+    swFanStatus OBJECT-TYPE
+           SYNTAX  INTEGER {
+              other(0),
+              working(1),
+              fail(2),
+              speed-0(3),
+	          speed-low(4),
+              speed-middle(5),
+              speed-high(6)
+     }
+
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the current fan status.
+             speed-0     : If the fan function is normal and the fan does not spin 
+	                       due to the temperature not  reaching the threshold,
+                           the status of the fan is speed 0.
+             speed-low   : Fan spin using the lowest speed.	
+             speed-middle: Fan spin using the middle speed.	     		   
+             speed-high  : Fan spin using the highest speed."		          
+        ::= { swFanEntry 3 }
+        
+    swFanPostion OBJECT-TYPE
+        SYNTAX INTEGER {
+        other(1),
+        left(2),
+        right(3),
+        back(4),
+        cpu(5)
+        }
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the position of the fan."
+        ::= { swFanEntry 4 }
+     swFanNumber OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the fan number."
+        ::= { swFanEntry 5 }
+
+     swFanSpeed OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the fan work speed(RPM)."
+        ::= { swFanEntry 6 }
+
+-- -----------------------------------------------------------------------------
+    swTemperatureTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF SwTemperatureEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "A list of temperature values."
+        ::= { swEquipment 8 }
+
+    swTemperatureEntry OBJECT-TYPE
+        SYNTAX          SwTemperatureEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "An entry of temperature values."
+        INDEX           { swTemperatureUnitIndex }
+        ::= { swTemperatureTable 1 }
+
+    SwTemperatureEntry ::= SEQUENCE {
+    			swTemperatureUnitIndex	      INTEGER,
+                swTemperatureCurrent          INTEGER,
+                swTemperatureHighThresh       INTEGER,
+                swTemperatureLowThresh        INTEGER
+                }
+
+    swTemperatureUnitIndex OBJECT-TYPE
+        SYNTAX INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS current
+        DESCRIPTION
+            "Indicates the unit ID in the System."
+        ::= { swTemperatureEntry 1 }
+
+    swTemperatureCurrent OBJECT-TYPE
+        SYNTAX          INTEGER(-500..500)
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     "The shelf current temperature."
+        ::= { swTemperatureEntry 2 }
+
+    swTemperatureHighThresh OBJECT-TYPE
+        SYNTAX          INTEGER (-500..500)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION     "The high threshold of shelf temperature."
+        ::= { swTemperatureEntry 3 }
+
+    swTemperatureLowThresh OBJECT-TYPE
+        SYNTAX          INTEGER(-500..500)
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION     "The low threshold of shelf temperature."
+        ::= { swTemperatureEntry 4 }
+        
+        
+-- -----------------------------------------------------------------------------
+    swUnitMgmt            OBJECT IDENTIFIER ::= { swEquipment 9 }
+
+    swUnitStackingVersion OBJECT-TYPE
+        SYNTAX  INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the version of this stacking system."
+        ::= { swUnitMgmt 1 }
+
+    swUnitMaxSupportedUnits OBJECT-TYPE
+        SYNTAX  INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The maximum number of units that are supported in the system."
+        ::= { swUnitMgmt 2 }
+
+    swUnitNumOfUnit OBJECT-TYPE
+        SYNTAX  INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current number of units."
+        ::= { swUnitMgmt 3 }
+
+    swUnitMgmtTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwUnitMgmtEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This table contains the unit information."
+        ::= { swUnitMgmt 4 }
+
+    swUnitMgmtEntry OBJECT-TYPE
+        SYNTAX  SwUnitMgmtEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of management information for each unit in the system."
+        INDEX  { swUnitMgmtId }
+        ::= { swUnitMgmtTable 1 }
+
+    SwUnitMgmtEntry ::=
+        SEQUENCE {
+            swUnitMgmtId
+                INTEGER,
+            swUnitMgmtMacAddr
+                MacAddress,
+            swUnitMgmtStartPort
+                INTEGER,
+            swUnitMgmtPortRange
+                INTEGER,
+			swUnitMgmtFrontPanelLedStatus
+				OCTET STRING,
+            swUnitMgmtCtrlMode
+                INTEGER,
+            swUnitMgmtCurrentMode
+                INTEGER,
+            swUnitMgmtVersion
+                DisplayString,
+            swUnitMgmtModuleName
+            	DisplayString,
+            swUnitMgmtPromVersion
+                DisplayString,
+            swUnitMgmtFirmwareVersion
+                DisplayString,
+            swUnitMgmtHardwareVersion
+                DisplayString,
+            swUnitMgmtPriority
+                INTEGER,
+            swUnitMgmtUserSetState
+                INTEGER,
+            swUnitMgmtExistState
+            	INTEGER,
+            swUnitMgmtBoxId
+                INTEGER,
+            swUnitMgmtSerialNumber
+                DisplayString
+            }
+
+    swUnitMgmtId OBJECT-TYPE
+        SYNTAX  INTEGER (1..13)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the specific entry in the stacking/chassis
+            table."
+        ::= { swUnitMgmtEntry 1 }
+
+    swUnitMgmtMacAddr OBJECT-TYPE
+        SYNTAX  MacAddress
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The MAC address of this unit."
+        ::= { swUnitMgmtEntry 2 }
+
+    swUnitMgmtStartPort OBJECT-TYPE
+        SYNTAX  INTEGER (1..65535)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the starting port of this unit."
+        ::= { swUnitMgmtEntry 3 }
+
+    swUnitMgmtPortRange OBJECT-TYPE
+        SYNTAX  INTEGER (0..65535)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the total ports of this unit."
+        ::= { swUnitMgmtEntry 4 }
+
+    swUnitMgmtFrontPanelLedStatus OBJECT-TYPE
+        SYNTAX  OCTET STRING (SIZE (0..255))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object is a set of system LED indicators. The first four
+             octets are defined as a system LED. The first LED is a power LED.
+             The second LED in the stacking module is a master LED but in the chassis is
+             a status LED. The third LED is a console LED. The fourth LED is
+             an RPS (Redundancy Power Supply) LED. The other octets are the
+             logical port LED (following dot1dBasePort ordering). Every two
+             bytes are presented to a port. The first byte is presented as the
+             link/activity LED. The second byte is presented as the speed LED.
+
+        	 system LED:
+             01 = fail/error/non existence.
+             02 = work normal.
+
+
+             link/activity LED :
+             The most significant bit is used for blinking/solid:
+                8 = The LED blinks.
+
+             The second most significant bit is used for link status:
+             	1 = link fail.
+             	2 = link pass.
+
+             speed LED :
+             	01 = 10Mbps.
+             	02 = 100Mbps.
+             	03 = 1000Mbps.
+
+            The four remaining bits are currently unused and must be set to 0.
+
+            Note:
+             For the DGS-3700, the first five octets are defined as the system LED.
+             The first LED is the power LED. The second LED is the console LED.
+             The third LED is the RPS (Redundancy Power Supply) LED. The fourth
+             LED is the management port LED. The fifth LED is the fan LED.
+             
+             For the DGS-3200-10 and DGS-3200-16, the first three octets are defined 
+             as the system LED. The first LED is the power LED. The second LED is the console LED.
+             The third LED is the RPS (Redundancy Power Supply) LED.
+             For the DGS-3200-24, the first three octets are defined as the system LED,
+             the definition of the first three octets is the same as the DGS-3200-10 and DGS-3200-16,
+             the fourth LED is the SD card LED. The following description is for the SD card LED:
+             01 = SD card is not present.
+             02 = SD card is present.
+             03 = fails to read/write SD card.
+             04 = read/write SD card successfully."
+             
+        ::= { swUnitMgmtEntry 5 }
+
+
+    swUnitMgmtCtrlMode OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    auto(2),
+                    stand-alone(3),
+                    master(4),
+                    slave(5)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the stacking mode the user configured for
+            the unit.  This object can only be configured when the device is
+            in standalone mode.
+
+            other (1) - This object indicates the stacking mode that the user
+                has configured for the unit. This object can only be configured
+                when the device is in standalone mode.
+            auto (2) - The system will auto-assign a stacking role to this
+                unit to be: standalone(3), master(4), or slave(5).
+            standalone (3) - The unit is forced to be in standalone mode.
+            master (4) - The unit is forced to be in master mode. If this unit is
+                selected to be a master, the unit can modify the configuration of the stacking system.
+            slave (5) - The unit is forced to be in slave mode. If this unit is
+                selected to be a slave, it can only view the configuration of
+                the stacking system."
+        ::= { swUnitMgmtEntry 6 }
+
+    swUnitMgmtCurrentMode OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    auto(2),
+                    stand-alone(3),
+                    master(4),
+                    slave(5),
+                    backup-master(6)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current stacking role of this unit."
+        ::= { swUnitMgmtEntry 7 }
+
+    swUnitMgmtVersion OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the version of this stacking unit."
+        ::= { swUnitMgmtEntry 8 }
+
+	swUnitMgmtModuleName OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+               "A textual string containing the stacking unit module name. "
+        ::= { swUnitMgmtEntry 9 }
+
+        swUnitMgmtPromVersion OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE (0..255))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+               "A textual string containing the PROM version of the
+                stacking unit. "
+        ::= { swUnitMgmtEntry 10 }
+
+    swUnitMgmtFirmwareVersion  OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE (0..255))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+               "A textual string containing the firmware version of the
+               stacking unit. "
+        ::= { swUnitMgmtEntry 11 }
+
+    swUnitMgmtHardwareVersion  OBJECT-TYPE
+        SYNTAX      DisplayString (SIZE (0..255))
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION
+               "A textual string containing the hardware version of the
+               stacking unit. "
+        ::= { swUnitMgmtEntry 12 }
+
+    swUnitMgmtPriority  OBJECT-TYPE
+        SYNTAX      INTEGER(1..63)
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+               "The Priority of the  stacking unit. "
+        ::= { swUnitMgmtEntry 13 }
+
+    swUnitMgmtUserSetState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    auto(2),
+                    user(3)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the user set state of this unit."
+        ::= { swUnitMgmtEntry 14 }
+
+    swUnitMgmtExistState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    exist(1),
+                    no-exist(2)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The state of existence of this unit."
+        ::= { swUnitMgmtEntry 15 }
+
+     swUnitMgmtBoxId  OBJECT-TYPE
+        SYNTAX      INTEGER {
+                    box-1(1),
+                    box-2(2),
+                    box-3(3),
+                    box-4(4),
+                    box-5(5),
+                    box-6(6),
+                    box-7(7),
+                    box-8(8),
+                    box-9(9),
+                    box-10(10),
+                    box-11(11),
+                    box-12(12),
+                    auto(13)
+                }
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+               "The box ID of the stacking unit.
+                When show, it shows the current box ID of this unit;
+                When set, it sets the new box ID, and the new box ID will
+                take effect after the next boot."
+        ::= { swUnitMgmtEntry 16 }
+
+     swUnitMgmtSerialNumber OBJECT-TYPE
+        SYNTAX DisplayString
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "A text string containing the serial number of the stacking unit."
+        ::= { swUnitMgmtEntry 17 }
+
+    swUnitTopology OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    stand-alone(1),
+                    duplex-chain(2),
+                    duplex-ring(3),
+                    star(4),
+                    unstable(5)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The stacking topology state."
+        ::= { swUnitMgmt 5 }
+
+   swUnitStackMode OBJECT-TYPE
+        SYNTAX  INTEGER {
+              enabled(1),
+              disabled(2)
+    	}
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "Indicates the stacking mode supported in the system."
+    ::= { swUnitMgmt 6 }
+
+   swUnitStackForceMasterRole OBJECT-TYPE
+        SYNTAX  INTEGER {
+              enabled(1),
+              disabled(2)
+    	}
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "Indicates the stack force master role mode supported in the system."
+    ::= { swUnitMgmt 7 }
+ 
+   swUnitStackTrapState OBJECT-TYPE
+        SYNTAX  INTEGER {
+              enabled(1),
+              disabled(2)
+    	}
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "Indicates the stacking trap state."
+    DEFVAL {enabled}
+    ::= { swUnitMgmt 8 }
+ 
+   swUnitStackLogState OBJECT-TYPE
+        SYNTAX  INTEGER {
+              enabled(1),
+              disabled(2)
+    	}
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+        "Indicates the stacking log state."
+    DEFVAL {enabled}
+    ::= { swUnitMgmt 9 }     
+     
+-- -----------------------------------------------------------------------------
+--  swExternalAlarmMgmt
+-- -----------------------------------------------------------------------------
+
+    swExternalAlarmTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwExternalAlarmEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of the status of each of the alarm channels by this agent."
+        ::= { swEquipment 10 }
+
+    swExternalAlarmEntry OBJECT-TYPE
+        SYNTAX  SwExternalAlarmEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "An entry containing objects with the status of each alarm channel."
+        INDEX   { swExternalAlarmChannel }
+        ::= { swExternalAlarmTable 1 }
+
+    SwExternalAlarmEntry ::=
+        SEQUENCE {
+            swExternalAlarmChannel
+                INTEGER,
+            swExternalAlarmMessage
+                DisplayString,
+            swExternalAlarmStatus
+                INTEGER
+        }
+
+    swExternalAlarmChannel OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The number of the alarm channel."
+        ::= { swExternalAlarmEntry 1 }
+
+    swExternalAlarmMessage OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..128))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Used to configure the alarm message when an alarm occurs on this channel.
+             If no alarm message is configured on this channel, a default alarm message will be generated."
+        ::= { swExternalAlarmEntry 2 }
+
+    swExternalAlarmStatus OBJECT-TYPE
+        SYNTAX  INTEGER {
+              alarming(1),
+              normal(2)
+    	}
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "Shows the current status of each alarm channel."
+        ::= { swExternalAlarmEntry 3 }
+        
+-- --------------------------------------------------------------------------------
+-- swEquipmentPowerSaving
+-- --------------------------------------------------------------------------------
+	swEquipmentPowerSaving OBJECT IDENTIFIER ::= { swEquipment 11 }
+	 
+   		swEquipPowerSavingLinkDetectState OBJECT-TYPE
+       		 SYNTAX  INTEGER {
+              		enabled(1),
+              		disabled(2)
+     			}
+    		MAX-ACCESS  read-write
+    		STATUS      current
+    		DESCRIPTION  "Indicates the equipment reduced power consumption state."
+    		::= { swEquipmentPowerSaving 1 }
+    		
+    	swEquipPowerSavingLenDetect OBJECT-TYPE
+       		 SYNTAX  INTEGER {
+              		enabled(1),
+              		disabled(2)
+     			}
+    		MAX-ACCESS  read-write
+    		STATUS      current
+    		DESCRIPTION  "Indicates the equipment reduced power consumption state with a link partner."
+    		::= { swEquipmentPowerSaving 2 }
+ 
+		swEquipPowerSavingHiberState OBJECT-TYPE
+				SYNTAX  INTEGER {
+				enabled(1),
+				disabled(2)
+				}
+				MAX-ACCESS  read-write
+				STATUS  current
+				DESCRIPTION
+				"This object indicates the power saving state of system hibernation."
+				DEFVAL {disabled}    
+				::= { swEquipmentPowerSaving 3 }
+		
+		swEquipPowerSavingPortLEDState OBJECT-TYPE
+				SYNTAX  INTEGER {
+				enabled(1),
+				disabled(2)
+				}
+				MAX-ACCESS  read-write
+				STATUS  current
+				DESCRIPTION
+				"This object indicates the power saving state of port LED."
+				DEFVAL {disabled}    
+				::= { swEquipmentPowerSaving 4 }        
+				
+		swEquipPowerSavingPortState OBJECT-TYPE
+				SYNTAX  INTEGER {
+				enabled(1),
+				disabled(2)
+				}
+				MAX-ACCESS  read-write
+				STATUS  current
+				DESCRIPTION
+				"This object indicates the power saving state of port."
+				DEFVAL {disabled}    
+				::= { swEquipmentPowerSaving 5 }  
+    		
+-- -----------------------------------------------------------------------------  	
+		swEquipPowerSavingScheduleCtrl OBJECT IDENTIFIER ::= { swEquipmentPowerSaving 6 }
+-- -----------------------------------------------------------------------------  
+		swEquipPowerSavingHibernationTable OBJECT-TYPE
+				SYNTAX  SEQUENCE OF SwEquipPowerSavingHibernationEntry
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"A list of the system hibernation configurations of the power saving."
+				::= { swEquipPowerSavingScheduleCtrl 1 }
+
+		swEquipPowerSavingHibernationEntry OBJECT-TYPE
+				SYNTAX  SwEquipPowerSavingHibernationEntry
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"An entry containing the system hibernation configurations of the power saving."
+				INDEX   { swTimeRangeMgmtRangeName }
+				::= { swEquipPowerSavingHibernationTable 1 }
+
+		SwEquipPowerSavingHibernationEntry ::=
+				SEQUENCE {
+				swEquipPowerSavingHiberRowStatus
+						RowStatus
+				}		
+
+		swEquipPowerSavingHiberRowStatus OBJECT-TYPE
+				SYNTAX  RowStatus
+				MAX-ACCESS  read-create
+				STATUS  current
+				DESCRIPTION
+				"This object indicates the status of this entry."
+				::= { swEquipPowerSavingHibernationEntry 100 }		
+				
+-- -----------------------------------------------------------------------------    		    	
+		swEquipPowerSavingPortLedTable OBJECT-TYPE
+				SYNTAX  SEQUENCE OF SwEquipPowerSavingPortLedEntry
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"A list of the port LED configurations of the power saving."
+				::= { swEquipPowerSavingScheduleCtrl 2 }
+
+		swEquipPowerSavingPortLedEntry OBJECT-TYPE
+				SYNTAX  SwEquipPowerSavingPortLedEntry
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"An entry containing the port LED configurations of the power saving."
+				INDEX   { swTimeRangeMgmtRangeName}
+				::= { swEquipPowerSavingPortLedTable 1 }
+
+		SwEquipPowerSavingPortLedEntry ::=
+				SEQUENCE {
+				swEquipPowerSavingPortLedRowStatus
+						RowStatus				
+				}
+
+		swEquipPowerSavingPortLedRowStatus OBJECT-TYPE
+				SYNTAX  RowStatus
+				MAX-ACCESS  read-create
+				STATUS  current
+				DESCRIPTION
+				"This object indicates the status of this entry."
+				::= { swEquipPowerSavingPortLedEntry 100 }	
+
+-- -----------------------------------------------------------------------------    
+		swEquipPowerSavingPortTable OBJECT-TYPE
+				SYNTAX  SEQUENCE OF SwEquipPowerSavingPortEntry
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"A list of the port configurations of the power saving."
+				::= { swEquipPowerSavingScheduleCtrl 3 }
+
+		swEquipPowerSavingPortEntry OBJECT-TYPE
+				SYNTAX  SwEquipPowerSavingPortEntry
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"An entry containing the port configurations of the power saving."
+				INDEX   { swEquipPowerSavingPortIndex, swTimeRangeMgmtRangeName }
+				::= { swEquipPowerSavingPortTable 1 }
+
+		SwEquipPowerSavingPortEntry ::=
+				SEQUENCE {
+				swEquipPowerSavingPortIndex
+						INTEGER,			
+				swEquipPowerSavingPortRowStatus
+						RowStatus				
+				} 
+
+		swEquipPowerSavingPortIndex OBJECT-TYPE
+				SYNTAX  INTEGER
+				MAX-ACCESS  not-accessible
+				STATUS  current
+				DESCRIPTION
+				"Indicates the module's port number.(1..Max port number in
+				the module)."
+				::= { swEquipPowerSavingPortEntry 1 }
+				
+		swEquipPowerSavingPortRowStatus OBJECT-TYPE
+				SYNTAX  RowStatus
+				MAX-ACCESS  read-create
+				STATUS  current
+				DESCRIPTION
+				"This object indicates the status of this entry."
+				::= { swEquipPowerSavingPortEntry 100 }	
+
+-- --------------------------------------------------------------------------------
+-- swEquipEeeMgmt 
+-- --------------------------------------------------------------------------------
+		swEquipEeeMgmt  OBJECT IDENTIFIER ::= { swEquipmentPowerSaving 20 }		
+		 
+		swEquipEeeState OBJECT-TYPE
+				SYNTAX  PortList
+				MAX-ACCESS  read-write
+				STATUS  current
+				DESCRIPTION
+					"This object indicates the EEE state of all ports.
+					
+					Note:
+					If the port's bit has a value of '1', specifies the EEE (Energy Efficient Ethernet) 
+					state of this port is 'Enabled',
+					otherwise, if the port's bit has a value of '0', specifies the EEE 
+					state of this port is 'Disabled'."
+				::= { swEquipEeeMgmt 1 }	
+    		
+-- --------------------------------------------------------------------------------
+-- swEquipmentTemperatureCtrl
+-- --------------------------------------------------------------------------------
+     swEquipmentTemperatureCtrl OBJECT IDENTIFIER ::= { swEquipment 12 }
+     
+     swTemperatureTrapState OBJECT-TYPE
+        SYNTAX  INTEGER {
+               enabled(1),
+              disabled(2)
+               }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object can enable or disable the warning temperature trap."
+        ::= { swEquipmentTemperatureCtrl 1 }
+
+     swTemperatureLogState OBJECT-TYPE
+        SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2)
+               }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object can enable or disable the warning temperature log."
+        ::= { swEquipmentTemperatureCtrl 2 }
+        
+-- -----------------------------------------------------------------------------    
+--	swEquipmentLEDCtrl OBJECT IDENTIFIER ::= { swEquipment 13 }
+-- -----------------------------------------------------------------------------        
+	swEquipmentLEDCtrl OBJECT IDENTIFIER ::= { swEquipment 13 }
+	
+	swEquipmentPortLEDState	OBJECT-TYPE
+        SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2)
+               }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the LED admin state of all ports."
+        DEFVAL {enabled}    
+        ::= { swEquipmentLEDCtrl 1 }
+
+-- -----------------------------------------------------------------------------
+--  swExternalAlarmStackingMgmt
+-- -----------------------------------------------------------------------------
+
+    swExternalAlarmStackingTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwExternalAlarmStackingEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of the status of each of the alarm channels by this agent."
+        ::= { swEquipment 15 }
+
+    swExternalAlarmStackingEntry OBJECT-TYPE
+        SYNTAX  SwExternalAlarmStackingEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "An entry containing objects with the status of each alarm channel."
+        INDEX   { swExternalAlarmStackingUnitIndex, swExternalAlarmStackingChannel }
+        ::= { swExternalAlarmStackingTable 1 }
+
+    SwExternalAlarmStackingEntry ::=
+        SEQUENCE {
+            swExternalAlarmStackingUnitIndex
+                INTEGER,
+            swExternalAlarmStackingChannel
+                INTEGER,
+            swExternalAlarmStackingMessage
+                DisplayString,
+            swExternalAlarmStackingStatus
+                INTEGER
+        }
+
+    swExternalAlarmStackingUnitIndex OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "Indicates the unit ID in the System.."
+        ::= { swExternalAlarmStackingEntry 1 }
+
+    swExternalAlarmStackingChannel OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "The number of the alarm channel."
+        ::= { swExternalAlarmStackingEntry 2 }
+
+    swExternalAlarmStackingMessage OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..128))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Used to configure the alarm message when an alarm occurs on this channel.
+             If no alarm message is configured on this channel, a default alarm message will be generated."
+        ::= { swExternalAlarmStackingEntry 3 }
+
+    swExternalAlarmStackingStatus OBJECT-TYPE
+        SYNTAX  INTEGER {
+              alarming(1),
+              normal(2)
+    	}
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "Shows the current status of each alarm channel."
+        ::= { swExternalAlarmStackingEntry 4 }
+        
+-- -----------------------------------------------------------------------------
+	swEquipmentNotifyMgmt           OBJECT IDENTIFIER ::= { swEquipmentNotify 1 }
+	swEquipmentNotification         OBJECT IDENTIFIER ::= { swEquipmentNotify 2 }
+
+
+	swEquipUnitNotification         OBJECT IDENTIFIER ::= { swEquipmentNotification 1 }
+	swEquipPowerNotification        OBJECT IDENTIFIER ::= { swEquipmentNotification 2 }
+	swEquipFanNotification          OBJECT IDENTIFIER ::= { swEquipmentNotification 3 }
+	swEquipTemperatureNotification  OBJECT IDENTIFIER ::= { swEquipmentNotification 4 }
+        swEquipExternalAlarmNotification  OBJECT IDENTIFIER ::= { swEquipmentNotification 5 }
+
+	swEquipUnitNotifyMgmt           OBJECT IDENTIFIER ::= { swEquipmentNotifyMgmt 1 }
+	swEquipPowerNotifyMgmt          OBJECT IDENTIFIER ::= { swEquipmentNotifyMgmt 2 }
+	swEquipFanNotifyMgmt            OBJECT IDENTIFIER ::= { swEquipmentNotifyMgmt 3 }
+	swEquipTemperatureNotifyMgmt    OBJECT IDENTIFIER ::= { swEquipmentNotifyMgmt 4 }
+
+-- -----------------------------------------------------------------------------
+    swUnitInsertSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swUnitInsert detection level."
+        ::= { swEquipUnitNotifyMgmt 1 }
+
+    swUnitRemoveSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swUnitRemove detection level."
+        ::= { swEquipUnitNotifyMgmt 2 }
+
+    swUnitFailureSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swUnitFailure detection level."
+        ::= { swEquipUnitNotifyMgmt 3 }
+
+-- -----------------------------------------------------------------------------
+    swPowerStatusChgSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swPowerStatusChg detection level."
+        ::= { swEquipPowerNotifyMgmt 1 }
+
+    swPowerFailureSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swPowerFailure detection level."
+        ::= { swEquipPowerNotifyMgmt 2 }
+
+    swPowerRecoverSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swPowerRecover detection level."
+        ::= { swEquipPowerNotifyMgmt 3 }
+
+-- -----------------------------------------------------------------------------
+    swFanFailureSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swFanFailure detection level."
+        ::= { swEquipFanNotifyMgmt 1 }
+
+    swFanRecoverSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swFanRecover detection level."
+        ::= { swEquipFanNotifyMgmt 2 }
+
+-- -----------------------------------------------------------------------------
+    swHighTemperatureSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swHighTemperature detection level."
+        ::= { swEquipTemperatureNotifyMgmt 1 }
+
+    swHighTemperatureRecoverSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swHighTemperatureRecover detection level."
+        ::= { swEquipTemperatureNotifyMgmt 2 }
+
+   swLowTemperatureSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swLowTemperature detection level."
+        ::= { swEquipTemperatureNotifyMgmt 3 }
+
+    swLowTemperatureRecoverSeverity OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the swLowTemperatureRecover detection level."
+        ::= { swEquipTemperatureNotifyMgmt 4 }
+
+
+-- -----------------------------------------------------------------------------
+	swEquipUnitNotifyPrefix 	 OBJECT IDENTIFIER ::= { swEquipUnitNotification 0 }
+
+    swUnitInsert NOTIFICATION-TYPE
+        OBJECTS         { swUnitMgmtId,
+						swUnitMgmtMacAddr
+                        }
+        STATUS          current
+        DESCRIPTION     "Unit Hot Insert notification."
+        ::= { swEquipUnitNotifyPrefix 1 }
+
+    swUnitRemove NOTIFICATION-TYPE
+        OBJECTS         { swUnitMgmtId,
+						swUnitMgmtMacAddr
+                        }
+        STATUS          current
+        DESCRIPTION     "Unit Hot Remove notification."
+        ::= { swEquipUnitNotifyPrefix 2 }
+
+    swUnitFailure NOTIFICATION-TYPE
+        OBJECTS         { swUnitMgmtId
+                        }
+        STATUS          current
+        DESCRIPTION     "Unit Failure notification."
+        ::= { swEquipUnitNotifyPrefix 3 }
+
+    swUnitTPChange NOTIFICATION-TYPE
+        OBJECTS         { swStackTopologyType,
+        									swUnitMgmtId,
+        									swUnitMgmtMacAddr
+                        }
+        STATUS          current
+        DESCRIPTION     "The stacking topology change notification."
+        ::= { swEquipUnitNotifyPrefix 4 }
+
+    swUnitRoleChange NOTIFICATION-TYPE
+        OBJECTS         { swStackRoleChangeType,
+							swUnitMgmtId
+						}
+        STATUS          current
+        DESCRIPTION     "The stacking unit role change notification."
+        ::= { swEquipUnitNotifyPrefix 5 }
+
+-- -----------------------------------------------------------------------------
+	swEquipPowerNotifyPerfix 	 OBJECT IDENTIFIER ::= { swEquipPowerNotification 0 }
+
+    swPowerStatusChg  NOTIFICATION-TYPE
+        OBJECTS         { swPowerUnitIndex,
+        					swPowerID,
+        					swPowerStatus
+                        }
+        STATUS          current
+        DESCRIPTION     "Power Status change notification. The notification is issued 
+                         when the swPowerStatus changes in the following cases:
+                         lowVoltage  -> overCurrent. 
+                         lowVoltage  -> working. 
+                         lowVoltage  -> disconnect. 
+                         lowVoltage  -> connect. 
+                         overCurrent -> lowVoltage. 
+                         overCurrent -> working. 
+                         overCurrent -> disconnect. 
+                         overCurrent -> connect. 
+                         working     -> lowVoltage. 
+                         working     -> overCurrent. 
+                         working     -> connect. 
+                         working     -> disconnect. 
+                         fail        -> connect. 
+                         fail        -> disconnect. 
+                         connect     -> lowVoltage. 
+                         connect     -> overCurrent. 
+                         connect     -> working. 
+                         connect     -> disconnect. 
+                         disconnect  -> lowVoltage. 
+                         disconnect  -> overCurrent. 
+                         disconnect  -> working. 
+                         disconnect  -> connect."
+        ::= { swEquipPowerNotifyPerfix  1 }
+
+
+    swPowerFailure  NOTIFICATION-TYPE
+        OBJECTS         { swPowerUnitIndex,
+        					swPowerID,
+        					swPowerStatus
+                        }
+        STATUS          current
+        DESCRIPTION     "Power Failure notification. The notification is issued 
+                         when the swPowerStatus changes in the following cases:
+                         lowVoltage  -> fail. 
+   						 overCurrent -> fail. 
+                         working     -> fail. 
+                         connect     -> fail. 
+                         disconnect  -> fail."
+        ::= { swEquipPowerNotifyPerfix  2 }
+
+    swPowerRecover NOTIFICATION-TYPE
+        OBJECTS         {swPowerUnitIndex,
+        					 swPowerID,
+        					 swPowerStatus
+                        }
+        STATUS          current
+        DESCRIPTION     "Power Recover notification. The notification is issued
+                         when the swPowerStatus changes in the following cases:
+                         fail -> lowVoltage.  
+                         fail -> overCurrent. 
+                         fail -> working."
+        ::= { swEquipPowerNotifyPerfix  3 }
+
+-- -----------------------------------------------------------------------------
+    swEquipFanNotifyPrefix 	 OBJECT IDENTIFIER ::= { swEquipFanNotification 0 }
+
+    swFanFailure NOTIFICATION-TYPE
+        OBJECTS         { swFanUnitIndex,
+        					swFanID
+
+                        }
+        STATUS          current
+        DESCRIPTION     "Fan Failure notification."
+        ::= { swEquipFanNotifyPrefix 1 }
+
+    swFanRecover NOTIFICATION-TYPE
+        OBJECTS         { swFanUnitIndex,
+        					swFanID
+                        }
+        STATUS          current
+        DESCRIPTION     "Fan Recover notification."
+        ::= { swEquipFanNotifyPrefix 2 }
+
+-- -----------------------------------------------------------------------------
+    swEquipTemperatureNotifyPrefix 	 OBJECT IDENTIFIER ::= { swEquipTemperatureNotification 0 }
+
+    swHighTemperature NOTIFICATION-TYPE
+        OBJECTS         { swTemperatureUnitIndex,
+                          swTemperSensorID,
+        				  swTemperatureCurrent
+                        }
+        STATUS          current
+        DESCRIPTION     "High Temperature notification."
+        ::= { swEquipTemperatureNotifyPrefix 1 }
+
+    swHighTemperatureRecover NOTIFICATION-TYPE
+        OBJECTS         { swTemperatureUnitIndex,
+                          swTemperSensorID,
+        				  swTemperatureCurrent
+                        }
+        STATUS          current
+        DESCRIPTION     "High Temperature notification."
+        ::= { swEquipTemperatureNotifyPrefix 2 }
+
+    swLowTemperature NOTIFICATION-TYPE
+        OBJECTS         { swTemperatureUnitIndex,
+                          swTemperSensorID,
+        				  swTemperatureCurrent
+                        }
+        STATUS          current
+        DESCRIPTION     "Low Temperature notification."
+        ::= { swEquipTemperatureNotifyPrefix 3 }
+
+    swLowTemperatureRecover NOTIFICATION-TYPE
+        OBJECTS         { swTemperatureUnitIndex,
+                          swTemperSensorID,
+        				  swTemperatureCurrent
+                        }
+        STATUS          current
+        DESCRIPTION     "Low Temperature notification."
+        ::= { swEquipTemperatureNotifyPrefix 4 }
+
+-- -----------------------------------------------------------------------------
+    swEquipExternalAlarmNotifyPrefix 	 OBJECT IDENTIFIER ::= { swEquipExternalAlarmNotification 0 }
+    
+    swExternalAlarm NOTIFICATION-TYPE
+        OBJECTS         { swExternalAlarmChannel,
+                          swExternalAlarmMessage
+                        }
+        STATUS          current
+        DESCRIPTION     "The notice of an Alarm in the specified channel."
+
+        ::= { swEquipExternalAlarmNotifyPrefix 1 }
+
+    swExternalAlarmStacking NOTIFICATION-TYPE
+        OBJECTS         { swExternalAlarmStackingUnitIndex, 
+                          swExternalAlarmStackingChannel,
+                          swExternalAlarmStackingMessage
+                        }
+        STATUS          current
+        DESCRIPTION     "The notice of an Alarm in the specified channel."
+        ::= { swEquipExternalAlarmNotifyPrefix 2 }
+--- -----------------------------------------------------------------------------
+    swNotificationBindings OBJECT IDENTIFIER ::= { swEquipmentNotify 3 }
+
+
+--- -----------------------------------------------------------------------------
+    swEquipTemperNotifyBindings  OBJECT IDENTIFIER ::= { swNotificationBindings 1 }
+
+    swTemperSensorID OBJECT-TYPE
+        SYNTAX     INTEGER
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This object indicates the ID of the temperature sensor in the unit."
+        ::= { swEquipTemperNotifyBindings 1 }
+
+    swEquipUnitNotifyBindings  OBJECT IDENTIFIER ::= { swNotificationBindings 2 }
+
+    	swStackTopologyType OBJECT-TYPE
+    	SYNTAX  INTEGER	{	
+    						chain(1),
+    					 	ring(2)
+    					}
+       	MAX-ACCESS  accessible-for-notify
+       	STATUS  current
+       	DESCRIPTION
+            "This object indicates the MAC address of the switch."
+       	    ::= { swEquipUnitNotifyBindings 1 }
+
+    	swStackRoleChangeType OBJECT-TYPE
+    	SYNTAX  INTEGER {
+    						backup-to-master(1),
+    						slave-to-master(2)
+    					}
+       	MAX-ACCESS  accessible-for-notify
+       	STATUS  current
+       	DESCRIPTION
+            "This object indicates the role information of the switch."
+       	    ::= { swEquipUnitNotifyBindings 2 }
+
+
+END

--- a/mibs/dlink/GENMGMT-MIB
+++ b/mibs/dlink/GENMGMT-MIB
@@ -1,0 +1,3549 @@
+AGENT-GENERAL-MIB  DEFINITIONS ::= BEGIN
+
+    IMPORTS
+        IpAddress, MODULE-IDENTITY,                        
+        OBJECT-TYPE,Integer32               FROM SNMPv2-SMI
+        TruthValue,RowStatus, MacAddress    FROM SNMPv2-TC
+        DisplayString                       FROM RFC1213-MIB
+        InetAddressType, InetAddress        FROM INET-ADDRESS-MIB
+        AgentNotifyLevel,dlink-common-mgmt  FROM DLINK-ID-REC-MIB
+	VlanId				    FROM Q-BRIDGE-MIB;
+
+      agentGeneralMgmt MODULE-IDENTITY
+            LAST-UPDATED "201206260000Z"
+            ORGANIZATION "D-Link Corp."
+            CONTACT-INFO
+                "http://support.dlink.com"
+            DESCRIPTION
+                    "The structure of general management information for enterprise."
+        ::= {  dlink-common-mgmt 1 }
+
+-- -----------------------------------------------------------------------------
+-- Textual Conventions
+-- -----------------------------------------------------------------------------
+-- This definition may be excluded if IPv6 is not supported
+Ipv6Address ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "2x:"
+        STATUS       current
+        DESCRIPTION
+                "This data type is used to model IPv6 addresses.
+                This is a binary string of 16 octets in network
+                byte-order."
+        SYNTAX       OCTET STRING (SIZE (16))
+
+UnitList                ::= OCTET STRING(SIZE (0..3))
+
+-- -----------------------------------------------------------------------------
+-- agentBasicInfo
+-- -----------------------------------------------------------------------------
+    agentBasicInfo          OBJECT IDENTIFIER ::= { agentGeneralMgmt 1 }
+
+    agentMgmtProtocolCapability OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    snmp-ip(2),
+                    snmp-ipx(3),
+                    snmp-ip-ipx(4)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The network management protocol(s) supported by this agent."
+        ::= { agentBasicInfo 1 }
+
+-- -----------------------------------------------------------------------------
+-- agentMibcapabilityTable
+-- -----------------------------------------------------------------------------
+    agentMibCapabilityTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentMibCapabilityEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of MIB capability entries supported by this agent."
+        ::= { agentBasicInfo 2 }
+
+    agentMibCapabilityEntry OBJECT-TYPE
+        SYNTAX  AgentMibCapabilityEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A MIB capability entry containing objects that describe a particular MIB
+             supported by this agent."
+        INDEX   { agentMibCapabilityIndex }
+        ::= { agentMibCapabilityTable 1 }
+
+    AgentMibCapabilityEntry ::=
+        SEQUENCE {
+            agentMibCapabilityIndex
+                Integer32,
+            agentMibCapabilityDescr
+                DisplayString,
+            agentMibCapabilityVersion
+                Integer32,
+            agentMibCapabilityType
+                INTEGER
+        }
+
+    agentMibCapabilityIndex OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "A list of Agent MIB Capability Description entries."
+        ::= { agentMibCapabilityEntry 1 }
+
+    agentMibCapabilityDescr OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..35))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The name of the MIB supported by the agent."
+        ::= { agentMibCapabilityEntry 2 }
+
+    agentMibCapabilityVersion OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The version of the MIB specified in this entry."
+        ::= { agentMibCapabilityEntry 3 }
+
+    agentMibCapabilityType OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    standard(2),
+                    proprietary(3),
+                    experiment(4)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The type of MIB specified in this entry."
+        ::= { agentMibCapabilityEntry 4 }
+
+
+    agentStatusConsoleInUse   OBJECT-TYPE
+        SYNTAX INTEGER {
+               other(1),
+               in-use(2),
+               not-in-use(3)
+               }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "This indicates whether the console is currently in use."
+        ::= { agentBasicInfo 3 }
+
+    agentStatusSaveCfg OBJECT-TYPE
+        SYNTAX INTEGER {
+               other(1),
+               proceeding(2),
+               completed(3),
+               failed(4)
+               }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "This indicates the status of the device configuration.
+
+            other (1) - This entry is currently in use but the conditions under
+                     which it will remain so are determined by each of the following values.
+            proceeding (2) - The device configuration is currently being saved into NV-RAM.
+            completed (3) - All of the device configuration parameters have been
+                     saved into NV-RAM.
+            failed (4) - The process to save the device configuration has failed."
+        ::= { agentBasicInfo 4 }
+
+    agentStatusFileTransfer OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1) ,
+                    in-process(2),
+                    invalid-file(3),
+                    violation(4),
+                    file-not-found(5),
+                    disk-full(6),
+                    complete(7),
+                    time-out(8),
+                    not-format(9),
+                    memory-full(10)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The status of the firmware download control. If the value is stated as 'other',
+             the firmware has not been updated since the device was started."
+        ::= { agentBasicInfo 5 }
+
+-- -----------------------------------------------------------------------------
+-- agentCPUutilizationTable
+-- -----------------------------------------------------------------------------
+    agentCPUutilization          OBJECT IDENTIFIER ::= { agentBasicInfo 6 }
+
+    agentCPUutilizationIn5sec OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The time scale is set at 5 second intervals.
+             The value will be between 0% (idle) and 100% (very busy)."
+        ::= { agentCPUutilization 1 }
+
+    agentCPUutilizationIn1min OBJECT-TYPE
+        SYNTAX  Integer32
+
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The time scale is set at 1 minute intervals.
+             The value will be between 0% (idle) and 100% (very busy)."
+        ::= { agentCPUutilization 2 }
+
+    agentCPUutilizationIn5min OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The time scale is set at 5 minute intervals.
+             The value will be between 0% (idle) and 100% (very busy)."
+        ::= { agentCPUutilization 3 }
+
+   agentDualImageStatus OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    not-supported(0),
+                    supported(1)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The dual image status."
+        ::= { agentBasicInfo 7 }
+
+-- -----------------------------------------------------------------------------
+-- agentPORTutilizationTable
+-- -----------------------------------------------------------------------------
+    agentPORTutilizationTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentPORTutilizationEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This table specifies the current utilization of a specified port."
+        ::= { agentBasicInfo 8 }
+
+    agentPORTutilizationEntry OBJECT-TYPE
+        SYNTAX  AgentPORTutilizationEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information regarding the port utilization function."
+        INDEX   { agentPORTutilizationProtIndex }
+        ::= { agentPORTutilizationTable 1 }
+
+    AgentPORTutilizationEntry ::=
+        SEQUENCE {
+            agentPORTutilizationProtIndex
+                INTEGER,
+            agentPORTutilizationTX
+                INTEGER,
+            agentPORTutilizationRX
+                INTEGER,
+            agentPORTutilizationUtil
+                INTEGER,
+            agentPORTutilizationRXUtil
+                INTEGER,                                
+            agentPORTutilizationTXUtil
+                INTEGER
+        }
+
+    agentPORTutilizationProtIndex OBJECT-TYPE
+        SYNTAX  INTEGER (1..65535)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the module's port number."
+        ::= { agentPORTutilizationEntry 1 }
+
+    agentPORTutilizationTX OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current rate of transmitted frames on the specified port."
+        ::= { agentPORTutilizationEntry 2 }
+
+    agentPORTutilizationRX OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current rate of received frames on the specified port."
+        ::= { agentPORTutilizationEntry 3 }
+
+    agentPORTutilizationUtil OBJECT-TYPE
+        SYNTAX  INTEGER (0..100)
+        UNITS       "%"
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current percentages regarding port statistics."
+        ::= { agentPORTutilizationEntry 4 }
+        
+    agentPORTutilizationRXUtil OBJECT-TYPE
+        SYNTAX  INTEGER (0..100)
+        UNITS       "%"
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current percentages regarding port receive packets statistics."
+        ::= { agentPORTutilizationEntry 5 }  
+          
+    agentPORTutilizationTXUtil OBJECT-TYPE
+        SYNTAX  INTEGER (0..100)
+        UNITS       "%"
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current percentages regarding port transmit packets statistics."
+        ::= { agentPORTutilizationEntry 6 }
+-- -----------------------------------------------------------------------------
+    agentDRAMutilizationTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentDRAMutilizationEntry
+        MAX-ACCESS not-accessible
+        STATUS  current
+        DESCRIPTION
+             "Information about DRAM memory."
+        ::={agentBasicInfo 9}
+
+     agentDRAMutilizationEntry OBJECT-TYPE
+        SYNTAX   AgentDRAMutilizationEntry
+        MAX-ACCESS not-accessible
+        STATUS   current
+        DESCRIPTION
+            "A list of information about DRAM memory."
+        INDEX {agentDRAMutilizationUnitID}
+        ::={agentDRAMutilizationTable 1}
+
+     AgentDRAMutilizationEntry ::=
+        SEQUENCE {
+                agentDRAMutilizationUnitID
+                         INTEGER,
+                agentDRAMutilizationTotalDRAM
+                         INTEGER,
+                agentDRAMutilizationUsedDRAM
+                         INTEGER,
+                agentDRAMutilization
+                         INTEGER
+                 }
+
+     agentDRAMutilizationUnitID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS read-only
+        STATUS  current
+        DESCRIPTION
+             "Specifies the unit ID.
+              If the ID equals zero, it means the current device."
+        ::={ agentDRAMutilizationEntry 1 }
+
+     agentDRAMutilizationTotalDRAM OBJECT-TYPE
+        SYNTAX  INTEGER
+        UNITS   "KB"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The size of total DRAM memory."
+        ::={agentDRAMutilizationEntry 2}
+
+     agentDRAMutilizationUsedDRAM OBJECT-TYPE
+        SYNTAX  INTEGER
+        UNITS   "KB"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The size of used DRAM memory."
+        ::={agentDRAMutilizationEntry 3}
+
+     agentDRAMutilization OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS read-only
+        STATUS  current
+        DESCRIPTION
+             "The percentage of used DRAM memory of the total DRAM memory available.
+              The value will be between 0% (idle) and 100% (very busy)."
+        ::={agentDRAMutilizationEntry 4}
+
+-- -----------------------------------------------------------------------------
+    agentFLASHutilizationTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFLASHutilizationEntry
+        MAX-ACCESS not-accessible
+        STATUS  current
+        DESCRIPTION
+             "Information about the flash memory."
+        ::={agentBasicInfo 10}
+
+     agentFLASHutilizationEntry OBJECT-TYPE
+        SYNTAX   AgentFLASHutilizationEntry
+        MAX-ACCESS not-accessible
+        STATUS   current
+        DESCRIPTION
+            "Information about the flash memory."
+        INDEX {agentFLASHutilizationUnitID}
+        ::={agentFLASHutilizationTable 1}
+
+     AgentFLASHutilizationEntry ::=
+        SEQUENCE {
+                 agentFLASHutilizationUnitID
+                         INTEGER,
+                 agentFLASHutilizationTotalFLASH
+                         INTEGER,
+                 agentFLASHutilizationUsedFLASH
+                         INTEGER,
+                 agentFLASHutilization
+                         INTEGER
+                 }
+
+     agentFLASHutilizationUnitID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS read-only
+        STATUS  current
+        DESCRIPTION
+             "Specifies the unit ID.
+              If the ID equals zero, it means the current device."
+        ::={ agentFLASHutilizationEntry 1 }
+
+     agentFLASHutilizationTotalFLASH OBJECT-TYPE
+        SYNTAX  INTEGER
+        UNITS   "KB"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The total size of flash memory."
+        ::={agentFLASHutilizationEntry 2}
+
+     agentFLASHutilizationUsedFLASH OBJECT-TYPE
+        SYNTAX  INTEGER
+        UNITS   "KB"
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "The size of the used flash memory."
+        ::={agentFLASHutilizationEntry 3}
+
+     agentFLASHutilization OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS read-only
+        STATUS  current
+        DESCRIPTION
+             "The percentage of used flash memory in total flash memory.
+              The value will be between 0% (idle) and 100% (very busy)."
+        ::={agentFLASHutilizationEntry 4}
+
+-- -----------------------------------------------------------------------------
+    agentStatusReset OBJECT-TYPE
+        SYNTAX INTEGER {
+               proceeding(1),
+               completed(2),
+               failed(3)
+               }
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "This indicates the status of 'agentReset'."
+        ::= { agentBasicInfo 11 }
+
+    agentSerialNumber OBJECT-TYPE
+        SYNTAX DisplayString
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "A text string containing the serial number of this device."
+        ::= { agentBasicInfo 12 }
+
+-- -----------------------------------------------------------------------------
+    agentFirmwareType OBJECT-TYPE
+        SYNTAX DisplayString
+        MAX-ACCESS read-only
+        STATUS current
+        DESCRIPTION
+            "A text string containing the firmware type."
+        ::= { agentBasicInfo 13 }
+
+-- -----------------------------------------------------------------------------
+-- agentBasicConfig
+-- -----------------------------------------------------------------------------
+    agentBasicConfig        OBJECT IDENTIFIER ::= { agentGeneralMgmt 2 }
+
+    agentBscSwFileTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentBscSwFileEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of MIB Basic Config entry support files updated by this agent."
+        ::= { agentBasicConfig 1 }
+
+    agentBscSwFileEntry OBJECT-TYPE
+        SYNTAX  AgentBscSwFileEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A basic configuration entry containing the objects that describe a particular MIB
+             supported by this agent."
+        INDEX   { agentBscSwFileIndex }
+        ::= { agentBscSwFileTable 1 }
+
+    AgentBscSwFileEntry ::=
+        SEQUENCE {
+            agentBscSwFileIndex
+                Integer32,
+            agentBscSwFileDscr
+                DisplayString,
+            agentBscSwFileAddr
+                IpAddress,
+            agentBscSwFileTransferType
+                INTEGER,
+            agentBscSwFile
+                DisplayString,
+            agentBscSwFileLocateId
+                INTEGER,
+            agentBscSwFileLoadType
+                INTEGER,
+            agentBscSwFileCtrl
+                INTEGER,
+            agentBscSwFileBIncrement
+                TruthValue,
+            agentBscSwFileCtrlID
+                INTEGER,
+            agentBscSwFileCtrlUnitID
+                UnitList,
+            agentBscSwFileIPv6Addr
+                Ipv6Address,
+            agentBscSwFileBootUpImage
+                TruthValue,
+            agentBscSwFileForceAgree
+                TruthValue,
+            agentBscSwFileInterfaceName
+                DisplayString,
+            agentBscSwFileServerDomainName	 
+                DisplayString  				
+        }
+
+    agentBscSwFileIndex OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS      read-only
+        STATUS  current
+        DESCRIPTION
+                "The table index for the file entry"
+        ::= { agentBscSwFileEntry 1 }
+
+    agentBscSwFileDscr OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The description of the software file purpose in this entry.
+             Note: For systems that do not support a change to this object, setting a value for
+             this object will cause the system to return bad-value error messages."
+        ::= { agentBscSwFileEntry 2 }
+
+    agentBscSwFileAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IP address where the file that needs to be downloaded is located, or the IP address
+            where the file will be uploaded to."
+        ::= {  agentBscSwFileEntry 3 }
+
+    agentBscSwFileTransferType OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    network-load(2),
+                    out-of-band-load(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The channel through which the file will be downloaded or uploaded.
+             Note: For systems that do not support all channels, setting a value to the unsupported
+             channel will cause the system to return bad-value error messages."
+        ::= { agentBscSwFileEntry 4 }
+
+    agentBscSwFile OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..128))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The name of the file to be downloaded from, or uploaded to, the TFTP server."
+        ::= { agentBscSwFileEntry 5 }
+
+     agentBscSwFileLocateId OBJECT-TYPE
+        SYNTAX  INTEGER (1..16)
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object describes the type of file.
+             runtime-code (1),
+             log-file (2),
+             cfg-file (3)
+             Note: For systems that do not support changes to this object, setting a value for
+             this object will cause the system to return bad-value error messages."
+        ::= { agentBscSwFileEntry 6 }
+
+     agentBscSwFileLoadType OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    upload(2),
+                    download(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+                "This object provides the user with a choice of uploading or downloading the selected file.
+                 Note: For systems  that do not support a change to this object, setting a value for this object
+                 will cause the system to return bad-value error messages."
+        ::= { agentBscSwFileEntry 7 }
+
+     agentBscSwFileCtrl OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    inactive(2),
+                    start(3),
+                    delete(4),
+                    config-as-bootup(5),
+                    apply(6)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object gives the user the option of downloading runtime software. This setting will take effect
+             when the system restarts. See Note (1) below
+
+                         Note:
+                         For systems that do not support changes to this object, setting a value to this object
+                         will cause the system to return bad-value error messages.
+
+                        start - Activate firmware.
+                delete (4) - Delete the firmware by indicated firmware ID.
+                config-as-bootup (5) - Configured as bootup firmware by the indicated
+            firmware(ID).
+            apply (6) - Apply the configuration to be the active configuration by the indicated config ID."
+        ::= { agentBscSwFileEntry 8 }
+
+        agentBscSwFileBIncrement OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This object indicates whether the previous configuration will remain
+             valid or not after downloading the configuration file.
+             True: Keep valid
+             False: Erase. "
+        ::= { agentBscSwFileEntry 9 }
+
+    agentBscSwFileCtrlID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The section ID of the firmware image or configuration file.
+             A value of 0 indicates the boot-up firmware image or configuration file."
+        ::= { agentBscSwFileEntry 10 }
+
+    agentBscSwFileCtrlUnitID OBJECT-TYPE
+        SYNTAX   UnitList
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Specifies  which unit of the switch stack the firmware image will be downloaded from.
+             One or more units can be set in this list. Each bit from the left to the right represents the
+             switch from unit ID 1 to unit ID 12.
+             A null entry in this field denotes all switches in the switch stack."
+        ::= { agentBscSwFileEntry 11 }
+
+    agentBscSwFileIPv6Addr OBJECT-TYPE
+        SYNTAX  Ipv6Address
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IPv6 address where the file will be downloaded from or uploaded to."
+        ::= {  agentBscSwFileEntry 12 }
+
+    agentBscSwFileBootUpImage OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "The result of the download will depend on whether the boot_up option is specified.
+             Case 1: In the case where the master unit provides the file system and the slave unit does
+                not provide the file system, when boot_up is specified, the file will be downloaded
+                to the boot_up image on the slave. If boot_up is not specified, then the file will
+                not be downloaded to this slave unit.
+
+             Case 2: In the case where the master unit does not provide the file system and the slave unit
+                provides the file system, when boot_up is specified, the file will be downloaded to
+                the boot_up image on the slave unit. If boot_up is not specified, the file will
+                not be downloaded to this slave unit.
+
+             Case 3: In the case where the master unit and the slave unit both support or do not support
+                the file system, the file will be downloaded to the specified file on the slave unit.
+                If boot_up is specified, the downloaded file will be assigned as the boot_up image.
+
+             True: boot_up option is specified.
+             False: boot_up option is not specified. "
+        ::= { agentBscSwFileEntry 13 }
+
+    agentBscSwFileForceAgree OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "When the force_agree option is specified, the reboot command will be executed
+             immediately, without any further confirmation from the user.
+
+             True: force_agree option is specified.
+             False: force_agree option is not specified. "
+        ::= { agentBscSwFileEntry 14 }
+
+    agentBscSwFileInterfaceName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE(0..12))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This node is used to specify the interface name when the agentBscSwFileIPv6Addr
+             is the link local address."
+        ::= { agentBscSwFileEntry 15 }
+
+   agentBscSwFileServerDomainName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE(0..255))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the domain name of the TFTP server."
+        ::= {  agentBscSwFileEntry 16 }
+
+    agentFileTransfer OBJECT-TYPE
+                SYNTAX INTEGER {
+                                other(1),
+                                start(2),
+                                start-and-reset(3),
+                                noaction(4)
+                        }
+                MAX-ACCESS read-write
+                STATUS obsolete
+                DESCRIPTION
+                        "This object will execute the download or upload action. If start (2) is chosen, it will
+                         begin to download/upload and no reset will follow. If start-and-reset (3) is chosen,
+                         then the reset will be activated after completing the download or upload.
+                         No action if noaction (4) is chosen.
+
+                         Note:
+                         Because these functions will be limited by the support for the system in question,
+                         some of the selected items will be invalid. When the user selects an invalid entry,
+                         the system will respond with a bad-value status."
+                ::= { agentBasicConfig 2 }
+
+    agentSystemReset OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    cold-start(2),
+                    warm-start(3),
+                    no-reset(4)
+                }
+        MAX-ACCESS  read-write
+        STATUS      deprecated
+        DESCRIPTION
+            "This object indicates the agent system reset state. Setting this
+             object to no-reset (4) has no effect. Setting this object to
+             cold-start (2) or warm-start (3) will reset the agent. The agent
+             always returns to no-reset (4) when this object is read.
+
+                         This object is replaced by 'agentReset'."
+        ::= { agentBasicConfig 3 }
+
+    agentRs232PortConfig OBJECT-TYPE
+        SYNTAX  INTEGER  {
+                    other(1),
+                    console(2),
+                    out-of-band(3),
+                                        notAvail(4)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the RS-232C mode once the device has restarted."
+        ::= { agentBasicConfig 4 }
+
+    agentOutOfBandBaudRateConfig OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    baudRate-2400 (2),
+                    baudRate-9600 (3),
+                    baudRate-19200(4),
+                    baudRate-38400(5),
+                    baudRate-115200(6)
+                }
+        MAX-ACCESS  read-write
+        STATUS  obsolete
+        DESCRIPTION
+            "This object allows the user to specify an out-of-band baud rate, which
+             will take effect upon system restart.
+
+                         Note:
+                         Because these functions will be limited by the support for the system
+                         in question, some of the selected items will be invalid. When the user
+                         selects an invalid entry, the system will respond with a bad-value error message.
+                         "
+        ::= { agentBasicConfig 5 }
+
+
+
+     agentSaveCfg OBJECT-TYPE
+        SYNTAX INTEGER {
+                                other(1),
+                                cfg-id1(2),
+                                cfg-id2(3),
+                                log(4),
+                                all(5)
+                        }
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This object indicates the type of save command to be executed, when saving to NV-RAM.
+             other (1) - None of the following.
+             cfg-id1 (2) - Save configuration ID1.
+             cfg-id2 (3)- Save configuration ID2.
+             log (4) - Save log.
+             all (5) - Save both (active configuration and log)."
+        ::= { agentBasicConfig 6 }
+
+
+-- -----------------------------------------------------------------------------
+-- swMultiImageInfoTable
+-- -----------------------------------------------------------------------------
+    swMultiImageInfoTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwMultiImageInfoEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            ""
+        ::= { agentBasicConfig 7 }
+
+    swMultiImageInfoEntry OBJECT-TYPE
+        SYNTAX  SwMultiImageInfoEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information about multiple image management."
+        INDEX  { swMultiImageInfoID }
+        ::= { swMultiImageInfoTable 1 }
+
+    SwMultiImageInfoEntry ::=
+        SEQUENCE {
+            swMultiImageInfoID
+                INTEGER,
+            swMultiImageVersion
+                DisplayString,
+            swMultiImageSize
+                Integer32,
+            swMultiImageUpdateTime
+                DisplayString,
+            swMultiImageFrom
+                DisplayString,
+            swMultiImageSendUser
+                DisplayString,
+            swMultiImageFileName
+                DisplayString
+        }
+    swMultiImageInfoID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The stacking section ID of the firmware image.
+             The stacking section ID = 256 * Unit ID + Image File ID."
+        ::= { swMultiImageInfoEntry 1 }
+
+    swMultiImageVersion OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded downloaded firmware version."
+        ::= { swMultiImageInfoEntry 2 }
+
+    swMultiImageSize OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded downloaded firmware size."
+        ::= { swMultiImageInfoEntry 3 }
+
+    swMultiImageUpdateTime OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded firmware update time."
+        ::= { swMultiImageInfoEntry 4 }
+
+    swMultiImageFrom OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..100))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded IP address of the TFTP server"
+        ::= { swMultiImageInfoEntry 5 }
+
+    swMultiImageSendUser OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The record of the user who downloaded the firmware."
+        ::= { swMultiImageInfoEntry 6 }
+
+     swMultiImageFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..255))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "When the system is set to boot from SD card, this object will display the recorded path name of the boot firmware file. "
+        ::= { swMultiImageInfoEntry 7 }
+        
+-- -----------------------------------------------------------------------------
+    agentMultiCfgMgmt OBJECT IDENTIFIER ::= { agentBasicConfig 8 }
+
+    swMultiCfgInfoTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwMultiCfgInfoEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            ""
+        ::= { agentMultiCfgMgmt 1 }
+
+    swMultiCfgInfoEntry OBJECT-TYPE
+        SYNTAX  SwMultiCfgInfoEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information about multiple configuration files."
+        INDEX  { swMultiCfgInfoID }
+        ::= { swMultiCfgInfoTable 1 }
+
+    SwMultiCfgInfoEntry ::=
+        SEQUENCE {
+            swMultiCfgInfoID
+                INTEGER,
+            swMultiCfgVersion
+                DisplayString,
+            swMultiCfgSize
+                Integer32,
+            swMultiCFgUpdateTime
+                DisplayString,
+            swMultiCfgFrom
+                DisplayString,
+            swMultiCfgSendUser
+                DisplayString,
+            swMultiCfgFileName
+                DisplayString
+        }
+    swMultiCfgInfoID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The section ID of the configuration files."
+        ::= { swMultiCfgInfoEntry 1 }
+
+    swMultiCfgVersion OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded downloaded configuration version."
+        ::= { swMultiCfgInfoEntry 2 }
+
+    swMultiCfgSize OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded downloaded configuration size (in bytes).
+             "
+        ::= { swMultiCfgInfoEntry 3 }
+
+    swMultiCFgUpdateTime OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded configuration update time
+            displayed in string format, i.e. yyyy/mon/dd hh:mm:ss."
+        ::= { swMultiCfgInfoEntry 4 }
+
+    swMultiCfgFrom OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..100))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The recorded IP address of the TFTP server."
+        ::= { swMultiCfgInfoEntry 5 }
+
+    swMultiCfgSendUser OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..32))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The record of the user who downloaded the configuration file"
+        ::= { swMultiCfgInfoEntry 6 }
+
+    swMultiCfgFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..255))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "When the system is set to boot from SD card, this object displays the recorded path name of the boot configuration file. "
+        ::= { swMultiCfgInfoEntry 7 }
+
+-- -----------------------------------------------------------------------------
+    swMultiCfgCurrentUsed OBJECT-TYPE
+        SYNTAX     INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The indicated configuration file ID of the system currently in use."
+        ::= { agentMultiCfgMgmt 2 }
+
+     swMultiCfgBootUp OBJECT-TYPE
+        SYNTAX     INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the configuration file ID which will take effect upon the next reboot."
+        ::= { agentMultiCfgMgmt 3 }
+
+
+
+-- -----------------------------------------------------------------------------
+-- swMultiCfgCtrlTable
+-- -----------------------------------------------------------------------------
+    swMultiCfgCtrlTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwMultiCfgCtrlEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            ""
+        ::= { agentMultiCfgMgmt 4 }
+
+    swMultiCfgCtrlEntry OBJECT-TYPE
+        SYNTAX  SwMultiCfgCtrlEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information about multiple configuration management."
+        INDEX  { swMultiCfgCtrlID }
+        ::= { swMultiCfgCtrlTable 1 }
+
+    SwMultiCfgCtrlEntry ::=
+        SEQUENCE {
+            swMultiCfgCtrlID
+                INTEGER,
+            swMultiCfgAction
+                INTEGER
+        }
+    swMultiCfgCtrlID OBJECT-TYPE
+        SYNTAX  INTEGER{
+                cfgId-1(1),
+                cfgId-2(2)
+        }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The section ID of the configuration file."
+        ::= { swMultiCfgCtrlEntry 1 }
+
+   swMultiCfgAction OBJECT-TYPE
+        SYNTAX  INTEGER
+             {
+                active(1),
+                delete(2),
+                apply(3),
+                none(4),
+                config-as-bootup-cfg(5)
+             }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "
+            save: Save configuration to active configuration ID when the parameter is omitted.
+                active: Set any valid configuration as the active configuration.
+                delete: Removes the configuration from the flash memory. This configuration
+                         cannot be the active or current configuration file.
+                apply: Loads the indicated configuration file and applies it to the system.
+                config-as-bootup-cfg: Configured as the boot-up configuration by the indicated configuration(ID)."
+        ::= { swMultiCfgCtrlEntry 2 }
+
+-- -----------------------------------------------------------------------------
+-- Add common severity control management
+-- -----------------------------------------------------------------------------
+   systemSeverityControlMgmt    OBJECT IDENTIFIER ::= { agentBasicConfig 9 }
+
+    systemSeverityTrapControl OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the level of trap severity control. The system has a severity level control
+             and each trap should have a severity control set. When trap events occur and its severity
+             is higher than the system severity control level, the trap works as defined. If the event
+             severity is lower than the system severity control level, the event is ignored as if it
+             did not occur."
+        ::= { systemSeverityControlMgmt 1 }
+
+    systemSeverityLogControl OBJECT-TYPE
+        SYNTAX  AgentNotifyLevel
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the level of trap severity control. The system has a severity level control and
+             each trap should have a severity control set. When trap events occur and its severity is
+             higher than the system severity control level, the trap works as defined. If the event
+             severity is lower than the system severity control level, the event is ignored as if
+             it did not occur."
+        ::= { systemSeverityControlMgmt 2 }
+
+-- -----------------------------------------------------------------------------
+-- agentTrustedHostMgmt
+-- -----------------------------------------------------------------------------
+    agentTrustedHostMgmt       OBJECT IDENTIFIER ::= { agentBasicConfig 10 }
+
+    agentTrustedHostTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentTrustedHostEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This table contains the trusted host information."
+        ::= { agentTrustedHostMgmt 1 }
+
+    agentTrustedHostEntry OBJECT-TYPE
+        SYNTAX  AgentTrustedHostEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information about the trusted hosts."
+        INDEX  { agentTrustedHostIndex }
+        ::= { agentTrustedHostTable 1 }
+
+    AgentTrustedHostEntry ::=
+        SEQUENCE {
+            agentTrustedHostIndex
+                INTEGER,
+            agentTrustedHostIPAddress
+                IpAddress,
+            agentTrustedHostRowStatus
+                RowStatus,
+            agentTrustedHostIPSubnetMask
+                IpAddress,
+            agentTrustedHostForSNMP
+                INTEGER,
+            agentTrustedHostForTELNET
+                INTEGER,
+            agentTrustedHostForSSH
+                INTEGER,
+            agentTrustedHostForHTTP
+                INTEGER,
+            agentTrustedHostForHTTPS
+                INTEGER,
+            agentTrustedHostForPING
+                INTEGER,
+            agentTrustedHostAddrType
+                InetAddressType,
+            agentTrustedHostAddr
+                InetAddress,
+            agentTrustedHostIPv6PrefixLen
+                INTEGER                
+        }
+
+    agentTrustedHostIndex OBJECT-TYPE
+        SYNTAX  INTEGER (1..30)
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The index of the trusted host entry."
+        ::= { agentTrustedHostEntry 1 }
+
+    agentTrustedHostIPAddress OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-create
+        STATUS  current
+        DESCRIPTION
+            "Specifies the IP address of the trusted host."
+        ::= { agentTrustedHostEntry 2 }
+
+    agentTrustedHostRowStatus OBJECT-TYPE
+        SYNTAX  RowStatus
+        MAX-ACCESS  read-create
+        STATUS  current
+        DESCRIPTION
+            "Indicates the status of this entry. When creating a trusted host
+             entry, the IP address should also be set."
+        ::= { agentTrustedHostEntry 3 }
+
+    agentTrustedHostIPSubnetMask OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-create
+        STATUS  current
+        DESCRIPTION
+            "Specifies the IP subnet mask of the trusted host."
+        ::= { agentTrustedHostEntry 4 }
+        
+    agentTrustedHostForSNMP OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the trusted host for SNMP."
+        ::= { agentTrustedHostEntry 5 }
+
+    agentTrustedHostForTELNET OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the trusted host for Telnet."
+        ::= { agentTrustedHostEntry 6 }
+
+    agentTrustedHostForSSH OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the trusted host for SSH."
+        ::= { agentTrustedHostEntry 7 }
+
+    agentTrustedHostForHTTP OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the trusted host for HTTP."
+        ::= { agentTrustedHostEntry 8 }
+
+    agentTrustedHostForHTTPS OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION 
+            "Specifies the trusted host for HTTPS."
+        ::= { agentTrustedHostEntry 9 }      
+	  
+    agentTrustedHostForPING OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the trusted host for PING."
+        ::= { agentTrustedHostEntry 10 }
+	
+    agentTrustedHostAddrType OBJECT-TYPE
+        SYNTAX  InetAddressType
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "The type of trusted host address as specified by
+             the 'agentTrustedHostAddr' object."
+        ::= { agentTrustedHostEntry 11 }
+	
+    agentTrustedHostAddr OBJECT-TYPE
+        SYNTAX  InetAddress
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the IP address of the trusted host."
+        ::= { agentTrustedHostEntry 12 }
+	
+     agentTrustedHostIPv6PrefixLen OBJECT-TYPE
+        SYNTAX  INTEGER (1..128)
+        MAX-ACCESS  read-create
+        STATUS      current
+        DESCRIPTION
+            "Specifies the IPv6 prefix length of the IPv6 trusted host."
+        ::= { agentTrustedHostEntry 13 }
+
+-- -----------------------------------------------------------------------------
+-- agentTrustedHostDelAllState
+-- -----------------------------------------------------------------------------
+    agentTrustedHostDelAllState OBJECT-TYPE
+        SYNTAX	INTEGER{
+			    		none(1),
+			    		start(2)
+			    		}
+        MAX-ACCESS  read-write
+        STATUS      current
+        DESCRIPTION
+            "Used to delete all trusted host entries."
+        ::= { agentTrustedHostMgmt 2 }
+
+-- -----------------------------------------------------------------------------
+-- agentFDBMgmt
+-- -----------------------------------------------------------------------------
+    agentFDBMgmt       OBJECT IDENTIFIER ::= { agentBasicConfig 11 }
+    agentFDBClearAllState OBJECT-TYPE
+        SYNTAX  INTEGER{
+                other(1),
+                start(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Used to clear all FDB entries."
+        ::= { agentFDBMgmt 1 }
+	
+    agentFDBClearByPortTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFDBClearByPortEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "Used to clear FDB entries by port."
+        ::= { agentFDBMgmt 2 }
+	
+    agentFDBClearByPortEntry OBJECT-TYPE
+        SYNTAX  AgentFDBClearByPortEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This is an entry of the agentFDBClearByPortTable."
+        INDEX  { agentFDBClearPortIndex }
+        ::= { agentFDBClearByPortTable 1 }
+	
+    AgentFDBClearByPortEntry ::=
+        SEQUENCE {
+            agentFDBClearPortIndex
+                INTEGER,
+            agentFDBClearByPortAction
+                INTEGER
+        }
+    agentFDBClearPortIndex OBJECT-TYPE
+	SYNTAX		INTEGER(1..65535)
+	MAX-ACCESS	not-accessible
+	STATUS		current
+        DESCRIPTION
+            "This object indicates the port number."
+        ::= { agentFDBClearByPortEntry 1 }	
+	
+    agentFDBClearByPortAction OBJECT-TYPE
+        SYNTAX  INTEGER{
+                other(1),
+                start(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates whether to clear FDB or not."
+        ::= { agentFDBClearByPortEntry 2 }
+	
+    agentFDBClearByVlanTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFDBClearByVlanEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "Used to clear FDB entries by port."
+        ::= { agentFDBMgmt 3 }
+	
+    agentFDBClearByVlanEntry OBJECT-TYPE
+        SYNTAX  AgentFDBClearByVlanEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This is an entry of agentFDBClearByPortTable."
+        INDEX  { agentFDBClearVid }
+        ::= { agentFDBClearByVlanTable 1 }
+	
+    AgentFDBClearByVlanEntry ::=
+        SEQUENCE {
+            agentFDBClearVid
+                VlanId,
+            agentFDBClearByVlanAction
+                INTEGER
+        }
+	
+    agentFDBClearVid OBJECT-TYPE
+        SYNTAX		VlanId
+        MAX-ACCESS	not-accessible
+        STATUS		current
+        DESCRIPTION
+            "This object indicates the VLAN-ID."
+        ::= { agentFDBClearByVlanEntry 1 }
+		
+    agentFDBClearByVlanAction OBJECT-TYPE
+        SYNTAX  INTEGER{
+                other(1),
+                start(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates whether to clear the FDB or not."
+        ::= { agentFDBClearByVlanEntry 2 }
+
+	agentFDBSecurityTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFDBSecurityEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "Used to display the FDB entries that have been created by the security module."
+        ::= { agentFDBMgmt 4}
+	
+    agentFDBSecurityEntry OBJECT-TYPE
+        SYNTAX  AgentFDBSecurityEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This is an entry of agentFDBSecurityTable."
+        INDEX  { 
+                 agentFDBVid,
+                 agentFDBMacAddress
+                 }
+        ::= { agentFDBSecurityTable 1 }
+	
+    AgentFDBSecurityEntry ::=
+        SEQUENCE {
+            agentFDBVid
+                VlanId,
+            agentFDBMacAddress
+                MacAddress,
+            agentFDBPort
+                INTEGER, 
+            agentFDBType
+                INTEGER,
+            agentFDBStatus
+                INTEGER,
+            agentFDBSecurityModule
+                INTEGER
+        }
+		
+    agentFDBVid OBJECT-TYPE
+		SYNTAX		VlanId
+		MAX-ACCESS	not-accessible
+		STATUS		current
+		DESCRIPTION
+			"This object indicates the VLAN-ID."
+		::= { agentFDBSecurityEntry 1 }
+
+    agentFDBMacAddress OBJECT-TYPE
+		SYNTAX		MacAddress
+		MAX-ACCESS	not-accessible
+		STATUS		current
+		DESCRIPTION
+			"This object indicates the MAC address."
+		::= { agentFDBSecurityEntry 2 }
+		
+    agentFDBPort OBJECT-TYPE
+		SYNTAX		INTEGER(1..65535)
+		MAX-ACCESS	read-only
+		STATUS		current
+		DESCRIPTION
+			"This object indicates the port number."
+		::= { agentFDBSecurityEntry 3 }
+		
+    agentFDBType OBJECT-TYPE
+		SYNTAX  INTEGER{
+	                dynamic(1),
+	                static(2)
+	                }
+		MAX-ACCESS	read-only
+		STATUS		current
+        DESCRIPTION
+            "This object indicates the MAC address type."
+        ::= { agentFDBSecurityEntry 4 }	
+		
+    agentFDBStatus OBJECT-TYPE
+        SYNTAX  INTEGER{
+                drop(1),
+                forward(2)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the MAC address's forwarding status."
+        ::= { agentFDBSecurityEntry 5}
+
+    agentFDBSecurityModule OBJECT-TYPE
+        SYNTAX  INTEGER{
+                dot1x(1),
+                wac(2),
+                jwac(3),
+                port-security(4),
+                mac-based-access-control(5),
+                compound-authentication(6)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION		
+            "This object is used to indicate which security module created the current MAC address.
+	    	dot1x: 802.1X.
+	    	wac: Web-based Access Control. 
+	    	jwac: Web-Based Access Control extension for Japan.
+	    	port-security: Port Security.
+	    	mac-based-access-control: MAC-based Access Control.
+	    	compound-authentication: Compound Authentication."
+        ::= { agentFDBSecurityEntry 6}
+
+
+-- -----------------------------------------------------------------------------
+-- agentARPMgmt
+-- -----------------------------------------------------------------------------
+    agentARPMgmt       OBJECT IDENTIFIER ::= { agentBasicConfig 12 }
+    agentARPClearAllState OBJECT-TYPE
+        SYNTAX  INTEGER{
+                other(1),
+                start(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Used to clear all ARP entries."
+        ::= { agentARPMgmt 1 }
+
+-- -----------------------------------------------------------------------------
+-- agentGratuitousARPMgmt
+-- -----------------------------------------------------------------------------
+      agentGratuitousARPMgmt  OBJECT IDENTIFIER ::={agentARPMgmt 2}
+
+      agentGratuitousARPSendIpifStatusUpState OBJECT-TYPE
+        SYNTAX  INTEGER{
+                   enabled(1),
+                   disabled(2)
+                }
+        MAX-ACCESS read-write
+        STATUS  current
+        DESCRIPTION
+              "This is used to enable/disable sending of gratuitous ARP request
+              packets while the IPIF interface comes up. This is used to automatically
+              announce the interface's IP address to other nodes. By default,
+               the state is enabled, and only one ARP packet will be broadcast."
+       DEFVAL { enabled }
+         ::={ agentGratuitousARPMgmt 1}
+
+      agentGratuitousARPSendDupIpDetectedState OBJECT-TYPE
+       SYNTAX INTEGER{
+                      enabled(1),
+                      disabled(2)
+                     }
+         MAX-ACCESS read-write
+         STATUS  current
+         DESCRIPTION
+               "This is used to enable/disable the sending of gratuitous ARP request
+                packets while a duplicate IP is detected. By default, the state is enabled.
+                The duplicate IP detected state indicates that the system has received an ARP request
+                packet that was sent by an IP address that matches the system's own IP address.
+                In this case, the system knows that somebody out there is using an IP address
+                that is in conflict with the system. In order to reclaim the correct host
+                of this IP address, the system can send out the gratuitous ARP request
+                packet for this duplicate IP address."
+        DEFVAL { enabled }
+         ::={ agentGratuitousARPMgmt 2}
+
+      agentGratuitousARPLearningState OBJECT-TYPE
+       SYNTAX INTEGER{
+                      enabled(1),
+                      disabled(2)
+                     }
+         MAX-ACCESS read-write
+         STATUS  current
+         DESCRIPTION
+                  "This is used to enable/disable learning of an ARP entry in the ARP
+                  cache based on the received gratuitous ARP packet. If the switch
+                  receives a gratuitous ARP request/reply packet and the sender's
+                  IP address is in its ARP table, it should update the ARP entry.
+                   By default, the state is disabled."
+         DEFVAL { disabled }
+         ::={ agentGratuitousARPMgmt 3}
+
+      agentGratuitousARPTable OBJECT-TYPE
+         SYNTAX SEQUENCE OF AgentGratuitousARPEntry
+         MAX-ACCESS not-accessible
+         STATUS current
+         DESCRIPTION
+           "Gratuitous ARP Table Information."
+         ::={ agentGratuitousARPMgmt 4}
+
+      agentGratuitousARPEntry OBJECT-TYPE
+        SYNTAX  AgentGratuitousARPEntry
+        MAX-ACCESS not-accessible
+        STATUS current
+        DESCRIPTION
+            "A list of information from the Gratuitous ARP Table."
+        INDEX {
+                 agentGratuitousARPInterfaceName
+              }
+        ::={ agentGratuitousARPTable 1 }
+
+       AgentGratuitousARPEntry ::=
+          SEQUENCE {
+                     agentGratuitousARPInterfaceName
+                          DisplayString,
+                     agentGratuitousARPPeriodicalSendInterval
+                            INTEGER,
+                       agentGratuitousARPTrapState
+                            INTEGER,
+                       agentGratuitousARPLogState
+                            INTEGER
+                   }
+
+       agentGratuitousARPInterfaceName  OBJECT-TYPE
+            SYNTAX  DisplayString
+            MAX-ACCESS read-only
+            STATUS  current
+            DESCRIPTION
+               "The name of the IP interface."
+            ::={agentGratuitousARPEntry 1}
+
+          agentGratuitousARPPeriodicalSendInterval OBJECT-TYPE
+               SYNTAX  INTEGER (0..65535)
+               UNITS        "seconds"
+               MAX-ACCESS read-write
+               STATUS  current
+               DESCRIPTION
+                 "This is used to configure the interval for the periodic sending of
+                 gratuitous ARP request packets.
+                 0 means do not send gratuitous ARP request packets periodically."
+               DEFVAL { 0 }
+                ::={agentGratuitousARPEntry  2}
+
+         agentGratuitousARPTrapState   OBJECT-TYPE
+               SYNTAX  INTEGER{
+                             enabled(1),
+                             disabled(2)
+                             }
+               MAX-ACCESS read-write
+               STATUS  current
+               DESCRIPTION
+                    "This indicates the state of the gratuitous ARP trap. The switch can
+                    trap the IP conflict events to inform the administrator.
+                     By default, the trap is disabled."
+                 DEFVAL { disabled }
+                ::={agentGratuitousARPEntry 3}
+
+         agentGratuitousARPLogState OBJECT-TYPE
+               SYNTAX  INTEGER{
+                             enabled(1),
+                             disabled(2)
+                             }
+               MAX-ACCESS read-write
+               STATUS  current
+               DESCRIPTION
+                    "This indicates the state of the gratuitous Log trap. The switch can
+                     log the IP conflict events to inform the administrator.
+                     By default, the event log is enabled."
+               DEFVAL { enabled }
+                ::={agentGratuitousARPEntry 4}
+                
+    agentARPTotalARPEntries OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "Used to display the total number of ARP entries."
+        ::= { agentARPMgmt 3 }
+
+    agentARPRetryTimes OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This indicates the retry times of the ARP request."
+        ::= { agentARPMgmt 4 }
+        
+-- -----------------------------------------------------------------------------
+-- swMultiImageCtrlTable
+-- -----------------------------------------------------------------------------
+    swMultiImageCtrlTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF SwMultiImageCtrlEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            ""
+        ::= { agentBasicConfig 13 }
+
+    swMultiImageCtrlEntry OBJECT-TYPE
+        SYNTAX  SwMultiImageCtrlEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information about multiple image management."
+        INDEX  { swMultiImageCtrlID }
+        ::= { swMultiImageCtrlTable 1 }
+
+    SwMultiImageCtrlEntry ::=
+        SEQUENCE {
+                swMultiImageCtrlID
+                        INTEGER,
+                swMultiImageCtrlAction
+                        INTEGER
+                }
+
+    swMultiImageCtrlID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The stacking section ID of the firmware image.
+             The stacking section ID = 256 * Unit ID + Image File ID."
+        ::= { swMultiImageCtrlEntry 1 }
+
+    swMultiImageCtrlAction OBJECT-TYPE
+        SYNTAX  INTEGER{
+                config-as-bootup-fw(1),
+                delete(2),
+                none(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the running status of the image which is
+             specified by swMultiImageCtrlID and swMultiImageCtrlUnitID.
+
+             config-as-bootup-fw (1) - Configured as the bootup firmware by the indicated firmware(ID).
+             delete (2) - Delete the firmware by indicated firmware ID.
+             none (3) - No action.
+             "
+        ::= { swMultiImageCtrlEntry 2 }
+
+-- -----------------------------------------------------------------------------
+    agentOutOfBandDataBits OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the out-of-band data bits."
+        ::= { agentBasicConfig 14 }
+
+    agentOutOfBandParityBits OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the out-of-band parity bits."
+        ::= { agentBasicConfig 15 }
+
+    agentOutOfBandStopBits OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the out-of-band stop bits."
+        ::= { agentBasicConfig 16 }
+
+    agentOutOfBandAutoLogoutConfig OBJECT-TYPE
+        SYNTAX  INTEGER {
+               never(1),
+               minutes-2(2),
+               minutes-5(3),
+               minutes-10(4),
+               minutes-15(5)
+               }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object allows the user to specify an out-of-band auto logout time."
+        ::= { agentBasicConfig 17 }
+
+-- -----------------------------------------------------------------------------
+-- agentBscFileSystemMgmt
+-- -----------------------------------------------------------------------------
+    agentBscFileSystemMgmt       OBJECT IDENTIFIER ::= { agentBasicConfig 18 }
+
+    agentBscFileSystemTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentBscFileSystemEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of MIB File System Basic Configuration entries supported
+             by the file update of this agent."
+        ::= { agentBscFileSystemMgmt 1 }
+
+    agentBscFileSystemEntry OBJECT-TYPE
+        SYNTAX  AgentBscFileSystemEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A File System basic configuration entry that contains objects
+             describing a particular MIB supported by this agent."
+        INDEX   { agentBscFileSystemIndex }
+        ::= { agentBscFileSystemTable 1 }
+
+    AgentBscFileSystemEntry ::=
+        SEQUENCE {
+                agentBscFileSystemIndex
+                        Integer32,
+                agentBscFileSystemDscr
+                        DisplayString,
+                agentBscFileSystemServerAddr
+                        IpAddress,
+                agentBscFileSystemServerIPv6Addr
+                        Ipv6Address,
+                agentBscFileSystemServerFileName
+                        DisplayString,
+                agentBscFileSystemDeviceDriverID
+                        INTEGER,
+                agentBscFileSystemDeviceFileName
+                        DisplayString,
+                agentBscFileSystemLoadType
+                        INTEGER,
+                agentBscFileSystemCtrlUnitID
+                        UnitList,
+                agentBscFileSystemBootUpImage
+                        TruthValue,
+                agentBscFileSystemForceAgree
+                        TruthValue,
+                agentBscFileSystemCtrl
+                        INTEGER,
+                agentBscFileSystemInterfaceName
+                        DisplayString,
+                agentBscFileSystemServerDomainName
+                        DisplayString,
+                agentBscFileSystemIncrement
+        		TruthValue,
+                agentBscFileSystemServerVrfName
+                        DisplayString
+
+        }
+
+    agentBscFileSystemIndex OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS      read-only
+        STATUS  current
+        DESCRIPTION
+        "The table index for the file entry.
+         This object describes the file type.
+             runtime-code (1),
+             log-file (2),
+             cfg-file (3),
+             attack-log-file (7)"
+        ::= { agentBscFileSystemEntry 1 }
+
+    agentBscFileSystemDscr OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The description of the software file purpose in this entry."
+        ::= { agentBscFileSystemEntry 2 }
+
+    agentBscFileSystemServerAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IP address where the file to be downloaded is located, or the IP address
+            where the file will be uploaded to."
+        ::= {  agentBscFileSystemEntry 3 }
+
+    agentBscFileSystemServerIPv6Addr OBJECT-TYPE
+        SYNTAX  Ipv6Address
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IPv6 address where the file is to be downloaded from or uploaded to."
+        ::= {  agentBscFileSystemEntry 4 }
+
+
+    agentBscFileSystemServerFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The name of the file to be downloaded from or uploaded to the TFTP server.
+        If agentBscFileSystemDeviceFileName is not set, the switch will default to using
+             the bootup file as the runtime image for the switch."
+        ::= { agentBscFileSystemEntry 5 }
+
+    agentBscFileSystemDeviceDriverID OBJECT-TYPE
+        SYNTAX  INTEGER {
+                        none(1),
+                        a(2),
+                        b(3),
+                        c(4),
+                        d(5),
+                        e(6),
+                        f(7),
+                        g(8),
+                        h(9),
+                        i(10),
+                        j(11),
+                        k(12),
+                        l(13),
+                        m(14),
+                        n(15),
+                        o(16),
+                        p(17),
+                        q(18),
+                        r(19),
+                        s(20),
+                        t(21),
+                        u(22),
+                        v(23),
+                        w(24),
+                        x(25),
+                        y(26),
+                        z(27)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Specifies the drive of the device that the firmware to be uploaded/downloaded is located.
+             If none (1) is specified, the switch will default to the current drive."
+        ::= { agentBscFileSystemEntry 6 }
+
+    agentBscFileSystemDeviceFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The name of the file to be downloaded to the device, or uploaded from the
+            device. When downloading or uploading, the agentBscFileSystemServerFileName object must also be set."
+        ::= { agentBscFileSystemEntry 7 }
+
+
+     agentBscFileSystemLoadType OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    upload(2),
+                    download(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+                "This object allows the user to select a download or upload function for the file.
+
+                         Note:
+                         For systems that do not support changes to this object, setting a value for
+                         this object will cause the system to return a bad-value error message.
+                         "
+        ::= { agentBscFileSystemEntry 8 }
+
+    agentBscFileSystemCtrlUnitID OBJECT-TYPE
+        SYNTAX   UnitList
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Specifies which unit of the switch stack the firmware image or configuration file should be downloaded from.
+             One or more units can be set in this list. Each bit from left to right represents the
+             switch from unit ID 1 to unit ID 12.
+             If this list is set to null it represents all stack switches."
+        ::= { agentBscFileSystemEntry 9 }
+
+    agentBscFileSystemBootUpImage OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "The result of the download will depend on whether the boot_up option has been specified.
+             Case 1: In the case of the master unit providing the file system and the slave unit
+                not providing the file system, when the boot_up parameter is specified, then the file will
+                be downloaded to the boot_up image on the slave. If the boot_up parameter is not specified,
+                then the file will not be downloaded to this slave unit.
+
+             Case 2: In the case of the master unit not providing the file system and the slave unit
+                providing the file system, when the boot_up parameter is specified, then the file will be downloaded
+                to the boot_up image on the slave unit. If boot_up is not specified, then the file will
+                not be downloaded to this slave unit.
+
+             Case 3: In the case of the master unit and the slave unit both supporting or not supporting the
+                file system, the file will be downloaded to the specified file on the slave unit. If boot_up
+                is specified, the downloaded file will be assigned as the boot_up image.
+
+             True: boot_up option is specified.
+             False: boot_up option is not specified.. "
+        ::= { agentBscFileSystemEntry 10 }
+
+    agentBscFileSystemForceAgree OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "When the force_agree option is specified, the reboot command will be executed immediately
+             without any further confirmation from the user.
+
+             True: force_agree option is specified.
+             False: force_agree option is not specified.. "
+        ::= { agentBscFileSystemEntry 11 }
+
+     agentBscFileSystemCtrl OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    inactive(2),
+                    start(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object allows the user to download runtime software. The settings
+                         will take effect when the system restarts. See Note (1) below
+
+                         Note 1:
+                         For systems which do not support value changes to this object,
+                         setting these values will cause the system to return a bad-value error message
+
+                        start (3) - activate firmware.
+        "
+        ::= { agentBscFileSystemEntry 12 }
+
+     agentBscFileSystemInterfaceName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..12))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+             "This node is used to specify the interface name when agentBscFileSystemServerIPv6Addr
+              is the local link address."
+        ::= {  agentBscFileSystemEntry 13 }
+        
+   agentBscFileSystemServerDomainName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE(0..255))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the domain name of the TFTP server."
+        ::= {  agentBscFileSystemEntry 14 }
+        
+   agentBscFileSystemIncrement OBJECT-TYPE
+        SYNTAX      TruthValue
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+             "If increment is specified, then the existing configuration will not be cleared before applying
+             of the new configuration. If it is not specified, then the existing configuration will be cleared
+             before applying of the new configuration.
+             True : keep valid
+             False : erase. "
+       	 ::= { agentBscFileSystemEntry 15 } 
+        
+   agentBscFileSystemServerVrfName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE(0..12))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the VRF name of the TFTP server.Input string 'reserved' 
+            for the global space."
+        ::= {  agentBscFileSystemEntry 16}
+	
+-- --------------------------------------------------------------------------------
+     agentBscFileSystemSaveConfigDriverID OBJECT-TYPE
+       SYNTAX  INTEGER {
+                        none(1),
+                        a(2),
+                        b(3),
+                        c(4),
+                        d(5),
+                        e(6),
+                        f(7),
+                        g(8),
+                        h(9),
+                        i(10),
+                        j(11),
+                        k(12),
+                        l(13),
+                        m(14),
+                        n(15),
+                        o(16),
+                        p(17),
+                        q(18),
+                        r(19),
+                        s(20),
+                        t(21),
+                        u(22),
+                        v(23),
+                        w(24),
+                        x(25),
+                        y(26),
+                        z(27)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The drive on the device that the configuration file is will be saved to.
+             If none (1) is specified, the switch places the file on the current drive by default."
+        ::= { agentBscFileSystemMgmt 2 }
+
+     agentBscFileSystemSaveConfigFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The name of the configuration file that will be saved to the device.
+             When agentBscFileSystemSaveCfg  is set to cfg (2), and if the agentBscFileSystemSaveConfigFileName
+             is not null, the configuration file will be saved to the set file name.
+             If set to null, the configuration file will be saved to the boot_up CFG file. "
+        ::= { agentBscFileSystemMgmt 3 }
+
+     agentBscFileSystemSaveCfg OBJECT-TYPE
+        SYNTAX INTEGER {
+                                other(1),
+                                cfg(2),
+                                log(3),
+                                all(4)
+                        }
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This indicates the method of saving information to the NV-RAM of the device.
+             other (1) - None of the following.
+             cfg (2) - Save configuration.
+             log (3) - Save log.
+             all (4) - Save both ( active configuration and log)."
+        ::= { agentBscFileSystemMgmt 4 }
+
+-- -----------------------------------------------------------------------------
+    agentFileSystemConfigTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFileSystemConfigEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This table indicates the information about the bootup files."
+        ::= { agentBscFileSystemMgmt 5 }
+
+    agentFileSystemConfigEntry OBJECT-TYPE
+        SYNTAX  AgentFileSystemConfigEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of information about the bootup files for each unit of the switch stack."
+        INDEX   { agentFileSystemUnit }
+        ::= { agentFileSystemConfigTable 1 }
+
+    AgentFileSystemConfigEntry ::=
+        SEQUENCE {
+                agentFileSystemUnit
+                        Integer32,
+                agentFileSystemDriverID
+                        INTEGER,
+                agentFileSystemBootImage
+                        DisplayString,
+                agentFileSystemBootConfig
+                        DisplayString,
+                agentFileSystemActConfig
+                        DisplayString
+
+        }
+
+    agentFileSystemUnit OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS      read-only
+        STATUS  current
+        DESCRIPTION
+                "The unit ID."
+        ::= { agentFileSystemConfigEntry 1 }
+
+     agentFileSystemDriverID OBJECT-TYPE
+       SYNTAX  INTEGER {
+                        none(1),
+                        a(2),
+                        b(3),
+                        c(4),
+                        d(5),
+                        e(6),
+                        f(7),
+                        g(8),
+                        h(9),
+                        i(10),
+                        j(11),
+                        k(12),
+                        l(13),
+                        m(14),
+                        n(15),
+                        o(16),
+                        p(17),
+                        q(18),
+                        r(19),
+                        s(20),
+                        t(21),
+                        u(22),
+                        v(23),
+                        w(24),
+                        x(25),
+                        y(26),
+                        z(27)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The drive on the device that the configuration file will be saved to.
+             If none (1) is specified, the switch will place  the file to the current drive by default."
+        ::= { agentFileSystemConfigEntry 2 }
+
+      agentFileSystemBootImage OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "When displayed, it shows the current bootup image file name.
+            When set, the set name will be set as the bootup image."
+        ::= { agentFileSystemConfigEntry 3 }
+
+      agentFileSystemBootConfig OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "When displayed, it shows the current bootup configuration file name.
+            When set, the set name will be set as the bootup configuration."
+        ::= { agentFileSystemConfigEntry 4 }
+
+      agentFileSystemActConfig OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "When displayed, it shows null.
+            When set, the set name will be active at once, but the set name
+            will not be set as the bootup configuration."
+        ::= { agentFileSystemConfigEntry 5 }
+
+-- -----------------------------------------------------------------------------
+    agentReboot OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    none(1),
+                    start(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Used to restart the switch."
+        ::= {  agentBasicConfig 19  }
+
+    agentReset OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    none(1),
+                    config(2),
+                    system(3),
+                                        reset(4),
+                    system-exclude-vlan(5),
+                    system-exclude-ip(6),
+                    system-exclude-vlan-ip(7)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Used to reset all switch parameters.
+
+                         none (1): No action. This is the default value of this object.
+                         config (2): All parameters are reset to default settings.
+                                                The device will neither save nor reboot.
+                         system (3): All parameters are reset to default settings.
+                                                The switch will then do a factory reset, save, and reboot.
+                         reset (4) : All parameters will be reset to default settings except for the
+                                                IP address, user account, and history log.
+                                                The device will neither save nor reboot.
+                         system-exclude-vlan(5)   : All parameters are reset to default settings except for VLAN.
+                                       The switch will then save its settings and reboot.
+             system-exclude-ip(6)     : All parameters are reset to default settings except IP address.
+                                       The switch will then save its settings and reboot.
+             system-exclude-vlan-ip(7): All parameters are reset to default settings except VLAN and IP address.
+                                       The switch will then save its settings and reboot.
+                        "
+        ::= {  agentBasicConfig 20  }
+
+-- -----------------------------------------------------------------------------
+-- agentFTPFileTable
+-- -----------------------------------------------------------------------------
+    agentFTPFileTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFTPFileEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of the MIB Basic Config entries support files updated by this agent."
+        ::= { agentBasicConfig 21 }
+
+    agentFTPFileEntry OBJECT-TYPE
+        SYNTAX  AgentFTPFileEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A basic configuration entry containing the objects describing a particular MIB
+             supported by this agent."
+        INDEX   { agentFTPFileIndex }
+        ::= { agentFTPFileTable 1 }
+
+    AgentFTPFileEntry ::=
+        SEQUENCE {
+            agentFTPFileIndex
+                Integer32,
+            agentFTPFileDscr
+                DisplayString,
+            agentFTPFileLoadType
+                INTEGER,
+            agentFTPFileAddr
+                IpAddress,
+            agentFTPTCPPort
+                INTEGER,
+            agentFTPFileName
+                DisplayString,
+            agentFTPUserName
+                DisplayString,
+            agentFTPPassword
+                DisplayString,
+            agentFTPFileCtrlID
+                INTEGER,
+            agentFTPFileBIncrement
+                TruthValue,
+            agentFTPFileCtrl
+                INTEGER,               
+			agentFTPFileBootUpImage
+				TruthValue,
+			agentFTPFileForceAgree
+				TruthValue,  
+			agentFTPFileIPv6Addr
+				DisplayString,
+			agentFTPFileInterfaceName
+				DisplayString,
+			agentFTPFileUnitID
+				UnitList					               
+        }
+                    
+    agentFTPFileIndex OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS      read-only
+        STATUS  current
+        DESCRIPTION
+                "The table index for the file entry. This object describes the file type
+                 runtime-code (1),
+                 log-file (2),
+                 cfg-file (3)"
+        ::= { agentFTPFileEntry 1 }
+
+    agentFTPFileDscr OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The description of the software file purpose in this entry.
+             Note: For systems which do not support changes to this object, setting a value for
+             this object will cause the system to return bad-value error messages."
+        ::= { agentFTPFileEntry 2 }
+
+    agentFTPFileLoadType OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    upload(2),
+                    download(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+                "This object provides the user with a choice of uploading or downloading the selected file.
+                 Note: For systems which do not support a change of this object, setting a value to this object
+                 will cause the system to return bad-value error messages."
+        ::= { agentFTPFileEntry 3 }
+
+    agentFTPFileAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IP address that the file to be downloaded is located on, or the IP address
+            where the file will be uploaded to."
+        ::= {  agentFTPFileEntry 4 }
+
+    agentFTPTCPPort  OBJECT-TYPE
+        SYNTAX      INTEGER
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The TCP port number being used to establish the command connection."
+        ::= { agentFTPFileEntry 5 }
+
+    agentFTPFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..128))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The name of the file to be downloaded from, or uploaded to, the FTP server."
+        ::= { agentFTPFileEntry 6 }
+
+     agentFTPUserName  OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This is the user name to enter in upload/download. "
+        ::= { agentFTPFileEntry 7 }
+
+     agentFTPPassword  OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This is the password to enter for an upload/download."
+        ::= { agentFTPFileEntry 8 }
+
+     agentFTPFileCtrlID OBJECT-TYPE
+        SYNTAX  INTEGER
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The section ID of the firmware image or configuration file.
+             A value of 0 indicates the boot-up firmware image or configuration file."
+        ::= { agentFTPFileEntry 9 }
+
+      agentFTPFileBIncrement OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This object indicates whether the previous configuration will remain
+             valid or not after downloading the configuration file.
+             True: Keep valid
+             False: Erase. "
+        ::= { agentFTPFileEntry 10 }
+
+
+     agentFTPFileCtrl OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    start(2)
+                    }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object gives the user the option to download runtime software. The setting will take effect
+             when the system restarts. See Note (1) below
+                  Note 1:
+                  For systems which do not support changes to this object, setting a value for this object
+                  will cause the system to return bad-value error messages. "
+        ::= { agentFTPFileEntry 11 }     
+            
+	agentFTPFileBootUpImage OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This object indicates whether to set the special file as a boot up file or not.
+			 True: The boot-up option is specified.
+			 False: The boot-up option is not specified."
+        ::= { agentFTPFileEntry 12 }    
+        
+	agentFTPFileForceAgree OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "When the force-agree option is specified, the reboot command will be executed
+			immediately without any further confirmation from the user.
+			True: Force-agree option is specified.
+			False: Force-agree option is not specified."
+        ::= { agentFTPFileEntry 13 } 
+                
+	agentFTPFileIPv6Addr  OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IPv6 address where the file is to be downloaded from or uploaded to."
+        ::= { agentFTPFileEntry 14 }          
+	
+	agentFTPFileInterfaceName  OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This node is used to specify the interface name when agentFTPFileIPv6Addr
+			is the local link address. "
+        ::= { agentFTPFileEntry 15 }	
+
+ 	agentFTPFileUnitID OBJECT-TYPE
+        SYNTAX   UnitList
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Specifies which unit of the switch stack the firmware image or configuration 
+			file should be downloaded from. One or more units can be set in this list. Each 
+			bit from left to right represents the switch from unit ID 1 to unit ID 12.If this
+			list is set to null it represents all stack switches."
+        ::= { agentFTPFileEntry 16 }        
+-- -----------------------------------------------------------------------------
+-- agentSnmpTrapState
+-- -----------------------------------------------------------------------------
+     agentSnmpTrapState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This object indicates if the SNMP trap is enabled or disabled."
+        ::= { agentBasicConfig 22 }
+
+-- -----------------------------------------------------------------------------
+--  agentOutOfBandMgmt
+-- -----------------------------------------------------------------------------
+
+    agentOutOfBandMgmt     OBJECT IDENTIFIER ::= { agentBasicConfig 23 }
+
+    agentOutOfBandMgmtState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Enables or disables the interface."
+        ::= { agentOutOfBandMgmt 1 }
+
+    agentOutOfBandMgmtIpAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IP address for out of band management. This object can only take the
+            value of the unicast IP address."
+        ::= { agentOutOfBandMgmt 2 }
+
+    agentOutOfBandMgmtSubnetMask OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IP net mask for out of band management."
+        ::= { agentOutOfBandMgmt 3 }
+
+    agentOutOfBandMgmtGateway OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The gateway for out of band management. "
+        ::= { agentOutOfBandMgmt 4 }
+
+    agentOutOfBandMgmtLinkStatus OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    link-up(1),
+                    link-down(2)
+                }
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The current Link status for out of band management."
+        ::= { agentOutOfBandMgmt 5 }      
+        
+        
+        
+        
+        
+
+-- -----------------------------------------------------------------------------
+--  agentTrapMgmt
+-- -----------------------------------------------------------------------------
+
+    agentTrapMgmt     OBJECT IDENTIFIER ::= { agentBasicConfig 24 }
+    
+    agentTrapColdStart OBJECT-TYPE
+        SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2)               
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a cold start event,
+             a trap will be sent out."
+    ::= { agentTrapMgmt 1 }
+
+  agentTrapWarmStart OBJECT-TYPE
+    	SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2) 
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a warm start event,
+             a trap will be sent out."
+    ::= { agentTrapMgmt 2 }    
+    
+  agentTrapRmonRisingAlarm OBJECT-TYPE
+    	SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2)
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a RMON rising alarm 
+             event , a trap will be sent out."
+    ::= { agentTrapMgmt 3 }
+
+  agentTrapRmonFallingAlarm OBJECT-TYPE
+    	SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2)
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a RMON falling alarm 
+             event, a trap will be sent out."
+    ::= { agentTrapMgmt 4 }
+
+  agentTrapCfgSave OBJECT-TYPE
+    	SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2) 
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a configuration saving 
+             completed event, a trap will be sent out."
+    ::= { agentTrapMgmt 5 }  
+
+  agentTrapCfgUpload OBJECT-TYPE
+    	SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2) 
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a configuration 
+             uploading completed event, a trap will be sent out."
+    ::= { agentTrapMgmt 6 }  
+
+  agentTrapCfgDownload OBJECT-TYPE
+    	SYNTAX  INTEGER {
+               enabled(1),
+               disabled(2) 
+            }
+    	MAX-ACCESS  read-write
+    	STATUS  current
+    	DESCRIPTION
+            "When enabled (1), whenever the device detects a configuration 
+             downloading completed event, a trap will be sent out"
+    ::= { agentTrapMgmt 7 }  
+                               
+                              
+-- -----------------------------------------------------------------------------
+-- agentFTPFileSystemTable
+-- -----------------------------------------------------------------------------
+    agentFTPFileSystemTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentFTPFileSystemEntry 
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "The FTP management table for the file system"
+        ::= { agentBasicConfig 25 }    
+        
+    agentFTPFileSystemEntry OBJECT-TYPE
+        SYNTAX  AgentFTPFileSystemEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A File System basic configuration entry that contains objects
+			 describing a particular MIB supported by this agent."
+        INDEX   { agentFTPFileSystemIndex }
+        ::= { agentFTPFileSystemTable 1 }  
+        
+   AgentFTPFileSystemEntry ::=
+        SEQUENCE {
+                agentFTPFileSystemIndex
+                        Integer32,
+                agentFTPFileSystemDscr
+                        DisplayString,  
+ 				agentFTPFileSystemLoadType
+                        INTEGER,                          
+                agentFTPFileSystemAddressType
+                        InetAddressType,
+				agentFTPFileSystemAddress
+						InetAddress, 
+				agentFTPFileSystemTCPPort 
+						INTEGER,   
+                agentFTPFileSystemServerFileName
+                        DisplayString,  
+                agentFTPFileSystemDeviceFileName
+                        DisplayString,
+ 				agentFTPFileSystemUserName
+						DisplayString,
+				agentFTPFileSystemPassword
+						DisplayString,		                     
+  				agentFTPFileSystemCtrlUnitID             
+                        UnitList,
+                agentFTPFileSystemBootUpImage
+                        TruthValue,   
+                agentFTPFileSystemCtrl
+                        INTEGER,
+                agentFTPFileSystemVrfName
+                        DisplayString
+        }
+
+    agentFTPFileSystemIndex OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS    not-accessible
+        STATUS  current
+        DESCRIPTION
+           	"The table index for the file entry."
+        ::= { agentFTPFileSystemEntry 1 }   
+        
+	agentFTPFileSystemDscr OBJECT-TYPE
+	   SYNTAX  DisplayString
+	   MAX-ACCESS      read-only
+	   STATUS  current
+	   DESCRIPTION
+	   		"The description of the software file purpose in this entry."
+	   ::= { agentFTPFileSystemEntry 2 }   
+                 
+    agentFTPFileSystemLoadType OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    upload(2),
+                    download(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+             "This object allows the user to select a download or upload function for the file."
+        ::= { agentFTPFileSystemEntry 3 }
+                 
+    agentFTPFileSystemAddressType OBJECT-TYPE   
+        SYNTAX  	InetAddressType
+        MAX-ACCESS  read-write
+        STATUS  	current
+        DESCRIPTION
+            "The address type of agentFTPFileSystemAddress."
+        ::= { agentFTPFileSystemEntry 4 }
+        
+     agentFTPFileSystemAddress OBJECT-TYPE
+     	SYNTAX 		InetAddress
+     	MAX-ACCESS	read-write
+     	STATUS	    current
+     	DESCRIPTION
+     		"This object indicates the FTP server address."
+     	::= {agentFTPFileSystemEntry 5}
+  
+	agentFTPFileSystemTCPPort  OBJECT-TYPE
+        SYNTAX      INTEGER
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The TCP port number being used to establish the control connection."
+        ::= { agentFTPFileSystemEntry 6 }
+  	   
+	agentFTPFileSystemServerFileName OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+	  	 	"The name of the file to be downloaded from or uploaded to the FTP server."
+	   ::= { agentFTPFileSystemEntry 7 }  
+	  
+    agentFTPFileSystemDeviceFileName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE (0..64))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The name of the file to be downloaded to the device, or uploaded from the
+             device. 
+             If agentFTPFileSystemDeviceFileName is not set, the switch will default to
+        	 the bootup file."
+       ::= { agentFTPFileSystemEntry 8 }
+
+     agentFTPFileSystemUserName  OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the user name to access the FTP server."
+        ::= { agentFTPFileSystemEntry 9 }
+
+     agentFTPFileSystemPassword  OBJECT-TYPE
+        SYNTAX  DisplayString
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the password to access the FTP server."
+        ::= { agentFTPFileSystemEntry 10 }
+                       
+    agentFTPFileSystemCtrlUnitID OBJECT-TYPE
+        SYNTAX   UnitList
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Specifies which unit of the switch stack the firmware image or configuration 
+			file should be downloaded from. One or more units can be set in this list. Each 
+			bit from left to right represents the switch from unit ID 1 to unit ID 12.If this
+			list is set to null it represents all stack switches."
+        ::= { agentFTPFileSystemEntry 11 }
+
+    agentFTPFileSystemBootUpImage OBJECT-TYPE
+        SYNTAX     TruthValue
+        MAX-ACCESS read-write
+        STATUS current
+        DESCRIPTION
+            "This object indicates whether to set the special file as the boot up file or not.
+			 True: The boot-up option is specified.
+			 False: The boot-up option is not specified."
+        ::= { agentFTPFileSystemEntry 12 }	   
+	 
+	agentFTPFileSystemCtrl  OBJECT-TYPE
+		SYNTAX  INTEGER {
+                    other(1),
+                    start(2)
+                    }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object allows the user to execute an FTP download/upload."
+        ::= { agentFTPFileSystemEntry 13 }
+                
+     agentFTPFileSystemVrfName OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE(0..12))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the VRF name of the FTP server.Input string 'reserved' 
+            for the global space."
+        ::= { agentFTPFileSystemEntry 14 }
+  
+-- -----------------------------------------------------------------------------
+-- agentBscCMDLogState
+-- -----------------------------------------------------------------------------
+   agentBscCMDLogState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                enabled(1),
+                disabled(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the command logging state."
+        ::= { agentBasicConfig 26 } 
+
+-- -----------------------------------------------------------------------------
+-- agentBscBroadcastPingReplyState
+-- -----------------------------------------------------------------------------
+    agentBscBroadcastPingReplyState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                enabled(1),
+                disabled(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the broadcast ping reply state."
+        ::= { agentBasicConfig 27 }
+	
+-- -----------------------------------------------------------------------------
+-- agentBscTftpConfigMgmt
+-- -----------------------------------------------------------------------------
+   agentBscTftpConfigMgmt       OBJECT IDENTIFIER ::= { agentBasicConfig 28 }
+
+   agentBscTftpCfgFirmwareFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The firmware pathname that needs to be downloaded/uploaded from/to the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 1 }
+
+   agentBscTftpCfgConfigFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The configuration pathname that needs to be downloaded/uploaded from/to the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 2 }
+        
+   agentBscTftpCfgLogFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The log pathname that needs to be uploaded to the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 3 }
+
+   agentBscTftpCfgAttackLogFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The attack log pathname that needs to be uploaded to the TFTP server."            
+        ::= {  agentBscTftpConfigMgmt 4 }
+
+   agentBscTftpCfgCertificateFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The certificate pathname that needs to be downloaded from the TFTP server."            
+        ::= {  agentBscTftpConfigMgmt 5 }
+        
+   agentBscTftpCfgKeyFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The key pathname that needs to be downloaded from the TFTP server."            
+        ::= {  agentBscTftpConfigMgmt 6 }
+        
+   agentBscTftpCfgTechSuooprtFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The technique's support information pathname that needs to be uploaded to the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 7 }
+
+   agentBscTftpCfgDebugLogFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The debug log pathname that needs to be uploaded to the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 8 }
+        
+   agentBscTftpCfgSIMFirmwareFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The firmware pathname that needs to be downloaded/uploaded from/to the TFTP server when it is SIM enabled."
+        ::= {  agentBscTftpConfigMgmt 9 }
+        
+   agentBscTftpCfgSIMConfigFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The configuration pathname that needs to be downloaded/uploaded from/to the TFTP server when it is SIM enabled."
+        ::= {  agentBscTftpConfigMgmt 10 }
+        
+   agentBscTftpCfgSIMLogFile OBJECT-TYPE
+	   SYNTAX  DisplayString (SIZE (0..64))
+	   MAX-ACCESS      read-write
+	   STATUS  current
+	   DESCRIPTION
+            "The log pathname that needs to be uploaded to the TFTP server when it is SIM enabled."
+        ::= {  agentBscTftpConfigMgmt 11 }         
+
+   agentBscTftpCfgServerIPAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IPv4 address of the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 12 }  
+
+   agentBscTftpCfgServerIPv6Addr OBJECT-TYPE
+        SYNTAX  Ipv6Address
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The IPv6 address of the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 13 }  
+
+   agentBscTftpCfgServerDomainName OBJECT-TYPE
+        SYNTAX  DisplayString  (SIZE(0..255))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The domain name of the TFTP server."
+        ::= {  agentBscTftpConfigMgmt 14 }  
+
+-- -----------------------------------------------------------------------------
+-- agentBscCommunityEncryptionState
+-- -----------------------------------------------------------------------------
+    agentBscCommunityEncryptionState OBJECT-TYPE
+        SYNTAX  INTEGER {
+                enabled(1),
+                disabled(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the encryption state on the SNMP community string."
+        ::= { agentBasicConfig 29 }
+ 
+-- -----------------------------------------------------------------------------
+-- agentSnmpUdpPort
+-- ----------------------------------------------------------------------------- 
+     agentSnmpUdpPort  OBJECT-TYPE
+         SYNTAX     INTEGER (1..65535)
+         MAX-ACCESS read-write
+         STATUS     current
+         DESCRIPTION
+             "This object indicates the snmp udp port number."
+         ::= { agentBasicConfig 30 } 
+
+-- -----------------------------------------------------------------------------
+-- agentResponseBroadcastRequest
+-- -----------------------------------------------------------------------------  
+     agentResponseBroadcastRequest  OBJECT-TYPE
+         SYNTAX     INTEGER {
+                     disabled(1),
+                     enabled(2)
+                 }
+         MAX-ACCESS read-write
+         STATUS     current
+         DESCRIPTION
+             "This object indicates the response broadcast request state."
+         ::= { agentBasicConfig 31 }
+
+-- -----------------------------------------------------------------------------
+-- agentIpProtocolConfig
+-- -----------------------------------------------------------------------------
+    agentIpProtoConfig      OBJECT IDENTIFIER ::= { agentGeneralMgmt 3 }
+
+    agentIpNumOfIf OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "The total number of IP interfaces supported by this agent."
+        ::= {  agentIpProtoConfig 1 }
+
+    agentIpTftpServerAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  obsolete
+        DESCRIPTION
+            "The IP address of the TFTP Server."
+        ::= {  agentIpProtoConfig 2 }
+
+    agentIpGetIpFrom OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    disabled(2),
+                    bootp(3),
+                    dhcp(4)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates if the agent will get its system IP address
+             from a Bootp/DHCP server at start up."
+        ::= { agentIpProtoConfig 3 }
+
+    agentIpAutoconfig OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    enabled(1),
+                    disabled(2)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "Indicates the status of automatically getting the configuration information
+             from a TFTP server connected to the device."
+        ::= { agentIpProtoConfig 4 }
+
+    agentIpAutoconfigTimeout OBJECT-TYPE
+        SYNTAX  Integer32
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This timer is used to limit the length of time for getting the configuration
+             information from a TFTP server connected to the device."
+        ::= { agentIpProtoConfig 5 }
+
+-- End of agentIpIfTable
+
+-- -----------------------------------------------------------------------------
+-- agentIptrapMangerTable
+-- -----------------------------------------------------------------------------
+        agentIpTrapManager      OBJECT IDENTIFIER ::= { agentGeneralMgmt 4 }
+
+--    agentIpTrapManagerTable OBJECT-TYPE-
+--        SYNTAX  SEQUENCE OF AgentIpTrapManagerEntry
+--        MAX-ACCESS  not-accessible
+--        STATUS  current
+--        DESCRIPTION
+--            "A list of trap managers that the SNMP traps will be sent to."
+--        ::= {  agentIpTrapManager 1 }
+
+--    agentIpTrapManagerEntry OBJECT-TYPE
+--        SYNTAX  AgentIpTrapManagerEntry
+--        MAX-ACCESS  not-accessible
+--        STATUS  obsolete
+--        DESCRIPTION
+--            "Each entry contains the particular trap manager settings."
+--        INDEX   { agentIpTrapManagerIpAddr }
+--        ::= { agentIpTrapManagerTable 1 }
+
+-- -----------------------------------------------------------------------------
+    agentTrapManagerTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentTrapManagerEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "A list of trap managers that the SNMP traps will be sent to."
+        ::= {  agentIpTrapManager 2 }
+
+    agentTrapManagerEntry OBJECT-TYPE
+        SYNTAX  AgentTrapManagerEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "Each entry contains the particular trap manager's settings."
+        INDEX   { agentTrapManagerIndex }
+        ::= { agentTrapManagerTable 1 }
+
+    AgentTrapManagerEntry ::=
+        SEQUENCE {
+                    agentTrapManagerIndex
+                        INTEGER,
+                    agentTrapManagerIpAddr
+                        IpAddress,
+                    agentTrapManagerComm
+                        DisplayString,
+                    agentTrapManagerMsgVer
+                        INTEGER,
+                    agentTrapManagerStatus
+                        INTEGER,
+                    agentTrapManagerUdpPort
+                    	INTEGER
+        }
+
+        agentTrapManagerIndex  OBJECT-TYPE
+            SYNTAX     INTEGER (1..65535)
+            MAX-ACCESS not-accessible
+            STATUS     current
+            DESCRIPTION
+                "A value that uniquely identifies trapDestEntry."
+            ::= { agentTrapManagerEntry 1 }
+
+    agentTrapManagerIpAddr OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The destination IP address for SNMP traps."
+        ::= { agentTrapManagerEntry 2 }
+
+    agentTrapManagerComm OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..20))
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "The community string used to encode SNMP trap packets being sent to the trap
+             manager."
+        ::= { agentTrapManagerEntry 3 }
+
+    agentTrapManagerMsgVer OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    snmpAgentVersionDependent(1),
+                    v1Trap(2),
+                    v2Trap(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the version of trap packets that will be sent to
+             this trap manager. The default setting is SNMP Agent Version Dependent.
+
+                         Note:
+                         Because some of these functions will be limited by the support of
+                         the system in question, some selected items may be invalid. If one
+                         of these items is selected, a bad value error message will prompt
+                         the user.
+"
+        ::= { agentTrapManagerEntry 4 }
+
+    agentTrapManagerStatus OBJECT-TYPE
+        SYNTAX  INTEGER {
+                    other(1),
+                    disabled(2),
+                    enabled(3)
+                }
+        MAX-ACCESS  read-write
+        STATUS  current
+        DESCRIPTION
+            "This object indicates whether or not the trap should be sent to
+             the trap manager."
+        ::= { agentTrapManagerEntry 5 }  
+        
+     agentTrapManagerUdpPort  OBJECT-TYPE
+         SYNTAX     INTEGER (1..65535)
+         MAX-ACCESS read-write
+         STATUS     current
+         DESCRIPTION
+             "This object indicates the Trap udp port number."
+         ::= { agentTrapManagerEntry 6 }
+
+-- -----------------------------------------------------------------------------
+-- agentPortTrapStateTable
+-- -----------------------------------------------------------------------------
+     agentPortTrapStateTable OBJECT-TYPE
+        SYNTAX  SEQUENCE OF AgentPortTrapStateEntry 
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "Use to Set/Get per port trap state."
+        ::= {  agentIpTrapManager 3 } 
+        
+    agentPortTrapStateEntry OBJECT-TYPE
+        SYNTAX  AgentPortTrapStateEntry
+        MAX-ACCESS  not-accessible
+        STATUS  current
+        DESCRIPTION
+            "This is an entry of the agentPortTrapStateTable."
+        INDEX   { agentTrapStatePortIndex }
+        ::= { agentPortTrapStateTable 1 }
+
+     AgentPortTrapStateEntry ::=
+        SEQUENCE {
+                    agentTrapStatePortIndex
+                        INTEGER,
+                    agentPortTrapState
+                        INTEGER
+        }    
+        
+     agentTrapStatePortIndex  OBJECT-TYPE
+         SYNTAX     INTEGER (1..65535)
+         MAX-ACCESS not-accessible
+         STATUS     current
+         DESCRIPTION
+             "This object indicates the port number."
+         ::= { agentPortTrapStateEntry 1 }
+  
+     agentPortTrapState OBJECT-TYPE
+         SYNTAX  INTEGER {
+                     enabled(1),
+                     disabled(2)
+                 }
+         MAX-ACCESS  read-write
+         STATUS  current
+         DESCRIPTION
+             "This object indicates the port trap status."
+         ::= { agentPortTrapStateEntry 2 }      
+   
+-- -----------------------------------------------------------------------------
+-- Add for Slip_Console mode swtich 11-9-2001 WindChen
+-- -----------------------------------------------------------------------------
+--      agentConsoleModeManager OBJECT IDENTIFIER ::= { agentGeneralMgmt 5 }
+
+
+
+-- -----------------------------------------------------------------------------
+-- Slip Mode Manager
+-- -----------------------------------------------------------------------------
+--      agentSlipModeManager    OBJECT IDENTIFIER ::= { agentGeneralMgmt 6 }
+
+
+-- -----------------------------------------------------------------------------
+-- Add common trap management
+-- -----------------------------------------------------------------------------
+        agentNotify     OBJECT IDENTIFIER ::= { agentGeneralMgmt 7 }
+
+        agentNotifMgmt      OBJECT IDENTIFIER ::= { agentNotify 1 }
+        agentNotifFirmware   OBJECT IDENTIFIER ::= { agentNotify 2 }
+
+        agentNotifyPrefix OBJECT IDENTIFIER ::= { agentNotifFirmware 0 }
+
+-- -----------------------------------------------------------------------------
+-- agentNotifMgmt
+-- -----------------------------------------------------------------------------
+
+--  systemSeverityControl OBJECT-TYPE
+--      SYNTAX  AgentNotifyLevel
+--      MAX-ACCESS  read-write
+--      STATUS  current
+--      DESCRIPTION
+--          "Indicates the level of trap severity control. The system has a severity level control
+--           and each trap should have a severity control set. When trap events occur and its severity
+--           is higher than the system severity control level, the trap works as defined. If the event
+--           severity is lower than the system severity control level, the event is ignored as if it did not occur.
+--      "
+--      ::= { agentNotifMgmt 1 }
+
+
+    notifFirmwareMgmt OBJECT IDENTIFIER ::= { agentNotifMgmt 2 }
+
+
+
+
+
+-- -----------------------------------------------------------------------------
+-- agentNotifFirmware OBJECT IDENTIFIER ::= { agentNotifyPrefix 0 }
+
+-- -----------------------------------------------------------------------------
+-- agentNotifFirmware
+-- -----------------------------------------------------------------------------
+    agentsystemRestart NOTIFICATION-TYPE
+        OBJECTS {
+              trapInfosystemRestart
+                        }
+        STATUS  current
+        DESCRIPTION
+            "This trap contains the reboot information."
+
+                ::= { agentNotifyPrefix 1 }
+
+
+    agentSaveToNVRAM NOTIFICATION-TYPE
+        OBJECTS         { unitID
+                        }
+        STATUS  current
+        DESCRIPTION
+            "This trap is sent whenever all the device configuration has been saved to NV-RAM."
+
+        ::= { agentNotifyPrefix 2 }
+
+    agentFileTransferStatusChange NOTIFICATION-TYPE
+        OBJECTS         {
+                                                unitID,
+                          agentStatusFileTransfer
+                        }
+        STATUS          current
+        DESCRIPTION     "File transfer status change notification."
+        ::= { agentNotifyPrefix 3 }
+
+    agentSetToFactoryDefault NOTIFICATION-TYPE
+        OBJECTS         { unitID
+                        }
+        STATUS  current
+        DESCRIPTION
+            "This trap is sent whenever the 'set to factory default' setting has been processed. "
+
+        ::= { agentNotifyPrefix 4 }
+
+    agentGratuitousARPTrap  NOTIFICATION-TYPE
+        OBJECTS   {
+
+                    agentGratuitousARPIpAddr,
+                    agentGratuitousARPMacAddr,
+                    agentGratuitousARPPortNumber,
+                    agentGratuitousARPInterfaceName
+                  }
+        STATUS  current
+        DESCRIPTION
+           "This trap is sent when there is an IP address conflict."
+        ::={agentNotifyPrefix 5}
+
+        agentLoginFailTrap  NOTIFICATION-TYPE
+        OBJECTS   {
+                    agentLoginType,
+                    agentLoginAAAMethod,
+                    agentLoginUserName,
+                    agentLoginIpAddr,
+                    agentLoginMacAddr,
+                    agentLoginAAAServerAddr,
+                    agentLoginFailInfo
+                  }
+        STATUS  current
+        DESCRIPTION
+           "The trap is sent when a login has failed through one of the login types (console, Telnet, web, SSL or SSH)."
+        ::={agentNotifyPrefix 6}
+
+        agentFirmwareUpgrade NOTIFICATION-TYPE
+        OBJECTS {
+                    swMultiImageVersion
+                }
+        STATUS  current
+        DESCRIPTION
+            "This trap is sent when the process of upgrading the firmware via SNMP has finished."
+
+                ::= { agentNotifyPrefix 7 }
+
+        agentAccessFlashFailed  NOTIFICATION-TYPE
+        OBJECTS {
+                    agentAccessFlashOper,
+                    agentAccessFlashAddr
+                  }
+        STATUS  current
+        DESCRIPTION
+           "The trap is sent when access to the flash fails."
+        ::={agentNotifyPrefix 8}
+
+        agentCfgOperCompleteTrap  NOTIFICATION-TYPE
+        OBJECTS {
+                    unitID,
+                    agentCfgOperate,
+                    agentLoginUserName
+                  }
+        STATUS  current
+        DESCRIPTION
+           "The trap is sent when the configuration is completely saved, uploaded 
+            or downloaded."
+        ::={agentNotifyPrefix 9}        
+
+-- -----------------------------------------------------------------------------
+-- agentNotifEquipment
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
+-- notificationBindings
+-- -----------------------------------------------------------------------------
+    notificationBindings OBJECT IDENTIFIER ::= { agentNotifFirmware 1 }
+
+    unitID OBJECT-TYPE
+        SYNTAX     INTEGER
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "The unit ID of the device which triggered the event."
+        ::= { notificationBindings 1 }
+
+    trapInfosystemRestart   OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..64))
+        MAX-ACCESS  read-only
+        STATUS  current
+        DESCRIPTION
+            "This object indicates the last time the device rebooted.
+            "
+        ::= { notificationBindings 2 }
+
+    agentGratuitousARPIpAddr       OBJECT-TYPE
+       SYNTAX      IpAddress
+       MAX-ACCESS  accessible-for-notify
+        STATUS  current
+        DESCRIPTION
+           "A duplicate IP address with the switch already exists."
+        ::={notificationBindings 3}
+
+    agentGratuitousARPMacAddr     OBJECT-TYPE
+       SYNTAX    MacAddress
+       MAX-ACCESS accessible-for-notify
+        STATUS  current
+        DESCRIPTION
+           "This object is the MAC address of the device which has the duplicate IP address."
+        ::={notificationBindings 4}
+
+   agentGratuitousARPPortNumber   OBJECT-TYPE
+        SYNTAX   DisplayString
+        MAX-ACCESS accessible-for-notify
+        STATUS  current
+        DESCRIPTION
+            "This indicates the portNum with a string.
+             For example, if the device is in standalone mode, and the port
+             number is 23, the string should be 23.
+             If the device is in stacking mode, and the unit ID is 2, and the
+             port number is 3, the string should be 2:3.
+            "
+        ::={notificationBindings 5}
+
+
+    agentLoginType OBJECT-TYPE
+                    SYNTAX  INTEGER {
+                            console(1),
+                            telnet(2),
+                            web(3),
+                            ssl(4),
+                            ssh(5)
+                        }
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "The type is the user login method type."
+        ::= { notificationBindings 6 }
+
+    agentLoginAAAMethod OBJECT-TYPE
+                    SYNTAX  INTEGER {
+                            none(1),
+                            local(2),
+                            server(3)
+                        }
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This method is the AAA login method."
+        ::= { notificationBindings 7 }
+
+    agentLoginUserName OBJECT-TYPE
+        SYNTAX     DisplayString
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This object is the name of the user that failed to login to the switch."
+        ::= { notificationBindings 8 }
+
+
+    agentLoginIpAddr   OBJECT-TYPE
+        SYNTAX  IpAddress
+        MAX-ACCESS  accessible-for-notify
+        STATUS  current
+        DESCRIPTION
+            "This object is the login type from the IP address."
+        ::= { notificationBindings 9 }
+
+
+    agentLoginMacAddr   OBJECT-TYPE
+        SYNTAX  MacAddress
+        MAX-ACCESS  accessible-for-notify
+        STATUS  current
+        DESCRIPTION
+            "This object is the login type from a MAC address."
+        ::= { notificationBindings 10 }
+
+
+    agentLoginAAAServerAddr       OBJECT-TYPE
+       SYNTAX      IpAddress
+       MAX-ACCESS  accessible-for-notify
+        STATUS  current
+        DESCRIPTION
+           "This object is the login type through a console authenticated by an AAA server."
+        ::= { notificationBindings 11 }
+
+    agentLoginFailInfo OBJECT-TYPE
+                    SYNTAX  INTEGER {
+                            other(1),
+                            authenticate-fail(2),
+                            server-timeout(3)
+                        }
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This object indicates the reason for the login failure."
+        ::= { notificationBindings 12 }
+
+    agentAccessFlashOper OBJECT-TYPE
+        SYNTAX  DisplayString (SIZE (0..64))
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This object indicates the operation of the access flash failure."
+        ::= { notificationBindings 13 }
+
+    agentAccessFlashAddr OBJECT-TYPE
+                    SYNTAX  INTEGER
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This object indicates the address of the access flash failure."
+        ::= { notificationBindings 14 }
+
+    agentCfgOperate OBJECT-TYPE
+        SYNTAX  INTEGER {
+                save(1),
+                upload(2),
+                download(3)
+                }    
+        MAX-ACCESS accessible-for-notify
+        STATUS     current
+        DESCRIPTION
+            "This object indicates the operation type of the configuration."
+        ::= { notificationBindings 15 }
+
+END
+
+
+
+
+
+

--- a/mibs/dlink/TIMERANGE-MIB
+++ b/mibs/dlink/TIMERANGE-MIB
@@ -1,0 +1,239 @@
+TIMERANGE-MIB DEFINITIONS ::= BEGIN
+
+     IMPORTS
+         MODULE-IDENTITY, OBJECT-TYPE     FROM SNMPv2-SMI
+         IpAddress                        FROM RFC1155-SMI
+         DateAndTime ,RowStatus, DisplayString
+                                          FROM SNMPv2-TC
+         dlink-common-mgmt                FROM DLINK-ID-REC-MIB;
+
+     swTimeRangeMIB MODULE-IDENTITY
+         LAST-UPDATED "0811200000Z"
+         ORGANIZATION "D-Link Corp."
+         CONTACT-INFO
+             "http://support.dlink.com"
+         DESCRIPTION
+             "This MIB defines a specific range of time to activate a function."
+         ::= { dlink-common-mgmt 50 }
+
+-- -----------------------------------------------------------------------------
+-- OID Tree Allocation in TimeRang.MIB
+-- -----------------------------------------------------------------------------
+    swTimeRangeCtrl             OBJECT IDENTIFIER ::= { swTimeRangeMIB 1 }
+    swTimeRangeInfo             OBJECT IDENTIFIER ::= { swTimeRangeMIB 2 }
+    swTimeRangeMgmt             OBJECT IDENTIFIER ::= { swTimeRangeMIB 3 }
+
+-- -----------------------------------------------------------------------------
+-- Object Definition for
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
+-- swTimeRangeMgmt
+-- -----------------------------------------------------------------------------
+       swTimeRangeMgmtTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF SwTimeRangeMgmtEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "A table that contains the information of each time range."
+           ::= { swTimeRangeMgmt 1 }
+
+       swTimeRangeMgmtEntry OBJECT-TYPE
+           SYNTAX      SwTimeRangeMgmtEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "A list of information of each time range."
+           INDEX { swTimeRangeMgmtRangeName }
+           ::= { swTimeRangeMgmtTable 1 }
+
+       SwTimeRangeMgmtEntry ::=
+           SEQUENCE {
+               swTimeRangeMgmtRangeName
+                   DisplayString,
+               swTimeRangeMgmtSelectDays
+                   DisplayString,
+               swTimeRangeMgmtStartTime
+                   DisplayString,
+               swTimeRangeMgmtEndTime
+                   DisplayString,
+               swimeRangeMgmtStatus
+                   RowStatus
+           }
+
+       swTimeRangeMgmtRangeName           OBJECT-TYPE
+           SYNTAX      DisplayString (SIZE (1..32))
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The range name of the time range."
+           ::= { swTimeRangeMgmtEntry 1 }
+
+       swTimeRangeMgmtSelectDays          OBJECT-TYPE
+           SYNTAX      DisplayString
+           MAX-ACCESS  read-create
+           STATUS      current
+           DESCRIPTION
+               "Each day in the week is presented by an abbreviation: 'SUN',
+                'MON', TUE', 'WED', 'THU', 'FRI', and 'SAT'. The 'SUN' stands
+                for Sunday, 'MON' stands for Monday, and so on. If more than
+                one day is required, a comma is used to separate those days."
+           ::= { swTimeRangeMgmtEntry 2 }
+
+       swTimeRangeMgmtStartTime        OBJECT-TYPE
+           SYNTAX      DisplayString (SIZE (8))
+           MAX-ACCESS  read-create
+           STATUS      current
+           DESCRIPTION
+                "The start time of a day. The format is hh:mm:ss ONLY; and
+                 cannot be set using a different format. The ending time must be
+                 set later than the starting time. The default value is 00:00:00."
+           ::= { swTimeRangeMgmtEntry 3 }
+
+       swTimeRangeMgmtEndTime  OBJECT-TYPE
+           SYNTAX      DisplayString (SIZE (8))
+           MAX-ACCESS  read-create
+           STATUS      current
+           DESCRIPTION
+               "The end time of a day. The format is hh:mm:ss ONLY; and cannot
+                be set using a different format. The ending time must be set later
+                than the starting time. The default value is 23:59:59."
+           ::= { swTimeRangeMgmtEntry 4 }
+
+       swimeRangeMgmtStatus OBJECT-TYPE
+           SYNTAX      RowStatus
+           MAX-ACCESS  read-create
+           STATUS      current
+           DESCRIPTION
+               "This object indicates the RowStatus of this entry."
+           ::= { swTimeRangeMgmtEntry  5 }
+
+-- -----------------------------------------------------------------------------
+       swTimeRangeACLTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF SwTimeRangeACLEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table maintains time-range settings associated with a specific
+                rule in the ACL rule table. Please refer to the swACLEtherRuleTable,
+                swACLIpRuleTable, swACLIpv6RuleTable and swACLPktContRuleTable
+                for detailed ACL rule information."
+           ::= { swTimeRangeMgmt 2 }
+
+       swTimeRangeACLEntry OBJECT-TYPE
+           SYNTAX      SwTimeRangeACLEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "The entry maintains time-range names associated with the ACL
+                rule table."
+           INDEX { swTimeRangeACLProfileID, swTimeRangeACLAccessID}
+           ::= { swTimeRangeACLTable 1 }
+
+       SwTimeRangeACLEntry ::=
+           SEQUENCE {
+               swTimeRangeACLProfileID
+                   INTEGER,
+               swTimeRangeACLAccessID
+                   INTEGER,
+               swTimeRangeACLTimeRangeName
+                   DisplayString
+           }
+
+       swTimeRangeACLProfileID OBJECT-TYPE
+           SYNTAX      INTEGER
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The ID of the ACL mask entry, which is unique in the mask
+                list."
+           ::= { swTimeRangeACLEntry 1 }
+
+       swTimeRangeACLAccessID OBJECT-TYPE
+           SYNTAX      INTEGER(1..65535)
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The ID of the ACL rule entry as related to the
+                swTimeRangeACLProfileID."
+           ::= { swTimeRangeACLEntry 2 }
+
+       swTimeRangeACLTimeRangeName OBJECT-TYPE
+           SYNTAX      DisplayString  (SIZE (0..32))
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "Specifies a time-range name associated with a specific ACL
+                entry. The time-range name must first be created before being
+                associated with the access rule. If this name is an empty
+                string, it means the time-range profile will no longer be
+                associated with the access rule. When a rule is de-associated
+                with a time range, the access rule will be enabled all the
+                time."
+           ::= { swTimeRangeACLEntry 3 }
+
+-- -----------------------------------------------------------------------------
+       swTimeRangeCPUACLTable OBJECT-TYPE
+           SYNTAX      SEQUENCE OF SwTimeRangeCPUACLEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "This table maintains time-range settings associated with a specific
+                rule in the CPU ACL rule table. Please refer to the swCpuAclEtherRuleTable,
+                swCpuAclIpRuleTable, swCpuAclPktContRuleTable and swCpuAclIpv6RuleTable
+                for detailed CPU ACL rule information."
+           ::= { swTimeRangeMgmt 3 }
+
+       swTimeRangeCPUACLEntry OBJECT-TYPE
+           SYNTAX      SwTimeRangeCPUACLEntry
+           MAX-ACCESS  not-accessible
+           STATUS      current
+           DESCRIPTION
+               "The entry maintains time-range names associated with the CPU ACL
+                rule table."
+           INDEX { swTimeRangeCPUACLProfileID, swTimeRangeCPUACLAccessID}
+           ::= { swTimeRangeCPUACLTable 1 }
+
+       SwTimeRangeCPUACLEntry ::=
+           SEQUENCE {
+               swTimeRangeCPUACLProfileID
+                   INTEGER,
+               swTimeRangeCPUACLAccessID
+                   INTEGER,
+               swTimeRangeCPUACLTimeRangeName
+                   DisplayString
+           }
+
+       swTimeRangeCPUACLProfileID OBJECT-TYPE
+           SYNTAX      INTEGER
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The ID of the CPU ACL mask entry, which is unique in the mask
+                list."
+           ::= { swTimeRangeCPUACLEntry 1 }
+
+       swTimeRangeCPUACLAccessID OBJECT-TYPE
+           SYNTAX      INTEGER(1..65535)
+           MAX-ACCESS  read-only
+           STATUS      current
+           DESCRIPTION
+               "The ID of the CPU ACL rule entry as related to the
+                swTimeRangeCPUACLProfileID."
+           ::= { swTimeRangeCPUACLEntry 2 }
+
+       swTimeRangeCPUACLTimeRangeName OBJECT-TYPE
+           SYNTAX      DisplayString  (SIZE (0..32))
+           MAX-ACCESS  read-write
+           STATUS      current
+           DESCRIPTION
+               "Specifies a time-range name associated with a specific CPU ACL
+                entry. The time-range name must first be created before being
+                associated with the access rule. If this name is an empty
+                string, it means the time-range profile will no longer be
+                associated with the access rule. When a rule is de-associated
+                with a time range, the access rule will be enabled all the
+                time."
+           ::= { swTimeRangeCPUACLEntry 3 }
+           
+END


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I don't have all the devices and FW combinations that Dlink has to offer, so the tests were done on the following devices:

### System info like FW version, HW version and Serial number now displaying properly:
Sucessful:
DGS-3620-28SC FW 3.00.004
DGS-3420-28SC FW 3.01.R003
DGS-3627G FW 3.00.B47
DGS-3420-28TC FW 3.01.R003 & FW 1.50.018
DES-3528 FW 3.00.012
DGS-3120-24TC FW 3.10.012

Not successful:
DES-3526 (OID returns empty)

### Temperature info:
Successful: 
DGS-3620-28SC FW 3.00.004
DGS-3420-28TC FW 1.50.018
DES-3528 FW 3.00.012
DGS-3120-24TC FW 3.10.012

Not successful:
DES-3526 & DGS-3627G  (Will never support it, switch does not have environment capabilities)
All DGS-3420-28xx with FW 3.01.R003. Seems to be a FW issue which we will take up with the vendors. We expect fixes in the near future in the FW release.

Screenshots of how the data displays is attached as well. 
![temperature](https://user-images.githubusercontent.com/24249616/34872535-e30ccb24-f799-11e7-9b70-027a2e5f4c5c.png)

![device-details](https://user-images.githubusercontent.com/24249616/34872549-ef95b586-f799-11e7-95c4-701ec37c1320.png)