### PR TITLE
Log an event for each Service Status change

### DIFF
--- a/check-services.php
+++ b/check-services.php
@@ -55,9 +55,7 @@ if ($options['h']) {
     }
 }
 
-// need to specify D.device_id as D_device_id because device_id gets overriden in the resulting raw by A.device_id if no attribs are defined for this device
-// TODO: a cleaner way
-$sql = 'SELECT D.device_id as D_device_id,D.*,S.*,A.* FROM `devices` AS D'
+$sql = 'SELECT D.*,S.*,attrib_value  FROM `devices` AS D'
        .' INNER JOIN `services` AS S ON S.device_id = D.device_id AND D.disabled = 0 '.$where
        .' LEFT JOIN `devices_attribs` as A ON D.device_id = A.device_id AND A.attrib_type = "override_icmp_disable"'
        .' ORDER by D.device_id DESC;';
@@ -77,7 +75,7 @@ foreach (dbFetchRows($sql) as $service) {
                 array($service['service_id'])
             );
         }
-        poll_service($service, $service['D_device_id']);
+        poll_service($service);
         $polled_services++;
     } else {
         d_echo("\nService check - ".$service['service_id']."\nSkipping service check because device "
@@ -94,7 +92,7 @@ foreach (dbFetchRows($sql) as $service) {
             log_event(
                 "Service check - {$service['service_desc']} ({$service['service_id']}) - 
                 Skipping service check because device {$service['hostname']} is down due to icmp",
-                $service['D_device_id'],
+                $service['device_id'],
                 'service',
                 4,
                 $service['service_id']

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -193,7 +193,7 @@ function poll_service($service)
         $new_status_text = isset($status_text[$new_status]) ? $status_text[$new_status] : 'Critical';
 
         log_event(
-            "Service changed status from $old_status_text to $new_status_text - {$service['service_desc']} ({$service['service_id']}) - 
+            "Service '{$service['service_type']}' changed status from $old_status_text to $new_status_text - {$service['service_desc']} - 
             $msg",
             $service['device_id'],
             'service',

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -113,7 +113,7 @@ function discover_service($device, $service)
     echo "$service ";
 }
 
-function poll_service($service, $device)
+function poll_service($service)
 {
     global $config;
 
@@ -195,7 +195,7 @@ function poll_service($service, $device)
         log_event(
             "Service changed status from $old_status_text to $new_status_text - {$service['service_desc']} ({$service['service_id']}) - 
             $msg",
-            $device,
+            $service['device_id'],
             'service',
             4,
             $service['service_id']

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -113,7 +113,7 @@ function discover_service($device, $service)
     echo "$service ";
 }
 
-function poll_service($service)
+function poll_service($service, $device)
 {
     global $config;
 
@@ -186,6 +186,20 @@ function poll_service($service)
         $update['service_changed'] = time();
         $update['service_status'] = $new_status;
         $update['service_message'] = $msg;
+
+        // TODO: Put the 3 lines below in a function getStatus(int) ?
+        $status_text = array(0 => 'OK', 1 => 'Warning', 3 => 'Unknown');
+        $old_status_text = isset($status_text[$old_status]) ? $status_text[$old_status] : 'Critical';
+        $new_status_text = isset($status_text[$new_status]) ? $status_text[$new_status] : 'Critical';
+
+        log_event(
+            "Service changed status from $old_status_text to $new_status_text - {$service['service_desc']} ({$service['service_id']}) - 
+            $msg",
+            $device,
+            'service',
+            4,
+            $service['service_id']
+        );
     }
 
     if ($service['service_message'] != $msg) {

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -193,12 +193,11 @@ function poll_service($service)
         $new_status_text = isset($status_text[$new_status]) ? $status_text[$new_status] : 'Critical';
 
         log_event(
-            "Service '{$service['service_type']}' changed status from $old_status_text to $new_status_text - {$service['service_desc']} - 
-            $msg",
+            "Service '{$service['service_type']}' changed status from $old_status_text to $new_status_text - {$service['service_desc']} - $msg",
             $service['device_id'],
             'service',
             4,
-            $service['service_id']
+            $service['service_id'],
         );
     }
 

--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -197,7 +197,7 @@ function poll_service($service)
             $service['device_id'],
             'service',
             4,
-            $service['service_id'],
+            $service['service_id']
         );
     }
 


### PR DESCRIPTION
Hello

Here is a proposal for a pièce of code to log (using log_events) each service status change onto the device itself. 

Let me know if we should create the "getStatusText()" function to convert the int to "OK", "Critical" etc etc . I searched for such a function but did not find it. 

I also add to use a hack for the SQL cause it would prevent the device_id valueto be available in the resulting $service when device_attribs is empty for the device. If you have a better way to suggest, I'll be happy to use it. 

PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
