### PR TITLE
fix composer GPL string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "keywords": ["network", "monitoring", "discovery", "alerting", "billing", "snmp", "distributed"],
     "homepage": "http://www.librenms.org/",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-or-later",
     "support": {
         "source": "https://github.com/librenms/librenms/",
         "docs": "http://docs.librenms.org/",


### PR DESCRIPTION
Fixes an error from packagist:
License "GPL-3.0" is a deprecated SPDX license identifier, use "GPL-3.0-only" or "GPL-3.0-or-later" instead

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
