### PR TITLE
Two fixes for Prometheus integration

### DIFF
--- a/includes/prometheus.inc.php
+++ b/includes/prometheus.inc.php
@@ -31,20 +31,19 @@ function prometheus_push($device, $measurement, $tags, $fields)
                         $k = preg_replace('/([_]{2})/', '_', $k);
                         $k = strtolower($k);
                         $vals = $vals . "$k $v\n";
-                    }
-                }
+                    } 
+                } 
 
                 foreach ($tags as $t => $v) {
                     if ($v !== null) {
-                        if(strpos($v,"/") === false) {
+                        if (strpos($v, "/") === false) {
                             ;
-                        }
-                        else {
+                        } else {
                             $v = str_replace("/", "", $v); // Prometheus does not accept "/" symbol in label names, so we need to strip them out
-                        }
+                        } 
                         $promtags = $promtags . "/$t/$v";
-                    }
-                }
+                    } 
+                } 
 
                 $promurl = $config['prometheus']['url'].'/metrics/job/'.$config['prometheus']['job'].'/instance/'.$device['hostname'].$promtags;
                 $promurl = str_replace(" ", "-", $promurl); // Prometheus doesn't handle tags with spaces in url

--- a/includes/prometheus.inc.php
+++ b/includes/prometheus.inc.php
@@ -29,6 +29,7 @@ function prometheus_push($device, $measurement, $tags, $fields)
                         $k = preg_replace('/([a-z]{1,})/', '$1_', $k); // Generally, metric naming in Prometheus is done with underscores without capital letters
                         $k = substr($k, 0, -1);
                         $k = preg_replace('/([_]{2})/', '_', $k);
+                        $k = preg_replace('/([0-9]{1,})(.*)/', '$2$1', $k); // Prometheus does not accept metric names that start with numbers, so we switch them
                         $k = strtolower($k);
                         $vals = $vals . "$k $v\n";
                     }
@@ -36,11 +37,7 @@ function prometheus_push($device, $measurement, $tags, $fields)
 
                 foreach ($tags as $t => $v) {
                     if ($v !== null) {
-                        if (strpos($v, "/") === false) {
-                            ;
-                        } else {
-                            $v = str_replace("/", "", $v); // Prometheus does not accept "/" symbol in label names, so we need to strip them out
-                        }
+                        $v = str_replace("/", "", $v); // Prometheus does not accept "/" symbol in label names, so we need to strip them out
                         $promtags = $promtags . "/$t/$v";
                     }
                 }

--- a/includes/prometheus.inc.php
+++ b/includes/prometheus.inc.php
@@ -31,8 +31,8 @@ function prometheus_push($device, $measurement, $tags, $fields)
                         $k = preg_replace('/([_]{2})/', '_', $k);
                         $k = strtolower($k);
                         $vals = $vals . "$k $v\n";
-                    } 
-                } 
+                    }
+                }
 
                 foreach ($tags as $t => $v) {
                     if ($v !== null) {
@@ -40,10 +40,10 @@ function prometheus_push($device, $measurement, $tags, $fields)
                             ;
                         } else {
                             $v = str_replace("/", "", $v); // Prometheus does not accept "/" symbol in label names, so we need to strip them out
-                        } 
+                        }
                         $promtags = $promtags . "/$t/$v";
-                    } 
-                } 
+                    }
+                }
 
                 $promurl = $config['prometheus']['url'].'/metrics/job/'.$config['prometheus']['job'].'/instance/'.$device['hostname'].$promtags;
                 $promurl = str_replace(" ", "-", $promurl); // Prometheus doesn't handle tags with spaces in url


### PR DESCRIPTION
This is a small fix for Prometheus integration that does two things:
1. Forces metric names to be lowercase as per naming guidelines 
2. Removes slashes from the names of labels, since Prometheus does not support this symbol. 

Tested with pushgateway 0.5.2 and prometheus 2.2.1 and a monitoring environment of... 5 devices. 😃 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
