### PR TITLE
device: Add Allied Telesis oxidized syslog hook support

### DIFF
--- a/scripts/syslog-notify-oxidized.php
+++ b/scripts/syslog-notify-oxidized.php
@@ -33,4 +33,6 @@ if (preg_match('/(SYS-(SW[0-9]+-)?5-CONFIG_I|VSHD-5-VSHD_SYSLOG_CONFIG_I): Confi
     oxidized_node_update($hostname, $msg);
 } elseif (preg_match('/UI_COMMIT: User \\\\\'(?P<user>.+?)\\\\\' .*/', $msg, $matches)) {
     oxidized_node_update($hostname, $msg, $matches['user']);
+} elseif (preg_match('/IMI.+.Startup-config saved on .+ by (?P<user>.+) via .*/', $msg, $matches)) {
+         oxidized_node_update($hostname, $msg, $matches['user']); //Alliedware Plus devices. Requires at least V5.4.8-2.1
 }


### PR DESCRIPTION
This patch adds support for Allied Telesis AW+ devices running at least 5.4.8-2.1 the ability to automatically have oxidized pull configs when the device config has been saved.

Syslog hook for LibreNMS config.php
```$config['os']['awplus']['syslog_hook'][] = Array  ('regex' => '/IMI.+.Startup-config saved on/', 'script' => '/opt/librenms/scripts/syslog-notify-oxidized.php');```

Note: V5.4.8-2.1 should be released on roughly Nov 2 2018.

Refer to the following for latest release notes:

https://www.alliedtelesis.com/documents/release-notes-alliedware-plus-548

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
