### PR TITLE
More secure password hashes

### DIFF
--- a/LibreNMS/Authentication/AuthorizerBase.php
+++ b/LibreNMS/Authentication/AuthorizerBase.php
@@ -27,7 +27,6 @@ namespace LibreNMS\Authentication;
 use LibreNMS\Config;
 use LibreNMS\Interfaces\Authentication\Authorizer;
 use LibreNMS\Exceptions\AuthenticationException;
-use Phpass\PasswordHash;
 
 abstract class AuthorizerBase implements Authorizer
 {
@@ -138,8 +137,7 @@ abstract class AuthorizerBase implements Authorizer
         } else {
             $token = strgen();
             $auth = strgen();
-            $hasher = new PasswordHash(8, false);
-            $token_id = $_SESSION['username'] . '|' . $hasher->HashPassword($_SESSION['username'] . $token);
+            $token_id = $_SESSION['username'] . '|' . password_hash($_SESSION['username'] . $token, PASSWORD_DEFAULT);
 
             $db_entry['session_username'] = $_SESSION['username'];
             $db_entry['session_token'] = $token;
@@ -169,8 +167,7 @@ abstract class AuthorizerBase implements Authorizer
             array($uname, $sess_id)
         );
 
-        $hasher = new PasswordHash(8, false);
-        if ($hasher->CheckPassword($uname . $session['session_token'], $hash)) {
+        if (password_verify($uname . $session['session_token'], $hash)) {
             $_SESSION['username'] = $uname;
             return true;
         }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1545,7 +1545,7 @@ users:
   Columns:
     - { Field: user_id, Type: int(11), 'Null': false, Extra: auto_increment }
     - { Field: username, Type: varchar(255), 'Null': false, Extra: '' }
-    - { Field: password, Type: varchar(60), 'Null': true, Extra: '' }
+    - { Field: password, Type: varchar(255), 'Null': true, Extra: '' }
     - { Field: realname, Type: varchar(64), 'Null': false, Extra: '' }
     - { Field: email, Type: varchar(64), 'Null': false, Extra: '' }
     - { Field: descr, Type: char(30), 'Null': false, Extra: '' }

--- a/scripts/auth_test.php
+++ b/scripts/auth_test.php
@@ -2,7 +2,6 @@
 <?php
 
 use LibreNMS\Authentication\Auth;
-use Phpass\PasswordHash;
 
 $options = getopt('u:rdvh');
 if (isset($options['h']) || !isset($options['u'])) {
@@ -96,8 +95,7 @@ try {
             exit;
         }
 
-        $hasher = new PasswordHash(8, false);
-        $token = $session['session_username'] . '|' . $hasher->HashPassword($session['session_username'] . $session['session_token']);
+        $token = $session['session_username'] . '|' . password_hash($session['session_username'] . $session['session_token'], PASSWORD_DEFAULT);
 
         $auth = $authorizer->reauthenticate($session['session_value'], $token);
         if ($auth) {

--- a/sql-schema/235.sql
+++ b/sql-schema/235.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users MODIFY password VARCHAR(255);


### PR DESCRIPTION
Use PHP 5.5 password_hash(), currently uses bcrypt
increase password field length as per php documentation

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
