### PR TITLE
Squelch PBN processor warnings

### DIFF
--- a/LibreNMS/Device/Processor.php
+++ b/LibreNMS/Device/Processor.php
@@ -60,7 +60,7 @@ class Processor extends Model implements DiscoveryModule, PollerModule, Discover
      * @param string $type
      * @param int $device_id
      * @param string $oid
-     * @param int $index
+     * @param int|string $index
      * @param string $description
      * @param int $precision The returned value will be divided by this number (should be factor of 10) If negative this oid returns idle cpu
      * @param int $current_usage
@@ -84,7 +84,7 @@ class Processor extends Model implements DiscoveryModule, PollerModule, Discover
         $proc = new static();
         $proc->processor_type = $type;
         $proc->device_id = $device_id;
-        $proc->processor_index = $index;
+        $proc->processor_index = (string)$index;
         $proc->processor_descr = $description;
         $proc->processor_precision = $precision;
         $proc->processor_usage = $current_usage;

--- a/LibreNMS/OS/Pbn.php
+++ b/LibreNMS/OS/Pbn.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Pbn.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\OS;
+
+use LibreNMS\Device\Processor;
+use LibreNMS\Interfaces\Discovery\ProcessorDiscovery;
+use LibreNMS\OS;
+
+class Pbn extends OS implements ProcessorDiscovery
+{
+    /**
+     * Discover processors.
+     * Returns an array of LibreNMS\Device\Processor objects that have been discovered
+     *
+     * @return array Processors
+     */
+    public function discoverProcessors()
+    {
+        return [
+            Processor::discover(
+                'pbn-cpu',
+                $this->getDeviceId(),
+                '.1.3.6.1.4.1.11606.10.9.109.1.1.1.1.5.1', // NMS-PROCESS-MIB::nmspmCPUTotal5min
+                0
+            )
+        ];
+    }
+}

--- a/includes/definitions/discovery/pbn.yaml
+++ b/includes/definitions/discovery/pbn.yaml
@@ -1,9 +1,0 @@
-mib: NMS-PROCESS-MIB
-modules:
-    processors:
-          data:
-              -
-                  oid: nmspmCPUTotal5min
-                  num_oid: '.1.3.6.1.4.1.11606.10.9.109.1.1.1.1.5.{{ $index }}'
-                  index: 0
-                  type: pbn-cpu


### PR DESCRIPTION
Don't use NMS-PROCESS-MIB for pbn processors.  This keeps tests from spitting out warnings about the broken mib.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
