### PR TITLE
fix: Stop including disabled ports in traffic overview

### DIFF
--- a/html/includes/graphs/device/bits.inc.php
+++ b/html/includes/graphs/device/bits.inc.php
@@ -4,7 +4,7 @@
 $ds_in  = 'INOCTETS';
 $ds_out = 'OUTOCTETS';
 
-foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ?', array($device['device_id'])) as $port) {
+foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled` = 0', array($device['device_id'])) as $port) {
     $ignore = 0;
     if (is_array($config['device_traffic_iftype'])) {
         foreach ($config['device_traffic_iftype'] as $iftype) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Simple. Fixes: #8028 

Disabled ports most likely don't collect stats if using selected port polling and the users chosen to disable it so don't include it.