### PR TITLE
Module tests update: per module output, only store modules data that are run

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -32,6 +32,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class ModuleTestHelper
 {
+    private static $module_tables;
+
     private $quiet = false;
     private $modules;
     private $variant;
@@ -41,7 +43,6 @@ class ModuleTestHelper
     private $snmprec_dir;
     private $json_dir;
     private $file_name;
-    private $module_tables;
     private $discovery_module_output = [];
     private $poller_module_output = [];
     private $discovery_output;
@@ -88,7 +89,10 @@ class ModuleTestHelper
         $influxdb = false;
         Config::set('nographite', true);
 
-        $this->module_tables = Yaml::parse($install_dir . '/tests/module_tables.yaml');
+        if (is_null(self::$module_tables)) {
+            // only load the yaml once, then keep it in memory
+            self::$module_tables = Yaml::parse($install_dir . '/tests/module_tables.yaml');
+        }
     }
 
     private static function compareOid($a, $b)
@@ -667,7 +671,7 @@ class ModuleTestHelper
      */
     public function getTableData()
     {
-        return array_intersect_key($this->module_tables, array_flip($this->getModules()));
+        return array_intersect_key(self::$module_tables, array_flip($this->getModules()));
     }
 
     /**
@@ -686,6 +690,8 @@ class ModuleTestHelper
                 return "Module $module not run. Modules: " . implode(',', array_keys($this->poller_module_output));
             }
         }
+
+        return $this->discovery_output;
     }
 
     /**
@@ -716,7 +722,7 @@ class ModuleTestHelper
      */
     public function getSupportedModules()
     {
-        return array_keys($this->module_tables);
+        return array_keys(self::$module_tables);
     }
 
     /**

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -596,7 +596,8 @@ class ModuleTestHelper
      * @param string $type poller|disco identified by "#### Load disco module" string
      * @return array
      */
-    private function extractModuleOutput($output, $type) {
+    private function extractModuleOutput($output, $type)
+    {
         $module_output = [];
         $module_start = "#### Load $type module ";
         $module_end = "#### Unload $type module %s ####";

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -189,7 +189,7 @@ class ModuleTestHelper
             'sysObjectID.0_get' => array('oid' => 'sysObjectID.0', 'mib' => 'SNMPv2-MIB', 'method' => 'get'),
         );
         foreach ($snmp_matches[0] as $index => $line) {
-            preg_match('/-m ([a-zA-Z0-9:\-]+)/', $line, $mib_matches);
+            preg_match('/-m \+?([a-zA-Z0-9:\-]+)/', $line, $mib_matches);
             $mib = $mib_matches[1];
             $method = $snmp_matches[1][$index];
             $oids = explode(' ', trim($snmp_matches[2][$index]));

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -683,8 +683,7 @@ class ModuleTestHelper
             if (isset($this->discovery_module_output[$module])) {
                 return $this->discovery_module_output[$module];
             } else {
-                // requested module not run don't spam all output
-                return '';
+                return "Module $module not run. Modules: " . implode(',', array_keys($this->poller_module_output));
             }
         }
     }
@@ -702,8 +701,7 @@ class ModuleTestHelper
             if (isset($this->poller_module_output[$module])) {
                 return $this->poller_module_output[$module];
             } else {
-                // requested module not run don't spam all output
-                return '';
+                return "Module $module not run. Modules: " . implode(',', array_keys($this->poller_module_output));
             }
         }
 

--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -508,10 +508,10 @@ class ModuleTestHelper
         $data = array();  // array to hold dumped data
 
         // Run discovery
+        $save_debug = $debug;
+        $save_vedbug = $vdebug;
         if ($this->quiet) {
             ob_start();
-            $save_debug = $debug;
-            $save_vedbug = $vdebug;
             $debug = true;
             $vdebug = false;
         }

