### PR TITLE
get geolocation at first poll

### DIFF
--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -84,7 +84,8 @@ class Location extends Model
 
             if (!$this->hasCoordinates() &&
                 \LibreNMS\Config::get('geoloc.latlng', true) &&
-                $this->timestamp && $this->timestamp->diffInDays() > 2
+                $this->timestamp 
+                #&& $this->timestamp->diffInDays() > 2
             ) {
                 $this->fetchCoordinates();
                 $this->updateTimestamps();

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -84,7 +84,7 @@ class Location extends Model
 
             if (!$this->hasCoordinates() &&
                 \LibreNMS\Config::get('geoloc.latlng', true) &&
-                (!$this->exists() || $this->timestamp && $this->timestamp->diffInDays() > 2)
+                (!$this->id || $this->timestamp && $this->timestamp->diffInDays() > 2)
             ) {
                 $this->fetchCoordinates();
                 $this->updateTimestamps();

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -84,8 +84,7 @@ class Location extends Model
 
             if (!$this->hasCoordinates() &&
                 \LibreNMS\Config::get('geoloc.latlng', true) &&
-                $this->timestamp 
-                #&& $this->timestamp->diffInDays() > 2
+                (!$this->exists() || $this->timestamp && $this->timestamp->diffInDays() > 2)
             ) {
                 $this->fetchCoordinates();
                 $this->updateTimestamps();


### PR DESCRIPTION
based on the logic of code, we will have to wait 2 days from adding new device for lat and lng to be updated

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.




based on the code, system will populate lat and lng only after 2 day after adding new device

(if lat & lang is not null system will never update lat and lng)

there is no need to wait for 2 days
