### PR TITLE
Add format field to Telegram transport

### DIFF
--- a/LibreNMS/Alert/Transport/Telegram.php
+++ b/LibreNMS/Alert/Transport/Telegram.php
@@ -35,6 +35,7 @@ class Telegram extends Transport
         }
         $telegram_opts['chat_id'] = $this->config['telegram-chat-id'];
         $telegram_opts['token'] = $this->config['telegram-token'];
+        $telegram_opts['format'] = $this->config['telegram-format'];
         return $this->contactTelegram($obj, $telegram_opts);
     }
 
@@ -51,7 +52,11 @@ class Telegram extends Transport
         $curl = curl_init();
         set_curl_proxy($curl);
         $text = urlencode($obj['msg']);
-        curl_setopt($curl, CURLOPT_URL, ("https://api.telegram.org/bot{$data['token']}/sendMessage?chat_id={$data['chat_id']}&text=$text"));
+        $format="";
+        if ($data['format']) {
+                $format="&parse_mode=".$data['format'];
+        }
+        curl_setopt($curl, CURLOPT_URL, ("https://api.telegram.org/bot{$data['token']}/sendMessage?chat_id={$data['chat_id']}&text=$text{$format}"));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         $ret  = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
@@ -79,11 +84,18 @@ class Telegram extends Transport
                     'name' => 'telegram-token',
                     'descr' => 'Telegram Token',
                     'type' => 'text',
+                ],
+                [
+                    'title' => 'Format',
+                    'name' => 'telegram-format',
+                    'descr' => 'Telegram format',
+                    'type' => 'text',
                 ]
             ],
             'validation' => [
                 'telegram-chat-id' => 'required|string',
                 'telegram-token' => 'required|string',
+                'telegram-format' => 'required|string',
             ]
         ];
     }


### PR DESCRIPTION
Allow set what format (Markdown or HTML) messages will be sent over Telegram transport alert.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
