### PR TITLE
Workaround for storage bigint

### DIFF
--- a/includes/polling/storage.inc.php
+++ b/includes/polling/storage.inc.php
@@ -36,7 +36,8 @@ foreach (dbFetchRows('SELECT * FROM storage WHERE device_id = ?', array($device[
     $tags = compact('mib', 'descr', 'rrd_name', 'rrd_def');
     data_update($device, 'storage', $tags, $fields);
 
-    $update = dbUpdate(array('storage_used' => $storage['used'], 'storage_free' => $storage['free'], 'storage_size' => $storage['size'], 'storage_units' => $storage['units'], 'storage_perc' => $percent), 'storage', '`storage_id` = ?', array($storage['storage_id']));
+    // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
+    $update = dbUpdate(array('storage_used' => (string)$storage['used'], 'storage_free' => (string)$storage['free'], 'storage_size' => (string)$storage['size'], 'storage_units' => $storage['units'], 'storage_perc' => $percent), 'storage', '`storage_id` = ?', array($storage['storage_id']));
 
     echo "\n";
 }//end foreach


### PR DESCRIPTION
Fix is to use mysqlnd driver instead of mysqli.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
