### PR TITLE
Fixed daily.sh overwriting custom alert sql

### DIFF
--- a/daily.php
+++ b/daily.php
@@ -256,12 +256,15 @@ if ($options['f'] === 'refresh_alert_rules') {
         }
 
         echo 'Refreshing alert rules queries' . PHP_EOL;
-        $rules = dbFetchRows('SELECT `id`, `rule`, `builder` FROM `alert_rules`');
+        $rules = dbFetchRows('SELECT `id`, `rule`, `builder`, `extra` FROM `alert_rules`');
         foreach ($rules as $rule) {
-            $data['query'] = GenSQL($rule['rule'], $rule['builder']);
-            if (!empty($data['query'])) {
-                dbUpdate($data, 'alert_rules', 'id=?', array($rule['id']));
-                unset($data);
+            $rule_options = json_decode($rule['extra'], true);
+            if ($rule_options['override_query'] !== 'on') {
+                $data['query'] = GenSQL($rule['rule'], $rule['builder']);
+                if (!empty($data['query'])) {
+                    dbUpdate($data, 'alert_rules', 'id=?', array($rule['id']));
+                    unset($data);
+                }
             }
         }
     } catch (LockException $e) {


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

Before, daily.sh would run GenSQL() and override the custom query.