### PR TITLE
Sane default temperature limits for Axis cameras

### DIFF
--- a/includes/discovery/sensors/temperature/axiscam.inc.php
+++ b/includes/discovery/sensors/temperature/axiscam.inc.php
@@ -15,5 +15,5 @@ foreach (array_keys($oids) as $index) {
     $current         = $cur_oid[$index]['tempSensorValue'];
     $oid             = $cur_oid.$index;
 
-    discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, 'axiscam', 'Temperature Sensor '.$index, '1', '1', '', '', '', '', $current);
+    discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, 'axiscam', 'Temperature Sensor '.$index, '1', '1', '5', '10', '30', '35', $current);
 }


### PR DESCRIPTION
Default behaviour is to set low limit to (current temperature - 10 deg) and high limit to (current temperature + 20 deg) upon discovery. Changing that to abs values +5 and +35 deg respectively to be in realistic boundaries.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
