### PR TITLE
Added support for syslog Oxidized notification on Huawei VRP switches…

### DIFF
--- a/scripts/syslog-notify-oxidized.php
+++ b/scripts/syslog-notify-oxidized.php
@@ -41,4 +41,7 @@ if (preg_match('/(SYS-(SW[0-9]+-)?5-CONFIG_I|VSHD-5-VSHD_SYSLOG_CONFIG_I): Confi
 } elseif (preg_match('/startup-config was changed by (?P<user>.+) from telnet client .*/', $msg, $matches)) {
     $username = $matches['user'];
     oxidized_node_update($hostname, $username, $msg);
+} elseif (preg_match('/HWCM\/4\/CFGCHANGE/', $msg, $matches)) { //Huawei VRP devices CFGCHANGE syslog
+    $username = 'not_provided'; //Huawei VRP syslog does not provide username here.
+    oxidized_node_update($hostname, $username, $msg);
 }


### PR DESCRIPTION
… (5720)
Hi,

The goal of this branch is to add support for Huawei VRP syslog to oxidized hook.

Apr 11 23:01:37 192.0.2.1 +01:00 my-device-name HWCM/4/CFGCHANGE:OID 1.3.6.1.4.1.2011.6.10.2.1 Configure changed. (EventIndex=353, CommandSource=1, ConfigSource=2, ConfigDestination=4)

Only change occurs in  scripts/syslog-notify-oxidized.php

Script for pre-commit ran successfully. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
