### PR TITLE
Full defaults for alert collection rules

### DIFF
--- a/html/includes/forms/alert-rules.inc.php
+++ b/html/includes/forms/alert-rules.inc.php
@@ -123,7 +123,11 @@ if (is_numeric($rule_id) && $rule_id > 0) {
         if ($rule_id) {
             $message = "Added Rule: <i>$name</i>";
         } else {
-            $message = 'Failed to add Rule: <i>' . $name . '</i>';
+            if (dbFetchCell('SELECT 1 FROM alert_rules WHERE name=?', [$name])) {
+                $message = "Rule named <i>$name</i> already exists";
+            } else {
+                $message = "Failed to add Rule: <i>$name</i>";
+            }
             $status = 'error';
         }
     }

--- a/html/includes/forms/sql-from-alert-collection.inc.php
+++ b/html/includes/forms/sql-from-alert-collection.inc.php
@@ -38,12 +38,21 @@ $template_id = $vars['template_id'];
 
 if (is_numeric($template_id)) {
     $rules = get_rules_from_json();
-
+    $rule = $rules[$template_id];
+    $default_extra = [
+        'mute' => false,
+        'count' => '-1',
+        'delay' => 60,
+        'invert' => false,
+        'interval' => 300,
+        'recovery' => true,
+    ];
     $output = [
         'status' => 'ok',
-        'name' => $rules[$template_id]['name'],
-        'builder' => QueryBuilderParser::fromOld($rules[$template_id]['rule'])->toArray(),
-        'extra' => $rules[$template_id]['extra']
+        'name' => $rule['name'],
+        'builder' => $rule['builder'] ?: QueryBuilderParser::fromOld($rule['rule'])->toArray(),
+        'extra' => array_replace($default_extra, (array)$rule['extra']),
+        'severity' => $rule['severity'] ?: 'critical'
     ];
 } else {
     $output = [


### PR DESCRIPTION
Fixes some of the dropdowns being in odd states when loading a rule from the collection.
Better error message if rule with same name exists.
Support all variables to be set in the rule collection

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
