### PR TITLE
Webui: Allow Submenus in Plugin Menu by removing the scrollable-menu …

### DIFF
--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -75,7 +75,7 @@ if ($config['title_image']) {
           </li>
           <li class="dropdown-submenu">
             <a><i class="fa fa-plug fa-fw fa-lg" aria-hidden="true"></i> Plugins</a>
-            <ul class="dropdown-menu scrollable-menu">
+            <ul class="dropdown-menu">
                 <?php
                 \LibreNMS\Plugins::call('menu');
 


### PR DESCRIPTION
Hello

The "scrollable-menu" class appears incompatible with nested submenus. Removing it for Plugin submenu would allow a plugin to use SubMenus itself. 

Use case: WeatherMap would list in a submenu all the weathermaps defined, allowing a quick access.

The patch for weathermap would come if this one is accepted.

Bye
PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
