### PR TITLE
Increase snmp execution time limit to 20 minutes

### DIFF
--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -365,19 +365,25 @@ $config['poller_modules']['bgp-peers'] = false;
 
 ### SNMP Settings
 
-```php
-$config['snmp']['timeout'] = 1;            # timeout in seconds
-$config['snmp']['retries'] = 5;            # how many times to retry the query
-$config['snmp']['transports'] = array('udp', 'udp6', 'tcp', 'tcp6');
-$config['snmp']['version'] = ['v2c', 'v3', 'v1'];         # Default versions to use
-$config['snmp']['port'] = 161;
-```
 Default SNMP options including retry and timeout settings and also default version and port.
+
+```php
+$config['snmp']['timeout'] = 1;            				# timeout in seconds
+$config['snmp']['retries'] = 5;            				# how many times to retry the query
+$config['snmp']['transports'] = array('udp', 'udp6', 'tcp', 'tcp6');	# Transports to use
+$config['snmp']['version'] = ['v2c', 'v3', 'v1'];         		# Default versions to use
+$config['snmp']['port'] = 161;						# Default port
+$config['snmp']['exec_timeout'] = 1200;					# execution time limit in seconds
+```
+>NOTE: `timeout` is the time to wait for an answer and `exec_timeout` is the max time to run a query. 
+
+The default v1/v2c snmp community to use, you can expand this array with `[1]`, `[2]`, `[3]`, etc.
 
 ```php
 $config['snmp']['community'][0] = "public";
 ```
-The default v1/v2c snmp community to use, you can expand this array with `[1]`, `[2]`, `[3]`, etc.
+
+The default v3 snmp details to use, you can expand this array with `[1]`, `[2]`, `[3]`, etc.
 
 ```php
 $config['snmp']['v3'][0]['authlevel'] = "noAuthNoPriv";  # noAuthNoPriv | authNoPriv | authPriv
@@ -387,7 +393,6 @@ $config['snmp']['v3'][0]['authalgo'] = "MD5";            # MD5 | SHA
 $config['snmp']['v3'][0]['cryptopass'] = "";             # Privacy (Encryption) Passphrase
 $config['snmp']['v3'][0]['cryptoalgo'] = "AES";          # AES | DES
 ```
-The default v3 snmp details to use, you can expand this array with `[1]`, `[2]`, `[3]`, etc.
 
 ### Auto discovery settings
 

--- a/includes/common.php
+++ b/includes/common.php
@@ -86,7 +86,7 @@ function external_exec($command)
     global $debug, $vdebug;
 
     $proc = new \Symfony\Component\Process\Process($command);
-    $proc->setTimeout(600);
+    $proc->setTimeout(Config::get('snmp.exec_timeout', 1200));
 
     if ($debug && !$vdebug) {
         $patterns = [


### PR DESCRIPTION
This is needed for discovery in some cases (mostly the arp-table module)
Add configuration value for this `snmp.exec_timeout`, no docs for now.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
