### PR TITLE
Change Billing Graph Data Max/Avg/Last from bytes to bits

### DIFF
--- a/includes/billing.php
+++ b/includes/billing.php
@@ -277,8 +277,8 @@ function getBillingBitsGraphData($bill_id, $from, $to, $reducefactor)
         }
 
         $period    = $row['period'];
-        $in_delta  = $row['in_delta'];
-        $out_delta = $row['out_delta'];
+        $in_delta  = $row['in_delta'] * 8;
+        $out_delta = $row['out_delta'] * 8;
         $last      = $timestamp;
 
         $iter_in     += $in_delta;
@@ -293,8 +293,8 @@ function getBillingBitsGraphData($bill_id, $from, $to, $reducefactor)
             $tot_period+= $period;
 
             if (++$iter >= $reducefactor) {
-                $out_data[$i] = round(($iter_out * 8 / $iter_period), 2);
-                $in_data[$i]  = round(($iter_in * 8 / $iter_period), 2);
+                $out_data[$i] = round(($iter_out / $iter_period), 2);
+                $in_data[$i]  = round(($iter_in / $iter_period), 2);
                 $tot_data[$i] = ($out_data[$i] + $in_data[$i]);
                 $ticks[$i]    = $timestamp;
                 $i++;
@@ -305,8 +305,8 @@ function getBillingBitsGraphData($bill_id, $from, $to, $reducefactor)
     }//end foreach
 
     if (isset($iter_in)) {  // Write last element
-        $out_data[$i] = round(($iter_out * 8 / $iter_period), 2);
-        $in_data[$i]  = round(($iter_in * 8 / $iter_period), 2);
+        $out_data[$i] = round(($iter_out / $iter_period), 2);
+        $in_data[$i]  = round(($iter_in / $iter_period), 2);
         $tot_data[$i] = ($out_data[$i] + $in_data[$i]);
         $ticks[$i]    = $timestamp;
         $i++;


### PR DESCRIPTION
The max/average/last stats introduced into the GraphData API calls in #8245 were incorrectly stored in bytes, not bits.  This PR fixes that.  This only affects data used in the new API calls.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
