### PR TITLE
Don't depend on String_Blade_Compiler so hard

### DIFF
--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * ViewServiceProvider.php
+ *
+ * Safely fall back to Laravel view service provider if String Blade Compiler is missing
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace App\Providers;
+
+
+class ViewServiceProvider extends \Illuminate\View\ViewServiceProvider
+{
+    public function register()
+    {
+        if (class_exists('Wpb\String_Blade_Compiler\ViewServiceProvider')) {
+            $this->app->register('Wpb\String_Blade_Compiler\ViewServiceProvider');
+        } else {
+            $this->app->register('Illuminate\View\ViewServiceProvider');
+        }
+    }
+
+    public function boot()
+    {
+        if (!class_exists('Wpb\String_Blade_Compiler\ViewServiceProvider')) {
+            \Toastr::error('Dependencies missing, check <a href="validate">validate</a>');
+        }
+    }
+}

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -25,7 +25,6 @@
 
 namespace App\Providers;
 
-
 class ViewServiceProvider extends \Illuminate\View\ViewServiceProvider
 {
     public function register()

--- a/config/app.php
+++ b/config/app.php
@@ -161,7 +161,6 @@ return [
         Illuminate\Session\SessionServiceProvider::class,
         Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
-        Wpb\String_Blade_Compiler\ViewServiceProvider::class,
 
         /*
          * Package Service Providers...
@@ -177,6 +176,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         App\Providers\ComposerServiceProvider::class,
+        App\Providers\ViewServiceProvider::class,
 
         /*
          * Vendor Service Providers...

--- a/html/legacy_index.php
+++ b/html/legacy_index.php
@@ -303,17 +303,17 @@ foreach (dbFetchRows('SELECT `notifications`.* FROM `notifications` WHERE NOT ex
 }
 
 if (is_array($msg_box)) {
-    echo("<script>
+    echo "<script>
         toastr.options.timeout = 10;
         toastr.options.extendedTimeOut = 20;
-    ");
+        </script>
+    ";
+
     foreach ($msg_box as $message) {
-        $message['type'] = mres($message['type']);
-        $message['message'] = mres($message['message']);
-        $message['title'] = mres($message['title']);
-        echo "toastr.".$message['type']."('".$message['message']."','".$message['title']."');\n";
+        Toastr::add($message['type'], $message['message'], $message['title']);
     }
-    echo("</script>");
+
+    echo Toastr::render();
 }
 
 if ($no_refresh !== true && $config['page_refresh'] != 0) {


### PR DESCRIPTION
Allows things to boot if it is missing but displays a toast.
Allows Toastr facade to work on legacy pages too.

Not 100% sure if we want this.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
