### PR TITLE
Fixes delta calculation for bgpPeers_cbgp metrics

### DIFF
--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -387,8 +387,8 @@ if ($config['enable_bgp']) {
                     );
 
                     foreach ($oids as $oid) {
-                        $tmp_delta = set_numeric($peer['c_update'][$oid] - $peer_afi[$oid]);
                         $tmp_prev  = set_numeric($peer_afi[$oid]);
+                        $tmp_delta = $cbgpPeers_cbgp_fields[$oid] - $tmp_prev;
                         if ($peer_afi[$oid . '_delta'] != $tmp_delta) {
                             $peer['c_update'][$oid . '_delta'] = $tmp_delta;
                         }


### PR DESCRIPTION
The values in the $peer['c_update'][$oid] array are set only if they have
changed. If the value has not changed, then zero is substituted for real
values, which leads to incorrect calculation of delta values and records
in the database:

SELECT AcceptedPrefixes,AcceptedPrefixes_prev,AcceptedPrefixes_delta
FROM bgpPeers_cbgp
WHERE device_id=115;

| AcceptedPrefixes | AcceptedPrefixes_prev | AcceptedPrefixes_delta |
|------------------|-----------------------|------------------------|
|               21 |                    21 |                    -21 |

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
