### PR TITLE
remove strict comparisons for check-services.php

### DIFF
--- a/check-services.php
+++ b/check-services.php
@@ -63,13 +63,13 @@ $sql = 'SELECT * FROM `devices` AS D'
 foreach (dbFetchRows($sql) as $service) {
     // Run the polling function if the associated device is up, "Disable ICMP Test" option is not enabled,
     // or service hostname/ip is different from associated device
-    if ($service['status'] === "1" || ($service['status'] === '0' && $service['status_reason'] === 'snmp') ||
+    if ($service['status'] == 1 || ($service['status'] == 0 && $service['status_reason'] === 'snmp') ||
         $service['attrib_value'] === 'true' || ($service['service_ip'] !== $service['hostname'] &&
         $service['service_ip'] !== inet6_ntop($service['ip']) )) {
         // Mark service check as enabled if it was disabled previously because device was down
-        if ($service['service_disabled'] === "1") {
+        if ($service['service_disabled']) {
             dbUpdate(
-                array('service_disabled' => '0'),
+                array('service_disabled' => 0),
                 'services',
                 '`service_id` = ?',
                 array($service['service_id'])
@@ -82,9 +82,9 @@ foreach (dbFetchRows($sql) as $service) {
                .$service['hostname']." is down due to icmp.\n");
         // Mark service check as disabled while device is down and log to eventlog that service check is skipped,
         // but only if it's not already marked as disabled
-        if ($service['service_disabled'] === "0") {
+        if (!$service['service_disabled']) {
             dbUpdate(
-                array('service_disabled' => '1'),
+                array('service_disabled' => 1),
                 'services',
                 '`service_id` = ?',
                 array($service['service_id'])


### PR DESCRIPTION
Required by #8935

That PR returns ints if appropriate
"0" => 0

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
