### PR TITLE
Selective Port polling improvements

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1187,11 +1187,13 @@ function is_port_valid($port, $device)
     if (empty($port['ifDescr'])) {
         // If these are all empty, we are just going to show blank names in the ui
         if (empty($port['ifAlias']) && empty($port['ifName'])) {
+            d_echo("ignored: empty ifDescr, ifAlias and ifName\n");
             return false;
         }
 
         // ifDescr should not be empty unless it is explicitly allowed
         if (!Config::getOsSetting($device['os'], 'empty_ifdescr', false)) {
+            d_echo("ignored: empty ifDescr\n");
             return false;
         }
     }

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -880,10 +880,6 @@ foreach ($ports as $port) {
 
         // Update Database
         if (count($port['update'])) {
-            if ($port_id == 2666) {
-                var_dump($port['update'], $port['skipped']);
-            }
-
             $updated = dbUpdate($port['update'], 'ports', '`port_id` = ?', array($port_id));
             // do we want to do something else with this?
             if (!empty($port['update_extended'])) {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -713,7 +713,6 @@ foreach ($ports as $port) {
         if (!empty($port['skipped'])) {
             echo " $port_id skipped.\n";
         } else {
-            var_dump($port['skipped']);
             // End parse ifAlias
             // Update IF-MIB metrics
             $_stat_oids = array_merge($stat_oids_db, $stat_oids_db_extended);

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -461,7 +461,7 @@ foreach ($port_stats as $ifIndex => $port) {
     /* Build a list of all ports, identified by their port_id, found within this poller run. */
         $ports_found[] = $port_id;
     } // Port vanished (mark as deleted) (except when skipped by selective port polling)
-    elseif(empty($ports[$port_id]['skipped'])) {
+    elseif (empty($ports[$port_id]['skipped'])) {
         if ($ports[$port_id]['deleted'] != '1') {
             dbUpdate(array('deleted' => '1'), 'ports', '`port_id` = ?', array($port_id));
             $ports[$port_id]['deleted'] = '1';
@@ -778,8 +778,7 @@ foreach ($ports as $port) {
                 $saturation_threshold = ($this_port['ifSpeed'] * ($config['alerts']['port_util_perc'] / 100));
                 echo 'IN: ' . $port['stats']['ifInBits_rate'] . ' OUT: ' . $port['stats']['ifOutBits_rate'] . ' THRESH: ' . $saturation_threshold;
                 if (($port['stats']['ifInBits_rate'] >= $saturation_threshold || $port['stats']['ifOutBits_rate'] >= $saturation_threshold) && $saturation_threshold > 0) {
-                    log_event('Port reached saturation threshold: ' . formatRates($port['stats']['ifInBits_rate']) . '/' . formatRates($port['stats']['ifOutBits_rate']) . ' - ifspeed: ' . formatRates($this_port['stats']['ifSpeed']),
-                        $device, 'interface', 4, $port['port_id']);
+                    log_event('Port reached saturation threshold: ' . formatRates($port['stats']['ifInBits_rate']) . '/' . formatRates($port['stats']['ifOutBits_rate']) . ' - ifspeed: ' . formatRates($this_port['stats']['ifSpeed']), $device, 'interface', 4, $port['port_id']);
                 }
             }
 

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -211,8 +211,10 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
         $total_port_count = count($ports);
         $walk_base = $total_port_count - $polled_port_count < 5 || $polled_port_count / $total_port_count > 0.9 ;
 
-        foreach ($table_base_oids as $oid) {
-            $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'IF-MIB');
+        if ($walk_base) {
+            foreach ($table_base_oids as $oid) {
+                $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'IF-MIB');
+            }
         }
 
         foreach ($polled_ports as $port_id => $port) {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -203,7 +203,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
         // remove the deleted and disabled ports and mark them skipped
         $polled_ports = array_filter($ports, function ($port) use ($ports) {
             $ports[$port['ifIndex']]['skipped'] = true;
-            return $port['deleted'] || $port['disabled'];
+            return !($port['deleted'] || $port['disabled']);
         });
 
         // if less than 5 ports or less than 10% of the total ports are skipped, walk the base oids instead of get
@@ -713,7 +713,7 @@ foreach ($ports as $port) {
 
         // We don't care about statistics for skipped selective polling ports
         if (!empty($port['skipped'])) {
-            echo " $port_id skipped.\n";
+            echo " $port_id skipped.";
         } else {
             // End parse ifAlias
             // Update IF-MIB metrics


### PR DESCRIPTION
Don't delete skipped ports when using selected polling
Improve output of port polling module.
Update ifOperStatus and ifAdminStatus even when skipping.

Warning! causes a semantic change where ifAdminStatus_prev and ifOperStatus_prev are updated every poll, so they will only be mismatched for one poll.  This could cause alerts to behave differently.

Add an optimization if less than 10% of the ports are disabled (or less than 5), walk the base oids.
Time improvement on test device Full: 12s, Selective: 8s, Optimized 4s. (no disabled ports on device, many down)

Another test device.

![image](https://user-images.githubusercontent.com/39462/40066671-46cdc956-582a-11e8-928a-80bbd81dd423.png)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
