### PR TITLE
[WIP] Allow librenms to execute SNMP via SSH

### DIFF
--- a/addhost.php
+++ b/addhost.php
@@ -75,7 +75,7 @@ if (isset($options['j'])) {
 
     $jump = explode('@', $options['j']);
 
-    if (count($jump === 2)) {
+    if (count($jump) === 2) {
         $jump_user = $jump[0];
         $jump_hostname = $jump[1];
     } else {

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -982,3 +982,7 @@ $config['bad_disk_regexp'] = [];
 
 // Snmptrap logging: none, unhandled, all
 $config['snmptraps']['eventlog'] = 'unhandled';
+
+// Jump Host
+$config['jump_cmd'] = '/bin/ssh';
+$config['jump_args'] = '-oControlMaster=auto -oControlPath=/tmp/ssh_mux_\\%h_\\%p_\\%r -oControlPersist=1m -oBatchMode=yes -oStrictHostKeyChecking=yes -oConnectTimeout=10 -l';

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -183,12 +183,14 @@ function gen_snmp_cmd($cmd, $device, $oids, $options = null, $mib = null, $mibdi
     }
 
     if ($device['jump_hostname'] && $device['jump_user']) {
-        $cmd = sprintf('%s %s %s %s -- %s', Config::get('jump_cmd'),
-                                            Config::get('jump_args'),
-                                            $device['jump_user'],
-                                            $device['jump_hostname'],
-                                            $cmd
-                                           );
+        $cmd = sprintf(
+            '%s %s %s %s -- %s',
+            Config::get('jump_cmd'),
+            Config::get('jump_args'),
+            $device['jump_user'],
+            $device['jump_hostname'],
+            $cmd
+        );
     }
 
     return $cmd;
@@ -304,7 +306,7 @@ function snmp_getnext($device, $oid, $options = null, $mib = null, $mibdir = nul
 
     recordSnmpStatistic('snmpgetnext', $time_start);
 
-    if ($device['jump_hostname'] && jump_error_check()) {
+    if ($device['jump_hostname'] && jump_error_check($data)) {
         return false;
     }
 
@@ -1424,7 +1426,8 @@ function oid_is_numeric($oid)
  * @param string $data
  * @return bool
  */
-function jump_error_check($data) {
+function jump_error_check($data)
+{
     if (preg_match('/(Connection closed by remote host|Could not resolve hostname|Operation timed out|Host key verification failed)/i', $data)) {
         return true;
     }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -475,6 +475,8 @@ devices:
     - { Field: notes, Type: text, 'Null': true, Extra: '' }
     - { Field: port_association_mode, Type: int(11), 'Null': false, Extra: '', Default: '1' }
     - { Field: max_depth, Type: int(11), 'Null': false, Extra: '', Default: '0' }
+    - { Field: jump_user, Type: varchar(255), 'Null': true, Extra: '' }
+    - { Field: jump_hostname, Type: varchar(255), 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [device_id], Unique: true, Type: BTREE }
     status: { Name: status, Columns: [status], Unique: false, Type: BTREE }

--- a/sql-schema/269.sql
+++ b/sql-schema/269.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `devices` ADD `jump_user` varchar(255) DEFAULT NULL;
+ALTER TABLE `devices` ADD `jump_hostname` varchar(255) DEFAULT NULL;
+


### PR DESCRIPTION
I'm not exactly sure if you'd want this changeset, so opening a pull request early to get some feedback.

I needed to poll  a device on a network that I didn't have direct access to, and DNS magic/SNMP proxy seemed unappealing, so I spent half an hour seeing if I could convince librenms to use netsnmp on a remote system.

It worked, and it's surprisingly performant.

There's some OpenSSH magic to make the SSH connection persist for the entire duration of the polling, caveats are the target system needs net-snmp, and the librenms mibs in the same location as the host.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
