### PR TITLE
Fix SYNSO-UPSMIB incorrect syntax

### DIFF
--- a/mibs/SYNSO-UPSMIB
+++ b/mibs/SYNSO-UPSMIB
@@ -8,7 +8,7 @@ IMPORTS
 	enterprises, IpAddress
 		FROM RFC1155-SMI
 	DisplayString
-		FROM RFC1213;
+		FROM RFC1213-MIB;
 
 
 synso			OBJECT IDENTIFIER ::= {enterprises 9557}


### PR DESCRIPTION
The SYNSO-UPSMIB had an incorrect import statement that would cause the snmptrapd service to fail/not start with a 'Cannot find module' error.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
