### PR TITLE
Update BEGEMOT-HAST-MIB

### DIFF
--- a/mibs/pfsense/BEGEMOT-HAST-MIB
+++ b/mibs/pfsense/BEGEMOT-HAST-MIB
@@ -30,7 +30,7 @@ BEGEMOT-HAST-MIB DEFINITIONS ::= BEGIN
 
 IMPORTS
     MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
-    Counter64, Integer32
+    Counter64, Integer32, Unsigned32
 	FROM SNMPv2-SMI
     TEXTUAL-CONVENTION, RowStatus
 	FROM SNMPv2-TC
@@ -318,7 +318,7 @@ hastResourceWorkerPid OBJECT-TYPE
     ::= { hastResourceEntry 22 }
 
 hastResourceLocalQueue OBJECT-TYPE
-    SYNTAX	UNSIGNED32
+    SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION
@@ -326,7 +326,7 @@ hastResourceLocalQueue OBJECT-TYPE
     ::= { hastResourceEntry 23 }
 
 hastResourceSendQueue OBJECT-TYPE
-    SYNTAX	UNSIGNED32
+    SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION
@@ -335,7 +335,7 @@ hastResourceSendQueue OBJECT-TYPE
     ::= { hastResourceEntry 24 }
 
 hastResourceRecvQueue OBJECT-TYPE
-    SYNTAX	UNSIGNED32
+    SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION
@@ -344,7 +344,7 @@ hastResourceRecvQueue OBJECT-TYPE
     ::= { hastResourceEntry 25 }
 
 hastResourceDoneQueue OBJECT-TYPE
-    SYNTAX	UNSIGNED32
+    SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION
@@ -352,7 +352,7 @@ hastResourceDoneQueue OBJECT-TYPE
     ::= { hastResourceEntry 26 }
 
 hastResourceIdleQueue OBJECT-TYPE
-    SYNTAX	UNSIGNED32
+    SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION


### PR DESCRIPTION
FIX: 
Due to a missing import and the uppercase after some SYNTAX this mib is not bein compiled correctly everywhere.
For example the one from Horizon OpenNMS fails with some errors 
ERROR: Cannot find symbol UNSIGNED32, Source: BEGEMOT-HAST-MIB.txt, Row: 321, Col: 17

The proposed change prevent the errors.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
