### PR TITLE
WebUI: Use of generate_url in Oxidized page

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1531,11 +1531,10 @@ function get_oxidized_nodes_list()
         " . $object['group'] . "
         </td>
         <td>
-          <button class='btn btn-default btn-sm' name='btn-refresh-node-devId" . $device['device_id'] . "' id='btn-refresh-nod
-e-devId" . $device['device_id'] . "' onclick='refresh_oxidized_node(\"" . $device['hostname'] . "\")'>
+          <button class='btn btn-default btn-sm' name='btn-refresh-node-devId" . $device['device_id'] . "' id='btn-refresh-node-devId" . $device['device_id'] . "' onclick='refresh_oxidized_node(\"" . $device['hostname'] . "\")'>
             <i class='fa fa-refresh'></i>
           </button>
-          <a href='/device/device=".$device['device_id']."/tab=showconfig/'>
+          <a href='" . generate_url(array('page' => 'device', 'device' => $device['device_id'], 'tab' => 'showconfig')) . "'>
             <i class='fa fa-align-justify fa-lg icon-theme'></i>
           </a>
         </td>


### PR DESCRIPTION
Hi,

I forgot to use generateURL in the Oxidized page, so the link may be malformed depending of webserver config. 
This patch uses generate_url instead. 

(cf 2nd remark of Ramshield in https://community.librenms.org/t/librenms-oxidized-hostname-is-empty/5413)

PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
