### PR TITLE
discovery.php: don't exit(5) without new devices discovered

### DIFF
--- a/discovery.php
+++ b/discovery.php
@@ -152,3 +152,8 @@ if (!isset($options['q'])) {
 }
 
 logfile($string);
+
+if ($doing !== 'new' && $discovered_devices == 0) {
+    # No discoverable devices, either down or disabled
+    exit(5);
+}

--- a/discovery.php
+++ b/discovery.php
@@ -152,8 +152,3 @@ if (!isset($options['q'])) {
 }
 
 logfile($string);
-
-if ($discovered_devices == 0) {
-    # No discoverable devices, either down or disabled
-    exit(5);
-}


### PR DESCRIPTION
Don't exit with a non-zero value in case no new devices were discovered, as non-zero codes are considered failed jobs for most cron implementations and produce logs like the following (in Debian):

```
cron.info CRON[963890]: (CRON) error (grandchild #963892 failed with exit status 5)
``` 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
