### PR TITLE
Removed NO_AUTO_CREATE_USER from mysql strict to support MySQL 8

### DIFF
--- a/LibreNMS/DB/Eloquent.php
+++ b/LibreNMS/DB/Eloquent.php
@@ -95,7 +95,7 @@ class Eloquent
     {
         if (self::isConnected()) {
             if ($strict) {
-                self::DB()->getPdo()->exec("SET sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
+                self::DB()->getPdo()->exec("SET sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'");
             } else {
                 self::DB()->getPdo()->exec("SET sql_mode=''");
             }

--- a/tests/DBSetupTest.php
+++ b/tests/DBSetupTest.php
@@ -115,7 +115,7 @@ class DBSetupTest extends DBTestCase
     public function testSqlMode()
     {
         $this->assertEquals(
-            'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION',
+            'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION',
             dbFetchCell("SELECT @@sql_mode")
         );
     }


### PR DESCRIPTION
https://laracasts.com/discuss/channels/laravel/help-about-mysql-80-problem?page=0

Allows MySQL 8 (Well tested on Percona 8) to work.