### PR TITLE
Fix Smokeping setup instructions so they actually work

### DIFF
--- a/doc/Extensions/Smokeping.md
+++ b/doc/Extensions/Smokeping.md
@@ -16,6 +16,7 @@ For new installations, we can use the included `scripts/gen_smokeping.php` scrip
 
 This guide assumes you have already [installed librenms](http://docs.librenms.org/Installation/Installing-LibreNMS/), and is working with either **Apache** or **nginx**.
 
+Note: You may need to install `fcgiwrap` as well (at least with `nginx`).
 
 ### Install Smokeping
 
@@ -53,7 +54,7 @@ LibreNMS comes equipped with a script which exports our list of nodes from Libre
 To generate the config file once: 
 
 ```bash
-php /opt/librenms/scripts/gen_smokeping.php > /opt/smokeping/etc/librenms.conf
+(echo "+ LibreNMS"; php -f /opt/librenms/scripts/gen_smokeping.php) | sudo tee /etc/smokeping/config.d/librenms.conf
 ```
 
 **However**, it is more desirable to set up a cron job which regenerates our list of nodes and adds these into Smokeping. You can add the following to the end of your librenms cron job, e.g. `nano /etc/cron.d/librenms` 
@@ -79,7 +80,7 @@ menu = Top
 title = Network Latency Grapher
 ```
 
-Which can cause Smokeping to not start. `echo "+ LibreNMS"` appends this in our smokeping config file. We could remove the above from the gen_smokeping script, however this may cause issues with LibreNMS failing to update with `daily.sh` due config files being modified. 
+Which can cause Smokeping to not start. `echo "+ LibreNMS"` prepends this in our smokeping config file. We could remove the above from the gen_smokeping script, however this may cause issues with LibreNMS failing to update with `daily.sh` due config files being modified. 
 
 
 ## Configure LibreNMS


### PR DESCRIPTION
I'm walking through installing smokeping, and running into some minor issues in the docs.

Basically: 
1. Smokeping is a `fastcgi` application, and the config in the docs assumes that you have a fastcgi handler installed (`fastcgi_pass unix:/var/run/fcgiwrap.socket;`). I did not, and you get confusing errors.
2. The Example config generation snippet generates a config that isn't valid (see the section about `Why echo "+ LibreNMS" ?`). Since I don't exactly want to wait a day for cron to do it's thing, I ran the manual generator, which causes smokeping to explode on start.
3. I'm still not sure where the smokeping stuff is supposed to show up in the LibreNMS UI.


- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

It's only a Docs change, so.... probably?
