### PR TITLE
fix: Change rootPort DB data type

### DIFF
--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1484,7 +1484,7 @@ stp:
     - { Field: topChanges, Type: mediumint(9), 'Null': false, Extra: '' }
     - { Field: designatedRoot, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: rootCost, Type: mediumint(9), 'Null': false, Extra: '' }
-    - { Field: rootPort, Type: mediumint(9), 'Null': false, Extra: '' }
+    - { Field: rootPort, Type: int(11), 'Null': true, Extra: '' }
     - { Field: maxAge, Type: mediumint(9), 'Null': false, Extra: '' }
     - { Field: helloTime, Type: mediumint(9), 'Null': false, Extra: '' }
     - { Field: holdTime, Type: mediumint(9), 'Null': false, Extra: '' }

--- a/sql-schema/246.sql
+++ b/sql-schema/246.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `stp` MODIFY `rootPort` int(11);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Some equipment reported back a value that was bigger than the current data type limits, hence it never got updated and was spamming the eventlog. This should fix that.