### PR TITLE
Avoid XML Errors due to additional empty line before output

### DIFF
--- a/html/graph-realtime.php
+++ b/html/graph-realtime.php
@@ -73,7 +73,7 @@ $height=125;            //SVG internal height : do not modify
 $width=300;             //SVG internal width : do not modify
 
 /********* Graph DATA **************/
-print('<?xml version="1.0" encoding="iso-8859-1"?>' . "\n");?>
+?>
 <svg width="100%" height="100%" viewBox="0 0 <?php echo("$width $height") ?>" preserveAspectRatio="none" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"
      onload="init(evt)">
   <g id="graph">


### PR DESCRIPTION
The additional blank line before the xml declaration causes xml errors on some systems. 
This can be solved by removing the xml declaration.

Tested with Firefox 60.0b6 and Chrome 65 on Windows 10


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
