### PR TITLE
sanitize oxidized geshi html output

### DIFF
--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -259,7 +259,7 @@ if (Auth::user()->hasGlobalAdmin()) {
         // $geshi->set_line_style('color: #999999');
         echo '<div class="config">';
         echo '<input id="linenumbers" class="btn btn-primary" type="submit" value="Hide line numbers"/>';
-        echo $geshi->parse_code();
+        echo htmlspecialchars_decode($geshi->parse_code());
         echo '</div>';
     }
 }//end if


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

When the output of a configuration file is parsed by Geshi it replaces quotes with html codes instead of leaving them as is. I have sanitized this back in to normal output.