### PR TITLE
api: Map LibreNMS OS' to known Oxidized models

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -876,6 +876,8 @@ Output:
 
 List devices for use with Oxidized. If you have group support enabled then a group will also be returned based on your config.
 
+> LibreNMS will automatically map the OS to the Oxidized model name if they don't match.
+
 Route: `/api/v0/oxidized(/:hostname)`
 
 Input (JSON):

--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -14,6 +14,8 @@ Then you can procede to the LibreNMS Web UI and go to Oxidized Settings in the E
 
 To have devices automatically added, you will need to configure oxidized to pull them from LibreNMS [Feeding Oxidized](#feeding-oxidized)
 
+LibreNMS will automatically map the OS to the Oxidized model name if they don't match. this means you shouldn't need to use the model_map config option within Oxidized.
+
 ### Detailed integration information
 ---
 

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1264,6 +1264,14 @@ function list_oxidized()
             }
         }
 
+        // We remap certain device OS' that have different names with Oxidized models
+        $models = [
+            'arista_eos' => 'eos',
+            'vyos'       => 'vyatta',
+        ];
+
+        $device['os'] = str_replace(array_keys($models), array_values($models), $device['os']);
+
         unset($device['location']);
         unset($device['sysname']);
         $devices[] = $device;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This will save people from mapping OS' in oxidized. Most likely is more to add but I don't know of them.