### PR TITLE
Fix a couple of validation items

### DIFF
--- a/LibreNMS/Validations/User.php
+++ b/LibreNMS/Validations/User.php
@@ -74,6 +74,7 @@ class User extends BaseValidation
                     "$dir/storage/framework/sessions/",
                     "$dir/storage/framework/views/",
                     "$dir/storage/debugbar/",
+                    "$dir/.pki/", // ignore files/folders created by setting the librenms home directory to the install directory
                 );
 
                 $files = array_filter(explode(PHP_EOL, $find_result), function ($file) use ($ignore_files) {

--- a/validate.php
+++ b/validate.php
@@ -143,7 +143,7 @@ if (!file_exists(Config::get('install_dir').'/config.php')) {
 if (\LibreNMS\DB\Eloquent::isConnected()) {
     $validator->ok('Database connection successful', null, 'database');
 } else {
-    $validator->fail('Error connecting to your database. '.$e->getMessage(), null, 'database');
+    $validator->fail('Error connecting to your database.', null, 'database');
 }
 
 Config::load();


### PR DESCRIPTION
- Ignore .pki/nssdb. This happens when /opt/librenms is set as the home directory of the librenms users, personally, I would suggest adding cd /opt/librenms in ./bashrc (or equivalent) instead.
- fix validate when db connection fails.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
