### PR TITLE
Update alert rules to match auth failure on Cisco

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -113,7 +113,7 @@
     "name": "Too many wireless clients"
   },
   {
-    "rule": "%syslog.timestamp >= %macros.past_5m && %syslog.msg ~ \"@authentication failure@\"",
+    "rule": "%syslog.timestamp >= %macros.past_5m && %syslog.msg ~ \"@authentication fail@\"",
     "name": "Syslog, Authentication failure on Device"
   },
   {


### PR DESCRIPTION
Cisco generates entires like these on authentication failure:

Login failed [user: ] [Source: ] [localport: 22] [Reason: Login Authentication Failed] at 08:09:04 cet Tue Apr 10 2018

The old regex would not match that since it looks for "failure" changing this to the more inclusive "fail" will catch Cisco failures while keeping current functionality.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
