### PR TITLE
Fix error in logout

### DIFF
--- a/app/Listeners/AuthEventListener.php
+++ b/app/Listeners/AuthEventListener.php
@@ -54,9 +54,7 @@ class AuthEventListener
     {
         DB::table('authlog')->insert(['user' => $event->user->username ?: '', 'address' => Request::ip(), 'result' => 'Logged Out']);
 
-        if (!isset($_SESSION)) {
-            session_start();
-        }
+        @session_start();
         unset($_SESSION['authenticated']);
         session_destroy();
     }


### PR DESCRIPTION
session_destroy(): Trying to destroy uninitialized session

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
