### PR TITLE
refactor: Allow _perc and _current columns to be string for alert rules

### DIFF
--- a/LibreNMS/Alerting/QueryBuilderFilter.php
+++ b/LibreNMS/Alerting/QueryBuilderFilter.php
@@ -101,7 +101,7 @@ class QueryBuilderFilter implements \JsonSerializable
                     continue;
                 }
 
-                $type = $this->getColumnType($column_type, $column);
+                $type = $this->getColumnType($column_type);
 
                 // ignore unsupported types (such as binary and blob)
                 if (is_null($type)) {
@@ -110,8 +110,12 @@ class QueryBuilderFilter implements \JsonSerializable
 
                 $field = "$table.$column";
 
-                // format enums as radios
-                if ($type == 'enum') {
+                if (ends_with($column, ['_perc', '_current'])) {
+                    $this->filter[$field] = [
+                        'id' => $field,
+                        'type' => 'string',
+                    ];
+                } elseif ($type == 'enum') {// format enums as radios
                     $values = explode(',', substr($column_type, 4));
                     $values = array_map(function ($val) {
                         return trim($val, "()' ");
@@ -135,11 +139,9 @@ class QueryBuilderFilter implements \JsonSerializable
     }
 
 
-    private function getColumnType($type, $field)
+    private function getColumnType($type)
     {
-        if (ends_with($field, ['_perc', '_current'])) {
-            return 'string';
-        } elseif (starts_with($type, ['varchar', 'text', 'double', 'float'])) {
+        if (starts_with($type, ['varchar', 'text', 'double', 'float'])) {
             return 'string';
         } elseif (starts_with($type, ['int', 'tinyint', 'smallint', 'mediumint', 'bigint'])) {
             return 'integer';

--- a/LibreNMS/Alerting/QueryBuilderFilter.php
+++ b/LibreNMS/Alerting/QueryBuilderFilter.php
@@ -101,7 +101,7 @@ class QueryBuilderFilter implements \JsonSerializable
                     continue;
                 }
 
-                $type = $this->getColumnType($column_type);
+                $type = $this->getColumnType($column_type, $column);
 
                 // ignore unsupported types (such as binary and blob)
                 if (is_null($type)) {
@@ -135,9 +135,11 @@ class QueryBuilderFilter implements \JsonSerializable
     }
 
 
-    private function getColumnType($type)
+    private function getColumnType($type, $field)
     {
-        if (starts_with($type, ['varchar', 'text', 'double', 'float'])) {
+        if (ends_with($field, ['_perc', '_current'])) {
+            return 'string';
+        } elseif (starts_with($type, ['varchar', 'text', 'double', 'float'])) {
             return 'string';
         } elseif (starts_with($type, ['int', 'tinyint', 'smallint', 'mediumint', 'bigint'])) {
             return 'integer';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Fixes: https://community.librenms.org/t/trouble-with-storage-in-new-alert-rules-format/3724