### PR TITLE
Fix vars parsing on normal get urls

### DIFF
--- a/html/includes/vars.inc.php
+++ b/html/includes/vars.inc.php
@@ -11,17 +11,21 @@ foreach ($_GET as $key => $get_var) {
     }
 }
 
+// handle normal encoded urls too
+$working_url = str_replace(['?', '&'], '/', $_SERVER['REQUEST_URI']);
+
 $base_url = parse_url($config["base_url"]);
 // don't parse the subdirectory, if there is one in the path
 if (strlen($base_url["path"]) > 1) {
+    $working_url = str_replace($base_url["path"], "", $working_url);
     $segments = explode('/', trim(str_replace($base_url["path"], "", $_SERVER['REQUEST_URI']), '/'));
-} else {
-    $segments = explode('/', trim($_SERVER['REQUEST_URI'], '/'));
 }
+
+$segments = explode('/', trim($working_url, '/'));
 
 foreach ($segments as $pos => $segment) {
     $segment = urldecode($segment);
-    if ($pos == '0') {
+    if ($pos == 0) {
         $vars['page'] = $segment;
     } else {
         list($name, $value) = explode('=', $segment);
@@ -38,5 +42,5 @@ foreach ($_GET as $name => $value) {
 }
 
 foreach ($_POST as $name => $value) {
-    $vars[$name] = ($value);
+    $vars[$name] = $value;
 }


### PR DESCRIPTION
(like a form with GET as the method)

The other fix is to modify all GET forms to use a url with a trailing slash.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
