### PR TITLE
feature: Macros for xDP neighbours alert rules

### DIFF
--- a/doc/Alerting/Macros.md
+++ b/doc/Alerting/Macros.md
@@ -168,6 +168,22 @@ Description: Ports that were previously up and have now gone down.
 
 Example: `macros.port_now_down = 1`
 
+### Port has xDP neighbour (Boolean)
+
+Entity: `%macros.port AND %links.local_port_id = %ports.port_id`
+
+Description: Ports that have an xDP (lldp, cdp, etc) neighbour.
+
+Example: `macros.port_has_xdp_neighbours = 1`
+
+### Port has xDP neighbour already known in LibreNMS (Boolean)
+
+Entity: `%macros.port_has_neighbours AND (%links.remote_port_id IS NOT NULL)`
+
+Description: Ports that have an xDP (lldp, cdp, etc) neighbour that is already known in libreNMS.
+
+Example: `macros.port_has_xdp_neighbours_device = 1`
+
 ### Device component down [JunOS]
 
 Entity: `sensors.sensor_class = "state" AND sensors.sensor_current != "6" AND sensors.sensor_type = "jnxFruState" AND sensors.sensor_current != "2"`

--- a/misc/macros.json
+++ b/misc/macros.json
@@ -25,6 +25,8 @@
     "port_in_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_out_usage_perc": "((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_now_down": "%ports.ifOperStatus != %ports.ifOperStatus_prev && %ports.ifOperStatus_prev = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port",
+    "port_has_xdp_neighbours": "(%macros.port && %links.local_port_id = %ports.port_id)",
+    "port_has_xdp_neighbours_device": "(%macros.port_has_neighbours && (%links.remote_port_id IS NOT NULL))",
     "pdu_over_amperage_apc": "%sensors.sensor_class = \"current\" && %sensors.sensor_descr = \"Bank Total\" && %sensors.sensor_current > %sensors.sensor_limit && %devices.os = \"apc\"",
     "sensor": "(%sensors.sensor_alert = 1)",
     "sensor_port_link": "(%sensors.entPhysicalIndex_measured = 'ports' && %sensors.entPhysicalIndex = %ports.ifIndex && %macros.port_up)",

--- a/misc/macros.json
+++ b/misc/macros.json
@@ -26,7 +26,7 @@
     "port_out_usage_perc": "((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_now_down": "%ports.ifOperStatus != %ports.ifOperStatus_prev && %ports.ifOperStatus_prev = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port",
     "port_has_xdp_neighbours": "(%macros.port && %links.local_port_id = %ports.port_id)",
-    "port_has_xdp_neighbours_device": "(%macros.port_has_neighbours && (%links.remote_port_id IS NOT NULL))",
+    "port_has_xdp_neighbours_device": "(%macros.port_has_xdp_neighbours && %links.remote_port_id IS NOT NULL)",
     "pdu_over_amperage_apc": "%sensors.sensor_class = \"current\" && %sensors.sensor_descr = \"Bank Total\" && %sensors.sensor_current > %sensors.sensor_limit && %devices.os = \"apc\"",
     "sensor": "(%sensors.sensor_alert = 1)",
     "sensor_port_link": "(%sensors.entPhysicalIndex_measured = 'ports' && %sensors.entPhysicalIndex = %ports.ifIndex && %macros.port_up)",


### PR DESCRIPTION
Simple macro to ease alert rules checking if an xDP entry exists and if this entry points to a known device. 

"port_has_xdp_neighbours": "(%macros.port && %links.local_port_id = %ports.port_id)",
We check here if we have a port and if an entry in links (all neighbours known in Librenms) matches the current port_id. 

"port_has_xdp_neighbours_device": "(%macros.port_has_neighbours && (%links.remote_port_id IS NOT NULL))",
We add to previous macro a check remote_port_id. If it is NOT NULL, then we know the remote_port_id is known to LibreNMS. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
