### PR TITLE
Adding application for drone stats

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -141,6 +141,9 @@ function nicecase($item)
         case 'zfs':
             return 'ZFS';
 
+        case 'drone-stats':
+            return 'Drone Stats';
+
         default:
             return ucfirst($item);
     }

--- a/html/includes/graphs/application/drone-stats_pending.inc.php
+++ b/html/includes/graphs/application/drone-stats_pending.inc.php
@@ -1,0 +1,36 @@
+<?php
+
+require 'includes/graphs/common.inc.php';
+$name = 'drone-stats';
+$app_id = $app['app_id'];
+$scale_min     = 0;
+$colours       = 'mixed';
+$unit_text     = 'Pending';
+$unitlen       = 18;
+$bigdescrlen   = 18;
+$smalldescrlen = 18;
+$dostack       = 0;
+$printtotal    = 0;
+$addarea       = 1;
+$transparency  = 33;
+
+$rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
+
+$array = array(
+    'pending' => array('descr' => 'Pending jobs','colour' => 'c13a38'),
+);
+
+$i = 0;
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    foreach ($array as $ds => $var) {
+        $rrd_list[$i]['filename'] = $rrd_filename;
+        $rrd_list[$i]['descr']    = $var['descr'];
+        $rrd_list[$i]['ds']       = $ds;
+        $rrd_list[$i]['colour']   = $var['colour'];
+        $i++;
+    }
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_v3_multiline.inc.php';

--- a/html/includes/graphs/application/drone-stats_running.inc.php
+++ b/html/includes/graphs/application/drone-stats_running.inc.php
@@ -1,0 +1,36 @@
+<?php
+
+require 'includes/graphs/common.inc.php';
+$name = 'drone-stats';
+$app_id = $app['app_id'];
+$scale_min     = 0;
+$colours       = 'mixed';
+$unit_text     = 'Running';
+$unitlen       = 18;
+$bigdescrlen   = 18;
+$smalldescrlen = 18;
+$dostack       = 0;
+$printtotal    = 0;
+$addarea       = 1;
+$transparency  = 33;
+
+$rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
+
+$array = array(
+    'running' => array('descr' => 'Running workers','colour' => 'bdc138'),
+);
+
+$i = 0;
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    foreach ($array as $ds => $var) {
+        $rrd_list[$i]['filename'] = $rrd_filename;
+        $rrd_list[$i]['descr']    = $var['descr'];
+        $rrd_list[$i]['ds']       = $ds;
+        $rrd_list[$i]['colour']   = $var['colour'];
+        $i++;
+    }
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_v3_multiline.inc.php';

--- a/html/includes/graphs/application/drone-stats_worker.inc.php
+++ b/html/includes/graphs/application/drone-stats_worker.inc.php
@@ -1,0 +1,36 @@
+<?php
+
+require 'includes/graphs/common.inc.php';
+$name = 'drone-stats';
+$app_id = $app['app_id'];
+$scale_min     = 0;
+$colours       = 'mixed';
+$unit_text     = 'Workers';
+$unitlen       = 18;
+$bigdescrlen   = 18;
+$smalldescrlen = 18;
+$dostack       = 0;
+$printtotal    = 0;
+$addarea       = 1;
+$transparency  = 33;
+
+$rrd_filename = rrd_name($device['hostname'], array('app', $name, $app_id));
+
+$array = array(
+    'worker' => array('descr' => 'Idle worker','colour' => '38c151'),
+);
+
+$i = 0;
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    foreach ($array as $ds => $var) {
+        $rrd_list[$i]['filename'] = $rrd_filename;
+        $rrd_list[$i]['descr']    = $var['descr'];
+        $rrd_list[$i]['ds']       = $ds;
+        $rrd_list[$i]['colour']   = $var['colour'];
+        $i++;
+    }
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_v3_multiline.inc.php';

--- a/html/pages/apps.inc.php
+++ b/html/pages/apps.inc.php
@@ -273,6 +273,11 @@ $graphs['powerdns-dnsdist'] = array(
     'rules_stats',
     'queries_drop',
 );
