### PR TITLE
Small fix for UBNT AirFiber gpsSync

### DIFF
--- a/includes/discovery/sensors/state/airos-af.inc.php
+++ b/includes/discovery/sensors/state/airos-af.inc.php
@@ -81,7 +81,7 @@ if (is_numeric($gps)) {
     if ($state_index_id !== null) {
         $states = array(
             array($state_index_id, 'off', 1, 1, 1),
-            array($state_index_id, 'on', 1, 4, 0),
+            array($state_index_id, 'on', 1, 2, 0),
         );
 
         foreach ($states as $value) {


### PR DESCRIPTION
Small fix for gpsSync state

gpsSync OBJECT-TYPE
        SYNTAX     Integer32 {
                off (1),
                on  (2)
        } 
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION "GPS Synchronization state (OFF, ON)"
        ::= { airFiberConfigEntry 8 }

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
