### PR TITLE
Add sysDescr and hardware for oxidized overrides

### DIFF
--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -84,7 +84,14 @@ $config['oxidized']['reload_nodes'] = true;
 
 To return an override to Oxidized you can do this by providing the override key, followed by matching a lookup for a host (or hosts), and finally by defining the overriding value itself. LibreNMS does not check for the validity of these attributes but will deliver them to Oxidized as defined.
 
-Matching of hosts can be done using `hostname`, `sysname`, `os` or `location` and including either a 'match' key and value, or a 'regex' key and value. The order is `hostname` is matched first, if nothing is found then `sysname` is tried, then `os`, and finally `location` is attempted.
+Matching of hosts can be done using `hostname`, `sysname`, `os`, `location`, `sysDescr` or `hardware` and including either a 'match' key and value, or a 'regex' key and value. The order of matching is:
+* `hostname` 
+* `sysname`
+* `sysDescr`
+* `hardware`
+* `os`
+* `location`
+* `ip`
 
 To match on the device hostnames or sysnames that contain 'lon-sw' or if the location contains 'London' then you would place the following within config.php:
 

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -1237,7 +1237,7 @@ function list_oxidized()
         $params = array($hostname);
     }
 
-    foreach (dbFetchRows("SELECT hostname,sysname,os,location,ip AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
+    foreach (dbFetchRows("SELECT hostname,sysname,sysDescr,hardware,os,location,ip AS ip FROM `devices` LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
         // Convert from packed value to human value
         $device['ip'] = inet6_ntop($device['ip']);
 
@@ -1274,6 +1274,8 @@ function list_oxidized()
 
         unset($device['location']);
         unset($device['sysname']);
+        unset($device['sysDescr']);
+        unset($device['hardware']);
         $devices[] = $device;
     }
 


### PR DESCRIPTION
This adds support for deciding oxidized group based on hardware and sysDescr fields in analogy to https://github.com/librenms/librenms/pull/7485. This feature is necessary to decide between HP Comware A switches with _cmdline-mode enable and without.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`