### PR TITLE
Fix storing metrics for SMART

### DIFF
--- a/includes/polling/applications/smart.inc.php
+++ b/includes/polling/applications/smart.inc.php
@@ -125,7 +125,7 @@ while (isset($lines[$int])) {
         'selective'=>$selective
     );
 
-    $metrics[$disk] = $metrics;
+    $metrics[$disk] = $fields;
     $tags = array('name' => $name, 'app_id' => $app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name);
     data_update($device, 'app', $tags, $fields);
 


### PR DESCRIPTION
This was an obvious bug, the pattern in all similar .inc.php files for other apps is always `$metrics[$something] = $fields`, assigning the array itself to be an element of itself must have been a mistake (that makes it impossible to create application metric based alerts based on disk SMART status).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
