### PR TITLE
Auto IPv6/IPv4 detection when adding host

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -73,7 +73,7 @@ if (!empty($argv[1])) {
     $snmpver   = strtolower($argv[3]);
 
     $port      = 161;
-    $transport = 'udp';
+    $transport = 'auto';
 
     $additional = array();
     if (isset($options['b'])) {

--- a/doc/Support/SNMP-Configuration-Examples.md
+++ b/doc/Support/SNMP-Configuration-Examples.md
@@ -169,7 +169,12 @@ vi /etc/snmp/snmpd.conf
 
 ```
 # Change RANDOMSTRINGGOESHERE to your preferred SNMP community string
-com2sec readonly  default         RANDOMSTRINGGOESHERE
+com2sec  readonly  default      RANDOMSTRINGGOESHERE
+com2sec6 readonly  default      RANDOMSTRINGGOESHERE
+
+# listen on IPv4 and IPv6
+agentaddress udp:161
+agentaddress udp6:161
 
 group MyROGroup v2c        readonly
 view all    included  .1                               80
@@ -179,7 +184,7 @@ syslocation Rack, Room, Building, City, Country [GPSX,Y]
 syscontact Your Name <your@email.address>
 
 #Distro Detection
-extend .1.3.6.1.4.1.2021.7890.1 distro /usr/bin/distro
+extend distro /usr/bin/distro
 ```
 
 If you have 'dmidecode' installed on your host, you can add the following lines for additional hardware detection.

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -382,7 +382,7 @@ function add_device()
 
     $hostname     = $data['hostname'];
     $port         = $data['port'] ? mres($data['port']) : $config['snmp']['port'];
-    $transport    = $data['transport'] ? mres($data['transport']) : 'udp';
+    $transport    = $data['transport'] ? mres($data['transport']) : 'auto';
     $poller_group = $data['poller_group'] ? mres($data['poller_group']) : 0;
     $force_add    = $data['force_add'] ? true : false;
     $snmp_disable = ($data['snmp_disable']);
@@ -1274,7 +1274,7 @@ function list_bills()
         $sql    .= ' AND `bill_id` IN (SELECT `bill_id` FROM `bill_perms` WHERE `user_id` = ?)';
         $param[] = $_SESSION['user_id'];
     }
-    
+
     if ($period === 'previous') {
         $select = "SELECT bills.bill_name, bills.bill_notes, bill_history.*, bill_history.traf_total as total_data, bill_history.traf_in as total_data_in, bill_history.traf_out as total_data_out ";
         $query = 'FROM `bills`
@@ -1331,7 +1331,7 @@ function get_bill_graph()
     if (!is_admin() && !is_read()) {
         check_bill_permission($bill_id);
     }
-    
+
     if ($graph_type == 'monthly') {
         $graph_type = 'historicmonthly';
     }
@@ -1367,7 +1367,7 @@ function get_bill_graphdata()
     } else if ($graph_type == 'monthly') {
         $graph_data = getHistoricTransferGraphData($bill_id);
     }
-    
+
     if (!isset($graph_data)) {
         api_error(400, "Unsupported graph type $graph_type");
     } else {
@@ -1397,7 +1397,7 @@ function get_bill_history()
 function get_bill_history_graph()
 {
     global $config;
-    
+
     $app = \Slim\Slim::getInstance();
     $router = $app->router()->getCurrentRoute()->getParams();
     $bill_id = mres($router['bill_id']);
@@ -1407,7 +1407,7 @@ function get_bill_history_graph()
     if (!is_admin() && !is_read()) {
         check_bill_permission($bill_id);
     }
-    
+
     $vars = array();
 
     switch ($graph_type) {
@@ -1415,13 +1415,13 @@ function get_bill_history_graph()
             $graph_type = 'historicbits';
             $vars['reducefactor'] = $_GET['reducefactor'];
             break;
-            
+
         case 'day':
         case 'hour':
             $vars['imgtype'] = $graph_type;
             $graph_type = 'historictransfer';
             break;
-            
+
         default:
             api_error(400, "Unknown Graph Type $graph_type");
             break;
@@ -1451,7 +1451,7 @@ function get_bill_history_graphdata()
     if (!is_admin() && !is_read()) {
         check_bill_permission($bill_id);
     }
-    
+
     switch ($graph_type) {
         case 'bits':
             $reducefactor = $_GET['reducefactor'];
@@ -1463,7 +1463,7 @@ function get_bill_history_graphdata()
             $graph_data = getBillingBandwidthGraphData($bill_id, $bill_hist_id, null, null, $graph_type);
             break;
     }
-    
+
     if (!isset($graph_data)) {
         api_error(400, "Unsupported graph type $graph_type");
     } else {

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -36,7 +36,7 @@ if (!empty($_POST['hostname'])) {
         if ($_POST['transport']) {
             $transport = clean($_POST['transport']);
         } else {
-            $transport = 'udp';
+            $transport = 'auto';
         }
 
         $additional = array();
@@ -156,17 +156,18 @@ $pagetitle[] = 'Add host';
             <input type="text" name="port" placeholder="port" class="form-control input-sm">
           </div>
           <div class="col-sm-3">
-            <select name="transport" id="transport" class="form-control input-sm">
-<?php
-foreach ($config['snmp']['transports'] as $transport) {
-    echo "<option value='".$transport."'";
-    if ($transport == $device['transport']) {
-        echo " selected='selected'";
-    }
-
-    echo '>'.$transport.'</option>';
-}
-?>
+            <select name="transport" id="transport" class="form-control input-sm" title="Transport: Connect to device via IPv4 or IPv6 and UDP or TCP">
+                <optgroup label="Auto">
+                    <option value="auto" selected="selected">UDP</option>
+                </optgroup>
+                <optgroup label="IPv4">
+                    <option value="udp">UDP</option>
+                    <option value="tcp">TCP</option>
+                </optgroup>
+                <optgroup label="IPv6">
+                    <option value="udp6">UDP</option>
+                    <option value="tcp6">TCP</option>
+                </optgroup>
             </select>
           </div>
         </div>

--- a/html/pages/device/edit/snmp.inc.php
+++ b/html/pages/device/edit/snmp.inc.php
@@ -144,7 +144,7 @@ echo "
     <input type=hidden name='editing' value='yes'>
     <div class='form-group'>
     <label for='snmpver' class='col-sm-2 control-label'>SNMP Details</label>
-    <div class='col-sm-1'>
+    <div class='col-sm-2'>
     <select id='snmpver' name='snmpver' class='form-control input-sm' onChange='changeForm();'>
     <option value='v1'>v1</option>
     <option value='v2c' ".($device['snmpver'] == 'v2c' ? 'selected' : '').">v2c</option>
@@ -154,7 +154,7 @@ echo "
     <div class='col-sm-2'>
     <input type='text' name='port' placeholder='port' class='form-control input-sm' value='".($device['port'] == $config['snmp']['port'] ? "" : $device['port'])."'>
     </div>
-    <div class='col-sm-1'>
+    <div class='col-sm-2'>
     <select name='transport' id='transport' class='form-control input-sm'>";
 foreach ($config['snmp']['transports'] as $transport) {
     echo "<option value='".$transport."'";
@@ -171,16 +171,16 @@ echo "      </select>
     <div class='form-group'>
     <div class='col-sm-2'>
     </div>
-    <div class='col-sm-1'>
+    <div class='col-sm-2'>
     <input id='timeout' name='timeout' class='form-control input-sm' value='".($device['timeout'] ? $device['timeout'] : '')."' placeholder='seconds' />
     </div>
-    <div class='col-sm-1'>
+    <div class='col-sm-2'>
     <input id='retries' name='retries' class='form-control input-sm' value='".($device['timeout'] ? $device['retries'] : '')."' placeholder='retries' />
     </div>
     </div>
     <div class='form-group'>
       <label for='port_assoc_mode' class='col-sm-2 control-label'>Port Association Mode</label>
-      <div class='col-sm-1'>
+      <div class='col-sm-2'>
         <select name='port_assoc_mode' id='port_assoc_mode' class='form-control input-sm'>
 ";
 
@@ -200,19 +200,19 @@ echo "        </select>
     </div>
     <div class='form-group'>
         <label for='max_repeaters' class='col-sm-2 control-label'>Max Repeaters</label>
-        <div class='col-sm-1'>
+        <div class='col-sm-2'>
             <input id='max_repeaters' name='max_repeaters' class='form-control input-sm' value='".$max_repeaters."' placeholder='max rep' />
         </div>
     </div>
     <div class='form-group'>
         <label for='max_oid' class='col-sm-2 control-label'>Max OIDs</label>
-        <div class='col-sm-1'>
+        <div class='col-sm-2'>
             <input id='max_oid' name='max_oid' class='form-control input-sm' value='".$max_oid."' placeholder='max oids' />
         </div>
     </div>
     <div id='snmpv1_2'>
     <div class='form-group'>
-    <label class='col-sm-3 control-label text-left'><h4><strong>SNMPv1/v2c Configuration</strong></h4></label>
+    <label class='col-sm-6 col-sm-offset-2 control-label'><h4 class='text-left'><strong>SNMPv1/v2c Configuration</strong></h4></label>
     </div>
     <div class='form-group'>
     <label for='community' class='col-sm-2 control-label'>SNMP Community</label>
@@ -223,7 +223,7 @@ echo "        </select>
     </div>
     <div id='snmpv3'>
     <div class='form-group'>
-    <label class='col-sm-3 control-label'><h4><strong>SNMPv3 Configuration</strong></h4></label>
+    <label class='col-sm-6 col-sm-offset-2 control-label'><h4 class='text-left'>SNMPv3 Configuration</strong></h4></label>
     </div>
     <div class='form-group'>
     <label for='authlevel' class='col-sm-2 control-label'>Auth Level</label>

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -67,7 +67,7 @@ function discover_new_device($hostname, $device = '', $method = '', $interface =
     }
 
     try {
-        $remote_device_id = addHost($hostname, '', '161', 'udp', Config::get('distributed_poller_group'));
+        $remote_device_id = addHost($hostname, '', '161', 'auto', Config::get('distributed_poller_group'));
         $remote_device = device_by_id_cache($remote_device_id, 1);
         echo '+[' . $remote_device['hostname'] . '(' . $remote_device['device_id'] . ')]';
         discover_device($remote_device);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -21,6 +21,7 @@ use LibreNMS\Exceptions\InvalidPortAssocModeException;
 use LibreNMS\Exceptions\LockException;
 use LibreNMS\Exceptions\SnmpVersionUnsupportedException;
 use LibreNMS\Util\IP;
+use LibreNMS\Util\IPv4;
 use LibreNMS\Util\MemcacheLock;
 
 function set_debug($debug)
@@ -495,7 +496,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'auto', 
         // determine transport, if auto (auto assumes udp)
         if ($transport == 'auto') {
             $transports = ['udp'];
-            // check if ip is ipv6,if so, try ipv6 first
+            // check if ip is ipv6, if so, try ipv6 first
             try {
                 if (IP::parse($ip)->getFamily() == 'ipv6') {
                     $transports = ['udp6', 'udp'];
@@ -1601,7 +1602,7 @@ function dnslookup($hostname, $type = 'auto')
 
     // try ipv4, we use gethostbyname here to so we also pull in hosts file
     $ipv4 = gethostbyname($hostname);
-    if (IP::isValid($ipv4)) {
+    if (IPv4::isValid($ipv4)) {
         return $ipv4;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -488,7 +488,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'auto', 
         $ip = dnslookup($host, $transport);
 
         // check if we have the host by IP
-        if ($force_add !== true && ip_exists($ip)) {
+        if ($check_ip && $force_add !== true && ip_exists($ip)) {
             $desc = $host == $ip ? $host : "$host ($ip)";
             throw new HostIpExistsException("Already have host with this IP $desc");
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -466,7 +466,7 @@ function delete_device($id)
  * @throws InvalidPortAssocModeException The given port association mode was invalid
  * @throws SnmpVersionUnsupportedException The given snmp version was invalid
  */
-function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $poller_group = '0', $force_add = false, $port_assoc_mode = 'ifIndex', $additional = array())
+function addHost($host, $snmp_version = '', $port = '161', $transport = 'auto', $poller_group = '0', $force_add = false, $port_assoc_mode = 'ifIndex', $additional = array())
 {
     global $config;
 
@@ -480,67 +480,84 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
         throw new InvalidPortAssocModeException("Invalid port association_mode '$port_assoc_mode'. Valid modes are: " . join(', ', get_port_assoc_modes()));
     }
 
-    // check if we have the host by IP
-    if ($config['addhost_alwayscheckip'] === true) {
-        $ip = gethostbyname($host);
-    } else {
-        $ip = $host;
-    }
-    if ($force_add !== true && ip_exists($ip)) {
-        throw new HostIpExistsException("Already have host with this IP $host");
-    }
+    // check ip and resolve auto transport (otherwise avoid dns queries)
+    $check_ip = Config::get('addhost_alwayscheckip', false);
+    $transports = [$transport];
+    if ($check_ip || $transport == 'auto') {
+        $ip = dnslookup($host, $transport);
 
-    // Test reachability
-    if (!$force_add) {
-        $address_family = snmpTransportToAddressFamily($transport);
-        $ping_result = isPingable($host, $address_family);
-        if (!$ping_result['result']) {
-            throw new HostUnreachablePingException("Could not ping $host");
+        // check if we have the host by IP
+        if ($force_add !== true && ip_exists($ip)) {
+            $desc = $host == $ip ? $host : "$host ($ip)";
+            throw new HostIpExistsException("Already have host with this IP $desc");
+        }
+
+        // determine transport, if auto (auto assumes udp)
+        if ($transport == 'auto') {
+            $transports = ['udp'];
+            // check if ip is ipv6,if so, try ipv6 first
+            try {
+                if (IP::parse($ip)->getFamily() == 'ipv6') {
+                    $transports = ['udp6', 'udp'];
+                }
+            } catch (InvalidIpException $e) {
+            }
         }
     }
 
-    // if $snmpver isn't set, try each version of snmp
-    if (empty($snmp_version)) {
-        $snmpvers = array('v2c', 'v3', 'v1');
-    } else {
-        $snmpvers = array($snmp_version);
-    }
-
-    if (isset($additional['snmp_disable']) && $additional['snmp_disable'] == 1) {
-        return createHost($host, '', $snmp_version, $port, $transport, array(), $poller_group, 1, true, $additional);
-    }
-    $host_unreachable_exception = new HostUnreachableException("Could not connect to $host, please check the snmp details and snmp reachability");
-    // try different snmp variables to add the device
-    foreach ($snmpvers as $snmpver) {
-        if ($snmpver === "v3") {
-            // Try each set of parameters from config
-            foreach ($config['snmp']['v3'] as $v3) {
-                $device = deviceArray($host, null, $snmpver, $port, $transport, $v3, $port_assoc_mode);
-                if ($force_add === true || isSNMPable($device)) {
-                    return createHost($host, null, $snmpver, $port, $transport, $v3, $poller_group, $port_assoc_mode, $force_add);
-                } else {
-                    $host_unreachable_exception->addReason("SNMP $snmpver: No reply with credentials " . $v3['authname'] . "/" . $v3['authlevel']);
-                }
+    foreach ($transports as $transport) {
+        // Test reachability
+        if (!$force_add) {
+            $address_family = snmpTransportToAddressFamily($transport);
+            $ping_result = isPingable($host, $address_family);
+            if (!$ping_result['result']) {
+                throw new HostUnreachablePingException("Could not ping $host");
             }
-        } elseif ($snmpver === "v2c" || $snmpver === "v1") {
-            // try each community from config
-            foreach ($config['snmp']['community'] as $community) {
-                $device = deviceArray($host, $community, $snmpver, $port, $transport, null, $port_assoc_mode);
+        }
 
-                if ($force_add === true || isSNMPable($device)) {
-                    return createHost($host, $community, $snmpver, $port, $transport, array(), $poller_group, $port_assoc_mode, $force_add);
-                } else {
-                    $host_unreachable_exception->addReason("SNMP $snmpver: No reply with community $community");
-                }
-            }
+        // if $snmpver isn't set, try each version of snmp
+        if (empty($snmp_version)) {
+            $snmpvers = array('v2c', 'v3', 'v1');
         } else {
-            throw new SnmpVersionUnsupportedException("Unsupported SNMP Version \"$snmpver\", must be v1, v2c, or v3");
+            $snmpvers = array($snmp_version);
         }
-    }
-    if (isset($additional['ping_fallback']) && $additional['ping_fallback'] == 1) {
-        $additional['snmp_disable'] = 1;
-        $additional['os'] = "ping";
-        return createHost($host, '', $snmp_version, $port, $transport, array(), $poller_group, 1, true, $additional);
+
+        if (isset($additional['snmp_disable']) && $additional['snmp_disable'] == 1) {
+            return createHost($host, '', $snmp_version, $port, $transport, array(), $poller_group, 1, true, $additional);
+        }
+        $host_unreachable_exception = new HostUnreachableException("Could not connect to $host, please check the snmp details and snmp reachability");
+        // try different snmp variables to add the device
+        foreach ($snmpvers as $snmpver) {
+            if ($snmpver === "v3") {
+                // Try each set of parameters from config
+                foreach ($config['snmp']['v3'] as $v3) {
+                    $device = deviceArray($host, null, $snmpver, $port, $transport, $v3, $port_assoc_mode);
+                    if ($force_add === true || isSNMPable($device)) {
+                        return createHost($host, null, $snmpver, $port, $transport, $v3, $poller_group, $port_assoc_mode, $force_add);
+                    } else {
+                        $host_unreachable_exception->addReason("SNMP $snmpver: No reply with credentials " . $v3['authname'] . "/" . $v3['authlevel']);
+                    }
+                }
+            } elseif ($snmpver === "v2c" || $snmpver === "v1") {
+                // try each community from config
+                foreach ($config['snmp']['community'] as $community) {
+                    $device = deviceArray($host, $community, $snmpver, $port, $transport, null, $port_assoc_mode);
+
+                    if ($force_add === true || isSNMPable($device)) {
+                        return createHost($host, $community, $snmpver, $port, $transport, array(), $poller_group, $port_assoc_mode, $force_add);
+                    } else {
+                        $host_unreachable_exception->addReason("SNMP $snmpver: No reply with community $community");
+                    }
+                }
+            } else {
+                throw new SnmpVersionUnsupportedException("Unsupported SNMP Version \"$snmpver\", must be v1, v2c, or v3");
+            }
+        }
+        if (isset($additional['ping_fallback']) && $additional['ping_fallback'] == 1) {
+            $additional['snmp_disable'] = 1;
+            $additional['os'] = "ping";
+            return createHost($host, '', $snmp_version, $port, $transport, array(), $poller_group, 1, true, $additional);
+        }
     }
     throw $host_unreachable_exception;
 }
@@ -1557,32 +1574,38 @@ function oxidized_reload_nodes()
 /**
  * Perform DNS lookup
  *
- * @param array $device Device array from database
- * @param string $type The type of record to lookup
+ * @param $hostname
+ * @param string $type  valid types: auto (ipv6 then ipv4), ipv6, ip, ipv4, udp6, udp, tcp6, tcp
  *
  * @return string ip
  *
-**/
-function dnslookup($device, $type = false, $return = false)
+ */
+function dnslookup($hostname, $type = 'auto')
 {
-    if (filter_var($device['hostname'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) == true || filter_var($device['hostname'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) == true) {
-        return false;
+    if (IP::isValid($hostname)) {
+        return $hostname;
     }
-    if (empty($type)) {
-        // We are going to use the transport to work out the record type
-        if ($device['transport'] == 'udp6' || $device['transport'] == 'tcp6') {
-            $type = DNS_AAAA;
-            $return = 'ipv6';
-        } else {
-            $type = DNS_A;
-            $return = 'ip';
+
+    $lookup_aaaa = ends_with($type, '6');
+
+    // try ipv6
+    if ($type == 'auto' || $lookup_aaaa) {
+        $record = dns_get_record($hostname, DNS_AAAA);
+        if (isset($record[0]['ipv6'])) {
+            return $record[0]['ipv6'];
+        } elseif ($lookup_aaaa) {
+            // we only want ipv6 addresses, don't try ipv4
+            return false;
         }
     }
-    if (empty($return)) {
-        return false;
+
+    // try ipv4, we use gethostbyname here to so we also pull in hosts file
+    $ipv4 = gethostbyname($hostname);
+    if (IP::isValid($ipv4)) {
+        return $ipv4;
     }
-    $record = dns_get_record($device['hostname'], $type);
-    return $record[0][$return];
+
+    return false;
 }//end dnslookup
 
 

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -229,7 +229,7 @@ function poll_device($device, $options)
     echo 'Hostname: ' . $device['hostname'] . PHP_EOL;
     echo 'Device ID: ' . $device['device_id'] . PHP_EOL;
     echo 'OS: ' . $device['os'];
-    $ip = dnslookup($device);
+    $ip = dnslookup($device['hostname'], $device['transport']);
     $db_ip = inet_pton($ip);
 
     if (!empty($db_ip) && inet6_ntop($db_ip) != inet6_ntop($device['ip'])) {

--- a/snmpd.conf.example
+++ b/snmpd.conf.example
@@ -1,5 +1,10 @@
 # Change RANDOMSTRINGGOESHERE to your preferred SNMP community string
-com2sec readonly  default         RANDOMSTRINGGOESHERE
+com2sec  readonly  default      RANDOMSTRINGGOESHERE
+com2sec6 readonly  default      RANDOMSTRINGGOESHERE
+
+# listen on IPv4 and IPv6
+agentaddress udp:161
+agentaddress udp6:161
 
 group MyROGroup v2c        readonly
 view all    included  .1                               80
@@ -9,5 +14,5 @@ syslocation Rack, Room, Building, City, Country [GPSX,Y]
 syscontact Your Name <your@email.address>
 
 #Distro Detection
-extend .1.3.6.1.4.1.2021.7890.1 distro /usr/bin/distro
+extend distro /usr/bin/distro
 


### PR DESCRIPTION
Fallback to ipv4 if snmpd isn't listening on ipv6 (as our example configures)
Update snmpd.conf example to listen on IPv6
refactor dnslookup() supports auto (ipv6 then ipv4) and hosts file for ipv4 at least.
Improve layout in the device snmp settings page

Tested adding:
ipv4 only
dual ipv4 listen only
dual dual listen

![image](https://user-images.githubusercontent.com/39462/37322271-88663662-264a-11e8-9987-9e085ba01379.png)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
