### PR TITLE
Dynamic_discovery_get_value in can_skip_sensor to use all oids in skip_values

### DIFF
--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -90,7 +90,7 @@ class YamlDiscovery
                         }
                     }
 
-                    if (static::canSkipItem($current_data['value'], $current_data, $group_options, $snmp_data)) {
+                    if (static::canSkipItem($current_data['value'], $index, $current_data, $group_options, $snmp_data)) {
                         continue;
                     }
 
@@ -227,15 +227,15 @@ class YamlDiscovery
      * @param array $item_snmp_data The pre-cache data array
      * @return bool
      */
-    private static function canSkipItem($value, $yaml_item_data, $group_options, $item_snmp_data = array())
+    static function canSkipItem($value, $index, $yaml_item_data, $group_options, $pre_cache = array())
     {
         $skip_values = array_replace((array)$group_options['skip_values'], (array)$yaml_item_data['skip_values']);
 
         foreach ($skip_values as $skip_value) {
-            if (is_array($skip_value) && $item_snmp_data) {
+            if (is_array($skip_value) && $pre_cache) {
                 // Dynamic skipping of data
                 $op = isset($skip_value['op']) ? $skip_value['op'] : '!=';
-                $tmp_value = $item_snmp_data[$skip_value['oid']];
+                $tmp_value = static::getValueFromData($skip_value['oid'],$index, $yaml_item_data, $pre_cache);
                 if (compare_var($tmp_value, $skip_value['value'], $op)) {
                     return true;
                 }

--- a/LibreNMS/Device/YamlDiscovery.php
+++ b/LibreNMS/Device/YamlDiscovery.php
@@ -227,7 +227,7 @@ class YamlDiscovery
      * @param array $item_snmp_data The pre-cache data array
      * @return bool
      */
-    static function canSkipItem($value, $index, $yaml_item_data, $group_options, $pre_cache = array())
+    public static function canSkipItem($value, $index, $yaml_item_data, $group_options, $pre_cache = array())
     {
         $skip_values = array_replace((array)$group_options['skip_values'], (array)$yaml_item_data['skip_values']);
 
@@ -235,7 +235,7 @@ class YamlDiscovery
             if (is_array($skip_value) && $pre_cache) {
                 // Dynamic skipping of data
                 $op = isset($skip_value['op']) ? $skip_value['op'] : '!=';
-                $tmp_value = static::getValueFromData($skip_value['oid'],$index, $yaml_item_data, $pre_cache);
+                $tmp_value = static::getValueFromData($skip_value['oid'], $index, $yaml_item_data, $pre_cache);
                 if (compare_var($tmp_value, $skip_value['value'], $op)) {
                     return true;
                 }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -18,6 +18,7 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\OS;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\IPv6;
+use LibreNMS\Device\YamlDiscovery;
 
 function discover_new_device($hostname, $device = '', $method = '', $interface = '')
 {
@@ -932,50 +933,6 @@ function ignore_storage($os, $descr)
 }
 
 /**
- * @param $value
- * @param $data
- * @param $group
- * @param null $index
- * @param array $pre_cache
- * @return bool
- */
-function can_skip_sensor($value, $index, $data, $group, $pre_cache = array())
-{
-    $skip_values = array_replace((array)$group['skip_values'], (array)$data['skip_values']);
-    foreach ($skip_values as $skip_value) {
-        if (is_array($skip_value) && $pre_cache) {
-            // Dynamic skipping of data
-            $op = isset($skip_value['op']) ? $skip_value['op'] : '!=';
-            $tmp_value = dynamic_discovery_get_value($skip_value['oid'], $index, $data, $pre_cache);
-            if (compare_var($tmp_value, $skip_value['value'], $op) == true) {
-                return true;
-            }
-        }
-        if ($value == $skip_value) {
-            return true;
-        }
-    }
-
-    $skip_value_lt = array_replace((array)$group['skip_value_lt'], (array)$data['skip_value_lt']);
-    foreach ($skip_value_lt as $skip_value) {
-        if ($value < $skip_value) {
-            return true;
-        }
-    }
-
-    $skip_value_gt = array_replace((array)$group['skip_value_gt'], (array)$data['skip_value_gt']);
-    foreach ($skip_value_gt as $skip_value) {
-        if ($value > $skip_value) {
-            return true;
-        }
-    }
-
-
-
-    return false;
-}
-
-/**
  * @param $valid
  * @param $device
  * @param $sensor_type
@@ -1033,7 +990,7 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
 
                 d_echo("Final sensor value: $value\n");
 
-                if (can_skip_sensor($value, $index, $data, $sensor_options, $pre_cache) === false && is_numeric($value)) {
+                if (YamlDiscovery::canSkipItem($value, $index, $data, $sensor_options, $pre_cache) === false && is_numeric($value)) {
                     $oid = str_replace('{{ $index }}', $index, $data['num_oid']);
 
                     // process the description

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -939,14 +939,14 @@ function ignore_storage($os, $descr)
  * @param array $pre_cache
  * @return bool
  */
-function can_skip_sensor($value, $data, $group, $pre_cache = array())
+function can_skip_sensor($value, $index, $data, $group, $pre_cache = array())
 {
     $skip_values = array_replace((array)$group['skip_values'], (array)$data['skip_values']);
     foreach ($skip_values as $skip_value) {
         if (is_array($skip_value) && $pre_cache) {
             // Dynamic skipping of data
             $op = isset($skip_value['op']) ? $skip_value['op'] : '!=';
-            $tmp_value = $pre_cache[$skip_value['oid']];
+            $tmp_value = dynamic_discovery_get_value($skip_value['oid'], $index, $data, $pre_cache);
             if (compare_var($tmp_value, $skip_value['value'], $op) == true) {
                 return true;
             }
@@ -1033,7 +1033,7 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
 
                 d_echo("Final sensor value: $value\n");
 
-                if (can_skip_sensor($value, $data, $sensor_options, $raw_data[$index]) === false && is_numeric($value)) {
+                if (can_skip_sensor($value, $index, $data, $sensor_options, $pre_cache) === false && is_numeric($value)) {
                     $oid = str_replace('{{ $index }}', $index, $data['num_oid']);
 
                     // process the description


### PR DESCRIPTION
Hello

While working on dynamic discovery of Huawei switch, I faced an issue where I needed to filter sensors with skip_values but the oid to use was not in the current table. Instead, I went with pre_cache, which works well for displaying variables with {{ xxxxx }}. 
But no success. 
While searching the reason, it appeared that the magic is done by dynamic_discovery_get_value for the variable replacement, but not in can_skip_sensor. 
This patches slightly changes the signature of can_skip_sensor function, and now uses dynamic_discovery_get_values fed with the complete $pre_cache. 

Works well in my lab and prod now. 

New YAML files using this feature will come in dedicated PRs for Huawei VRP switches. 

PipoCanaja

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
