### PR TITLE
Better handling of log file failures

### DIFF
--- a/app/Checks.php
+++ b/app/Checks.php
@@ -220,6 +220,16 @@ class Checks
             $commands[] = "usermod -a -G $group $current_user";
         }
 
+        // check for invalid log setting
+        $log_file = config('app.log');
+        if (!is_file($log_file) || !is_writable($log_file)) {
+            $dirs = [$log_file];
+            $commands = [
+                '<h3>Cannot write to log file: &quot;' . $log_file . '&quot;</h3>',
+                'Make sure it exists and is writable, or change your LOG_DIR setting.'
+            ];
+        }
+
         // selinux:
         $commands[] = '<h4>If using SELinux you may also need:</h4>';
         foreach ($dirs as $dir) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,7 +18,6 @@ class AppServiceProvider extends ServiceProvider
      * Bootstrap any application services.
      *
      * @return void
-     * @throws DatabaseConnectException caught by App\Exceptions\Handler and displayed to the user
      */
     public function boot()
     {
@@ -28,9 +27,11 @@ class AppServiceProvider extends ServiceProvider
         // load config
         Config::load();
 
-        // direct log output to librenms.log
-        Log::getMonolog()->popHandler(); // remove existing errorlog logger
-        Log::useFiles(Config::get('log_file', base_path('logs/librenms.log')), 'error');
+        // redirect log to config location, unless APP_LOG is set
+        if (!config('app.log')) {
+            Log::getMonolog()->popHandler(); // remove existing errorlog logger
+            Log::useFiles(Config::get('log_file', base_path('logs/librenms.log')), 'error');
+        }
 
         // Blade directives (Yucky because of < L5.5)
         Blade::directive('config', function ($key) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,7 +42,7 @@ $app->singleton(
 );
 
 $app->configureMonologUsing(function (Monolog\Logger $logger) use ($app) {
-    $path = $app->basePath(config('app.log'));
+    $path = config('app.log') ?: $app->basePath('logs/librenms.log');
     $logger->pushHandler(new \Monolog\Handler\StreamHandler($path));
 });
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -43,7 +43,7 @@ $app->singleton(
 
 $app->configureMonologUsing(function (Monolog\Logger $logger) use ($app) {
     $path = config('app.log') ?: $app->basePath('logs/librenms.log');
-    $logger->pushHandler(new \Monolog\Handler\StreamHandler($path));
+    $logger->pushHandler(new \Monolog\Handler\StreamHandler($path, \Monolog\Logger::toMonologLevel(config('app.log_level', 'debug'))));
 });
 
 /*

--- a/config/app.php
+++ b/config/app.php
@@ -122,7 +122,7 @@ return [
 
     'log' => env('APP_LOG'),  // log file to write to
 
-    'log_level' => env('APP_LOG_LEVEL', 'debug'),
+    'log_level' => env('APP_LOG_LEVEL', 'error'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -120,7 +120,7 @@ return [
     |
     */
 
-    'log' => env('APP_LOG', 'logs/librenms.log'),  // log to the default file, until boot
+    'log' => env('APP_LOG'),  // log file to write to
 
     'log_level' => env('APP_LOG_LEVEL', 'debug'),
 


### PR DESCRIPTION
Fix issues when APP_LOG is empty, unwritable , or pointed at a directory.
APP_LOG takes precedence over $config['log_file'] now.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
