### PR TITLE
Ensure the checks for ASA context devices are strict

### DIFF
--- a/includes/discovery/sensors/entity-sensor.inc.php
+++ b/includes/discovery/sensors/entity-sensor.inc.php
@@ -138,7 +138,7 @@ if (!empty($entity_oids)) {
                     $valid_sensor = false;
                 }
             }
-            if ($current == '-127' || ($device['os'] == 'asa' && str_contains($device['hardware'], 'sc'))) {
+            if ($current == '-127' || ($device['os'] == 'asa' && ends_with($device['hardware'], 'sc'))) {
                 $valid_sensor = false;
             }
             // Check for valid sensors

--- a/includes/polling/os/asa.inc.php
+++ b/includes/polling/os/asa.inc.php
@@ -10,7 +10,7 @@
  * option) any later version.  Please see LICENSE.txt at the top level of
  * the source code distribution for details.
  */
-if (!str_contains($device['hardware'], 'sc')) {
+if (!ends_with($device['hardware'], 'sc')) {
     $oids = 'entPhysicalModelName.1 entPhysicalSoftwareRev.1 entPhysicalSerialNum.1 entPhysicalModelName.4 entPhysicalSoftwareRev.4';
 
     $data = snmp_get_multi($device, $oids, '-OQUs', 'ENTITY-MIB');

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -683,7 +683,7 @@ foreach ($ports as $port) {
                 }
             } else {
                 if ($oid == 'ifOperStatus' || $oid == 'ifAdminStatus') {
-                    if ($port[$oid . '_prev'] != $this_port[$oid]) {
+                    if ($port[$oid.'_prev'] == null) {
                         $port['update'][$oid . '_prev'] = $this_port[$oid];
                     }
                 }


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

At some stage, hardware gets set to ciscoASA5506 for example and then these checks would match. They are only supposed to match ciscoASA5506sc as an example. This may fix the first issue as well but I can't work out why devices end up like that.