### PR TITLE
changed is_file to rrdtool_check_rrd_exists in php-fpm and squid applications graphs.

### DIFF
--- a/html/includes/graphs/application/php-fpm_stats.inc.php
+++ b/html/includes/graphs/application/php-fpm_stats.inc.php
@@ -27,7 +27,7 @@ $array = array(
 );
 
 $i = 0;
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     foreach ($array as $ds => $var) {
         $rrd_list[$i]['filename'] = $rrd_filename;
         $rrd_list[$i]['descr']    = $var['descr'];

--- a/html/includes/graphs/application/squid_bytehit.inc.php
+++ b/html/includes/graphs/application/squid_bytehit.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_clients.inc.php
+++ b/html/includes/graphs/application/squid_clients.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_cputime.inc.php
+++ b/html/includes/graphs/application/squid_cputime.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_cpuusage.inc.php
+++ b/html/includes/graphs/application/squid_cpuusage.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_filedescr.inc.php
+++ b/html/includes/graphs/application/squid_filedescr.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_http.inc.php
+++ b/html/includes/graphs/application/squid_http.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_httpbw.inc.php
+++ b/html/includes/graphs/application/squid_httpbw.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_memory.inc.php
+++ b/html/includes/graphs/application/squid_memory.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_objcount.inc.php
+++ b/html/includes/graphs/application/squid_objcount.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_pagefaults.inc.php
+++ b/html/includes/graphs/application/squid_pagefaults.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_reqhit.inc.php
+++ b/html/includes/graphs/application/squid_reqhit.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_server.inc.php
+++ b/html/includes/graphs/application/squid_server.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_serverbw.inc.php
+++ b/html/includes/graphs/application/squid_serverbw.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,

--- a/html/includes/graphs/application/squid_sysnumread.inc.php
+++ b/html/includes/graphs/application/squid_sysnumread.inc.php
@@ -14,7 +14,7 @@ $transparency  = 15;
 
 $rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
 
-if (is_file($rrd_filename)) {
+if (rrdtool_check_rrd_exists($rrd_filename)) {
     $rrd_list = array(
         array(
             'filename' => $rrd_filename,


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

---
I ran into an issue where the webserver was not talking to the RRDCached server to plot some application graphs, php-fpm and squid, investigating I found that the webserver was looking for the file locally.

Changed the is_file function to the rrdtool_check_rrd_exists function in the php scripts that generate the graphics for php-fpm and squid.