### PR TITLE
Handle database exceptions properly

### DIFF
--- a/LibreNMS/Exceptions/DatabaseConnectException.php
+++ b/LibreNMS/Exceptions/DatabaseConnectException.php
@@ -19,7 +19,7 @@
  *
  * @package    LibreNMS
  * @link       http://librenms.org
- * @copyright  2017 Tony Murray
+ * @copyright  2018 Tony Murray
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
@@ -27,5 +27,23 @@ namespace LibreNMS\Exceptions;
 
 class DatabaseConnectException extends \Exception
 {
-
+    /**
+     * Render the exception into an HTTP or JSON response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render(\Illuminate\Http\Request $request)
+    {
+        if ($request->wantsJson()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Error connecting to database: ' . $this->getMessage(),
+            ]);
+        } else {
+            $message = "<h2 style='color:darkred'>Error connecting to database.</h2>";
+            $message .= $this->getMessage();
+            return response($message);
+        }
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,24 +16,21 @@ class AppServiceProvider extends ServiceProvider
      * Bootstrap any application services.
      *
      * @return void
+     * @throws DatabaseConnectException caught by App\Exceptions\Handler and displayed to the user
      */
     public function boot()
     {
         // connect legacy db
         //FIXME this is for auth right now, remove later
-        try {
-            $db_config = config('database.connections')[config('database.default')];
-            dbConnect(
-                $db_config['host'],
-                $db_config['username'],
-                $db_config['password'],
-                $db_config['database'],
-                $db_config['port'],
-                $db_config['unix_socket']
-            );
-        } catch (DatabaseConnectException $e) {
-            // ignore failures here
-        }
+        $db_config = config('database.connections')[config('database.default')];
+        dbConnect(
+            $db_config['host'],
+            $db_config['username'],
+            $db_config['password'],
+            $db_config['database'],
+            $db_config['port'],
+            $db_config['unix_socket']
+        );
 
         // load config
         Config::load();

--- a/includes/dbFacile.php
+++ b/includes/dbFacile.php
@@ -78,7 +78,6 @@ function dbConnect($db_host = null, $db_user = '', $db_pass = '', $db_name = '',
     }
 
     $database_link = @mysqli_connect('p:' . $db_host, $db_user, $db_pass, null, $db_port, $db_socket);
-    mysqli_options($database_link, MYSQLI_OPT_LOCAL_INFILE, false);
     if ($database_link === false) {
         $error = mysqli_connect_error();
         if ($error == 'No such file or directory') {
@@ -86,6 +85,8 @@ function dbConnect($db_host = null, $db_user = '', $db_pass = '', $db_name = '',
         }
         throw new DatabaseConnectException($error);
     }
+
+    mysqli_options($database_link, MYSQLI_OPT_LOCAL_INFILE, false);
 
     $database_db = mysqli_select_db($database_link, $db_name);
     if (!$database_db) {

--- a/includes/init.php
+++ b/includes/init.php
@@ -105,10 +105,11 @@ if (!module_selected('nodb', $init_modules)) {
     } catch (\LibreNMS\Exceptions\DatabaseConnectException $e) {
         if (isCli()) {
             echo 'MySQL Error: ' . $e->getMessage() . PHP_EOL;
+            exit(2);
         } else {
-            echo "<h2>MySQL Error</h2><p>" . $e->getMessage() . "</p>";
+            // punt to the Laravel error handler
+            throw $e;
         }
-        exit(2);
     }
 }
 


### PR DESCRIPTION
Display the errors to the user
Hide the query, unless APP_DEBUG=true in .env
Much easier to display output for other exceptions now, just need to add a render() function to them

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
