### PR TITLE
webui: added back devices sort by status

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -2129,11 +2129,11 @@ label {
 }
 
 .device-table-icon {
-    text-align: center;
-    display: block;
-    width: 70px;
-    height: 32px;
-    line-height: 32px;
+  padding-left:7px;
+  display: inline-block;
+  width: 64px;
+  height: 32px;
+  line-height: 32px;
 }
 
 .device-table-icon img {

--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -141,7 +141,6 @@ foreach (dbFetchRows($sql, $param) as $device) {
 
     if ($device['ignore'] == '1') {
         $extra = 'label-default';
-        $msg = 'ignored';
         if ($device['status'] == '1') {
             $extra = 'label-warning';
         }

--- a/html/pages/devices.inc.php
+++ b/html/pages/devices.inc.php
@@ -371,10 +371,12 @@ if ($format == "graph") {
     ';
 
     if ($subformat == "detail") {
-        echo '<th data-column-id="icon" data-width="80px" data-sortable="false" data-searchable="false" data-formatter="icon">Vendor</th>';
+        echo '<th data-column-id="status" data-formatter="status" data-width="7px" data-searchable="false">&nbsp;</th>';
+        echo '<th data-column-id="icon" data-width="70px" data-searchable="false" data-formatter="icon">Vendor</th>';
     }
 
     if ($subformat != "detail") {
+        echo '<th data-column-id="status" data-formatter="status" data-width="7px" data-searchable="false">&nbsp;</th>';
         echo '<th data-column-id="hostname" data-order="asc" data-formatter="device">Device</th>';
     } else {
         echo '<th data-column-id="hostname" data-order="asc">Device</th>';
@@ -411,14 +413,14 @@ if ($format == "graph") {
             rowCount: [50, 100, 250, -1],
             columnSelection: true,
             formatters: {
-                "msg": function (column, row) {
-                    return "<span class=\"alert-status\">" + row.msg + "</span>";
+                "status": function (column, row) {
+                    return "<span class=\"alert-status " + row.extra + "\" style=\"float:left;\"></span>";
                 },
                 "icon": function (column, row) {
-                    return "<span class='alert-status " + row.extra + "' style='float:left;'></span><span class=\"device-table-icon\">" + row.icon + "</span>";
+                    return "<span class=\"device-table-icon\">" + row.icon + "</span>";
                 },
                 "device": function (column, row) {
-                    return "<span class='alert-status " + row.extra + "' style='float:left;margin-right:10px;'></span><span style=''>" + row.hostname + "</span>";
+                    return "<span style=''>" + row.hostname + "</span>";
                 },
             },
             templates: {

--- a/html/pages/devices.inc.php
+++ b/html/pages/devices.inc.php
@@ -414,13 +414,13 @@ if ($format == "graph") {
             columnSelection: true,
             formatters: {
                 "status": function (column, row) {
-                    return "<span class=\"alert-status " + row.extra + "\" style=\"float:left;\"></span>";
+                    return "<span class=\"alert-status " + row.extra + "\"></span>";
                 },
                 "icon": function (column, row) {
                     return "<span class=\"device-table-icon\">" + row.icon + "</span>";
                 },
                 "device": function (column, row) {
-                    return "<span style=''>" + row.hostname + "</span>";
+                    return "<span>" + row.hostname + "</span>";
                 },
             },
             templates: {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

as mentioned by @murrant , with last devices webui push this sort-able column was removed
with this i added it back and still trying to keep the page tidy enough

<img width="611" alt="screen shot 2018-01-17 at 2 53 04 pm" src="https://user-images.githubusercontent.com/3048315/35043686-33d3f1c2-fb96-11e7-8c7e-2d63900ce394.png">
<img width="736" alt="screen shot 2018-01-17 at 2 53 12 pm" src="https://user-images.githubusercontent.com/3048315/35043687-33f4f9f8-fb96-11e7-9385-e29746e66d2a.png">

