### PR TITLE
Even more widget fixes/improvements

### DIFF
--- a/app/Http/Controllers/Select/PortController.php
+++ b/app/Http/Controllers/Select/PortController.php
@@ -62,6 +62,8 @@ class PortController extends SelectController
     {
         /** @var \Illuminate\Database\Eloquent\Builder $query */
         $query = Port::hasAccess($request->user())
+            ->isNotDeleted()
+            ->has('device')
             ->with(['device' => function ($query) {
                 $query->select('device_id', 'hostname', 'sysName');
             }])

--- a/app/Http/Controllers/Widgets/DeviceSummaryController.php
+++ b/app/Http/Controllers/Widgets/DeviceSummaryController.php
@@ -65,12 +65,12 @@ abstract class DeviceSummaryController extends WidgetController
         ];
 
         $data['ports'] = [
-            'count' => Port::hasAccess($user)->count(),
-            'up' => Port::hasAccess($user)->isUp()->count(),
-            'down' => Port::hasAccess($user)->isDown()->count(),
-            'ignored' => Port::hasAccess($user)->isIgnored()->count(),
-            'shutdown' => Port::hasAccess($user)->isShutdown()->count(),
-            'errored' => $data['summary_errors'] ? Port::hasAccess($user)->hasErrors()->count() : -1,
+            'count' => Port::hasAccess($user)->isNotDeleted()->count(),
+            'up' => Port::hasAccess($user)->isNotDeleted()->isUp()->count(),
+            'down' => Port::hasAccess($user)->isNotDeleted()->isDown()->count(),
+            'ignored' => Port::hasAccess($user)->isNotDeleted()->isIgnored()->count(),
+            'shutdown' => Port::hasAccess($user)->isNotDeleted()->isShutdown()->count(),
+            'errored' => $data['summary_errors'] ? Port::hasAccess($user)->isNotDeleted()->hasErrors()->count() : -1,
         ];
 
         if ($data['show_services']) {

--- a/app/Http/Controllers/Widgets/WidgetController.php
+++ b/app/Http/Controllers/Widgets/WidgetController.php
@@ -93,12 +93,28 @@ abstract class WidgetController extends Controller
         return $this->settings;
     }
 
+    /**
+     * @param View|string $view
+     * @param string $title
+     * @param array $settings
+     * @param string $status
+     * @return \Illuminate\Http\JsonResponse
+     */
     private function formatResponse($view, $title, $settings, $status = 'ok')
     {
+        if ($view instanceof View) {
+            $html = $view->__toString();
+            $show_settings = (int)starts_with($view->getName(), 'widgets.settings.');
+        } else {
+            $html = (string)$view;
+            $show_settings = (int)$this->show_settings;
+        }
+
         return response()->json([
             'status' => $status,
             'title' => __($title),
-            'html' => is_string($view) ? $view : $view->__toString(),
+            'html' => $html,
+            'show_settings' => $show_settings,
             'settings' => $settings,
         ]);
     }

--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -635,7 +635,6 @@ if (empty($vars['bare']) || $vars['bare'] == "no") {
         $("#widget_body_"+id+" .bootgrid-table").bootgrid("destroy");
         $("#widget_body_"+id+" *").off();
         var $widget_body = $("#widget_body_"+id);
-        $widget_body.empty();
         if ($widget_body.parent().data('settings') == 1 ) {
             settings = 1;
         } else {
@@ -652,6 +651,7 @@ if (empty($vars['bare']) || $vars['bare'] == "no") {
             dataType: "json",
             success: function (data) {
                 var $widget_body = $("#widget_body_"+id);
+                $widget_body.empty();
                 if (data.status === 'ok') {
                     $("#widget_title_"+id).html(data.title);
                     $widget_body.html(data.html).parent().data('settings', data.show_settings);
@@ -661,6 +661,7 @@ if (empty($vars['bare']) || $vars['bare'] == "no") {
             },
             error: function (data) {
                 var $widget_body = $("#widget_body_"+id);
+                $widget_body.empty();
                 if (data.responseJSON.error) {
                     $widget_body.html('<div class="alert alert-info">' + data.responseJSON.error + '</div>');
                 } else {

--- a/html/pages/front/tiles.php
+++ b/html/pages/front/tiles.php
@@ -634,8 +634,9 @@ if (empty($vars['bare']) || $vars['bare'] == "no") {
     function widget_reload(id,data_type) {
         $("#widget_body_"+id+" .bootgrid-table").bootgrid("destroy");
         $("#widget_body_"+id+" *").off();
-        $("#widget_body_"+id).empty();
-        if( $("#widget_body_"+id).parent().data('settings') == 1 ) {
+        var $widget_body = $("#widget_body_"+id);
+        $widget_body.empty();
+        if ($widget_body.parent().data('settings') == 1 ) {
             settings = 1;
         } else {
             settings = 0;
@@ -645,24 +646,25 @@ if (empty($vars['bare']) || $vars['bare'] == "no") {
             url: 'ajax/dash/' + data_type,
             data: {
                 id: id,
-                dimensions: {x:$("#widget_body_"+id).width(), y:$("#widget_body_"+id).height()},
+                dimensions: {x:$widget_body.width(), y:$widget_body.height()},
                 settings:settings
             },
             dataType: "json",
             success: function (data) {
-                if (data.status == 'ok') {
+                var $widget_body = $("#widget_body_"+id);
+                if (data.status === 'ok') {
                     $("#widget_title_"+id).html(data.title);
-                    $("#widget_body_"+id).html(data.html);
-                }
-                else {
-                    $("#widget_body_"+id).html('<div class="alert alert-info">' + data.message + '</div>');
+                    $widget_body.html(data.html).parent().data('settings', data.show_settings);
+                } else {
+                    $widget_body.html('<div class="alert alert-info">' + data.message + '</div>');
                 }
             },
             error: function (data) {
+                var $widget_body = $("#widget_body_"+id);
                 if (data.responseJSON.error) {
-                    $("#widget_body_"+id).html('<div class="alert alert-info">' + data.responseJSON.error + '</div>');
+                    $widget_body.html('<div class="alert alert-info">' + data.responseJSON.error + '</div>');
                 } else {
-                    $("#widget_body_"+id).html('<div class="alert alert-info"><?php echo __('Problem with backend'); ?></div>');
+                    $widget_body.html('<div class="alert alert-info"><?php echo __('Problem with backend'); ?></div>');
                 }
             }
         });


### PR DESCRIPTION
Device Summary: don't count deleted ports
General: prevent widget refresh while in settings (synchronize "show_settings" between frontend and backend)
General: reduce reload flicker by delaying clearing of old content until the backend is complete.
Port Select: exclude deleted and orphaned ports

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
