### PR TITLE
Nginx : add allow ipv6 address localhost nginx-status

### DIFF
--- a/doc/Extensions/Applications.md
+++ b/doc/Extensions/Applications.md
@@ -598,6 +598,7 @@ location /nginx-status {
     stub_status on;
     access_log   off;
     allow 127.0.0.1;
+    allow ::1;
     deny all;
 }
 ```


### PR DESCRIPTION
Following the modification of the SNMP Nginx agent (https://github.com/librenms/librenms-agent/commit/e0dcd4a064cedb09241e4af17198bf61e8fd1bf3), linux distributions make requests in IPV6, so you must allow ::1 


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
