### PR TITLE
Move the HttpAuthAuthorizer guest user check from userExists() to authenticate()

### DIFF
--- a/LibreNMS/Authentication/HttpAuthAuthorizer.php
+++ b/LibreNMS/Authentication/HttpAuthAuthorizer.php
@@ -18,20 +18,11 @@ class HttpAuthAuthorizer extends MysqlAuthorizer
             return true;
         }
 
-        if (Config::has('http_auth_guest') && parent::userExists(Config::get('http_auth_guest'))) {
+        if (Config::has('http_auth_guest') && $this->userExists(Config::get('http_auth_guest'))) {
             return true;
         }
 
         throw new AuthenticationException('No matching user found and http_auth_guest is not set');
-    }
-
-    public function userExists($username, $throw_exception = false)
-    {
-        if (parent::userExists($username)) {
-            return true;
-        }
-
-        return false;
     }
 
 

--- a/LibreNMS/Authentication/HttpAuthAuthorizer.php
+++ b/LibreNMS/Authentication/HttpAuthAuthorizer.php
@@ -18,16 +18,16 @@ class HttpAuthAuthorizer extends MysqlAuthorizer
             return true;
         }
 
+        if (Config::has('http_auth_guest') && parent::userExists(Config::get('http_auth_guest'))) {
+            return true;
+        }
+
         throw new AuthenticationException('No matching user found and http_auth_guest is not set');
     }
 
     public function userExists($username, $throw_exception = false)
     {
         if (parent::userExists($username)) {
-            return true;
-        }
-
-        if (Config::has('http_auth_guest') && parent::userExists(Config::get('http_auth_guest'))) {
             return true;
         }
 


### PR DESCRIPTION
User creation starts with a call to `userExists()`. When using `auth_mechanism = http-auth` and `http_auth_guest`, `userExists()` returns true and creation fails. Move the guest user check to the `authenticate()` function to avoid this issue.

This change works in my environment, but we're not using guest users, so my testing is limited. I submitted this as WIP for that reason.

This should make HttpAuthAuthorizer `authenticate()` match with [ADAuthorizationAuthorizer](https://github.com/librenms/librenms/blob/1f1fcf56fbd644ccebe2e7e239374fd1b1687a77/LibreNMS/Authentication/ADAuthorizationAuthorizer.php#L60) and [LdapAuthorizationAuthorizer](https://github.com/librenms/librenms/blob/1f1fcf56fbd644ccebe2e7e239374fd1b1687a77/LibreNMS/Authentication/LdapAuthorizationAuthorizer.php#L87).

A forum user also seems to have run across the same issue: https://community.librenms.org/t/adduser-php-says-user-already-exists/1798

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
