### PR TITLE
Fix UniFi OS polling (because I broke it last time)

### DIFF
--- a/includes/polling/os/unifi.inc.php
+++ b/includes/polling/os/unifi.inc.php
@@ -1,5 +1,5 @@
 <?php
-if ($data = snmp_get_multi($device, 'unifiApSystemModel unifiApSystemVersion', '-OQUs', 'UBNT-UniFi-MIB')) {
+if ($data = snmp_getnext_multi($device, 'unifiApSystemModel unifiApSystemVersion', '-OQUs', 'UBNT-UniFi-MIB')) {
     $hardware = $data['unifiApSystemModel'];
     $version = $data['unifiApSystemVersion'];
 } elseif ($data = snmp_getnext_multi($device, 'dot11manufacturerProductName dot11manufacturerProductVersion', '-OQUs', 'IEEE802dot11-MIB')) {


### PR DESCRIPTION
It appears the merged version of #8005 had a fairly major bug insofar as it didn't pull the unifiApSystemModel.0 entity, nor did it use snmp_getnext_multi() on unifiApSystemModel - so it wasn't ever successfully pulling either oid.

Changed the function to snmp_getnext_multi() to fix. Five extra characters. I'm not sure how I missed this, my bad...

Before;

```
#### Load poller module os ####
SNMP[/usr/bin/snmpget -v2c -c COMMUNITY -OQUs -m UBNT-UniFi-MIB -M /opt/librenms/mibs:/opt/librenms/mibs/ubnt udp:HOSTNAME:161 unifiApSystemModel unifiApSystemVersion]
unifiApSystemModel = No Such Instance currently exists at this OID
unifiApSystemVersion = No Such Instance currently exists at this OID

SNMP[/usr/bin/snmpgetnext -v2c -c COMMUNITY -OQUs -m IEEE802dot11-MIB -M /opt/librenms/mibs:/opt/librenms/mibs/ubnt udp:HOSTNAME:161 dot11manufacturerProductName dot11manufacturerProductVersion]
dot11manufacturerProductName.5 = UAP-AC-Mesh
sysDescr.0 = "UAP-AC-Mesh *86"

Hardware: UAP-AC-Mesh
Version: 
Features: 
Serial: 
```

After:

```
#### Load poller module os ####
SNMP[/usr/bin/snmpgetnext -v2c -c COMMUNITY -OQUs -m UBNT-UniFi-MIB -M /opt/librenms/mibs:/opt/librenms/mibs/ubnt udp:HOSTNAME:161 unifiApSystemModel unifiApSystemVersion]
unifiApSystemModel.0 = UAP-AC-Mesh
unifiApSystemVersion.0 = *86

SQL[INSERT INTO `eventlog` (`host`,`device_id`,`reference`,`type`,`datetime`,`severity`,`message`,`username`)  VALUES ('20','20','NULL','system',NOW(),'3','OS Version -> 3.9.18.8086','')] 
SQL[INSERT INTO `eventlog` (`host`,`device_id`,`reference`,`type`,`datetime`,`severity`,`message`,`username`)  VALUES ('20','20','NULL','system',NOW(),'3','Hardware -> UAP-AC-Mesh','')] 
Hardware: UAP-AC-Mesh
Version: 3.9.18.8086
Features: 
Serial: 
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
