### PR TITLE
Update badge background for selected pagemenu item (mono.css)

### DIFF
--- a/html/css/mono.css
+++ b/html/css/mono.css
@@ -114,3 +114,10 @@
   100% { transform: rotate(360deg); transform: rotate(360deg); }
 }
 
+.pagemenu-selected {
+  background-color: #777;
+  border: 0;
+  box-shadow: none;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+}

--- a/html/index.php
+++ b/html/index.php
@@ -129,7 +129,7 @@ if (empty($config['favicon'])) {
   <link href="css/leaflet.awesome-markers.css" rel="stylesheet" type="text/css" />
   <link href="css/select2.min.css" rel="stylesheet" type="text/css" />
   <link href="<?php echo($config['stylesheet']);  ?>?ver=291727421" rel="stylesheet" type="text/css" />
-  <link href="css/<?php echo $config['site_style']; ?>.css?ver=632417639" rel="stylesheet" type="text/css" />
+  <link href="css/<?php echo $config['site_style']; ?>.css?ver=632417642" rel="stylesheet" type="text/css" />
 <?php
 
 foreach ((array)$config['webui']['custom_css'] as $custom_css) {


### PR DESCRIPTION
This brings the background color in line with the user notification number badge background in the upper right corner.
The previous background was too bright for mono.css to properly read the white menu item text.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


Before:
![screen shot 2018-01-27 at 11 37 05](https://user-images.githubusercontent.com/800047/35471198-a09a81e6-0356-11e8-895e-c4918fc567bd.png)

After:
![screen shot 2018-01-27 at 11 36 23](https://user-images.githubusercontent.com/800047/35471200-a81cc23a-0356-11e8-9361-281587baf486.png)
