### PR TITLE
Removed the static Slack Priority field

### DIFF
--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -63,8 +63,8 @@ class Slack extends Transport
                     'text' => $slack_msg,
                     'mrkdwn_in' => ['text', 'fallback'],
                     'author_name' => $api['author_name'],
-                    ],
                 ],
+            ],
             'channel' => $api['channel'],
         ];
         $alert_message = json_encode($data);

--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -63,15 +63,8 @@ class Slack extends Transport
                     'text' => $slack_msg,
                     'mrkdwn_in' => ['text', 'fallback'],
                     'author_name' => $api['author_name'],
-                    'fields' => [
-                        [
-                            'title' => 'Priority',
-                            'value' => ucfirst($obj['severity']),
-                            'short' => false,
-                        ]
                     ],
                 ],
-            ],
             'channel' => $api['channel'],
         ];
         $alert_message = json_encode($data);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Remove the static priority included in every Slack notification.