### PR TITLE
fix: Pushover message fix to enable templates

### DIFF
--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -78,14 +78,7 @@ class Pushover implements Transport
                     break;
             }
             $data['title'] = $title_text . " - " . $obj['hostname'] . " - " . $obj['name'];
-            $message_text  = "Timestamp: " . $obj['timestamp'];
-            if (!empty($obj['faults'])) {
-                $message_text .= "\n\nFaults:\n";
-                foreach ($obj['faults'] as $k => $faults) {
-                    $message_text .= "#" . $k . " " . $faults['string'] . "\n";
-                }
-            }
-            $data['message'] = $message_text;
+            $data['message'] = $obj['msg'];
             $curl            = curl_init();
             set_curl_proxy($curl);
             curl_setopt($curl, CURLOPT_URL, 'https://api.pushover.net/1/messages.json');


### PR DESCRIPTION
Have changed a small part to make the "Alert Templates" function with Pushover transport.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
