### PR TITLE
Refactor database and config init

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -28,19 +28,44 @@ namespace LibreNMS;
 class Config
 {
     /**
-     * Load the user config from config.php
+     * Load the config, if the database connected, pull in database settings.
      *
-     * @param string $install_dir
-     * @return array
+     * return &array
      */
-    public static function &load($install_dir = null)
+    public static function &load()
     {
         global $config;
 
-        if (empty($install_dir)) {
-            $install_dir = __DIR__ . '/../';
+        self::loadFiles();
+
+        // Make sure the database is connected
+        if (dbIsConnected()) {
+            // pull in the database config settings
+            self::mergeDb();
+
+            // load graph types from the database
+            self::loadGraphsFromDb();
         }
-        $install_dir = realpath($install_dir);
+
+        // Process $config to tidy up
+        self::processConfig();
+
+        return $config;
+    }
+
+    /**
+     * Load the user config from config.php, defaults.inc.php and definitions.inc.php, etc.
+     * Erases existing config.
+     *
+     * @return array
+     */
+    private static function &loadFiles()
+    {
+        global $config;
+
+        $config = []; // start fresh
+
+        $install_dir = realpath(__DIR__ . '/../');
         $config['install_dir'] = $install_dir;
 
         // load defaults
@@ -56,34 +81,6 @@ class Config
 
         // Load user config
         include $install_dir . '/config.php';
-
-        return $config;
-    }
-
-    /**
-     * Load Config from the database
-     *
-     * @throws Exceptions\DatabaseConnectException
-     */
-    public static function &loadFromDatabase()
-    {
-        global $config;
-
-        if (empty($config)) {
-            self::load();
-        }
-
-        // Make sure the database is connected
-        dbConnect();
-
-        // pull in the database config settings
-        self::mergeDb();
-
-        // load graph types from the database
-        self::loadGraphsFromDb();
-
-        // Process $config to tidy up
-        self::processConfig();
 
         return $config;
     }
@@ -427,5 +424,41 @@ class Config
             d_echo("Copied deprecated config $old to $new\n");
             self::set($new, self::get($old));
         }
+    }
+
+    /**
+     * Get just the database connection settings from config.php
+     *
+     * @return array (keys: db_host, db_port, db_name, db_user, db_pass, db_socket)
+     */
+    public static function getDatabaseSettings()
+    {
+        // Do not access global $config in this function!
+
+        $keys = $config = [
+            'db_host' => '',
+            'db_port' => '',
+            'db_name' => '',
+            'db_user' => '',
+            'db_pass' => '',
+            'db_socket' => '',
+        ];
+
+        @include __DIR__ . '/../config.php';
+
+        // Check for testing database
+        if (getenv('DBTEST')) {
+            if (isset($config['test_db_name'])) {
+                $config['db_name'] = $config['test_db_name'];
+            }
+            if (isset($config['test_db_user'])) {
+                $config['db_user'] = $config['test_db_user'];
+            }
+            if (isset($config['test_db_pass'])) {
+                $config['db_pass'] = $config['test_db_pass'];
+            }
+        }
+
+        return array_intersect_key($config, $keys); // return only the db settings
     }
 }

--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -444,7 +444,9 @@ class Config
             'db_socket' => '',
         ];
 
