### PR TITLE
contrib: Add systemd service and timers

### DIFF
--- a/contrib/systemd/librenms@.service
+++ b/contrib/systemd/librenms@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=LibreNMS %I
+
+[Service]
+Type=oneshot
+ExecStart=/opt/librenms/scripts/timer.sh %i
+User=librenms
+Nice=10

--- a/contrib/systemd/librenms@alerts.timer
+++ b/contrib/systemd/librenms@alerts.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=LibreNMS alerts
+
+[Timer]
+Unit=librenms@alerts.service
+OnCalendar=minutely
+RandomizedDelaySec=5s
+
+[Install]
+WantedBy=basic.target

--- a/contrib/systemd/librenms@billing-calculate.timer
+++ b/contrib/systemd/librenms@billing-calculate.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=LibreNMS billing-calculate
+
+[Timer]
+Unit=librenms@billing-calculate.service
+OnCalendar=daily
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=basic.target

--- a/contrib/systemd/librenms@check-services.timer
+++ b/contrib/systemd/librenms@check-services.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=LibreNMS check-services
+
+[Timer]
+Unit=librenms@check-services.service
+OnBootSec=60
+OnUnitInactiveSec=5m
+RandomizedDelaySec=30s
+
+[Install]
+WantedBy=basic.target
+

--- a/contrib/systemd/librenms@daily.timer
+++ b/contrib/systemd/librenms@daily.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=LibreNMS daily
+
+[Timer]
+Unit=librenms@daily.service
+OnCalendar=daily
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=basic.target

--- a/contrib/systemd/librenms@discovery-new.timer
+++ b/contrib/systemd/librenms@discovery-new.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=LibreNMS discovery-new
+
+[Timer]
+Unit=librenms@discovery-new.service
+OnBootSec=60
+OnUnitInactiveSec=5m
+RandomizedDelaySec=30s
+
+[Install]
+WantedBy=basic.target

--- a/contrib/systemd/librenms@discovery.timer
+++ b/contrib/systemd/librenms@discovery.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=LibreNMS discovery
+
+[Timer]
+Unit=librenms@discovery.service
+OnBootSec=60
+OnUnitInactiveSec=6h
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=basic.target
+

--- a/contrib/systemd/librenms@poll-billing.timer
+++ b/contrib/systemd/librenms@poll-billing.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=LibreNMS poll-billing
+
+[Timer]
+Unit=librenms@poll-billing.service
+OnBootSec=60
+OnUnitInactiveSec=5m
+RandomizedDelaySec=30s
+
+[Install]
+WantedBy=basic.target

--- a/contrib/systemd/librenms@poller.timer
+++ b/contrib/systemd/librenms@poller.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=LibreNMS poller
+
+[Timer]
+Unit=librenms@poller.service
+OnCalendar=*-*-* *:1/5:00
+
+[Install]
+WantedBy=basic.target

