### PR TITLE
Override default device grouping radius

### DIFF
--- a/html/includes/common/worldmap.inc.php
+++ b/html/includes/common/worldmap.inc.php
@@ -124,7 +124,7 @@ if ($config['map']['engine'] == 'leaflet') {
         if (!empty($widget_settings['group_radius'])) {
             $group_radius = $widget_settings['group_radius'];
         } else {
-            $group_radius = Config::get('leaflet.group_radius', 80;
+            $group_radius = Config::get('leaflet.group_radius', 80);
         }
         if (empty($widget_settings['status']) && $widget_settings['status'] != '0') {
             $widget_settings['status'] = '0,1';

--- a/html/includes/common/worldmap.inc.php
+++ b/html/includes/common/worldmap.inc.php
@@ -21,6 +21,8 @@
  * @package LibreNMS
  * @subpackage Frontpage
  */
+use LibreNMS\Config;
+
 require_once $config['install_dir'] . '/includes/alerts.inc.php';
 require_once $config['install_dir'] . '/includes/device-groups.inc.php';
 
@@ -121,10 +123,8 @@ if ($config['map']['engine'] == 'leaflet') {
         }
         if (!empty($widget_settings['group_radius'])) {
             $group_radius = $widget_settings['group_radius'];
-        } elseif (!empty($config['custom_worldmap'])) {
-            $group_radius = $config['custom_worldmap']['group_radius'];
         } else {
-            $group_radius = 80;
+            $group_radius = Config::get('leaflet.group_radius', 80;
         }
         if (empty($widget_settings['status']) && $widget_settings['status'] != '0') {
             $widget_settings['status'] = '0,1';

--- a/html/includes/common/worldmap.inc.php
+++ b/html/includes/common/worldmap.inc.php
@@ -121,6 +121,8 @@ if ($config['map']['engine'] == 'leaflet') {
         }
         if (!empty($widget_settings['group_radius'])) {
             $group_radius = $widget_settings['group_radius'];
+        } elseif (!empty($config['custom_worldmap'])) {
+            $group_radius = $config['custom_worldmap']['group_radius'];
         } else {
             $group_radius = 80;
         }


### PR DESCRIPTION
Added an option to override the default group_radius 80. Usefull in fullscreenmap

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