+$graphs['drone-stats'] = array(
+    'worker',
+    'pending',
+    'running'
+);
 echo '<div class="panel panel-default">';
 echo '<div class="panel-heading">';
 echo "<span style='font-weight: bold;'>Apps</span> &#187; ";

--- a/html/pages/device/apps/drone-stats.inc.php
+++ b/html/pages/device/apps/drone-stats.inc.php
@@ -1,0 +1,30 @@
+<?php
+
+global $config;
+
+$graphs = array(
+    'drone-stats_worker' => 'Idle workers',
+    'drone-stats_pending' => 'Pending jobs',
+    'drone-stats_running' => 'Running workers',
+);
+
+foreach ($graphs as $key => $text) {
+    $graph_type  = $key;
+
+    $graph_array['height'] = '100';
+    $graph_array['width']  = '215';
+    $graph_array['to']     = $config['time']['now'];
+    $graph_array['id']     = $app['app_id'];
+    $graph_array['type']   = 'application_'.$key;
+
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
+    include 'includes/print-graphrow.inc.php';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+}

--- a/includes/polling/applications/drone-stats.inc.php
+++ b/includes/polling/applications/drone-stats.inc.php
@@ -1,0 +1,31 @@
+<?php
+
+use LibreNMS\RRD\RrdDefinition;
+
+//NET-SNMP-EXTEND-MIB::nsExtendOutputFull."drone-stats"
+$name = 'drone-stats';
+$app_id = $app['app_id'];
+$oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.11.100.114.111.110.101.95.115.116.97.116.115';
+$options = '-O qv';
+$mib = 'NET-SNMP-EXTEND-MIB';
+$stats = snmp_get($device, $oid, $options, $mib);
+
+echo ' '.$name;
+
+list ($worker, $pending, $running) = explode("|", $stats);
+
+$rrd_name = array('app', $name, $app_id);
+$rrd_def = RrdDefinition::make()
+    ->addDataset('worker', 'GAUGE', 0)
+    ->addDataset('pending', 'GAUGE', 0)
+    ->addDataset('running', 'GAUGE', 0);
+
+$fields = array(
+    'worker' => intval(trim($worker, '"')),
+    'pending' => intval(trim($pending, '"')),
+    'running' => intval(trim($running, '"')),
+);
+
+$tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
+data_update($device, 'app', $tags, $fields);
+update_application($app, $stats, $fields);


### PR DESCRIPTION
I wanted to write a little integration with Drone CI. There you can read out currently idling workers, running workers and the size of the queued jobs list. This will be reported by an SNMP extend command in following way:

```
33|0|0
```

I can submit the script for this later to the agents repository as well.

Also `snmpwalk` properly shows them:

```
$ snmpwalk -v 2c -c COMMUNITY HOST .1.3.6.1.4.1.8072.1.3.2.3.1
iso.3.6.1.4.1.8072.1.3.2.3.1.1.11.100.114.111.110.101.95.115.116.97.116.115 = STRING: "33|0|0"
iso.3.6.1.4.1.8072.1.3.2.3.1.2.11.100.114.111.110.101.95.115.116.97.116.115 = STRING: "33|0|0"
iso.3.6.1.4.1.8072.1.3.2.3.1.3.11.100.114.111.110.101.95.115.116.97.116.115 = INTEGER: 1
iso.3.6.1.4.1.8072.1.3.2.3.1.4.11.100.114.111.110.101.95.115.116.97.116.115 = INTEGER: 0
```

Any idea why LibreNMS does not show them in the UI? It is simply empty:

<img width="1535" alt="bildschirmfoto 2018-05-31 um 00 59 32" src="https://user-images.githubusercontent.com/245432/40752021-eef2ce98-646d-11e8-92d9-85a0b7bab34f.png">

Sorry if this all looks totally wrong. I just wanted to have some custom graphs in the monitoring setup and thought that this is the way to handle it. Did I maybe messed up with the OID or did I forgot to register the data somewhere?

Thanks

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)