### PR TITLE
Clear the OS cache when running collect and save test data scripts

### DIFF
--- a/scripts/collect-snmp-data.php
+++ b/scripts/collect-snmp-data.php
@@ -119,6 +119,7 @@ try {
 
 
     echo "Capturing Data: ";
+    update_os_cache(true); // Force update of OS Cache
     $capture->captureFromDevice($device['device_id'], true, $prefer_new_snmprec);
 } catch (InvalidModuleException $e) {
     echo $e->getMessage() . PHP_EOL;

--- a/scripts/save-test-data.php
+++ b/scripts/save-test-data.php
@@ -119,7 +119,7 @@ try {
         }
         echo PHP_EOL;
 
-
+        update_os_cache(true); // Force update of OS Cache
         $tester = new ModuleTestHelper($modules, $target_os, $target_variant);
 
         $test_data = $tester->generateTestData($snmpsim, $no_save);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Caught me out a few times this. No reason not to clear cache when running these scripts.