### PR TITLE
Improved port polling in certain scenarios

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -175,8 +175,6 @@ $dot3_oids = [
     'dot3StatsDuplexStatus',
 ];
 
-$pvid_oids = 'dot1qPvid';
-
 // Query known ports and mapping table in order of discovery to make sure
 // the latest discoverd/polled port is in the mapping tables.
 $ports_mapped = get_ports_mapped($device['device_id'], true);
@@ -256,8 +254,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
                     $port_stats = snmp_get_multi($device, $extra_oids, '-OQUst', 'EtherLike-MIB', null, $port_stats);
 
                     if ($device['os'] != 'asa') {
-                        $extra_pvid_oids = "$pvid_oid.$ifIndex";
-                        $port_stats = snmp_get_multi($device, $extra_pvid_oids, '-OQUst', 'Q-BRIDGE-MIB', null, $port_stats);
+                        $port_stats = snmp_get_multi($device, "dot1qPvid.$ifIndex", '-OQUst', 'Q-BRIDGE-MIB', null, $port_stats);
                     }
                 }
             }

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -175,9 +175,7 @@ $dot3_oids = [
     'dot3StatsDuplexStatus',
 ];
 
-$pvid_oids = [
-    'dot1qPvid',
-];
+$pvid_oids = ['dot1qPvid'];
 
 // Query known ports and mapping table in order of discovery to make sure
 // the latest discoverd/polled port is in the mapping tables.

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -175,6 +175,10 @@ $dot3_oids = [
     'dot3StatsDuplexStatus',
 ];
 
+$pvid_oids = [
+    'dot1qPvid',
+];
+
 // Query known ports and mapping table in order of discovery to make sure
 // the latest discoverd/polled port is in the mapping tables.
 $ports_mapped = get_ports_mapped($device['device_id'], true);
@@ -212,6 +216,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
         $walk_base = $total_port_count - $polled_port_count < 5 || $polled_port_count / $total_port_count > 0.9 ;
 
         if ($walk_base) {
+            echo "Not enough ports for selected port polling, walking base OIDs instead\n";
             foreach ($table_base_oids as $oid) {
                 $port_stats = snmpwalk_cache_oid($device, $oid, $port_stats, 'IF-MIB');
             }
@@ -251,6 +256,11 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
 
                     $port_stats = snmp_get_multi($device, $oids, '-OQUst', 'IF-MIB', null, $port_stats);
                     $port_stats = snmp_get_multi($device, $extra_oids, '-OQUst', 'EtherLike-MIB', null, $port_stats);
+
+                    if ($device['os'] != 'asa') {
+                        $extra_pvid_oids = implode(".$ifIndex ", $pvid_oids) . ".$ifIndex";
+                        $port_stats = snmp_get_multi($device, $extra_pvid_oids, '-OQUst', 'Q-BRIDGE-MIB', null, $port_stats);
+                    }
                 }
             }
         }
@@ -281,6 +291,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
                 $port_stats = snmpwalk_cache_oid($device, 'dot3StatsIndex', $port_stats, 'EtherLike-MIB');
             }
             $port_stats = snmpwalk_cache_oid($device, 'dot3StatsDuplexStatus', $port_stats, 'EtherLike-MIB');
+            $port_stats = snmpwalk_cache_oid($device, 'dot1qPvid', $port_stats, 'Q-BRIDGE-MIB');
         }
     }
 }
@@ -375,8 +386,6 @@ if ($device['os_group'] == 'cisco' && $device['os'] != 'asa') {
     $port_stats = snmpwalk_cache_oid($device, 'vmVlan', $port_stats, 'CISCO-VLAN-MEMBERSHIP-MIB');
     $port_stats = snmpwalk_cache_oid($device, 'vlanTrunkPortEncapsulationOperType', $port_stats, 'CISCO-VTP-MIB');
     $port_stats = snmpwalk_cache_oid($device, 'vlanTrunkPortNativeVlan', $port_stats, 'CISCO-VTP-MIB');
-} elseif ($device['os'] != 'asa') {
-    $port_stats = snmpwalk_cache_oid($device, 'dot1qPvid', $port_stats, 'Q-BRIDGE-MIB');
 }//end if
 
 $polled = time();

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -175,7 +175,7 @@ $dot3_oids = [
     'dot3StatsDuplexStatus',
 ];
 
-$pvid_oids = ['dot1qPvid'];
+$pvid_oids = 'dot1qPvid';
 
 // Query known ports and mapping table in order of discovery to make sure
 // the latest discoverd/polled port is in the mapping tables.
@@ -256,7 +256,7 @@ if ($device['os'] === 'f5' && (version_compare($device['version'], '11.2.0', '>=
                     $port_stats = snmp_get_multi($device, $extra_oids, '-OQUst', 'EtherLike-MIB', null, $port_stats);
 
                     if ($device['os'] != 'asa') {
-                        $extra_pvid_oids = implode(".$ifIndex ", $pvid_oids) . ".$ifIndex";
+                        $extra_pvid_oids = "$pvid_oid.$ifIndex";
                         $port_stats = snmp_get_multi($device, $extra_pvid_oids, '-OQUst', 'Q-BRIDGE-MIB', null, $port_stats);
                     }
                 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

Small improvements to ports polling time. Tested with and without selected ports polling on Cisco IOS and Arista EOS devices.