### PR TITLE
WebUI: Oxidized Device List: Link to config and refreshDevice Btn

### DIFF
--- a/html/includes/forms/refresh-oxidized-node.inc.php
+++ b/html/includes/forms/refresh-oxidized-node.inc.php
@@ -15,17 +15,6 @@ header('Content-type: application/json');
 use LibreNMS\Config;
 use LibreNMS\Authentication\Auth;
 
-function oxidized_node_update($hostname, $msg, $username = '')
-{
-    $postdata = ["user" => $username, "msg" => $msg];
-    $oxidized_url = Config::get('oxidized.url');
-    if (!empty($oxidized_url)) {
-        Requests::put("$oxidized_url/node/next/$hostname", [], json_encode($postdata), ['proxy' => get_proxy()]);
-        return true;
-    } 
-    return false;
-}//end oxidized_node_update()
-
 $device_hostname = clean($_POST['device_hostname']);
 if (Auth::user()->hasGlobalAdmin() && isset($device_hostname)) {
     if (oxidized_node_update($device_hostname, "LibreNMS GUI refresh", $_SESSION['username'])) {

--- a/html/includes/forms/refresh-oxidized-node.inc.php
+++ b/html/includes/forms/refresh-oxidized-node.inc.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2018 PipoCanaja <pipocanaja@gmail.com>
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ */
+
+header('Content-type: application/json');
+
+use LibreNMS\Config;
+use LibreNMS\Authentication\Auth;
+
+$device_hostname = clean($_POST['device_hostname']);
+if (Auth::user()->hasGlobalAdmin() && isset($device_hostname)) {
+    if (oxidized_node_update($device_hostname, "LibreNMS GUI refresh", $_SESSION['username'])) {
+        $status  = 'ok';
+        $message = 'Queued refresh in oxidized for device ' . $device_hostname;
+    } else {
+        $status  = 'error';
+        $message = 'ERROR: Could not queue refresh of oxidized device' . $device_hostname;
+    };
+} else {
+    $status  = 'error';
+    $message = 'ERROR: Could not queue refresh oxidized device';
+}
+
+$output = array(
+    'status'  => $status,
+    'message' => $message,
+);
+
+header('Content-type: application/json');
+echo _json_encode($output);
+
+
+function oxidized_node_update($hostname, $msg, $username = '')
+{
+    $postdata = ["user" => $username, "msg" => $msg];
+    $oxidized_url = Config::get('oxidized.url');
+    if (!empty($oxidized_url)) {
+        Requests::put("$oxidized_url/node/next/$hostname", [], json_encode($postdata), ['proxy' => get_proxy()]);
+        return true;
+    } else {
+        return false;
+    }
+}//end oxidized_node_update()

--- a/html/includes/forms/refresh-oxidized-node.inc.php
+++ b/html/includes/forms/refresh-oxidized-node.inc.php
@@ -15,6 +15,17 @@ header('Content-type: application/json');
 use LibreNMS\Config;
 use LibreNMS\Authentication\Auth;
 
+function oxidized_node_update($hostname, $msg, $username = '')
+{
+    $postdata = ["user" => $username, "msg" => $msg];
+    $oxidized_url = Config::get('oxidized.url');
+    if (!empty($oxidized_url)) {
+        Requests::put("$oxidized_url/node/next/$hostname", [], json_encode($postdata), ['proxy' => get_proxy()]);
+        return true;
+    } 
+    return false;
+}//end oxidized_node_update()
+
 $device_hostname = clean($_POST['device_hostname']);
 if (Auth::user()->hasGlobalAdmin() && isset($device_hostname)) {
     if (oxidized_node_update($device_hostname, "LibreNMS GUI refresh", $_SESSION['username'])) {
@@ -36,16 +47,3 @@ $output = array(
 
 header('Content-type: application/json');
 echo _json_encode($output);
-
-
-function oxidized_node_update($hostname, $msg, $username = '')
-{
-    $postdata = ["user" => $username, "msg" => $msg];
-    $oxidized_url = Config::get('oxidized.url');
-    if (!empty($oxidized_url)) {
-        Requests::put("$oxidized_url/node/next/$hostname", [], json_encode($postdata), ['proxy' => get_proxy()]);
-        return true;
-    } else {
-        return false;
-    }
-}//end oxidized_node_update()

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1530,6 +1530,15 @@ function get_oxidized_nodes_list()
         <td>
         " . $object['group'] . "
         </td>
+        <td>
+          <button class='btn btn-default btn-sm' name='btn-refresh-node-devId" . $device['device_id'] . "' id='btn-refresh-nod
+e-devId" . $device['device_id'] . "' onclick='refresh_oxidized_node(\"" . $device['hostname'] . "\")'>
+            <i class='fa fa-refresh'></i>
+          </button>
+          <a href='/device/device=".$device['device_id']."/tab=showconfig/'>
+            <i class='fa fa-align-justify fa-lg icon-theme'></i>
+          </a>
+        </td>
         </tr>";
     }
 }

--- a/html/pages/oxidized.inc.php
+++ b/html/pages/oxidized.inc.php
@@ -34,6 +34,7 @@ $pagetitle[] = 'Oxidized';
                                 <th data-column-id="last_update">Last Update</th>
                                 <th data-column-id="model">Model</th>
                                 <th data-column-id="group">Group</th>
+                                <th data-column-id="actions"></th>
                             </tr>
                             </thead>
                             <tbody>
@@ -62,6 +63,28 @@ $pagetitle[] = 'Oxidized';
     </div>
 </div>
 <script>
+
+    function refresh_oxidized_node(device_hostname){
+        $.ajax({
+            type: 'POST',
+            url: 'ajax_form.php',
+            data: {
+                type: "refresh-oxidized-node",
+                device_hostname: device_hostname
+            },
+            success: function (data) {
+                if(data['status'] == 'ok') {
+                    toastr.success(data['message']);
+                } else {
+                    toastr.error(data['message']);
+                }
+            },
+            error:function(){
+                toastr.error('An error occured while refreshing an oxidized node (hostname: ' + device_hostname + ')');
+            }
+        });
+    }
+    
     $("[name='btn-search']").on('click', function (event) {
         event.preventDefault();
         var $this = $(this);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2644,4 +2644,3 @@ function oxidized_node_update($hostname, $msg, $username = 'not_provided')
     }
     return false;
 }//end oxidized_node_update()
-

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2621,3 +2621,27 @@ function is_disk_valid($disk, $device)
     }
     return true;
 }
+
+
+/**
+ * Queues a hostname to be refreshed by Oxidized
+ * Settings: oxidized.url
+ *
+ * @param string $hostname
+ * @param string $msg
+ * @param string $username
+ * @return bool
+ */
+function oxidized_node_update($hostname, $msg, $username = 'not_provided')
+{
+    // Work around https://github.com/rack/rack/issues/337
+    $msg = str_replace("%", "", $msg);
+    $postdata = ["user" => $username, "msg" => $msg];
+    $oxidized_url = Config::get('oxidized.url');
+    if (!empty($oxidized_url)) {
+        Requests::put("$oxidized_url/node/next/$hostname", [], json_encode($postdata), ['proxy' => get_proxy()]);
+        return true;
+    }
+    return false;
+}//end oxidized_node_update()
+

--- a/scripts/syslog-notify-oxidized.php
+++ b/scripts/syslog-notify-oxidized.php
@@ -6,17 +6,6 @@ require __DIR__ . '/../includes/init.php';
 
 use LibreNMS\Config;
 
-function oxidized_node_update($hostname, $msg, $username = 'not_provided')
-{
-    // Work around https://github.com/rack/rack/issues/337
-    $msg = str_replace("%", "", $msg);
-    $postdata = ["user" => $username, "msg" => $msg];
-    $oxidized_url = Config::get('oxidized.url');
-    if (!empty($oxidized_url)) {
-        Requests::put("$oxidized_url/node/next/$hostname", [], json_encode($postdata), ['proxy' => get_proxy()]);
-    }
-}//end oxidized_node_update()
-
 $hostname = $argv[1];
 $os = $argv[2];
 $msg = $argv[3];


### PR DESCRIPTION
Hello all,

Here is a patch adding 2 new icons in each device of the Oxidized list. 
- One does directly link to the configuration display page. 
- The other uses the Oxidized API to queue a new scan of the configuration on the device. 

![capture d ecran 2018-09-01 a 21 09 17](https://user-images.githubusercontent.com/38363551/44949144-f1e5dc00-ae2b-11e8-8578-fec741323e9e.png)

Concerning the code itself, I am pretty sure there is something better to do with the function : 
- function oxidized_node_update($hostname, $msg, $username = '')

I copied it from syslog-notify-oxidized.php and this is code duplication. But so far syslog-notify-oxidized.php  is not loading html/includes/functions.inc.php so putting it there would not help. 

Let me know what you suggest. 

PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
