### PR TITLE
Update Mattermost transport with configurable author_name

### DIFF
--- a/LibreNMS/Alert/Transport/Mattermost.php
+++ b/LibreNMS/Alert/Transport/Mattermost.php
@@ -38,6 +38,7 @@ class Mattermost extends Transport
             'username' => $this->config['mattermost-username'],
             'icon' => $this->config['mattermost-icon'],
             'channel' => $this->config['mattermost-channel'],
+            'author_name' => $this->config['mattermost-author_name'],
         ];
 
         return $this->contactMattermost($obj, $mattermost_opts);
@@ -65,7 +66,7 @@ class Mattermost extends Transport
                     'title' => $obj['title'],
                     'text' => $obj['msg'],
                     'mrkdwn_in' => ['text', 'fallback'],
-                    'author_name' => $obj['hostname'],
+                    'author_name' => $api['author_name'],
                 ],
             ],
             'channel' => $api['channel'],
@@ -123,6 +124,12 @@ class Mattermost extends Transport
                     'title' => 'Icon',
                     'name' => 'mattermost-icon',
                     'descr' => 'Icon URL',
+                    'type' => 'text',
+                ],
+                [
+                    'title' => 'Author_name',
+                    'name' => 'mattermost-author_name',
+                    'descr' => 'Optional name used to identify the author',
                     'type' => 'text',
                 ],
             ],


### PR DESCRIPTION
Regarding Mattermost api doc  [author_name is optional](https://docs.mattermost.com/developer/message-attachments.html#author-details) 
And no reason to force hostname to author_name because hostname
already exist in alert topic, so make author_name configurable.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
