### PR TITLE
Provide simple/complex Oxidized configs

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1213,42 +1213,28 @@ function list_oxidized()
         $params = array($hostname);
     }
 
-    foreach (dbFetchRows("SELECT hostname,sysname,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
-        if ($config['oxidized']['group_support'] == "true") {
-            foreach ($config['oxidized']['group']['hostname'] as $host_group) {
-                if (preg_match($host_group['regex'].'i', $device['hostname'])) {
-                    $device['group'] = $host_group['group'];
-                    break;
-                }
+    foreach (dbFetchRows("SELECT hostname,sysname,os,location,INET6_NTOA(ip) AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
+
+        // Pre-populate the group with the default
+        if (!empty($config['oxidized']['default_group'])) {
+            $device['group'] = $config['oxidized']['default_group'];
+        }
+
+        foreach ($config['oxidized']['maps'] as $maps_column => $maps) {
+            if ($maps_column == "group" && (!isset($config['oxidized']['group_support']) or $config['oxidized']['group_support'] !== true)) {
+                continue;
             }
-            if (empty($device['group'])) {
-                foreach ($config['oxidized']['group']['sysname'] as $host_group) {
-                    if (preg_match($host_group['regex'].'i', $device['sysname'])) {
-                        $device['group'] = $host_group['group'];
+            foreach ($maps as $field_type => $fields) {
+                foreach ($fields as $field) {
+                    if (preg_match($field['regex'].'i', $device[$field_type]))
+                    {
+                        $device[$maps_column] = $field[$maps_column];
                         break;
                     }
                 }
-            }
-            if (empty($device['group'])) {
-                foreach ($config['oxidized']['group']['os'] as $host_group) {
-                    if ($host_group['match'] === $device['os']) {
-                        $device['group'] = $host_group['group'];
-                        break;
-                    }
-                }
-            }
-            if (empty($device['group'])) {
-                foreach ($config['oxidized']['group']['location'] as $host_group) {
-                    if (preg_match($host_group['regex'].'i', $device['location'])) {
-                        $device['group'] = $host_group['group'];
-                        break;
-                    }
-                }
-            }
-            if (empty($device['group']) && !empty($config['oxidized']['default_group'])) {
-                $device['group'] = $config['oxidized']['default_group'];
             }
         }
+
         unset($device['location']);
         unset($device['sysname']);
         $devices[] = $device;


### PR DESCRIPTION
This patch provides the ability to override most aspects of the configuration output provided to Oxidized. This should be backwards compatible with any current maps defined previously but allows for extra features such as group overrides in Oxidized as well as IP changes (for hosts that are treated differently inside Oxidized), as well as ProxyHost additions. Of course, this goes further and allows for any flag that can be defined within Oxidized to be mapped in the config.

Examples

1) Define a group for these hosts
```php
$config['oxidized']['maps']['group']['sysname'][] = array('regex' => '/^(foo|bar)/', 'group' => 'myGroup');
$config['oxidized']['maps']['group']['sysname'][] = array('regex' => '/^(baz)/', 'group' => 'anotherGroup');
```
2) Provide a proxy host for these hosts to bounce through
```php
$config['oxidized']['maps']['ssh_proxy']['sysname'][] = array('regex' => '/foo/', 'ssh_proxy' => 'mySshProxyHost');
$config['oxidized']['maps']['ssh_proxy']['sysname'][] = array('regex' => '/bar/', 'ssh_proxy' => 'anotherSshProxyHost');
```
3) Allow overrides of IP addresses so the external DNS is not used for connections
```php
$config['oxidized']['maps']['ip']['sysname'][] = array('regex' => '/baz/', 'ip' => '10.10.0.23');
$config['oxidized']['maps']['ip']['sysname'][] = array('regex' => '/lala/', 'ip' => '192.168.0.243');
```
As already mentioned, this doesn't stop with the above examples.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
