### PR TITLE
libvirt: Fix libvirt VM info

### DIFF
--- a/html/includes/print-vm.inc.php
+++ b/html/includes/print-vm.inc.php
@@ -10,10 +10,10 @@ if (getidbyname($vm['vmwVmDisplayName'])) {
 
 echo '</td>';
 
-if ($vm['vmwVmState'] == 'powered off') {
-    echo '<td class="list"><span style="min-width:40px; display:inline-block;" class="label label-default">OFF</span></td>';
-} else {
+if ($vm['vmwVmState'] == 'running' || $vm['vmwVmState'] == 'powered on') {
     echo '<td class="list"><span style="min-width:40px; display:inline-block;" class="label label-success">ON</span></td>';
+} else {
+    echo '<td class="list"><span style="min-width:40px; display:inline-block;" class="label label-default">OFF</span></td>';
 }
 
 if ($vm['vmwVmGuestOS'] == 'E: tools not installed') {

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1599,7 +1599,7 @@ vminfo:
     - { Field: id, Type: int(11), 'Null': false, Extra: auto_increment }
     - { Field: device_id, Type: int(11), 'Null': false, Extra: '' }
     - { Field: vm_type, Type: varchar(16), 'Null': false, Extra: '', Default: vmware }
-    - { Field: vmwVmVMID, Type: int(11), 'Null': false, Extra: '' }
+    - { Field: vmwVmVMID, Type: char(36), 'Null': false, Extra: '' }
     - { Field: vmwVmDisplayName, Type: varchar(128), 'Null': false, Extra: '' }
     - { Field: vmwVmGuestOS, Type: varchar(128), 'Null': false, Extra: '' }
     - { Field: vmwVmMemSize, Type: int(11), 'Null': false, Extra: '' }

--- a/sql-schema/240.sql
+++ b/sql-schema/240.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `vminfo` MODIFY `vmwVmVMID` CHAR(36) NOT NULL;


### PR DESCRIPTION
Note: I am a C/C++/Python guy, not a PHP guy, so be gentle/check carefully. I have tested this a bit on my qemu/kvm setup.

Commit message:
```Now we get all VMs (not just running ones), and we properly
display the power state. We now track VMs by UUID(permanent),
rather than temporary ID, which can change as other VMs are
deleted etc. This will reduce event log spam, and obviously
would be required if graphs etc. were added at a later date.

Note: possible VM states in current libvirt master branch:
- "no state",
- "running",
- "idle",
- "paused",
- "in shutdown",
- "shut off",
- "crashed",
- "pmsuspended"
```
Thus I modified the html to only consider "running" as ON, and everything else as OFF. Previously the code was actually wrong, and it displayed everything as ON. The states have not changed in at least 4 years: https://github.com/libvirt/libvirt/blame/master/tools/virsh-domain-monitor.c#L142-L150

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
