### PR TITLE
Run both legacy schema and migrations in the same run if needed

### DIFF
--- a/includes/sql-schema/update.php
+++ b/includes/sql-schema/update.php
@@ -55,10 +55,7 @@ try {
         $migrate_opts['--seed'] = true;
         $return = Artisan::call('migrate', $migrate_opts);
         echo Artisan::output();
-    } elseif ($db_rev == 1000) {
-        $return = Artisan::call('migrate', $migrate_opts);
-        echo Artisan::output();
-    } else {
+    } elseif ($db_rev < 1000) {
         // legacy update
         d_echo("DB Schema update started....\n");
 
@@ -102,6 +99,12 @@ try {
 
         echo "-- Done\n";
         // end legacy update
+        $db_rev = get_db_schema();
+    }
+
+    if ($db_rev == 1000) {
+        $return = Artisan::call('migrate', $migrate_opts);
+        echo Artisan::output();
     }
 
     if (isset($schemaLock)) {


### PR DESCRIPTION
That way any new migrations get applied when needed, not the next ./daily.sh run.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
