### PR TITLE
Fix DB Schema seeder possibility to skip schema files

### DIFF
--- a/database/seeds/DefaultLegacySchemaSeeder.php
+++ b/database/seeds/DefaultLegacySchemaSeeder.php
@@ -36,8 +36,11 @@ class DefaultLegacySchemaSeeder extends Seeder
     {
         // insert version 1000 to prevent legacy schema code from running.
         // additionally prevents seeder from being run again by build-base.php / includes/sql-schema/update.php.
-        if (!\DB::table('dbSchema')->exists()) {
+        $version = \DB::table('dbSchema')->value('version');
+        if (!$version) {
             \DB::table('dbSchema')->insert(['version' => 1000]);
+        } elseif ($version == 281) {
+            \DB::table('dbSchema')->update(['version' => 1000]);
         }
     }
 }


### PR DESCRIPTION
Only when people run seeder manually before updating to schema 1000

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
