### PR TITLE
device: "NEWSEED" Support

### DIFF
--- a/includes/definitions/netagent2.yaml
+++ b/includes/definitions/netagent2.yaml
@@ -7,3 +7,5 @@ over:
 discovery:
     - sysDescr_regex:
         - '/^NET Agent II/'
+    - sysObjectID:
+        - .1.3.6.1.4.1.935.1.1.1


### PR DESCRIPTION
NEWSEED UPS support.
(plugin megatec netagent2 snmp ext. device.)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

---

./scripts/collect-snmp-data.php -h 136 -m os

> OS: netagent2
> Module(s): os
> 
> Capturing Data:  sysDescr.0 sysObjectID.0 sysName.0 SNMPv2-MIB::sysDescr.0 SNMPv2-MIB::sysObjectID.0 .1.3.6.1.4.1.12148.10.2.6.0 sysUpTime.0 sysLocation.0 sysContact.0 snmpEngineTime.0 hrSystemUptime.0 .1.3.6.1.2.1.33.1.1.4.0
> 
> Updated snmprec data /opt/librenms/tests/snmpsim/netagent2.snmprec
> 
> Verify this file does not contain any private data before submitting!

---

cat /opt/librenms/tests/snmpsim/netagent2.snmprec

> 1.3.6.1.2.1.1.1.0|4|NET Agent II
> 1.3.6.1.2.1.1.2.0|6|.1.3.6.1.4.1.935
> 1.3.6.1.2.1.1.3.0|67|10010682
> 1.3.6.1.2.1.1.4.0|4|<private>
> 1.3.6.1.2.1.1.5.0|4|<private>
> 1.3.6.1.2.1.1.6.0|4|<private>
> 1.3.6.1.2.1.33.1.1.4.0|4|3.6.DY520
> 1.3.6.1.4.1.935.1.1.1.2.2.1.0|2|100
> 1.3.6.1.4.1.935.1.1.1.2.2.3.0|2|250
> 1.3.6.1.4.1.935.1.1.1.2.2.7.0|2|0
> 1.3.6.1.4.1.935.1.1.1.3.2.1.0|2|2545
> 1.3.6.1.4.1.935.1.1.1.3.2.4.0|2|500
> 1.3.6.1.4.1.935.1.1.1.4.1.1.0|2|9
> 1.3.6.1.4.1.935.1.1.1.4.2.1.0|2|2285
> 1.3.6.1.4.1.935.1.1.1.4.2.2.0|2|500
> 1.3.6.1.4.1.935.1.1.1.4.2.3.0|2|44
> 1.3.6.1.6.3.10.2.1.3.0|2|93094

