### PR TITLE
Set Content-type header in the API transport if the text to be sent is valid JSON

### DIFF
--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -45,7 +45,7 @@ class Api implements Transport
                 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, strtoupper($method));
                 if (json_decode($api) !== NULL) {
-                        curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-type: application/json"));
+                    curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-type: application/json"));
                 }
                 curl_setopt($curl, CURLOPT_POSTFIELDS, $api);
                 $ret = curl_exec($curl);

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -44,6 +44,9 @@ class Api implements Transport
                 curl_setopt($curl, CURLOPT_URL, ($method == "get" ? $host."?".$api : $host));
                 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, strtoupper($method));
+                if (json_decode($api) !== NULL) {
+                        curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-type: application/json"));
+                }
                 curl_setopt($curl, CURLOPT_POSTFIELDS, $api);
                 $ret = curl_exec($curl);
                 $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -44,7 +44,7 @@ class Api implements Transport
                 curl_setopt($curl, CURLOPT_URL, ($method == "get" ? $host."?".$api : $host));
                 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, strtoupper($method));
-                if (json_decode($api) !== NULL) {
+                if (json_decode($api) !== null) {
                     curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-type: application/json"));
                 }
                 curl_setopt($curl, CURLOPT_POSTFIELDS, $api);


### PR DESCRIPTION
This change makes the API transport attempt to decode the request body text that is to be posted to the API endpoint as JSON prior to the data being posted. If the body text is identified as valid JSON, the Content-type HTTP header is set to 'application/json', which is required by many API endpoints that expect JSON formatted inputs.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
