### PR TITLE
Fixed PagerDuty alert to show rule name + device as summary

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -93,10 +93,9 @@ class Pagerduty extends Transport
                 'custom_details'  => substr(implode(PHP_EOL, array_column($obj['faults'], 'string')), 0, 1020) . '....' ?: 'Test',
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
+                'summary'  => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),
             ],
         ];
-
-        $data['payload']['summary'] = ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']);
 
         $url = 'https://events.pagerduty.com/v2/enqueue';
         $client = new Client();

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -90,11 +90,13 @@ class Pagerduty extends Transport
             'event_action' => $obj['event_type'],
             'dedup_key'    => $obj['uid'],
             'payload'    => [
-                'summary'  => implode(PHP_EOL, array_column($obj['faults'], 'string')) ?: 'Test',
+                'custom_details'  => substr(implode(PHP_EOL, array_column($obj['faults'], 'string')), 0, 1020) . '....' ?: 'Test',
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
             ],
         ];
+
+        $data['payload']['summary'] = ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']);
 
         $url = 'https://events.pagerduty.com/v2/enqueue';
         $client = new Client();


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`

When I converted this I used the faults instead of the rule title like the legacy transport. This fixes that.