### PR TITLE
removed div by 100. Mantisa SNMP value was not 0.01 resolution

### DIFF
--- a/includes/discovery/sensors/ber/junos.inc.php
+++ b/includes/discovery/sensors/ber/junos.inc.php
@@ -26,7 +26,7 @@ foreach ($pre_cache['junos_ifotn_oids'] as $index => $entry) {
         $limit = null;
         $warn_limit = null;
         $tmp_exp = $pre_cache['junos_ifotn_oids'][$index.".1"]['jnxoptIfOTNPMCurrentFECBERExponent'];
-        $current = ($entry['jnxoptIfOTNPMCurrentFECBERMantissa']/100)*pow(10, (-$tmp_exp));
+        $current = ($entry['jnxoptIfOTNPMCurrentFECBERMantissa'])*pow(10, (-$tmp_exp));
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         discover_sensor($valid['sensor'], 'ber', $device, $oid, $index, 'junos', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);

--- a/includes/polling/sensors/ber/junos.inc.php
+++ b/includes/polling/sensors/ber/junos.inc.php
@@ -4,6 +4,6 @@ if ($device['os'] == 'junos') {
     echo 'JunOS: ';
 
     $sensor_exp_value = snmp_get($device, 'JNX-OPT-IF-EXT-MIB::jnxoptIfOTNPMCurrentFECBERExponent.'.$sensor['sensor_index'].'.1', '-Oqv');
-    $sensor_value = ($sensor_value/100)*pow(10, -$sensor_exp_value);
+    $sensor_value = ($sensor_value)*pow(10, -$sensor_exp_value);
     unset($sensor_exp_value);
 }


### PR DESCRIPTION
Assumed that all SNMP values regarding DWDM should be divided by 100 was not the case for prefec  BER.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
