### PR TITLE
Syslog name translation

### DIFF
--- a/doc/Extensions/Syslog.md
+++ b/doc/Extensions/Syslog.md
@@ -289,3 +289,18 @@ $config['os']['screenos']['syslog_hook'][] = Array('regex' => '/System configura
 $config['os']['awplus']['syslog_hook'][] = Array('regex' => '/IMI.+.Startup-config saved on/', 'script' => '/opt/librenms/scripts/syslog-notify-oxidized.php');
 ```
 
+### Configuration Options
+
+#### Matching syslogs to hosts with different names
+
+In some cases, you may get logs that aren't being associated with the device in LibreNMS. For example, in LibreNMS the device is known as "ne-core-01", and that's how DNS resolves. However, the received syslogs are for "loopback.core-nw". 
+
+To fix this issue, you can configure LibreNMS to translate the incoming syslog hostname into another hostname, so that the logs get associated with the correct device.
+
+Example:
+```ssh
+$config['syslog_xlate'] = array(
+        'loopback0.core7k1.noc.net' => 'n7k1-core7k1',
+        'loopback0.core7k2.noc.net' => 'n7k2-core7k2'
+);
+```

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -5,7 +5,6 @@
 // $device_id_ip = @dbFetchCell("SELECT device_id FROM ipv4_addresses AS A, ports AS I WHERE A.ipv4_address = '" . $entry['host']."' AND I.port_id = A.port_id");
 use LibreNMS\Config;
 
-
 function get_cache($host, $value)
 {
     global $dev_cache;

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -3,6 +3,7 @@
 // FIXME : use db functions properly
 // $device_id_host = @dbFetchCell("SELECT device_id FROM devices WHERE `hostname` = '".mres($entry['host'])."' OR `sysName` = '".mres($entry['host'])."'");
 // $device_id_ip = @dbFetchCell("SELECT device_id FROM ipv4_addresses AS A, ports AS I WHERE A.ipv4_address = '" . $entry['host']."' AND I.port_id = A.port_id");
+use LibreNMS\Config;
 
 
 function get_cache($host, $value)
@@ -49,6 +50,7 @@ function get_cache($host, $value)
 function process_syslog($entry, $update)
 {
     global $config, $dev_cache;
+    $syslog_xlate = Config::get('syslog_xlate');
 
     foreach ($config['syslog_filter'] as $bi) {
         if (strpos($entry['msg'], $bi) !== false) {
@@ -57,8 +59,8 @@ function process_syslog($entry, $update)
     }
 
     $entry['host'] = preg_replace("/^::ffff:/", "", $entry['host']);
-    if (array_key_exists($entry['host'], $config['syslog_xlate'])) {
-        $entry['host'] = $config['syslog_xlate'][$entry['host']];
+    if (array_key_exists($entry['host'], $syslog_xlate)) {
+        $entry['host'] = $syslog_xlate[$entry['host']];
     }
     $entry['device_id'] = get_cache($entry['host'], 'device_id');
     if ($entry['device_id']) {

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -49,7 +49,6 @@ function get_cache($host, $value)
 function process_syslog($entry, $update)
 {
     global $config, $dev_cache;
-    $syslog_xlate = Config::get('syslog_xlate');
 
     foreach ($config['syslog_filter'] as $bi) {
         if (strpos($entry['msg'], $bi) !== false) {
@@ -58,8 +57,8 @@ function process_syslog($entry, $update)
     }
 
     $entry['host'] = preg_replace("/^::ffff:/", "", $entry['host']);
-    if (array_key_exists($entry['host'], $syslog_xlate)) {
-        $entry['host'] = $syslog_xlate[$entry['host']];
+    if ($new_host = Config::get('syslog_xlate.' . $entry['host'])) {
+        $entry['host'] = $new_host;
     }
     $entry['device_id'] = get_cache($entry['host'], 'device_id');
     if ($entry['device_id']) {

--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -57,6 +57,9 @@ function process_syslog($entry, $update)
     }
 
     $entry['host'] = preg_replace("/^::ffff:/", "", $entry['host']);
+    if (array_key_exists($entry['host'], $config['syslog_xlate'])) {
+        $entry['host'] = $config['syslog_xlate'][$entry['host']];
+    }
     $entry['device_id'] = get_cache($entry['host'], 'device_id');
     if ($entry['device_id']) {
         $os = get_cache($entry['host'], 'os');


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

This helps to solve an issue where syslog data is not being associated with the proper device because the following conditions are true:
1) The device is forwarding syslog through another host 
2) The device's resolved DNS name does not match the SysName


In our case, we poll devices on one IP address but Syslogs are forwarded from a second interface to another host, which collects them before forwarding them onto LibreNMS. 
Because the sending IP address doesn't match, as well as the hostname it sends from doesn't match any hostname that LibreNMS has, the logs are never associated with a device. This solves that problem, by allowing users to provide a translation table in config.php. For example:

`$config['syslog_xlate'] = array(
        'loopback0.core7k1.noc' => 'n7k1-core7k1',
        'loopback0.core7k2.noc' => 'n7k2-core7k2'
);`


