### PR TITLE
webui : Oxidized rights enforcement

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1512,11 +1512,19 @@ function get_oxidized_nodes_list()
 
     foreach ($data as $object) {
         $device = device_by_name($object['name']);
+        if (! device_permitted($device['device_id'])) {
+            //user cannot see this device, so let's skip it. 
+            continue;
+        }
         $fa_color = $object['status'] == 'success' ? 'success' : 'danger';
         echo "
         <tr>
         <td>
-        " . generate_device_link($device) . "
+        " . generate_device_link($device);
+        if ($device['device_id'] == 0) { 
+            echo "(device '" . $object['name'] . "' not in LibreNMS)"; 
+        }
+        echo "
         </td>
         <td>
         <i class='fa fa-square text-" . $fa_color . "'></i>
@@ -1531,12 +1539,23 @@ function get_oxidized_nodes_list()
         " . $object['group'] . "
         </td>
         <td>
+        ";
+        if (! $device['device_id'] == 0) {
+            echo "
           <button class='btn btn-default btn-sm' name='btn-refresh-node-devId" . $device['device_id'] . "' id='btn-refresh-node-devId" . $device['device_id'] . "' onclick='refresh_oxidized_node(\"" . $device['hostname'] . "\")'>
             <i class='fa fa-refresh'></i>
           </button>
           <a href='" . generate_url(array('page' => 'device', 'device' => $device['device_id'], 'tab' => 'showconfig')) . "'>
             <i class='fa fa-align-justify fa-lg icon-theme'></i>
           </a>
+            ";
+        } else {
+            echo "
+          <button class='btn btn-default btn-sm' disabled name='btn-refresh-node-devId" . $device['device_id'] . "' id='btn-refresh-node-devId" . $device['device_id'] . "'>
+            <i class='fa fa-refresh'></i>
+          </button>";
+        }
+        echo "
         </td>
         </tr>";
     }

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1513,7 +1513,7 @@ function get_oxidized_nodes_list()
     foreach ($data as $object) {
         $device = device_by_name($object['name']);
         if (! device_permitted($device['device_id'])) {
-            //user cannot see this device, so let's skip it. 
+            //user cannot see this device, so let's skip it.
             continue;
         }
         $fa_color = $object['status'] == 'success' ? 'success' : 'danger';
@@ -1521,8 +1521,8 @@ function get_oxidized_nodes_list()
         <tr>
         <td>
         " . generate_device_link($device);
-        if ($device['device_id'] == 0) { 
-            echo "(device '" . $object['name'] . "' not in LibreNMS)"; 
+        if ($device['device_id'] == 0) {
+            echo "(device '" . $object['name'] . "' not in LibreNMS)";
         }
         echo "
         </td>


### PR DESCRIPTION
This patch allow checking the rights for a device (and will not display it if the user cannot see it). 

It does also give an explanation on devices that appear in the list (because they exist in Oxidized) but cannot be clicked (because they do not exist in LibreNMS).
 
![capture](https://user-images.githubusercontent.com/38363551/47018312-ceb18a80-d154-11e8-8295-a5443cf5e979.PNG)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
