### PR TITLE
Removed nobulk option from routeros

### DIFF
--- a/includes/definitions/routeros.yaml
+++ b/includes/definitions/routeros.yaml
@@ -2,7 +2,6 @@ os: routeros
 text: 'Mikrotik RouterOS'
 icon: mikrotik
 type: network
-nobulk: true
 mib_dir:
     - mikrotik
 rfc1628_compat: true


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Removed based on the info from: https://community.librenms.org/t/help-improving-polling-time-mikrotik-ccr-1240-ports/4284/8

This was originally in from the fork so is definitely 6+ years old in use.