### PR TITLE
Support Brocade G620 description 

### DIFF
--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -1314,8 +1314,11 @@ function rewrite_brocade_fc_switches($descr)
         case "148":
             $hardware = "Brocade 7840 Switch";
             break;
+        case "162":
+            $hardware = "Brocade G620 Switch";
+            break;
         case "170":
-            $hardware = "Brocade 6610 Switch";
+            $hardware = "Brocade G610 Switch";
             break;
         default:
             $hardware = "Unknown Brocade FC Switch";


### PR DESCRIPTION
and rename brocade 6610 to best known description, G610. 6610 is in fact name with Dell-EMC OEM Brocade G610.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