--- a/includes/graphite.inc.php
+++ b/includes/graphite.inc.php
@@ -15,7 +15,7 @@
 function graphite_update($device, $measurement, $tags, $fields)
 {
     global $graphite, $config;
-    if ($graphite !== false) {
+    if ($graphite != false) {
         $timestamp = time();
         $graphite_prefix = $config['graphite']['prefix'];
         // metrics will be built as prefix.hostname.measurement.field value timestamp

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -25,7 +25,6 @@
 
 namespace LibreNMS\Tests;
 
-use LibreNMS\Config;
 use LibreNMS\Exceptions\FileNotFoundException;
 use LibreNMS\Exceptions\InvalidModuleException;
 use LibreNMS\Util\ModuleTestHelper;
@@ -37,8 +36,8 @@ class OSModulesTest extends DBTestCase
      *
      * @group os
      * @dataProvider dumpedDataProvider
-     * @param string $target_os name of the (and variant) to test
-     * @param string $filename file name of the json data
+     * @param string $os base os
+     * @param string $variant optional variant
      * @param array $modules modules to test for this os
      */
     public function testOS($os, $variant, $modules)

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -49,8 +49,8 @@ class OSModulesTest extends DBTestCase
         try {
             $helper = new ModuleTestHelper($modules, $os, $variant);
             $helper->setQuiet();
-            $filename = $helper->getJsonFilepath(true);
 
+            $filename = $helper->getJsonFilepath(true);
             $expected_data = $helper->getTestData();
             $results = $helper->generateTestData($snmpsim, true);
         } catch (FileNotFoundException $e) {
@@ -65,6 +65,9 @@ class OSModulesTest extends DBTestCase
             $this->fail("$os: Failed to collect data.");
         }
 
+        // output all discovery and poller output if debug mode is enabled for phpunit
+        $debug = in_array('--debug', $_SERVER['argv'], true);
+
         foreach ($modules as $module) {
             $expected = $expected_data[$module]['discovery'];
             $actual = $results[$module]['discovery'];
@@ -73,7 +76,7 @@ class OSModulesTest extends DBTestCase
                 $actual,
                 "OS $os: Discovered $module data does not match that found in $filename\n"
                 . print_r(array_diff($expected, $actual), true)
-                . $helper->getDiscoveryOutput($module)
+                . $helper->getDiscoveryOutput($debug ? null : $module)
                 . "\nOS $os: Polled $module data does not match that found in $filename"
             );
 
@@ -88,7 +91,7 @@ class OSModulesTest extends DBTestCase
                 $actual,
                 "OS $os: Polled $module data does not match that found in $filename\n"
                 . print_r(array_diff($expected, $actual), true)
-                . $helper->getPollerOutput($module)
+                . $helper->getPollerOutput($debug ? null : $module)
                 . "\nOS $os: Polled $module data does not match that found in $filename"
             );
         }

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -71,7 +71,7 @@ class OSModulesTest extends DBTestCase
                 $actual,
                 "OS $os: Discovered $module data does not match that found in $filename\n"
                 . print_r(array_diff($expected, $actual), true)
-                . $helper->getLastDiscoveryOutput()
+                . $helper->getDiscoveryOutput($module)
                 . "\nOS $os: Polled $module data does not match that found in $filename"
             );
 
@@ -82,7 +82,7 @@ class OSModulesTest extends DBTestCase
                 $actual,
                 "OS $os: Polled $module data does not match that found in $filename\n"
                 . print_r(array_diff($expected, $actual), true)
-                . $helper->getLastPollerOutput()
+                . $helper->getPollerOutput($module)
                 . "\nOS $os: Polled $module data does not match that found in $filename"
             );
         }

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -55,8 +55,10 @@ class OSModulesTest extends DBTestCase
             $results = $helper->generateTestData($snmpsim, true);
         } catch (FileNotFoundException $e) {
             $this->fail($e->getMessage());
+            return;
         } catch (InvalidModuleException $e) {
             $this->fail($e->getMessage());
+            return;
         }
 
         if (is_null($results)) {
@@ -75,7 +77,11 @@ class OSModulesTest extends DBTestCase
                 . "\nOS $os: Polled $module data does not match that found in $filename"
             );
 
-            $expected = $expected_data[$module]['poller'] == 'matches discovery' ? $expected_data[$module]['discovery'] : $expected_data[$module]['poller'];
+            if ($expected_data[$module]['poller'] == 'matches discovery') {
+                $expected = $expected_data[$module]['discovery'];
+            } else {
+                $expected = $expected_data[$module]['poller'];
+            }
             $actual = $results[$module]['poller'];
             $this->assertEquals(
                 $expected,

--- a/tests/data/allied_alliedware.json
+++ b/tests/data/allied_alliedware.json
@@ -1,11 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
     "arp-table": {
         "discovery": {
             "ipv4_mac": [
@@ -41,7 +34,7 @@
                 }
             ]
         },
-        "poller": "matches discovery"
+        "poller": null
     },
     "bgp-peers": {
         "discovery": {
@@ -5919,13 +5912,6 @@
         },
         "poller": "matches discovery"
     },
