### PR TITLE
Add support for Rancid GIT

### DIFF
--- a/doc/Extensions/Rancid.md
+++ b/doc/Extensions/Rancid.md
@@ -36,7 +36,7 @@ The options shown below also contains the default values.
 
 `sudo apt-get install rancid subversion`
 
-Edit Rancid config file to use subversion instead of default cvs, and adds a group:
+Edit Rancid config file to use subversion or git instead of default cvs, and adds a group:
 `sudo vi /etc/rancid/rancid.conf`
 
 `LIST_OF_GROUPS="librenms"`
@@ -130,6 +130,7 @@ Add Rancid into LibreNMS config.php:
 ```php
 ### Rancid
 $config['rancid_configs'][]             = '/var/lib/rancid/librenms/configs/';
+$config['rancid_repo_type']             = 'svn';
 $config['rancid_ignorecomments']        = 0;
 ```
 

--- a/doc/Extensions/Rancid.md
+++ b/doc/Extensions/Rancid.md
@@ -130,7 +130,7 @@ Add Rancid into LibreNMS config.php:
 ```php
 ### Rancid
 $config['rancid_configs'][]             = '/var/lib/rancid/librenms/configs/';
-$config['rancid_repo_type']             = 'svn';
+$config['rancid_repo_type']             = 'svn';  //'svn' or 'git'
 $config['rancid_ignorecomments']        = 0;
 ```
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -435,6 +435,7 @@ Enable / disable additional port statistics.
 
 ```php
 $config['rancid_configs'][]             = '/var/lib/rancid/network/configs/';
+$config['rancid_repo_type']             = 'svn';
 $config['rancid_ignorecomments']        = 0;
 ```
 Rancid configuration, `rancid_configs` is an array containing all of the locations of your rancid files.

--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -2,14 +2,15 @@
 
 // FIXME svn stuff still using optc etc, won't work, needs updating!
 use LibreNMS\Authentication\Auth;
