### PR TITLE
Deprecate PHP < 7.1.3

### DIFF
--- a/LibreNMS/Validations/Updates.php
+++ b/LibreNMS/Validations/Updates.php
@@ -72,7 +72,7 @@ class Updates extends BaseValidation
                         "You are on the PHP 5.3 support branch, this will prevent automatic updates.",
                         "Update to PHP 5.6.4 or newer (PHP 7.2 recommended) to continue to receive updates."
                     );
-                } elseif ($versions['local_branch'] == 'php70') {
+                } elseif ($versions['local_branch'] == 'php56') {
                     $validator->warn(
                         "You are on the PHP 5.6/7.0 support branch, this will prevent automatic updates.",
                         "Update to PHP 7.1.3 or newer (PHP 7.2 recommended) to continue to receive updates."

--- a/LibreNMS/Validations/Updates.php
+++ b/LibreNMS/Validations/Updates.php
@@ -70,7 +70,12 @@ class Updates extends BaseValidation
                 if ($versions['local_branch'] == 'php53') {
                     $validator->warn(
                         "You are on the PHP 5.3 support branch, this will prevent automatic updates.",
-                        "Update to PHP 5.6.4 or newer (PHP 7.1 recommended) to continue to receive updates."
+                        "Update to PHP 5.6.4 or newer (PHP 7.2 recommended) to continue to receive updates."
+                    );
+                } elseif ($versions['local_branch'] == 'php70') {
+                    $validator->warn(
+                        "You are on the PHP 5.6/7.0 support branch, this will prevent automatic updates.",
+                        "Update to PHP 7.1.3 or newer (PHP 7.2 recommended) to continue to receive updates."
                     );
                 } else {
                     $validator->warn(

--- a/daily.php
+++ b/daily.php
@@ -160,9 +160,16 @@ if ($options['f'] === 'handle_notifiable') {
 
         // if update is not set to false and version is min or newer
         if (Config::get('update') && $options['r']) {
+            if ($options['r'] === 'php53') {
+                $phpver   = '5.6.4';
+                $eol_date = 'January 10th, 2018';
+            } else {
+                $phpver   = '7.1.3';
+                $eol_date = 'February 1st, 2019';
+            }
             new_notification(
                 $error_title,
-                'PHP version 5.6.4 is the minimum supported version as of January 10, 2018.  We recommend you update to PHP a supported version of PHP (7.1 suggested) to continue to receive updates.  If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.',
+                "PHP version $phpver is the minimum supported version as of $eol_date.  We recommend you update to PHP a supported version of PHP (7.2 suggested) to continue to receive updates.  If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.",
                 2,
                 'daily.sh'
             );

--- a/daily.sh
+++ b/daily.sh
@@ -126,16 +126,23 @@ set_notifiable_result() {
 #######################################
 check_php_ver() {
     local branch=$(git rev-parse --abbrev-ref HEAD)
-    local ver_res=$(php -r "echo (int)version_compare(PHP_VERSION, '5.6.4', '<');")
-    if [[ "$branch" == "php53" ]] && [[ "$ver_res" == "0" ]]; then
+    local ver_56=$(php -r "echo (int)version_compare(PHP_VERSION, '5.6.4', '<');")
+    local ver_71=$(php -r "echo (int)version_compare(PHP_VERSION, '7.1.3', '<');")
+    if [[ "$branch" == "php53" ]] && [[ "$ver_56" == "0" ]]; then
         status_run "Supported PHP version, switched back to master branch." 'git checkout master'
         branch="master"
-    elif [[ "$branch" != "php53" ]] && [[ "$ver_res" == "1" ]]; then
+    elif [[ "$branch" == "php70" ]] && [[ "$ver_71" == "0" ]]; then
+        status_run "Supported PHP version, switched back to master branch." 'git checkout master'
+        branch="master"
+    elif [[ "$branch" != "php53" ]] && [[ "$ver_56" == "1" ]]; then
         status_run "Unsupported PHP version, switched to php53 branch." 'git checkout php53'
         branch="php53"
+    elif [[ "$branch" != "php70" ]] && [[ "$ver_71" == "1" ]]; then
+        status_run "Unsupported PHP version, switched to php70 branch." 'git checkout php70'
+        branch="php70"
     fi
 
-    set_notifiable_result phpver ${ver_res}
+    set_notifiable_result phpver ${branch}
 
     return ${ver_res};
 }

--- a/daily.sh
+++ b/daily.sh
@@ -131,15 +131,15 @@ check_php_ver() {
     if [[ "$branch" == "php53" ]] && [[ "$ver_56" == "0" ]]; then
         status_run "Supported PHP version, switched back to master branch." 'git checkout master'
         branch="master"
-    elif [[ "$branch" == "php70" ]] && [[ "$ver_71" == "0" ]]; then
+    elif [[ "$branch" == "php56" ]] && [[ "$ver_71" == "0" ]]; then
         status_run "Supported PHP version, switched back to master branch." 'git checkout master'
         branch="master"
     elif [[ "$branch" != "php53" ]] && [[ "$ver_56" == "1" ]]; then
         status_run "Unsupported PHP version, switched to php53 branch." 'git checkout php53'
         branch="php53"
-    elif [[ "$branch" != "php70" ]] && [[ "$ver_71" == "1" ]]; then
-        status_run "Unsupported PHP version, switched to php70 branch." 'git checkout php70'
-        branch="php70"
+    elif [[ "$branch" != "php56" ]] && [[ "$ver_71" == "1" ]]; then
+        status_run "Unsupported PHP version, switched to php56 branch." 'git checkout php56'
+        branch="php56"
     fi
 
     set_notifiable_result phpver ${branch}


### PR DESCRIPTION
Doing this whilst I've got a cold, probably a better way to do it but it should work.

Only tested whilst running php 7.2.4

DO NOT MERGE UNTIL FEB 1st.