-    "sensors": {
-        "discovery": {
-            "sensors": [],
-            "state_indexes": []
-        },
-        "poller": "matches discovery"
-    },
     "storage": {
         "discovery": {
             "storage": [
@@ -5961,11 +5947,5 @@
                 }
             ]
         }
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
-        },
-        "poller": "matches discovery"
     }
 }

--- a/tests/data/allied_awplusv2.json
+++ b/tests/data/allied_awplusv2.json
@@ -1,11 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
     "arp-table": {
         "discovery": {
             "ipv4_mac": [
@@ -16,19 +9,7 @@
                 }
             ]
         },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
+        "poller": null
     },
     "mempools": {
         "discovery": {
@@ -10670,25 +10651,6 @@
     "processors": {
         "discovery": {
             "processors": []
-        },
-        "poller": "matches discovery"
-    },
-    "sensors": {
-        "discovery": {
-            "sensors": [],
-            "state_indexes": []
-        },
-        "poller": "matches discovery"
-    },
-    "storage": {
-        "discovery": {
-            "storage": []
-        },
-        "poller": "matches discovery"
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
         },
         "poller": "matches discovery"
     }

--- a/tests/data/allied_websmart.json
+++ b/tests/data/allied_websmart.json
@@ -1,17 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
-    "arp-table": {
-        "discovery": {
-            "ipv4_mac": []
-        },
-        "poller": "matches discovery"
-    },
     "mempools": {
         "discovery": {
             "mempools": []
@@ -5157,25 +5144,6 @@
     "processors": {
         "discovery": {
             "processors": []
-        },
-        "poller": "matches discovery"
-    },
-    "sensors": {
-        "discovery": {
-            "sensors": [],
-            "state_indexes": []
-        },
-        "poller": "matches discovery"
-    },
-    "storage": {
-        "discovery": {
-            "storage": []
-        },
-        "poller": "matches discovery"
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
         },
         "poller": "matches discovery"
     }

--- a/tests/data/arbos.json
+++ b/tests/data/arbos.json
@@ -1,29 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
-    "arp-table": {
-        "discovery": {
-            "ipv4_mac": []
-        },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
-    },
     "mempools": {
         "discovery": {
             "mempools": [
@@ -2939,14 +2914,7 @@
             "processors": []
         },
         "poller": "matches discovery"
-    },
-    "sensors": {
-        "discovery": {
-            "sensors": [],
-            "state_indexes": []
-        },
-        "poller": "matches discovery"
-    },
+    }
     "storage": {
         "discovery": {
             "storage": [
@@ -3060,11 +3028,5 @@
                 }
             ]
         }
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
-        },
-        "poller": "matches discovery"
     }
 }

--- a/tests/data/awplus.json
+++ b/tests/data/awplus.json
@@ -1,11 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
     "arp-table": {
         "discovery": {
             "ipv4_mac": [
@@ -36,7 +29,7 @@
                 }
             ]
         },
-        "poller": "matches discovery"
+        "poller": null
     },
     "bgp-peers": {
         "discovery": {
@@ -12582,11 +12575,5 @@
                 }
             ]
         }
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
-        },
-        "poller": "matches discovery"
     }
 }

--- a/tests/data/cnos.json
+++ b/tests/data/cnos.json
@@ -1,35 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
-    },
-    "mempools": {
-        "discovery": {
-            "mempools": []
-        },
-        "poller": "matches discovery"
-    },
-    "ports": {
-        "discovery": {
-            "ports": []
-        },
-        "poller": "matches discovery"
-    },
     "os": {
         "discovery": {
             "devices": [
@@ -48,31 +17,6 @@
                     "icon": "lenovo.svg"
                 }
             ]
-        },
-        "poller": "matches discovery"
-    },
-    "processors": {
-        "discovery": {
-            "processors": []
-        },
-        "poller": "matches discovery"
-    },
-    "sensors": {
-        "discovery": {
-            "sensors": [],
-            "state_indexes": []
-        },
-        "poller": "matches discovery"
-    },
-    "storage": {
-        "discovery": {
-            "storage": []
-        },
-        "poller": "matches discovery"
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
         },
         "poller": "matches discovery"
     }

