### PR TITLE
fix: Fixed sysname -> sysName for device dependancy display

### DIFF
--- a/html/pages/device-dependencies.inc.php
+++ b/html/pages/device-dependencies.inc.php
@@ -156,7 +156,7 @@ $(document).ready(function() {
                 editSelect.append($('<option>', { value: 0, text: 'None'}));
                 manParentDevstoClr.append($('<option>', { value: 0, text: 'None'}));
                 $.each(output.deps, function (i,elem) {
-                    var devtext = elem.hostname + ' (' + elem.sysname + ')';
+                    var devtext = elem.hostname + ' (' + elem.sysName + ')';
                     manParentDevs.append($('<option>',{value:elem.id, text:devtext}));
                     editSelect.append($('<option>',{value:elem.id, text:devtext}));
                     manAllDevs.append($('<option>',{value:elem.id, text:devtext}));


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Simple fix. Changes (undefined) to the actual (sysName).