### PR TITLE
Disable used rules in template map for select them

### DIFF
--- a/html/includes/forms/attach-alert-template.inc.php
+++ b/html/includes/forms/attach-alert-template.inc.php
@@ -53,11 +53,21 @@ if (!is_numeric($_POST['template_id'])) {
         $message = "Alert rules have been attached to this template.";
     }
 }//end if
-$old_rules2 = array_diff($old_rules, $new_rules);
+//$old_rules = array_diff($old_rules, $new_rules);
+foreach ($old_rules as $rule) {
+    $rule_name[] = dbFetchCell("SELECT `name` FROM `alert_rules` WHERE `id` = ". $rule);
+}
+foreach ($new_rules as $template) {
+    $template_name[] = dbFetchCell("SELECT `name` FROM `alert_templates` WHERE `id` = ". $_POST['template_id']);
+    $nrule_name[] = dbFetchCell("SELECT `name` FROM `alert_rules` WHERE `id` = ". $template);
+}
 $response = array(
     'status'        => $status,
     'message'       => $message,
     'new_rules'     => $new_rules,
-    'old_rules2'     => $old_rules2
+    'nrule_name'     => $nrule_name,
+    'old_rules'     => $old_rules,
+    'rule_name'     => $rule_name,
+    'template_name'     => $template_name
 );
 echo _json_encode($response);

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -33,7 +33,7 @@ if (!LegacyAuth::user()->hasGlobalAdmin()) {
                     <div class="form-group">
                         <label for="rules_list">Select rules</label>
                         <select multiple="multiple" class="form-control" id="rules_list" name="rules_list" size="10">
-                            <option></option>
+                            <option>--Clear Rules--</option>
 <?php
 
 foreach (dbFetchRows("SELECT `id`,`rule`,`name` FROM `alert_rules`", array()) as $rule) {
@@ -99,17 +99,27 @@ $('#alert-template-attach').click('', function(event) {
         type: 'POST',
         url: 'ajax_form.php',
         data: { type: "attach-alert-template", template_id: template_id, rule_id: rules },
-        dataType: "html",
-        success: function(msg) {
-            if(msg.indexOf("ERROR:") <= -1) {
-                toastr.success(msg);
+        dataType: "json",
+        success: function(data) {
+            if (data.status == 'ok') {
+                toastr.success(data.message);
                 $("#attach-alert-template").modal('hide');
+                $.each( data.old_rules2, function(index, itemData){
+                    $("#rules_list option[value=" + itemData + "]").removeAttr('disabled', false);
+                    console.log ('Old Rules '+index+' - '+itemData);
+                });
+                $.each( data.new_rules, function(index, itemData){
+                    $("#rules_list option[value=" + itemData + "]").prop('disabled', true);
+                    console.log ('New Rules '+index+' - '+itemData);
+                });
             } else {
-                $('#template_error').html('<div class="alert alert-danger">'+msg+'</div>');
+                //$('#template_error').html('<div class="alert alert-danger">'+msg+'</div>');
+                toastr.error(data.message);
             }
         },
-        error: function() {
-            $("#template_error").html('<div class="alert alert-danger">The alert rules could not be attached to this template.</div>');
+        error: function(data) {
+            //$("#template_error").html('<div class="alert alert-danger">The alert rules could not be attached to this template.</div>');
+            toastr.error(data.message);
         }
     });
 });

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -37,11 +37,11 @@ if (!LegacyAuth::user()->hasGlobalAdmin()) {
 <?php
 
 foreach (dbFetchRows("SELECT `id`,`rule`,`name` FROM `alert_rules`", array()) as $rule) {
-    $is_avail = dbFetchCell("SELECT `alert_templates_id` FROM `alert_template_map` WHERE `alert_rule_id` = " . $rule['id']);
+    $is_avail = dbFetchCell("SELECT `alert_templates_id` FROM `alert_template_map` WHERE `alert_rule_id` = ?", [$rule['id']]);
     if (!isset($is_avail)) {
         echo '<option value="' . $rule['id'] . '">' . $rule['name'] . '</option>';
     } else {
-        $template = dbFetchCell("SELECT `name` FROM `alert_templates` WHERE `id` = ". $is_avail);
+        $template = dbFetchCell("SELECT `name` FROM `alert_templates` WHERE `id` = ?", [$is_avail]);
         echo '<option value="' . $rule['id'] . '" disabled>' . $rule['name'] . ' - Used in template: ' . $template . '</option>';
     }
 }
@@ -76,6 +76,7 @@ $('#attach-alert-template').on('show.bs.modal', function(e) {
             $.each( output.rule_id, function( i, elem) {
                 elem = parseInt(elem);
                 selected_items.push(elem);
+                $("#rules_list option[value='"+ elem + "']").attr('disabled', false);
             });
             $('#rules_list').val(selected_items);
         }
@@ -107,13 +108,11 @@ $('#alert-template-attach').click('', function(event) {
                 $.each( data.old_rules, function(index, itemData){
                     if (itemData != "--Clear Rules--") {
                         $("#rules_list option[value=" + itemData + "]").prop('disabled', false).text(data.rule_name[index]);
-                        console.log('Removed Rules ' + index + ' - RuleID: ' + itemData + ' - Rule: ' + data.rule_name[index]);
                     }
                 });
                 $.each( data.new_rules, function(index, itemData){
                     if (itemData != "--Clear Rules--") {
                         $("#rules_list option[value=" + itemData + "]").prop('disabled', true).text(data.nrule_name[index] + ' - Used in template:' + data.template_name[index]);
-                        console.log('Added Rules ' + index + ' - RuleID ' + itemData + ' - Template: ' + data.template_name[index] + ' - Rule:' + data.nrule_name[index]);
                     }
                 });
             } else {

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -76,7 +76,6 @@ $('#attach-alert-template').on('show.bs.modal', function(e) {
             $.each( output.rule_id, function( i, elem) {
                 elem = parseInt(elem);
                 selected_items.push(elem);
-                $("#rules_list option[value=" + elem + "]").prop('disabled', false)
             });
             $('#rules_list').val(selected_items);
         }

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -76,6 +76,7 @@ $('#attach-alert-template').on('show.bs.modal', function(e) {
             $.each( output.rule_id, function( i, elem) {
                 elem = parseInt(elem);
                 selected_items.push(elem);
+                $("#rules_list option[value=" + elem + "]").prop('disabled', false)
             });
             $('#rules_list').val(selected_items);
         }

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -104,13 +104,17 @@ $('#alert-template-attach').click('', function(event) {
             if (data.status == 'ok') {
                 toastr.success(data.message);
                 $("#attach-alert-template").modal('hide');
-                $.each( data.old_rules2, function(index, itemData){
-                    $("#rules_list option[value=" + itemData + "]").removeAttr('disabled', false);
-                    console.log ('Old Rules '+index+' - '+itemData);
+                $.each( data.old_rules, function(index, itemData){
+                    if (itemData != "--Clear Rules--") {
+                        $("#rules_list option[value=" + itemData + "]").prop('disabled', false).text(data.rule_name[index]);
+                        console.log('Removed Rules ' + index + ' - RuleID: ' + itemData + ' - Rule: ' + data.rule_name[index]);
+                    }
                 });
                 $.each( data.new_rules, function(index, itemData){
-                    $("#rules_list option[value=" + itemData + "]").prop('disabled', true);
-                    console.log ('New Rules '+index+' - '+itemData);
+                    if (itemData != "--Clear Rules--") {
+                        $("#rules_list option[value=" + itemData + "]").prop('disabled', true).text(data.nrule_name[index] + ' - Used in template:' + data.template_name[index]);
+                        console.log('Added Rules ' + index + ' - RuleID ' + itemData + ' - Template: ' + data.template_name[index] + ' - Rule:' + data.nrule_name[index]);
+                    }
                 });
             } else {
                 //$('#template_error').html('<div class="alert alert-danger">'+msg+'</div>');

--- a/html/includes/modal/attach_alert_template.inc.php
+++ b/html/includes/modal/attach_alert_template.inc.php
@@ -3,6 +3,7 @@
  * LibreNMS
  *
  * Copyright (c) 2014 Neil Lathwood <https://github.com/laf/ http://www.lathwood.co.uk/fa>
+ * Copyright (c) 2018 TheGreatDoc <https://github.com/thegreatdoc/>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -36,7 +37,13 @@ if (!LegacyAuth::user()->hasGlobalAdmin()) {
 <?php
 
 foreach (dbFetchRows("SELECT `id`,`rule`,`name` FROM `alert_rules`", array()) as $rule) {
-    echo '<option value="'.$rule['id'].'">'.$rule['name'].'</option>';
+    $is_avail = dbFetchCell("SELECT `alert_templates_id` FROM `alert_template_map` WHERE `alert_rule_id` = " . $rule['id']);
+    if (!isset($is_avail)) {
+        echo '<option value="' . $rule['id'] . '">' . $rule['name'] . '</option>';
+    } else {
+        $template = dbFetchCell("SELECT `name` FROM `alert_templates` WHERE `id` = ". $is_avail);
+        echo '<option value="' . $rule['id'] . '" disabled>' . $rule['name'] . ' - Used in template: ' . $template . '</option>';
+    }
 }
 ?>
                         </select>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

If you map 2 templates to the same rule, it will always use the one with lower id.
With this, you wont be able to map a second template to the same rule. It will disable the option and tell you what template is already mapped to that rule.