### PR TITLE
Allow more complete overrides on Oxidized output

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -439,7 +439,7 @@ class Config
         self::deprecatedVariable('rrdgraph_real_95th', 'rrdgraph_real_percentile');
         self::deprecatedVariable('fping_options.millisec', 'fping_options.interval');
         self::deprecatedVariable('discovery_modules.cisco-vrf', 'discovery_modules.vrf');
-        self::deprecatedVariable('oxidixed.groups', 'oxidized.maps.groups');
+        self::deprecatedVariable('oxidixed.group', 'oxidized.maps.group');
 
         // make sure we have full path to binaries in case PATH isn't set
         foreach (array('fping', 'fping6', 'snmpgetnext', 'rrdtool') as $bin) {

--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -439,7 +439,7 @@ class Config
         self::deprecatedVariable('rrdgraph_real_95th', 'rrdgraph_real_percentile');
         self::deprecatedVariable('fping_options.millisec', 'fping_options.interval');
         self::deprecatedVariable('discovery_modules.cisco-vrf', 'discovery_modules.vrf');
-
+        self::deprecatedVariable('oxidixed.groups', 'oxidized.maps.groups');
 
         // make sure we have full path to binaries in case PATH isn't set
         foreach (array('fping', 'fping6', 'snmpgetnext', 'rrdtool') as $bin) {

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -78,22 +78,43 @@ To do so, edit the option in Global Settings>External Settings>Oxidized Integrat
 $config['oxidized']['reload_nodes'] = true;
 
 ```
+### Creating overrides
 
-### Working with groups
+To return an override to Oxidized you can do this by providing the override key, followed by matching a lookup for a host (or hosts), and finally by defining the overriding value itself. LibreNMS does not check for the validity of these attributes but will deliver them to Oxidized as defined.
 
-To return a group to Oxidized you can do this by matching a regex for either `hostname`, `sysname`, `os` or `location`. The order is `hostname` is matched first, if nothing is found then `sysname` is tried, then `os`, and finally `location` is attempted.
-The first match found will be used. To match on the device hostnames or sysnames that contain 'lon-sw' or if the location contains 'London' then you would place the following within config.php:
+Matching of hosts can be done using `hostname`, `sysname`, `os` or `location` and including either a 'match' key and value, or a 'regex' key and value. The order is `hostname` is matched first, if nothing is found then `sysname` is tried, then `os`, and finally `location` is attempted.
+
+To match on the device hostnames or sysnames that contain 'lon-sw' or if the location contains 'London' then you would place the following within config.php:
 
 ```php
-$config['oxidized']['group']['hostname'][] = array('regex' => '/^lon-sw/', 'group' => 'london-switches');
-$config['oxidized']['group']['sysname'][] = array('regex' => '/^lon-sw/', 'group' => 'london-switches');
-$config['oxidized']['group']['location'][] = array('regex' => '/london/', 'group' => 'london-switches');
+$config['oxidized']['maps']['group']['hostname'][] = array('regex' => '/^lon-sw/', 'group' => 'london-switches');
+$config['oxidized']['maps']['group']['sysname'][] = array('regex' => '/^lon-sw/', 'group' => 'london-switches');
+$config['oxidized']['maps']['group']['location'][] = array('regex' => '/london/', 'group' => 'london-switches');
 ```
 
 To match on a device os of edgeos then please use the following:
 
 ```php
-$config['oxidized']['group']['os'][] = array('match' => 'edgeos', 'group' => 'wireless');
+$config['oxidized']['maps']['group']['os'][] = array('match' => 'edgeos', 'group' => 'wireless');
+```
+
+To override the IP Oxidized uses to poll the device, you can add the following within config.php:
+
+```php
+$config['oxidized']['maps']['ip']['sysname'][] = array('regex' => '/^my.node/', 'ip' => '192.168.1.10');
+$config['oxidized']['maps']['ip']['sysname'][] = array('match' => 'my-other.node', 'ip' => '192.168.1.20');
+```
+
+This allows extending the configuration further by providing a completely flexible model for custom flags and settings, for example, below shows the ability to add an ssh_proxy configuration with a host to your Oxidized configuration:
+
+```php
+$config['oxidized']['maps']['ssh_proxy']['sysname'][] = array('regex' => '/^my.node/', 'ssh_proxy' => 'my-ssh-gateway.node');
+```
+
+Or of course, any custom value that could be needed or wanted can be applied, for example, setting a "myAttribute" to "Super cool value" for any configured and enabled "routeros" device.
+
+```php
+$config['oxidized']['maps']['myAttribute']['os'][] = array('match' => 'routeros', 'myAttribute' => 'Super cool value');
 ```
 
 Verify the return of groups by querying the API:

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -105,7 +105,7 @@ $config['oxidized']['maps']['ip']['sysname'][] = array('regex' => '/^my.node/', 
 $config['oxidized']['maps']['ip']['sysname'][] = array('match' => 'my-other.node', 'ip' => '192.168.1.20');
 ```
 
-This allows extending the configuration further by providing a completely flexible model for custom flags and settings, for example, below shows the ability to add an ssh_proxy configuration with a host to your Oxidized configuration:
+This allows extending the configuration further by providing a completely flexible model for custom flags and settings, for example, below shows the ability to add an ssh_proxy host within Oxidized simply by adding the below to your configuration:
 
 ```php
 $config['oxidized']['maps']['ssh_proxy']['sysname'][] = array('regex' => '/^my.node/', 'ssh_proxy' => 'my-ssh-gateway.node');

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1237,42 +1237,28 @@ function list_oxidized()
         $params = array($hostname);
     }
 
-    foreach (dbFetchRows("SELECT hostname,sysname,os,location FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
-        if ($config['oxidized']['group_support'] == "true") {
-            foreach ($config['oxidized']['group']['hostname'] as $host_group) {
-                if (preg_match($host_group['regex'].'i', $device['hostname'])) {
-                    $device['group'] = $host_group['group'];
-                    break;
-                }
+    foreach (dbFetchRows("SELECT hostname,sysname,os,location,INET6_NTOA(ip) AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
+
+        // Pre-populate the group with the default
+        if (!empty($config['oxidized']['default_group'])) {
+            $device['group'] = $config['oxidized']['default_group'];
+        }
+
+        foreach ($config['oxidized']['maps'] as $maps_column => $maps) {
+            if ($maps_column == "group" && (!isset($config['oxidized']['group_support']) or $config['oxidized']['group_support'] !== true)) {
+                continue;
             }
-            if (empty($device['group'])) {
-                foreach ($config['oxidized']['group']['sysname'] as $host_group) {
-                    if (preg_match($host_group['regex'].'i', $device['sysname'])) {
-                        $device['group'] = $host_group['group'];
+            foreach ($maps as $field_type => $fields) {
+                foreach ($fields as $field) {
+                    if (preg_match($field['regex'].'i', $device[$field_type]))
+                    {
+                        $device[$maps_column] = $field[$maps_column];
                         break;
                     }
                 }
-            }
-            if (empty($device['group'])) {
-                foreach ($config['oxidized']['group']['os'] as $host_group) {
-                    if ($host_group['match'] === $device['os']) {
-                        $device['group'] = $host_group['group'];
-                        break;
-                    }
-                }
-            }
-            if (empty($device['group'])) {
-                foreach ($config['oxidized']['group']['location'] as $host_group) {
-                    if (preg_match($host_group['regex'].'i', $device['location'])) {
-                        $device['group'] = $host_group['group'];
-                        break;
-                    }
-                }
-            }
-            if (empty($device['group']) && !empty($config['oxidized']['default_group'])) {
-                $device['group'] = $config['oxidized']['default_group'];
             }
         }
+
         unset($device['location']);
         unset($device['sysname']);
         $devices[] = $device;

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1238,7 +1238,6 @@ function list_oxidized()
     }
 
     foreach (dbFetchRows("SELECT hostname,sysname,os,location,ip AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
-
         // Convert from packed value to human value
         $device['ip'] = inet6_ntop($device['ip']);
 
@@ -1257,8 +1256,7 @@ function list_oxidized()
                     if (isset($field['regex']) && preg_match($field['regex'].'i', $device[$field_type])) {
                         $device[$maps_column] = $field[$maps_column];
                         break;
-                    }
-                    elseif (isset($field['match']) && $field['match'] == $device[$field_type]) {
+                    } elseif (isset($field['match']) && $field['match'] == $device[$field_type]) {
                         $device[$maps_column] = $field[$maps_column];
                         break;
                     }

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1238,20 +1238,18 @@ function list_oxidized()
     }
 
     foreach (dbFetchRows("SELECT hostname,sysname,os,location,INET6_NTOA(ip) AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
-
         // Pre-populate the group with the default
         if (!empty($config['oxidized']['default_group'])) {
             $device['group'] = $config['oxidized']['default_group'];
         }
-
         foreach ($config['oxidized']['maps'] as $maps_column => $maps) {
+            // Based on Oxidized group support we can apply groups by setting group_support to true
             if ($maps_column == "group" && (!isset($config['oxidized']['group_support']) or $config['oxidized']['group_support'] !== true)) {
                 continue;
             }
             foreach ($maps as $field_type => $fields) {
                 foreach ($fields as $field) {
-                    if (preg_match($field['regex'].'i', $device[$field_type]))
-                    {
+                    if (preg_match($field['regex'].'i', $device[$field_type])) {
                         $device[$maps_column] = $field[$maps_column];
                         break;
                     }

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1239,7 +1239,7 @@ function list_oxidized()
 
     foreach (dbFetchRows("SELECT hostname,sysname,os,location,INET6_NTOA(ip) AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
         // Pre-populate the group with the default
-        if ($config['oxidized']['group_support'] === "true" && !empty($config['oxidized']['default_group'])) {
+        if ($config['oxidized']['group_support'] === true && !empty($config['oxidized']['default_group'])) {
             $device['group'] = $config['oxidized']['default_group'];
         }
         foreach ($config['oxidized']['maps'] as $maps_column => $maps) {
@@ -1249,7 +1249,11 @@ function list_oxidized()
             }
             foreach ($maps as $field_type => $fields) {
                 foreach ($fields as $field) {
-                    if (preg_match($field['regex'].'i', $device[$field_type])) {
+                    if(isset($field['regex']) && preg_match($field['regex'].'i', $device[$field_type])) {
+                        $device[$maps_column] = $field[$maps_column];
+                        break;
+                    }
+                    elseif(isset($field['match']) && $field['match'] == $device[$field_type]) {
                         $device[$maps_column] = $field[$maps_column];
                         break;
                     }

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1239,7 +1239,7 @@ function list_oxidized()
 
     foreach (dbFetchRows("SELECT hostname,sysname,os,location,INET6_NTOA(ip) AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
         // Pre-populate the group with the default
-        if (!empty($config['oxidized']['default_group'])) {
+        if ($config['oxidized']['group_support'] === true && !empty($config['oxidized']['default_group'])) {
             $device['group'] = $config['oxidized']['default_group'];
         }
         foreach ($config['oxidized']['maps'] as $maps_column => $maps) {

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1239,7 +1239,7 @@ function list_oxidized()
 
     foreach (dbFetchRows("SELECT hostname,sysname,os,location,INET6_NTOA(ip) AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
         // Pre-populate the group with the default
-        if ($config['oxidized']['group_support'] === true && !empty($config['oxidized']['default_group'])) {
+        if ($config['oxidized']['group_support'] === "true" && !empty($config['oxidized']['default_group'])) {
             $device['group'] = $config['oxidized']['default_group'];
         }
         foreach ($config['oxidized']['maps'] as $maps_column => $maps) {


### PR DESCRIPTION
This patch provides the ability to override most aspects of the configuration output provided to Oxidized. This is now backwards compatible with any current groups defined previously but allows for extra features such as group overrides in Oxidized as well as IP changes (for hosts that are treated differently inside Oxidized), as well as ProxyHost additions. Of course, this goes further and allows for any flag that can be defined within Oxidized to be mapped in the config.

Examples

1) Define a group for these hosts
```php
$config['oxidized']['maps']['group']['sysname'][] = array('regex' => '/^(foo|bar)/', 'group' => 'myGroup');
$config['oxidized']['maps']['group']['sysname'][] = array('regex' => '/^(baz)/', 'group' => 'anotherGroup');
```
2) Provide a proxy host for these hosts to bounce through
```php
$config['oxidized']['maps']['ssh_proxy']['sysname'][] = array('regex' => '/foo/', 'ssh_proxy' => 'mySshProxyHost');
$config['oxidized']['maps']['ssh_proxy']['sysname'][] = array('regex' => '/bar/', 'ssh_proxy' => 'anotherSshProxyHost');
```
3) Allow overrides of IP addresses so the external DNS is not used for connections
```php
$config['oxidized']['maps']['ip']['sysname'][] = array('regex' => '/baz/', 'ip' => '10.10.0.23');
$config['oxidized']['maps']['ip']['sysname'][] = array('regex' => '/lala/', 'ip' => '192.168.0.243');
```
As already mentioned, this doesn't stop with the above examples.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
