### PR TITLE
Update moxa-etherdevice.inc.php

### DIFF
--- a/includes/polling/os/moxa-etherdevice.inc.php
+++ b/includes/polling/os/moxa-etherdevice.inc.php
@@ -10,9 +10,18 @@
  * the source code distribution for details.
  */
 
-// switchModel:
-$hardware = snmp_get($device, $device['sysObjectID'].'.1.2.0', '-OQvs');
-// firmwareVersion:
-$version = snmp_get($device, $device['sysObjectID'].'.1.4.0', '-OQvs');
-// serialNumber (not supported on all models):
-$serial = snmp_get($device, $device['sysObjectID'].'.1.78.0', '-OQvs');
+// hardware => switchModel.0
+// version => firmwareVersion.0
+// serial => serialNumber.0 (not supported on all models)
+
+$oids = array(
+    'hardware' => $device['sysObjectID'].'.1.2.0',
+    'version' => $device['sysObjectID'].'.1.4.0', 
+    'serial' => $device['sysObjectID'].'.1.78.0', 
+);
+  
+$os_data = snmp_get_multi_oid($device, $oids);
+
+foreach ($oids as $var => $oid) {
+    $$var = trim($os_data[$oid], '"');
+}

--- a/includes/polling/os/moxa-etherdevice.inc.php
+++ b/includes/polling/os/moxa-etherdevice.inc.php
@@ -12,8 +12,8 @@
 
 $oids = array(
     'hardware' => $device['sysObjectID'].'.1.2.0',
-    'version' => $device['sysObjectID'].'.1.4.0', 
-    'serial' => $device['sysObjectID'].'.1.78.0', 
+    'version' => $device['sysObjectID'].'.1.4.0',
+    'serial' => $device['sysObjectID'].'.1.78.0',
 );
   
 $os_data = snmp_get_multi_oid($device, $oids);

--- a/includes/polling/os/moxa-etherdevice.inc.php
+++ b/includes/polling/os/moxa-etherdevice.inc.php
@@ -10,12 +10,9 @@
  * the source code distribution for details.
  */
 
-
-// Moxa people enjoy creating MIBs for each model!
-if ($device['sysDescr'] == 'IKS-6726A-2GTXSFP-T') {
-    $mibmod = 'MOXA-IKS6726A-MIB';
-} elseif ($device['sysDescr'] == 'EDS-G508E-T') {
-    $mibmod = 'MOXA-EDSG508E-MIB';
-}
-$version = snmp_get($device, "firmwareVersion.0", "-OQvs", $mibmod);
-$hardware =  $device['sysDescr'];
+// switchModel:
+$hardware = snmp_get($device, $device['sysObjectID'].'.1.2.0', '-OQvs');
+// firmwareVersion:
+$version = snmp_get($device, $device['sysObjectID'].'.1.4.0', '-OQvs');
+// serialNumber (not supported on all models):
+$serial = snmp_get($device, $device['sysObjectID'].'.1.78.0', '-OQvs');

--- a/includes/polling/os/moxa-etherdevice.inc.php
+++ b/includes/polling/os/moxa-etherdevice.inc.php
@@ -22,5 +22,4 @@ foreach ($oids as $var => $oid) {
     $$var = trim($os_data[$oid], '"');
 }
 
-unset($oids);
-unset($os_data);
+unset($oids, $os_data);

--- a/includes/polling/os/moxa-etherdevice.inc.php
+++ b/includes/polling/os/moxa-etherdevice.inc.php
@@ -10,10 +10,6 @@
  * the source code distribution for details.
  */
 
-// hardware => switchModel.0
-// version => firmwareVersion.0
-// serial => serialNumber.0 (not supported on all models)
-
 $oids = array(
     'hardware' => $device['sysObjectID'].'.1.2.0',
     'version' => $device['sysObjectID'].'.1.4.0', 
@@ -25,3 +21,6 @@ $os_data = snmp_get_multi_oid($device, $oids);
 foreach ($oids as $var => $oid) {
     $$var = trim($os_data[$oid], '"');
 }
+
+unset($oids);
+unset($os_data);


### PR DESCRIPTION
Would rather rely on `sysObjectID` when getting the hardware/software information as the `sysDescr` may be changed through the web interface of the device. Use numeric OID-s only.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
