### PR TITLE
AD Authorization fixes

### DIFF
--- a/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
@@ -8,6 +8,7 @@ use LibreNMS\Exceptions\AuthenticationException;
 class ADAuthorizationAuthorizer extends MysqlAuthorizer
 {
     use LdapSessionCache;
+    use ADUtils;
 
     protected static $AUTH_IS_EXTERNAL = 1;
     protected static $CAN_UPDATE_PASSWORDS = 0;
@@ -73,7 +74,7 @@ class ADAuthorizationAuthorizer extends MysqlAuthorizer
         $search = ldap_search(
             $this->ldap_connection,
             Config::get('auth_ad_base_dn'),
-            ActiveDirectoryAuthorizer::userFilter($username),
+            $this->userFilter($username),
             array('samaccountname')
         );
         $entries = ldap_get_entries($this->ldap_connection, $search);
@@ -104,7 +105,7 @@ class ADAuthorizationAuthorizer extends MysqlAuthorizer
         $search = ldap_search(
             $this->ldap_connection,
             Config::get('auth_ad_base_dn'),
-            ActiveDirectoryAuthorizer::userFilter($username),
+            $this->userFilter($username),
             array('memberOf')
         );
         $entries = ldap_get_entries($this->ldap_connection, $search);
@@ -136,137 +137,21 @@ class ADAuthorizationAuthorizer extends MysqlAuthorizer
         $search = ldap_search(
             $this->ldap_connection,
             Config::get('auth_ad_base_dn'),
-            ActiveDirectoryAuthorizer::userFilter($username),
+            $this->userFilter($username),
             $attributes
         );
         $entries = ldap_get_entries($this->ldap_connection, $search);
 
         if ($entries['count']) {
-            $user_id = preg_replace('/.*-(\d+)$/', '$1', $this->sidFromLdap($entries[0]['objectsid'][0]));
+            $user_id = $this->getUseridFromSid($this->sidFromLdap($entries[0]['objectsid'][0]));
         }
 
         $this->authLdapSessionCacheSet('userid', $user_id);
         return $user_id;
     }
 
-    public function getUserlist()
+    protected function getConnection()
     {
-        $userlist = array();
-        $userhash = array();
-
-        $ldap_groups = $this->getGroupList();
-
-        foreach ($ldap_groups as $ldap_group) {
-            $search_filter = "(&(memberOf:1.2.840.113556.1.4.1941:=$ldap_group)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))";
-            if (Config::get('auth_ad_user_filter')) {
-                $search_filter = "(&{" . Config::get('auth_ad_user_filter') . $search_filter . ")";
-            }
-            $search = ldap_search($this->ldap_connection, Config::get('auth_ad_base_dn'), $search_filter, array('samaccountname','displayname','objectsid','mail'));
-            $results = ldap_get_entries($this->ldap_connection, $search);
-
-            foreach ($results as $result) {
-                if (isset($result['samaccountname'][0])) {
-                    $userid = preg_replace(
-                        '/.*-(\d+)$/',
-                        '$1',
-                        $this->sidFromLdap($result['objectsid'][0])
-                    );
-
-                    // don't make duplicates, user may be member of more than one group
-                    $userhash[$result['samaccountname'][0]] = array(
-                        'realname' => $result['displayName'][0],
-                        'user_id'  => $userid,
-                        'email'    => $result['mail'][0]
-                    );
-                }
-            }
-        }
-
-        foreach (array_keys($userhash) as $key) {
-            $userlist[] = array(
-                'username' => $key,
-                'realname' => $userhash[$key]['realname'],
-                'user_id'  => $userhash[$key]['user_id'],
-                'email'    => $userhash[$key]['email']
-            );
-        }
-
-        return $userlist;
-    }
-
-    protected function getFullname($username)
-    {
-        $attributes = array('name');
-        $result = ldap_search(
-            $this->ldap_connection,
-            Config::get('auth_ad_base_dn'),
-            ActiveDirectoryAuthorizer::userFilter($username),
-            $attributes
-        );
-        $entries = ldap_get_entries($this->ldap_connection, $result);
-        if ($entries['count'] > 0) {
-            $membername = $entries[0]['name'][0];
-        } else {
-            $membername = $username;
-        }
-
-        return $membername;
-    }
-
-
-    public function getGroupList()
-    {
-        $ldap_groups   = array();
-
-        // show all Active Directory Users by default
-        $default_group = 'Users';
-
-        if (Config::has('auth_ad_group')) {
-            if (Config::get('auth_ad_group') !== $default_group) {
-                $ldap_groups[] = Config::get('auth_ad_group');
-            }
-        }
-
-        if (!Config::has('auth_ad_groups') && !Config::has('auth_ad_group')) {
-            $ldap_groups[] = $this->getDn($default_group);
-        }
-
-        foreach (Config::get('auth_ad_groups') as $key => $value) {
-            $ldap_groups[] = $this->getDn($key);
-        }
-
-        return $ldap_groups;
-    }
-
-    protected function getDn($samaccountname)
-    {
-        $attributes = array('dn');
-        $result = ldap_search(
-            $this->ldap_connection,
-            Config::get('auth_ad_base_dn'),
-            ActiveDirectoryAuthorizer::groupFilter($samaccountname),
-            $attributes
-        );
-        $entries = ldap_get_entries($this->ldap_connection, $result);
-        if ($entries['count'] > 0) {
-            return $entries[0]['dn'];
-        } else {
-            return '';
-        }
-    }
-
-    protected function getCn($dn)
-    {
-        preg_match('/[^,]*/', $dn, $matches, PREG_OFFSET_CAPTURE, 3);
-        return $matches[0][0];
-    }
-
-    protected function sidFromLdap($sid)
-    {
-        $sidHex = unpack('H*hex', $sid);
-        $subAuths = unpack('H2/H2/n/N/V*', $sid);
-        $revLevel = hexdec(substr($sidHex, 0, 2));
-        $authIdent = hexdec(substr($sidHex, 4, 12));
-        return 'S-'.$revLevel.'-'.$authIdent.'-'.implode('-', $subAuths);
+        return $this->ldap_connection;
     }
 }

