### PR TITLE
Updated example for new alerting engine

### DIFF
--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -116,7 +116,6 @@ Unique-ID: {{ $alert->uid }}
 Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif
 @if ($alert->faults) Faults:
 @foreach ($alert->faults as $key => $value)
-  #{{ $key }}: {{ $value['string'] }}
 @endforeach
 @endif
 Alert sent to:
@@ -133,11 +132,11 @@ Severity: {{ $alert->severity }}
 Timestamp: {{ $alert->timestamp }}
 Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif
 @foreach ($alert->faults as $key => $value)
-Physical Interface: $value['ifDescr']
-Interface Description: $value['ifAlias']
-Interface Speed: @php echo ($value['ifSpeed']/1000000000); @endphp Gbs
-Inbound Utilization: @php echo (($value['ifInOctets_rate']*8)/$value['ifSpeed'])*100; @endphp%
-Outbound Utilization: @php echo (($value['ifOutOctets_rate']*8)/$value['ifSpeed'])*100; @endphp%
+Physical Interface: {{ $value['ifDescr'] }}
+Interface Description: {{ $value['ifAlias'] }}
+Interface Speed: {{ ($value['ifSpeed']/1000000000) }} Gbs
+Inbound Utilization: {{ (($value['ifInOctets_rate']*8)/$value['ifSpeed'])*100 }}
+Outbound Utilization: {{ (($value['ifOutOctets_rate']*8)/$value['ifSpeed'])*100 }}
 @endforeach
 ```
 
@@ -281,7 +280,6 @@ Alert-ID: {{ $alert->id }} <br>
 Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif <br>
 @if ($alert->faults) Faults:
 @foreach ($alert->faults as $key => $value)
-#{{ $key }}: {{ $value['string'] }}<br>
 @endforeach 
 @if ($alert->faults) <b>Faults:</b><br>
 @foreach ($alert->faults as $key => $value)<img src="https://server/graph.php?device={{ $value['device_id'] }}&type=device_processor&width=459&height=213&lazy_w=552&from=end-72h><br>

--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -116,6 +116,7 @@ Unique-ID: {{ $alert->uid }}
 Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif
 @if ($alert->faults) Faults:
 @foreach ($alert->faults as $key => $value)
+  {{ $key }}: {{ $value['string'] }}
 @endforeach
 @endif
 Alert sent to:
@@ -280,6 +281,7 @@ Alert-ID: {{ $alert->id }} <br>
 Rule: @if ($alert->name) {{ $alert->name }} @else {{ $alert->rule }} @endif <br>
 @if ($alert->faults) Faults:
 @foreach ($alert->faults as $key => $value)
+{{ $key }}: {{ $value['string'] }}<br>
 @endforeach 
 @if ($alert->faults) <b>Faults:</b><br>
 @foreach ($alert->faults as $key => $value)<img src="https://server/graph.php?device={{ $value['device_id'] }}&type=device_processor&width=459&height=213&lazy_w=552&from=end-72h><br>


### PR DESCRIPTION
 
Using the example of port utilization caused errors when trying to use it with the new alert system.  Putting variables in curly braces and removing php calls resolved it.  Updating docs to reflect this.

Also removed examples with hash tags in the body of the template as pasting this in will cause syntax errors by the alerts script.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
