### PR TITLE
Add feature to sort alert schedules by status

### DIFF
--- a/html/includes/table/alert-schedule.inc.php
+++ b/html/includes/table/alert-schedule.inc.php
@@ -31,7 +31,13 @@ if (empty($total)) {
     $total = 0;
 }
 
-if (!isset($sort) || empty($sort)) {
+if (isset($sort) && !empty($sort)) {
+    list($sort_column, $sort_order) = explode(' ', trim($sort));
+    if ($sort_column == 'status') {
+        $sort_by_status = true;
+        $sort = "`S`.`start`  $sort_order";
+    }
+} else {
     $sort = '`S`.`start` DESC ';
 }
 
@@ -106,6 +112,18 @@ foreach (dbFetchRows($sql, $param) as $schedule) {
         'id'                    => $schedule['schedule_id'],
         'status'                => $status,
     );
+}
+
+if (isset($sort_by_status) && $sort_by_status) {
+    if ($sort_order == 'asc') {
+        usort($response, function ($a, $b) {
+            return $a['status'] - $b['status'];
+        });
+    } else {
+        usort($response, function ($a, $b) {
+            return $b['status'] - $a['status'];
+        });
+    }
 }
 
 $output = array(

--- a/html/pages/alert-schedule.inc.php
+++ b/html/pages/alert-schedule.inc.php
@@ -43,7 +43,7 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
                     <th data-column-id="end_recurring_hr">End recurring hr</th>
                     <th data-column-id="recurring_day" data-sortable="false" data-searchable="false">Recurring on days</th>
                     <th data-column-id="actions" data-sortable="false" data-searchable="false" data-formatter="commands">Actions</th>
-                    <th data-column-id="status" data-sortable="false" data-searchable="false" data-formatter="schedstatus">Status</th>
+                    <th data-column-id="status" data-searchable="false" data-formatter="schedstatus">Status</th>
                 </tr>
             </thead>
         </table>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


It's should be very useful to sort alert status by status.