### PR TITLE
LDAP debug output

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -403,7 +403,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         ldap_set_option(
             $this->ldap_connection,
             LDAP_OPT_NETWORK_TIMEOUT,
-            Config::has('auth_ad_timeout') ? Config::has('auth_ad_timeout') : 5
+            Config::get('auth_ad_timeout', 5)
         );
 
         // With specified bind user

--- a/scripts/auth_test.php
+++ b/scripts/auth_test.php
@@ -3,18 +3,17 @@
 
 use LibreNMS\Authentication\Auth;
 
-$options = getopt('u:rdvh');
-if (isset($options['h']) || !isset($options['u'])) {
+$options = getopt('u:rldvh');
+if (isset($options['h']) || (!isset($options['l']) && !isset($options['u']))) {
     echo ' -u <username>  (Required) username to test
  -r             Reauthenticate user, (requires previous web login with "Remember me" enabled)
+ -l             List all users (checks that auth can enumerate all allowed users)
  -d             Enable debug output
  -v             Enable verbose debug output
  -h             Display this help message
 ';
     exit;
 }
-
-$test_username = $options['u'];
 
 if (isset($options['d'])) {
     $debug = true;
@@ -82,6 +81,14 @@ try {
         }
     }
 
+    if (isset($options['l'])) {
+        $users = $authorizer->getUserlist();
+        echo "Users: " . implode(', ', array_column($users, 'username')) . PHP_EOL;
+        echo "Total users: " . count($users) . PHP_EOL;
+        exit;
+    }
+
+    $test_username = $options['u'];
     $auth = false;
     if (isset($options['r'])) {
         echo "Reauthenticate Test\n";

--- a/scripts/auth_test.php
+++ b/scripts/auth_test.php
@@ -21,8 +21,9 @@ if (isset($options['d'])) {
 }
 
 if (isset($options['v'])) {
-    // might need more options for other auth methods
-    $config['auth_ad_debug'] = 1; // active_directory
+    // Enable debug mode for auth methods that have it
+    $config['auth_ad_debug'] = 1;
+    $config['auth_ldap_debug'] = 1;
 }
 
 $init_modules = array('web', 'auth');


### PR DESCRIPTION
Updated LDAP and AD docs
ldap protocol default to v3 (so we don't have to set it all the time).  If this fails it should revert to v2.
ad was using auth_ad_timeout incorrectly (1 I think)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
