### PR TITLE
Stop Eloquent from loading another DB conn for poller/discovery

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -99,7 +99,7 @@ ini_set('display_errors', 1);
 if (!module_selected('nodb', $init_modules)) {
     // Connect to database
     try {
-        \LibreNMS\DB\Eloquent::boot();
+        // \LibreNMS\DB\Eloquent::boot();
 
         dbConnect();
     } catch (\LibreNMS\Exceptions\DatabaseConnectException $e) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

For now, stop opening another db connection per poller thread.