### PR TITLE
Fix Exception in GraylogAPI.php

### DIFF
--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -125,7 +125,7 @@ class GraylogApi
             $ip = gethostbyname($device->hostname);
             $device_query = 'source:"' . $device->hostname . '" || source:"' . $ip . '"';
             if ($device->ip && $ip != $device->ip) {
-                $query .= ' || source:"' . $device->ip . '"';
+                $device_query .= ' || source:"' . $device->ip . '"';
             }
 
             $query[] = '(' . $device_query . ')';


### PR DESCRIPTION
Fix the following exception, occurring when device known IP address is different than the one returned by gethostbyname() function call.

production.ERROR: ErrorException: Array to string conversion in /opt/librenms/app/ApiClients/GraylogApi.php:128

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
