### PR TITLE
Added Alertmanager transport

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -1,0 +1,110 @@
+<?php
+/* Copyright (C) 2019 LibreNMS
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+/**
+ * API Transport
+ * @copyright 2019 LibreNMS
+ * @license GPL
+ * @package LibreNMS
+ * @subpackage Alerts
+ */
+namespace LibreNMS\Alert\Transport;
+
+use LibreNMS\Alert\Transport;
+use LibreNMS\Config;
+
+class Alertmanager extends Transport
+{
+    public function deliverAlert($obj, $opts)
+    {
+        $alertmanager_opts['url'] = $this->config['alertmanager-url'];
+        foreach (explode(PHP_EOL, $this->config['alertmanager-options']) as $option) {
+            list($k,$v) = explode('=', $option);
+            $alertmanager_opts[$k] = $v;
+        }
+        return $this->contactAlertmanager($obj, $alertmanager_opts);
+    }
+
+    public static function contactAlertmanager($obj, $api)
+    {
+        global $config;
+        if ($obj['state'] == 0) {
+            $alertmanager_status = 'resolved';
+        } else { 
+            $alertmanager_status = 'firing';
+        }
+        $gen_url          = ($config['base_url'] . 'device/device=' . $obj['device_id']);
+        $host             = ($api['url'] . '/api/v1/alerts');
+        $curl             = curl_init();
+        $alertmanager_msg = strip_tags($obj['msg']);
+        $data             = [[
+            'status' => $alertmanager_status,
+            'generatorURL' => $gen_url,
+            'annotations' => [
+                'summary' => $obj['name'],
+                'title' => $obj['title'],
+                'description' => $alertmanager_msg,
+            ],
+            'labels' => [
+                    'alertname' => $obj['name'],
+                    'severity' => $obj['severity'],
+                    'instance' => $obj['hostname'],
+                    'source' => $api['source'],
+                ],
+        ]];
+
+        $alert_message = json_encode($data);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        set_curl_proxy($curl);
+        curl_setopt($curl, CURLOPT_URL, $host);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $alert_message);
+
+        $ret  = curl_exec($curl);
+        $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        if ($code != 200) {
+            var_dump("API '$host' returned Error"); //FIXME: propper debuging
+            var_dump("Params: " . $alert_message); //FIXME: propper debuging
+            var_dump("Return: " . $ret); //FIXME: propper debuging
+            return 'HTTP Status code ' . $code;
+        }
+        return true;
+    }
+
+    public static function configTemplate()
+    {
+        return [
+            'config' => [
+                [
+                    'title' => 'Alertmanager URL',
+                    'name' => 'alertmanager-url',
+                    'descr' => 'Alertmanager Webhook URL',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'Alertmanager Options',
+                    'name' => 'alertmanager-options',
+                    'descr' => 'Alertmanager Options',
+                    'type' => 'textarea',
+                ]
+            ],
+            'validation' => [
+                'alertmanager-url' => 'required|url',
+            ]
+        ];
+    }
+}
+

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 /**
- * API Transport
+ * Alertmanager Transport
  * @copyright 2019 LibreNMS
  * @license GPL
  * @package LibreNMS
@@ -29,6 +29,7 @@ class Alertmanager extends Transport
 {
     public function deliverAlert($obj, $opts)
     {
+        $alertmanager_opts = [];
         $alertmanager_opts['url'] = $this->config['alertmanager-url'];
         foreach (explode(PHP_EOL, $this->config['alertmanager-options']) as $option) {
             list($k,$v) = explode('=', $option);
@@ -45,7 +46,7 @@ class Alertmanager extends Transport
         } else { 
             $alertmanager_status = 'firing';
         }
-        $gen_url          = ($config['base_url'] . 'device/device=' . $obj['device_id']);
+        $gen_url          = (Config::get('base_url') . 'device/device=' . $obj['device_id']);
         $host             = ($api['url'] . '/api/v1/alerts');
         $curl             = curl_init();
         $alertmanager_msg = strip_tags($obj['msg']);
@@ -76,9 +77,6 @@ class Alertmanager extends Transport
         $ret  = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         if ($code != 200) {
-            var_dump("API '$host' returned Error"); //FIXME: propper debuging
-            var_dump("Params: " . $alert_message); //FIXME: propper debuging
-            var_dump("Return: " . $ret); //FIXME: propper debuging
             return 'HTTP Status code ' . $code;
         }
         return true;

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -42,7 +42,7 @@ class Alertmanager extends Transport
     {
         if ($obj['state'] == 0) {
             $alertmanager_status = 'resolved';
-        } else { 
+        } else {
             $alertmanager_status = 'firing';
         }
         $gen_url          = (Config::get('base_url') . 'device/device=' . $obj['device_id']);
@@ -104,4 +104,3 @@ class Alertmanager extends Transport
         ];
     }
 }
-

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -40,7 +40,6 @@ class Alertmanager extends Transport
 
     public static function contactAlertmanager($obj, $api)
     {
-        global $config;
         if ($obj['state'] == 0) {
             $alertmanager_status = 'resolved';
         } else { 

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -24,6 +24,24 @@ To include users that have `Global-Read`, `Administrator` or `Normal-User` permi
 ## Using a Proxy?
 [Proxy Configuration](../Support/Configuration.md#proxy-support)
 
+## Alertmanager
+Alertmanager is an alert handling software, initially developed for alert processing sent by Prometheus. 
+
+It has built-in functionality for deduplicating, grouping and routing alerts based on configurable criteria. 
+
+LibreNMS uses alert grouping by alert rule, which can produce an array of alerts of similar content for an array of hosts, whereas Alertmanager can group them by alert meta, ideally producing one single notice in case an issue occurs. 
+
+The one and only possible parameter to be passed is `source` - this is required to distinguish LibreNMS alerts from alerts coming from different sources. 
+
+[Alertmanager Docs](https://prometheus.io/docs/alerting/alertmanager/)
+
+**Example:**
+
+| Config | Example |
+| ------ | ------- |
+| Alertmanager URL      | http://alertmanager.example.com |
+| Alertmanager Options: | source=librenms |
+
 ## API
 API transports definitions are a bit more complex than the E-Mail configuration.
 


### PR DESCRIPTION
This is a new Transport pull request that offers integration with Alertmanager from Prometheus stack. 
Here is a depiction of how alerts look like from Alertmanager interface. Please note I have real hostnames crossed out here for security reasons. 
<img width="562" alt="screenshot_1" src="https://user-images.githubusercontent.com/6848635/50978623-814b7c00-14fd-11e9-8455-d0a2bf108fd8.png">

Initially the code is based on Slack Transport, since it was easy to read for me. If there are some issues - please let me know and I will try to improve. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
