### PR TITLE
Improve display for 802.1X NAC

### DIFF
--- a/html/js/librenms.js
+++ b/html/js/librenms.js
@@ -498,3 +498,32 @@ function init_select2(selector, type, data, selected) {
         $select.trigger('change');
     }
 }
+
+function humanize_duration(seconds) {
+    // transform xxx seconds into yy years MM months dd days hh hours mm:ss
+    
+    var duration = moment.duration(Number(seconds), 's');
+    var years = duration.years(),
+        months = duration.months(),
+        days = duration.days(),
+        hrs = duration.hours(),
+        mins = duration.minutes(),
+        secs = duration.seconds();
+    var res = '';
+
+    if (years) {
+        res += years + 'y ';
+    }
+    if (months) {
+        res += months + 'm ';
+    }
+    if (days) {
+        res += days + 'd ';
+    }
+    if (hrs) {
+        res += hrs + 'h ';
+    }
+    res += mins + 'm ' + secs + 's ';
+
+    return res;
+}

--- a/html/legacy_index.php
+++ b/html/legacy_index.php
@@ -137,7 +137,7 @@ foreach ((array)$config['webui']['custom_css'] as $custom_css) {
     }
     ?>
   <script src="js/select2.min.js"></script>
-  <script src="js/librenms.js?ver=20181221"></script>
+  <script src="js/librenms.js?ver=20190122"></script>
   <script type="text/javascript">
 
     <!-- Begin

