### PR TITLE
Removed redundant grouping from SQL query

### DIFF
--- a/html/includes/table/fdb-search.inc.php
+++ b/html/includes/table/fdb-search.inc.php
@@ -76,8 +76,7 @@ if ($vars['searchby'] != 'ip' && $vars['searchby'] != 'dnsname') {
     $sql .= " LEFT JOIN `ipv4_mac` AS `M` USING (`mac_address`)";
 }
 $sql .= $where;
-$sql .= " GROUP BY `device_id`, `port_id`, `mac_address`, `vlan`, `hostname`, `ifAlias`,";
-$sql .= " `ifAdminStatus`, `ifDescr`, `ifOperStatus`, `ifInErrors`, `ifOutErrors`";
+$sql .= " GROUP BY `device_id`, `port_id`, `mac_address`, `vlan`";
 
 // Get most likely endpoint port_id, used to add a visual marker for this element
 // in the list


### PR DESCRIPTION
This change is made for "FDB table" web interface page, which uses redundant information for "GROUP BY" statement. More information available in community forums: https://community.librenms.org/t/fdb-table-page-produces-high-load/5831

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
