### PR TITLE
use UTC if date.timezone is not set

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -64,7 +64,7 @@ return [
     |
     */
 
-    'timezone' => ini_get('date.timezone'), // use existing timezone
+    'timezone' => ini_get('date.timezone') ?: 'UTC', // use existing timezone
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
date.timezone is not guaranteed to be set. This fix falls back to a sensible default (UTC).

Fixes this annoying message after `composer install`:
> PHP Notice:  date_default_timezone_set(): Timezone ID '' is invalid in /tmp/librenms/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php on line 49




DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
