### PR TITLE
alert: Added support for disabling recovery notifications

### DIFF
--- a/LibreNMS/Alerting/QueryBuilderFilter.php
+++ b/LibreNMS/Alerting/QueryBuilderFilter.php
@@ -32,7 +32,9 @@ use Symfony\Component\Yaml\Yaml;
 class QueryBuilderFilter implements \JsonSerializable
 {
     private static $table_blacklist = [
-        'device_group_device'
+        'device_group_device',
+        'alerts',
+        'alert_log',
     ];
 
     private $filter = [];

--- a/doc/Alerting/Rules.md
+++ b/doc/Alerting/Rules.md
@@ -58,6 +58,7 @@ Here are some of the other options available when adding an alerting rule:
 - Interval: The interval of time in seconds between alerts for an event until Max alert is reached.
 - Mute alerts: Disables sending alert rule through alert transport. But will still show the alert in the Web UI.
 - Invert match: Invert the matching rule (ie. alert on items that _don't_ match the rule).
+- Disable recovery: This will disable the recovery notification from being sent.
 
 ## Procedure
 You can associate a rule to a procedure by giving the URL of the procedure when creating the rule. Only links like "http://" are supported, otherwise an error will be returned. Once configured, procedure can be opened from the Alert widget through the "Open" button, which can be shown/hidden from the widget configuration box.

--- a/doc/Alerting/Rules.md
+++ b/doc/Alerting/Rules.md
@@ -58,7 +58,7 @@ Here are some of the other options available when adding an alerting rule:
 - Interval: The interval of time in seconds between alerts for an event until Max alert is reached.
 - Mute alerts: Disables sending alert rule through alert transport. But will still show the alert in the Web UI.
 - Invert match: Invert the matching rule (ie. alert on items that _don't_ match the rule).
-- Disable recovery: This will disable the recovery notification from being sent.
+- Recovery alerts: This will disable the recovery notification from being sent if turned off.
 
 ## Procedure
 You can associate a rule to a procedure by giving the URL of the procedure when creating the rule. Only links like "http://" are supported, otherwise an error will be returned. Once configured, procedure can be opened from the Alert widget through the "Open" button, which can be shown/hidden from the widget configuration box.

--- a/html/includes/forms/alert-rules.inc.php
+++ b/html/includes/forms/alert-rules.inc.php
@@ -70,7 +70,6 @@ if ($invert == 'on') {
 }
 
 $recovery = empty($recovery) ? $recovery = false : true;
-print_r($recovery);exit;
 
 $extra = array(
     'mute'     => $mute,

--- a/html/includes/forms/alert-rules.inc.php
+++ b/html/includes/forms/alert-rules.inc.php
@@ -37,18 +37,18 @@ if (is_admin() === false) {
 $status = 'ok';
 $message = '';
 
-$builder_json  = $_POST['builder_json'];
-$query         = QueryBuilderParser::fromJson($builder_json)->toSql();
-$rule_id       = $_POST['rule_id'];
-$count         = mres($_POST['count']);
-$delay         = mres($_POST['delay']);
-$interval      = mres($_POST['interval']);
-$mute          = mres($_POST['mute']);
-$invert        = mres($_POST['invert']);
-$name          = mres($_POST['name']);
-$proc          = mres($_POST['proc']);
-$no_recovery    = ($_POST['no_recovery']);
-$severity      = mres($_POST['severity']);
+$builder_json = $_POST['builder_json'];
+$query        = QueryBuilderParser::fromJson($builder_json)->toSql();
+$rule_id      = $_POST['rule_id'];
+$count        = mres($_POST['count']);
+$delay        = mres($_POST['delay']);
+$interval     = mres($_POST['interval']);
+$mute         = mres($_POST['mute']);
+$invert       = mres($_POST['invert']);
+$name         = mres($_POST['name']);
+$proc         = mres($_POST['proc']);
+$recovery     = ($vars['recovery']);
+$severity     = mres($_POST['severity']);
 
 if (!is_numeric($count)) {
     $count = '-1';
@@ -69,15 +69,16 @@ if ($invert == 'on') {
     $invert = false;
 }
 
-$no_recovery = empty($no_recovery) ? $no_recovery = false : true;
+$recovery = empty($recovery) ? $recovery = false : true;
+print_r($recovery);exit;
 
 $extra = array(
-    'mute'        => $mute,
-    'count'       => $count,
-    'delay'       => $delay_sec,
-    'invert'      => $invert,
-    'interval'    => $interval_sec,
-    'no_recovery' => $no_recovery,
+    'mute'     => $mute,
+    'count'    => $count,
+    'delay'    => $delay_sec,
+    'invert'   => $invert,
+    'interval' => $interval_sec,
+    'recovery' => $recovery,
 );
 
 $extra_json = json_encode($extra);

--- a/html/includes/forms/alert-rules.inc.php
+++ b/html/includes/forms/alert-rules.inc.php
@@ -38,16 +38,17 @@ $status = 'ok';
 $message = '';
 
 $builder_json  = $_POST['builder_json'];
-$query    = QueryBuilderParser::fromJson($builder_json)->toSql();
-$rule_id  = $_POST['rule_id'];
-$count    = mres($_POST['count']);
-$delay    = mres($_POST['delay']);
-$interval = mres($_POST['interval']);
-$mute     = mres($_POST['mute']);
-$invert   = mres($_POST['invert']);
-$name     = mres($_POST['name']);
-$proc     = mres($_POST['proc']);
-$severity = mres($_POST['severity']);
+$query         = QueryBuilderParser::fromJson($builder_json)->toSql();
+$rule_id       = $_POST['rule_id'];
+$count         = mres($_POST['count']);
+$delay         = mres($_POST['delay']);
+$interval      = mres($_POST['interval']);
+$mute          = mres($_POST['mute']);
+$invert        = mres($_POST['invert']);
+$name          = mres($_POST['name']);
+$proc          = mres($_POST['proc']);
+$no_recovery    = ($_POST['no_recovery']);
+$severity      = mres($_POST['severity']);
 
 if (!is_numeric($count)) {
     $count = '-1';
@@ -68,12 +69,15 @@ if ($invert == 'on') {
     $invert = false;
 }
 
+$no_recovery = empty($no_recovery) ? $no_recovery = false : true;
+
 $extra = array(
-    'mute'     => $mute,
-    'count'    => $count,
-    'delay'    => $delay_sec,
-    'invert'   => $invert,
-    'interval' => $interval_sec,
+    'mute'        => $mute,
+    'count'       => $count,
+    'delay'       => $delay_sec,
+    'invert'      => $invert,
+    'interval'    => $interval_sec,
+    'no_recovery' => $no_recovery,
 );
 
 $extra_json = json_encode($extra);

--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -97,9 +97,15 @@ if (is_admin()) {
                             <div class='col-sm-2'>
                                 <input type="checkbox" name="mute" id="mute">
                             </div>
-                            <label for='invert' class='col-sm-3 control-label'>Invert match: </label>
+                            <label for='invert' class='col-sm-2 control-label'>Invert match: </label>
                             <div class='col-sm-2'>
                                 <input type='checkbox' name='invert' id='invert'>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for='no_recovery' class='col-sm-3 control-label'>Disable recovery: </label>
+                            <div class='col-sm-2'>
+                                <input type='checkbox' name='no_recovery' id='no_recovery'>
                             </div>
                         </div>
                         <div class="form-group">
@@ -110,7 +116,7 @@ if (is_admin()) {
                         </div>
                         <div class='form-group'>
                             <label for='proc' class='col-sm-3 control-label'>Procedure URL: </label>
-                            <div class='col-sm-5'>
+                            <div class='col-sm-9'>
                                 <input type='text' id='proc' name='proc' class='form-control validation' pattern='(http|https)://.*' maxlength='80'>
                             </div>
                         </div>
@@ -263,6 +269,7 @@ if (is_admin()) {
                 $severity.val($severity.find("option[selected]").val());
                 $("#mute").bootstrapSwitch('state', false);
                 $("#invert").bootstrapSwitch('state', false);
+                $("#no_recovery").bootstrapSwitch('state', false);
                 $(this).find("input[type=text]").val("");
                 $('#count').val('-1');
                 $('#delay').val('5 m');
@@ -319,6 +326,7 @@ if (is_admin()) {
 
                 $("[name='mute']").bootstrapSwitch('state', extra.mute);
                 $("[name='invert']").bootstrapSwitch('state', extra.invert);
+                $("[name='no_recovery']").bootstrapSwitch('state', extra.no_recovery)
             } else {
                 $('#count').val('-1');
             }

--- a/html/includes/modal/new_alert_rule.inc.php
+++ b/html/includes/modal/new_alert_rule.inc.php
@@ -103,9 +103,9 @@ if (is_admin()) {
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for='no_recovery' class='col-sm-3 control-label'>Disable recovery: </label>
+                            <label for='recovery' class='col-sm-3 control-label'>Recovery alerts: </label>
                             <div class='col-sm-2'>
-                                <input type='checkbox' name='no_recovery' id='no_recovery'>
+                                <input type='checkbox' name='recovery' id='recovery'>
                             </div>
                         </div>
                         <div class="form-group">
@@ -269,7 +269,7 @@ if (is_admin()) {
                 $severity.val($severity.find("option[selected]").val());
                 $("#mute").bootstrapSwitch('state', false);
                 $("#invert").bootstrapSwitch('state', false);
-                $("#no_recovery").bootstrapSwitch('state', false);
+                $("#recovery").bootstrapSwitch('state', true);
                 $(this).find("input[type=text]").val("");
                 $('#count').val('-1');
                 $('#delay').val('5 m');
@@ -326,7 +326,10 @@ if (is_admin()) {
 
                 $("[name='mute']").bootstrapSwitch('state', extra.mute);
                 $("[name='invert']").bootstrapSwitch('state', extra.invert);
-                $("[name='no_recovery']").bootstrapSwitch('state', extra.no_recovery)
+                if (typeof extra.recovery == 'undefined') {
+                    extra.recovery = true;
+                }
+                $("[name='recovery']").bootstrapSwitch('state', extra.recovery)
             } else {
                 $('#count').val('-1');
             }

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -770,6 +770,10 @@ function RunAlerts()
         $noacc            = false;
         $updet            = false;
         $rextra           = json_decode($alert['extra'], true);
+        if (!isset($rextra['recovery'])) {
+            // backwards compatibility check
+            $rextra['recovery'] = true;
+        }
         $chk              = dbFetchRow('SELECT alerts.alerted,devices.ignore,devices.disabled FROM alerts,devices WHERE alerts.device_id = ? && devices.device_id = alerts.device_id && alerts.rule_id = ?', array($alert['device_id'], $alert['rule_id']));
 
         if ($chk['alerted'] == $alert['state']) {
@@ -844,7 +848,7 @@ function RunAlerts()
             log_event('Skipped alerts because all parent devices are down', $alert['device_id'], 'alert', 1);
         }
 
-        if ($alert['state'] == 0 && $rextra['no_recovery']) {
+        if ($alert['state'] == 0 && $rextra['recovery']) {
             // Rule is set to not send a recovery alert
             $noiss = true;
         }

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -774,6 +774,7 @@ function RunAlerts()
             // backwards compatibility check
             $rextra['recovery'] = true;
         }
+
         $chk              = dbFetchRow('SELECT alerts.alerted,devices.ignore,devices.disabled FROM alerts,devices WHERE alerts.device_id = ? && devices.device_id = alerts.device_id && alerts.rule_id = ?', array($alert['device_id'], $alert['rule_id']));
 
         if ($chk['alerted'] == $alert['state']) {
@@ -848,7 +849,7 @@ function RunAlerts()
             log_event('Skipped alerts because all parent devices are down', $alert['device_id'], 'alert', 1);
         }
 
-        if ($alert['state'] == 0 && $rextra['recovery']) {
+        if ($alert['state'] == 0 && $rextra['recovery'] == false) {
             // Rule is set to not send a recovery alert
             $noiss = true;
         }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Added support for disabling sending recovery notifications.

Also:

  - blacklisted two more tables from being used in the query builder. No reason people should be alerting on those.
  - Also clear out the 'count' value for an alert so that alerts will be raised if matched again.

I've tested this with two of the exact same rules, one however had recovery alerts disabled. Max 5 alerts, repeated every 1 second.

I received 5 alerts for each, renamed the device so the alerts would clear and received just one recovery email. Then renamed the device back and alerts triggered again through the same sequence.