### PR TITLE
Change max load from 5000 to 50000

### DIFF
--- a/includes/polling/ucd-mib.inc.php
+++ b/includes/polling/ucd-mib.inc.php
@@ -165,9 +165,9 @@ $load_raw = snmp_get_multi($device, 'laLoadInt.1 laLoadInt.2 laLoadInt.3', '-OQU
 // Check to see that the 5-min OID is actually populated before we make the rrd
 if (is_numeric($load_raw[2]['laLoadInt'])) {
     $rrd_def = RrdDefinition::make()
-        ->addDataset('1min', 'GAUGE', 0, 50000)
-        ->addDataset('5min', 'GAUGE', 0, 50000)
-        ->addDataset('15min', 'GAUGE', 0, 50000);
+        ->addDataset('1min', 'GAUGE', 0)
+        ->addDataset('5min', 'GAUGE', 0)
+        ->addDataset('15min', 'GAUGE', 0);
 
     $fields = array(
         '1min'   => $load_raw[1]['laLoadInt'],

--- a/includes/polling/ucd-mib.inc.php
+++ b/includes/polling/ucd-mib.inc.php
@@ -165,9 +165,9 @@ $load_raw = snmp_get_multi($device, 'laLoadInt.1 laLoadInt.2 laLoadInt.3', '-OQU
 // Check to see that the 5-min OID is actually populated before we make the rrd
 if (is_numeric($load_raw[2]['laLoadInt'])) {
     $rrd_def = RrdDefinition::make()
-        ->addDataset('1min', 'GAUGE', 0, 5000)
-        ->addDataset('5min', 'GAUGE', 0, 5000)
-        ->addDataset('15min', 'GAUGE', 0, 5000);
+        ->addDataset('1min', 'GAUGE', 0, 50000)
+        ->addDataset('5min', 'GAUGE', 0, 50000)
+        ->addDataset('15min', 'GAUGE', 0, 50000);
 
     $fields = array(
         '1min'   => $load_raw[1]['laLoadInt'],


### PR DESCRIPTION
Perhaps a load value of 50000% seems excessive, however it can happen. (Example: a heavily loaded compute node with 48 CPU cores that produces loads of ~15000%, printed as 150 by tools like htop).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
