### PR TITLE
Revert "fix stupid error in vars.inc.php"

### DIFF
--- a/html/includes/vars.inc.php
+++ b/html/includes/vars.inc.php
@@ -13,7 +13,7 @@ foreach ($_GET as $key => $get_var) {
 
 $base_url = parse_url($config["base_url"]);
 // don't parse the subdirectory, if there is one in the path
-if (!empty($base_url["path"])) {
+if (strlen($base_url["path"]) > 1) {
     $segments = explode('/', trim(str_replace($base_url["path"], "", $_SERVER['REQUEST_URI']), '/'));
 } else {
     $segments = explode('/', trim($_SERVER['REQUEST_URI'], '/'));


### PR DESCRIPTION
Breaks links to `/device/device=xx`