### PR TITLE
pre-commit.php updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ after_failure:
   - tail /tmp/snmpsimd.log
 
 script:
-  - php scripts/pre-commit.php -l
-  - php scripts/pre-commit.php -s
-  - php scripts/pre-commit.php -u --db --snmpsim --fail-fast
+  - php scripts/pre-commit.php -q -l
+  - php scripts/pre-commit.php -q -s
+  - php scripts/pre-commit.php -q -u --db --snmpsim --fail-fast
   - bash -n daily.sh
   - pylint -E poller-wrapper.py discovery-wrapper.py
   - bash scripts/deploy-docs.sh

--- a/LibreNMS/Util/Snmpsim.php
+++ b/LibreNMS/Util/Snmpsim.php
@@ -72,7 +72,11 @@ class Snmpsim
         }
 
         if (isCli() && !$this->proc->isRunning()) {
-            echo `tail -5 $this->log` . PHP_EOL;
+            // if starting failed, run snmpsim again and output to the console and validate the data
+            passthru($this->getCmd(false) . ' --validate-data');
+
+            echo "\nFailed to start Snmpsim. Scroll up for error.\n";
+            exit;
         }
     }
 
@@ -149,7 +153,9 @@ class Snmpsim
     {
         $cmd = "snmpsimd.py --data-dir={$this->snmprec_dir} --agent-udpv4-endpoint={$this->ip}:{$this->port}";
 
-        if ($with_log) {
+        if (is_null($this->log)) {
+            $cmd .= " --logging-method=null";
+        } elseif ($with_log) {
             $cmd .= " --logging-method=file:{$this->log}";
         }
 

--- a/doc/Developing/Creating-Release.md
+++ b/doc/Developing/Creating-Release.md
@@ -16,7 +16,7 @@ We utilise [Readmegen](https://github.com/fojuth/readmegen) to automatically pop
 Install `readmegen` using `composer`:
 
 ```bash
-./composer.phar update
+./scripts/composer_wrapper.php install
 ```
 
 You can now create the update change log by running (201608 was our last release):

--- a/doc/Developing/Licensing.md
+++ b/doc/Developing/Licensing.md
@@ -72,12 +72,11 @@ project.
     - Include its name, source URL, copyright notice, and license in `doc/General/Credits.md`
 
 - To add a php dependency, please use composer
-    - Add the dependency `composer require --update-no-dev slim/slim`
-    - Add the files and commit `composer commit` or `git add -f vendor/ composer.json; git commit`
+    - Add the dependency `composer require slim/slim`
 
     - Updating php dependencies
-        - Update dependencies `composer update --no-dev`
-        - Add the files and commit `composer commit` or `git add -f vendor/; git commit`
+        - Update dependencies `FORCE=1 php56 ./scripts/composer_wrapper.php update`
+        - Commit the updated composer.lock file
 
 - To add a javascript dependency
     - Where possible please include minimized libraries in the html/js/ folder.

--- a/scripts/pre-commit.php
+++ b/scripts/pre-commit.php
@@ -32,7 +32,7 @@ Running $filename without options runs all checks.
   -o, --os        Specific OS to run tests on. Implies --unit, --db, --snmpsim
   -m, --module    Specific Module to run tests on. Implies --unit, --db, --snmpsim
   -f, --fail-fast Quit when any failure is encountered
-  -p, --passthru  Display output from checks as it comes
+  -q, --quiet     Hide output unless there is an error
       --db        Run unit tests that require a database
       --snmpsim   Use snmpsim for unit tests
   -c, --commands  Print commands only, no checks
@@ -41,7 +41,7 @@ Running $filename without options runs all checks.
 }
 
 // set up some variables
-$passthru = check_opt($options, 'p', 'passthru');
+$passthru = !check_opt($options, 'q', 'quiet');
 $command_only = check_opt($options, 'c', 'commands');
 $fail_fast = check_opt($options, 'f', 'fail-fast');
 $return = 0;
@@ -303,36 +303,6 @@ function build_excludes($exclude_string, $excludes)
 }
 
 /**
- * Find an executable
- *
- * @param string|array $execs executable names to find
- * @return string the path to the executable, or '' if it is not found
- * @throws Exception Could not find the Executable
- */
-function find_exec($execs)
-{
-    foreach ((array)$execs as $exec) {
-        // check vendor bin first
-        $vendor_bin_dir = './vendor/bin/';
-        if (is_executable($vendor_bin_dir . $exec)) {
-            return $vendor_bin_dir . $exec;
-        }
-
-        // check path
-        $path_exec = shell_exec("which $exec 2> /dev/null");
-        if (!empty($path_exec)) {
-            return trim($path_exec);
-        }
-
-        // check the cwd
-        if (is_executable('./' . $exec)) {
-            return './' . $exec;
-        }
-    }
-    throw new Exception('Executable not found');
-}
-
-/**
  * Check for an executable and return the path to it
  * If it does not exist, run composer update.
  * If composer isn't installed, print error and exit.
@@ -342,15 +312,20 @@ function find_exec($execs)
  */
 function check_exec($exec)
 {
-    try {
-        return find_exec($exec);
-    } catch (Exception $e) {
-        try {
-            shell_exec("scripts/composer_wrapper.php install");
-            return find_exec($exec);
-        } catch (Exception $ce) {
-            echo "\nCould not find $exec. Please install composer.\nYou can find more info at http://docs.librenms.org/Developing/Validating-Code/\n";
-            exit(1);
-        }
+    $path = "vendor/bin/$exec";
+
+    if (is_executable($path)) {
+        return $path;
     }
+
+    echo "Running composer install to install developer dependencies.\n";
+    passthru("scripts/composer_wrapper.php install");
+
+    if (is_executable($path)) {
+        return $path;
+    }
+
+    echo "\nRunning installing deps with composer failed.\n You should try running './scripts/composer_wrapper.php install' by hand\n";
+    echo "You can find more info at http://docs.librenms.org/Developing/Validating-Code/\n";
+    exit(1);
 }

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -103,7 +103,8 @@ $snmpsim_port = $snmpsim->getPort();
 
 if (!$snmpsim->isRunning()) {
     echo "Failed to start snmpsim, make sure it is installed, working, and there are no bad snmprec files.\n";
-    exit;
+    echo "Run ./scripts/save-test-data.php --snmpsim to see the log output\n";
+    exit(1);
 }
 
 

--- a/tests/OSDiscoveryTest.php
+++ b/tests/OSDiscoveryTest.php
@@ -101,8 +101,9 @@ class OSDiscoveryTest extends TestCase
     private function checkOS($expected_os, $filename = null)
     {
         $community = $filename ?: $expected_os;
-        global $debug;
+        global $debug, $vdebug;
         $debug = true;
+        $vdebug = true;
         ob_start();
         $os = getHostOS($this->genDevice($community));
         $output = ob_get_contents();
@@ -119,18 +120,18 @@ class OSDiscoveryTest extends TestCase
      */
     private function genDevice($community)
     {
-        return array(
+        return [
             'device_id' => 1,
-            'hostname' => $this->snmpsimIp,
+            'hostname' => $this->snmpsim->getIP(),
             'snmpver' => 'v2c',
-            'port' => $this->snmpsimPort,
+            'port' => $this->snmpsim->getPort(),
             'timeout' => 3,
             'retries' => 0,
             'snmp_max_repeaters' => 10,
             'community' => $community,
             'os' => 'generic',
             'os_group' => '',
-        );
+        ];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,10 +25,20 @@
 
 namespace LibreNMS\Tests;
 
+use LibreNMS\Util\Snmpsim;
+
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected $snmpsimIp = '127.1.6.2';
-    protected $snmpsimPort = 1161;
+    /** @var Snmpsim snmpsim instance */
+    protected $snmpsim = null;
+
+    public function __construct($name = null, $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        // grab global $snmpsim from bootstrap and make it accessible
+        global $snmpsim;
+        $this->snmpsim = $snmpsim;
+    }
 
     public function dbSetUp()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,8 +51,8 @@ ini_set('display_errors', 1);
 
 update_os_cache(true); // Force update of OS Cache
 
+$snmpsim = new Snmpsim('127.1.6.2', 1162, null);
 if (getenv('SNMPSIM')) {
-    $snmpsim = new Snmpsim('127.1.6.2');
     $snmpsim->fork();
 
     // make PHP hold on a reference to $snmpsim so it doesn't get destructed


### PR DESCRIPTION
Update pre-commit.php to use composer installed binaries only.
Change default pre-commit.php mode to "passthrough", add --quiet switch
Disable the log for unit tests to speed things up hopefully
A few doc updates

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
