### PR TITLE
Add additional composite index to syslog table

### DIFF
--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1561,6 +1561,7 @@ syslog:
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
     program: { Name: program, Columns: [program], Unique: false, Type: BTREE }
     priority_level: { Name: priority_level, Columns: [priority, level], Unique: false, Type: BTREE }
+    device_id-timestamp: { Name: device_id-timestamp, Columns: [device_id, timestamp], Unique: false, Type: BTREE }
 tnmsneinfo:
   Columns:
     - { Field: id, Type: int(11), 'Null': false, Extra: auto_increment }

--- a/sql-schema/273.sql
+++ b/sql-schema/273.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `syslog` ADD KEY `device_id-timestamp` (`device_id`,`timestamp`);


### PR DESCRIPTION
Add additional composite index to speed up display of pages where a device has a lot of syslogs. In our environment, this took page loads for some devices from over 60 seconds to nearly instant

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
