### PR TITLE
Support for HTML tags in TELEGRAM transport

### DIFF
--- a/LibreNMS/Alert/Transport/Telegram.php
+++ b/LibreNMS/Alert/Transport/Telegram.php
@@ -51,7 +51,7 @@ class Telegram extends Transport
         $curl = curl_init();
         set_curl_proxy($curl);
         $text = urlencode($obj['msg']);
-        curl_setopt($curl, CURLOPT_URL, ("https://api.telegram.org/bot{$data['token']}/sendMessage?chat_id={$data['chat_id']}&text=$text"));
+        curl_setopt($curl, CURLOPT_URL, ("https://api.telegram.org/bot{$data['token']}/sendMessage?chat_id={$data['chat_id']}&parse_mode=html&text=$text"));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         $ret  = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
This update will add support for HTML tags in TELEGRAM Transport

Here is the list of all tags that you can use in alert template for telegram transport.

```
<b>bold</b>, <strong>bold</strong>
<i>italic</i>, <em>italic</em>
<a href="http://www.example.com/">inline URL</a>
<code>inline fixed-width code</code>
<pre>pre-formatted fixed-width code block</pre>
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
