### PR TITLE
RRDCached-Security clearify security

### DIFF
--- a/doc/Extensions/RRDCached-Security.md
+++ b/doc/Extensions/RRDCached-Security.md
@@ -1,5 +1,5 @@
 ### Securing with nginx
-According to the [man page](https://linux.die.net/man/1/rrdcached), under "SECURITY CONSIDERATIONS", rrdcached has no authentication or security except for running under a unix socket. To secure your rrdcached installation, you can proxy it using nginx to allow only specific IPs to connect.
+According to the [man page](https://linux.die.net/man/1/rrdcached), under "SECURITY CONSIDERATIONS", rrdcached has no authentication or security except for running under a unix socket. If you choose to use a network socket instead of a unix socket, you will need to secure your rrdcached installation. To do so you can proxy rrdcached using nginx to allow only specific IPs to connect.
 
 using the same setup above, using nginx version 1.9.0 or later, you can follow this setup to proxy the default rrdcached port to the local unix socket.
 


### PR DESCRIPTION
Clarify that additional security is only needed if you use a network socket instead of a unix socket. This might reduce confusion since the default directions on https://docs.librenms.org/#Extensions/RRDCached/ only setup unix sockets so no further steps are needed.

Source information found at: https://oss.oetiker.ch/rrdtool/doc/rrdcached.en.html#SECURITY_CONSIDERATIONS

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
