### PR TITLE
WebUI: Display MAX rrd value in Service Graphs

### DIFF
--- a/html/includes/graphs/device/service.inc.php
+++ b/html/includes/graphs/device/service.inc.php
@@ -47,7 +47,7 @@ if (is_file($check_script)) {
 
 include "includes/graphs/common.inc.php";
 $rrd_options .= " -l 0 -E ";
-$rrd_options .= " COMMENT:'                       Now      Avg      Max\\n'";
+$rrd_options .= " COMMENT:'                      Now     Avg      Max\\n'";
 $rrd_additions = "";
 
 // Remove encoded characters
@@ -74,13 +74,21 @@ if ($services[$vars['service']]['service_ds'] != "") {
             $rrd_additions .= $check_graph[$ds];
         } else {
             // Build the graph ourselves
-            $color = $config['graph_colours']['mixed'][2];
+            if (preg_match('/loss/i', $ds)) {
+                $tint = "pinks";
+            } else {
+                $tint = "blues";
+            }
+            $color_avg = $config['graph_colours'][$tint][2];
+            $color_max = $config['graph_colours'][$tint][0];
 
             $rrd_additions .= " DEF:DS=" . $rrd_filename . ":".$ds.":AVERAGE ";
-            $rrd_additions .= " AREA:DS#" . $color . ":'" . str_pad(substr(ucfirst($ds)." (".$label.")", 0, 15), 15) . "' ";
+            $rrd_additions .= " DEF:DS_MAX=" . $rrd_filename . ":".$ds.":MAX ";
+            $rrd_additions .= " AREA:DS_MAX#" . $color_max . ":";
+            $rrd_additions .= " AREA:DS#" . $color_avg . ":'" . str_pad(substr(ucfirst($ds)." (".$label.")", 0, 15), 15) . "' ";
             $rrd_additions .= " GPRINT:DS:LAST:%5.2lf%s ";
             $rrd_additions .= " GPRINT:DS:AVERAGE:%5.2lf%s ";
-            $rrd_additions .= " GPRINT:DS:MAX:%5.2lf%s\\l ";
+            $rrd_additions .= " GPRINT:DS_MAX:MAX:%5.2lf%s\\l ";
         }
     }
 }


### PR DESCRIPTION
Hi

This patch does add the MAX graph (AREA) for the Service graphs. And the Max numerical value is as well taken from the MAX RRD value instead of AVERAGE. 

When scaling to larger amount of time, displaying like today the average only makes all spikes disappear, and the Max value does not make much sense.

I also added a color choice to *pinkify* the "Loss" graphs. 

Exemple with HTTP graphs polling google: 

![http-exemple](https://user-images.githubusercontent.com/38363551/43886912-7760b28c-9bbd-11e8-875b-b2afe140bdf9.png)

PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
