### PR TITLE
Fix AD auth with large SID components

### DIFF
--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -345,19 +345,19 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
 
     protected function sidFromLdap($sid)
     {
-            $sidUnpacked = unpack('H*hex', $sid);
-            $sidHex = array_shift($sidUnpacked);
-            $subAuths = unpack('H2/H2/n/N/V*', $sid);
-            if (PHP_INT_SIZE <= 4){
-                for ($i = 1; $i <= count($subAuths); $i++) {
-                    if ($subAuths[$i] < 0) {
-                        $subAuths[$i] = $subAuths[$i] + 0x100000000;
-                    }
+        $sidUnpacked = unpack('H*hex', $sid);
+        $sidHex = array_shift($sidUnpacked);
+        $subAuths = unpack('H2/H2/n/N/V*', $sid);
+        if (PHP_INT_SIZE <= 4) {
+            for ($i = 1; $i <= count($subAuths); $i++) {
+                if ($subAuths[$i] < 0) {
+                    $subAuths[$i] = $subAuths[$i] + 0x100000000;
                 }
             }
-            $revLevel = hexdec(substr($sidHex, 0, 2));
-            $authIdent = hexdec(substr($sidHex, 4, 12));
-            return 'S-'.$revLevel.'-'.$authIdent.'-'.implode('-', $subAuths);
+        }
+        $revLevel = hexdec(substr($sidHex, 0, 2));
+        $authIdent = hexdec(substr($sidHex, 4, 12));
+        return 'S-'.$revLevel.'-'.$authIdent.'-'.implode('-', $subAuths);
     }
 
     /**

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -348,6 +348,13 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
             $sidUnpacked = unpack('H*hex', $sid);
             $sidHex = array_shift($sidUnpacked);
             $subAuths = unpack('H2/H2/n/N/V*', $sid);
+            if (PHP_INT_SIZE <= 4){
+                for ($i = 1; $i <= count($subAuths); $i++) {
+                    if ($subAuths[$i] < 0) {
+                        $subAuths[$i] = $subAuths[$i] + 0x100000000;
+                    }
+                }
+            }
             $revLevel = hexdec(substr($sidHex, 0, 2));
             $authIdent = hexdec(substr($sidHex, 4, 12));
             return 'S-'.$revLevel.'-'.$authIdent.'-'.implode('-', $subAuths);


### PR DESCRIPTION
Per http://php.net/manual/en/function.unpack.php unpack on 32bit will convert large unsigned long values into signed long values, so we check for PHP_INT_SIZE and fix them up if necessary.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
