### PR TITLE
Fixing HP Proliant state sensors

### DIFF
--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -73,7 +73,8 @@ foreach ($tables as $tablevalue) {
                 null,
                 $entry[$oid],
                 'snmp',
-                $index);
+                $index
+            );
 
             //Create Sensor To State Index
             create_sensor_to_state_index($device, $state_name, $index);

--- a/includes/discovery/sensors/state/hp.inc.php
+++ b/includes/discovery/sensors/state/hp.inc.php
@@ -23,89 +23,60 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
-$tables = array(
-    array('cpqDaPhyDrvTable','.1.3.6.1.4.1.232.3.2.5.1.1.6.','cpqDaPhyDrvStatus','cpqDaPhyDrvBay','CPQIDA-MIB'),
-    array('cpqDaAccelTable','.1.3.6.1.4.1.232.3.2.2.2.1.2.','cpqDaAccelCondition','cpqDaAccelCntlrIndex','CPQIDA-MIB'),
-    array('cpqHeFltTolPowerSupplyTable','.1.3.6.1.4.1.232.6.2.9.3.1.4.','cpqHeFltTolPowerSupplyCondition','cpqHeFltTolPowerSupplyBay','CPQHLTH-MIB','cpqHeFltTolPowerSupplyPresent'),
-    array('cpqHeFltTolFanTable','.1.3.6.1.4.1.232.6.2.6.7.1.9.','cpqHeFltTolFanCondition','cpqHeFltTolFanIndex ','CPQHLTH-MIB','cpqHeFltTolFanPresent'),
-);
+// One could add more entries from deviceGroup, but this will do as a start
+$tables = [
+    ['cpqDaPhyDrvStatus','.1.3.6.1.4.1.232.3.2.5.1.1.6.','Status','CPQIDA-MIB', [
+        ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'other'],
+        ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'ok'],
+        ['value' => 3, 'generic' => 2, 'graph' => 0, 'descr' => 'failed'],
+        ['value' => 4, 'generic' => 2, 'graph' => 0, 'descr' => 'predictiveFailure'],
+        ['value' => 5, 'generic' => 1, 'graph' => 0, 'descr' => 'erasing'],
+        ['value' => 6, 'generic' => 1, 'graph' => 0, 'descr' => 'eraseDone'],
+        ['value' => 7, 'generic' => 1, 'graph' => 0, 'descr' => 'eraseQueued'],
+        ['value' => 8, 'generic' => 2, 'graph' => 0, 'descr' => 'ssdWearOut'],
+        ['value' => 9, 'generic' => 3, 'graph' => 0, 'descr' => 'notAuthenticated'],
+    ]],
+    ['cpqDaPhyDrvSmartStatus','.1.3.6.1.4.1.232.3.2.5.1.1.57.','S.M.A.R.T.','CPQIDA-MIB', [
+        ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'other'],
+        ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'ok'],
+        ['value' => 3, 'generic' => 1, 'graph' => 0, 'descr' => 'replaceDrive'],
+        ['value' => 4, 'generic' => 1, 'graph' => 0, 'descr' => 'replaceDriveSSDWearOut'],
+    ]],
+];
 
