### PR TITLE
Add support for older Airmux-400

### DIFF
--- a/includes/definitions/radwin.yaml
+++ b/includes/definitions/radwin.yaml
@@ -6,6 +6,6 @@ over:
     - { graph: device_bits, text: 'Device Traffic' }
 discovery:
     - sysObjectID:
-        - .1.3.6.1.4.1.4458.20.3.1.2
+        - .1.3.6.1.4.1.4458.20.3.
         - .1.3.6.1.4.1.4458.20.5.
         - .1.3.6.1.4.1.4458.20.6.


### PR DESCRIPTION
Removed sysObjectID extension to allow discovery of older RAD Airmux 400 devices

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
