### PR TITLE
Restore vendor contents even if composer is not available

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -227,6 +227,12 @@ main () {
                 status_run 'Cleaning up DB' "$DAILY_SCRIPT cleanup"
             ;;
             post-pull)
+                # Check for missing vendor dir
+                if [ ! -f vendor/autoload.php ]; then
+                    git checkout 609676a9f8d72da081c61f82967e1d16defc0c4e -- vendor/
+                    git reset HEAD vendor/  # don't add vendor directory to the index
+                fi
+
                 status_run 'Updating Composer packages' "${COMPOSER} install --no-dev" 'update'
 
                 # Check if we need to revert (Must be in post pull so we can update it)

--- a/includes/init.php
+++ b/includes/init.php
@@ -39,7 +39,7 @@ require_once $install_dir . '/includes/common.php';
 
 # composer autoload
 if (!is_file($install_dir . '/vendor/autoload.php')) {
-    c_echo("%RError: Missing dependencies%n, run: %Bcomposer install --no-dev%n\n\n");
+    c_echo("%RError: Missing dependencies%n, run: %B./scripts/composer_wrapper.php install --no-dev%n\n\n");
 }
 require $install_dir . '/vendor/autoload.php';
 

--- a/validate.php
+++ b/validate.php
@@ -103,13 +103,13 @@ if (!str_contains(shell_exec('php scripts/composer_wrapper.php --version'), 'Com
 $dep_check = shell_exec('php scripts/composer_wrapper.php install --no-dev --dry-run');
 preg_match_all('/Installing ([^ ]+\/[^ ]+) \(/', $dep_check, $dep_missing);
 if (!empty($dep_missing[0])) {
-    print_fail("Missing dependencies!", "composer install --no-dev");
+    print_fail("Missing dependencies!", "./scripts/composer_wrapper.php install --no-dev");
     $pre_checks_failed = true;
     print_list($dep_missing[1], "\t %s\n");
 }
 preg_match_all('/Updating ([^ ]+\/[^ ]+) \(/', $dep_check, $dep_outdated);
 if (!empty($dep_outdated[0])) {
-    print_fail("Outdated dependencies", "composer install --no-dev");
+    print_fail("Outdated dependencies", "./scripts/composer_wrapper.php install --no-dev");
     print_list($dep_outdated[1], "\t %s\n");
 }
 


### PR DESCRIPTION
Leave the code in both places for safety.

If composer is not available some things will fail the first run due to timing, but the user will end up with a functioning LibreNMS afterwards.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
