### PR TITLE
Bug - Apc - Humidity sensor negative value filtering

### DIFF
--- a/includes/definitions/discovery/apc.yaml
+++ b/includes/definitions/discovery/apc.yaml
@@ -321,6 +321,10 @@ modules:
                         oid: rPDU2SensorTempHumidityStatusType
                         op: '='
                         value: 4
+                      - 
+                        oid: rPDU2SensorTempHumidityStatusRelativeHumidity
+                        op: '<'
+                        value: 0
         airflow:
             data:
                 -


### PR DESCRIPTION
Hello

We have  PDUs (APC) that were returning "-1" as Humidity value, and it seems that this happens when the optional humidity sensor is not plugged into the PDU. 
This PR is adding a check to skip the negative values.

Bye
PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

