### PR TITLE
feature: Added HTML tag support for msteams transport

### DIFF
--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -31,7 +31,7 @@ class Msteams extends Transport
         $data  = array(
             'title' => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),
             'themeColor' => $color,
-            'text' => strip_tags($obj['msg'],'<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>')
+            'text' => strip_tags($obj['msg'], '<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>')
         );
         $curl  = curl_init();
         set_curl_proxy($curl);

--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -31,7 +31,7 @@ class Msteams extends Transport
         $data  = array(
             'title' => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),
             'themeColor' => $color,
-            'text' => strip_tags($obj['msg'])
+            'text' => strip_tags($obj['msg'],'<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>')
         );
         $curl  = curl_init();
         set_curl_proxy($curl);


### PR DESCRIPTION
Added support to use HTML tags in alert templates for Microsoft teams transport.
This will allow the customization of how the alerts will appear in MS teams.

Supported tags are documented [here](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/cards/cards-format#html-formatting-for-connector-cards)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
