### PR TITLE
Add Mapquest API Geocode support

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -556,6 +556,16 @@ function location_to_latlng($device)
                         $api_url = "https://maps.googleapis.com/maps/api/geocode/json?address=$new_device_location";
                     }
                     break;
+                case "mapquest":
+                    d_echo("Mapquest geocode engine being used\n");
+                    $api_key = ($config['geoloc']['api_key']);
+                     if (!empty($api_key)) {
+                        d_echo("Use Mapquest API key: $api_key\n");
+                        $api_url = "http://open.mapquestapi.com/geocoding/v1/address?key=$api_key&location=$new_device_location&thumbMaps=false";
+                     } else {
+                        d_echo("No geocode API key set\n");
+                     }
+                    break;
             }
             $curl_init = curl_init($api_url);
             set_curl_proxy($curl_init);
@@ -574,6 +584,13 @@ function location_to_latlng($device)
                         $bad_loc = true;
                     }
                     break;
+                case "mapquest":
+                if ($data['info']['statuscode'] == 0) {
+                        $loc['lat'] = $data['results'][0]['locations'][0]['latLng']['lat'];
+                        $loc['lng'] = $data['results'][0]['locations'][0]['latLng']['lng'];
+                } else {
+                        $bad_loc = true;
+                }
             }
             if ($bad_loc === true) {
                 d_echo("Bad lat / lng received\n");


### PR DESCRIPTION
Since the Google API for geocoding is no longer free, I added support to use the Mapquest geocoding API which currently offers a free tier.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
