### PR TITLE
Fixed documentation. This way autodiscovery with snmpv3 works

### DIFF
--- a/doc/Extensions/Auto-Discovery.md
+++ b/doc/Extensions/Auto-Discovery.md
@@ -22,7 +22,7 @@ $config['snmp']['community'][] = "my_custom_community";
 $config['snmp']['community'][] = "another_community";
 
 // v3
-$config['snmp']['v3'][0]['authlevel'] = 'AuthPriv';
+$config['snmp']['v3'][0]['authlevel'] = 'authPriv';
 $config['snmp']['v3'][0]['authname'] = 'my_username';
 $config['snmp']['v3'][0]['authpass'] = 'my_password';
 $config['snmp']['v3'][0]['authalgo'] = 'MD5';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

This is a documentation fix. snmpv3 autodiscovery only works if the authPriv is written in camel case.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
