### PR TITLE
device: Add Allied Telesis CPU info

### DIFF
--- a/includes/discovery/processors/awplus.inc.php
+++ b/includes/discovery/processors/awplus.inc.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * awplus.inc.php
+ *
+ * LibreNMS processor discovery module for Alliedware Plus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @author     Matt Read <matt.read@alliedtelesis.co.nz>
+ */
+
+if ($device['os'] === 'awplus') {
+    echo 'AWPlus: ';
+    $awplus_procs = snmpwalk_group($device, 'cpuUtilisationStackEntry', 'AT-SYSINFO-MIB');
+    foreach ($awplus_procs as $proc_index => $proc_info) {
+        $usage = $proc_info['cpuUtilisationStackAvgLastMinute'];
+        if (is_numeric($usage)) {
+            $descr = "Processor $proc_index";
+            discover_processor($valid['processor'], $device, ".1.3.6.1.4.1.207.8.4.4.3.3.8.1.4.$proc_index", $proc_index, 'awplus', $descr, '1', $usage, null, null);
+        }
+    }
+}


### PR DESCRIPTION
Added support to poll both standalone devices and VCStacked device's CPU info.

-----

This works, however I don't like that on the device summary it shows the last polled CPU (e.g. CPU 8 in a stack of 8 switches), as usually the stack master will be stack member 1:

![image](https://user-images.githubusercontent.com/4696925/35079494-cf46cf54-fc6c-11e7-9930-2d0d189841bd.png)


Can you see a way of modifying what I have (which I mostly copied from acos.inc.php) so Processor 1 will be what is shows on the device summary page?

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
