### PR TITLE
Poll sensors as enum values instead of labels.

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -12,7 +12,7 @@ function bulk_sensor_snmpget($device, $sensors)
             return $data['sensor_oid'];
         }, $chunk);
         $oids = implode(' ', $oids);
-        $multi_response = snmp_get_multi_oid($device, $oids, '-OUQnt');
+        $multi_response = snmp_get_multi_oid($device, $oids, '-OUQnte');
         $cache = array_merge($cache, $multi_response);
     }
     return $cache;


### PR DESCRIPTION
Most of the time they should be polled as values anyway, but sometimes the mib might get loaded...  If we set -Oe, then we always get the numeric value of the poller.
All sensors should get a numeric value anyway.

This allows people to get away with mis-matched sensor names...

We still have to handle state sensors that return string values though.

Thoughts?

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
