### PR TITLE
Fix for get_alert API method.

### DIFF
--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1014,7 +1014,7 @@ function list_alerts()
     $sql = '';
     if (isset($router['id']) && $router['id'] > 0) {
         $alert_id = mres($router['id']);
-        $sql      = 'AND id=?';
+        $sql      = 'AND `A`.id=?';
         array_push($param, $alert_id);
     }
 


### PR DESCRIPTION
Fix for get_alert API method. Tested on MySQL-community 5.7.22 and MariaDB 10.2.14.
Issue log sample: 
2018-05-02 07:10:44 MySQL Error: Column 'id' in where clause is ambiguous (SELECT `D`.`hostname`, `A`.*, `R`.`severity` FROM `alerts` AS `A`, `devices` AS `D`, `alert_rules` AS `R` WHERE `D`.`device_id` = `A`.`device_id` AND `A`.`rule_id` = `R`.`id` AND `A`.`state` IN ('1') AND id='31731')

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
