### PR TITLE
Check for session_handler

### DIFF
--- a/LibreNMS/Validations/Php.php
+++ b/LibreNMS/Validations/Php.php
@@ -59,7 +59,7 @@ class Php extends BaseValidation
     private function checkSessionDirWritable(Validator $validator)
     {
         $path = session_save_path() === '' ? '/tmp' : session_save_path();
-        if (!is_writable($path)) {
+        if (!is_writable($path) and ini_get(save_handler) == "file") {
             $result = ValidationResult::fail("The session directory ($path) is not writable.");
 
             $group_id = filegroup($path);


### PR DESCRIPTION
Add a check to only display an error for the session file path being writable if `session_handler` is set to `file`

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
