### PR TITLE
Changed jnxProductQFX511048S4Q to jnxProductQFX511048S4C in rewrites.php

### DIFF
--- a/includes/rewrites.php
+++ b/includes/rewrites.php
@@ -979,7 +979,7 @@ function rewrite_junos_hardware($hardware)
         'jnxProductNameMX80'           => 'MX80',
         'jnxProductName'               => '',
         'jnxProductQFX510048S6Q'       => 'QFX5100-48S6Q',
-        'jnxProductQFX511048S4Q'       => 'QFX5110-48S4Q',
+        'jnxProductQFX511048S4C'       => 'QFX5110-48S4C',
         'jnxProductQFX510096S8Q'       => 'QFX5100-96S8Q',
     );
 


### PR DESCRIPTION
Originally had this pull request earlier this year to add support for this: #8466 but looks like Juniper changed this at some point when the Juniper chassis mibs were updated here: #8678

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