--- a/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
@@ -8,7 +8,7 @@ use LibreNMS\Exceptions\AuthenticationException;
 class ADAuthorizationAuthorizer extends MysqlAuthorizer
 {
     use LdapSessionCache;
-    use ADUtils;
+    use ActiveDirectoryCommon;
 
     protected static $AUTH_IS_EXTERNAL = 1;
     protected static $CAN_UPDATE_PASSWORDS = 0;
@@ -54,7 +54,7 @@ class ADAuthorizationAuthorizer extends MysqlAuthorizer
     public function authenticate($username, $password)
     {
         if ($this->userExists($username)) {
-            $this->addUser($username, null);
+//            $this->addUser($username, null, $this->getUserlevel($username));
             return true;
         }
 

--- a/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/ADAuthorizationAuthorizer.php
@@ -54,7 +54,6 @@ class ADAuthorizationAuthorizer extends MysqlAuthorizer
     public function authenticate($username, $password)
     {
         if ($this->userExists($username)) {
-//            $this->addUser($username, null, $this->getUserlevel($username));
             return true;
         }
 

--- a/LibreNMS/Authentication/ADUtils.php
+++ b/LibreNMS/Authentication/ADUtils.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * ADUtils.php
+ *
+ * Common code from AD auth modules
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Authentication;
+
+use LibreNMS\Config;
+
+trait ADUtils
+{
+    protected function getUseridFromSid($sid)
+    {
+        return preg_replace('/.*-(\d+)$/', '$1', $sid);
+    }
+
+    protected function sidFromLdap($sid)
+    {
+        $sidUnpacked = unpack('H*hex', $sid);
+        $sidHex = array_shift($sidUnpacked);
+        $subAuths = unpack('H2/H2/n/N/V*', $sid);
+        if (PHP_INT_SIZE <= 4) {
+            for ($i = 1; $i <= count($subAuths); $i++) {
+                if ($subAuths[$i] < 0) {
+                    $subAuths[$i] = $subAuths[$i] + 0x100000000;
+                }
+            }
+        }
+        $revLevel = hexdec(substr($sidHex, 0, 2));
+        $authIdent = hexdec(substr($sidHex, 4, 12));
+        return 'S-'.$revLevel.'-'.$authIdent.'-'.implode('-', $subAuths);
+    }
+
+    protected function getCn($dn)
+    {
+        $dn = str_replace('\\,', '~C0mmA~', $dn);
+        preg_match('/[^,]*/', $dn, $matches, PREG_OFFSET_CAPTURE, 3);
+        return str_replace('~C0mmA~', ',', $matches[0][0]);
+    }
+
+    protected function getDn($samaccountname)
+    {
+        $link_identifier = $this->getConnection();
+        $attributes = ['dn'];
+        $result = ldap_search(
+            $link_identifier,
+            Config::get('auth_ad_base_dn'),
+            $this->groupFilter($samaccountname),
+            $attributes
+        );
+        $entries = ldap_get_entries($link_identifier, $result);
+        if ($entries['count'] > 0) {
+            return $entries[0]['dn'];
+        } else {
+            return '';
+        }
+    }
+
+    protected function userFilter($username)
+    {
+        // don't return disabled users
+        $user_filter = "(&(samaccountname=$username)(!(useraccountcontrol:1.2.840.113556.1.4.803:=2))";
+
+        $extra = Config::get('auth_ad_user_filter');
+        if ($extra) {
+            $user_filter .= $extra;
+        }
+        $user_filter .= ')';
+
+        return $user_filter;
+    }
+
+    protected function groupFilter($groupname)
+    {
+        $group_filter = "(samaccountname=$groupname)";
+
+        $extra = Config::get('auth_ad_group_filter');
+        if ($extra) {
+            $group_filter = "(&$extra$group_filter)";
+        }
+
+        return $group_filter;
+    }
+
+    protected function getFullname($username)
+    {
+        $connection = $this->getConnection();
+        $attributes = ['name'];
+        $result = ldap_search(
+            $connection,
+            Config::get('auth_ad_base_dn'),
+            $this->userFilter($username),
+            $attributes
+        );
+        $entries = ldap_get_entries($connection, $result);
+        if ($entries['count'] > 0) {
+            $membername = $entries[0]['name'][0];
+        } else {
+            $membername = $username;
+        }
+
+        return $membername;
+    }
+
+    public function getGroupList()
+    {
+        $ldap_groups   = array();
+
+        // show all Active Directory Users by default
+        $default_group = 'Users';
+
+        if (Config::has('auth_ad_group')) {
+            if (Config::get('auth_ad_group') !== $default_group) {
+                $ldap_groups[] = Config::get('auth_ad_group');
+            }
+        }
+
+        if (!Config::has('auth_ad_groups') && !Config::has('auth_ad_group')) {
+            $ldap_groups[] = $this->getDn($default_group);
+        }
+
+        foreach (Config::get('auth_ad_groups') as $key => $value) {
+            $ldap_groups[] = $this->getDn($key);
+        }
+
+        return $ldap_groups;
+    }
+
+    public function getUserlist()
+    {
+        $connection = $this->getConnection();
+
+        $userlist = array();
+        $ldap_groups = $this->getGroupList();
+
+        foreach ($ldap_groups as $ldap_group) {
+            $search_filter = "(&(memberOf:1.2.840.113556.1.4.1941:=$ldap_group)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))";
+            if (Config::get('auth_ad_user_filter')) {
+                $search_filter = "(&" . Config::get('auth_ad_user_filter') . $search_filter .")";
+            }
+            $attributes = array('samaccountname', 'displayname', 'objectsid', 'mail');
+            $search = ldap_search($connection, Config::get('auth_ad_base_dn'), $search_filter, $attributes);
+            $results = ldap_get_entries($connection, $search);
+
+            foreach ($results as $result) {
+                if (isset($result['samaccountname'][0])) {
+                    $userlist[$result['samaccountname'][0]] = $this->userFromAd($result);
+                }
+            }
+        }
+
+        return array_values($userlist);
+    }
+
+    /**
+     * Generate a user array from an AD LDAP entry
+     * Must have the attributes: objectsid, samaccountname, displayname, mail
+     * @internal
+     *
+     * @param $entry
+     * @return array
+     */
+    protected function userFromAd($entry)
+    {
+        return array(
+            'user_id' => $this->getUseridFromSid($this->sidFromLdap($entry['objectsid'][0])),
+            'username' => $entry['samaccountname'][0],
+            'realname' => $entry['displayname'][0],
+            'email' => isset($entry['mail'][0]) ? $entry['mail'][0] : null,
+            'descr' => '',
+            'level' => $this->getUserlevel($entry['samaccountname'][0]),
+            'can_modify_passwd' => 0,
+        );
+    }
+}

--- a/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
+++ b/LibreNMS/Authentication/ActiveDirectoryAuthorizer.php
@@ -10,6 +10,8 @@ use LibreNMS\Exceptions\AuthenticationException;
 
 class ActiveDirectoryAuthorizer extends AuthorizerBase
 {
+    use ADUtils;
+
     protected static $CAN_UPDATE_PASSWORDS = 0;
 
     protected $ldap_connection;
@@ -58,8 +60,6 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
     protected function userInGroup($username, $groupname)
     {
         // check if user is member of the given group or nested groups
-
-
         $search_filter = "(&(objectClass=group)(cn=$groupname))";
 
         // get DN for auth_ad_group
@@ -93,7 +93,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
             Config::get('auth_ad_base_dn'),
             // add 'LDAP_MATCHING_RULE_IN_CHAIN to the user filter to search for $username in nested $group_dn
             // limiting to "DN" for shorter array
-            "(&" . static::userFilter($username) . "(memberOf:1.2.840.113556.1.4.1941:=$group_dn))",
+            "(&" . $this->userFilter($username) . "(memberOf:1.2.840.113556.1.4.1941:=$group_dn))",
             array("DN")
         );
         $entries = ldap_get_entries($this->ldap_connection, $search);
@@ -108,7 +108,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $search = ldap_search(
             $this->ldap_connection,
             Config::get('auth_ad_base_dn'),
-            static::userFilter($username),
+            $this->userFilter($username),
             array('samaccountname')
         );
         $entries = ldap_get_entries($this->ldap_connection, $search);
@@ -155,7 +155,7 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         $search = ldap_search(
             $this->ldap_connection,
             Config::get('auth_ad_base_dn'),
-            static::userFilter($username),
+            $this->userFilter($username),
             $attributes
         );
         $entries = ldap_get_entries($this->ldap_connection, $search);
@@ -200,164 +200,6 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         }
 
         return array();
-    }
-
-
-    public function getUserlist()
-    {
-        $this->bind(); // make sure we called bind
-
-        $userlist = array();
-        $ldap_groups = $this->getGroupList();
-
-        foreach ($ldap_groups as $ldap_group) {
-            $search_filter = "(&(memberOf:1.2.840.113556.1.4.1941:=$ldap_group)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))";
-            if (Config::get('auth_ad_user_filter')) {
-                $search_filter = "(&" . Config::get('auth_ad_user_filter') . $search_filter .")";
-            }
-            $attributes = array('samaccountname', 'displayname', 'objectsid', 'mail');
-            $search = ldap_search($this->ldap_connection, Config::get('auth_ad_base_dn'), $search_filter, $attributes);
-            $results = ldap_get_entries($this->ldap_connection, $search);
-
-            foreach ($results as $result) {
-                if (isset($result['samaccountname'][0])) {
-                    $userlist[$result['samaccountname'][0]] = $this->userFromAd($result);
-                }
-            }
-        }
-
-        return array_values($userlist);
-    }
-
-    /**
-     * Generate a user array from an AD LDAP entry
-     * Must have the attributes: objectsid, samaccountname, displayname, mail
-     * @internal
-     *
-     * @param $entry
-     * @return array
-     */
-    protected function userFromAd($entry)
-    {
-        return array(
-            'user_id' => $this->getUseridFromSid($this->sidFromLdap($entry['objectsid'][0])),
-            'username' => $entry['samaccountname'][0],
-            'realname' => $entry['displayname'][0],
-            'email' => isset($entry['mail'][0]) ? $entry['mail'][0] : null,
-            'descr' => '',
-            'level' => $this->getUserlevel($entry['samaccountname'][0]),
-            'can_modify_passwd' => 0,
-        );
-    }
-
-    protected function getEmail($username)
-    {
-        $this->bind(); // make sure we called bind
-
-        $attributes = array('mail');
-        $search = ldap_search(
-            $this->ldap_connection,
-            Config::get('auth_ad_base_dn'),
-            static::userFilter($username),
-            $attributes
-        );
-        $result = ldap_get_entries($this->ldap_connection, $search);
-        unset($result[0]['mail']['count']);
-        return current($result[0]['mail']);
-    }
-
-    protected function getFullname($username)
-    {
-        $this->bind(); // make sure we called bind
-
-        $attributes = array('name');
-        $result = ldap_search(
-            $this->ldap_connection,
-            Config::get('auth_ad_base_dn'),
-            static::userFilter($username),
-            $attributes
-        );
-        $entries = ldap_get_entries($this->ldap_connection, $result);
-        if ($entries['count'] > 0) {
-            $membername = $entries[0]['name'][0];
-        } else {
-            $membername = $username;
-        }
-
-        return $membername;
-    }
-
-
-    public function getGroupList()
-    {
-        $ldap_groups   = array();
-
-        // show all Active Directory Users by default
-        $default_group = 'Users';
-
-        if (Config::has('auth_ad_group')) {
-            if (Config::get('auth_ad_group') !== $default_group) {
-                $ldap_groups[] = Config::get('auth_ad_group');
-            }
-        }
-
-        if (!Config::has('auth_ad_groups') && !Config::has('auth_ad_group')) {
-            $ldap_groups[] = $this->getDn($default_group);
-        }
-
-        foreach (Config::get('auth_ad_groups') as $key => $value) {
-            $ldap_groups[] = $this->getDn($key);
-        }
-
-        return $ldap_groups;
-    }
-
-    protected function getDn($samaccountname)
-    {
-        $this->bind(); // make sure we called bind
-
-        $attributes = array('dn');
-        $result = ldap_search(
-            $this->ldap_connection,
-            Config::get('auth_ad_base_dn'),
-            static::groupFilter($samaccountname),
-            $attributes
-        );
-        $entries = ldap_get_entries($this->ldap_connection, $result);
-        if ($entries['count'] > 0) {
-            return $entries[0]['dn'];
-        } else {
-            return '';
-        }
-    }
-
-    protected function getCn($dn)
-    {
-        $dn = str_replace('\\,', '~C0mmA~', $dn);
-        preg_match('/[^,]*/', $dn, $matches, PREG_OFFSET_CAPTURE, 3);
-        return str_replace('~C0mmA~', ',', $matches[0][0]);
-    }
-
-    protected function getUseridFromSid($sid)
-    {
-        return preg_replace('/.*-(\d+)$/', '$1', $sid);
-    }
-
-    protected function sidFromLdap($sid)
-    {
-        $sidUnpacked = unpack('H*hex', $sid);
-        $sidHex = array_shift($sidUnpacked);
-        $subAuths = unpack('H2/H2/n/N/V*', $sid);
-        if (PHP_INT_SIZE <= 4) {
-            for ($i = 1; $i <= count($subAuths); $i++) {
-                if ($subAuths[$i] < 0) {
-                    $subAuths[$i] = $subAuths[$i] + 0x100000000;
-                }
-            }
-        }
-        $revLevel = hexdec(substr($sidHex, 0, 2));
-        $authIdent = hexdec(substr($sidHex, 4, 12));
-        return 'S-'.$revLevel.'-'.$authIdent.'-'.implode('-', $subAuths);
     }
 
     /**
@@ -434,29 +276,9 @@ class ActiveDirectoryAuthorizer extends AuthorizerBase
         ldap_set_option($this->ldap_connection, LDAP_OPT_PROTOCOL_VERSION, 3);
     }
 
-    public static function userFilter($username)
+    protected function getConnection()
     {
-        // don't return disabled users
-        $user_filter = "(&(samaccountname=$username)(!(useraccountcontrol:1.2.840.113556.1.4.803:=2))";
-
-        $extra = Config::get('auth_ad_user_filter');
-        if ($extra) {
-            $user_filter .= $extra;
-        }
-        $user_filter .= ')';
-
-        return $user_filter;
-    }
-
-    public static function groupFilter($groupname)
-    {
-        $group_filter = "(samaccountname=$groupname)";
-
-        $extra = Config::get('auth_ad_group_filter');
-        if ($extra) {
-            $group_filter = "(&$extra$group_filter)";
-        }
-
-        return $group_filter;
+        $this->bind(); // make sure connected and bound
+        return $this->ldap_connection;
     }
 }

--- a/LibreNMS/Authentication/ActiveDirectoryCommon.php
+++ b/LibreNMS/Authentication/ActiveDirectoryCommon.php
@@ -226,4 +226,11 @@ trait ActiveDirectoryCommon
         $entry = ldap_get_entries($connection, $search);
         return substr($this->sidFromLdap($entry[0]['objectsid'][0]), 0, 41);
     }
+
+    /**
+     * Provide a connected and bound ldap connection resource
+     *
+     * @return resource
+     */
+    abstract protected function getConnection();
 }

--- a/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php
@@ -47,6 +47,8 @@ use Session;
 
 class LdapAuthorizationAuthorizer extends AuthorizerBase
 {
+    use LdapSessionCache;
+
     protected $ldap_connection;
     protected static $AUTH_IS_EXTERNAL = 1;
 
@@ -243,48 +245,6 @@ class LdapAuthorizationAuthorizer extends AuthorizerBase
 
         return $membername;
     }
-
-
-    protected function authLdapSessionCacheGet($attr)
-    {
-        $ttl = Config::get('auth_ldap_cache_ttl', 300);
-
-        // no session, don't cache
-        if (!class_exists('Session')) {
-            return null;
-        }
-
-        // auth_ldap cache present in this session?
-        if (!Session::has('auth_ldap')) {
-            return null;
-        }
-
-        $cache = Session::get('auth_ldap');
-
-        // $attr present in cache?
-        if (! isset($cache[$attr])) {
-            return null;
-        }
-
-        // Value still valid?
-        if (time() - $cache[$attr]['last_updated'] >= $ttl) {
-            return null;
-        }
-
-        $cache[$attr]['value'];
-    }
-
-
-    protected function authLdapSessionCacheSet($attr, $value)
-    {
-        if (class_exists('Session')) {
-            Session::put($attr, [
-                'value' => $value,
-                'last_updated' => Carbon::now(),
-            ]);
-        }
-    }
-
 
     public function getGroupList()
     {

--- a/LibreNMS/Authentication/LdapSessionCache.php
+++ b/LibreNMS/Authentication/LdapSessionCache.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * LdapSessionCache.php
+ *
+ * Session cache for ldap queries
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Authentication;
+
+use LibreNMS\Config;
+use Session;
+
+trait LdapSessionCache
+{
+    protected function authLdapSessionCacheGet($attr)
+    {
+        $ttl = Config::get('auth_ldap_cache_ttl', 300);
+
+        // no session, don't cache
+        if (!class_exists('Session')) {
+            return null;
+        }
+
+        // auth_ldap cache present in this session?
+        if (!Session::has('auth_ldap')) {
+            return null;
+        }
+
+        $cache = Session::get('auth_ldap');
+
+        // $attr present in cache?
+        if (! isset($cache[$attr])) {
+            return null;
+        }
+
+        // Value still valid?
+        if (time() - $cache[$attr]['last_updated'] >= $ttl) {
+            return null;
+        }
+
+        $cache[$attr]['value'];
+    }
+
+
+    protected function authLdapSessionCacheSet($attr, $value)
+    {
+        if (class_exists('Session')) {
+            Session::put($attr, [
+                'value' => $value,
+                'last_updated' => Carbon::now(),
+            ]);
+        }
+    }
+}

--- a/LibreNMS/Authentication/LdapSessionCache.php
+++ b/LibreNMS/Authentication/LdapSessionCache.php
@@ -57,7 +57,7 @@ trait LdapSessionCache
             return null;
         }
 
-        $cache[$attr]['value'];
+        return $cache[$attr]['value'];
     }
 
 

