### PR TITLE
Updated LTM discovery to fix route domain ID breaking the hex to stri…

### DIFF
--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -75,7 +75,7 @@ if (!is_null($ltmVirtualServEntry) || !is_null($ltmVsStatusEntry) || !is_null($l
 
                 // Trim IPv4 response to remove route domain ID
                 if (strlen($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index]) == 23) {
-                    $ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index] = substr($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index],0 , 11);
+                    $ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index] = substr($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index], 0, 11);
                 }
 
                 // Now that we have our UID we can pull all the other data we need.

--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -75,7 +75,7 @@ if (!is_null($ltmVirtualServEntry) || !is_null($ltmVsStatusEntry) || !is_null($l
 
                 // Trim IPv4 response to remove route domain ID
                 if (strlen($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index]) == 23) {
-                    $ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index] = substr($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index],0,11);
+                    $ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index] = substr($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index],0 , 11);
                 }
 
                 // Now that we have our UID we can pull all the other data we need.

--- a/includes/discovery/loadbalancers/f5-ltm.inc.php
+++ b/includes/discovery/loadbalancers/f5-ltm.inc.php
@@ -73,6 +73,11 @@ if (!is_null($ltmVirtualServEntry) || !is_null($ltmVsStatusEntry) || !is_null($l
                 // The UID is far too long to have in a RRD filename, use a hash of it instead.
                 $result['hash'] = hash('crc32', $result['UID']);
 
+                // Trim IPv4 response to remove route domain ID
+                if (strlen($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index]) == 23) {
+                    $ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index] = substr($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index],0,11);
+                }
+
                 // Now that we have our UID we can pull all the other data we need.
                 $result['IP'] = IP::fromHexString($ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.3.'.$index], true);
                 $result['port'] = $ltmVirtualServEntry['1.3.6.1.4.1.3375.2.2.10.1.2.1.6.'.$index];


### PR DESCRIPTION
…ng IPv4 conversion

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

When using multiple route domains on the F5 devices the v4 virtual server IP address is appended with padding and a route domain ID. These values are returned as a hex string via SNMP. 

When not in a route domain it looks like this and it converts to hex correctly. 
  10.191.61.128 returns as Hex-STRING: 0A BF 3D 80 
When in a route domain the response looks like this where 1 is the route domain ID.
  10.191.61.128%1 -> Hex-STRING: 0A BF 3D 80 00 00 00 01
This padding and route domain ID breaks the Hex -> string conversion since the returned value now converts to garbage characters. 

This behaviour is not present with IPv6 IPs where only the address is always returned regardless of the VS being in a route domain or not. 

In this fix a check is done against the string length to see if the v4 IP has been padded with a route domain IP and if it has that is trimmed to be the correct length. 

Screenshot of the IPs being null 
![ltm-vs-ip-notworking](https://user-images.githubusercontent.com/29460571/35349798-2caab8c8-00f9-11e8-8287-32a5df09bcd2.PNG)

Screen shot of the IPs being properly returned. 
![ltm-vs-ip-working](https://user-images.githubusercontent.com/29460571/35349797-2c7b3b02-00f9-11e8-944e-62ea02bf95b2.PNG)