### PR TITLE
Cisco: change notKnown status to unknown and not warning

### DIFF
--- a/includes/discovery/sensors/state/cisco.inc.php
+++ b/includes/discovery/sensors/state/cisco.inc.php
@@ -50,7 +50,7 @@ foreach ($tables as $tablevalue) {
         if ($state_index_id !== null) {
             if ($state_name == 'cRFStatusUnitState' || $state_name == 'cRFStatusPeerUnitState') {
                 $states = array(
-                    array($state_index_id,'notKnown',0,1,1) ,
+                    array($state_index_id,'notKnown',0,1,3) ,
                     array($state_index_id,'disabled',0,2,0) ,
                     array($state_index_id,'initialization',0,3,1) ,
                     array($state_index_id,'negotiation',0,4,1) ,

--- a/includes/discovery/sensors/state/cisco.inc.php
+++ b/includes/discovery/sensors/state/cisco.inc.php
@@ -44,102 +44,92 @@ foreach ($tables as $tablevalue) {
 
         //Create State Index
         $state_name = $tablevalue[2];
-        $state_index_id = create_state_index($state_name);
 
         //Create State Translation
         if ($state_index_id !== null) {
             if ($state_name == 'cRFStatusUnitState' || $state_name == 'cRFStatusPeerUnitState') {
-                $states = array(
-                    array($state_index_id,'notKnown',0,1,3) ,
-                    array($state_index_id,'disabled',0,2,0) ,
-                    array($state_index_id,'initialization',0,3,1) ,
-                    array($state_index_id,'negotiation',0,4,1) ,
-                    array($state_index_id,'standbyCold',0,5,1) ,
-                    array($state_index_id,'standbyColdConfig',0,6,1) ,
-                    array($state_index_id,'standbyColdFileSys',0,7,1) ,
-                    array($state_index_id,'standbyColdBulk',0,8,1) ,
-                    array($state_index_id,'standbyHot',0,9,0) ,
-                    array($state_index_id,'activeFast',0,10,1) ,
-                    array($state_index_id,'activeDrain',0,11,1) ,
-                    array($state_index_id,'activePreconfig',0,12,1) ,
-                    array($state_index_id,'activePostconfig',0,13,1) ,
-                    array($state_index_id,'active',0,14,0) ,
-                    array($state_index_id,'activeExtraload',0,15,1) ,
-                    array($state_index_id,'activeHandback',0,16,1)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'notKnown'],
+                    ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'disabled'],
+                    ['value' => 3, 'generic' => 1, 'graph' => 0, 'descr' => 'initialization'],
+                    ['value' => 4, 'generic' => 1, 'graph' => 0, 'descr' => 'negotiation'],
+                    ['value' => 5, 'generic' => 1, 'graph' => 0, 'descr' => 'standbyCold'],
+                    ['value' => 6, 'generic' => 1, 'graph' => 0, 'descr' => 'standbyColdConfig'],
+                    ['value' => 7, 'generic' => 1, 'graph' => 0, 'descr' => 'standbyColdFileSys'],
+                    ['value' => 8, 'generic' => 1, 'graph' => 0, 'descr' => 'standbyColdBulk'],
+                    ['value' => 9, 'generic' => 0, 'graph' => 0, 'descr' => 'standbyHot'],
+                    ['value' => 10, 'generic' => 1, 'graph' => 0, 'descr' => 'activeFast'],
+                    ['value' => 11, 'generic' => 1, 'graph' => 0, 'descr' => 'activeDrain'],
+                    ['value' => 12, 'generic' => 1, 'graph' => 0, 'descr' => 'activePreconfig'],
+                    ['value' => 13, 'generic' => 1, 'graph' => 0, 'descr' => 'activePostconfig'],
+                    ['value' => 14, 'generic' => 0, 'graph' => 0, 'descr' => 'active'],
+                    ['value' => 15, 'generic' => 1, 'graph' => 0, 'descr' => 'activeExtraload'],
+                    ['value' => 16, 'generic' => 1, 'graph' => 0, 'descr' => 'activeHandback']
+                ];
             } elseif ($state_name == 'cRFCfgRedundancyOperMode') {
-                $states = array(
-                    array($state_index_id,'nonRedundant',0,1,0) ,
-                    array($state_index_id,'staticLoadShareNonRedundant',0,2,0) ,
-                    array($state_index_id,'dynamicLoadShareNonRedundant',0,3,0) ,
-                    array($state_index_id,'staticLoadShareRedundant',0,4,0) ,
-                    array($state_index_id,'dynamicLoadShareRedundant',0,5,0) ,
-                    array($state_index_id,'coldStandbyRedundant',0,6,0) ,
-                    array($state_index_id,'warmStandbyRedundant',0,7,0) ,
-                    array($state_index_id,'hotStandbyRedundant',0,8,0)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 0, 'graph' => 0, 'descr' => 'nonRedundant'],
+                    ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'staticLoadShareNonRedundant'],
+                    ['value' => 3, 'generic' => 0, 'graph' => 0, 'descr' => 'dynamicLoadShareNonRedundant'],
+                    ['value' => 4, 'generic' => 0, 'graph' => 0, 'descr' => 'staticLoadShareRedundant'],
+                    ['value' => 5, 'generic' => 0, 'graph' => 0, 'descr' => 'dynamicLoadShareRedundant'],
+                    ['value' => 6, 'generic' => 0, 'graph' => 0, 'descr' => 'coldStandbyRedundant'],
+                    ['value' => 7, 'generic' => 0, 'graph' => 0, 'descr' => 'warmStandbyRedundant'],
+                    ['value' => 8, 'generic' => 0, 'graph' => 0, 'descr' => 'hotStandbyRedundant']
+                ];
             } elseif ($state_name == 'cswRingRedundant') {
-                $states = array(
-                    array($state_index_id,'true',0,1,0) ,
-                    array($state_index_id,'false',0,2,2)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 0, 'graph' => 0, 'descr' => 'true'],
+                    ['value' => 2, 'generic' => 2, 'graph' => 0, 'descr' => 'false']
+                ];
             } elseif ($state_name == 'cswSwitchRole') {
-                $states = array(
-                    array($state_index_id,'master',0,1,0) ,
-                    array($state_index_id,'member',0,2,0) ,
-                    array($state_index_id,'notMember',0,3,0) ,
-                    array($state_index_id,'standby',0,4,0)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 0, 'graph' => 0, 'descr' => 'master'],
+                    ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'member'],
+                    ['value' => 3, 'generic' => 0, 'graph' => 0, 'descr' => 'notMember'],
+                    ['value' => 4, 'generic' => 0, 'graph' => 0, 'descr' => 'standby']
+                ];
             } elseif ($state_name == 'cswSwitchState') {
-                $states = array(
-                    array($state_index_id,'waiting',0,1,1) ,
-                    array($state_index_id,'progressing',0,2,1) ,
-                    array($state_index_id,'added',0,3,1) ,
-                    array($state_index_id,'ready',0,4,0) ,
-                    array($state_index_id,'sdmMismatch',0,5,2) ,
-                    array($state_index_id,'verMismatch',0,6,2) ,
-                    array($state_index_id,'featureMismatch',0,7,2) ,
-                    array($state_index_id,'newMasterInit',0,8,2) ,
-                    array($state_index_id,'provisioned',0,9,1) ,
-                    array($state_index_id,'invalid',0,10,2) ,
-                    array($state_index_id,'removed',0,11,1)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 1, 'graph' => 0, 'descr' => 'waiting'],
+                    ['value' => 2, 'generic' => 1, 'graph' => 0, 'descr' => 'progressing'],
+                    ['value' => 3, 'generic' => 1, 'graph' => 0, 'descr' => 'added'],
+                    ['value' => 4, 'generic' => 0, 'graph' => 0, 'descr' => 'ready'],
+                    ['value' => 5, 'generic' => 2, 'graph' => 0, 'descr' => 'sdmMismatch'],
+                    ['value' => 6, 'generic' => 2, 'graph' => 0, 'descr' => 'verMismatch'],
+                    ['value' => 7, 'generic' => 2, 'graph' => 0, 'descr' => 'featureMismatch'],
+                    ['value' => 8, 'generic' => 2, 'graph' => 0, 'descr' => 'newMasterInit'],
+                    ['value' => 9, 'generic' => 1, 'graph' => 0, 'descr' => 'provisioned'],
+                    ['value' => 10, 'generic' => 2, 'graph' => 0, 'descr' => 'invalid'],
+                    ['value' => 11, 'generic' => 1, 'graph' => 0, 'descr' => 'removed']
+                ];
             } elseif ($state_name == 'cefcFRUPowerOperStatus') {
-                $states = array(
-                    array($state_index_id,'off (other)',0,1,2) ,
-                    array($state_index_id,'on',0,2,0) ,
-                    array($state_index_id,'off (admin)',0,3,1) ,
-                    array($state_index_id,'off (denied)',0,4,2) ,
-                    array($state_index_id,'off (environmental)',0,5,2) ,
-                    array($state_index_id,'off (temperature)',0,6,2) ,
-                    array($state_index_id,'off (fan)',0,7,2) ,
-                    array($state_index_id,'failed',0,8,2) ,
-                    array($state_index_id,'on (fan failed)',0,9,1) ,
-                    array($state_index_id,'off (cooling)',0,10,2) ,
-                    array($state_index_id,'off (connector rating)',0,11,2) ,
-                    array($state_index_id,'on (no inline power)',0,12,1)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 2, 'graph' => 0, 'descr' => 'off (other)'],
+                    ['value' => 2, 'generic' => 0, 'graph' => 0, 'descr' => 'on'],
+                    ['value' => 3, 'generic' => 1, 'graph' => 0, 'descr' => 'off (admin)'],
+                    ['value' => 4, 'generic' => 2, 'graph' => 0, 'descr' => 'off (denied)'],
+                    ['value' => 5, 'generic' => 2, 'graph' => 0, 'descr' => 'off (environmental)'],
+                    ['value' => 6, 'generic' => 2, 'graph' => 0, 'descr' => 'off (temperature)'],
+                    ['value' => 7, 'generic' => 2, 'graph' => 0, 'descr' => 'off (fan)'],
+                    ['value' => 8, 'generic' => 2, 'graph' => 0, 'descr' => 'failed'],
+                    ['value' => 9, 'generic' => 1, 'graph' => 0, 'descr' => 'on (fan failed)'],
+                    ['value' => 10, 'generic' => 2, 'graph' => 0, 'descr' => 'off (cooling)'],
+                    ['value' => 11, 'generic' => 2, 'graph' => 0, 'descr' => 'off (connector rating)'],
+                    ['value' => 12, 'generic' => 1, 'graph' => 0, 'descr' => 'on (no inline power)']
+                ];
             } else {
-                $states = array(
-                    array($state_index_id,'normal',0,1,0) ,
-                    array($state_index_id,'warning',0,2,1) ,
-                    array($state_index_id,'critical',0,3,2) ,
-                    array($state_index_id,'shutdown',0,4,3) ,
-                    array($state_index_id,'notPresent',0,5,3) ,
-                    array($state_index_id,'notFunctioning',0,6,2)
-                );
+                $states = [
+                    ['value' => 1, 'generic' => 0, 'graph' => 0, 'descr' => 'normal'],
+                    ['value' => 2, 'generic' => 1, 'graph' => 0, 'descr' => 'warning'],
+                    ['value' => 3, 'generic' => 2, 'graph' => 0, 'descr' => 'critical'],
+                    ['value' => 4, 'generic' => 3, 'graph' => 0, 'descr' => 'shutdown'],
+                    ['value' => 5, 'generic' => 3, 'graph' => 0, 'descr' => 'notPresent'],
+                    ['value' => 6, 'generic' => 2, 'graph' => 0, 'descr' => 'notFunctioning']
+                ];
             }
 
-            foreach ($states as $value) {
-                $insert = array(
-                    'state_index_id' => $value[0],
-                    'state_descr' => $value[1],
-                    'state_draw_graph' => $value[2],
-                    'state_value' => $value[3],
-                    'state_generic_value' => $value[4]
-                );
-                dbInsert($insert, 'state_translations');
-            }
+            create_state_index($state_name, $states);
         }
 
         foreach ($temp as $index => $entry) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


------------------------------------

The cRFStatusPeerUnitState is used for the VSS Peer Status, problem is that a lot of devices return a warning because the VSS Peer State is in warning when the status is "notKnown".

But a notKnown status should be categorized as LibreNMS "Unknown" and gray but not as a "Warning" and yellow status.