### PR TITLE
Fix port_id is null in ospf poller

### DIFF
--- a/includes/polling/ospf.inc.php
+++ b/includes/polling/ospf.inc.php
@@ -78,10 +78,10 @@ foreach ($vrfs_lite_cisco as $vrf_lite) {
     foreach ($ospf_ports_poll as $ospf_port_id => $ospf_port) {
         // find port_id
         if ($ospf_port['ospfAddressLessIf']) {
-            $ospf_port['port_id'] = $device_model->ports()->where('ifIndex', $ospf_port['ospfAddressLessIf'])->value('port_id');
+            $ospf_port['port_id'] = (int)$device_model->ports()->where('ifIndex', $ospf_port['ospfAddressLessIf'])->value('port_id');
         } else {
             // FIXME force same device ?
-            $ospf_port['port_id'] = Ipv4Address::query()
+            $ospf_port['port_id'] = (int)Ipv4Address::query()
                 ->where('ipv4_address', $ospf_port['ospfIfIpAddress'])
                 ->where('context_name', $device['context_name'])
                 ->value('port_id');


### PR DESCRIPTION
set it to 0 instead of null
https://pastebin.com/5PeQSjW8

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
