### PR TITLE
Fix hostname lookup for distributed poller on some platforms

### DIFF
--- a/doc/Extensions/Distributed-Poller.md
+++ b/doc/Extensions/Distributed-Poller.md
@@ -125,7 +125,7 @@ Running an install of LibreNMS in /opt/librenms
 
 `config.php`
 ```php
-$config['distributed_poller_name']           = file_get_contents('/etc/hostname');
+$config['distributed_poller_name']           = php_uname('n');
 $config['distributed_poller_group']          = '0';
 $config['distributed_poller_memcached_host'] = "example.com";
 $config['distributed_poller_memcached_port'] = 11211;
@@ -149,7 +149,7 @@ Running an install of LibreNMS in /opt/librenms
 
 `config.php`
 ```php
-$config['distributed_poller_name']           = file_get_contents('/etc/hostname');
+$config['distributed_poller_name']           = php_uname('n');
 $config['distributed_poller_group']          = '0';
 $config['distributed_poller_memcached_host'] = "example.com";
 $config['distributed_poller_memcached_port'] = 11211;
@@ -171,7 +171,7 @@ Running an install of LibreNMS in /opt/librenms
 
 `config.php`
 ```php
-$config['distributed_poller_name']           = file_get_contents('/etc/hostname');
+$config['distributed_poller_name']           = php_uname('n');
 $config['distributed_poller_group']          = '2,3';
 $config['distributed_poller_memcached_host'] = "example.com";
 $config['distributed_poller_memcached_port'] = 11211;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -858,7 +858,7 @@ $config['api_demo'] = 0;
 // Set this to 1 if you want to disable some untrusting features for the API
 // Distributed Poller-Settings
 $config['distributed_poller']                = false;
-$config['distributed_poller_name']           = trim(file_get_contents('/proc/sys/kernel/hostname'));
+$config['distributed_poller_name']           = php_uname('n');
 $config['distributed_poller_group']          = 0;
 $config['distributed_poller_memcached_host'] = 'example.net';
 $config['distributed_poller_memcached_port'] = '11211';


### PR DESCRIPTION
May cause warnings about poller not polling if the name doesn't match exactly as the old one.
Just delete from /pollers

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
