### PR TITLE
Correct smokeping integration example

### DIFF
--- a/doc/Extensions/Smokeping.md
+++ b/doc/Extensions/Smokeping.md
@@ -198,7 +198,7 @@ In terms of configuration, simply add the location of where smokeping data such 
 $config['smokeping']['dir'] = '/var/lib/smokeping'; // Ubuntu 16.04 Location
 #$config['smokeping']['dir'] = '/opt/smokeping/data';
 $config['smokeping']['pings'] = 20;		// should be equal to "pings" in your smokeping config
-$config['smokeping_server_hostname'].
+$config['smokeping']['integration'] = true;
 ```
 
 You should now see a new tab in your device page called ping.


### PR DESCRIPTION
The only mention in the sourcecode I can find to 'smokeping_server_hostname' is in this doc, and such an option doesn't really make sense. Integrating to an existing install will still require the $config['smokeping']['integration'] = true option though.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