--- a/tests/data/dell-ups.json
+++ b/tests/data/dell-ups.json
@@ -1,11 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
     "arp-table": {
         "discovery": {
             "ipv4_mac": [
@@ -16,25 +9,7 @@
                 }
             ]
         },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
-    },
-    "mempools": {
-        "discovery": {
-            "mempools": []
-        },
-        "poller": "matches discovery"
+        "poller": null
     },
     "ports": {
         "discovery": {
@@ -749,17 +724,5 @@
                 }
             ]
         }
-    },
-    "storage": {
-        "discovery": {
-            "storage": []
-        },
-        "poller": "matches discovery"
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
-        },
-        "poller": "matches discovery"
     }
 }

--- a/tests/data/junos_ex.json
+++ b/tests/data/junos_ex.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
     "bgp-peers": {
         "discovery": {
             "devices": [
@@ -117,9 +116,7 @@
             ],
             "bgpPeers_cbgp": []
         }
-    }
-}
-=======
+    },
     "processors": {
         "discovery": {
             "processors": [
@@ -150,4 +147,3 @@
         "poller": "matches discovery"
     }
 }
->>>>>>> Extract DiscoveryItem and move some things to better places.

--- a/tests/data/radlan.json
+++ b/tests/data/radlan.json
@@ -1,11 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
     "arp-table": {
         "discovery": {
             "ipv4_mac": [
@@ -16,25 +9,7 @@
                 }
             ]
         },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
-    },
-    "mempools": {
-        "discovery": {
-            "mempools": []
-        },
-        "poller": "matches discovery"
+        "poller": null
     },
     "ports": {
         "discovery": {
@@ -14727,25 +14702,6 @@
                     "processor_perc_warn": "75"
                 }
             ]
-        },
-        "poller": "matches discovery"
-    },
-    "sensors": {
-        "discovery": {
-            "sensors": [],
-            "state_indexes": []
-        },
-        "poller": "matches discovery"
-    },
-    "storage": {
-        "discovery": {
-            "storage": []
-        },
-        "poller": "matches discovery"
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
         },
         "poller": "matches discovery"
     }

--- a/tests/data/routeros.json
+++ b/tests/data/routeros.json
@@ -1,11 +1,4 @@
 {
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
     "arp-table": {
         "discovery": {
             "ipv4_mac": [
@@ -86,19 +79,7 @@
                 }
             ]
         },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
+        "poller": null
     },
     "mempools": {
         "discovery": {

--- a/tests/data/screenos.json
+++ b/tests/data/screenos.json
@@ -4333,6 +4333,6 @@
                 }
             ]
         },
-        "poller": "matches discovery"
+        "poller": null
     }
 }

--- a/tests/data/stoneos.json
+++ b/tests/data/stoneos.json
@@ -37,31 +37,6 @@
             ]
         }
     },
-    "applications": {
-        "discovery": {
-            "applications": [],
-            "application_metrics": []
-        },
-        "poller": "matches discovery"
-    },
-    "arp-table": {
-        "discovery": {
-            "ipv4_mac": []
-        },
-        "poller": "matches discovery"
-    },
-    "bgp-peers": {
-        "discovery": {
-            "devices": [
-                {
-                    "bgpLocalAs": null
-                }
-            ],
-            "bgpPeers": [],
-            "bgpPeers_cbgp": []
-        },
-        "poller": "matches discovery"
-    },
     "mempools": {
         "discovery": {
             "mempools": [
@@ -4157,18 +4132,6 @@
                     "state_generic_value": "3"
                 }
             ]
-        },
-        "poller": "matches discovery"
-    },
-    "storage": {
-        "discovery": {
-            "storage": []
-        },
-        "poller": "matches discovery"
-    },
-    "wireless": {
-        "discovery": {
-            "wireless_sensors": []
         },
         "poller": "matches discovery"
     }

--- a/tests/module_tables.yaml
+++ b/tests/module_tables.yaml
@@ -25,6 +25,7 @@ ports:
         excluded_fields: [device_id, port_id, poll_time, poll_period]
         joins:
             - { left: ports.port_id, right: ports_statistics.port_id }
+        order_by: ports.ifIndex, ports.ifDescr, ports.ifName
 os:
     devices:
         included_fields: [sysName, sysObjectID, sysDescr, sysContact, version, hardware, features, location, os, type, serial, icon]


### PR DESCRIPTION
- Don't save data for modules that were not run
- Save output for each module and only output the errorred module
- Full output when phpunit --debug is used

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
