### PR TITLE
Added conntrack support

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -43,6 +43,7 @@ class Application extends BaseModel
 
     protected static $display_name = [
         'bind' => 'BIND',
+        'conntrack' => 'Conntrack',
         'dhcp-stats' => 'DHCP Stats',
         'exim-stats' => 'EXIM Stats',
         'fbsd-nfs-client' => 'FreeBSD NFS Client',

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -144,6 +144,9 @@ function nicecase($item)
         case 'asterisk':
             return 'Asterisk';
 
+        case 'conntrack':
+            return 'Conntrack';
+
         default:
             return ucfirst($item);
     }

--- a/html/includes/graphs/application/conntrack_icmp.inc.php
+++ b/html/includes/graphs/application/conntrack_icmp.inc.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * conntrack_icmp.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+$rrd = rrd_name($device['hostname'], array('app', 'conntrack', $app['app_id']));
+if (rrdtool_check_rrd_exists($rrd)) {
+    $rrd_filename = $rrd;
+}
+
+$colours = 'mixed';
+$unit_text = 'ICMP';
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'icmp_u',
+            'descr' => 'unreplied',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'icmp_ha',
+            'descr' => 'half-assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'icmp_tot',
+            'descr' => 'total',
+            'area' => true,
+        )
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi_line.inc.php';

--- a/html/includes/graphs/application/conntrack_igmp.inc.php
+++ b/html/includes/graphs/application/conntrack_igmp.inc.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * conntrack_igmp.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+$rrd = rrd_name($device['hostname'], array('app', 'conntrack', $app['app_id']));
+if (rrdtool_check_rrd_exists($rrd)) {
+    $rrd_filename = $rrd;
+}
+
+$colours = 'mixed';
+$unit_text = 'IGMP';
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'igmp_u',
+            'descr' => 'unreplied',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'igmp_ha',
+            'descr' => 'half-assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'igmp_tot',
+            'descr' => 'total',
+            'area' => true,
+        )
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi_line.inc.php';

--- a/html/includes/graphs/application/conntrack_other.inc.php
+++ b/html/includes/graphs/application/conntrack_other.inc.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * conntrack_other.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+$rrd = rrd_name($device['hostname'], array('app', 'conntrack', $app['app_id']));
+if (rrdtool_check_rrd_exists($rrd)) {
+    $rrd_filename = $rrd;
+}
+
+$colours = 'mixed';
+$unit_text = 'Other';
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'other_a',
+            'descr' => 'assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'other_u',
+            'descr' => 'unreplied',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'other_ha',
+            'descr' => 'half-assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'other_tot',
+            'descr' => 'total',
+            'area' => true,
+        )
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi_line.inc.php';

--- a/html/includes/graphs/application/conntrack_tcp.inc.php
+++ b/html/includes/graphs/application/conntrack_tcp.inc.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * conntrack_tcp.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+$rrd = rrd_name($device['hostname'], array('app', 'conntrack', $app['app_id']));
+if (rrdtool_check_rrd_exists($rrd)) {
+    $rrd_filename = $rrd;
+}
+
+$colours = 'mixed';
+$unit_text = 'TCP';
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_ss',
+            'descr' => 'SYN_SENT',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_sr',
+            'descr' => 'SYN_RECV',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_e',
+            'descr' => 'ESTABLISHED',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_fw',
+            'descr' => 'FIN_WAIT',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_cw',
+            'descr' => 'CLOSE_WAIT',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_la',
+            'descr' => 'LAST_ACK',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_tw',
+            'descr' => 'TIME_WAIT',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_c',
+            'descr' => 'CLOSE',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_ss2',
+            'descr' => 'SYN_SENT2',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_n',
+            'descr' => 'NONE',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_unk',
+            'descr' => 'unknown',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_a',
+            'descr' => 'assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_u',
+            'descr' => 'unreplied',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_ha',
+            'descr' => 'half-assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tcp_tot',
+            'descr' => 'total',
+            'area' => true,
+        )
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi_line.inc.php';

--- a/html/includes/graphs/application/conntrack_total.inc.php
+++ b/html/includes/graphs/application/conntrack_total.inc.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * conntrack_total.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+$rrd = rrd_name($device['hostname'], array('app', 'conntrack', $app['app_id']));
+if (rrdtool_check_rrd_exists($rrd)) {
+    $rrd_filename = $rrd;
+}
+
+$colours = 'mixed';
+$unit_text = 'Total';
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tot_a',
+            'descr' => 'assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tot_u',
+            'descr' => 'unreplied',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tot_ha',
+            'descr' => 'half-assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'tot',
+            'descr' => 'total',
+            'area' => true,
+        )
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi_line.inc.php';

--- a/html/includes/graphs/application/conntrack_udp.inc.php
+++ b/html/includes/graphs/application/conntrack_udp.inc.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * conntrack_udp.inc.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+$rrd = rrd_name($device['hostname'], array('app', 'conntrack', $app['app_id']));
+if (rrdtool_check_rrd_exists($rrd)) {
+    $rrd_filename = $rrd;
+}
+
+$colours = 'mixed';
+$unit_text = 'UDP';
+
+if (rrdtool_check_rrd_exists($rrd_filename)) {
+    $rrd_list = array(
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'udp_a',
+            'descr' => 'assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'udp_u',
+            'descr' => 'unreplied',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'udp_ha',
+            'descr' => 'half-assured',
+            'area' => true,
+        ),
+        array(
+            'filename' => $rrd_filename,
+            'ds' => 'udp_tot',
+            'descr' => 'total',
+            'area' => true,
+        )
+    );
+} else {
+    echo "file missing: $rrd_filename";
+}
+
+require 'includes/graphs/generic_multi_line.inc.php';

