### PR TITLE
Ignore plugin hook calling errors

### DIFF
--- a/LibreNMS/Plugins.php
+++ b/LibreNMS/Plugins.php
@@ -90,9 +90,9 @@ class Plugins
         if (!empty(self::$plugins[$hook])) {
             foreach (self::$plugins[$hook] as $name) {
                 if (!is_array($params)) {
-                    call_user_func(array($name, $hook));
+                    @call_user_func(array($name, $hook));
                 } else {
-                    call_user_func_array(array($name, $hook), $params);
+                    @call_user_func_array(array($name, $hook), $params);
                 }
             }
         }


### PR DESCRIPTION
Mostly this is because the plugin methods aren't static.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
