### PR TITLE
Make alert transport form compatible with sql strict mode

### DIFF
--- a/html/includes/forms/alert-transports.inc.php
+++ b/html/includes/forms/alert-transports.inc.php
@@ -62,6 +62,8 @@ if (empty($name)) {
     $status = 'error';
     $message = 'Missing transport information';
 } else {
+    
+    $is_default = $is_default ? 1 : 0;
     $details = array(
         'transport_name' => $name,
         'is_default' => $is_default

--- a/html/includes/forms/alert-transports.inc.php
+++ b/html/includes/forms/alert-transports.inc.php
@@ -46,14 +46,8 @@ $message = '';
 
 $transport_id        = $vars['transport_id'];
 $name                = $vars['name'];
-$is_default          = isset($vars['is_default']) ? $vars['is_default'] : null;
+$is_default          = isset($vars['is_default']) ? 1 : 0;
 $transport_type      = $vars['transport-type'];
-
-if ($is_default == 'on') {
-    $is_default = true;
-} else {
-    $is_default = false;
-}
 
 if (empty($name)) {
     $status = 'error';
@@ -62,7 +56,6 @@ if (empty($name)) {
     $status = 'error';
     $message = 'Missing transport information';
 } else {
-    $is_default = $is_default ? 1 : 0;
     $details = array(
         'transport_name' => $name,
         'is_default' => $is_default

--- a/html/includes/forms/alert-transports.inc.php
+++ b/html/includes/forms/alert-transports.inc.php
@@ -46,7 +46,7 @@ $message = '';
 
 $transport_id        = $vars['transport_id'];
 $name                = $vars['name'];
-$is_default          = isset($vars['is_default']) ? 1 : 0;
+$is_default          = (int)(isset($vars['is_default']) && $vars['is_default'] == 'on');
 $transport_type      = $vars['transport-type'];
 
 if (empty($name)) {

--- a/html/includes/forms/alert-transports.inc.php
+++ b/html/includes/forms/alert-transports.inc.php
@@ -62,7 +62,6 @@ if (empty($name)) {
     $status = 'error';
     $message = 'Missing transport information';
 } else {
-    
     $is_default = $is_default ? 1 : 0;
     $details = array(
         'transport_name' => $name,


### PR DESCRIPTION
A quick fix to have the form compatible with users running sql strict mode (like my own team).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
