### PR TITLE
webui: Improve alert details display for bgp and sensors

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1193,7 +1193,7 @@ function alert_details($details)
 
         if ($tmp_alerts['sensor_id']) {
             $details = "Current Value: " . $tmp_alerts['sensor_current'] . " (" . $tmp_alerts['sensor_class'] . ")<br>  ";
-            $details_a[] = array();
+            $details_a = array();
 
             if ($tmp_alerts['sensor_limit_low']) {
                 $details_a[] = "low: " . $tmp_alerts['sensor_limit_low'];

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1193,7 +1193,7 @@ function alert_details($details)
 
         if ($tmp_alerts['sensor_id']) {
             $details = "Current Value: " . $tmp_alerts['sensor_current'] . " (" . $tmp_alerts['sensor_class'] . ")<br>  ";
-            $details_a = array();
+            $details_a = [];
 
             if ($tmp_alerts['sensor_limit_low']) {
                 $details_a[] = "low: " . $tmp_alerts['sensor_limit_low'];

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -720,23 +720,6 @@ function generate_sensor_link($args, $text = null, $type = null)
         $args['graph_type'] = "sensor_" . $type;
     }
 
-    $details = "Current Value: " . $args['sensor_current'] . " (" . $args['sensor_class'] . ")<br>  ";
-
-    if ($args['sensor_limit_low']) {
-        $details_a[] = "low: " . $args['sensor_limit_low'];
-    }
-    if ($args['sensor_limit_low_warn']) {
-        $details_a[]= "low_warn: " . $args['sensor_limit_low_warn'];
-    }
-    if ($args['sensor_limit_warn']) {
-        $details_a[]= "high_warn: " . $args['sensor_limit_warn'];
-    }
-    if ($args['sensor_limit']) {
-        $details_a[]= "high: " . $args['sensor_limit'];
-    }
-
-    $details .= implode(', ', $details_a);
-
     if (!isset($args['hostname'])) {
         $args = array_merge($args, device_by_id_cache($args['device_id']));
     }
@@ -764,9 +747,9 @@ function generate_sensor_link($args, $text = null, $type = null)
 
     $url = generate_sensor_url($args);
     if (port_permitted($args['interface_id'], $args['device_id'])) {
-        return overlib_link($url, $text, $content, null) . "<br>" . $details;
+        return overlib_link($url, $text, $content, null);
     } else {
-        return fixifName($text) . "<br>" . $details;
+        return fixifName($text);
     }
 }//end generate_sensor_link()
 
@@ -1206,7 +1189,22 @@ function alert_details($details)
         }
 
         if ($tmp_alerts['sensor_id']) {
-            $fault_detail .= generate_sensor_link($tmp_alerts, $tmp_alerts['name']) . ';&nbsp;';
+            $details = "Current Value: " . $tmp_alerts['sensor_current'] . " (" . $tmp_alerts['sensor_class'] . ")<br>  ";
+            if ($tmp_alerts['sensor_limit_low']) {
+                $details_a[] = "low: " . $tmp_alerts['sensor_limit_low'];
+            }
+            if ($tmp_alerts['sensor_limit_low_warn']) {
+                $details_a[]= "low_warn: " . $tmp_alerts['sensor_limit_low_warn'];
+            }
+            if ($tmp_alerts['sensor_limit_warn']) {
+                $details_a[]= "high_warn: " . $tmp_alerts['sensor_limit_warn'];
+            }
+            if ($tmp_alerts['sensor_limit']) {
+                $details_a[]= "high: " . $tmp_alerts['sensor_limit'];
+            }
+            $details .= implode(', ', $details_a);
+
+            $fault_detail .= generate_sensor_link($tmp_alerts, $tmp_alerts['name']) . ';&nbsp; <br>' . $details;
             $fallback = false;
         }
         if ($tmp_alerts['bgpPeer_id']) {

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1219,7 +1219,7 @@ function alert_details($details)
                 "'>" . $tmp_alerts['bgpPeerIdentifier'] . "</a>";
             $fault_detail .= ", AS" . $tmp_alerts['bgpPeerRemoteAs'];
             $fault_detail .= ", State " . $tmp_alerts['bgpPeerState'];
-            $fallback = false; 
+            $fallback = false;
         }
         if ($tmp_alerts['type'] && $tmp_alerts['label']) {
             if ($tmp_alerts['error'] == "") {

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -13,6 +13,7 @@
  */
 
 use LibreNMS\Authentication\LegacyAuth;
+use LibreNMS\Config;
 
 /**
  * Compare $t with the value of $vars[$v], if that exists
@@ -706,8 +707,6 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
 
 function generate_sensor_link($args, $text = null, $type = null)
 {
-    global $config;
-
     $args = cleanPort($args);
 
     if (!$text) {
@@ -732,15 +731,15 @@ function generate_sensor_link($args, $text = null, $type = null)
     $graph_array['legend'] = 'yes';
     $graph_array['height'] = '100';
     $graph_array['width'] = '340';
-    $graph_array['to'] = $config['time']['now'];
-    $graph_array['from'] = $config['time']['day'];
+    $graph_array['to'] = Config::get('time.now');
+    $graph_array['from'] = Config::get('time.day');
     $graph_array['id'] = $args['sensor_id'];
     $content .= generate_graph_tag($graph_array);
-    $graph_array['from'] = $config['time']['week'];
+    $graph_array['from'] = Config::get('time.week');
     $content .= generate_graph_tag($graph_array);
-    $graph_array['from'] = $config['time']['month'];
+    $graph_array['from'] = Config::get('time.month');
     $content .= generate_graph_tag($graph_array);
-    $graph_array['from'] = $config['time']['year'];
+    $graph_array['from'] = Config::get('time.year');
     $content .= generate_graph_tag($graph_array);
     $content .= '</div>';
 
@@ -756,7 +755,7 @@ function generate_sensor_link($args, $text = null, $type = null)
 
 function generate_sensor_url($sensor, $vars = array())
 {
-    return generate_url(array('page' => 'graphs', 'id' => $sensor['sensor_id'], 'type' => $sensor['graph_type'], 'from' => $config['time']['day']), $vars);
+    return generate_url(array('page' => 'graphs', 'id' => $sensor['sensor_id'], 'type' => $sensor['graph_type'], 'from' => Config::get('time.day')), $vars);
 }//end generate_sensor_url()
 
  
@@ -1683,8 +1682,6 @@ function get_dashboards($user_id = null)
  * @param string $transparency value of desired transparency applied to rrdtool options (values 01 - 99)
  * @return array containing transparency and stacked setup
  */
-
-use LibreNMS\Config;
 
 function generate_stacked_graphs($transparency = '88')
 {

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -704,7 +704,79 @@ function generate_port_link($port, $text = null, $type = null, $overlib = 1, $si
     }
 }//end generate_port_link()
 
+function generate_sensor_link($args, $text = null, $type = null)
+{
+    global $config;
 
+    $args = cleanPort($args);
+
+    if (!$text) {
+        $text = fixIfName($args['sensor_descr']);
+    }
+
+    if (!$type) {
+        $args['graph_type'] = "sensor_" . $args['sensor_class'];
+    } else {
+        $args['graph_type'] = "sensor_" . $type;
+    }
+
+    $details = "Current Value: " . $args['sensor_current'] . " (" . $args['sensor_class'] . ")<br>  ";
+
+    if ($args['sensor_limit_low']) {
+        $details_a[] = "low: " . $args['sensor_limit_low'];
+    }
+    if ($args['sensor_limit_low_warn']) {
+        $details_a[]= "low_warn: " . $args['sensor_limit_low_warn'];
+    }
+    if ($args['sensor_limit_warn']) {
+        $details_a[]= "high_warn: " . $args['sensor_limit_warn'];
+    }
+    if ($args['sensor_limit']) {
+        $details_a[]= "high: " . $args['sensor_limit'];
+    }
+
+    $details .= implode(', ', $details_a);
+
+    if (!isset($args['hostname'])) {
+        $args = array_merge($args, device_by_id_cache($args['device_id']));
+    }
+
+    $content = '<div class=list-large>' . $text . '</div>';
+
+    $content .= "<div style=\'width: 850px\'>";
+    $graph_array = array();
+    $graph_array['type'] = $args['graph_type'];
+    $graph_array['legend'] = 'yes';
+    $graph_array['height'] = '100';
+    $graph_array['width'] = '340';
+    $graph_array['to'] = $config['time']['now'];
+    $graph_array['from'] = $config['time']['day'];
+    $graph_array['id'] = $args['sensor_id'];
+    $content .= generate_graph_tag($graph_array);
+    $graph_array['from'] = $config['time']['week'];
+    $content .= generate_graph_tag($graph_array);
+    $graph_array['from'] = $config['time']['month'];
+    $content .= generate_graph_tag($graph_array);
+    $graph_array['from'] = $config['time']['year'];
+    $content .= generate_graph_tag($graph_array);
+    $content .= '</div>';
+
+
+    $url = generate_sensor_url($args);
+    if (port_permitted($args['interface_id'], $args['device_id'])) {
+        return overlib_link($url, $text, $content, null) . "<br>" . $details;
+    } else {
+        return fixifName($text) . "<br>" . $details;
+    }
+}//end generate_sensor_link()
+
+
+function generate_sensor_url($sensor, $vars = array())
+{
+    return generate_url(array('page' => 'graphs', 'id' => $sensor['sensor_id'], 'type' => $sensor['graph_type'], 'from' => $config['time']['day']), $vars);
+}//end generate_sensor_url()
+
+ 
 function generate_port_url($port, $vars = array())
 {
     return generate_url(array('page' => 'device', 'device' => $port['device_id'], 'tab' => 'port', 'port' => $port['port_id']), $vars);
@@ -1133,6 +1205,22 @@ function alert_details($details)
             $fallback = false;
         }
 
+        if ($tmp_alerts['sensor_id']) {
+            $fault_detail .= generate_sensor_link($tmp_alerts, $tmp_alerts['name']) . ';&nbsp;';
+            $fallback = false;
+        }
+        if ($tmp_alerts['bgpPeer_id']) {
+            // If we have a bgpPeer_id, we format the data accordingly
+            $fault_detail .= "BGP peer <a href='" .
+                generate_url(array('page' => 'device',
+                            'device' => $tmp_alerts['device_id'],
+                            'tab' => 'routing',
+                            'proto' => 'bgp')) .
+                "'>" . $tmp_alerts['bgpPeerIdentifier'] . "</a>";
+            $fault_detail .= ", AS" . $tmp_alerts['bgpPeerRemoteAs'];
+            $fault_detail .= ", State " . $tmp_alerts['bgpPeerState'];
+            $fallback = false; 
+        }
         if ($tmp_alerts['type'] && $tmp_alerts['label']) {
             if ($tmp_alerts['error'] == "") {
                 $fault_detail .= ' ' . $tmp_alerts['type'] . ' - ' . $tmp_alerts['label'] . ';&nbsp;';

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -726,23 +726,27 @@ function generate_sensor_link($args, $text = null, $type = null)
     $content = '<div class=list-large>' . $text . '</div>';
 
     $content .= "<div style=\'width: 850px\'>";
-    $graph_array = array();
-    $graph_array['type'] = $args['graph_type'];
-    $graph_array['legend'] = 'yes';
-    $graph_array['height'] = '100';
-    $graph_array['width'] = '340';
-    $graph_array['to'] = Config::get('time.now');
-    $graph_array['from'] = Config::get('time.day');
-    $graph_array['id'] = $args['sensor_id'];
+    $graph_array = [
+        'type' => $args['graph_type'],
+        'legend' => 'yes',
+        'height' => '100',
+        'width' => '340',
+        'to' => Config::get('time.now'),
+        'from' => Config::get('time.day'),
+        'id' => $args['sensor_id'],
+        ];
     $content .= generate_graph_tag($graph_array);
+
     $graph_array['from'] = Config::get('time.week');
     $content .= generate_graph_tag($graph_array);
+
     $graph_array['from'] = Config::get('time.month');
     $content .= generate_graph_tag($graph_array);
+
     $graph_array['from'] = Config::get('time.year');
     $content .= generate_graph_tag($graph_array);
-    $content .= '</div>';
 
+    $content .= '</div>';
 
     $url = generate_sensor_url($args);
     if (port_permitted($args['interface_id'], $args['device_id'])) {
@@ -1189,6 +1193,8 @@ function alert_details($details)
 
         if ($tmp_alerts['sensor_id']) {
             $details = "Current Value: " . $tmp_alerts['sensor_current'] . " (" . $tmp_alerts['sensor_class'] . ")<br>  ";
+            $details_a[] = array();
+
             if ($tmp_alerts['sensor_limit_low']) {
                 $details_a[] = "low: " . $tmp_alerts['sensor_limit_low'];
             }


### PR DESCRIPTION
This change is improving the default display of alerts for BGP Peers and Sensors. The best solution would probably be, IMO, to use the templating system that is already creating emails and all other transports to create this text. This would allow everybody to customize the alerts display in the GUI. 

But this looks like a too big change for me right now. So until then, this PR will give more details and links for BGP and Sensor based alerts. 

![capture d ecran 2018-12-10 a 21 59 44](https://user-images.githubusercontent.com/38363551/49762272-926c5780-fcc9-11e8-8e7b-2b678833ce1e.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
