### PR TITLE
Storage Graph that shows used Bytes rather than a percentage utilization

### DIFF
--- a/html/includes/graphs/storage/used.inc.php
+++ b/html/includes/graphs/storage/used.inc.php
@@ -1,0 +1,60 @@
+<?php
+
+$scale_min = '0';
+$scale_max = '100';
+
+require 'includes/graphs/common.inc.php';
+
+$rrd_options .= ' -b 1024';
+
+$iter = '1';
+
+$rrd_options .= " COMMENT:'                    Size      Used       Free  % Used   Change\\n'";
+
+$hostname = gethostbyid($storage['device_id']);
+
+$colour      = 'CC0000';
+$colour_area = 'ffaaaa';
+
+$descr = rrdtool_escape($storage['storage_descr'], 12);
+
+$percentage = round($storage['storage_perc'], 0);
+
+$background = get_percentage_colours($percentage, $storage['storage_perc_warn']);
+
+$rrd_options .= " DEF:used=$rrd_filename:used:AVERAGE";
+$rrd_options .= " DEF:free=$rrd_filename:free:AVERAGE";
+$rrd_options .= " VDEF:firstx=used,FIRST";
+$rrd_options .= " VDEF:lastx=used,LAST";
+
+$rrd_options .= " CDEF:size=used,free,+";
+$rrd_options .= " CDEF:perc=used,size,/,100,*";
+$rrd_options .= " CDEF:diffx=used,POP,lastx,firstx,-";
+$rrd_options .= " VDEF:diff=diffx,LAST";
+
+$rrd_options .= " AREA:used#" . $background['right'] . ":";
+$rrd_options .= " LINE1.25:used#" . $background['left'] . ":'$descr'";
+$rrd_options .= " GPRINT:size:LAST:%6.2lf%sB";
+$rrd_options .= " GPRINT:used:LAST:%6.2lf%sB";
+$rrd_options .= " GPRINT:free:LAST:%6.2lf%sB";
+$rrd_options .= " GPRINT:perc:LAST:%5.2lf%%";
+$rrd_options .= " GPRINT:diff:%6.2lf%sB\\n";
+
+if ($_GET['previous']) {
+    $descr = rrdtool_escape('Prev '.$storage['storage_descr'], 12);
+
+    $colour      = '99999999';
+    $colour_area = '66666666';
+
+    $rrd_options .= " DEF:usedX=$rrd_filename:used:AVERAGE:start=".$prev_from.':end='.$from;
+    $rrd_options .= " DEF:freeX=$rrd_filename:free:AVERAGE:start=".$prev_from.':end='.$from;
+    $rrd_options .= " SHIFT:usedX:$period";
+    $rrd_options .= " SHIFT:freeX:$period";
+    $rrd_options .= ' CDEF:sizeX=usedX,freeX,+';
+    $rrd_options .= ' CDEF:percX=usedX,sizeX,/,100,*';
+    $rrd_options .= ' AREA:percX#'.$colour_area.':';
+    $rrd_options .= ' LINE1.25:percX#'.$colour.":'$descr'";
+    $rrd_options .= ' GPRINT:sizeX:LAST:%6.2lf%sB';
+    $rrd_options .= ' GPRINT:freeX:LAST:%6.2lf%sB';
+    $rrd_options .= " GPRINT:percX:LAST:%5.2lf%%\\n";
+}

--- a/html/includes/graphs/storage/used.inc.php
+++ b/html/includes/graphs/storage/used.inc.php
@@ -41,10 +41,8 @@ $rrd_options .= " GPRINT:perc:LAST:%5.2lf%%";
 $rrd_options .= " GPRINT:diff:%6.2lf%sB\\n";
 
 if ($_GET['previous']) {
-    $descr = rrdtool_escape('Prev '.$storage['storage_descr'], 12);
-
-    $colour      = '99999999';
-    $colour_area = '66666666';
+    $colour      = '77777777';
+    $colour_area = '33333333';
 
     $rrd_options .= " DEF:usedX=$rrd_filename:used:AVERAGE:start=".$prev_from.':end='.$from;
     $rrd_options .= " DEF:freeX=$rrd_filename:free:AVERAGE:start=".$prev_from.':end='.$from;


### PR DESCRIPTION
Usefull if volume can grow in total size. Which causes the percentage Graph to drop.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.