### PR TITLE
device: Fix awplus $hardware for certain products

### DIFF
--- a/includes/polling/os/awplus.inc.php
+++ b/includes/polling/os/awplus.inc.php
@@ -1,9 +1,15 @@
 <?php
 
 //$hardware and $serial use snmp_getnext as the OID for these is not always fixed.
-//However, the first OID is the device baseboard. 
+//However, the first OID is the device baseboard.
 
 $hardware = snmp_getnext($device, "rscBoardName", "-OQv", "AT-RESOURCE-MIB");
 $version = snmp_get($device, "currSoftVersion.0", "-OQv", "AT-SETUP-MIB");
 $hostname = snmp_get($device, "sysName.0", "-OQv", "SNMPv2-MIB");
 $serial = snmp_getnext($device, "rscBoardSerialNumber", "-OQv", "AT-RESOURCE-MIB");
+
+// SBx8100 platform has line cards show up first in "rscBoardName" above.
+if (strpos($hardware, 'SBx81') !== false) {
+    $hardware = snmp_get($device, "sysObjectID.0", "-OQvs", "SNMPv2-MIB:AT-PRODUCT-MIB");
+    $hardware = str_replace('at', '', $hardware);
+}


### PR DESCRIPTION
awplus.inc.php uses snmpgetnext for $hardware.

This works well for 99% of products however chassis
product SBx8100 does not show the chassis as the first product.

This adds an exception to follow for this product

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
