### PR TITLE
F5 APM current sessions graphing

### DIFF
--- a/html/includes/graphs/device/bigip_apm_curr_sessions.inc.php
+++ b/html/includes/graphs/device/bigip_apm_curr_sessions.inc.php
@@ -1,0 +1,19 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'apm_sessions');
+
+require 'includes/graphs/common.inc.php';
+
+$ds = 'sessions';
+
+$colour_area = '9999cc';
+$colour_line = '0000cc';
+
+$colour_area_max = '9999cc';
+
+$graph_max = 1;
+$graph_min = 0;
+
+$unit_text = 'Sessions';
+
+require 'includes/graphs/generic_simplex.inc.php';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -541,6 +541,11 @@ $config['graph_types']['device']['arbos_flows']['section']         = 'graphs';
 $config['graph_types']['device']['arbos_flows']['order']           = '0';
 $config['graph_types']['device']['arbos_flows']['descr']           = 'Accumulative flow count per SP device';
 
+//F5 specific graphs
+$config['graph_types']['device']['apm_sessions']['section']      = 'apm';
+$config['graph_types']['device']['apm_sessions']['order']        = '0';
+$config['graph_types']['device']['apm_sessions']['descr']        = 'Active Sessions';
+
 // Device Types
 $i = 0;
 $config['device_types'][$i]['text'] = 'Servers';

--- a/includes/polling/os/f5.inc.php
+++ b/includes/polling/os/f5.inc.php
@@ -2,3 +2,19 @@
 $version = trim(snmp_get($device, '.1.3.6.1.4.1.3375.2.1.4.2.0', '-OQv'), '"');
 $hardware = trim(snmp_get($device, '.1.3.6.1.4.1.3375.2.1.3.5.2.0', '-OQv'), '"');
 $serial = trim(snmp_get($device, '.1.3.6.1.4.1.3375.2.1.3.3.3.0', '-OQv'), '"');
+
+use LibreNMS\RRD\RrdDefinition;
+
+$sessions = snmp_get($device, 'apmAccessStatCurrentActiveSessions.0', '-OQv', 'F5-BIGIP-APM-MIB');
+
+if (is_numeric($sessions)) {
+    $rrd_def = RrdDefinition::make()->addDataset('sessions', 'GAUGE', 0);
+
+    $fields = array(
+        'sessions' => $sessions,
+    );
+
+    $tags = compact('rrd_def');
+    data_update($device, 'apm_sessions', $tags, $fields);
+    $graphs['apm_sessions'] = true;
+}

--- a/sql-schema/269.sql
+++ b/sql-schema/269.sql
@@ -1,0 +1,1 @@
+INSERT INTO `graph_types`(`graph_type`, `graph_subtype`, `graph_section`, `graph_descr`, `graph_order`) VALUES ('device',  'apm_sessions',  'apm',  'Active Sessions',  0);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

While this creates the graphs under Apm for the F5s, there is no data. I can pull the data manually. Maybe I have the definition incorrect in includes/polling/os/f5.inc.php?

snmpget -m /opt/librenms/mibs/f5/F5-BIGIP-APM-MIB -v 3 -u <user> -l authPriv -a SHA -A  <password> -x AES -X <password> <server>  apmAccessStatCurrentActiveSessions.0
F5-BIGIP-APM-MIB::apmAccessStatCurrentActiveSessions.0 = Wrong Type (should be Counter64): Gauge32: 1245

or maybe it's because the OID has the incorrect type in it, although the result is actually correct.