### PR TITLE
Fixed device dependancy webui issues

### DIFF
--- a/html/includes/forms/delete-host-dependency.inc.php
+++ b/html/includes/forms/delete-host-dependency.inc.php
@@ -15,35 +15,38 @@
 use LibreNMS\Authentication\Auth;
 
 if (!Auth::user()->hasGlobalAdmin()) {
-    $status = array('status' => 1, 'message' => 'You need to be admin');
+    $status = ['status' => 1, 'message' => 'You need to be admin'];
 } else {
-    if ($_POST['device_id']) {
-        if (!is_numeric($_POST['device_id'])) {
-            $status = array('status' => 1, 'message' => 'Wrong device id!');
+    if ($vars['device_id']) {
+        if (!is_numeric($vars['device_id'])) {
+            $status = ['status' => 1, 'message' => 'Wrong device id!'];
         } else {
-            if (dbDelete('device_relationships', '`child_device_id` = ?', array($_POST['device_id']))) {
-                $status = array('status' => 0, 'message' => 'Device dependency has been deleted.');
+            if (dbDelete('device_relationships', '`child_device_id` = ?', [$vars['device_id']])) {
+                $status = ['status' => 0, 'message' => 'Device dependency has been deleted.'];
             } else {
-                $status = array('status' => 1, 'message' => 'Device dependency cannot be deleted.');
+                $status = ['status' => 1, 'message' => 'Device dependency cannot be deleted.'];
             }
         }
-    } elseif ($_POST['parent_ids']) {
+    } elseif ($vars['parent_ids']) {
         $error = false;
-        foreach ($_POST['parent_ids'] as $parent) {
+        foreach ($vars['parent_ids'] as $parent) {
+            if (!is_numeric($parent)) {
+                $parent = getidbyname($parent);
+            }
             if (is_numeric($parent) && $parent != 0) {
-                if (!dbDelete('device_relationships', ' `parent_device_id` = ?', array($parent))) {
+                if (!dbDelete('device_relationships', ' `parent_device_id` = ?', [$parent])) {
                     $error = true;
-                    $status = array('status' => 1, 'message' => 'Device dependency cannot be deleted.');
+                    $status = ['status' => 1, 'message' => 'Device dependency cannot be deleted.'];
                 }
             } elseif ($parent == 0) {
-                $status = array('status' => 1, 'message' => 'No dependency to delete.');
+                $status = ['status' => 1, 'message' => 'No dependency to delete.'];
                 $error = true;
                 break;
             }
         }
 
         if (!$error) {
-            $status = array('status' => 0, 'message' => 'Device dependencies has been deleted');
+            $status = ['status' => 0, 'message' => 'Device dependencies has been deleted'];
         } else {
         }
     }

--- a/html/includes/modal/edit_host_dependency.inc.php
+++ b/html/includes/modal/edit_host_dependency.inc.php
@@ -89,12 +89,10 @@ $('#hostdep-save').click('', function(event) {
     var device_id = $("#edit-device_id").val();
     var device_ids = [];
     var parent_ids = [];
-    var parent_hosts = [];
     device_ids.push(device_id);
     $("#availableparents option:selected").each( function() {
         if ($(this).length) {
             parent_ids.push($(this).val());
-            parent_hosts.push($(this).text());
         }
     });
 

--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -852,7 +852,6 @@ function IsParentDown($device)
         return false;
     }
 
-
     $down_parent_count = dbFetchCell("SELECT count(*) from devices as d LEFT JOIN devices_attribs as a ON d.device_id=a.device_id LEFT JOIN device_relationships as r ON d.device_id=r.parent_device_id WHERE d.status=0 AND d.ignore=0 AND d.disabled=0 AND r.child_device_id=? AND (d.status_reason='icmp' OR (a.attrib_type='override_icmp_disable' AND a.attrib_value=true))", array($device));
     if ($down_parent_count == $parent_count) {
         return true;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

When debugging the dependancy issue someone raised I found I couldn't actually manage them via the webui. This is because rather than the expected ID, a name is sent. Instead of trying to find the break I decided that it would make more sense to support both numerical IDs and hostnames.