### PR TITLE
fix: Use email_user variable as from name for emails if available

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -933,7 +933,7 @@ function send_mail($emails, $subject, $message, $html = false)
 
         foreach (parse_email($config['email_from']) as $from => $from_name) {
             if (empty($from_name)) {
-                $from_name = Config::get('email_user', null);
+                $from_name = Config::get('email_user');
             }
             $mail->setFrom($from, $from_name);
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -932,6 +932,9 @@ function send_mail($emails, $subject, $message, $html = false)
         $mail->Hostname = php_uname('n');
 
         foreach (parse_email($config['email_from']) as $from => $from_name) {
+            if (empty($from_name)) {
+                $from_name = Config::get('email_user', null);
+            }
             $mail->setFrom($from, $from_name);
         }
         foreach ($emails as $email => $email_name) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

I wouldn't call this a bug but fixed anyway. Fixes: #7910 