-        @include __DIR__ . '/../config.php';
+        if (is_file(__DIR__ . '/../config.php')) {
+            include __DIR__ . '/../config.php';
+        }
 
         // Check for testing database
         if (getenv('DBTEST')) {

--- a/LibreNMS/IRCBot.php
+++ b/LibreNMS/IRCBot.php
@@ -509,14 +509,7 @@ class IRCBot
     {
         if (!is_resource($this->sql)) {
             try {
-                $this->sql = dbConnect(
-                    $this->config['db_host'],
-                    $this->config['db_user'],
-                    $this->config['db_pass'],
-                    $this->config['db_name'],
-                    $this->config['db_port'],
-                    $this->config['db_socket']
-                );
+                $this->sql = dbConnect();
             } catch (DatabaseConnectException $e) {
                 $this->log('Cannot connect to MySQL: ' . $e->getMessage());
                 return die();

--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -89,11 +89,13 @@ class Database extends BaseValidation
 
     private function checkCollation(Validator $validator)
     {
+        $db_name = dbFetchCell('SELECT DATABASE()');
+
         // Test for correct character set and collation
         $db_collation_sql = "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME 
             FROM information_schema.SCHEMATA S 
-            WHERE schema_name = '" . Config::get('db_name') .
-            "' AND  ( DEFAULT_CHARACTER_SET_NAME != 'utf8' OR DEFAULT_COLLATION_NAME != 'utf8_unicode_ci')";
+            WHERE schema_name = '$db_name' AND 
+            ( DEFAULT_CHARACTER_SET_NAME != 'utf8' OR DEFAULT_COLLATION_NAME != 'utf8_unicode_ci')";
         $collation = dbFetchRows($db_collation_sql);
         if (empty($collation) !== true) {
             $validator->fail(
@@ -104,8 +106,8 @@ class Database extends BaseValidation
 
         $table_collation_sql = "SELECT T.TABLE_NAME, C.CHARACTER_SET_NAME, C.COLLATION_NAME 
             FROM information_schema.TABLES AS T, information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS C 
-            WHERE C.collation_name = T.table_collation AND T.table_schema = '" . Config::get('db_name') .
-            "' AND  ( C.CHARACTER_SET_NAME != 'utf8' OR C.COLLATION_NAME != 'utf8_unicode_ci' );";
+            WHERE C.collation_name = T.table_collation AND T.table_schema = '$db_name' AND
+             ( C.CHARACTER_SET_NAME != 'utf8' OR C.COLLATION_NAME != 'utf8_unicode_ci' );";
         $collation_tables = dbFetchRows($table_collation_sql);
         if (empty($collation_tables) !== true) {
             $result = ValidationResult::fail('MySQL tables collation is wrong: ')
@@ -115,8 +117,8 @@ class Database extends BaseValidation
         }
 
         $column_collation_sql = "SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME 
-FROM information_schema.COLUMNS  WHERE TABLE_SCHEMA = '" . Config::get('db_name') .
-            "'  AND  ( CHARACTER_SET_NAME != 'utf8' OR COLLATION_NAME != 'utf8_unicode_ci' );";
+            FROM information_schema.COLUMNS  WHERE TABLE_SCHEMA = '$db_name' AND
+            ( CHARACTER_SET_NAME != 'utf8' OR COLLATION_NAME != 'utf8_unicode_ci' );";
         $collation_columns = dbFetchRows($column_collation_sql);
         if (empty($collation_columns) !== true) {
             $result = ValidationResult::fail('MySQL column collation is wrong: ')

--- a/build-base.php
+++ b/build-base.php
@@ -24,32 +24,37 @@
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
+use LibreNMS\Exceptions\DatabaseConnectException;
+
 if (!isset($init_modules)) {
+    $init_modules = array('nodb');
+    require __DIR__ . '/includes/init.php';
+
     $opts = getopt('ldh:u:p:n:t:s:');
 
-    $db_vars = array(
-        'db_host' => 'h',
-        'db_user' => 'u',
-        'db_pass' => 'p',
-        'db_name' => 'n',
-        'db_port' => 't',
-        'db_socket' => 's',
-    );
-
-    $config = array();
-    foreach ($db_vars as $setting => $opt) {
-        if (isset($opts[$opt])) {
-            $config[$setting] = $opts[$opt];
+    try {
+        if (isset($opts['h'])) {
+            dbConnect(
+                isset($opts['h']) ? $opts['h'] : null,
+                isset($opts['u']) ? $opts['u'] : '',
+                isset($opts['p']) ? $opts['p'] : '',
+                isset($opts['n']) ? $opts['n'] : '',
+                isset($opts['t']) ? $opts['t'] : null,
+                isset($opts['s']) ? $opts['s'] : null
+            );
+        } else {
+            // use configured database credentials
+            dbConnect();
         }
+    } catch (DatabaseConnectException $e) {
+        echo $e->getMessage() . PHP_EOL;
+        exit;
     }
-
-    $init_modules = array();
-    require __DIR__  . '/includes/init.php';
 
     $debug = isset($opts['d']);
     $skip_schema_lock = isset($opts['l']);
 }
 
-require 'includes/sql-schema/update.php';
+require __DIR__ . '/includes/sql-schema/update.php';
 
 exit($return);

--- a/html/index.php
+++ b/html/index.php
@@ -53,7 +53,7 @@ $msg_box = array();
 // Check for install.inc.php
 if (!file_exists('../config.php') && $_SERVER['PATH_INFO'] != '/install.php') {
     // no config.php does so let's redirect to the install
-    header("Location: {$config['base_url']}/install.php");
+    header("Location: /install.php");
     exit;
 }
 

--- a/html/install.php
+++ b/html/install.php
@@ -37,19 +37,12 @@ $dbuser = @$_POST['dbuser'] ?: 'librenms';
 $dbpass = @$_POST['dbpass'] ?: '';
 $dbname = @$_POST['dbname'] ?: 'librenms';
 $dbport = @$_POST['dbport'] ?: 3306;
-$dbsocket = @$_POST['dbsocket'] ?: '';
-$config['db_host']=$dbhost;
-$config['db_user']=$dbuser;
-$config['db_pass']=$dbpass;
-$config['db_name']=$dbname;
-$config['db_port']=$dbport;
-$config['db_socket']=$dbsocket;
-
-if (!empty($config['db_socket'])) {
-    $config['db_host'] = 'localhost';
-    $config['db_port'] = null;
+if (empty($_POST['dbsocket'])) {
+    $dbsocket = null;
 } else {
-    $config['db_socket'] = null;
+    $dbhost = 'localhost';
+    $dbsocket = $_POST['dbsocket'];
+    $dbport = null;
 }
 
 $add_user = @$_POST['add_user'] ?: '';
@@ -61,7 +54,7 @@ $add_email = @$_POST['add_email'] ?: '';
 if ($stage > 1) {
     try {
         if ($stage != 6) {
-            dbConnect();
+            dbConnect($dbhost, $dbuser, $dbpass, $dbname, $dbport, $dbsocket);
         }
         if ($stage == 2 && $_SESSION['build-ok'] == true) {
             $stage = 3;

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -17,6 +17,7 @@
  * 3. Oh, and dbFetchAll() is now dbFetchRows()
  */
 
+use LibreNMS\Config;
 use LibreNMS\Exceptions\DatabaseConnectException;
 
 function dbIsConnected()
@@ -33,18 +34,18 @@ function dbIsConnected()
  * Connect to the database.
  * Will use global $config variables if they are not sent: db_host, db_user, db_pass, db_name, db_port, db_socket
  *
- * @param string $host
- * @param string $user
- * @param string $password
- * @param string $database
- * @param string $port
- * @param string $socket
+ * @param string $db_host
+ * @param string $db_user
+ * @param string $db_pass
+ * @param string $db_name
+ * @param string $db_port
+ * @param string $db_socket
  * @return mysqli
  * @throws DatabaseConnectException
  */
-function dbConnect($host = null, $user = '', $password = '', $database = '', $port = null, $socket = null)
+function dbConnect($db_host = null, $db_user = '', $db_pass = '', $db_name = '', $db_port = null, $db_socket = null)
 {
-    global $config, $database_link;
+    global $database_link;
 
     if (dbIsConnected()) {
         return $database_link;
@@ -54,32 +55,35 @@ function dbConnect($host = null, $user = '', $password = '', $database = '', $po
         throw new DatabaseConnectException("mysqli extension not loaded!");
     }
 
-    $host = empty($host) ? $config['db_host'] : $host;
-    $user = empty($user) ? $config['db_user'] : $user;
-    $password = empty($password) ? $config['db_pass'] : $password;
-    $database = empty($database) ? $config['db_name'] : $database;
-    $port = empty($port) ? $config['db_port'] : $port;
-    $socket = empty($socket) ? $config['db_socket'] : $socket;
+    if (is_null($db_host)) {
+        extract(Config::getDatabaseSettings());
+        /** @var string $db_host */
+        /** @var string $db_port */
+        /** @var string $db_socket */
+        /** @var string $db_name */
+        /** @var string $db_user */
+        /** @var string $db_pass */
+    }
 
-    $database_link = mysqli_connect('p:' . $host, $user, $password, null, $port, $socket);
+    $database_link = mysqli_connect('p:' . $db_host, $db_user, $db_pass, null, $db_port, $db_socket);
     mysqli_options($database_link, MYSQLI_OPT_LOCAL_INFILE, false);
     if ($database_link === false) {
         $error = mysqli_connect_error();
         if ($error == 'No such file or directory') {
-            $error = 'Could not connect to ' . $host;
+            $error = 'Could not connect to ' . $db_host;
         }
         throw new DatabaseConnectException($error);
     }
 
-    $database_db = mysqli_select_db($database_link, $config['db_name']);
+    $database_db = mysqli_select_db($database_link, $db_name);
     if (!$database_db) {
-        $db_create_sql = "CREATE DATABASE " . $config['db_name'] . " CHARACTER SET utf8 COLLATE utf8_unicode_ci";
+        $db_create_sql = "CREATE DATABASE $db_name CHARACTER SET utf8 COLLATE utf8_unicode_ci";
         mysqli_query($database_link, $db_create_sql);
-        $database_db = mysqli_select_db($database_link, $database);
+        $database_db = mysqli_select_db($database_link, $db_name);
     }
 
     if (!$database_db) {
-        throw new DatabaseConnectException("Could not select database: $database. " . mysqli_error($database_link));
+        throw new DatabaseConnectException("Could not select database: $db_name. " . mysqli_error($database_link));
     }
 
     dbQuery("SET NAMES 'utf8'");

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -65,6 +65,13 @@ function dbConnect($db_host = null, $db_user = '', $db_pass = '', $db_name = '',
         /** @var string $db_pass */
     }
 
+    if (empty($db_socket)) {
+        $db_socket = null;
+    }
+    if (!is_numeric($db_port)) {
+        $db_port = null;
+    }
+
     $database_link = mysqli_connect('p:' . $db_host, $db_user, $db_pass, null, $db_port, $db_socket);
     mysqli_options($database_link, MYSQLI_OPT_LOCAL_INFILE, false);
     if ($database_link === false) {

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -56,7 +56,8 @@ function dbConnect($db_host = null, $db_user = '', $db_pass = '', $db_name = '',
     }
 
     if (is_null($db_host)) {
-        extract(Config::getDatabaseSettings());
+        $db_config = Config::getDatabaseSettings();
+        extract($db_config);
         /** @var string $db_host */
         /** @var string $db_port */
         /** @var string $db_socket */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -424,8 +424,10 @@ function delete_device($id)
         dbDelete('sensors_to_state_indexes', "`sensor_id` = ?", array($sensor_id));
     }
     $fields = array('device_id','host');
+
+    $db_name = dbFetchCell('SELECT DATABASE()');
     foreach ($fields as $field) {
-        foreach (dbFetch("SELECT table_name FROM information_schema.columns WHERE table_schema = ? AND column_name = ?", array($config['db_name'],$field)) as $table) {
+        foreach (dbFetch("SELECT table_name FROM information_schema.columns WHERE table_schema = ? AND column_name = ?", [$db_name, $field]) as $table) {
             $table = $table['table_name'];
             $entries = (int) dbDelete($table, "`$field` =  ?", array($id));
             if ($entries > 0 && $debug === true) {
@@ -2294,10 +2296,11 @@ function dump_db_schema()
     global $config;
 
     $output = array();
+    $db_name = dbFetchCell('SELECT DATABASE()');
 
-    foreach (dbFetchRows("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = '{$config['db_name']}' ORDER BY TABLE_NAME;") as $table) {
+    foreach (dbFetchRows("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = '$db_name' ORDER BY TABLE_NAME;") as $table) {
         $table = $table['TABLE_NAME'];
-        foreach (dbFetchRows("SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '{$config['db_name']}' AND TABLE_NAME='$table'") as $data) {
+        foreach (dbFetchRows("SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '$db_name' AND TABLE_NAME='$table'") as $data) {
             $def = array(
                 'Field'   => $data['COLUMN_NAME'],
                 'Type'    => $data['COLUMN_TYPE'],

--- a/includes/init.php
+++ b/includes/init.php
@@ -35,7 +35,6 @@ global $config;
 error_reporting(E_ERROR|E_PARSE|E_CORE_ERROR|E_COMPILE_ERROR);
 
 $install_dir = realpath(__DIR__ . '/..');
-$config['install_dir'] = $install_dir;
 chdir($install_dir);
 
 require_once $install_dir . '/includes/common.php';
@@ -93,29 +92,11 @@ if (module_selected('alerts', $init_modules)) {
 // Display config.php errors instead of http 500
 $display_bak = ini_get('display_errors');
 ini_set('display_errors', 1);
-Config::load($install_dir);
-// set display_errors back
-ini_set('display_errors', $display_bak);
 
 if (!module_selected('nodb', $init_modules)) {
-    // Check for testing database
-    if (getenv('DBTEST')) {
-        if (isset($config['test_db_name'])) {
-            $config['db_name'] = $config['test_db_name'];
-        }
-        if (isset($config['test_db_user'])) {
-            $config['db_user'] = $config['test_db_user'];
-        }
-        if (isset($config['test_db_pass'])) {
-            $config['db_pass'] = $config['test_db_pass'];
-        }
-    }
-
     // Connect to database
     try {
         dbConnect();
-
-        Config::loadFromDatabase();
     } catch (\LibreNMS\Exceptions\DatabaseConnectException $e) {
         if (isCli()) {
             echo 'MySQL Error: ' . $e->getMessage() . PHP_EOL;
@@ -125,6 +106,13 @@ if (!module_selected('nodb', $init_modules)) {
         exit(2);
     }
 }
+
+// try to load from database, otherwise, just process config
+Config::load();
+
+// set display_errors back
+ini_set('display_errors', $display_bak);
+
 
 if (isset($config['php_memory_limit']) && is_numeric($config['php_memory_limit']) && $config['php_memory_limit'] > 128) {
     ini_set('memory_limit', $config['php_memory_limit'].'M');

--- a/includes/sql-schema/update.php
+++ b/includes/sql-schema/update.php
@@ -13,6 +13,7 @@
  */
 
 use LibreNMS\Config;
+use LibreNMS\Exceptions\DatabaseConnectException;
 use LibreNMS\Exceptions\LockException;
 use LibreNMS\Util\FileLock;
 use LibreNMS\Util\MemcacheLock;
@@ -21,8 +22,14 @@ global $database_link;
 
 if (!isset($init_modules) && php_sapi_name() == 'cli') {
     // Not called from within discovery, let's load up the necessary stuff.
-    $init_modules = array();
+    $init_modules = array('nodb');
     require realpath(__DIR__ . '/../..') . '/includes/init.php';
+    try {
+        dbConnect();
+    } catch (DatabaseConnectException $e) {
+        echo $e->getMessage() . PHP_EOL;
+        exit;
+    }
 }
 
 $return = 0;
@@ -37,7 +44,8 @@ try {
     }
 
     // only import build.sql to an empty database
-    $tables = dbFetchRows("SHOW TABLES FROM " . Config::get('db_name'));
+    $tables = dbFetchRows("SHOW TABLES");
+
     if (empty($tables)) {
         echo "-- Creating base database structure\n";
         $step = 0;
@@ -70,7 +78,7 @@ try {
         d_echo("DB Schema already up to date.\n");
     } else {
         // Set Database Character set and Collation
-        dbQuery('ALTER DATABASE ? CHARACTER SET utf8 COLLATE utf8_unicode_ci;', array(array(Config::get('db_name'))));
+        dbQuery('ALTER DATABASE CHARACTER SET utf8 COLLATE utf8_unicode_ci;');
 
         $db_rev = get_db_schema();
         $insert = ($db_rev == 0); // if $db_rev == 0, insert the first update

--- a/scripts/build-schema.php
+++ b/scripts/build-schema.php
@@ -3,30 +3,8 @@
 
 $install_dir = realpath(__DIR__ . '/..');
 
-if (getenv('DBTEST')) {
-    if (!is_file($install_dir . '/config.php')) {
-        exec("cp $install_dir/tests/config/config.test.php $install_dir/config.php");
-        $create_db = true;
-    }
-}
-
-$init_modules = array();
-require realpath(__DIR__ . '/..') . '/includes/init.php';
-
-if (getenv('DBTEST')) {
-    if ($create_db === true) {
-        $sql_mode = dbFetchCell("SELECT @@global.sql_mode as sql_mode");
-        dbQuery("SET NAMES 'utf8'");
-        dbQuery("SET CHARACTER SET 'utf8'");
-        dbQuery("SET COLLATION_CONNECTION = 'utf8_unicode_ci'");
-        dbQuery("SET GLOBAL sql_mode='ONLY_FULL_GROUP_BY,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
-        dbQuery("USE " . $config['db_name']);
-        $build_base = $config['install_dir'] . '/build-base.php';
-        exec($build_base, $schema);
-    }
-
-    sleep(60);//Sleep for 60 seconds to ensure db work has completed
-}
+// update.php will call init.php
+require $install_dir . '/includes/sql-schema/update.php';
 
 $file = $install_dir . '/misc/db_schema.yaml';
 $yaml = Symfony\Component\Yaml\Yaml::dump(dump_db_schema(), 3, 2);

--- a/tests/DBSetupTest.php
+++ b/tests/DBSetupTest.php
@@ -78,7 +78,7 @@ class DBSetupTest extends DBTestCase
     {
         global $config;
 
-        $collation = dbFetchRows("SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA S WHERE schema_name = '" . $config['db_name'] . "' AND  ( DEFAULT_CHARACTER_SET_NAME != 'utf8' OR DEFAULT_COLLATION_NAME != 'utf8_unicode_ci')");
+        $collation = dbFetchRows("SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA S WHERE schema_name = '$this->db_name' AND  ( DEFAULT_CHARACTER_SET_NAME != 'utf8' OR DEFAULT_COLLATION_NAME != 'utf8_unicode_ci')");
         if (isset($collation[0])) {
             $error = implode(' ', $collation[0]);
         } else {
@@ -91,7 +91,7 @@ class DBSetupTest extends DBTestCase
     {
         global $config;
 
-        $collation = dbFetchRows("SELECT T.TABLE_NAME, C.CHARACTER_SET_NAME, C.COLLATION_NAME FROM information_schema.TABLES AS T, information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS C WHERE C.collation_name = T.table_collation AND T.table_schema = '" . $config['db_name'] . "' AND  ( C.CHARACTER_SET_NAME != 'utf8' OR C.COLLATION_NAME != 'utf8_unicode_ci' );");
+        $collation = dbFetchRows("SELECT T.TABLE_NAME, C.CHARACTER_SET_NAME, C.COLLATION_NAME FROM information_schema.TABLES AS T, information_schema.COLLATION_CHARACTER_SET_APPLICABILITY AS C WHERE C.collation_name = T.table_collation AND T.table_schema = '$this->db_name' AND  ( C.CHARACTER_SET_NAME != 'utf8' OR C.COLLATION_NAME != 'utf8_unicode_ci' );");
         $error = '';
         foreach ($collation as $id => $data) {
             $error .= implode(' ', $data) . PHP_EOL;
@@ -103,7 +103,7 @@ class DBSetupTest extends DBTestCase
     {
         global $config;
 
-        $collation = dbFetchRows("SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME FROM information_schema.COLUMNS  WHERE TABLE_SCHEMA = '" . $config['db_name'] . "'  AND  ( CHARACTER_SET_NAME != 'utf8' OR COLLATION_NAME != 'utf8_unicode_ci' );");
+        $collation = dbFetchRows("SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME FROM information_schema.COLUMNS  WHERE TABLE_SCHEMA = '$this->db_name'  AND  ( CHARACTER_SET_NAME != 'utf8' OR COLLATION_NAME != 'utf8_unicode_ci' );");
         $error = '';
         foreach ($collation as $id => $data) {
             $error .= implode(' ', $data) . PHP_EOL;

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -27,10 +27,13 @@ namespace LibreNMS\Tests;
 
 class DBTestCase extends TestCase
 {
+    protected $db_name;
+
     public function setUp()
     {
         parent::setUp();
         $this->dbSetUp();
+        $this->db_name = dbFetchCell('SELECT DATABASE()');
     }
 
     public function tearDown()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,13 +23,15 @@
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
+use LibreNMS\Config;
+use LibreNMS\Exceptions\DatabaseConnectException;
 use LibreNMS\Util\Snmpsim;
 
 global $config;
 
 $install_dir = realpath(__DIR__ . '/..');
 
-$init_modules = array('web', 'discovery', 'polling');
+$init_modules = array('web', 'discovery', 'polling', 'nodb');
 
 if (!getenv('SNMPSIM')) {
     $init_modules[] = 'mocksnmp';
@@ -39,8 +41,6 @@ if (getenv('DBTEST')) {
     if (!is_file($install_dir . '/config.php')) {
         exec("cp $install_dir/tests/config/config.test.php $install_dir/config.php");
     }
-} else {
-    $init_modules[] = 'nodb';
 }
 
 require $install_dir . '/includes/init.php';
@@ -64,12 +64,21 @@ if (getenv('SNMPSIM')) {
 if (getenv('DBTEST')) {
     global $schema, $sql_mode;
 
+    try {
+        dbConnect();
+    } catch (DatabaseConnectException $e) {
+        echo $e->getMessage() . PHP_EOL;
+    }
+
     $sql_mode = dbFetchCell("SELECT @@global.sql_mode");
-    $empty_db = (dbFetchCell("SELECT count(*) FROM `information_schema`.`tables` WHERE `table_type` = 'BASE TABLE' AND `table_schema` = ?", array($config['db_name'])) == 0);
+    $db_name = dbFetchCell("SELECT DATABASE()");
+    $empty_db = (dbFetchCell("SELECT count(*) FROM `information_schema`.`tables` WHERE `table_type` = 'BASE TABLE' AND `table_schema` = ?", [$db_name]) == 0);
     dbQuery("SET GLOBAL sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
 
     $cmd = $config['install_dir'] . '/build-base.php';
     exec($cmd, $schema);
+
+    Config::load(); // reload the config including database config
 
     register_shutdown_function(function () use ($empty_db, $sql_mode) {
         global $config;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -80,9 +80,10 @@ if (getenv('DBTEST')) {
         // restore sql_mode
         dbQuery("SET GLOBAL sql_mode='$sql_mode'");
 
+        $db_name = dbFetchCell('SELECT DATABASE()');
         if ($empty_db) {
-            dbQuery("DROP DATABASE " . $config['db_name']);
-        } elseif (isset($config['test_db_name']) && $config['db_name'] == $config['test_db_name']) {
+            dbQuery("DROP DATABASE $db_name");
+        } elseif (isset($config['test_db_name']) && $config['test_db_name'] == $db_name) {
             // truncate tables
             $tables = dbFetchColumn('SHOW TABLES');
 

--- a/validate.php
+++ b/validate.php
@@ -141,13 +141,12 @@ if (!file_exists(Config::get('install_dir').'/config.php')) {
 try {
     dbConnect();
 
-    // pull in the database config settings
-    Config::loadFromDatabase();
-
     $validator->ok('Database connection successful', null, 'database');
 } catch (\LibreNMS\Exceptions\DatabaseConnectException $e) {
     $validator->fail('Error connecting to your database. '.$e->getMessage(), null, 'database');
 }
+
+Config::load();
 
 $precheck_complete = true; // disable shutdown function
 print_header($validator->getVersions());


### PR DESCRIPTION
Connect to the database without loading full config
Load config completely so post-processing is always done consistently.
Erase existing $config when loading, fixes issues in case we load the config twice.
If the database is not connected, don't try to load database settings. (Fixes some db errors on install)
Attempt to remove $config access/modification before init.php
Remove usage of db_name, that might not match the connected database.
Centralize db config loading, so we consistently apply db_test database settings.
Many of these changes are influenced by Laravel port.

Tested:
-  install
-  validate (web + cli with/without db_test)
-  tests (with/without db/snmpsim)
-  build-base.php (with/without command line options/config.php/db_test)
-  poller.php


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
