### PR TITLE
Fix remember me

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -33,7 +33,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\Session\Middleware\AuthenticateSession::class,
+//            \Illuminate\Session\Middleware\AuthenticateSession::class, // Works in Laravel 5.5
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \App\Http\Middleware\LegacyExternalAuth::class,


### PR DESCRIPTION
remember me and AuthenticateSession are incompatible on Laravel 5.4

https://github.com/laravel/framework/commit/6ca154f2b6713da598082cdaf7a1a042fc3e648a

More info: https://kfirba.me/blog/the-undocumented-authenticatesession-middleware-decoded

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
