### PR TITLE
Update boss.inc.php

### DIFF
--- a/includes/polling/os/boss.inc.php
+++ b/includes/polling/os/boss.inc.php
@@ -21,6 +21,10 @@ $details = explode('  ', $sysDescr);
 $details = str_replace('ERS-', 'Ethernet Routing Switch ', $details);
 
 $hardware = explode(' (', $details[0]);
+
+// Make boss devices hardware string compact
+$hardware[0] = str_replace('Ethernet Routing Switch ', 'ERS-', $hardware[0]);
+$hardware[0] = str_replace('Virtual Services Platform ', 'VSP-', $hardware[0]);
 $hardware = $hardware[0];
 
 // Is this a 5500 series or 5600 series stack?


### PR DESCRIPTION
Boss hardware has a very long sysDescr string that hardware is pulled from.  I want to convert these long strings to "ERS-" and "VSP-".  This makes it easier to view via the gui.  I have tested on large install and works as expected.

root@cox-home-dashboard:~# snmpwalk -v2c -c public 192.168.1.6 .1.3.6.1.2.1.1.1
iso.3.6.1.2.1.1.1.0 = STRING: "Ethernet Routing Switch 4850GTS-PWR+  HW:14       FW:5.8.0.3   SW:v5.11.1.013 BN:13 (c) Avaya Networks"
root@cox-home-dashboard:~# snmpwalk -v2c -c public 192.168.1.9 .1.3.6.1.2.1.1.1
iso.3.6.1.2.1.1.1.0 = STRING: "Ethernet Routing Switch 3510GT-PWR+   HW:17       FW:5.3.0.8   SW:v5.3.6.015 BN:15 (c) Extreme Networks"

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
