### PR TITLE
Fix victorops recovery alerts

### DIFF
--- a/LibreNMS/Alert/Transport/Victorops.php
+++ b/LibreNMS/Alert/Transport/Victorops.php
@@ -41,7 +41,7 @@ class Victorops extends Transport
         $url = $opts['url'];
 
         $protocol = array(
-            'entity_id' => ($obj['id'] ? $obj['id'] : $obj['uid']),
+            'entity_id' => str($obj['id'] ? $obj['id'] : $obj['uid']),
             'state_start_time' => strtotime($obj['timestamp']),
             'entity_display_name' => $obj['title'],
             'state_message' => $obj['msg'],

--- a/LibreNMS/Alert/Transport/Victorops.php
+++ b/LibreNMS/Alert/Transport/Victorops.php
@@ -41,7 +41,7 @@ class Victorops extends Transport
         $url = $opts['url'];
 
         $protocol = array(
-            'entity_id' => str($obj['id'] ? $obj['id'] : $obj['uid']),
+            'entity_id' => strval($obj['id'] ? $obj['id'] : $obj['uid']),
             'state_start_time' => strtotime($obj['timestamp']),
             'entity_display_name' => $obj['title'],
             'state_message' => $obj['msg'],


### PR DESCRIPTION
VO will not accept an int as an entity ID, this causes issues when issuing recovery alerts as the entity_id is the only way to link incidents.  I have tested this with VO and incidents will alert AND recover.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
