### PR TITLE
Fix missing config setting in DB seed alert.transports.mail

### DIFF
--- a/database/seeds/DefaultConfigSeeder.php
+++ b/database/seeds/DefaultConfigSeeder.php
@@ -398,6 +398,18 @@ class DefaultConfigSeeder extends Seeder
                 "config_disabled" => "0",
             ],
             [
+                "config_name" => "alert.transports.mail",
+                "config_value" => "false",
+                "config_default" => "false",
+                "config_descr" => "Mail alerting transport",
+                "config_group" => "alerting",
+                "config_group_order" => "0",
+                "config_sub_group" => "transports",
+                "config_sub_group_order" => "0",
+                "config_hidden" => "0",
+                "config_disabled" => "0",
+            ],
+            [
                 "config_name" => "alert.pagerduty.account",
                 "config_value" => "",
                 "config_default" => "",


### PR DESCRIPTION
If you were getting "No config item" when trying to enable email.  Running the config seeder again will fix it.

```php artisan db:seed --class=DefaultConfigSeeder```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
