### PR TITLE
docs: fix for syslog-ng config in the docs

### DIFF
--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -44,7 +44,7 @@ options {
         stats_freq(0);
         bad_hostname("^gconfd$");
 };
- 
+
  
 source s_sys {
     system();

--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -44,25 +44,25 @@ options {
         stats_freq(0);
         bad_hostname("^gconfd$");
 };
-
-
+ 
+ 
 source s_sys {
     system();
     internal();
-
+ 
 };
 
 source s_net {
         tcp(port(514) flags(syslog-protocol));
         udp(port(514) flags(syslog-protocol));
 };
-
+ 
 
 ########################
 # Destinations
 ########################
 destination d_librenms {
-        program("/opt/librenms/syslog.php" template ("$HOST||$FACILITY||$PRIORITY||$LEVEL||$TAG||$R_YEAR-$R_MONTH-$R_DAY$R_HOUR:$R_MIN:$R_SEC||$MSG||$PROGRAM\n") template-escape(yes));
+        program("/opt/librenms/syslog.php" template ("$HOST||$FACILITY||$PRIORITY||$LEVEL||$TAG||$R_YEAR-$R_MONTH-$R_DAY $R_HOUR:$R_MIN:$R_SEC||$MSG||$PROGRAM\n") template-escape(yes));
 };
 
 filter f_kernel     { facility(kern); };


### PR DESCRIPTION
I guess it didn't copy over correctly the last fix. It was reported to not be working I tested this and seems to be okay now at the time. It was showing 00:00 00 0000

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
