### PR TITLE
Added option to disable port discovery and poll if ifAdminStatus down

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -516,7 +516,7 @@ Examples:
 $config['bad_if'][] = "voip-null";
 $config['bad_iftype'][] = "voiceEncap";
 $config['bad_if_regexp'][] = '/^lo[0-9].*/';    // loopback
-$config['bad_ifAdminStatus'][] = '/down/';  
+$config['bad_ifAdminStatus'][] = 'down';  
 ```
 Numerous defaults exist for this array already (see includes/defaults.inc.php for the full list). You can expand this list
 by continuing the array.
@@ -531,7 +531,7 @@ by continuing the array.
 
 `bad_ifalias_regexp` is matched against the ifAlias value as a regular expression.
 
-`bad_ifAdminStatus` is matched against the bad_ifAdminStatus value as a regular expression. 
+`bad_ifAdminStatus` is matched against the bad_ifAdminStatus value. 
 
 ### Interfaces that shouldn't be ignored
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -516,6 +516,7 @@ Examples:
 $config['bad_if'][] = "voip-null";
 $config['bad_iftype'][] = "voiceEncap";
 $config['bad_if_regexp'][] = '/^lo[0-9].*/';    // loopback
+$config['bad_ifAdminStatus'][] = '/down/';  
 ```
 Numerous defaults exist for this array already (see includes/defaults.inc.php for the full list). You can expand this list
 by continuing the array.
@@ -529,6 +530,8 @@ by continuing the array.
 `bad_ifname_regexp` is matched against the ifName value as a regular expression.
 
 `bad_ifalias_regexp` is matched against the ifAlias value as a regular expression.
+
+`bad_ifAdminStatus` is matched against the bad_ifAdminStatus value as a regular expression. 
 
 ### Interfaces that shouldn't be ignored
 

--- a/includes/discovery/ports.inc.php
+++ b/includes/discovery/ports.inc.php
@@ -8,6 +8,9 @@ $port_stats = snmpwalk_cache_oid($device, 'ifDescr', $port_stats, 'IF-MIB');
 $port_stats = snmpwalk_cache_oid($device, 'ifName', $port_stats, 'IF-MIB');
 $port_stats = snmpwalk_cache_oid($device, 'ifAlias', $port_stats, 'IF-MIB');
 $port_stats = snmpwalk_cache_oid($device, 'ifType', $port_stats, 'IF-MIB');
+$port_stats = snmpwalk_cache_oid($device, 'ifAdminStatus', $port_stats, 'IF-MIB');
+
+
 
 // End Building SNMP Cache Array
 d_echo($port_stats);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1134,27 +1134,36 @@ function is_port_valid($port, $device)
     $ifAlias = $port['ifAlias'];
     $ifType  = $port['ifType'];
 
+    // Changed by F.Marton 10102018
+    $ifAdminStatus = $port['ifAdminStatus'];
+    foreach (Config::getCombined($device['os'], 'bad_ifAdminStatus') as $bi) {
+        if ($ifAdminStatus == $bi) {
+            d_echo("ignored $ifName by ifAdminStatus: $ifAdminStatus (matched: $bi)\n");
+            return false;
+        }
+    }
+
     if (str_i_contains($ifDescr, Config::getOsSetting($device['os'], 'good_if'))) {
         return true;
     }
 
     foreach (Config::getCombined($device['os'], 'bad_if') as $bi) {
         if (str_i_contains($ifDescr, $bi)) {
-            d_echo("ignored by ifDescr: $ifDescr (matched: $bi)\n");
+            d_echo("ignored $ifName by ifDescr: $ifDescr (matched: $bi)\n");
             return false;
         }
     }
 
     foreach (Config::getCombined($device['os'], 'bad_if_regexp') as $bir) {
         if (preg_match($bir ."i", $ifDescr)) {
-            d_echo("ignored by ifDescr: $ifDescr (matched: $bir)\n");
+            d_echo("ignored $ifName by ifDescr: $ifDescr (matched: $bir)\n");
             return false;
         }
     }
 
     foreach (Config::getCombined($device['os'], 'bad_ifname_regexp') as $bnr) {
         if (preg_match($bnr ."i", $ifName)) {
-            d_echo("ignored by ifName: $ifName (matched: $bnr)\n");
+            d_echo("ignored $ifName by ifName: $ifName (matched: $bnr)\n");
             return false;
         }
     }
@@ -1162,14 +1171,14 @@ function is_port_valid($port, $device)
 
     foreach (Config::getCombined($device['os'], 'bad_ifalias_regexp') as $bar) {
         if (preg_match($bar ."i", $ifAlias)) {
-            d_echo("ignored by ifName: $ifAlias (matched: $bar)\n");
+            d_echo("ignored $ifName by ifName: $ifAlias (matched: $bar)\n");
             return false;
         }
     }
 
     foreach (Config::getCombined($device['os'], 'bad_iftype') as $bt) {
         if (str_contains($ifType, $bt)) {
-            d_echo("ignored by ifType: $ifType (matched: $bt )\n");
+            d_echo("ignored $ifName by ifType: $ifType (matched: $bt )\n");
             return false;
         }
     }


### PR DESCRIPTION
Issue:
I have network with many nodes and many ports in a node. I want to discover the used ports only. In this case there are less port.rrd so the summary size is smaller for whole network.

Changes:
ifAdminStatus can be used as filter for port discovery and poll
ifName is printed out in debug mode when discovery and poll

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
