### PR TITLE
Improve LDAP filter in the getUserlist() function

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -136,7 +136,7 @@ class LdapAuthorizer extends AuthorizerBase
         try {
             $connection = $this->getLdapConnection();
 
-            $filter = '(' . Config::get('auth_ldap_prefix') . '*)';
+            $filter = '(&(' . Config::get('auth_ldap_prefix') . '*)(memberOf=' . trim(Config::get('auth_ldap_group'), ',') . '))';
             $search = ldap_search($connection, trim(Config::get('auth_ldap_suffix'), ','), $filter);
             $entries = ldap_get_entries($connection, $search);
 


### PR DESCRIPTION
Improve LDAP filtering to improve the speed of some pages (Dashboard and
Edit User mainly). If we don't apply this filter all the users are getted
from LDAP and used in to the loop, with 2k users (for us) the page take
more than 15 seconds to be loaded.

I have check than people still have differante access with this fix.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
