### PR TITLE
Tweak multi_bits_separated graph rendering

### DIFF
--- a/html/includes/graphs/generic_multi_bits_separated.inc.php
+++ b/html/includes/graphs/generic_multi_bits_separated.inc.php
@@ -132,7 +132,7 @@ if (!$noagg) {
     $rrd_options .= ' VDEF:totalin=aggrinbytes,TOTAL';
     $rrd_options .= ' VDEF:totalout=aggroutbytes,TOTAL';
     $rrd_options .= " COMMENT:' \\n'";
-    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate', ($descr_len + 5)), 0, ($descr_len + 5)) . 'In' . "'";
+    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate', ($descr_len + 4)), 0, ($descr_len + 4)) . ' In' . "'";
     $rrd_options .= " GPRINT:aggrinbits:LAST:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggrinbits:MAX:%6.2lf%s$units";
@@ -141,7 +141,7 @@ if (!$noagg) {
     }
 
     $rrd_options .= "\\n";
-    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate', ($descr_len + 5)), 0, ($descr_len + 5)) . 'Out' . "'";
+    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate', ($descr_len + 4)), 0, ($descr_len + 4)) . 'Out' . "'";
     $rrd_options .= " GPRINT:aggroutbits:LAST:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggroutbits:MAX:%6.2lf%s$units";

--- a/html/includes/graphs/generic_multi_bits_separated.inc.php
+++ b/html/includes/graphs/generic_multi_bits_separated.inc.php
@@ -19,7 +19,7 @@ $stacked = generate_stacked_graphs();
 
 $i = 0;
 if ($width > '500') {
-    $descr_len = 18;
+    $descr_len = 40;
 } else {
     $descr_len = 8;
     $descr_len += round(($width - 260) / 9.5);
@@ -131,8 +131,8 @@ if (!$noagg) {
     $rrd_options .= ' CDEF:aggroutbits=aggroutbytes,' . $multiplier . ',*';
     $rrd_options .= ' VDEF:totalin=aggrinbytes,TOTAL';
     $rrd_options .= ' VDEF:totalout=aggroutbytes,TOTAL';
-    $rrd_options .= " COMMENT:' \\\\n'";
-    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate In', ($descr_len + 5)), 0, ($descr_len + 5)) . "'";
+    $rrd_options .= " COMMENT:' \\n'";
+    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate', ($descr_len + 5)), 0, ($descr_len + 5)) . 'In' . "'";
     $rrd_options .= " GPRINT:aggrinbits:LAST:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggrinbits:MAX:%6.2lf%s$units";
@@ -140,8 +140,8 @@ if (!$noagg) {
         $rrd_options .= " GPRINT:totalin:%6.2lf%s$total_units";
     }
 
-    $rrd_options .= "\\\\n";
-    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate Out', ($descr_len + 5)), 0, ($descr_len + 5)) . "'";
+    $rrd_options .= "\\n";
+    $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate', ($descr_len + 5)), 0, ($descr_len + 5)) . 'Out' . "'";
     $rrd_options .= " GPRINT:aggroutbits:LAST:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.2lf%s$units";
     $rrd_options .= " GPRINT:aggroutbits:MAX:%6.2lf%s$units";
@@ -149,7 +149,7 @@ if (!$noagg) {
         $rrd_options .= " GPRINT:totalout:%6.2lf%s$total_units";
     }
 
-    $rrd_options .= "\\\\n";
+    $rrd_options .= "\\n";
 }
 
 if ($custom_graph) {


### PR DESCRIPTION
* remove extra backslashes that were getting rendered
* Aline aggregate in/out text with interface in/out text
* Adjust description length for graphs with widths > 500

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
