### PR TITLE
Added hiding of disabled/ignored ports in graph and device ports view.

### DIFF
--- a/html/includes/graphs/device/bits.inc.php
+++ b/html/includes/graphs/device/bits.inc.php
@@ -4,7 +4,7 @@
 $ds_in  = 'INOCTETS';
 $ds_out = 'OUTOCTETS';
 
-foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled` = 0', array($device['device_id'])) as $port) {
+foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled` = \'0\' AND `ignore` = \'0\'', array($device['device_id'])) as $port) {
     $ignore = 0;
     if (is_array($config['device_traffic_iftype'])) {
         foreach ($config['device_traffic_iftype'] as $iftype) {

--- a/html/includes/graphs/location/bits.inc.php
+++ b/html/includes/graphs/location/bits.inc.php
@@ -6,7 +6,7 @@ $ds_out = 'OUTOCTETS';
 
 $i = 1;
 foreach ($devices as $device) {
-    foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ?', array($device['device_id'])) as $int) {
+    foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled` = \'0\' AND `ignore` = \'0\'', array($device['device_id'])) as $int) {
         $ignore = 0;
         if (is_array($config['device_traffic_iftype'])) {
             foreach ($config['device_traffic_iftype'] as $iftype) {


### PR DESCRIPTION
When disabling or ignoring ports in the "Ports Settings" (http://<nms_host>/device/device=<device_id>/tab=edit/section=ports/) then the ports are still shown under the Port tab for a specific device (http://<nms_host>/device/device=<device_id>/section=ports/) and in the Overall Traffic Graph.
To keep the view and graph more clear, this change only shows the ports which are not disabled or ignored.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [y] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
