### PR TITLE
Adding support for embedded graphs in email alerts

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -965,8 +965,7 @@ function send_mail($emails, $subject, $message, $html = false)
                 $image = file_get_contents($item, false, stream_context_create($arrContextOptions));
                 if ($config['webui']['graph_type'] == 'svg') {
                     $mail->addStringEmbeddedImage($image, $countcheck, 'graph.svg', 'base64', 'image/svg+xml');
-                }
-                else {
+                } else {
                     $mail->addStringEmbeddedImage($image, $countcheck, 'graph.png', 'base64', 'image/png');
                 }
                 $countcheck++;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -950,28 +950,23 @@ function send_mail($emails, $subject, $message, $html = false)
         if ($html) {
             $mail->isHTML(true);
             //Addding functionality to support cid embedded graphs
-				$arrContextOptions=array(
-				    "ssl"=>array(
-				        "verify_peer"=>false,
-				        "verify_peer_name"=>false,
-				        "timeout" => 1200,
-				    ),
+            $arrContextOptions=array(
+                "ssl"=>array(
+                "verify_peer"=>false,
+                "verify_peer_name"=>false,
+                "timeout" => 1200,
+                ),
 				);
-
-				preg_match_all('/ alt=\"(.*?)\"/', $mail->Body, $match);
-
-				$countcheck = 0;
-				$newcidhtml = $mail->Body;
-				foreach ($match[1] as $item) {
-
-				$newcidhtml=preg_replace("/\bembedimage\b/i", $countcheck, $newcidhtml, 1);
-
-				            $image = file_get_contents($item, false, stream_context_create($arrContextOptions));
-				            $mail->addStringEmbeddedImage($image, $countcheck, 'graph.png', 'base64', 'image/png');
-				$countcheck++;
-				                }
-
-				$mail->Body = $newcidhtml;
+            preg_match_all('/ alt=\"(.*?)\"/', $mail->Body, $match);
+            $countcheck = 0;
+            $newcidhtml = $mail->Body;
+            foreach ($match[1] as $item) {
+                $newcidhtml=preg_replace("/\bembedimage\b/i", $countcheck, $newcidhtml, 1);
+                $image = file_get_contents($item, false, stream_context_create($arrContextOptions));
+                $mail->addStringEmbeddedImage($image, $countcheck, 'graph.png', 'base64', 'image/png');
+                $countcheck++;
+            }
+            $mail->Body = $newcidhtml;
         }
         switch (strtolower(trim($config['email_backend']))) {
             case 'sendmail':

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -963,7 +963,12 @@ function send_mail($emails, $subject, $message, $html = false)
             foreach ($match[1] as $item) {
                 $newcidhtml=preg_replace("/\bembedimage\b/i", $countcheck, $newcidhtml, 1);
                 $image = file_get_contents($item, false, stream_context_create($arrContextOptions));
-                $mail->addStringEmbeddedImage($image, $countcheck, 'graph.png', 'base64', 'image/png');
+                if ($config['webui']['graph_type'] == 'svg') {
+                    $mail->addStringEmbeddedImage($image, $countcheck, 'graph.svg', 'base64', 'image/svg+xml');
+                }
+                else {
+                    $mail->addStringEmbeddedImage($image, $countcheck, 'graph.png', 'base64', 'image/png');
+                }
                 $countcheck++;
             }
             $mail->Body = $newcidhtml;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -949,6 +949,29 @@ function send_mail($emails, $subject, $message, $html = false)
         $mail->Body = $message;
         if ($html) {
             $mail->isHTML(true);
+            //Addding functionality to support cid embedded graphs
+				$arrContextOptions=array(
+				    "ssl"=>array(
+				        "verify_peer"=>false,
+				        "verify_peer_name"=>false,
+				        "timeout" => 1200,
+				    ),
+				);
+
+				preg_match_all('/ alt=\"(.*?)\"/', $mail->Body, $match);
+
+				$countcheck = 0;
+				$newcidhtml = $mail->Body;
+				foreach ($match[1] as $item) {
+
+				$newcidhtml=preg_replace("/\bembedimage\b/i", $countcheck, $newcidhtml, 1);
+
+				            $image = file_get_contents($item, false, stream_context_create($arrContextOptions));
+				            $mail->addStringEmbeddedImage($image, $countcheck, 'graph.png', 'base64', 'image/png');
+				$countcheck++;
+				                }
+
+				$mail->Body = $newcidhtml;
         }
         switch (strtolower(trim($config['email_backend']))) {
             case 'sendmail':

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -956,7 +956,7 @@ function send_mail($emails, $subject, $message, $html = false)
                 "verify_peer_name"=>false,
                 "timeout" => 1200,
                 ),
-				);
+                );
             preg_match_all('/ alt=\"(.*?)\"/', $mail->Body, $match);
             $countcheck = 0;
             $newcidhtml = $mail->Body;


### PR DESCRIPTION
Created functionality to support embedded graphs in HTML emails.

To help test
```./scripts/github-apply 8646```

Add this line somewhere in your config.php
```$config['allow_unauth_graphs'] = true;```

Add this line in your HTML template and change the alt value to your graph.
```<img width="800" height="300" src="cid:embedimage" alt="https://SERVERIP/GRAPHLINK">```

Request references:
https://community.librenms.org/t/embed-graph-in-alert-email/3418/5
https://community.librenms.org/t/feature-request-embed-images-into-email
https://community.librenms.org/t/graphs-on-email/3749/4
https://community.librenms.org/t/alert-template-with-graph/3523

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
