### PR TITLE
Add Hardware, Version, and Serial strings to EqualLogic OS

### DIFF
--- a/includes/polling/os/equallogic.inc.php
+++ b/includes/polling/os/equallogic.inc.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * equallogic.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Nick Peelman
+ * @author     Nick Peelman <nick@peelman.us>
+ */
+
+$hardware = implode(', ', explode(PHP_EOL, snmp_walk($device, 'eqlMemberProductFamily', '-Ovqa', 'EQLMEMBER-MIB')));
+$version = implode(', ', explode(PHP_EOL, snmp_walk($device, 'eqlMemberSerialNumber', '-Ovqa', 'EQLMEMBER-MIB')));
+$serial = implode(', ', explode(PHP_EOL, snmp_walk($device, 'eqlMemberServiceTag.1', '-Oqvs', 'EQLMEMBER-MIB')));


### PR DESCRIPTION
Uses snmpwalks because a given SNMP node can report for multiple members, which show up as unique indices.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
