### PR TITLE
Typo fix

### DIFF
--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -58,7 +58,7 @@ class Database extends BaseValidation
             );
             return;
         } elseif ($current > $latest) {
-            $validator->warn("Your schema ($current) is newer than than expected ($latest).  If you just switch to the stable release from the daily release, your database is in between releases and this will be resolved with the next release.");
+            $validator->warn("Your schema ($current) is newer than than expected ($latest).  If you just switched to the stable release from the daily release, your database is in between releases and this will be resolved with the next release.");
         }
 
         $this->checkCollation($validator);


### PR DESCRIPTION
This is just a small typo fix, that I stumbled upon when switching between releases.

`[WARN]  Your schema (273) is newer than than expected (272).  If you just switch to the stable release from the daily release, your database is in between releases and this will be resolved with the next release.`

Vs

`[WARN]  Your schema (273) is newer than than expected (272).  If you just switched to the stable release from the daily release, your database is in between releases and this will be resolved with the next release.`

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