+use LibreNMS\Config;
 
 if (Auth::user()->hasGlobalAdmin()) {
-    if (!is_array($config['rancid_configs'])) {
-        $config['rancid_configs'] = array($config['rancid_configs']);
+    if (!is_array(Config::get('rancid_configs'))) {
+        Config::set('rancid_configs', array(Config::get('rancid_configs')));
     }
 
-    if (isset($config['rancid_configs'][0])) {
-        foreach ($config['rancid_configs'] as $configs) {
+    if (isset(Config::get('rancid_configs')[0])) {
+        foreach (Config::get('rancid_configs') as $configs) {
             if ($configs[(strlen($configs) - 1)] != '/') {
                 $configs .= '/';
             }
@@ -19,9 +20,9 @@ if (Auth::user()->hasGlobalAdmin()) {
             } elseif (is_file($configs.strtok($device['hostname'], '.'))) { // Strip domain
                 $file = $configs.strtok($device['hostname'], '.');
             } else {
-                if (!empty($config['mydomain'])) { // Try with domain name if set
-                    if (is_file($configs.$device['hostname'].'.'.$config['mydomain'])) {
-                        $file = $configs.$device['hostname'].'.'.$config['mydomain'];
+                if (!empty(Config::get('mydomain'))) { // Try with domain name if set
+                    if (is_file($configs.$device['hostname'].'.'.Config::get('mydomain'))) {
+                        $file = $configs.$device['hostname'].'.'.Config::get('mydomain');
                     }
                 }
             } // end if
@@ -41,7 +42,7 @@ if (Auth::user()->hasGlobalAdmin()) {
             echo generate_link('Latest', array('page' => 'device', 'device' => $device['device_id'], 'tab' => 'showconfig'));
         }
 
-        if ($config['rancid_repo_type'] == 'svn' && function_exists('svn_log')) {
+        if (Config::get('rancid_repo_type') == 'svn' && function_exists('svn_log')) {
             $sep     = ' | ';
             $svnlogs = svn_log($file, SVN_REVISION_HEAD, null, 8);
             $revlist = array();
@@ -54,7 +55,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                     echo '<span class="pagemenu-selected">';
                 }
 
-                $linktext = 'r'.$svnlog['rev'].' <small>'.date($config['dateformat']['byminute'], strtotime($svnlog['date'])).'</small>';
+                $linktext = 'r'.$svnlog['rev'].' <small>'.date(Config::get('dateformat')['byminute'], strtotime($svnlog['date'])).'</small>';
                 echo generate_link($linktext, array('page' => 'device', 'device' => $device['device_id'], 'tab' => 'showconfig', 'rev' => $svnlog['rev']));
 
                 if ($vars['rev'] == $svnlog['rev']) {
@@ -64,7 +65,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $sep = ' | ';
             }
         }//end if
-        if ($config['rancid_repo_type'] == 'git') {
+        if (Config::get('rancid_repo_type') == 'git') {
             $sep     = ' | ';
 
             chdir($configs);
@@ -87,7 +88,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                     echo '<span class="pagemenu-selected">';
                 }
 
-                $linktext = 'r'.$gitlog['rev'].' <small>'.date($config['dateformat']['byminute'], $gitlog['date']).'</small>';
+                $linktext = 'r'.$gitlog['rev'].' <small>'.date(Config::get('dateformat')['byminute'], $gitlog['date']).'</small>';
                 echo generate_link($linktext, array('page' => 'device', 'device' => $device['device_id'], 'tab' => 'showconfig', 'rev' => $gitlog['rev']));
 
                 if ($vars['rev'] == $gitlog['rev']) {
@@ -100,7 +101,7 @@ if (Auth::user()->hasGlobalAdmin()) {
 
         print_optionbar_end();
 
-        if ($config['rancid_repo_type'] == 'svn') {
+        if (Config::get('rancid_repo_type') == 'svn') {
             if (function_exists('svn_log') && in_array($vars['rev'], $revlist)) {
                 list($diff, $errors) = svn_diff($file, ($vars['rev'] - 1), $file, $vars['rev']);
                 if (!$diff) {
@@ -119,7 +120,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $text = fread($fh, filesize($file));
                 fclose($fh);
             }
-        } elseif ($config['rancid_repo_type'] == 'git') {
+        } elseif (Config::get('rancid_repo_type') == 'git') {
             if (in_array($vars['rev'], $revlist)) {
                 chdir($configs);
                 $diff = external_exec('git diff ' . $vars['rev'] . '^ ' . $vars['rev'] . ' ' . $file);
@@ -135,7 +136,7 @@ if (Auth::user()->hasGlobalAdmin()) {
             }
         }
 
-        if ($config['rancid_ignorecomments']) {
+        if (Config::get('rancid_ignorecomments')) {
             $lines = explode("\n", $text);
             for ($i = 0; $i < count($lines); $i++) {
                 if ($lines[$i][0] == '#') {
@@ -145,11 +146,11 @@ if (Auth::user()->hasGlobalAdmin()) {
 
             $text = join("\n", $lines);
         }
-    } elseif ($config['oxidized']['enabled'] === true && isset($config['oxidized']['url'])) {
+    } elseif (Config::get('oxidized')['enabled'] === true && isset(Config::get('oxidized')['url'])) {
         // Try with hostname as set in librenms first
         $oxidized_hostname = $device['hostname'];
         // fetch info about the node and then a list of versions for that node
-        $node_info = json_decode(file_get_contents($config['oxidized']['url'].'/node/show/'.$oxidized_hostname.'?format=json'), true);
+        $node_info = json_decode(file_get_contents(Config::get('oxidized')['url'].'/node/show/'.$oxidized_hostname.'?format=json'), true);
         
         // Try other hostname format if Oxidized request failed
         if (! $node_info) {
@@ -157,18 +158,18 @@ if (Auth::user()->hasGlobalAdmin()) {
             if (strpos($oxidized_hostname, '.') !== false) {
                 // Use short name
                 $oxidized_hostname = strtok($device['hostname'], '.');
-            } elseif ($config['mydomain']) {
-                $oxidized_hostname = $device['hostname'].'.'.$config['mydomain'];
+            } elseif (Config::get('mydomain')) {
+                $oxidized_hostname = $device['hostname'].'.'.Config::get('mydomain');
             }
 
             // Try Oxidized again with new hostname, if it has changed
             if ($oxidized_hostname != $device['hostname']) {
-                $node_info = json_decode(file_get_contents($config['oxidized']['url'].'/node/show/'.$oxidized_hostname.'?format=json'), true);
+                $node_info = json_decode(file_get_contents(Config::get('oxidized')['url'].'/node/show/'.$oxidized_hostname.'?format=json'), true);
             }
         }
 
-        if ($config['oxidized']['features']['versioning'] === true) { // fetch a list of versions
-            $config_versions = json_decode(file_get_contents($config['oxidized']['url'].'/node/version?node_full='.(isset($node_info['full_name']) ? $node_info['full_name'] : $oxidized_hostname).'&format=json'), true);
+        if (Config::get('oxidized')['features']['versioning'] === true) { // fetch a list of versions
+            $config_versions = json_decode(file_get_contents(Config::get('oxidized')['url'].'/node/version?node_full='.(isset($node_info['full_name']) ? $node_info['full_name'] : $oxidized_hostname).'&format=json'), true);
         }
 
         $config_total = 1;
@@ -206,7 +207,7 @@ if (Auth::user()->hasGlobalAdmin()) {
             }
 
             if (isset($previous_config)) {
-                $url = $config['oxidized']['url'].'/node/version/diffs?node='.$oxidized_hostname;
+                $url = Config::get('oxidized')['url'].'/node/version/diffs?node='.$oxidized_hostname;
                 if (!empty($node_info['group'])) {
                     $url .= '&group='.$node_info['group'];
                 }
@@ -215,10 +216,10 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $text = file_get_contents($url); // fetch diff
             } else {
                 // fetch current_version
-                $text = file_get_contents($config['oxidized']['url'].'/node/version/view?node='.$oxidized_hostname.(!empty($node_info['group']) ? '&group='.$node_info['group'] : '').'&oid='.$current_config['oid'].'&date='.urlencode($current_config['date']).'&num='.$current_config['version'].'&format=text');
+                $text = file_get_contents(Config::get('oxidized')['url'].'/node/version/view?node='.$oxidized_hostname.(!empty($node_info['group']) ? '&group='.$node_info['group'] : '').'&oid='.$current_config['oid'].'&date='.urlencode($current_config['date']).'&num='.$current_config['version'].'&format=text');
             }
         } else {  // just fetch the only version
-            $text = file_get_contents($config['oxidized']['url'].'/node/fetch/'.(!empty($node_info['group']) ? $node_info['group'].'/' : '').$oxidized_hostname);
+            $text = file_get_contents(Config::get('oxidized')['url'].'/node/fetch/'.(!empty($node_info['group']) ? $node_info['group'].'/' : '').$oxidized_hostname);
         }
 
         if (is_array($node_info) || $config_total > 1) {

--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -3,6 +3,7 @@
 // FIXME svn stuff still using optc etc, won't work, needs updating!
 use LibreNMS\Authentication\Auth;
 use LibreNMS\Config;
+use Symfony\Component\Process\Process;
 
 if (Auth::user()->hasGlobalAdmin()) {
     if (!is_array(Config::get('rancid_configs'))) {
@@ -68,9 +69,9 @@ if (Auth::user()->hasGlobalAdmin()) {
         if (Config::get('rancid_repo_type') == 'git') {
             $sep     = ' | ';
 
-            chdir($configs);
-            $gitlogs_raw = external_exec('git log -n 8 --pretty=format:"%h;%ct" ' . $file);
-            $gitlogs_raw = explode(PHP_EOL, $gitlogs_raw);
+            $process = new Process(array('git', 'log', '-n 8', '--pretty=format:%h;%ct', $file), $configs);
+            $process->run();
+            $gitlogs_raw = explode(PHP_EOL, $process->getOutput());
             $gitlogs = array();
 
             foreach ($gitlogs_raw as $gl) {
@@ -122,8 +123,9 @@ if (Auth::user()->hasGlobalAdmin()) {
             }
         } elseif (Config::get('rancid_repo_type') == 'git') {
             if (in_array($vars['rev'], $revlist)) {
-                chdir($configs);
-                $diff = external_exec('git diff ' . $vars['rev'] . '^ ' . $vars['rev'] . ' ' . $file);
+                $process = new Process(array('git', 'diff', $vars['rev'] . '^', $vars['rev'], $file), $configs);
+                $process->run();
+                $diff = $process->getOutput();
                 if (!$diff) {
                     $text = 'No Difference';
                 } else {

--- a/html/pages/device/showconfig.inc.php
+++ b/html/pages/device/showconfig.inc.php
@@ -130,6 +130,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                     $text = 'No Difference';
                 } else {
                     $text = $diff;
+                    $previous_config = $vars['rev'] . '^';
                 }
             } else {
                 $fh   = fopen($file, 'r') or die("Can't open file");

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -516,6 +516,7 @@ $config['billing']['base'] = 1000;
 // Set the base to divider bytes to kB, MB, GB ,... (1000|1024)
 // External Integration
 // $config['rancid_configs'][]             = '/var/lib/rancid/network/configs/';
+$config['rancid_repo_type'] = 'svn';
 $config['rancid_ignorecomments'] = 0;
 // Ignore lines starting with #
 // $config['collectd_dir']                 = '/var/lib/collectd/rrd';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`


This pull req adds support for Rancid GIT backend (instead of the current supported SVN).
Not only git is preferred these days, also php-svn is non-existing on php 7+, so the only Rancid option is broken on PHP 7+, so might be nice to have this included :)