### PR TITLE
Attempt to make proxy sub-dir -> app no subdir work

### DIFF
--- a/app/Helpers/Common.php
+++ b/app/Helpers/Common.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Helpers.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+if (!function_exists('str_start')) {
+    /**
+     * Begin a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $prefix
+     * @return string
+     */
+    function str_start($value, $prefix)
+    {
+        $quoted = preg_quote($prefix, '/');
+        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+    }
+}
+
+if (!function_exists('str_finish')) {
+    /**
+     * Cap a string with a single instance of a given value.
+     *
+     * @param  string $value
+     * @param  string $cap
+     * @return string
+     */
+    function finish($value, $cap)
+    {
+        $quoted = preg_quote($cap, '/');
+        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
+    }
+}

--- a/app/Helpers/HelperOverload.php
+++ b/app/Helpers/HelperOverload.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * HelperOverload.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2018 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+// override the default route helper to provide support for proxy with subdir and app without
+if (!function_exists('route')) {
+    /**
+     * Generate the URL to a named route.
+     *
+     * @param  string  $name
+     * @param  array   $parameters
+     * @param  bool    $absolute
+     * @return string
+     */
+    function route($name, $parameters = [], $absolute = true)
+    {
+        $appUrlSuffix = config('app.url_suffix');
+
+        // Additional check, do the workaround only when a suffix is present and only when urls are absolute
+        if ($appUrlSuffix && $absolute) {
+            $appUrl = config('app.url'); // in your case: http://app.dev
+
+            // Add the relative path to the app root url
+            $relativePath = app('url')->route($name, $parameters, false);
+            $url = $appUrl.$relativePath;
+        } else {
+            // This is the default behavior of route() you can find in laravel\vendor\laravel\framework\src\Illuminate\Foundation\helpers.php
+            $url = app('url')->route($name, $parameters, $absolute);
+        }
+
+        return $url;
+    }
+}

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -14,6 +14,7 @@ define('LARAVEL_START', microtime(true));
 |
 */
 
+include __DIR__ . '/../app/Helpers/HelperOverload.php';
 @include __DIR__ . '/../vendor/autoload.php';
 
 if (!class_exists(\App\Checks::class)) {

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,9 @@
         "ext-mysqlnd": "*"
     },
     "autoload": {
+        "files": [
+            "app/Helpers/Common.php"
+        ],
         "psr-4": {
             "App\\": "app",
             "LibreNMS\\": "LibreNMS",

--- a/config/app.php
+++ b/config/app.php
@@ -55,6 +55,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application URL Suffix
+    |--------------------------------------------------------------------------
+    |
+    | Required when the application is accessed via a proxy using a subdirectory
+    | but the application itself is not accessed via a subdirectory
+    |
+    */
+
+    'url_suffix' => env('APP_URL_SUFFIX'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,11 @@
 |
 */
 
+// handle proxy with subdirectory and app without
+if ($appUrl = trim(config('app.url'), '/')) {
+    \URL::forceRootUrl(str_finish(config('app.url'), '/') . config('app.url_suffix'));
+}
+
 // Auth
 Auth::routes();
 


### PR DESCRIPTION
Set APP_URL and APP_URL_SUFFIX in .env

Not sure if this is the correct fix.  A proxy with a subdirectory redirecting to the app that isn't using a subdirectory is particularly difficult and has a chance to break normal users.

Need all configurations to test this, not just the type it is trying to fix.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
