### PR TITLE
Added missing Config dependency

### DIFF
--- a/html/includes/table/poll-log.inc.php
+++ b/html/includes/table/poll-log.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Config;
 use LibreNMS\Authentication\Auth;
 
 $sql = ' FROM `devices` AS D ';


### PR DESCRIPTION
Without this small fix, poll log does not display anything. The error log will contain: 
`2018/07/18 07:32:58 [error] 12726#0: *3775216 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Class 'Config' not found in /opt/librenms/html/includes/table/poll-log.inc.php on line 24" while reading response header from upstream, client: 10.10.10.10, server: 10.10.10.2, request: "POST /ajax_table.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "10.10.10.2", referrer: "https://10.10.10.2/poll-log/filter=unpolled/"`

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
