### PR TITLE
Allow to use full DN as value for member attribute instead of member: username

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -35,7 +35,7 @@ class LdapAuthorizer extends AuthorizerBase
                                 Config::get('auth_ldap_groupmemberattr', 'memberUid'),
                                 $this->getMembername($username)
                             );
-                          }
+                        }
                         if ($ldap_comparison === true) {
                             return true;
                         }

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -21,16 +21,21 @@ class LdapAuthorizer extends AuthorizerBase
                     return true;
                 } else {
                     foreach ($ldap_groups as $ldap_group) {
-                        $ldap_comparison = ldap_compare(
-                            $connection,
-                            $ldap_group,
-                            Config::get('auth_ldap_groupmemberattr', 'memberUid'),
-                            if (Config::get('auth_ldap_userdn') === true) { 
+                        if (Config::get('auth_ldap_userdn') === true) {
+                            $ldap_comparison = ldap_compare(
+                                $connection,
+                                $ldap_group,
+                                Config::get('auth_ldap_groupmemberattr', 'memberUid'),
                                 $this->getFullDn($username)
-                            } else {
+                            );
+                        } else {
+                            $ldap_comparison = ldap_compare(
+                                $connection,
+                                $ldap_group,
+                                Config::get('auth_ldap_groupmemberattr', 'memberUid'),
                                 $this->getMembername($username)
-                            }
-                        );
+                            );
+                          }
                         if ($ldap_comparison === true) {
                             return true;
                         }

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -25,7 +25,11 @@ class LdapAuthorizer extends AuthorizerBase
                             $connection,
                             $ldap_group,
                             Config::get('auth_ldap_groupmemberattr', 'memberUid'),
-                            $this->getMembername($username)
+                            if (Config::get('auth_ldap_userdn') === true) { 
+                                $this->getFullDn($username)
+                            } else {
+                                $this->getMembername($username)
+                            }
                         );
                         if ($ldap_comparison === true) {
                             return true;
@@ -99,7 +103,11 @@ class LdapAuthorizer extends AuthorizerBase
             if (count($group_names) > 1) {
                 $ldap_group_filter = "(|{$ldap_group_filter})";
             }
-            $filter = "(&{$ldap_group_filter}(" . trim(Config::get('auth_ldap_groupmemberattr', 'memberUid')) . "=" . $this->getMembername($username) . "))";
+            if (Config::get('auth_ldap_userdn') === true) {
+                $filter = "(&{$ldap_group_filter}(" . trim(Config::get('auth_ldap_groupmemberattr', 'memberUid')) . "=" . $this->getFullDn($username) . "))";
+            } else {
+                $filter = "(&{$ldap_group_filter}(" . trim(Config::get('auth_ldap_groupmemberattr', 'memberUid')) . "=" . $this->getMembername($username) . "))";
+            }
             $search = ldap_search($connection, Config::get('auth_ldap_groupbase'), $filter);
             $entries = ldap_get_entries($connection, $search);
 

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -158,6 +158,7 @@ $config['auth_ldap_group']  = 'cn=groupname,ou=groups,dc=example,dc=com'; // gen
 $config['auth_ldap_groupmemberattr'] = 'memberUid'; // attribute to use to see if a user is a member of a group
 $config['auth_ldap_uid_attribute'] = 'uidnumber';   // attribute for unique id
 $config['auth_ldap_debug'] = false;                 // enable for verbose debug messages
+$config['auth_ldap_userdn'] = true;                 // Uses a users full DN as the value of the member attribute in a group instead of member: username. (it’s member: uid=username,ou=groups,dc=domain,dc=com)
 ```
 
 ### LDAP bind user (optional)

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -631,7 +631,7 @@ $config['auth_ldap_groupmemberattr']            = 'memberUid';
 $config['auth_ldap_emailattr']                  = 'mail';
 $config['auth_ldap_cache_ttl'] = 300;
 // How long in seconds should ldap* module cache user information in $_SESSION
-$config['auth_ldap_userdn']                     = true;
+$config['auth_ldap_userdn']                     = false;
 // Uses a users full DN as the value of the member attribute in a group (instead of member: username, it’s member: uid=username,ou=groups,dc=domain,dc=com).
 
 // Active Directory Authentication

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -631,6 +631,8 @@ $config['auth_ldap_groupmemberattr']            = 'memberUid';
 $config['auth_ldap_emailattr']                  = 'mail';
 $config['auth_ldap_cache_ttl'] = 300;
 // How long in seconds should ldap* module cache user information in $_SESSION
+$config['auth_ldap_userdn']                     = true;
+// Uses a users full DN as the value of the member attribute in a group (instead of member: username, it’s member: uid=username,ou=groups,dc=domain,dc=com).
 
 // Active Directory Authentication
 $config['auth_ad_user_filter'] = "(objectclass=user)";


### PR DESCRIPTION
Allow to use full DN as value for member attribute instead of member: username

I dont use LDAP so this should be tested with both methods.

For using fulldn as user `$config['ldap_auth_userdn'] = true;` must be set in config.php

This comes from https://community.librenms.org/t/feature-request-full-dn-as-group-member-attibute-in-ldap-auth/4805

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
