### PR TITLE
Do not fail validation when IPv6 is disabled by unloading the module.

### DIFF
--- a/LibreNMS/Validations/Programs.php
+++ b/LibreNMS/Validations/Programs.php
@@ -68,7 +68,7 @@ class Programs extends BaseValidation
             return;
         }
 
-        if (str_contains($output, '::1 is unreachable')) {
+        if (str_contains($output, '::1 is unreachable') || str_contains($output, 'Address family not supported')) {
             $validator->warn("IPv6 is disabled on your server, you will not be able to add IPv6 devices.");
             return;
         }


### PR DESCRIPTION
This changeset resolves an issue where validation fails on systems where IPv6 is disabled by unloading/omitting the relevant kernel modules (as opposed to disabling via sysctl). 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
