### PR TITLE
Workaround for billing with large bps

### DIFF
--- a/poll-billing.php
+++ b/poll-billing.php
@@ -91,7 +91,7 @@ function CollectData($bill_id)
             $port_data['out_delta'] = '0';
         }
 
-        $fields = array('timestamp' => $now, 'in_counter' => set_numeric($port_data['in_measurement']), 'out_counter' => set_numeric($port_data['out_measurement']), 'in_delta' => set_numeric($port_data['in_delta']), 'out_delta' => set_numeric($port_data['out_delta']));
+        $fields = array('timestamp' => $now, 'in_counter' => (string)set_numeric($port_data['in_measurement']), 'out_counter' => (string)set_numeric($port_data['out_measurement']), 'in_delta' => (string)set_numeric($port_data['in_delta']), 'out_delta' => (string)set_numeric($port_data['out_delta']));
         if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
             $fields['bill_id'] = $bill_id;
             $fields['port_id'] = $port_id;

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -91,6 +91,7 @@ function CollectData($bill_id)
             $port_data['out_delta'] = '0';
         }
 
+        // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
         $fields = array('timestamp' => $now, 'in_counter' => (string)set_numeric($port_data['in_measurement']), 'out_counter' => (string)set_numeric($port_data['out_measurement']), 'in_delta' => (string)set_numeric($port_data['in_delta']), 'out_delta' => (string)set_numeric($port_data['out_delta']));
         if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
             $fields['bill_id'] = $bill_id;

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -128,7 +128,8 @@ function CollectData($bill_id)
     if (!empty($period) && $period < '0') {
         logfile("BILLING: negative period! id:$bill_id period:$period delta:$delta in_delta:$in_delta out_delta:$out_delta");
     } else {
-        dbInsert(array('bill_id' => $bill_id, 'timestamp' => $now, 'period' => $period, 'delta' => $delta, 'in_delta' => $in_delta, 'out_delta' => $out_delta), 'bill_data');
+        // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
+        dbInsert(array('bill_id' => $bill_id, 'timestamp' => $now, 'period' => $period, 'delta' => (string)$delta, 'in_delta' => (string)$in_delta, 'out_delta' => (string)$out_delta), 'bill_data');
     }
 }//end CollectData()
 


### PR DESCRIPTION
Workaround for mysqli driver mucking up BIGINT
Real fix is for users to switch to mysqlnd

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
