### PR TITLE
HPE ILO power fix

### DIFF
--- a/includes/definitions/discovery/hpe-ilo.yaml
+++ b/includes/definitions/discovery/hpe-ilo.yaml
@@ -19,7 +19,7 @@ modules:
                     snmp_flags: '-OQUs'
                     index: 'cpqHeTemperatureCelsius.{{ $index }}'
                     descr: cpqHeTemperatureLocale
-                    high_limit: cpqHeTemperatureThreshold
+                    high_limit: '90' #cpqHeTemperatureThreshold
                 -
                     oid: cpqDaPhyDrvTable
                     value: cpqDaPhyDrvCurrentTemperature


### PR DESCRIPTION
cpqHeTemperatureThreshold is '0', which cause alerts. Fixed to '90'. Tested on Proliant Gen8-9.