### PR TITLE
Feature: Plugins in the Port page

### DIFF
--- a/LibreNMS/Plugins.php
+++ b/LibreNMS/Plugins.php
@@ -82,6 +82,16 @@ class Plugins
         return $plugin;
     }//end load()
 
+    public static function countHooks($hook)
+    {
+        // count all plugins implementing a specific hook
+        self::start();
+        if (!empty(self::$plugins[$hook])) {
+            return count(self::$plugins[$hook]);
+        } else {
+            return false;
+        }
+    }
 
     public static function call($hook, $params = false)
     {

--- a/doc/Extensions/Plugin-System.md
+++ b/doc/Extensions/Plugin-System.md
@@ -4,8 +4,9 @@ source: Extensions/Plugin-System.md
 > This will most likely be deprecated in favour of adding the possible extensions to the core code base.
 
 This documentation will hopefully give you a basis for how to write a plugin for LibreNMS.
+A test plugin is included in LibreNMS distribution.
 
-A test plugin is available on GitHub: https://github.com/laf/Test
+### Generic structure ###
 
 Plugins need to be installed into html/plugins
 
@@ -48,17 +49,36 @@ PluginName.inc.php - This file is the main included file when browsing to the pl
 
 ### System Hooks ###
 
-System hooks are called as functions within your plugin class, so for example to create a menu entry within the Plugin dropdown you would do:
-
-```
-  public function menu() {
-    echo('<li><a href="plugin/p='.get_class().'">'.get_class().'</a></li>');
-  }
-```
-
-This would then add the name and a link to your plugin.
-
+System hooks are called as functions within your plugin class. 
 The following system hooks are currently available:
 
-menu()
-* This is called to build the plugin menu system and you can use this to link to your plugin (you don't have to).
+* menu()
+  * This is called to build the plugin menu system and you can use this to link to your plugin (you don't have to).
+```
+    public static function menu() {
+        echo('<li><a href="plugin/p='.get_class().'">'.get_class().'</a></li>');
+    }
+```
+
+* device_overview_container($device)
+  * This is called in the Device Overview page. You receive the $device as a parameter, can do your work here and display your results in a frame. 
+
+```
+    public function device_overview_container($device) {
+        echo('<div class="container-fluid"><div class="row"> <div class="col-md-12"> <div class="panel panel-default panel-condensed"> <div class="panel-heading"><strong>'.get_class().' Plugin </strong> </div>');
+        echo('  Example plugin in "Device - Overview" tab <br>');
+        echo('</div></div></div></div>');
+    }
+```
+
+* port_container($device, $port)
+  * This is called in the Port page, in the "Plugins" menu_option that will appear when your plugin gets enabled. In this function, you can do your work and display your results in a frame. 
+
+```
+    public function port_container($device, $port) {
+        echo('<div class="container-fluid"><div class="row"> <div class="col-md-12"> <div class="panel panel-default panel-condensed"> <div class="panel-heading"><strong>'.get_class().' plugin in "Port" tab</strong> </div>');
+        echo ('Example display in Port tab</br>');
+        echo('</div></div></div></div>');
+    }
+```
+

--- a/html/pages/device/port.inc.php
+++ b/html/pages/device/port.inc.php
@@ -104,8 +104,8 @@ if (count($components) > 0) {
     $menu_options['cbqos'] = 'CBQoS';
 }
 
-// If enabled via config, display the Plugin Link
-if ($config['enable_ports_plugins'] > 0) {
+if (LibreNMS\Plugins::count_hook('port_container')) {
+    // Checking if any plugin implements the port_container. If yes, allow to display the menu_option
     $menu_options['plugins'] = 'Plugins';
 }
 

--- a/html/pages/device/port.inc.php
+++ b/html/pages/device/port.inc.php
@@ -104,6 +104,11 @@ if (count($components) > 0) {
     $menu_options['cbqos'] = 'CBQoS';
 }
 
+// If enabled via config, display the Plugin Link
+if($config['enable_ports_plugins'] > 0) {
+    $menu_options['plugins'] = 'Plugins';
+}
+
 $sep = '';
 foreach ($menu_options as $option => $text) {
     echo $sep;

--- a/html/pages/device/port.inc.php
+++ b/html/pages/device/port.inc.php
@@ -104,7 +104,7 @@ if (count($components) > 0) {
     $menu_options['cbqos'] = 'CBQoS';
 }
 
-if (LibreNMS\Plugins::count_hook('port_container')) {
+if (LibreNMS\Plugins::countHooks('port_container')) {
     // Checking if any plugin implements the port_container. If yes, allow to display the menu_option
     $menu_options['plugins'] = 'Plugins';
 }

--- a/html/pages/device/port.inc.php
+++ b/html/pages/device/port.inc.php
@@ -105,7 +105,7 @@ if (count($components) > 0) {
 }
 
 // If enabled via config, display the Plugin Link
-if($config['enable_ports_plugins'] > 0) {
+if ($config['enable_ports_plugins'] > 0) {
     $menu_options['plugins'] = 'Plugins';
 }
 

--- a/html/pages/device/port/plugins.inc.php
+++ b/html/pages/device/port/plugins.inc.php
@@ -9,9 +9,6 @@
  * the source code distribution for details.
  */
 $pagetitle[] = 'Plugins';
-$port_id_notes = 'port_id_notes:' . $port['port_id'];
-$device_id = $device['device_id'];
-$data = get_dev_attrib($device, $port_id_notes);
 ?>
 <h3>Plugins</h3>
 <hr>

--- a/html/pages/device/port/plugins.inc.php
+++ b/html/pages/device/port/plugins.inc.php
@@ -14,4 +14,3 @@ $pagetitle[] = 'Plugins';
 <hr>
 <?php
     LibreNMS\Plugins::call('port_container', $device, $port);
-?>

--- a/html/pages/device/port/plugins.inc.php
+++ b/html/pages/device/port/plugins.inc.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+$pagetitle[] = 'Plugins';
+$port_id_notes = 'port_id_notes:' . $port['port_id'];
+$device_id = $device['device_id'];
+$data = get_dev_attrib($device, $port_id_notes);
+?>
+<h3>Plugins</h3>
+<hr>
+<?php
+    LibreNMS\Plugins::call('port_container', $device, $port);
+?>

--- a/html/plugins/Test/Test.php
+++ b/html/plugins/Test/Test.php
@@ -4,18 +4,21 @@ namespace LibreNMS\Plugins;
 
 class Test
 {
-
     public static function menu()
     {
         echo '<li><a href="plugin/p=Test">Test</a></li>';
     }//end menu()
 
 
-    /*
-        public function device_overview_container($device) {
+    public function device_overview_container($device) {
         echo('<div class="container-fluid"><div class="row"> <div class="col-md-12"> <div class="panel panel-default panel-condensed"> <div class="panel-heading"><strong>'.get_class().' Plugin </strong> </div>');
         echo('  Example plugin in "Device - Overview" tab <br>');
         echo('</div></div></div></div>');
-        }
-     */
+    }
+
+    public function port_container($device, $port) {
+		echo('<div class="container-fluid"><div class="row"> <div class="col-md-12"> <div class="panel panel-default panel-condensed"> <div class="panel-heading"><strong>'.get_class().' plugin in "Port" tab</strong> </div>');
+	    echo ('Example display in Port tab</br>');
+	    echo('</div></div></div></div>');
+    }
 }


### PR DESCRIPTION
Added new plugin menu_option in the "port" page, which contain hook calling public function port_container($device, $port) in plugins.
The display of this menu_option is conditionnal, and enabled with the following option in config.php: 
$config['enable_ports_plugins'] = 1;

![pluginmenuoptionwithtestpluginenabled](https://user-images.githubusercontent.com/38363551/39678679-278fccdc-5191-11e8-8ab7-7e239f7c8fa2.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
