### PR TITLE
Added automatic generation of the list of available transports (alerting)

### DIFF
--- a/doc/Alerting/Creating-Transport.md
+++ b/doc/Alerting/Creating-Transport.md
@@ -21,14 +21,6 @@ data should be validated and how. Validation is done using [Laravel validation](
 
 The following function is __not__ required for new Transports and is for legacy reasons only. `deliverAlertOld()`.
 
-### WebUI
-At present you will also need to add the new transport to the select part of the form in
-`html/includes/modal/edit_alert_transport.inc.php`. I.e:
-
-`<option value="discord-form">Discord</option>`
-
-Please ensure you add the new entry in the correct location sorted alphabetically.
-
 ### Documentation
 Please don't forget to update the [Transport](Transports.md) file to include details of your new transport.
 

--- a/html/includes/modal/edit_alert_transport.inc.php
+++ b/html/includes/modal/edit_alert_transport.inc.php
@@ -43,11 +43,15 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
 
 // Create list of transport
 $transport_dir = Config::get('install_dir').'/LibreNMS/Alert/Transport';
+$transports_list = array();
 foreach (scandir($transport_dir) as $transport) {
     $transport = strstr($transport, '.', true);
     if (empty($transport)) {
         continue;
     }
+    $transports_list[] = $transport;
+}
+foreach ($transports_list as $transport) {
     echo '<option value="'.strtolower($transport).'-form">'.$transport.'</option>';
 }
 ?>
@@ -63,15 +67,8 @@ foreach (scandir($transport_dir) as $transport) {
                     </form>
 <?php
 
-// Fetch list of transport classes
-$transport_dir = Config::get('install_dir').'/LibreNMS/Alert/Transport';
 $switches = []; // store names of bootstrap switches
-
-foreach (scandir($transport_dir) as $transport) {
-    $transport = strstr($transport, '.', true);
-    if (empty($transport)) {
-        continue;
-    }
+foreach ($transports_list as $transport) {
     $class = 'LibreNMS\\Alert\\Transport\\'.$transport;
 
     if (!method_exists($class, 'configTemplate')) {

--- a/html/includes/modal/edit_alert_transport.inc.php
+++ b/html/includes/modal/edit_alert_transport.inc.php
@@ -39,37 +39,18 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
                             <label for='transport-choice' class='col-sm-3 col-md-2 control-label'>Transport type: </label>
                             <div class="col-sm-3">
                                 <select name='transport-choice' id='transport-choice' class='form-control'>
-                                    <option value="api-form">API</option>
-                                    <option value="boxcar-form">Boxcar</option>
-                                    <option value="canopsis-form">Canopsis</option>
-                                    <option value="ciscospark-form">Cisco Spark</option>
-                                    <option value="clickatell-form">Clickatell</option>
-                                    <option value="discord-form">Discord</option>
-                                    <option value="elasticsearch-form">Elasticsearch</option>
-                                    <option value="gitlab-form">Gitlab</option>
-                                    <option value="hipchat-form">Hipchat</option>
-                                    <option value="irc-form">IRC</option>
-                                    <option value="jira-form">Jira</option>
-                                    <option value="kayako-form">Kayako Classic</option>
-                                    <option value="mail-form" selected>Mail</option>
-                                    <option value="msteams-form">Microsoft Teams</option>
-                                    <option value="nagios-form">Nagios</option>
-                                    <option value="opsgenie-form">OpsGenie</option>
-                                    <option value="osticket-form">osTicket</option>
-                                    <option value="pagerduty-form">PagerDuty</option>
-                                    <option value="hue-form">Phillips Hue</option>
-                                    <option value="playsms-form">PlaySMS</option>
-                                    <option value="pushbullet-form">Pushbullet</option>
-                                    <option value="pushover-form">Pushover</option>
-                                    <option value="rocket-form">Rocket.chat</option>
-                                    <option value="slack-form">Slack</option>
-                                    <option value="smseagle-form">SMSEagle</option>
-                                    <option value="smsfeedback-form">SMSFeedback</option>
-                                    <option value="syslog-form">Syslog</option>
-                                    <option value="telegram-form">Telegram</option>
-                                    <option value="twilio-form">Twilio</option>
-                                    <option value="victorops-form">Victorops</option>
-                                    <!--Insert more transport type options here has support is added. Value should be: [transport_name]-form -->
+<?php
+
+// Create list of transport
+$transport_dir = Config::get('install_dir').'/LibreNMS/Alert/Transport';
+foreach (scandir($transport_dir) as $transport) {
+    $transport = strstr($transport, '.', true);
+    if (empty($transport)) {
+        continue;
+    }
+    echo '<option value="'.strtolower($transport).'-form">'.$transport.'</option>';
+}
+?>
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


This patch allows you to avoid manually adding a transport to the list of available transports. In addition, in custom installations, where their own transports were added, the need to manually update the file "html/includes/modal/edit_alert_transport.inc.php" broke the automatic update (git detected a conflict and required manual solution). With this patch, you can avoid this, add local transports that remain outside the git repository and there is no need to create and maintain your fork in order to add your transports or add them to the upstream (they may have no value outside the local installation).