### PR TITLE
Bug - correcting size and non significant zeroes

### DIFF
--- a/html/includes/table/sensors-common.php
+++ b/html/includes/table/sensors-common.php
@@ -121,7 +121,7 @@ foreach (dbFetchRows($sql, $param) as $sensor) {
     } else {
         // we have another sensor
         $current_label = get_sensor_label_color($sensor);
-        $sensor_current = "<span class='label $current_label'>".(format_si($sensor['sensor_current'])+0)." $unit</span>";
+        $sensor_current = "<span class='label $current_label'>".format_si($sensor['sensor_current']).$unit."</span>";
     }
 
     $response[] = array(

--- a/html/pages/device/health/sensors.inc.php
+++ b/html/pages/device/health/sensors.inc.php
@@ -23,13 +23,13 @@ foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `devi
         $sensor_current = get_state_label($sensor['state_generic_value'], $state_translation[0]['state_descr'] . " (".$sensor['sensor_current'].")");
     } else {
         $current_label = get_sensor_label_color($sensor);
-        $sensor_current = "<span class='label $current_label'>".(format_si($sensor['sensor_current'])+0)." $unit</span>";
+        $sensor_current = "<span class='label $current_label'>".format_si($sensor['sensor_current']).$unit."</span>";
     }
 
-    $sensor_limit = (format_si($sensor['sensor_limit'])+0)." $unit";
-    $sensor_limit_low = (format_si($sensor['sensor_limit_low'])+0)." $unit";
-    $sensor_limit_warn = (format_si($sensor['sensor_limit_warn'])+0)." $unit";
-    $sensor_limit_low_warn = (format_si($sensor['sensor_limit_low_warn'])+0)." $unit";
+    $sensor_limit = format_si($sensor['sensor_limit']).$unit;
+    $sensor_limit_low = format_si($sensor['sensor_limit_low']).$unit;
+    $sensor_limit_warn = format_si($sensor['sensor_limit_warn']).$unit;
+    $sensor_limit_low_warn = format_si($sensor['sensor_limit_low_warn']).$unit;
 
     echo "<div class='panel panel-default'>
         <div class='panel-heading'>

--- a/includes/common.php
+++ b/includes/common.php
@@ -627,7 +627,7 @@ function format_si($value, $round = '2', $sf = '3')
         $value = $value * -1;
     }
 
-    return number_format(round($value, $round), $sf, '.', '').$ext;
+    return (number_format(round($value, $round), $sf, '.', '')+0)." ".$ext;
 }
 
 function format_bi($value, $round = '2', $sf = '3')
@@ -646,8 +646,7 @@ function format_bi($value, $round = '2', $sf = '3')
     if ($neg) {
         $value = $value * -1;
     }
-
-    return number_format(round($value, $round), $sf, '.', '').$ext;
+    return (number_format(round($value, $round), $sf, '.', '')+0)." ".$ext;
 }
 
 function format_number($value, $base = '1000', $round = 2, $sf = 3)


### PR DESCRIPTION
Correcting a bug added in #9550

Here we change format_si() and format_bi() to remove non significant zeros, and clean up the attempt to do this at a later stage in sensor value display.

Also added a space between value and size in format_si and bi, as the best practices suggest to do. 
https://physics.nist.gov/cuu/Units/checklist.html

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
