### PR TITLE
Bugfix: Correct config template for API transport

### DIFF
--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -87,8 +87,8 @@ class Api extends Transport
                     'descr' => 'API Method: GET or POST',
                     'type' => 'select',
                     'options' => [
-                        'get' => 'get',
-                        'get' => 'get'
+                        'GET' => 'GET',
+                        'POST' => 'POST'
                     ]
                 ],
                 [


### PR DESCRIPTION
Due to bug in the implementation of the alert transport mapping introduced in #8660  , the API transport is unable to be configured via the new interface. Only the 'get' method is displayed in the UI and the defined validation is expecting uppercase "GET" or "POST" as the method, making it impossible to configure the API transport.

This change corrects the name to option value mapping to uppercase GET and adds back the POST method option. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
