### PR TITLE
Correct sound for pushover.net

### DIFF
--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -319,7 +319,7 @@ Get your Access Token from your Pushbullet's settings page and set it in your tr
 ## Pushover
 If you want to change the [notification sounds](https://pushover.net/api#sounds) then add it in Pushover Options:
 
-`sound_critical=falling`
+`sound=falling`
 
 Enabling Pushover support is fairly easy, there are only two required parameters.
 
@@ -335,7 +335,7 @@ Now copy your API Key and obtain your User Key from the newly created Applicatio
 | ------ | ------- |
 | Api Key | APPLICATIONAPIKEYGOESHERE |
 | User Key | USERKEYGOESHERE |
-| Pushover Options | sound_critical=falling |
+| Pushover Options | sound=falling |
 
 ## Rocket.chat
 The Rocket.chat transport will POST the alert message to your Rocket.chat Incoming WebHook using the

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -317,9 +317,14 @@ Get your Access Token from your Pushbullet's settings page and set it in your tr
 | Access Token | MYFANCYACCESSTOKEN |
 
 ## Pushover
-If you want to change the [notification sounds](https://pushover.net/api#sounds) then add it in Pushover Options:
+If you want to change the default [notification sound](https://pushover.net/api#sounds) for all notifications then you can add the following in Pushover Options:
 
 `sound=falling`
+
+You also have the possibility to change sound per severity:
+`sound_critical=falling`
+`sound_warning=siren`
+`sound_ok=magic`
 
 Enabling Pushover support is fairly easy, there are only two required parameters.
 
@@ -335,7 +340,9 @@ Now copy your API Key and obtain your User Key from the newly created Applicatio
 | ------ | ------- |
 | Api Key | APPLICATIONAPIKEYGOESHERE |
 | User Key | USERKEYGOESHERE |
-| Pushover Options | sound=falling |
+| Pushover Options | sound_critical=falling |
+|  | sound_warning=siren |
+|  | sound_ok=magic |
 
 ## Rocket.chat
 The Rocket.chat transport will POST the alert message to your Rocket.chat Incoming WebHook using the


### PR DESCRIPTION
pushover.net should now use sound= instead of critical.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