--- a/html/pages/apps.inc.php
+++ b/html/pages/apps.inc.php
@@ -278,6 +278,14 @@ $graphs['asterisk'] = array(
     'channels',
     'sip',
 );
+$graphs['conntrack'] = array(
+    'tcp',
+    'udp',
+    'icmp',
+    'igmp',
+    'other',
+    'total',
+);
 echo '<div class="panel panel-default">';
 echo '<div class="panel-heading">';
 echo "<span style='font-weight: bold;'>Apps</span> &#187; ";

--- a/html/pages/device/apps/conntrack.inc.php
+++ b/html/pages/device/apps/conntrack.inc.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * conntrack.inc.php
+ *
+ * Graphs for conntrack
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+global $config;
+
+$graphs = array(
+    'conntrack_tcp' => 'TCP',
+    'conntrack_udp' => 'UDP',
+    'conntrack_icmp' => 'ICMP',
+    'conntrack_igmp' => 'IGMP',
+    'conntrack_other' => 'Other',
+    'conntrack_total' => 'Total',
+);
+
+foreach ($graphs as $key => $text) {
+    $graph_array['height'] = '100';
+    $graph_array['width']  = '215';
+    $graph_array['to']     = $config['time']['now'];
+    $graph_array['id']     = $app['app_id'];
+    $graph_array['type']   = 'application_'.$key;
+
+    echo '<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">'.$text.'</h3>
+    </div>
+    <div class="panel-body">
+    <div class="row">';
+    include 'includes/print-graphrow.inc.php';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+}

--- a/includes/polling/applications/conntrack.inc.php
+++ b/includes/polling/applications/conntrack.inc.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * conntrack.inc.php
+ *
+ * Connection tracking polling module
+ * Capable of collecting stats from direct SNMP connection
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ */
+
+use LibreNMS\RRD\RrdDefinition;
+
+global $config;
+$data = '';
+$name = 'conntrack';
+$app_id = $app['app_id'];
+
+echo ' ' . $name;
+
+// nsExtendOutputFull."conntrack"
+$oid = '.1.3.6.1.4.1.8072.1.3.2.3.1.2.9.99.111.110.110.116.114.97.99.107';
+$data = snmp_get($device, $oid, '-Oqv');
+
+print "the data is: ";
+print $data;
+
+if (!empty($data)) {
+    $ds_list = array(
+        'tcp_ss' => 'GAUGE',
+        'tcp_sr' => 'GAUGE',
+        'tcp_e' => 'GAUGE',
+        'tcp_fw' => 'GAUGE',
+        'tcp_cw' => 'GAUGE',
+        'tcp_la' => 'GAUGE',
+        'tcp_tw' => 'GAUGE',
+        'tcp_c' => 'GAUGE',
+        'tcp_ss2' => 'GAUGE',
+        'tcp_n' => 'GAUGE',
+        'tcp_unk' => 'GAUGE',
+        'tcp_a' => 'GAUGE',
+        'tcp_u' => 'GAUGE',
+        'tcp_ha' => 'GAUGE',
+        'tcp_tot' => 'GAUGE',
+        'udp_a' => 'GAUGE',
+        'udp_u' => 'GAUGE',
+        'udp_ha' => 'GAUGE',
+        'udp_tot' => 'GAUGE',
+        'icmp_u' => 'GAUGE',
+        'icmp_ha' => 'GAUGE',
+        'icmp_tot' => 'GAUGE',
+        'igmp_u' => 'GAUGE',
+        'igmp_ha' => 'GAUGE',
+        'igmp_tot' => 'GAUGE',
+        'other_a' => 'GAUGE',
+        'other_u' => 'GAUGE',
+        'other_ha' => 'GAUGE',
+        'other_tot' => 'GAUGE',
+        'tot_a' => 'GAUGE',
+        'tot_u' => 'GAUGE',
+        'tot_ha' => 'GAUGE',
+        'tot' => 'GAUGE',
+    );
+
+    //decode and flatten the data
+    $stats = array();
+    foreach (explode(" ", $data) as $stat) {
+        list($name, $value) = explode(':', $stat);
+        $stats[$name] = $value;
+    }
+    d_echo($stats);
+
+    // only the stats we store in rrd
+    $rrd_def = new RrdDefinition();
+    $fields = array();
+    foreach ($ds_list as $key => $type) {
+        $rrd_def->addDataset($key, $type, 0);
+
+        if (isset($stats[$key])) {
+            $fields[$key] = $stats[$key];
+        } else {
+            $fields[$key] = 'U';
+        }
+    }
+
+    $rrd_name = array('app', 'conntrack', $app_id);
+    $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
+    data_update($device, 'app', $tags, $fields);
+    update_application($app, $data, $fields);
+}
+
+unset($data, $stats, $rrd_def, $rrd_name, $rrd_keys, $tags, $fields);


### PR DESCRIPTION
This commit adds visualization and installation instructions of Netfilter Conntrack application that has been pulled recently: https://github.com/librenms/librenms-agent/pull/200

Visual representation of data as an example: 
<img width="953" alt="librenms_conntrack" src="https://user-images.githubusercontent.com/6848635/46862157-f46d2580-ce1c-11e8-98de-fd547d94b930.png">

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
