### PR TITLE
Add SG350-10 to bad_ifXentry list

### DIFF
--- a/includes/definitions/ciscosb.yaml
+++ b/includes/definitions/ciscosb.yaml
@@ -18,6 +18,7 @@ bad_ifXEntry:
     - SG300-20
     - SG300-28
     - SG300-28MP
+    - SG350-10
 poller_modules:
     bgp-peers: 0
     hr-mib: 0


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

---

The `ciscosb` HC counter woes continue in the latest generation of the devices.

On a Cisco SG350-10 running the latest firmware (`2.3.5.63`) the packet counters are still empty:

<details><summary>`snmpwalk` excerpt`</summary>

```
% grep 'OutOctets.. ' snmpwalkout
IF-MIB::ifOutOctets.1 = Counter32: 167982184
IF-MIB::ifOutOctets.2 = Counter32: 552957166
IF-MIB::ifOutOctets.3 = Counter32: 1098625406
IF-MIB::ifOutOctets.4 = Counter32: 11203616
IF-MIB::ifOutOctets.5 = Counter32: 62578049
IF-MIB::ifOutOctets.6 = Counter32: 306059344
IF-MIB::ifOutOctets.7 = Counter32: 11638025
IF-MIB::ifOutOctets.8 = Counter32: 10701823
IF-MIB::ifOutOctets.9 = Counter32: 0
IF-MIB::ifHCOutOctets.1 = Counter64: 168003429
IF-MIB::ifHCOutOctets.2 = Counter64: 552967067
IF-MIB::ifHCOutOctets.3 = Counter64: 1098715052
IF-MIB::ifHCOutOctets.4 = Counter64: 11208127
IF-MIB::ifHCOutOctets.5 = Counter64: 62582560
IF-MIB::ifHCOutOctets.6 = Counter64: 306315891
IF-MIB::ifHCOutOctets.7 = Counter64: 11643263
IF-MIB::ifHCOutOctets.8 = Counter64: 10706334
IF-MIB::ifHCOutOctets.9 = Counter64: 0
% grep 'OutUcastPkts.. ' snmpwalkout
IF-MIB::ifOutUcastPkts.1 = Counter32: 988873
IF-MIB::ifOutUcastPkts.2 = Counter32: 547307
IF-MIB::ifOutUcastPkts.3 = Counter32: 946915
IF-MIB::ifOutUcastPkts.4 = Counter32: 9203
IF-MIB::ifOutUcastPkts.5 = Counter32: 52749
IF-MIB::ifOutUcastPkts.6 = Counter32: 336632
IF-MIB::ifOutUcastPkts.7 = Counter32: 11195
IF-MIB::ifOutUcastPkts.8 = Counter32: 13244
IF-MIB::ifOutUcastPkts.9 = Counter32: 0
IF-MIB::ifHCOutUcastPkts.1 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.2 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.3 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.4 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.5 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.6 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.7 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.8 = Counter64: 0
IF-MIB::ifHCOutUcastPkts.9 = Counter64: 0
%
```

</details>

I only have a SG350-10 for testing, [the Cisco homepage](https://www.cisco.com/c/en/us/support/switches/350-series-managed-switches/tsd-products-support-series-home.html) has the complete list of devices in the family.