### PR TITLE
Fix Q-BRIDGE-MIB VLANs

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -53,6 +53,7 @@ class ModuleTestHelper
     private $exclude_from_all = ['arp-table'];
     private $module_deps = [
         'arp-table' => ['ports', 'arp-table'],
+        'vlans' => ['ports', 'vlans'],
     ];
 
 
@@ -686,7 +687,7 @@ class ModuleTestHelper
                         return array_diff_key($row, $keys);
                     }, $rows);
                 }
-                
+
                 if (isset($key)) {
                     $data[$module][$key][$table] = $rows;
                 } else {

--- a/includes/discovery/vlans/q-bridge-mib.inc.php
+++ b/includes/discovery/vlans/q-bridge-mib.inc.php
@@ -11,6 +11,18 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
     $tagoruntag   = snmpwalk_cache_oid($device, 'dot1qVlanCurrentEgressPorts', array(), 'Q-BRIDGE-MIB', null, '-OQUs --hexOutputLength=0');
     $untag        = snmpwalk_cache_oid($device, 'dot1qVlanCurrentUntaggedPorts', array(), 'Q-BRIDGE-MIB', null, '-OQUs --hexOutputLength=0');
 
+    // drop dot1qVlanTimeMark, we don't care about it
+    $tagoruntag = array_reduce(array_keys($tagoruntag), function($result, $key) use ($tagoruntag) {
+        list($time, $new_key) = explode('.', $key);
+        $result[$new_key] = $tagoruntag[$key];
+        return $result;
+    }, []);
+    $untag = array_reduce(array_keys($untag), function($result, $key) use ($untag) {
+        list($time, $new_key) = explode('.', $key);
+        $result[$new_key] = $untag[$key];
+        return $result;
+    }, []);
+
     foreach ($vlans as $vlan_id => $vlan) {
         d_echo(" $vlan_id");
         if (is_array($vlans_db[$vtpdomain_id][$vlan_id])) {
@@ -36,13 +48,14 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
 
         $device['vlans'][$vtpdomain_id][$vlan_id] = $vlan_id;
 
-        $id = "0.$vlan_id";
-        $untagged_ids = q_bridge_bits2indices($untag[$id]['dot1qVlanCurrentUntaggedPorts']);
-        $egress_ids = q_bridge_bits2indices($tagoruntag[$id]['dot1qVlanCurrentEgressPorts']);
+        $untagged_ids = q_bridge_bits2indices($untag[$vlan_id]['dot1qVlanCurrentUntaggedPorts']);
+        $egress_ids = q_bridge_bits2indices($tagoruntag[$vlan_id]['dot1qVlanCurrentEgressPorts']);
 
         foreach ($egress_ids as $port_id) {
-            $ifIndex = $base_to_index[$port_id];
-            $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = (in_array($port_id, $untagged_ids) ? 1 : 0);
+            if (isset($base_to_index[$port_id])) {
+                $ifIndex = $base_to_index[$port_id];
+                $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = (in_array($port_id, $untagged_ids) ? 1 : 0);
+            }
         }
     }
 }

--- a/tests/data/comware.json
+++ b/tests/data/comware.json
@@ -49670,5 +49670,1942 @@
             ]
         },
         "poller": "matches discovery"
+    },
+    "vlans": {
+        "discovery": {
+            "vlans": [
+                {
+                    "vlan_vlan": "1",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 0001",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                },
+                {
+                    "vlan_vlan": "27",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 0027",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                },
+                {
+                    "vlan_vlan": "100",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 0100",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                },
+                {
+                    "vlan_vlan": "500",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 0500",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                },
+                {
+                    "vlan_vlan": "501",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 0501",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                },
+                {
+                    "vlan_vlan": "505",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 0505",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                },
+                {
+                    "vlan_vlan": "1000",
+                    "vlan_domain": "1",
+                    "vlan_name": "VLAN 1000",
+                    "vlan_type": null,
+                    "vlan_mtu": null
+                }
+            ],
+            "ports_vlans": [
+                {
+                    "vlan": "1",
+                    "baseport": "1",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "2",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "3",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "4",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "5",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "6",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "7",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "8",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "9",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "10",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "11",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "12",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "13",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "14",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "15",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "16",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "17",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "18",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "19",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "20",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "21",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "22",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "23",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "24",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "25",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "26",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "27",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "28",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "29",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "30",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "31",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "32",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "33",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "34",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "35",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "36",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "37",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "38",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "39",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "40",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "41",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "42",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "43",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "44",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "45",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "46",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "47",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "48",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "49",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "50",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "51",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "52",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "53",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "54",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "55",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "56",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "57",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "58",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "59",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "60",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "61",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "65",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "66",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "67",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "68",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "69",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "70",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "71",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "72",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "73",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "74",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "75",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "76",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "77",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "78",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "79",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "80",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "81",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "82",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "83",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "84",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "85",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "86",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "87",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "88",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "89",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "90",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "91",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "92",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "93",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "94",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "95",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "96",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "97",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "98",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "99",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "100",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "101",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "102",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "103",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "104",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "105",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "106",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "107",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "108",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "109",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "113",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "114",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "115",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "116",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "117",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "118",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "119",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "120",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "121",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "122",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "123",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "124",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "125",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "126",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "133",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "135",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "138",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "142",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "143",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "387",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "388",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "395",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "403",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "404",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "411",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "412",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "435",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "436",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "443",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "451",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "452",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "459",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "1",
+                    "baseport": "460",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "133",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "135",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "139",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "140",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "387",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "388",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "395",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "403",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "404",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "411",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "412",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "435",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "436",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "443",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "451",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "452",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "459",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "27",
+                    "baseport": "460",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "133",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "135",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "139",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "140",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "387",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "388",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "395",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "403",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "404",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "411",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "412",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "435",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "436",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "443",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "451",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "452",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "459",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "100",
+                    "baseport": "460",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "33",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "34",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "35",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "36",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "37",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "38",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "39",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "40",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "41",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "66",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "67",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "89",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "133",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "135",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "139",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "140",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "387",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "388",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "395",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "403",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "404",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "411",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "412",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "435",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "436",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "443",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "451",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "452",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "459",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "500",
+                    "baseport": "460",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "33",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "34",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "35",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "36",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "37",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "38",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "39",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "40",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "41",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "66",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "67",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "89",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "0"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "133",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "135",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "139",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "140",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "387",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "388",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "395",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "403",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "404",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "411",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "412",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "435",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "436",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "443",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "451",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "452",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "459",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                },
+                {
+                    "vlan": "501",
+                    "baseport": "460",
+                    "priority": "0",
+                    "state": "unknown",
+                    "cost": "0",
+                    "untagged": "1"
+                }
+            ]
+        }
     }
 }

--- a/tests/module_tables.yaml
+++ b/tests/module_tables.yaml
@@ -53,6 +53,13 @@ toner:
     toner:
         excluded_fields: [device_id, toner_id]
         order_by: toner_oid, toner_index
+vlans:
+    vlans:
+        excluded_fields: [vlan_id, device_id]
+        order_by: vlan_domain, vlan_vlan
+    ports_vlans:
+        excluded_fields: [port_vlan_id, device_id, port_id]
+        order_by: vlan, baseport
 wireless:
     wireless_sensors:
         excluded_fields: [device_id, sensor_id, access_point_id, lastupdate]


### PR DESCRIPTION
Properly handle dot1qVlanTimeMark index (by ignoring it instead of assuming it is 0)
Adds test data for at least one device that uses Q-BRIDGE-MIB.

Fixes: #8516

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
