### PR TITLE
Allow the hostname to resolve to the sysName, ie Dynamic DNS

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -284,6 +284,10 @@ Enable or disable the sysDescr output for a device.
 $config['force_ip_to_sysname'] = false;
 ```
 When using IP addresses as a hostname you can instead represent the devices on the WebUI by its SNMP sysName resulting in an easier to read overview of your network. This would apply on networks where you don't have DNS records for most of your devices.
+```php
+$config['force_hostname_to_sysname'] = false;
+```
+When using a dynamic DNS hostname or one that does not resolve, this option would allow you to make use of the SNMP sysName instead as the preferred reference to the device.
 
 ```php
 $config['device_traffic_iftype'][] = '/loopback/';

--- a/includes/common.php
+++ b/includes/common.php
@@ -1203,6 +1203,11 @@ function format_hostname($device, $hostname = '')
             $hostname = $device['sysName'];
         }
     }
+    if ($config['force_hostname_to_sysname'] === true && !empty($device['sysName'])) {
+        if (filter_var($hostname, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) == false && filter_var($hostname, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) == false) {
+            $hostname = $device['sysName'];
+        }
+    }
     return $hostname;
 }//end format_hostname
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -845,7 +845,8 @@ $config['dateformat']['mysql']['time']    = '%H:%i:%s';
 
 $config['enable_clear_discovery'] = 1;
 // Set this to 0 if you want to disable the web option to rediscover devices
-$config['force_ip_to_sysname']    = false;// Set to true if you want to use sysName in place of IPs
+$config['force_ip_to_sysname']          = false;// Set to true if you want to use sysName in place of IPs
+$config['force_hostname_to_sysname']    = false;// Set to true if you want to use sysNAme in place of a hostname, ie Dynamic DNS
 
 // Allow duplicate devices by sysName
 $config['allow_duplicate_sysName'] = false;// Set to true if you want to allow duplicate sysName's


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

The purpose of this update is to allow one to add and monitor a device using a dynamic dns name, or an entry that you do not want to display as the default name. This option allows you to change the displayed name to match the sysName regardless of the DNS name.