### PR TITLE
Optimisation - VRP - Only fetch the necessary OIDs for POE polling

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -300,7 +300,7 @@ if ($config['enable_ports_poe']) {
         );
 
         foreach ($vrp_poe_oids as $oid) {
-            $port_stats = snmpwalk_cache_oid($device,  $oid, $port_stats, 'HUAWEI-POE-MIB');
+            $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'HUAWEI-POE-MIB');
         }
     } else {
         //Any other device, generic polling

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -290,7 +290,18 @@ if ($config['enable_ports_poe']) {
         }
     } elseif ($device['os'] == 'vrp') {
         echo 'HwPoePortEntry' ;
-        $port_stats = snmpwalk_cache_oid($device, 'HwPoePortEntry', $port_stats, 'HUAWEI-POE-MIB');
+
+        $vrp_poe_oids = array(
+            'hwPoePortReferencePower',
+            'hwPoePortMaximumPower',
+            'hwPoePortConsumingPower',
+            'hwPoePortPeakPower',
+            'hwPoePortEnable',
+        );
+
+        foreach ($vrp_poe_oids as $oid) {
+            $port_stats = snmpwalk_cache_oid($device,  $oid, $port_stats, 'HUAWEI-POE-MIB');
+        }
     } else {
         //Any other device, generic polling
         $port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');


### PR DESCRIPTION
Hello

For VRP devices supporting POE, the goal is to fetch only the strict necessary values instead of all the table to improve the polling time (devices tested, 5720, are quite slow to return SNMP values).

Test Data is unchanged. 

Bye
PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

