### PR TITLE
Changed limit values in routeros.yaml

### DIFF
--- a/includes/definitions/discovery/routeros.yaml
+++ b/includes/definitions/discovery/routeros.yaml
@@ -36,10 +36,10 @@ modules:
                     num_oid: .1.3.6.1.4.1.14988.1.1.3.10.
                     divisor: 10
                     descr: 'Temperature {{ $index }}'
-                    low_limit: -40
-                    low_warn_limit: -35
-                    warn_limit: 65
-                    high_limit: 70
+                    low_limit: -400
+                    low_warn_limit: -350
+                    warn_limit: 650
+                    high_limit: 700
                 -
                     oid: mtxrHlProcessorTemperature
                     num_oid: .1.3.6.1.4.1.14988.1.1.3.11.


### PR DESCRIPTION
Limits do not account for the divisor of 10.
So need to be 10 x the actual value.
See https://github.com/librenms/librenms/issues/8602


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
