### PR TITLE
refactor: Use snmp.version config option to allow users to set versions available

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -350,7 +350,7 @@ $config['poller_modules']['bgp-peers'] = 0;
 $config['snmp']['timeout'] = 1;            # timeout in seconds
 $config['snmp']['retries'] = 5;            # how many times to retry the query
 $config['snmp']['transports'] = array('udp', 'udp6', 'tcp', 'tcp6');
-$config['snmp']['version'] = ['v1', 'v2c', 'v3'];         # Default versions to use
+$config['snmp']['version'] = ['v2c', 'v3', 'v1'];         # Default versions to use
 $config['snmp']['port'] = 161;
 ```
 Default SNMP options including retry and timeout settings and also default version and port.

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -350,7 +350,7 @@ $config['poller_modules']['bgp-peers'] = 0;
 $config['snmp']['timeout'] = 1;            # timeout in seconds
 $config['snmp']['retries'] = 5;            # how many times to retry the query
 $config['snmp']['transports'] = array('udp', 'udp6', 'tcp', 'tcp6');
-$config['snmp']['version'] = "v2c";         # Default version to use
+$config['snmp']['version'] = ['v1', 'v2c', 'v3'];         # Default versions to use
 $config['snmp']['port'] = 161;
 ```
 Default SNMP options including retry and timeout settings and also default version and port.

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -148,9 +148,9 @@ $pagetitle[] = 'Add host';
           <label for="snmpver" class="col-sm-3 control-label">SNMP Version</label>
           <div class="col-sm-3">
             <select name="snmpver" id="snmpver" class="form-control input-sm" onChange="changeForm();">
-                <option value="v1">v1</option>
-                <option value="v2c" selected>v2c</option>
-                <option value="v3">v3</option>
+              <option value="v1">v1</option>
+              <option value="v2c" selected>v2c</option>
+              <option value="v3">v3</option>
             </select>
           </div>
           <div class="col-sm-3">

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Config;
 use LibreNMS\Exceptions\HostUnreachableException;
 use LibreNMS\Util\IP;
 
@@ -147,9 +148,15 @@ $pagetitle[] = 'Add host';
           <label for="snmpver" class="col-sm-3 control-label">SNMP Version</label>
           <div class="col-sm-3">
             <select name="snmpver" id="snmpver" class="form-control input-sm" onChange="changeForm();">
-              <option value="v1">v1</option>
-              <option value="v2c" selected>v2c</option>
-              <option value="v3">v3</option>
+                <?php
+                foreach (Config::get('snmp.version') as $snmp_version) {
+                    echo "<option value=\"$snmp_version\"";
+                    if ($snmp_version === 'v2c') {
+                        echo " selected";
+                    }
+                    echo ">$snmp_version</option>";
+                }
+                ?>
             </select>
           </div>
           <div class="col-sm-3">

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -148,15 +148,9 @@ $pagetitle[] = 'Add host';
           <label for="snmpver" class="col-sm-3 control-label">SNMP Version</label>
           <div class="col-sm-3">
             <select name="snmpver" id="snmpver" class="form-control input-sm" onChange="changeForm();">
-                <?php
-                foreach (Config::get('snmp.version') as $snmp_version) {
-                    echo "<option value=\"$snmp_version\"";
-                    if ($snmp_version === 'v2c') {
-                        echo " selected";
-                    }
-                    echo ">$snmp_version</option>";
-                }
-                ?>
+                <option value="v1">v1</option>
+                <option value="v2c" selected>v2c</option>
+                <option value="v3">v3</option>
             </select>
           </div>
           <div class="col-sm-3">

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-use LibreNMS\Config;
 use LibreNMS\Exceptions\HostUnreachableException;
 use LibreNMS\Util\IP;
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -157,7 +157,7 @@ $config['snmp']['transports'] = array(
     'tcp6',
 );
 
-$config['snmp']['version'] = ['v1', 'v2c', 'v3'];
+$config['snmp']['version'] = ['v2c', 'v3', 'v1'];
 // Default version to use
 // SNMPv1/2c default settings
 $config['snmp']['community'][0] = 'public';

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -157,7 +157,7 @@ $config['snmp']['transports'] = array(
     'tcp6',
 );
 
-$config['snmp']['version'] = 'v2c';
+$config['snmp']['version'] = ['v1', 'v2c', 'v3'];
 // Default version to use
 // SNMPv1/2c default settings
 $config['snmp']['community'][0] = 'public';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -501,7 +501,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
 
     // if $snmpver isn't set, try each version of snmp
     if (empty($snmp_version)) {
-        $snmpvers = array('v2c', 'v3', 'v1');
+        $snmpvers = Config::get('snmp.version');
     } else {
         $snmpvers = array($snmp_version);
     }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

`$config['snmp']['version']` was unused before. This allows people to disable snmp versions they don't need.