--- a/html/pages/device/nac.inc.php
+++ b/html/pages/device/nac.inc.php
@@ -35,20 +35,20 @@ if ($device['os'] === 'vrp') {
             <table id="nac-grid" data-toggle="bootgrid" class="table table-condensed table-responsive table-striped">
                 <thead>
                 <tr>
-                    <th data-column-id="port_id">Port</th>
-                    <th data-column-id="mac_address">MAC Address</th>
-                    <th data-column-id="ip_address">IP Address</th>
-                    <th data-column-id="vlan"<?php echo $vlan_visibility ?>>Vlan</th>
-                    <th data-column-id="domain" data-formatter="nac_domain">Domain</th>
+                    <th data-column-id="port_id" data-width="100px">Port</th>
+                    <th data-column-id="mac_address" data-width="150px" data-formatter="tooltip">MAC Address</th>
+                    <th data-column-id="ip_address" data-width="140px" data-formatter="tooltip">IP Address</th>
+                    <th data-column-id="vlan" data-width="60px" data-formatter="tooltip"<?php echo $vlan_visibility ?>>Vlan</th>
+                    <th data-column-id="domain" data-formatter="nac_domain" data-formatter="tooltip">Domain</th>
                     <th data-column-id="host_mode"<?php echo $mode_visibility ?>data-formatter="nac_mode">Mode</th>
-                    <th data-column-id="username">Username</th>
-                    <th data-column-id="authz_by" data-visible="false">Auth By</th>
-                    <th data-column-id="timeout"<?php echo $timeout_visibility ?>>Timeout</th>
+                    <th data-column-id="username" data-width="250px" data-formatter="tooltip">Username</th>
+                    <th data-column-id="authz_by" data-visible="false" data-formatter="tooltip">Auth By</th>
+                    <th data-column-id="timeout"<?php echo $timeout_visibility ?> data-formatter="time_interval">Timeout</th>
                     <th data-column-id="time_elapsed"<?php echo $t_elapsed_visibility ?> data-formatter="time_interval">Time Elapsed</th>
                     <th data-column-id="time_left"<?php echo $t_left_visibility ?> data-formatter="time_interval">Time Left</th>
-                    <th data-column-id="authc_status" data-formatter="nac_authc">AuthC</th>
-                    <th data-column-id="authz_status" data-formatter="nac_authz">AuthZ</th>
-                    <th data-column-id="method" data-formatter="nac_method">Method</th>
+                    <th data-column-id="authc_status" data-formatter="nac_authc" data-formatter="tooltip">AuthC</th>
+                    <th data-column-id="authz_status" data-width="70px" data-formatter="nac_authz">AuthZ</th>
+                    <th data-column-id="method" data-width="100px" data-formatter="nac_method">Method</th>
                 </tr>
                 </thead>
             </table>
@@ -69,9 +69,40 @@ if ($device['os'] === 'vrp') {
         formatters: {
             "time_interval": function (column, row) {
                 var value = row[column.id];
-                return moment.duration(Number(value), 's').humanize();
+                var duration = moment.duration(Number(value), 's');
+                var years = duration.years(),
+                    months = duration.months(),
+                    days = duration.days(),
+                    hrs = duration.hours(),
+                    mins = duration.minutes(),
+                    secs = duration.seconds();
+
+                var res = '';
+                    res_light = '';
+
+                if (years) {
+                    res += years + 'y ';
+                }
+                if (months) {
+                    res += months + 'm ';
+                }
+                if (days) {
+                    res += days + 'd ';
+                }
+                if (hrs) {
+                    res += hrs + 'h ';
+                }
+                res += mins + 'm ' + secs + 's ';
+                
+                var arr = res.split(' ');
+                res_light = arr.slice(0, 2).join(' ');
+
+                return "<span title=\'" + res.trim() + "\' data-toggle=\'tooltip\'>" + res_light + "</span>";
             },
-            "nac_authz": function (column, row) {
+            "tooltip": function (column, row) {
+                var value = row[column.id];
+                return "<span title=\'" + value + "\' data-toggle=\'tooltip\'>" + value + "</span>";
+            },            "nac_authz": function (column, row) {
                 var value = row[column.id];
 
                 if (value === 'authorizationSuccess' || value === 'sussess') { 
@@ -80,7 +111,7 @@ if ($device['os'] === 'vrp') {
                 } else if (value === 'authorizationFailed') {
                     return "<i class=\"fa fa-times-circle fa-lg icon-theme\" aria-hidden=\"true\" style=\"color:red;\"></i>";
                 } else {
-                    return "<span class=\'label label-default\'>" + value + "</span>";
+                    return "<span class=\'label label-default\' title=\'" + value + "\' data-toggle=\'tooltip\'>" + value + "</span>";
                 }
             },
             "nac_domain": function (column, row) {
@@ -92,7 +123,7 @@ if ($device['os'] === 'vrp') {
                 } else if (value === 'Disabled') {
                     return "<i class=\"fa fa-desktop fa-lg icon-theme\"  aria-hidden=\"true\"></i>";
                 } else {
-                    return "<span class=\'label label-default\'>" + value + "</span>";
+                    return "<span class=\'label label-default\' title=\'" + value + "\' data-toggle=\'tooltip\'>" + value + "</span>";
                 }
             },
             "nac_authc": function (column, row) {
@@ -110,7 +141,7 @@ if ($device['os'] === 'vrp') {
                 } else if (value === '6') {
                     return "<i class=\"fa fa-times-circle fa-lg icon-theme\"  aria-hidden=\"true\" style=\"color:red;\"></i>";
                 } else {
-                    return "<span class=\'label label-default\'>" + value + "</span>";
+                    return "<span class=\'label label-default\' title=\'" + value + "\' data-toggle=\'tooltip\'>" + value + "</span>";
                 }
             },
             "nac_method": function (column, row) {
@@ -122,7 +153,7 @@ if ($device['os'] === 'vrp') {
                 } else if (value === 'other') {
                     return "<span class=\"label label-danger\">Disabled</span>";
                 } else {
-                    return "<span class=\'label label-default\'>" + value + "</span>";
+                    return "<span class=\'label label-default\' title=\'" + value + "\' data-toggle=\'tooltip\'>" + value + "</span>";
                 }
             }
         }

--- a/html/pages/device/nac.inc.php
+++ b/html/pages/device/nac.inc.php
@@ -70,8 +70,7 @@ if ($device['os'] === 'vrp') {
             "time_interval": function (column, row) {
                 var value = row[column.id];
                 var res = humanize_duration(value);
-                var arr = res.split(' ');
-                var res_light = arr.slice(0, 2).join(' ');
+                var res_light = res.split(' ').slice(0, 2).join(' ');
                 return "<span title=\'" + res.trim() + "\' data-toggle=\'tooltip\'>" + res_light + "</span>";
             },
             "tooltip": function (column, row) {

--- a/html/pages/device/nac.inc.php
+++ b/html/pages/device/nac.inc.php
@@ -47,7 +47,7 @@ if ($device['os'] === 'vrp') {
                     <th data-column-id="time_elapsed"<?php echo $t_elapsed_visibility ?> data-formatter="time_interval">Time Elapsed</th>
                     <th data-column-id="time_left"<?php echo $t_left_visibility ?> data-formatter="time_interval">Time Left</th>
                     <th data-column-id="authc_status" data-formatter="nac_authc" data-formatter="tooltip">AuthC</th>
-                    <th data-column-id="authz_status" data-width="70px" data-formatter="nac_authz">AuthZ</th>
+                    <th data-column-id="authz_status" data-width="76px" data-formatter="nac_authz">AuthZ</th>
                     <th data-column-id="method" data-width="100px" data-formatter="nac_method">Method</th>
                 </tr>
                 </thead>

--- a/html/pages/device/nac.inc.php
+++ b/html/pages/device/nac.inc.php
@@ -44,8 +44,8 @@ if ($device['os'] === 'vrp') {
                     <th data-column-id="username" data-width="250px" data-formatter="tooltip">Username</th>
                     <th data-column-id="authz_by" data-visible="false" data-formatter="tooltip">Auth By</th>
                     <th data-column-id="timeout"<?php echo $timeout_visibility ?> data-formatter="time_interval">Timeout</th>
-                    <th data-column-id="time_elapsed"<?php echo $t_elapsed_visibility ?> data-formatter="time_interval">Time Elapsed</th>
-                    <th data-column-id="time_left"<?php echo $t_left_visibility ?> data-formatter="time_interval">Time Left</th>
+                    <th data-column-id="time_elapsed"<?php echo $t_elapsed_visibility ?> data-formatter="time_interval">Elapsed time</th>
+                    <th data-column-id="time_left"<?php echo $t_left_visibility ?> data-formatter="time_interval">Time left</th>
                     <th data-column-id="authc_status" data-formatter="nac_authc" data-formatter="tooltip">AuthC</th>
                     <th data-column-id="authz_status" data-width="76px" data-formatter="nac_authz">AuthZ</th>
                     <th data-column-id="method" data-width="100px" data-formatter="nac_method">Method</th>
@@ -69,34 +69,9 @@ if ($device['os'] === 'vrp') {
         formatters: {
             "time_interval": function (column, row) {
                 var value = row[column.id];
-                var duration = moment.duration(Number(value), 's');
-                var years = duration.years(),
-                    months = duration.months(),
-                    days = duration.days(),
-                    hrs = duration.hours(),
-                    mins = duration.minutes(),
-                    secs = duration.seconds();
-
-                var res = '';
-                    res_light = '';
-
-                if (years) {
-                    res += years + 'y ';
-                }
-                if (months) {
-                    res += months + 'm ';
-                }
-                if (days) {
-                    res += days + 'd ';
-                }
-                if (hrs) {
-                    res += hrs + 'h ';
-                }
-                res += mins + 'm ' + secs + 's ';
-                
+                var res = humanize_duration(value);
                 var arr = res.split(' ');
-                res_light = arr.slice(0, 2).join(' ');
-
+                var res_light = arr.slice(0, 2).join(' ');
                 return "<span title=\'" + res.trim() + "\' data-toggle=\'tooltip\'>" + res_light + "</span>";
             },
             "tooltip": function (column, row) {

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -69,7 +69,7 @@
         <script src="js/lazyload.js"></script>
     @endif
     <script src="{{ asset('js/select2.min.js') }}"></script>
-    <script src="{{ asset('js/librenms.js?ver=20181221') }}"></script>
+    <script src="{{ asset('js/librenms.js?ver=20190122') }}"></script>
     <script type="text/javascript">
 
         <!-- Begin


### PR DESCRIPTION
- fixed length for port, mac-addr, IP, vlan, username, AuthZ
- tooltip on cells in case the text is too long
- improve the duration display (the 2 bigger units are in the table, and the complete (year, month, days, hours, min, sec) in the tooltip). 

Example:
![capture d ecran 2019-01-20 a 00 15 31](https://user-images.githubusercontent.com/38363551/51433367-190d4080-1c49-11e9-80d3-61b87f02e6b2.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
