### PR TITLE
Feature: PoE graphs

### DIFF
--- a/html/includes/graphs/port/poe.inc.php
+++ b/html/includes/graphs/port/poe.inc.php
@@ -1,0 +1,28 @@
+<?php
+
+$oids = array(
+        'PortConsumption',
+        'PortPwrAvailable',
+        'PortPwrAllocated',
+        'PortMaxPwrDrawn',
+         );
+
+$i            = 0;
+$rrd_filename = get_port_rrdfile_path($device['hostname'], $port['port_id'], 'poe');
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    foreach ($oids as $oid) {
+        $rrd_list[$i]['filename'] = $rrd_filename;
+        $rrd_list[$i]['descr']    = substr($oid, 4);
+        $rrd_list[$i]['ds']       = $oid;
+        $i++;
+    }
+}
+
+$colours    = 'mixed';
+$nototal    = 1;
+$unit_text  = 'W';
+$divider = 1000;
+$scale_min  = 0;
+
+require 'includes/graphs/generic_v3_multiline_float.inc.php';

--- a/html/pages/device/port/graphs.inc.php
+++ b/html/pages/device/port/graphs.inc.php
@@ -26,6 +26,7 @@ if (rrdtool_check_rrd_exists(get_port_rrdfile_path($device['hostname'], $port['p
             <div class="panel-heading">
                 <h3 class="panel-title">Interface Non Unicast</h3>
             </div>';
+
     $graph_type = 'port_nupkts';
     echo '<div class="panel-body">';
         include 'includes/print-interface-graphs.inc.php';
@@ -35,11 +36,24 @@ if (rrdtool_check_rrd_exists(get_port_rrdfile_path($device['hostname'], $port['p
             <div class="panel-heading">
                 <h3 class="panel-title">Interface Errors</h3>
             </div>';
+
     $graph_type = 'port_errors';
 
     echo '<div class="panel-body">';
         include 'includes/print-interface-graphs.inc.php';
     echo '</div></div>';
+
+    if (rrdtool_check_rrd_exists(get_port_rrdfile_path($device['hostname'], $port['port_id'], 'poe'))) {
+        echo '<div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">PoE</h3>
+            </div>';
+        $graph_type = 'port_poe';
+        
+        echo '<div class="panel-body">';
+            include 'includes/print-interface-graphs.inc.php';
+        echo '</div></div>';
+    }
 
     if (rrdtool_check_rrd_exists(get_port_rrdfile_path($device['hostname'], $port['port_id'], 'dot3'))) {
         echo '<div class="panel panel-default">
@@ -47,7 +61,7 @@ if (rrdtool_check_rrd_exists(get_port_rrdfile_path($device['hostname'], $port['p
                 <h3 class="panel-title">Ethernet Errors</h3>
             </div>';
         $graph_type = 'port_etherlike';
-        
+
         echo '<div class="panel-body">';
             include 'includes/print-interface-graphs.inc.php';
         echo '</div></div>';

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -4,175 +4,190 @@
 use LibreNMS\RRD\RrdDefinition;
 
 $data_oids = array(
-    'ifName',
-    'ifDescr',
-    'ifAlias',
-    'ifAdminStatus',
-    'ifOperStatus',
-    'ifMtu',
-    'ifSpeed',
-    'ifHighSpeed',
-    'ifType',
-    'ifPhysAddress',
-    'ifPromiscuousMode',
-    'ifConnectorPresent',
-    'ifDuplex',
-    'ifTrunk',
-    'ifVlan',
-);
+        'ifName',
+        'ifDescr',
+        'ifAlias',
+        'ifAdminStatus',
+        'ifOperStatus',
+        'ifMtu',
+        'ifSpeed',
+        'ifHighSpeed',
+        'ifType',
+        'ifPhysAddress',
+        'ifPromiscuousMode',
+        'ifConnectorPresent',
+        'ifDuplex',
+        'ifTrunk',
+        'ifVlan',
+        );
 
 $stat_oids = array(
-    'ifInErrors',
-    'ifOutErrors',
-    'ifInUcastPkts',
-    'ifOutUcastPkts',
-    'ifInNUcastPkts',
-    'ifOutNUcastPkts',
-    'ifHCInMulticastPkts',
-    'ifHCInBroadcastPkts',
-    'ifHCOutMulticastPkts',
-    'ifHCOutBroadcastPkts',
-    'ifInOctets',
-    'ifOutOctets',
-    'ifHCInOctets',
-    'ifHCOutOctets',
-    'ifInDiscards',
-    'ifOutDiscards',
-    'ifInUnknownProtos',
-    'ifInBroadcastPkts',
-    'ifOutBroadcastPkts',
-    'ifInMulticastPkts',
-    'ifOutMulticastPkts',
-);
+        'ifInErrors',
+        'ifOutErrors',
+        'ifInUcastPkts',
+        'ifOutUcastPkts',
+        'ifInNUcastPkts',
+        'ifOutNUcastPkts',
+        'ifHCInMulticastPkts',
+        'ifHCInBroadcastPkts',
+        'ifHCOutMulticastPkts',
+        'ifHCOutBroadcastPkts',
+        'ifInOctets',
+        'ifOutOctets',
+        'ifHCInOctets',
+        'ifHCOutOctets',
+        'ifInDiscards',
+        'ifOutDiscards',
+        'ifInUnknownProtos',
+        'ifInBroadcastPkts',
+        'ifOutBroadcastPkts',
+        'ifInMulticastPkts',
+        'ifOutMulticastPkts',
+        );
 
 $stat_oids_db = array(
-    'ifInOctets',
-    'ifOutOctets',
-    'ifInErrors',
-    'ifOutErrors',
-    'ifInUcastPkts',
-    'ifOutUcastPkts',
-);
+        'ifInOctets',
+        'ifOutOctets',
+        'ifInErrors',
+        'ifOutErrors',
+        'ifInUcastPkts',
+        'ifOutUcastPkts',
+        );
 
 $stat_oids_db_extended = array(
-    'ifInNUcastPkts',
-    'ifOutNUcastPkts',
-    'ifInDiscards',
-    'ifOutDiscards',
-    'ifInUnknownProtos',
-    'ifInBroadcastPkts',
-    'ifOutBroadcastPkts',
-    'ifInMulticastPkts',
-    'ifOutMulticastPkts',
-);
+        'ifInNUcastPkts',
+        'ifOutNUcastPkts',
+        'ifInDiscards',
+        'ifOutDiscards',
+        'ifInUnknownProtos',
+        'ifInBroadcastPkts',
+        'ifOutBroadcastPkts',
+        'ifInMulticastPkts',
+        'ifOutMulticastPkts',
+        );
 
 $cisco_oids = array(
-    'locIfHardType',
-    'locIfInRunts',
-    'locIfInGiants',
-    'locIfInCRC',
-    'locIfInFrame',
-    'locIfInOverrun',
-    'locIfInIgnored',
-    'locIfInAbort',
-    'locIfCollisions',
-    'locIfInputQueueDrops',
-    'locIfOutputQueueDrops',
-);
+        'locIfHardType',
+        'locIfInRunts',
+        'locIfInGiants',
+        'locIfInCRC',
+        'locIfInFrame',
+        'locIfInOverrun',
+        'locIfInIgnored',
+        'locIfInAbort',
+        'locIfCollisions',
+        'locIfInputQueueDrops',
+        'locIfOutputQueueDrops',
+        );
 
 $pagp_oids = array(
-    'pagpOperationMode',
-);
+        'pagpOperationMode',
+        );
 
 $pagp_extended_oids = array(
-    'pagpPortState',
-    'pagpPartnerDeviceId',
-    'pagpPartnerLearnMethod',
-    'pagpPartnerIfIndex',
-    'pagpPartnerGroupIfIndex',
-    'pagpPartnerDeviceName',
-    'pagpEthcOperationMode',
-    'pagpDeviceId',
-    'pagpGroupIfIndex',
-);
+        'pagpPortState',
+        'pagpPartnerDeviceId',
+        'pagpPartnerLearnMethod',
+        'pagpPartnerIfIndex',
+        'pagpPartnerGroupIfIndex',
+        'pagpPartnerDeviceName',
+        'pagpEthcOperationMode',
+        'pagpDeviceId',
+        'pagpGroupIfIndex',
+        );
 
 $ifmib_oids = array(
-    'ifDescr',
-    'ifAdminStatus',
-    'ifOperStatus',
-    'ifLastChange',
-    'ifType',
-    'ifPhysAddress',
-    'ifMtu',
-    'ifInErrors',
-    'ifOutErrors',
-    'ifInDiscards',
-    'ifOutDiscards',
-);
+        'ifDescr',
+        'ifAdminStatus',
+        'ifOperStatus',
+        'ifLastChange',
+        'ifType',
+        'ifPhysAddress',
+        'ifMtu',
+        'ifInErrors',
+        'ifOutErrors',
+        'ifInDiscards',
+        'ifOutDiscards',
+        );
 
 $table_base_oids = array(
-    'ifName',
-    'ifAlias',
-    'ifDescr',
-    'ifHighSpeed',
-    'ifOperStatus',
-    'ifAdminStatus',
-);
+        'ifName',
+        'ifAlias',
+        'ifDescr',
+        'ifHighSpeed',
+        'ifOperStatus',
+        'ifAdminStatus',
+        );
 
 $hc_mappings = array(
-    'ifHCInOctets' => 'ifInOctets',
-    'ifHCOutOctets' => 'ifOutOctets',
-    'ifHCInUcastPkts' => 'ifInUcastPkts',
-    'ifHCOutUcastPkts' => 'ifOutUcastPkts',
-    'ifHCInBroadcastPkts' => 'ifInBroadcastPkts',
-    'ifHCOutBroadcastPkts' => 'ifOutBroadcastPkts',
-    'ifHCInMulticastPkts' => 'ifInMulticastPkts',
-    'ifHCOutMulticastPkts' => 'ifOutMulticastPkts',
-);
+        'ifHCInOctets' => 'ifInOctets',
+        'ifHCOutOctets' => 'ifOutOctets',
+        'ifHCInUcastPkts' => 'ifInUcastPkts',
+        'ifHCOutUcastPkts' => 'ifOutUcastPkts',
+        'ifHCInBroadcastPkts' => 'ifInBroadcastPkts',
+        'ifHCOutBroadcastPkts' => 'ifOutBroadcastPkts',
+        'ifHCInMulticastPkts' => 'ifInMulticastPkts',
+        'ifHCOutMulticastPkts' => 'ifOutMulticastPkts',
+        );
 
 $hc_oids = array(
-    'ifInMulticastPkts',
-    'ifInBroadcastPkts',
-    'ifOutMulticastPkts',
-    'ifOutBroadcastPkts',
-    'ifHCInOctets',
-    'ifHCInUcastPkts',
-    'ifHCInMulticastPkts',
-    'ifHCInBroadcastPkts',
-    'ifHCOutOctets',
-    'ifHCOutUcastPkts',
-    'ifHCOutMulticastPkts',
-    'ifHCOutBroadcastPkts',
-    'ifPromiscuousMode',
-    'ifConnectorPresent',
-);
+        'ifInMulticastPkts',
+        'ifInBroadcastPkts',
+        'ifOutMulticastPkts',
+        'ifOutBroadcastPkts',
+        'ifHCInOctets',
+        'ifHCInUcastPkts',
+        'ifHCInMulticastPkts',
+        'ifHCInBroadcastPkts',
+        'ifHCOutOctets',
+        'ifHCOutUcastPkts',
+        'ifHCOutMulticastPkts',
+        'ifHCOutBroadcastPkts',
+        'ifPromiscuousMode',
+        'ifConnectorPresent',
+        );
 
 $nonhc_oids = array(
-    'ifSpeed',
-    'ifInOctets',
-    'ifInUcastPkts',
-    'ifInUnknownProtos',
-    'ifOutOctets',
-    'ifOutUcastPkts',
-);
+        'ifSpeed',
+        'ifInOctets',
+        'ifInUcastPkts',
+        'ifInUnknownProtos',
+        'ifOutOctets',
+        'ifOutUcastPkts',
+        );
 
 $shared_oids = array(
-    'ifInErrors',
-    'ifOutErrors',
-    'ifInNUcastPkts',
-    'ifOutNUcastPkts',
-    'ifInDiscards',
-    'ifOutDiscards',
-    'ifPhysAddress',
-    'ifLastChange',
-    'ifType',
-    'ifMtu',
-);
+        'ifInErrors',
+        'ifOutErrors',
+        'ifInNUcastPkts',
+        'ifOutNUcastPkts',
+        'ifInDiscards',
+        'ifOutDiscards',
+        'ifPhysAddress',
+        'ifLastChange',
+        'ifType',
+        'ifMtu',
+        );
+
+
+$vrp_poe_oids = array(
+        'hwPoePortName',
+        'hwPoePortEnable',
+        'hwPoePortPriority',
+        'hwPoePortMaximumPower',
+        'hwPoePortPowerOnStatus',
+        'hwPoePortPowerStatus',
+        'hwPoePortPdClass',
+        'hwPoePortReferencePower',
+        'hwPoePortConsumingPower',
+        'hwPoePortPeakPower',
+        'hwPoePortAveragePower',
+        );
 
 $dot3_oids = [
-    'dot3StatsIndex',
+'dot3StatsIndex',
     'dot3StatsDuplexStatus',
-];
+    ];
 
 echo 'Caching Oids: ';
 $port_stats = array();
