### PR TITLE
fix: Handle escaping output within bootgrid form

### DIFF
--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -200,7 +200,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != "hide") || !isset($vars[
             } else {
                 $dataselected = "";
             }
-            $output .= "<option value='" . $data['ifType'] . "' " . $dataselected . ">" . $data['ifType'] . "</option>";
+            $output .= "<option value='" . clean_bootgrid($data['ifType']) . "' " . $dataselected . ">" . clean_bootgrid($data['ifType']) . "</option>";
         }
     }
 
@@ -223,7 +223,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != "hide") || !isset($vars[
             } else {
                 $portdescrib = "";
             }
-            $output .= "<option value='" . $data['port_descr_type'] . "' " . $portdescrib . ">" . ucfirst(display($data['port_descr_type'])) . "</option>";
+            $output .= "<option value='" . clean_bootgrid($data['port_descr_type']) . "' " . $portdescrib . ">" . ucfirst(clean_bootgrid($data['port_descr_type'])) . "</option>";
         }
     }
 
@@ -252,7 +252,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != "hide") || !isset($vars[
                 $locationselected = "";
             }
             $ui_location = strlen($location) > 15 ? substr($location, 0, 15) . "..." : $location;
-            $output .= "<option value='" . $location . "' " . $locationselected . ">" . $ui_location . "</option>";
+            $output .= "<option value='" . clean_bootgrid($location) . "' " . $locationselected . ">" . clean_bootgrid($ui_location) . "</option>";
         }
     }
 


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Overall I don't think this is the right way to fix this but we already have the function and it does work so until we start rolling the new webui this will do.

Fixes: #8035 