### PR TITLE
Update Applications.md

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -59,7 +59,7 @@ wget https://raw.githubusercontent.com/librenms/librenms-agent/master/snmp/apach
 2. Make the script executable (chmod +x /etc/snmp/apache-stats.py)
 
 3. Verify it is working by running /etc/snmp/apache-stats.py
-(In some cases urlgrabber needs to be installed, in Debian it can be achieved by: apt-get install python-urlgrabber)
+In some cases urlgrabber and pycurl needs to be installed, in Debian this can be achieved by: apt-get install python-urlgrabber python-pycurl . Make sure to remove /tmp/apache-snmp afterwards.
 
 4. Edit your snmpd.conf file (usually /etc/snmp/snmpd.conf) and add:
 ```
@@ -67,6 +67,11 @@ extend apache /etc/snmp/apache-stats.py
 ```
 
 5. Restart snmpd on your host
+
+6. Test by running
+```
+snmpwalk <various options depending on your setup> localhost NET-SNMP-EXTEND-MIB::nsExtendOutput2Table
+```
 
 ##### Agent
 [Install the agent](Agent-Setup.md) on this device if it isn't already and copy the `apache` script to `/usr/lib/check_mk_agent/local/`


### PR DESCRIPTION
Added a hint about removing /tmp/apache-snmp if the apache-stats.py script has been run manually. If run as root, it leaves behind a file which the user running snmpd cannot overwrite. Causing snmpd to not produce apache stats.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
