### PR TITLE
Checking for 'none' as the only device relationship

### DIFF
--- a/html/pages/device/edit/device.inc.php
+++ b/html/pages/device/edit/device.inc.php
@@ -7,7 +7,7 @@ if ($_POST['editing']) {
         $updated = 0;
 
         if (isset($_POST['parent_id'])) {
-            $parent_id = $_POST['parent_id'];
+            $parent_id = array_diff((array)$_POST['parent_id'], ['0']);
             $res = dbDelete('device_relationships', '`child_device_id` = ?', array($device['device_id']));
             if (!in_array('0', $pr)) {
                 foreach ($parent_id as $pr) {


### PR DESCRIPTION
Per a discussion with @murrant in Discord, this change adds a check to make sure `None` is not the relationship that is being queried against on save.  'None' has an ID of '0' in the $_POST['parents_id'] array. 

Without this check added, the Librenms error log contains entries like this when you save an edit to a device if `none` is the relationship that is selected.

```2018-06-21 09:18:25 MySQL Error: Cannot add or update a child row: a foreign key constraint fails (`librenms`.`device_relationships`, CONSTRAINT `device_relationship_parent_device_id_fk` FOREIGN KEY (`parent_device_id`) REFERENCES `devices` (`device_id`) ON DELETE CASCADE) (INSERT INTO `device_relationships` (`parent_device_id`,`child_device_id`)  VALUES ('0','35'))```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
