### PR TITLE
MySQL-community maintenance scheduling fix. 

### DIFF
--- a/html/includes/forms/schedule-maintenance.inc.php
+++ b/html/includes/forms/schedule-maintenance.inc.php
@@ -100,8 +100,8 @@ if ($sub_type == 'new-maintenance') {
         }
         
         // recurring = 0 => empty no reccurency values to be sure.
-        $start_recurring_dt = '0000-00-00';
-        $end_recurring_dt = null;
+        $start_recurring_dt = '1970-01-02';
+        $end_recurring_dt = '1970-01-02';
         $start_recurring_hr = '00:00:00';
         $end_recurring_hr = '00:00:00';
         $recurring_day = null;


### PR DESCRIPTION
Fix for recurring date placeholders in maintenance scheduling form. Only actual for MySQL-community, tested on 5.7.20 and 5.7.22.
More information: https://community.librenms.org/t/mysql-and-scheduled-maintenace/3100

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
