### PR TITLE
snmp_max_oid per Os support and snmpv1 multi_oid fix

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2481,7 +2481,12 @@ function get_device_oid_limit($device)
 {
     global $config;
 
-    $max_oid = $device['snmp_max_oid'];
+    //Some Os only work with specific max_oid values
+    if ((isset($device['os'], $config['os'][$device['os']]['snmp_max_oid']) && $config['os'][$device['os']]['snmp_max_oid'])) {
+        $max_oid = $config['os'][$device['os']]['snmp_max_oid'];
+    } else {
+        $max_oid = $device['snmp_max_oid'];
+    }
 
     if (isset($max_oid) && $max_oid > 0) {
         return $max_oid;

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -222,12 +222,24 @@ function snmp_get_multi_oid($device, $oids, $options = '-OUQn', $mib = null, $mi
 {
     $time_start = microtime(true);
 
-    if (is_array($oids)) {
-        $oids = implode(' ', $oids);
+    if ($device['snmpver'] == 'v1') {
+        $oids = explode(" ", $oids);
+        $data = [];
+        foreach ($oids as $oid) {
+            $cmd = gen_snmpget_cmd($device, $oid, $options, $mib, $mibdir);
+            $query = trim(external_exec($cmd));
+            if (!empty($query)) {
+                $data[] = $query;
+            }
+        }
+        $data = implode("\n", $data);
+    } else {
+        if (is_array($oids)) {
+            $oids = implode(' ', $oids);
+        }
+        $cmd = gen_snmpget_cmd($device, $oids, $options, $mib, $mibdir);
+        $data = trim(external_exec($cmd));
     }
-
-    $cmd = gen_snmpget_cmd($device, $oids, $options, $mib, $mibdir);
-    $data = trim(external_exec($cmd));
 
     $array = array();
     $oid = '';

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -339,6 +339,9 @@
         "nobulk": {
             "type": "boolean"
         },
+        "snmp_max_oid": {
+            "type": "string"
+        },
         "ifXmcbc": {
             "type": "boolean"
         },


### PR DESCRIPTION
_The difference between SNMPv1 and the later versions becomes apparent when one of the OIDs being requested is not valid. SNMPv2c (and SNMPv3) will display what information they can._

So if one oid is wrong or doesn't exist, v1 will trhow an error instead of showing the working ones.
It's safe to get one by one.
#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
