### PR TITLE
BUG: typo in the sensor_id key in app/Model/Sensor.php

### DIFF
--- a/app/Models/Sensor.php
+++ b/app/Models/Sensor.php
@@ -5,7 +5,7 @@ namespace App\Models;
 class Sensor extends BaseModel
 {
     public $timestamps = false;
-    protected $primaryKey = 'sensors_id';
+    protected $primaryKey = 'sensor_id';
 
     protected static $icons = array(
         'fanspeed' => 'tachometer',


### PR DESCRIPTION
The row in the table does spell "sensor_id" and the app/Model/Sensor.php spells it "sensors_id" which prevents from using it.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