--- a/doc/Installation/Installation-Ubuntu-1604-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Apache.md
@@ -108,7 +108,7 @@ Copy, enable and start systemd timers:
 
     cp /opt/librenms/contrib/systemd/* /etc/systemd/system/
     systemctl daemon-reload
-    for timer in /lib/systemd/system/librenms@*.timer; do systemctl enable --now $(basename $timer); done
+    for timer in /etc/systemd/system/librenms@*.timer; do systemctl enable --now $(basename $timer); done
 
 #### Copy logrotate config
 

--- a/doc/Installation/Installation-Ubuntu-1604-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Apache.md
@@ -100,15 +100,15 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
 
 ### Background jobs
 
-If your upgrading LibreNMS, ensure to remove the crontab:
+If you are upgrading LibreNMS, ensure to remove the crontab:
 
-    rm -fv /etc/cron.d/librenms
+    rm -fv /etc/cron.d/librenms*
 
 Copy, enable and start systemd timers:
 
-    cp /opt/librenms/contrib/systemd/* /lib/systemd/system/
+    cp /opt/librenms/contrib/systemd/* /etc/systemd/system/
     systemctl daemon-reload
-    for timer in /lib/systemd/system/librenms@*.timer; do systemctl enable $(basename $timer) && systemctl start $(basename $timer); done
+    for timer in /lib/systemd/system/librenms@*.timer; do systemctl enable --now $(basename $timer); done
 
 #### Copy logrotate config
 

--- a/doc/Installation/Installation-Ubuntu-1604-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Apache.md
@@ -102,7 +102,7 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
 
 If your upgrading LibreNMS, ensure to remove the crontab:
 
-    rm -fv /opt/librenms/librenms.nonroot.cron
+    rm -fv /etc/cron.d/librenms
 
 Copy, enable and start systemd timers:
 

--- a/doc/Installation/Installation-Ubuntu-1604-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Apache.md
@@ -98,9 +98,17 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
     chmod +x /usr/bin/distro
     systemctl restart snmpd
 
-### Cron job
+### Background jobs
 
-    cp /opt/librenms/librenms.nonroot.cron /etc/cron.d/librenms
+If your upgrading LibreNMS, ensure to remove the crontab:
+
+    rm -fv /opt/librenms/librenms.nonroot.cron
+
+Copy, enable and start systemd timers:
+
+    cp /opt/librenms/contrib/systemd/* /lib/systemd/system/
+    systemctl daemon-reload
+    for timer in /lib/systemd/system/librenms@*.timer; do systemctl enable $(basename $timer) && systemctl start $(basename $timer); done
 
 #### Copy logrotate config
 

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -111,9 +111,9 @@ If are upgrading LibreNMS, ensure to remove the crontab:
 
 Copy, enable and start systemd timers:
 
-    cp /opt/librenms/contrib/systemd/* /lib/systemd/system/
+    cp /opt/librenms/contrib/systemd/* /etc/systemd/system/
     systemctl daemon-reload
-    for timer in /lib/systemd/system/librenms@*.timer; do systemctl enable $(basename $timer) && systemctl start $(basename $timer); done
+    for timer in /etc/systemd/system/librenms@*.timer; do systemctl enable $(basename $timer) && systemctl start $(basename $timer); done
 
 #### Copy logrotate config
 

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -105,9 +105,9 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
 
 ### Background jobs
 
-If your upgrading LibreNMS, ensure to remove the crontab:
+If are upgrading LibreNMS, ensure to remove the crontab:
 
-    rm -fv /etc/cron.d/librenms
+    rm -fv /etc/cron.d/librenms*
 
 Copy, enable and start systemd timers:
 

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -103,9 +103,17 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
     chmod +x /usr/bin/distro
     systemctl restart snmpd
 
-### Cron job
+### Background jobs
 
-    cp /opt/librenms/librenms.nonroot.cron /etc/cron.d/librenms
+If your upgrading LibreNMS, ensure to remove the crontab:
+
+    rm -fv /opt/librenms/librenms.nonroot.cron
+
+Copy, enable and start systemd timers:
+
+    cp /opt/librenms/contrib/systemd/* /lib/systemd/system/
+    systemctl daemon-reload
+    for timer in /lib/systemd/system/librenms@*.timer; do systemctl enable $(basename $timer) && systemctl start $(basename $timer); done
 
 #### Copy logrotate config
 

--- a/doc/Installation/Installation-Ubuntu-1604-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1604-Nginx.md
@@ -107,7 +107,7 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
 
 If your upgrading LibreNMS, ensure to remove the crontab:
 
-    rm -fv /opt/librenms/librenms.nonroot.cron
+    rm -fv /etc/cron.d/librenms
 
 Copy, enable and start systemd timers:
 

--- a/scripts/timer.sh
+++ b/scripts/timer.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+# This wrapper script is used by systemd timers
+
+case "$1" in
+  "discovery")
+    exec /opt/librenms/cronic /opt/librenms/discovery-wrapper.py 1
+  ;;
+  "discovery-new")
+    exec /opt/librenms/discovery.php -h new
+  ;;
+  "poller")
+    exec /opt/librenms/cronic /opt/librenms/poller-wrapper.py 16
+  ;;
+  "daily")
+    exec /opt/librenms/daily.sh
+  ;;
+  "alerts")
+    exec /opt/librenms/alerts.php
+  ;;
+  "poll-billing")
+    exec /opt/librenms/poll-billing.php
+  ;;
+  "billing-calculate")
+    exec /opt/librenms/billing-calculate.php
+  ;;
+  "check-services")
+    exec /opt/librenms/check-services.php
+  ;;
+  *)
+    echo "invalid command: $1"
+    exit 1
+esac


### PR DESCRIPTION
## Advantages

- prevents concurrent runs of the same job
- processes are started with low scheduler priority
- random delays reduce system load
- journalctl simplifies debugging

## Useful commands
### Show timer status

    systemctl list-timers

### Show timer output

    journalctl -fu librenms@\*

## Misc

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)