### PR TITLE
Fix oxidized configuration fetch for empty group

### DIFF
--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -157,16 +157,16 @@ if (Auth::user()->hasGlobalAdmin()) {
             }
 
             if (isset($previous_config)) {
-                $url = $config['oxidized']['url'].'/node/version/diffs?node='.$oxidized_hostname.'&group=';
+                $url = $config['oxidized']['url'].'/node/version/diffs?node='.$oxidized_hostname;
                 if (!empty($node_info['group'])) {
-                    $url .= $node_info['group'];
+                    $url .= '&group='.$node_info['group'];
                 }
                 $url .= '&oid='.$current_config['oid'].'&date='.urlencode($current_config['date']).'&num='.$current_config['version'].'&oid2='.$previous_config['oid'].'&format=text';
 
                 $text = file_get_contents($url); // fetch diff
             } else {
                 // fetch current_version
-                $text = file_get_contents($config['oxidized']['url'].'/node/version/view?node='.$oxidized_hostname.'&group='.(!empty($node_info['group']) ? $node_info['group'] : '').'&oid='.$current_config['oid'].'&date='.urlencode($current_config['date']).'&num='.$current_config['version'].'&format=text');
+                $text = file_get_contents($config['oxidized']['url'].'/node/version/view?node='.$oxidized_hostname.(!empty($node_info['group']) ? '&group='.$node_info['group'] : '').'&oid='.$current_config['oid'].'&date='.urlencode($current_config['date']).'&num='.$current_config['version'].'&format=text');
             }
         } else {  // just fetch the only version
             $text = file_get_contents($config['oxidized']['url'].'/node/fetch/'.(!empty($node_info['group']) ? $node_info['group'].'/' : '').$oxidized_hostname);


### PR DESCRIPTION
Sending an empty group to Oxidized results in it not finding a node's
configuration even though it will find it just fine when the group is
not specified.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
