### PR TITLE
Fixed alert log showing only green instead of all by default

### DIFF
--- a/html/pages/alert-log.inc.php
+++ b/html/pages/alert-log.inc.php
@@ -36,6 +36,12 @@ if (isset($_POST['device_id'])) {
 } else {
     $default_option = '';
 }
+if (isset($_POST['state'])) {
+    $state = htmlspecialchars($_POST['state']);
+} else {
+    $state = '-1';
+}
+
 
 ?>
 
@@ -90,7 +96,7 @@ if (isset($_POST['device_id'])) {
             return {
                 id: "alertlog",
                 device_id: '<?php echo htmlspecialchars($_POST['device_id']); ?>',
-                state: '<?php echo htmlspecialchars($_POST['state']); ?>'
+                state: '<?php echo $state; ?>'
             };
         },
         url: "ajax_table.php"


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

By default, when you access Alert History it was showing only OK (Green) ones instead of all. You had to hit filter to show them.