-$x=0;
 foreach ($tables as $tablevalue) {
-    $temp = snmpwalk_cache_multi_oid($device, $tablevalue[0], array(), $tablevalue[4], 'hp');
-    $cur_oid = $tablevalue[1];
+    list($oid, $num_oid, $descr, $mib, $states) = $tablevalue;
+    $temp = snmpwalk_cache_multi_oid($device, $oid, [], $mib, 'hp', '-OQUse');
 
-    if (is_array($temp)) {
+    if (!empty($temp)) {
         //Create State Index
-        $state_name = $tablevalue[2];
-        $state_index_id = create_state_index($state_name);
-
-        //Create State Translation
-        if ($state_index_id !== null) {
-            if ($state_name == 'cpqDaPhyDrvStatus') {
-                $states = array(
-                    array($state_index_id,'other',1,1,3),
-                    array($state_index_id,'ok',1,2,0),
-                    array($state_index_id,'failed',1,3,2),
-                    array($state_index_id,'predictiveFailure',1,4,2),
-                    array($state_index_id,'erasing',1,5,1),
-                    array($state_index_id,'eraseDone',1,6,1),
-                    array($state_index_id,'eraseQueued',1,7,1),
-                    array($state_index_id,'ssdWearOut',1,8,2),
-                    array($state_index_id,'notAuthenticated',1,9,3),
-                );
-            } elseif ($state_name == 'cpqDaAccelCondition') {
-                $states = array(
-                    array($state_index_id,'other',1,1,3),
-                    array($state_index_id,'ok',1,2,0),
-                    array($state_index_id,'degraded',1,3,2),
-                    array($state_index_id,'failed',1,4,3),
-                );
-            } elseif ($state_name == 'cpqHeFltTolPowerSupplyCondition') {
-                $states = array(
-                    array($state_index_id,'other',1,1,3),
-                    array($state_index_id,'ok',1,2,0),
-                    array($state_index_id,'degraded',1,3,1),
-                    array($state_index_id,'failed',1,4,1),
-                );
-            } elseif ($state_name == 'cpqHeFltTolFanCondition') {
-                $states = array(
-                    array($state_index_id,'other',1,1,3),
-                    array($state_index_id,'ok',1,2,0),
-                    array($state_index_id,'degraded',1,3,1),
-                    array($state_index_id,'failed',1,4,2),
-                );
-            }
-
-            foreach ($states as $value) {
-                $insert = array(
-                    'state_index_id' => $value[0],
-                    'state_descr' => $value[1],
-                    'state_draw_graph' => $value[2],
-                    'state_value' => $value[3],
-                    'state_generic_value' => $value[4]
-                );
-                dbInsert($insert, 'state_translations');
-            }
-        }
+        $state_name = $oid;
+        $state_index_id = create_state_index($state_name, $states);
 
         foreach ($temp as $index => $entry) {
-            if ($state_name == 'cpqDaPhyDrvStatus') {
-                $descr = 'HDD #'.trim(snmp_get($device, ".1.3.6.1.4.1.232.3.2.5.1.1.5.$index", "-Ovqn"), '"'). " Status";
-            } elseif ($state_name == 'cpqDaAccelCondition') {
-                $descr = 'CTRL #'.trim(snmp_get($device, ".1.3.6.1.4.1.232.3.2.2.2.1.1.$index", "-Ovqn"), '"'). " Status";
-            } elseif ($state_name == 'cpqHeFltTolPowerSupplyCondition' && $temp[$index][$tablevalue[5]] == 'present') {
-                $descr = 'PSU #'.trim(snmp_get($device, "1.3.6.1.4.1.232.6.2.9.3.1.2.$index", "-Ovqn"), '"')." Status";
-            } elseif ($state_name == 'cpqHeFltTolFanCondition' && $temp[$index][$tablevalue[5]] == 'present') {
-                $descr = 'FAN #'.trim(snmp_get($device, "1.3.6.1.4.1.232.6.2.6.7.1.2.$index", "-Ovqn"), '"')." Status";
-            } else {
-                continue;
-            }
+            $drive_bay = snmp_get($device, "cpqDaPhyDrvBay.$index", '-Ovqn', 'CPQIDA-MIB');
+
             //Discover Sensors
-            discover_sensor($valid['sensor'], 'state', $device, $cur_oid.$index, $x . $index, $state_name, $descr, '1', '1', null, null, null, null, $temp[$index][$tablevalue[2]], 'snmp', $index);
+            discover_sensor(
+                $valid['sensor'],
+                'state',
+                $device,
+                $num_oid . $index,
+                $index,
+                $state_name,
+                "Drive  $drive_bay $descr",
+                1,
+                1,
+                null,
+                null,
+                null,
+                null,
+                $entry[$oid],
+                'snmp',
+                $index);
+
             //Create Sensor To State Index
-            create_sensor_to_state_index($device, $state_name, $x . $index);
+            create_sensor_to_state_index($device, $state_name, $index);
         }
     }
-    $x++;
 }


### PR DESCRIPTION
The support to HP Proliant disk discovery was originally introduced at #6124.

However that code contains a few errors that prevent it from doing what it was intended to do.

1) The MIB that contains cpqDaPhyDrvStatus and cpqDaPhyDrvSmartStatus is **CPQIDA-MIB**, not 
CPQSINFO-MIB.

2) The OID in the code that iterates the array in order to find the disk number should drop the last digit (.1) as that indicates the disk in position (1) and we end up missing the Disk # as follows:
```
Sensor Added: state cpqDaPhyDrvSmartStatus 10.0 Disk #
Sensor Added: state cpqDaPhyDrvStatus 00.0 Disk #
```

Having made the changes described herein, the following is seen in the recent events

```
State sensor Disk # has changed from (0) to (2)
State sensor Disk # has changed from (0) to (2)
Sensor Updated: state cpqDaPhyDrvSmartStatus 10.0 Disk #1
Sensor Updated: state cpqDaPhyDrvStatus 00.0 Disk #1
```

The only other issue that I can name is that the states are not expanded properly in the UI, i.e. 2 should equal to OK.


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


