### PR TITLE
Fixed incorrect divisor for #8746

### DIFF
--- a/includes/discovery/sensors/current/procurve.inc.php
+++ b/includes/discovery/sensors/current/procurve.inc.php
@@ -1,7 +1,7 @@
 <?php
 $multiplier    = 1;
 $divisor       = 1000000;
-$divisor_alarm = 10000000;
+$divisor_alarm = 1000000;
 foreach ($pre_cache['procurve_hpicfXcvrInfoTable'] as $index => $entry) {
     if (is_numeric($entry['hpicfXcvrBias']) && $entry['hpicfXcvrBias'] != 0) {
         $oid                       = '.1.3.6.1.4.1.11.2.14.11.5.1.82.1.1.1.1.13.' . $index;


### PR DESCRIPTION
This is a fix for #8746, which added support of SFP module discovery on Procurve devices. I noticed a lot of false positive alerts for current bias when we launched this in production, so looked once more through MIB/code. 

MIB data: 
hpicfXcvrBias - Tx bias current in microamps
hpicfXcvrBiasHiAlarm - Transceiver bias high alarm threshold limit in microamps
hpicfXcvrBiasLoAlarm - Transceiver bias low alarm threshold limit in microamps

Sensor discovery sample: 
hpicfXcvrBias.49 = 23254
hpicfXcvrBiasHiAlarm.49 = 100000
hpicfXcvrBiasLoAlarm.49 = 0
hpicfXcvrBiasHiWarn.49 = 90000
hpicfXcvrBiasLoWarn.49 = 100

So yes, my mistake was to use 10^-7 instead of 10^-6 divisor for these fields. Fix is in this pull request. Sorry for the inconveniences caused. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
