### PR TITLE
Restrict storage discovery walks to os

### DIFF
--- a/includes/discovery/storage/eql-storage.inc.php
+++ b/includes/discovery/storage/eql-storage.inc.php
@@ -12,26 +12,28 @@
  * the source code distribution for details.
  */
 
-$eql_storage = snmpwalk_cache_oid($device, 'EqliscsiVolumeEntry', null, 'EQLVOLUME-MIB', 'equallogic');
+if ($device['os'] == 'equalogic') {
+    $eql_storage = snmpwalk_cache_oid($device, 'EqliscsiVolumeEntry', null, 'EQLVOLUME-MIB', 'equallogic');
 
-if (is_array($eql_storage)) {
-    echo 'EqliscsiVolumeEntry ';
-    foreach ($eql_storage as $index => $storage) {
-        $fstype = $storage['eqliscsiVolumeAdminStatus'];
-        $descr  = $storage['eqliscsiVolumeName'];
-        $units  = 1000000;
-        $size = $storage['eqliscsiVolumeSize'] * $units;
-        $used = $storage['eqliscsiVolumeStatusAllocatedSpace'] * $units;
-        if (is_int($index)) {
-            discover_storage($valid_storage, $device, $index, $fstype, 'eql-storage', $descr, $size, $units, $used);
-        } else {
-            // Trying to search the last '.' and take something after it as index
-            $arrindex = explode(".", $index);
-            $newindex = (int)(end($arrindex))+0;
-            if (is_int($newindex)) {
-                discover_storage($valid_storage, $device, $newindex, $fstype, 'eql-storage', $descr, $size, $units, $used);
+    if (is_array($eql_storage)) {
+        echo 'EqliscsiVolumeEntry ';
+        foreach ($eql_storage as $index => $storage) {
+            $fstype = $storage['eqliscsiVolumeAdminStatus'];
+            $descr = $storage['eqliscsiVolumeName'];
+            $units = 1000000;
+            $size = $storage['eqliscsiVolumeSize'] * $units;
+            $used = $storage['eqliscsiVolumeStatusAllocatedSpace'] * $units;
+            if (is_int($index)) {
+                discover_storage($valid_storage, $device, $index, $fstype, 'eql-storage', $descr, $size, $units, $used);
+            } else {
+                // Trying to search the last '.' and take something after it as index
+                $arrindex = explode(".", $index);
+                $newindex = (int)(end($arrindex)) + 0;
+                if (is_int($newindex)) {
+                    discover_storage($valid_storage, $device, $newindex, $fstype, 'eql-storage', $descr, $size, $units, $used);
+                }
             }
+            unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
         }
-        unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
     }
 }

--- a/includes/discovery/storage/hpe-ilo.inc.php
+++ b/includes/discovery/storage/hpe-ilo.inc.php
@@ -1,20 +1,22 @@
 <?php
 
-$ilo_storage = snmpwalk_group($device, 'cpqHoFileSysEntry', 'CPQHOST-MIB', 1, array(), 'hp');
-$units = 1024*1024;
+if (in_array($device['os'], ['windows', 'hpe-ilo']) || $device['os_group'] == 'unix') {
+    $ilo_storage = snmpwalk_group($device, 'cpqHoFileSysEntry', 'CPQHOST-MIB', 1, array(), 'hp');
+    $units = 1024 * 1024;
 
-if (is_array($ilo_storage)) {
-    echo 'HPE ILO4 ';
-    foreach ($ilo_storage as $index => $storage) {
-        $type = $storage['cpqHoFileSysDesc'];
-        preg_match_all("/\\[:(.*?)\\]/", $type, $matches);
-        $fstype = $matches[1][0];
-        $descr = $storage['cpqHoFileSysDesc'];
-        $size = $storage['cpqHoFileSysSpaceTotal'];
-        $used = $storage['cpqHoFileSysSpaceUsed'];
-        if (is_int($index)) {
-            discover_storage($valid_storage, $device, $index, $fstype, 'hpe-ilo', $descr, $size, $units, $used);
+    if (is_array($ilo_storage)) {
+        echo 'HPE ILO4 ';
+        foreach ($ilo_storage as $index => $storage) {
+            $type = $storage['cpqHoFileSysDesc'];
+            preg_match_all("/\\[:(.*?)\\]/", $type, $matches);
+            $fstype = $matches[1][0];
+            $descr = $storage['cpqHoFileSysDesc'];
+            $size = $storage['cpqHoFileSysSpaceTotal'];
+            $used = $storage['cpqHoFileSysSpaceUsed'];
+            if (is_int($index)) {
+                discover_storage($valid_storage, $device, $index, $fstype, 'hpe-ilo', $descr, $size, $units, $used);
+            }
+            unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
         }
-        unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
     }
 }

--- a/includes/discovery/storage/netapp-storage.inc.php
+++ b/includes/discovery/storage/netapp-storage.inc.php
@@ -2,26 +2,28 @@
 
 use LibreNMS\Config;
 
-$netapp_storage = snmpwalk_cache_oid($device, 'dfEntry', null, 'NETAPP-MIB');
+if ($device['os'] == 'netapp') {
+    $netapp_storage = snmpwalk_cache_oid($device, 'dfEntry', null, 'NETAPP-MIB');
 
-if (is_array($netapp_storage)) {
-    echo 'dfEntry ';
-    foreach ($netapp_storage as $index => $storage) {
-        $fstype = $storage['dfType'];
-        $descr  = $storage['dfFileSys'];
-        $units  = 1024;
-        if (isset($storage['df64TotalKBytes']) && is_numeric($storage['df64TotalKBytes'])) {
-            $size = ($storage['df64TotalKBytes'] * $units);
-            $used = ($storage['df64UsedKBytes'] * $units);
-        } else {
-            $size = ($storage['dfKBytesTotal'] * $units);
-            $used = ($storage['dfKBytesUsed'] * $units);
+    if (is_array($netapp_storage)) {
+        echo 'dfEntry ';
+        foreach ($netapp_storage as $index => $storage) {
+            $fstype = $storage['dfType'];
+            $descr = $storage['dfFileSys'];
+            $units = 1024;
+            if (isset($storage['df64TotalKBytes']) && is_numeric($storage['df64TotalKBytes'])) {
+                $size = ($storage['df64TotalKBytes'] * $units);
+                $used = ($storage['df64UsedKBytes'] * $units);
+            } else {
+                $size = ($storage['dfKBytesTotal'] * $units);
+                $used = ($storage['dfKBytesUsed'] * $units);
+            }
+
+            if (is_numeric($index)) {
+                discover_storage($valid_storage, $device, $index, $fstype, 'netapp-storage', $descr, $size, $units, $used);
+            }
+
+            unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
         }
-
-        if (is_numeric($index)) {
-            discover_storage($valid_storage, $device, $index, $fstype, 'netapp-storage', $descr, $size, $units, $used);
-        }
-
-        unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
     }
 }

--- a/includes/discovery/storage/nimbleos.inc.php
+++ b/includes/discovery/storage/nimbleos.inc.php
@@ -24,19 +24,21 @@
  */
 use LibreNMS\Config;
 
-$nimble_storage = snmpwalk_cache_oid($device, 'volEntry', null, 'NIMBLE-MIB');
-if (is_array($nimble_storage)) {
-    echo 'volEntry ';
-    foreach ($nimble_storage as $index => $storage) {
-        $units  = 1024*1024;
-        $fstype = $storage['volOnline'];
-        $descr  = $storage['volName'];
-        //nimble uses a high 32bit counter and a low 32bit counter to make a 64bit counter
-        $size = (($storage['volSizeHigh'] << 32 ) + $storage['volSizeLow']) * $units;
-        $used = (($storage['volUsageHigh'] << 32 ) + $storage['volUsageLow']) * $units;
-        if (is_numeric($index)) {
-            discover_storage($valid_storage, $device, $index, $fstype, 'nimbleos', $descr, $size, $units, $used);
+if ($device['os'] == 'nimbleos') {
+    $nimble_storage = snmpwalk_cache_oid($device, 'volEntry', null, 'NIMBLE-MIB');
+    if (is_array($nimble_storage)) {
+        echo 'volEntry ';
+        foreach ($nimble_storage as $index => $storage) {
+            $units = 1024 * 1024;
+            $fstype = $storage['volOnline'];
+            $descr = $storage['volName'];
+            //nimble uses a high 32bit counter and a low 32bit counter to make a 64bit counter
+            $size = (($storage['volSizeHigh'] << 32) + $storage['volSizeLow']) * $units;
+            $used = (($storage['volUsageHigh'] << 32) + $storage['volUsageLow']) * $units;
+            if (is_numeric($index)) {
+                discover_storage($valid_storage, $device, $index, $fstype, 'nimbleos', $descr, $size, $units, $used);
+            }
+            unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
         }
-        unset($deny, $fstype, $descr, $size, $used, $units, $storage_rrd, $old_storage_rrd, $hrstorage_array);
     }
 }


### PR DESCRIPTION
leave hrstorage and ucd unrestricted
Not sure on the ilo, but I think linux and windows servers can return data

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
