### PR TITLE
apps:smart: Fix display of WD drives

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1595,7 +1595,7 @@ function get_disks_with_smart($device, $app_id)
     foreach (glob($pattern) as $rrd) {
         $filename = basename($rrd, '.rrd');
 
-        list(,,, $disk) = explode("-", $filename);
+        list(,,, $disk) = explode("-", $filename, 4);
 
         if ($disk) {
             array_push($disks, $disk);


### PR DESCRIPTION
WD drives have a dash in the serial number, e.g. WD-WCCXXXXXXXXX.
The librenms-agent script changed to using serial numbers in
librenms/librenms-agent@3a84624
As we split the name by the same char, we discarded everything after WD,
which made all WD drives in the system appear as one, and broke the generated
links.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
