### PR TITLE
Palo Alto HA Alert Rule references non-existent column in sensors table

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -277,7 +277,7 @@
   "name": "Cisco NX-OS device has a bad fan"
   },
   {
-    "rule": "%devices.os = \"panos\" & %sensors.type = \"panSysHAState\" && %sensors.sensor_current = \"1\" && %sensors.sensor_prev = \"2\"",
+    "rule": "%devices.os = \"panos\" & %sensors.sensor_type = \"panSysHAState\" && %sensors.sensor_current = \"1\" && %sensors.sensor_prev = \"2\"",
     "name": "Palo Alto Networks passive firewall changed to active"
   },
   {


### PR DESCRIPTION

The "**Palo Alto Networks passive firewall changed to active**" alert rule references the "type"

column in the sensors table.  However there is no "type" column.  This should be "sensor_type".  This is indicated
by the error in the logs:

`MySQL Error: Unknown column 'sensors.type' in 'where clause' (SELECT * FROM devices,sensors WHERE (( sensors.device_id = devices.device_id ) && devices.device_id = '102') && (devices.os = "panos" & sensors.type = "panSysHAState"  &&  sensors.sensor_current = "1"  &&  sensors.sensor_prev = "2"  ))
`

Updated the rule to reference the correct column.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