@@ -222,7 +237,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
         $hc_test = array_slice($port_stats, 0, 1);
         // If the device doesn't have ifXentry data, fetch ifEntry instead.
         if ((!isset($hc_test[0]['ifHCInOctets']) && !is_numeric($hc_test[0]['ifHCInOctets'])) ||
-            ((!isset($hc_test[0]['ifHighSpeed']) && !is_numeric($hc_test[0]['ifHighSpeed'])))) {
+                ((!isset($hc_test[0]['ifHighSpeed']) && !is_numeric($hc_test[0]['ifHighSpeed'])))) {
             $port_stats = snmpwalk_cache_oid($device, 'ifEntry', $port_stats, 'IF-MIB', null, '-OQUst');
         } else {
             // For devices with ifXentry data, only specific ifEntry keys are fetched to reduce SNMP load
@@ -271,11 +286,43 @@ if ($device['adsl_count'] > '0') {
     $port_stats = snmpwalk_cache_oid($device, '.1.3.6.1.2.1.10.94.1.1.7.1.5', $port_stats, 'ADSL-LINE-MIB');
     $port_stats = snmpwalk_cache_oid($device, '.1.3.6.1.2.1.10.94.1.1.7.1.6', $port_stats, 'ADSL-LINE-MIB');
     $port_stats = snmpwalk_cache_oid($device, '.1.3.6.1.2.1.10.94.1.1.7.1.7', $port_stats, 'ADSL-LINE-MIB');
-}//end if
-
+}
+//end if
 if ($config['enable_ports_poe']) {
-    $port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
-    $port_stats = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats, 'CISCO-POWER-ETHERNET-EXT-MIB');
+    // Code by OS device
+
+    if ($device['os'] == 'procurve') {
+        $port_stats_poe = snmpwalk_cache_oid($device, 'pethPsePortEntry', array(), 'POWER-ETHERNET-MIB');
+    }
+
+    if ($device['os'] == 'ios') {
+        $port_stats_poe = snmpwalk_cache_oid($device, 'pethPsePortEntry', array(), 'POWER-ETHERNET-MIB');
+        $port_stats_poe = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats_poe, 'CISCO-POWER-ETHERNET-EXT-MIB');
+        $port_ent_to_if = snmpwalk_cache_oid($device, 'portIfIndex', array(), 'CISCO-STACK-MIB');
+        foreach ($port_ent_to_if as $p_index => $p_stats) {
+            if ($p_stats[portIfIndex] > 0) {
+                $port_stats[$p_stats[portIfIndex]]['portIfIndex_rev'] = $p_index;
+            }
+            $port_stats[$p_stats]['portIfIndex'] = $p_index;
+        }
+        $entPhysicalAlias = snmpwalk_cache_oid($device, 'entPhysicalAlias', array(), 'ENTITY-MIB');
+        foreach ($entPhysicalAlias as $p_index => $p_stats) {
+            if ($p_stats[entPhysicalAlias] > 0) {
+                $port_stats[$p_stats[entPhysicalAlias]]['entPhysicalAlias_rev'] = $p_index;
+            }
+        }
+        foreach ($port_stats_poe as $p_index => $p_stats) {
+            echo 'Processing '. $p_index . "\n";
+            if ($port_ent_to_if[$p_index] && $port_ent_to_if[$p_index][portIfIndex] && $port_stats[$port_ent_to_if[$p_index][portIfIndex]]) {
+                //echo '    OK\n';
+                $port_stats[$port_ent_to_if[$p_index][portIfIndex]]=$port_stats[$port_ent_to_if[$p_index][portIfIndex]]+$p_stats;
+            }
+        }
+    }
+    if ($device['os'] == 'vrp') {
+        echo 'HwPoePortEntry' ;
+        $port_stats = snmpwalk_cache_oid($device, 'HwPoePortEntry', $port_stats, 'HUAWEI-POE-MIB');
+    }
 }
 
 if ($device['os_group'] == 'cisco' && $device['os'] != 'asa') {
@@ -303,7 +350,9 @@ if ($device['os_group'] == 'cisco' && $device['os'] != 'asa') {
 $polled = time();
 
 // End Building SNMP Cache Array
-d_echo($port_stats);
+
+//d_echo('d_echo($port_stats) : ');
+//d_echo($port_stats);
 
 // By default libreNMS uses the ifIndex to associate ports on devices with ports discoverd/polled
 // before and stored in the database. On Linux boxes this is a problem as ifIndexes may be
@@ -344,31 +393,29 @@ foreach ($port_stats as $ifIndex => $port) {
     $port_id = get_port_id($ports_mapped, $port, $port_association_mode);
 
     if (is_port_valid($port, $device)) {
-        echo 'valid';
-
         // Port newly discovered?
         if (! $ports[$port_id]) {
             /**
-              * When using the ifName or ifDescr as means to map discovered ports to
-              * known ports in the DB (think of port association mode) it's possible
-              * that we're facing the problem that the ifName or ifDescr polled from
-              * the device is unset or an empty string (like when querying some ubnt
-              * devices...). If this happends we have no way to map this port to any
-              * port found in the database. As reported this situation may occur for
-              * the time of one poll and might resolve automagically before the next
-              * poller run happens. Without this special case this would lead to new
-              * ports added to the database each time this situation occurs. To give
-              * the user the choice between »a lot of new ports« and »some poll runs
-              * are missed but ports stay stable« the 'ignore_unmapable_port' option
-              * has been added to configure this behaviour. To skip the port in this
-              * loop is sufficient as the next loop is looping only over ports found
-              * in the database and "maps back". As we did not add a new port to the
-              * DB here, there's no port to be mapped to.
-              *
-              * I'm using the in_array() check here, as I'm not sure if an "ifIndex"
-              * can be legally set to 0, which would yield True when checking if the
-              * value is empty().
-              */
+             * When using the ifName or ifDescr as means to map discovered ports to
+             * known ports in the DB (think of port association mode) it's possible
+             * that we're facing the problem that the ifName or ifDescr polled from
+             * the device is unset or an empty string (like when querying some ubnt
+             * devices...). If this happends we have no way to map this port to any
+             * port found in the database. As reported this situation may occur for
+             * the time of one poll and might resolve automagically before the next
+             * poller run happens. Without this special case this would lead to new
+             * ports added to the database each time this situation occurs. To give
+             * the user the choice between »a lot of new ports« and »some poll runs
+             * are missed but ports stay stable« the 'ignore_unmapable_port' option
+             * has been added to configure this behaviour. To skip the port in this
+             * loop is sufficient as the next loop is looping only over ports found
+             * in the database and "maps back". As we did not add a new port to the
+             * DB here, there's no port to be mapped to.
+             *
+             * I'm using the in_array() check here, as I'm not sure if an "ifIndex"
+             * can be legally set to 0, which would yield True when checking if the
+             * value is empty().
+             */
             if ($config['ignore_unmapable_port'] === true and in_array($port[$port_association_mode], array ('', null))) {
                 continue;
             }
@@ -376,7 +423,7 @@ foreach ($port_stats as $ifIndex => $port) {
             $port_id         = dbInsert(array('device_id' => $device['device_id'], 'ifIndex' => $ifIndex, 'ifName' => $ifName), 'ports');
             dbInsert(array('port_id' => $port_id), 'ports_statistics');
             $ports[$port_id] = dbFetchRow('SELECT * FROM `ports` WHERE `port_id` = ?', array($port_id));
-            echo 'Adding: '.$ifName.'('.$ifIndex.')('.$port_id.')';
+            echo ('Adding: '.$ifName.'('.$ifIndex.')('.$port_id.')');
             // print_r($ports);
         } // Port re-discovered after previous deletion?
         elseif ($ports[$port_id]['deleted'] == 1) {
@@ -389,16 +436,16 @@ foreach ($port_stats as $ifIndex => $port) {
         }
 
         /** Assure stable bidirectional port mapping between DB and polled data
-          *
-          * Store the *current* ifIndex in the port info array containing all port information
-          * fetched from the database, as this is the only means we have to map ports_stats we
-          * just polled from the device to a port in $ports. All code below an includeed below
-          * will and has to map a port using it's ifIndex.
-          */
+         *
+         * Store the *current* ifIndex in the port info array containing all port information
+         * fetched from the database, as this is the only means we have to map ports_stats we
+         * just polled from the device to a port in $ports. All code below an includeed below
+         * will and has to map a port using it's ifIndex.
+         */
         $ports[$port_id]['ifIndex'] = $ifIndex;
         $port_stats[$ifIndex]['port_id'] = $port_id;
 
-    /* Build a list of all ports, identified by their port_id, found within this poller run. */
+        /* Build a list of all ports, identified by their port_id, found within this poller run. */
         $ports_found[] = $port_id;
     } // Port vanished (mark as deleted)
     else {
@@ -590,8 +637,8 @@ foreach ($ports as $port) {
                 $port_tune = $attribs['ifName_tune:'.$port['ifName']];
                 $device_tune = $attribs['override_rrdtool_tune'];
                 if ($port_tune == "true" ||
-                    ($device_tune == "true" && $port_tune != 'false') ||
-                    ($config['rrdtool_tune'] == "true" && $port_tune != 'false' && $device_tune != 'false')) {
+                        ($device_tune == "true" && $port_tune != 'false') ||
+                        ($config['rrdtool_tune'] == "true" && $port_tune != 'false' && $device_tune != 'false')) {
                     if ($oid == 'ifSpeed') {
                         $tune_port = true;
                     }
@@ -623,12 +670,12 @@ foreach ($ports as $port) {
         // Parse description (usually ifAlias) if config option set
         if (isset($config['port_descr_parser']) && is_file($config['install_dir'].'/'.$config['port_descr_parser'])) {
             $port_attribs = array(
-                'type',
-                'descr',
-                'circuit',
-                'speed',
-                'notes',
-            );
+                    'type',
+                    'descr',
+                    'circuit',
+                    'speed',
+                    'notes',
+                    );
 
             include $config['install_dir'].'/'.$config['port_descr_parser'];
 
@@ -701,9 +748,9 @@ foreach ($ports as $port) {
             $port['stats']['ifOutBits_perc'] = round(($port['stats']['ifOutBits_rate'] / $this_port['ifSpeed'] * 100));
         }
 
-        echo 'bps('.formatRates($port['stats']['ifInBits_rate']).'/'.formatRates($port['stats']['ifOutBits_rate']).')';
-        echo 'bytes('.formatStorage($port['stats']['ifInOctets_diff']).'/'.formatStorage($port['stats']['ifOutOctets_diff']).')';
-        echo 'pkts('.format_si($port['stats']['ifInUcastPkts_rate']).'pps/'.format_si($port['stats']['ifOutUcastPkts_rate']).'pps)';
+        echo "bps(" . formatRates($port['stats']['ifInBits_rate']) . "/" . formatRates($port['stats']['ifOutBits_rate']) . ")";
+        echo "bytes(" . formatStorage($port['stats']['ifInOctets_diff']) . "/" . formatStorage($port['stats']['ifOutOctets_diff']) . ")";
+        echo "pkts(" . format_si($port['stats']['ifInUcastPkts_rate']) . "pps/" . format_si($port['stats']['ifOutUcastPkts_rate']) . "pps)";
 
         // Port utilisation % threshold alerting. // FIXME allow setting threshold per-port. probably 90% of ports we don't care about.
         if ($config['alerts']['port_util_alert'] && $port['ignore'] == '0') {
@@ -737,22 +784,22 @@ foreach ($ports as $port) {
             ->addDataset('OUTMULTICASTPKTS', 'DERIVE', 0, 12500000000);
 
         $fields = array(
-            'INOCTETS'         => $this_port['ifInOctets'],
-            'OUTOCTETS'        => $this_port['ifOutOctets'],
-            'INERRORS'         => $this_port['ifInErrors'],
-            'OUTERRORS'        => $this_port['ifOutErrors'],
-            'INUCASTPKTS'      => $this_port['ifInUcastPkts'],
-            'OUTUCASTPKTS'     => $this_port['ifOutUcastPkts'],
-            'INNUCASTPKTS'     => $this_port['ifInNUcastPkts'],
-            'OUTNUCASTPKTS'    => $this_port['ifOutNUcastPkts'],
-            'INDISCARDS'       => $this_port['ifInDiscards'],
-            'OUTDISCARDS'      => $this_port['ifOutDiscards'],
-            'INUNKNOWNPROTOS'  => $this_port['ifInUnknownProtos'],
-            'INBROADCASTPKTS'  => $this_port['ifInBroadcastPkts'],
-            'OUTBROADCASTPKTS' => $this_port['ifOutBroadcastPkts'],
-            'INMULTICASTPKTS'  => $this_port['ifInMulticastPkts'],
-            'OUTMULTICASTPKTS' => $this_port['ifOutMulticastPkts'],
-        );
+                'INOCTETS'         => $this_port['ifInOctets'],
+                'OUTOCTETS'        => $this_port['ifOutOctets'],
+                'INERRORS'         => $this_port['ifInErrors'],
+                'OUTERRORS'        => $this_port['ifOutErrors'],
+                'INUCASTPKTS'      => $this_port['ifInUcastPkts'],
+                'OUTUCASTPKTS'     => $this_port['ifOutUcastPkts'],
+                'INNUCASTPKTS'     => $this_port['ifInNUcastPkts'],
+                'OUTNUCASTPKTS'    => $this_port['ifOutNUcastPkts'],
+                'INDISCARDS'       => $this_port['ifInDiscards'],
+                'OUTDISCARDS'      => $this_port['ifOutDiscards'],
+                'INUNKNOWNPROTOS'  => $this_port['ifInUnknownProtos'],
+                'INBROADCASTPKTS'  => $this_port['ifInBroadcastPkts'],
+                'OUTBROADCASTPKTS' => $this_port['ifOutBroadcastPkts'],
+                'INMULTICASTPKTS'  => $this_port['ifInMulticastPkts'],
+                'OUTMULTICASTPKTS' => $this_port['ifOutMulticastPkts'],
+                );
 
         if ($tune_port === true) {
             rrdtool_tune('port', $rrdfile, $this_port['ifSpeed']);

--- a/includes/polling/ports/port-poe.inc.php
+++ b/includes/polling/ports/port-poe.inc.php
@@ -2,60 +2,76 @@
 
 use LibreNMS\RRD\RrdDefinition;
 
-$cpe_oids = array(
-    'cpeExtPsePortEnable',
-    'cpeExtPsePortDiscoverMode',
-    'cpeExtPsePortDeviceDetected',
-    'cpeExtPsePortIeeePd',
-    'cpeExtPsePortAdditionalStatus',
-    'cpeExtPsePortPwrMax',
-    'cpeExtPsePortPwrAllocated',
-    'cpeExtPsePortPwrAvailable',
-    'cpeExtPsePortPwrConsumption',
-    'cpeExtPsePortMaxPwrDrawn',
-    'cpeExtPsePortEntPhyIndex',
-    'cpeExtPsePortEntPhyIndex',
-    'cpeExtPsePortPolicingCapable',
-    'cpeExtPsePortPolicingEnable',
-    'cpeExtPsePortPolicingAction',
-    'cpeExtPsePortPwrManAlloc',
-);
+if (($device['os'] == 'vrp')) {
+    //Tested against Huawei 5720 access switches
+    if (isset($this_port['hwPoePortEnable'])) {
+        $rrd_name = getPortRrdName($port_id, 'poe');
+        $rrd_def = RrdDefinition::make()
+            ->addDataset('PortPwrAllocated', 'GAUGE', 0)
+            ->addDataset('PortPwrAvailable', 'GAUGE', 0)
+            ->addDataset('PortConsumption', 'GAUGE', 0)
+            ->addDataset('PortMaxPwrDrawn', 'GAUGE', 0);
+        $upd = "$polled:".$this_port['hwPoePortReferencePower'].':'.$this_port['hwPoePortMaximumPower'].':'.$this_port['hwPoePortConsumingPower'].':'.$this_port['hwPoePortPeakPower'];
 
-$peth_oids = array(
-    'pethPsePortAdminEnable',
-    'pethPsePortPowerPairsControlAbility',
-    'pethPsePortPowerPairs',
-    'pethPsePortDetectionStatus',
-    'pethPsePortPowerPriority',
-    'pethPsePortMPSAbsentCounter',
-    'pethPsePortType',
-    'pethPsePortPowerClassifications',
-    'pethPsePortInvalidSignatureCounter',
-    'pethPsePortPowerDeniedCounter',
-    'pethPsePortOverLoadCounter',
-    'pethPsePortShortCounter',
-    'pethMainPseConsumptionPower',
-);
+        $fields = array(
+                'PortPwrAllocated'   => $this_port['hwPoePortReferencePower'],
+                'PortPwrAvailable'   => $this_port['hwPoePortMaximumPower'],
+                'PortConsumption'    => $this_port['hwPoePortConsumingPower'],
+                'PortMaxPwrDrawn'    => $this_port['hwPoePortPeakPower'],
+                   );
 
-if ($this_port['dot3StatsIndex'] && $port['ifType'] == 'ethernetCsmacd') {
-    $rrd_name = getPortRrdName($port_id, 'poe');
-    $rrd_def = RrdDefinition::make()
-        ->addDataset('PortPwrAllocated', 'GAUGE', 0)
-        ->addDataset('PortPwrAvailable', 'GAUGE', 0)
-        ->addDataset('PortConsumption', 'DERIVE', 0)
-        ->addDataset('PortMaxPwrDrawn', 'GAUGE', 0);
+        $tags = compact('ifName', 'rrd_name', 'rrd_def');
+        data_update($device, 'poe', $tags, $fields);
+        echo 'PoE(vrp) ';
+    }
+} elseif (($device['os'] == 'ios')||($device['os'] == 'ciscosb')) {
+    // Code for Cisco IOS, tested on 2960X
+    if (isset($this_port['cpeExtPsePortPwrAllocated'])) {
+        // if we have cpeExtPsePortPwrAllocated, we have the complete array so we can populate the RRD
+        $rrd_name = getPortRrdName($port_id, 'poe');
+        $rrd_def = RrdDefinition::make()
+            ->addDataset('PortPwrAllocated', 'GAUGE', 0)
+            ->addDataset('PortPwrAvailable', 'GAUGE', 0)
+            ->addDataset('PortConsumption', 'GAUGE', 0)
+            ->addDataset('PortMaxPwrDrawn', 'GAUGE', 0);
 
-    $upd = "$polled:".$port['cpeExtPsePortPwrAllocated'].':'.$port['cpeExtPsePortPwrAvailable'].':'.$port['cpeExtPsePortPwrConsumption'].':'.$port['cpeExtPsePortMaxPwrDrawn'];
+        $upd = "$polled:".$port['cpeExtPsePortPwrAllocated'].':'.$port['cpeExtPsePortPwrAvailable'].':'.
+            $port['cpeExtPsePortPwrConsumption'].':'.$port['cpeExtPsePortMaxPwrDrawn'];
+        echo "$this_port[cpeExtPsePortPwrAllocated],$this_port[cpeExtPsePortPwrAvailable],$this_port[cpeExtPsePortPwrConsumption],$this_port[cpeExtPsePortMaxPwrDrawn]\n";
+        $fields = array(
+                'PortPwrAllocated'   => $this_port['cpeExtPsePortPwrAllocated'],
+                'PortPwrAvailable'   => $this_port['cpeExtPsePortPwrAvailable'],
+                'PortConsumption'    => $this_port['cpeExtPsePortPwrConsumption'],
+                'PortMaxPwrDrawn'    => $this_port['cpeExtPsePortMaxPwrDrawn'],
+                   );
 
-    $fields = array(
-        'PortPwrAllocated'   => $port['cpeExtPsePortPwrAllocated'],
-        'PortPwrAvailable'   => $port['cpeExtPsePortPwrAvailable'],
-        'PortConsumption'    => $port['cpeExtPsePortPwrConsumption'],
-        'PortMaxPwrDrawn'    => $port['cpeExtPsePortMaxPwrDrawn'],
-    );
+        $tags = compact('ifName', 'rrd_name', 'rrd_def');
+        data_update($device, 'poe', $tags, $fields);
+        echo 'PoE(IOS) ';
+    }//end if
+} else {
+    //This is the legacy code, to be tested against devices
+    if ($this_port['dot3StatsIndex'] && $port['ifType'] == 'ethernetCsmacd') {
+        $rrd_name = getPortRrdName($port_id, 'poe');
+        $rrd_def = RrdDefinition::make()
+            ->addDataset('PortPwrAllocated', 'GAUGE', 0)
+            ->addDataset('PortPwrAvailable', 'GAUGE', 0)
+            ->addDataset('PortConsumption', 'GAUGE', 0)
+            ->addDataset('PortMaxPwrDrawn', 'GAUGE', 0);
 
-    $tags = compact('ifName', 'rrd_name', 'rrd_def');
-    data_update($device, 'poe', $tags, $fields);
+        $upd = "$polled:".$port['cpeExtPsePortPwrAllocated'].':'.$port['cpeExtPsePortPwrAvailable'].':'.
+            $port['cpeExtPsePortPwrConsumption'].':'.$port['cpeExtPsePortMaxPwrDrawn'];
 
-    echo 'PoE ';
-}//end if
+        $fields = array(
+                'PortPwrAllocated'   => $port['cpeExtPsePortPwrAllocated'],
+                'PortPwrAvailable'   => $port['cpeExtPsePortPwrAvailable'],
+                'PortConsumption'    => $port['cpeExtPsePortPwrConsumption'],
+                'PortMaxPwrDrawn'    => $port['cpeExtPsePortMaxPwrDrawn'],
+                   );
+
+        $tags = compact('ifName', 'rrd_name', 'rrd_def');
+        data_update($device, 'poe', $tags, $fields);
+
+        echo 'PoE(generic) ';
+    }//end if
+}

--- a/mibs/huawei/HUAWEI-POE-MIB.mib
+++ b/mibs/huawei/HUAWEI-POE-MIB.mib
@@ -1,0 +1,720 @@
+
+--  ===========================================================
+-- Copyright (C)  2009 by  HUAWEI TECHNOLOGIES. All rights reserved.
+-- 
+-- Description:    HUAWEI POE MIB Definition 
+-- Reference:      This mib was extracted from IEEE 802.3af
+-- Version:        V1.0
+-- History:        Liuhui ,2009-08-24, Create
+-- ===========================================================
+
+	HUAWEI-POE-MIB DEFINITIONS ::= BEGIN
+ 
+		IMPORTS
+			hwDatacomm			
+				FROM HUAWEI-MIB			
+			InterfaceIndex			
+				FROM IF-MIB			
+			EnabledStatus			
+				FROM P-BRIDGE-MIB			
+			OBJECT-GROUP, NOTIFICATION-GROUP			
+				FROM SNMPv2-CONF			
+			Integer32, OBJECT-TYPE, MODULE-IDENTITY, NOTIFICATION-TYPE			
+				FROM SNMPv2-SMI;
+	
+	
+		hwPoeMIB MODULE-IDENTITY 
+			LAST-UPDATED "200908241133Z"		-- August 24, 2009 at 11:33 GMT
+			ORGANIZATION 
+				"Huawei Technologies co.,Ltd."
+			CONTACT-INFO 
+				"R&D BeiJing, Huawei Technologies co.,Ltd.
+				Huawei Bld.,NO.3 Xinxi Rd., 
+				Shang-Di Information Industry Base,
+				Hai-Dian District Beijing P.R. China
+				Zip:100085 
+				Http://www.huawei.com                       
+				E-mail:support@huawei.com"
+			DESCRIPTION 
+				"The HUAWEI-POE-MIB contains objects to manage POE."
+			::= { hwDatacomm 195 }
+		
+	
+--
+-- Node definitions
+--
+	
+		hwPoeGlobalObjects OBJECT IDENTIFIER ::= { hwPoeMIB 1 }
+		
+		
+		hwPoePower OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the maximum POE power of the system."
+			::= { hwPoeGlobalObjects 1 }
+			
+		hwPoePowerRsvPercent OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the reserved percent of total POE power."
+			::= { hwPoeGlobalObjects 4 }
+		
+		hwPoePowerUtilizationThreshold OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the utilization threshold of total POE power."
+			::= { hwPoeGlobalObjects 5 }		
+		
+		hwPoeSlotTable OBJECT-TYPE
+			SYNTAX SEQUENCE OF HwPoeSlotEntry
+			MAX-ACCESS not-accessible
+			STATUS current
+			DESCRIPTION
+				"This object indicates the slot configuration table of POE."
+			::= { hwPoeMIB 2 }
+		
+		
+		hwPoeSlotEntry OBJECT-TYPE
+			SYNTAX HwPoeSlotEntry
+			MAX-ACCESS not-accessible
+			STATUS current
+			DESCRIPTION
+				"This object indicates the entry of the slot configuration table of POE."
+			INDEX { hwPoeSlotId }
+			::= { hwPoeSlotTable 1 }
+		
+		HwPoeSlotEntry ::=
+			SEQUENCE { 
+				hwPoeSlotId
+					Integer32,
+				hwPoeSlotMaximumPower
+					Integer32,
+				hwPoeSlotAvailablePower
+					Integer32,
+				hwPoeSlotReferencePower
+					Integer32,
+				hwPoeSlotConsumingPower
+					Integer32,
+				hwPoeSlotPeakPower
+					Integer32,
+				hwPoeSlotLegacyDetect
+					EnabledStatus,
+				hwPoeSlotPowerManagementManner
+					INTEGER,
+				hwPoeSlotIsPoeDevice
+					OCTET STRING,
+				hwPoeDimmId
+				  Integer32,
+				hwPoeSlotPowerRsvPercent
+				  Integer32,
+				hwPoeSlotPowerUtilizationThreshold
+				  Integer32
+			 }
+
+		
+		hwPoeSlotId OBJECT-TYPE
+			SYNTAX Integer32 (0..8)
+			MAX-ACCESS not-accessible
+			STATUS current
+			DESCRIPTION
+				"This object identifies the slot ID."
+			::= { hwPoeSlotEntry 1 }
+		
+		
+		hwPoeSlotMaximumPower OBJECT-TYPE
+			SYNTAX Integer32 (0..1600000)
+			UNITS "mW"
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the maximum power set by users. The value is expressed in mW."
+			DEFVAL { '1B1980'h }
+			::= { hwPoeSlotEntry 2 }
+		
+		
+		hwPoeSlotAvailablePower OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object idenfies the available Power. The value is expressed in mW."
+			::= { hwPoeSlotEntry 3 }
+		
+		
+		hwPoeSlotReferencePower OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the total reference power of a slot. The value is expressed in mW."
+			::= { hwPoeSlotEntry 4 }
+		
+		
+		hwPoeSlotConsumingPower OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the total consuming power of a slot. The value is expressed in mW."
+			::= { hwPoeSlotEntry 5 }
+		
+		
+		hwPoeSlotPeakPower OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the total peak power of a slot. The value is expressed in mW."
+			::= { hwPoeSlotEntry 6 }
+		
+		
+		hwPoeSlotLegacyDetect OBJECT-TYPE
+			SYNTAX EnabledStatus
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object indicates the compatibility detection of a non-standard device. (1:enable;  2:disable(default))"
+			DEFVAL { disabled }
+			::= { hwPoeSlotEntry 7 }
+		
+		
+		hwPoeSlotPowerManagementManner OBJECT-TYPE
+			SYNTAX INTEGER
+				{
+				manual(1),
+				auto(2)
+				}
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the power management manner. (1:manual, 2:auto(default))."
+			DEFVAL { auto }
+			::= { hwPoeSlotEntry 8 }
+		
+		
+		hwPoeSlotIsPoeDevice OBJECT-TYPE
+			SYNTAX OCTET STRING
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object indicates whether the device supports PoE."
+			::= { hwPoeSlotEntry 9 }
+		
+
+		hwPoeDimmId OBJECT-TYPE
+			SYNTAX Integer32 (0..1)
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the DIMM ID."
+			::= { hwPoeSlotEntry 10 }
+
+		hwPoeSlotPowerRsvPercent OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the reserved percent of POE power in slot."
+			::= { hwPoeSlotEntry 11 }
+
+		hwPoeSlotPowerUtilizationThreshold OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the utilization threshold of total POE power in slot."
+			::= { hwPoeSlotEntry 12 }
+		
+		hwPoePortTable OBJECT-TYPE
+			SYNTAX SEQUENCE OF HwPoePortEntry
+			MAX-ACCESS not-accessible
+			STATUS current
+			DESCRIPTION
+				"This object indicates the table that contains the configuration parameters of a POE interface. One entry corresponds to a POE interface."
+			::= { hwPoeMIB 3 }
+		
+		
+		hwPoePortEntry OBJECT-TYPE
+			SYNTAX HwPoePortEntry
+			MAX-ACCESS not-accessible
+			STATUS current
+			DESCRIPTION
+				"This object indicates the entry of POE Port Table."
+			INDEX { hwPoePortIfIndex }
+			::= { hwPoePortTable 1 }
+		
+		HwPoePortEntry ::=
+			SEQUENCE { 
+				hwPoePortIfIndex
+					InterfaceIndex,
+				hwPoePortName
+					OCTET STRING,
+				hwPoePortEnable
+					EnabledStatus,
+				hwPoePortPriority
+					INTEGER,
+				hwPoePortMaximumPower
+					Integer32,
+				hwPoePortPowerOnStatus
+					OCTET STRING,
+				hwPoePortPowerStatus
+					OCTET STRING,
+				hwPoePortPdClass
+					Integer32,
+				hwPoePortReferencePower
+					Integer32,
+				hwPoePortConsumingPower
+					Integer32,
+				hwPoePortPeakPower
+					Integer32,
+				hwPoePortAveragePower
+					Integer32,
+				hwPoePortCurrent
+					OCTET STRING,
+				hwPoePortVoltage
+					OCTET STRING,
+				hwPoePortManualOperation
+					INTEGER
+			 }
+
+		
+		hwPoePortIfIndex OBJECT-TYPE
+			SYNTAX InterfaceIndex
+			MAX-ACCESS not-accessible
+			STATUS current
+			DESCRIPTION
+				"This object indicates the interface index."
+			::= { hwPoePortEntry 1 }
+		
+		
+		hwPoePortName OBJECT-TYPE
+			SYNTAX OCTET STRING
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object indicates the interface name."
+			::= { hwPoePortEntry 2 }
+		
+		
+		hwPoePortEnable OBJECT-TYPE
+			SYNTAX EnabledStatus
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object indicates the enabling status of an interface. (1:enable(default);  2:disable)"
+			DEFVAL { enable }
+			::= { hwPoePortEntry 3 }
+		
+		
+		hwPoePortPriority OBJECT-TYPE
+			SYNTAX INTEGER
+				{
+				critical(1),
+				high(2),
+				low(3)
+				}
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the priority of an interface. (1:critical, 2:high, 3:low(default))"
+			DEFVAL { low }
+			::= { hwPoePortEntry 4 }
+		
+		
+		hwPoePortMaximumPower OBJECT-TYPE
+			SYNTAX Integer32 (0..30000)
+			UNITS "mW"
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object identifies the maximum power of an interface.The value is expressed in mW."
+			DEFVAL { '9088'h }
+			::= { hwPoePortEntry 5 }
+		
+		
+		hwPoePortPowerOnStatus OBJECT-TYPE
+			SYNTAX OCTET STRING
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object indicates the powering status of an interface."
+			::= { hwPoePortEntry 6 }
+		
+		
+		hwPoePortPowerStatus OBJECT-TYPE
+			SYNTAX OCTET STRING
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object indicates the status of an interface."
+			::= { hwPoePortEntry 7 }
+		
+		
+		hwPoePortPdClass OBJECT-TYPE
+			SYNTAX Integer32 (0..7)
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the class of a PD."
+			::= { hwPoePortEntry 8 }
+		
+		
+		hwPoePortReferencePower OBJECT-TYPE
+			SYNTAX Integer32 (0..30000)
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the guaranteed power of an interface. The value is expressed in mW."
+			::= { hwPoePortEntry 9 }
+		
+		
+		hwPoePortConsumingPower OBJECT-TYPE
+			SYNTAX Integer32 (0..30000)
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the consuming power of an interface. The value is expressed in mW."
+			::= { hwPoePortEntry 10 }
+		
+		
+		hwPoePortPeakPower OBJECT-TYPE
+			SYNTAX Integer32 (0..30000)
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the peak power of an interface. The value is expressed in mW."
+			::= { hwPoePortEntry 11 }
+		
+		
+		hwPoePortAveragePower OBJECT-TYPE
+			SYNTAX Integer32 (0..30000)
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object identifies the average power of an interface. The value is expressed in mW."
+			::= { hwPoePortEntry 12 }
+		
+		
+		hwPoePortCurrent OBJECT-TYPE
+			SYNTAX OCTET STRING
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object indicates the current of an interface. The value is expressed in mA."
+			::= { hwPoePortEntry 13 }
+		
+		
+		hwPoePortVoltage OBJECT-TYPE
+			SYNTAX OCTET STRING
+			MAX-ACCESS read-only
+			STATUS current
+			DESCRIPTION
+				"This object indicates the voltage of an interface. The value is expressed in V."
+			::= { hwPoePortEntry 14 }
+		
+		
+		hwPoePortManualOperation OBJECT-TYPE
+			SYNTAX INTEGER
+				{
+				powerOff(1),
+				powerOn(2)
+				}
+			MAX-ACCESS read-write
+			STATUS current
+			DESCRIPTION
+				"This object indicates that a PD connected to an interface is powered on or powered off manually."
+			::= { hwPoePortEntry 15 }
+		
+
+		
+		hwPoeTrapObjects OBJECT IDENTIFIER ::= { hwPoeMIB 39 }
+		
+		hwPoePdPriority OBJECT-TYPE
+			SYNTAX INTEGER
+				{
+				critical(1),
+				high(2),
+				low(3)
+				}
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the PD priority.(1:critical, 2:high, 3:low(default))"
+			::= { hwPoeTrapObjects 1 }
+		
+		hwPoeSlotNum OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the slot ID."
+			::= { hwPoeTrapObjects 2 }
+
+		hwPoeCurConsumPower OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the current consuming power."
+			::= { hwPoeTrapObjects 3 }
+
+		hwPoeConsumPowerThreshold OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the threshold of consuming power."
+			::= { hwPoeTrapObjects 4 }
+			
+		hwPoeDeviceID OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the device ID."
+			::= { hwPoeTrapObjects 5 }
+		
+		hwFrameID OBJECT-TYPE
+			SYNTAX Integer32
+			MAX-ACCESS accessible-for-notify
+			STATUS current
+			DESCRIPTION
+				"This object identifies the CSS Frame ID."
+			::= { hwPoeTrapObjects 6 }
+			
+		hwPoeNotification OBJECT IDENTIFIER ::= { hwPoeMIB 40 }
+		
+		
+		hwPoeDimmError NOTIFICATION-TYPE
+			OBJECTS { hwPoeSlotNum, hwPoeDimmId }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates the Dimm chip error."
+			::= { hwPoeNotification 1 }
+		
+		
+		hwPoePowerOff NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates a PD connected to an interface is powered off."
+			::= { hwPoeNotification 2 }
+		
+		
+		hwPoePowerOn NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that a PD connected to an interface is powered on."
+			::= { hwPoeNotification 3 }
+		
+		
+		hwPoeSlotPowerOverload NOTIFICATION-TYPE
+			OBJECTS { hwPoeSlotNum, hwPoeSlotConsumingPower }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the power consumed by a slot exceeds the threshold."
+			::= { hwPoeNotification 4 }
+		
+		
+		hwPoeSlotPowerOverloadResume NOTIFICATION-TYPE
+			OBJECTS { hwPoeSlotNum, hwPoeSlotConsumingPower }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the power consumed by a slot does not exceed the threshold."
+			::= { hwPoeNotification 5 }
+		
+		
+		hwPoePdPowerOverload NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName, hwPoePortConsumingPower, hwPoePortMaximumPower }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates the power consumed by a PD connected to an interface exceeds the threshold."
+			::= { hwPoeNotification 6 }
+		
+		
+		hwPoePdPowerOverloadResume NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName, hwPoePortConsumingPower, hwPoePortMaximumPower }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the power consumed by a PD connected to an interface does not exceed the threshold."
+			::= { hwPoeNotification 7 }
+		
+		hwPoePdConnected NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that a PD is connected to an interface."
+			::= { hwPoeNotification 8 }
+		
+		
+		hwPoePdDisconnected NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that a PD is disconnected from an interface."
+			::= { hwPoeNotification 9 }
+		
+		hwPoePdClassInvalid NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that a PD of an invalid class is detected."
+			::= { hwPoeNotification 10 }
+		
+		hwPoePdClassOvercurrent NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that overcurrent occurs during the classification of a PD."
+			::= { hwPoeNotification 11 }
+		
+		hwPoePdPowerOvercurrent NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that overcurrent occurs during the powering of a PD."
+			::= { hwPoeNotification 12 }
+		
+		hwPoePdPowerOvercurrentResume NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that overcurrent is rectified."
+			::= { hwPoeNotification 13 }
+		
+		hwPoePowerOnFail NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that a PD fails to be powered on."
+			::= { hwPoeNotification 14 }
+		
+		hwPoePowerOffCurrentLimits NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that a PD is powered off because its current meets or exceeds the limit of current."
+			::= { hwPoeNotification 15 }
+		
+		hwPoePdPriorityDifferent NOTIFICATION-TYPE
+			OBJECTS { hwPoePortName, hwPoePortPriority, hwPoePdPriority }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the priority of PD is different from the port."
+			::= { hwPoeNotification 16 }
+		
+		hwPoePowerOverUtilizationThreshold  NOTIFICATION-TYPE
+		  OBJECTS { hwPoeDeviceID, hwPoeCurConsumPower, hwPoeConsumPowerThreshold}
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the PSE is overdrawing power."
+			::= { hwPoeNotification 17 }
+		
+		hwPoePowerOverUtilizationThresholdResume  NOTIFICATION-TYPE
+		  OBJECTS { hwPoeDeviceID, hwPoeCurConsumPower, hwPoeConsumPowerThreshold}
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the PSE is not overdrawing power."
+			::= { hwPoeNotification 18 }
+			
+		hwPoeBoardInsertedWrongFrame  NOTIFICATION-TYPE
+		  OBJECTS {hwFrameID, hwPoeSlotNum }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the poe board is inserted in the frame does not support poe."
+			::= { hwPoeNotification 19 }			
+						
+		hwPoePowerAbsent  NOTIFICATION-TYPE
+		  OBJECTS {hwFrameID, hwPoeSlotNum }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the poe power is absent."
+			::= { hwPoeNotification 20 }
+
+		hwPoePowerAbsentResume  NOTIFICATION-TYPE
+		  OBJECTS {hwFrameID, hwPoeSlotNum }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the poe power is present."
+			::= { hwPoeNotification 21 }
+
+		hwPoeRpsPowerOutputAlarm  NOTIFICATION-TYPE
+		  OBJECTS {hwPoeSlotNum }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the RPS power can not provide POE power for this device."
+			::= { hwPoeNotification 22 }
+
+		hwPoeRpsPowerOutputAlarmResume  NOTIFICATION-TYPE
+		  OBJECTS {hwPoeSlotNum }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates that the RPS power can provide POE power for this device."
+			::= { hwPoeNotification 23 }
+
+		
+		hwPoeConformance OBJECT IDENTIFIER ::= { hwPoeMIB 100 }
+		
+		
+		hwPoeGroups OBJECT IDENTIFIER ::= { hwPoeConformance 1 }
+		
+		
+		hwPoeSlotGroup OBJECT-GROUP
+			OBJECTS { hwPoeSlotMaximumPower, hwPoeSlotReferencePower, hwPoeSlotConsumingPower, hwPoeSlotPeakPower, hwPoeSlotPowerManagementManner, 
+				hwPoeSlotIsPoeDevice, hwPoeSlotLegacyDetect, hwPoeSlotPowerRsvPercent, hwPoeSlotPowerUtilizationThreshold, hwPoeDimmId,
+				hwPoeSlotAvailablePower }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates the POE's slot table group."
+			::= { hwPoeGroups 1 }
+		
+		
+		hwPoePortGroup OBJECT-GROUP
+			OBJECTS { hwPoePortEnable, hwPoePortPriority, hwPoePortMaximumPower, hwPoePortPowerOnStatus, hwPoePortPowerStatus, 
+				hwPoePortReferencePower, hwPoePortName, hwPoePortConsumingPower, hwPoePortPeakPower, hwPoePortAveragePower, 
+				hwPoePortCurrent, hwPoePortVoltage, hwPoePortManualOperation, hwPoePortPdClass }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates the POE's port table group."
+			::= { hwPoeGroups 2 }
+		
+		
+		hwPoeGlobalGroup OBJECT-GROUP
+			OBJECTS { hwPoePowerUtilizationThreshold, hwPoePowerRsvPercent, hwPoePower }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates the POE's global table group."
+			::= { hwPoeGroups 3 }
+		
+		
+		hwPoeNotificationGroup NOTIFICATION-GROUP
+			NOTIFICATIONS { hwPoeDimmError, hwPoePowerOff, hwPoePowerOn, hwPoePdPowerOverload, hwPoePdPowerOverloadResume, 
+				hwPoePdConnected, hwPoePdDisconnected, hwPoePdClassInvalid, hwPoePdClassOvercurrent, hwPoePdPowerOvercurrent, 
+				hwPoePdPowerOvercurrentResume, hwPoePowerOnFail, hwPoePowerOffCurrentLimits, hwPoePowerOverUtilizationThresholdResume , hwPoePowerOverUtilizationThreshold , 
+				hwPoePdPriorityDifferent, hwPoeSlotPowerOverload, hwPoeSlotPowerOverloadResume , hwPoeBoardInsertedWrongFrame ,hwPoePowerAbsent,hwPoePowerAbsentResume,
+				hwPoeRpsPowerOutputAlarm, hwPoeRpsPowerOutputAlarmResume }
+			STATUS current
+			DESCRIPTION 
+				"This object indicates the POE's notification table group."
+			::= { hwPoeGroups 4 }
+		
+		hwPoeTrapObjectsGroup OBJECT-GROUP
+			OBJECTS { hwPoePdPriority, hwPoeSlotNum, hwPoeCurConsumPower,hwPoeConsumPowerThreshold,hwPoeDeviceID,hwFrameID }
+			STATUS current
+			DESCRIPTION 
+				"Description."
+			::= { hwPoeGroups 5 }
+		
+	
+	END
+
+--
+-- HUAWEI-POE-MIB.mib
+--


### PR DESCRIPTION
Hello,

I did some tests and enhancements in the POE polling code (Cisco, Huawei), and also added graphing code in the port page. 

Then code has been tested onto Cisco 2960X, and Huawei 5720 access switches.

PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
