### PR TITLE
Fixed slack options not showing in the webui

### DIFF
--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -98,7 +98,7 @@ class Slack extends Transport
                 ],
                 [
                     'title' => 'Slack Options',
-                    'name' => 'options',
+                    'name' => 'slack-options',
                     'descr' => 'Slack Options',
                     'type' => 'textarea',
                 ]

--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -33,7 +33,7 @@ class Slack extends Transport
             return $this->deliverAlertOld($obj, $opts);
         }
         $slack_opts['url'] = $this->config['slack-url'];
-        foreach (explode(PHP_EOL, $this->config['options']) as $option) {
+        foreach (explode(PHP_EOL, $this->config['slack-options']) as $option) {
             list($k,$v) = explode('=', $option);
             $slack_opts[$k] = $v;
         }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

This will cause a loss of the options for slack (only author_name) but this isn't classed as critical to notify users imho.