### PR TITLE
Reference config options for new beta poller service

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -885,6 +885,20 @@ $config['distributed_poller_group']          = 0;
 $config['distributed_poller_memcached_host'] = 'example.net';
 $config['distributed_poller_memcached_port'] = '11211';
 
+// BETA polller service config options.
+// See https://docs.librenms.org/Extensions/Poller-Service/ for more information
+//$config['service_poller_workers']              = 24;     # Processes spawned for polling
+//$config['service_services_workers']            = 8;      # Processes spawned for service polling
+//$config['service_discovery_workers']           = 16;     # Processes spawned for discovery
+// Optional BETA polller service Settings
+//$config['service_poller_frequency']            = 300;    # Seconds between polling attempts
+//$config['service_services_frequency']          = 300;    # Seconds between service polling attempts
+//$config['service_discovery_frequency']         = 21600;  # Seconds between discovery runs
+//$config['service_billing_frequency']           = 300;    # Seconds between billing calculations
+//$config['service_billing_calculate_frequency'] = 60;     # Billing interval
+//$config['service_poller_down_retry']           = 60;     # Seconds between failed polling attempts
+//$config['service_loglevel']                    = 'INFO'; # Must be one of 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
+
 // Stats callback system
 $config['callback_post']  = 'https://stats.librenms.org/log.php';
 $config['callback_clear'] = 'https://stats.librenms.org/clear.php';


### PR DESCRIPTION
Config options for the new beta poller service aren't referenced in this file. Seems important to keep track of all available config options here.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
