### PR TITLE
Added auto width and height dimensions parameters

### DIFF
--- a/doc/Extensions/Dashboards.md
+++ b/doc/Extensions/Dashboards.md
@@ -67,3 +67,12 @@ In the dashboard, you want to create an interface graph select the widget called
 * Note: you can map the port by description or the alias or by port id. You will need to know this in order to map the port to the graph. 
 
 ![port-bits-graph](/img/port-bits-port.png)
+
+### Dimension parameter replacement for Generic-image widget
+
+When using the Generic-image widget you can provide the width and height of the widget with your request.
+This will ensure that the image will fit nicely with the dimensions if the Generic-image widget.
+You can add @AUTO_HEIGHT@ and @AUTO_WIDTH@ to the Image URL as parameters.
+Examples: 
++ http://librenms.example.com/graph.php?id=333%2C444&type=multiport_bits_separate&legend=no&absolute=1&from=-14200&width=@AUTO_WIDTH@&height=@AUTO_HEIGHT@
++ http://example.com/myimage.php?size=@AUTO_WIDTH@x@AUTO_HEIGHT@

--- a/html/includes/common/generic-image.inc.php
+++ b/html/includes/common/generic-image.inc.php
@@ -57,6 +57,12 @@ if (defined('SHOW_SETTINGS') || empty($widget_settings)) {
 </form>';
 } else {
     $widget_settings['title'] = $widget_settings['image_title'];
+    if (strstr($widget_settings['image_url'], '@AUTO_HEIGHT@')) {
+        $widget_settings['image_url'] = str_replace('@AUTO_HEIGHT@', $widget_dimensions['y'], $widget_settings['image_url']);
+    }
+    if (strstr($widget_settings['image_url'], '@AUTO_WIDTH@')) {
+        $widget_settings['image_url'] = str_replace('@AUTO_WIDTH@', $widget_dimensions['x'], $widget_settings['image_url']);
+    }
     if (strstr($widget_settings['image_url'], '?')) {
         $widget_settings['image_url'] .= "&".mt_rand();
     } else {


### PR DESCRIPTION
Added the ability to substituted special parameters for width and height of the Generic-image widget to be added to an Image URL.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
