### PR TITLE
Feature : Use IOS POE code for IOSXE

### DIFF
--- a/includes/polling/ports/port-poe.inc.php
+++ b/includes/polling/ports/port-poe.inc.php
@@ -25,8 +25,8 @@ if (($device['os'] == 'vrp')) {
         data_update($device, 'poe', $tags, $fields);
         echo 'PoE(vrp) ';
     }
-} elseif (($device['os'] == 'ios')) {
-    // Code for Cisco IOS, tested on 2960X
+} elseif (($device['os'] == 'ios') || ($device['os'] == 'iosxe')) {
+    // Code for Cisco IOS and IOSXE, tested on 2960X
     if (isset($this_port['cpeExtPsePortPwrAllocated'])) {
         // if we have cpeExtPsePortPwrAllocated, we have the complete array so we can populate the RRD
         $upd = "$polled:".$port['cpeExtPsePortPwrAllocated'].':'.$port['cpeExtPsePortPwrAvailable'].':'.


### PR DESCRIPTION
We match "iosxe" OS as well for POE polling on cisco devices, as they are using the same MIBs.
This will add support for Catalyst 3850, as well as probably Cat4500 family as well.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
