### PR TITLE
Added ignore mount point effects macOS

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -698,6 +698,7 @@ $config['ignore_mount_regexp'][] = '/^(dev|proc)fs/';
 $config['ignore_mount_regexp'][] = '/^\/dev\/md0/';
 $config['ignore_mount_regexp'][] = '/^\/var\/dhcpd\/dev/';
 $config['ignore_mount_regexp'][] = '/UMA/';
+$config['ignore_mount_regexp'][] = "/^\/Volumes\/OS X Base System/";
 
 $config['ignore_mount_removable'] = 1;
 // Ignore removable disk storage


### PR DESCRIPTION
added in $config['ignore_mount_regexp'][] = "/^\/Volumes\/OS X Base System/"; 
This should ignore osx recovery caching

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
