### PR TITLE
Use single quotes in example SNMP community per issue 8342

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -21,7 +21,7 @@ $config['base_url']        = "/";
 #$config['rrdcached']    = "unix:/var/run/rrdcached.sock";
 
 ### Default community
-$config['snmp']['community'] = array("public");
+$config['snmp']['community'] = array('public');
 
 ### Authentication Model
 $config['auth_mechanism'] = "mysql"; # default, other options: ldap, http-auth


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


To reduce confusion I've replaced the double quotes with single quotes in the example provided in config.php. See bug 8342