### PR TITLE
Add History to Billing API Functions

### DIFF
--- a/doc/API/Bills.md
+++ b/doc/API/Bills.md
@@ -5,12 +5,14 @@ source: API/Bills.md
 Retrieve the list of bills currently in the system.
 
 Route: `/api/v0/bills`
+       `/api/v0/bills?period=previous`
 
 Input:
 
 Example:
 ```curl
 curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/bills
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/bills?period=previous
 ```
 
 Output:
@@ -64,12 +66,16 @@ Output:
 Retrieve a specific bill
 
 Route: `/api/v0/bills/:id`
+       `/api/v0/bills/:id?period=previous`
        `/api/v0/bills?ref=:ref`
+       `/api/v0/bills?ref=:ref&period=previous`
        `/api/v0/bills?custid=:custid`
+       `/api/v0/bills?custid=:custid&period=previous`
 
   - id is the specific bill id
   - ref is the billing reference
   - custid is the customer reference
+  - period=previous indicates you would like the data for the last complete period rather than the current period
 
 Input:
 

--- a/doc/API/Bills.md
+++ b/doc/API/Bills.md
@@ -131,3 +131,49 @@ Output:
  ]
 }
 ```
+
+### `get_bill_history`
+
+Retrieve the history of specific bill
+
+Route: `/api/v0/bills/:id/history`
+
+Input:
+
+Example:
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/bills/1/history
+```
+
+Output:
+```json
+{
+ "status": "ok",
+ "bill_history": [
+    {
+        "bill_hist_id": "1",
+        "bill_id": "1",
+        "updated": "2018-02-06 17:01:01",
+        "bill_datefrom": "2018-02-01 00:00:00",
+        "bill_dateto": "2018-02-28 23:59:59",
+        "bill_type": "CDR",
+        "bill_allowed": "100000000",
+        "bill_used": "229963765",
+        "bill_overuse": "129963765",
+        "bill_percent": "229.96",
+        "rate_95th_in": "229963765",
+        "rate_95th_out": "1891344",
+        "rate_95th": "229963765",
+        "dir_95th": "in",
+        "rate_average": "136527101",
+        "rate_average_in": "135123359",
+        "rate_average_out": "1403743",
+        "traf_in": "3235123452544",
+        "traf_out": "33608406566",
+        "traf_total": "3268731859110",
+        "pdf": null
+    }
+ ],
+ "count": 1,
+}
+```

--- a/html/api_v0.php
+++ b/html/api_v0.php
@@ -113,6 +113,7 @@ $app->group(
                     function () use ($app) {
                         $app->get('/:bill_id', 'authToken', 'list_bills')->name('get_bill');
                         // api/v0/bills/$bill_id
+                        $app->get('/:bill_id/history', 'authToken', 'get_bill_history')->name('get_bill_history');
                     }
                 );
                 $app->get('/bills', 'authToken', 'list_bills')->name('list_bills');


### PR DESCRIPTION
This PR introduces history functions for billing in the API.  It enables:
  * /api/v0/bills?period=previous - billing list for previous completed period (same as selecting "Previous Billing Period" in UI)
  * /api/v0/bills/1?period=previous - as above, with single bill selected
  * /api/v0/bills/1/history - retrieve all history data for the selected bill

This brings some parity between information available in the UI and information in the API.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