--- a/LibreNMS/Authentication/LdapSessionCache.php
+++ b/LibreNMS/Authentication/LdapSessionCache.php
@@ -25,6 +25,7 @@
 
 namespace LibreNMS\Authentication;
 
+use Carbon\Carbon;
 use LibreNMS\Config;
 use Session;
 

--- a/LibreNMS/Authentication/MysqlAuthorizer.php
+++ b/LibreNMS/Authentication/MysqlAuthorizer.php
@@ -104,7 +104,7 @@ class MysqlAuthorizer extends AuthorizerBase
             $user_id = $new_user->user_id;
 
             // set auth_id
-            $new_user->auth_id = $user_id;
+            $new_user->auth_id = $this->getUserid($username);
             $new_user->save();
 
             if ($user_id) {

--- a/app/Providers/LegacyUserProvider.php
+++ b/app/Providers/LegacyUserProvider.php
@@ -32,6 +32,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 use LibreNMS\Authentication\LegacyAuth;
 use LibreNMS\Exceptions\AuthenticationException;
+use Log;
 use Request;
 use Session;
 use Toastr;
@@ -199,7 +200,7 @@ class LegacyUserProvider implements UserProvider
             }
 
             if (empty($new_user)) {
-                Toastr::info("No user ($auth_id) [$username]");
+                Log::error("Auth Error ($type): No user ($auth_id) [$username]");
                 return null;
             }
         }


### PR DESCRIPTION
Remove mres() and $_SESSION usage.
Remove broken addUser function and use Mysql addUser.
Extract common AD auth code to ADUtils

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
