### PR TITLE
snmpscan.py: ignore bad DNS config

### DIFF
--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -30,7 +30,7 @@ import json
 from collections import namedtuple
 from multiprocessing import Pool
 from os import path, chdir
-from socket import gethostbyname, gethostbyaddr, herror
+from socket import gethostbyname, gethostbyaddr, herror, gaierror
 from subprocess import check_output, CalledProcessError
 from sys import stdout
 from time import time
@@ -114,10 +114,11 @@ def scan_host(ip):
 
     try:
         try:
+            # attempt to convert IP to hostname, if anything goes wrong, just use the IP
             tmp = gethostbyaddr(ip)[0]
             if gethostbyname(tmp) == ip:  # check that forward resolves
                 hostname = tmp
-        except herror:
+        except (herror, gaierror):
             pass
 
         try:


### PR DESCRIPTION
When someone has configured reverse dns that points to an incorrect dns hostname, this should revert to IP properly

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
