### PR TITLE
Check sysDescr for JunOS version.

### DIFF
--- a/includes/polling/os/junos.inc.php
+++ b/includes/polling/os/junos.inc.php
@@ -22,6 +22,10 @@ if (is_numeric($srx_sess_data[0]['jnxJsSPUMonitoringCurrentFlowSession'])) {
 
 $version = snmp_get($device, 'jnxVirtualChassisMemberSWVersion.0', '-Oqv', 'JUNIPER-VIRTUALCHASSIS-MIB');
 if (empty($version)) {
+    preg_match('/kernel JUNOS (\S+),/', $device['sysDescr'], $jun_ver);
+    $version = $jun_ver[1];
+}
+if (empty($version)) {
     preg_match('/\[(.+)\]/', snmp_get($device, '.1.3.6.1.2.1.25.6.3.1.2.2', '-Oqv', 'HOST-RESOURCES-MIB'), $jun_ver);
     $version = $jun_ver[1];
 }


### PR DESCRIPTION
Some JunOS routers (seems to be mainly larger ones like MX480/960+) doesn't have the OID checked for software version. This patch checks sysDescr, where it seems to be mentioned in most (all?) models.

This saves an SNMP query each poll too.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
