### PR TITLE
Fix regression in VC hardware detection for JunOS

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1097,7 +1097,7 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
                         $sensor_name = $data['state_name'] ?: $data['oid'];
                         create_state_index($sensor_name, $data['states']);
                     } else {
-                        // We default to 1 for both divisors / multipler so it should be safe to do the calculation using both.
+                        // We default to 1 for both divisors / multipliers so it should be safe to do the calculation using both.
                         $value = ($value / $divisor) * $multiplier;
                     }
 

--- a/includes/polling/os/junos.inc.php
+++ b/includes/polling/os/junos.inc.php
@@ -35,7 +35,7 @@ if (strpos($device['sysDescr'], 'olive')) {
     $serial   = '';
 } else {
     $boxDescr = snmp_get($device, 'jnxBoxDescr.0', '-Oqv', 'JUNIPER-MIB');
-    if (!empty($boxDescr)) {
+    if (!empty($boxDescr) && $boxDescr != "Juniper Virtual Chassis Switch") {
         $hardware = $boxDescr;
     } else {
         $hardware = snmp_translate($device['sysObjectID'], 'Juniper-Products-MIB:JUNIPER-CHASSIS-DEFINES-MIB', 'junos');


### PR DESCRIPTION
PR #9546 has resulted in Platform being detected as "Juniper Virtual Chassis Switch" when a set of devices is stacked. Hence, no more possibility to see whether it is for example an EX2300 or EX3400 virtual-chassis.

This commit falls back to using rewrite_junos_hardware() if the "Juniper Virtual Chassis Switch" string is detected in boxDescr, resulting in usable hardware data.

Example SNMP output from boxDescr on an EX3400-48T switch with VC enabled:
mschmidt@nlrtm1-librenms1:~$ snmpwalk -v2c -cremoved -m JUNIPER-MIB -M /opt/librenms/mibs hostname jnxBoxDescr
JUNIPER-MIB::jnxBoxDescr.0 = STRING: Juniper Virtual Chassis Switch

Caveat - it's possible to build a virtual-chassis of multiple switch models, but only for higher end hardware. With this commit, we would now report back the hardware only for the primary device: https://www.juniper.net/documentation/en_US/junos/topics/concept/virtual-chassis-ex4200-overview.html#jd0e75

You can detect the hardware of the individual members with the JUNIPER-VIRTUALCHASSIS-MIB which is already in the LibreNMS MIB directory, but I haven't implemented that since the whole virtual-chassis is polled by LibreNMS as one big device.

Example SNMP output:
mschmidt@martijn-dev:~$ snmpwalk -v2c -cremoved -m JUNIPER-VIRTUALCHASSIS-MIB -M /opt/librenms/mibs/junos hostname jnxVirtualChassisMemberModel
JUNIPER-VIRTUALCHASSIS-MIB::jnxVirtualChassisMemberModel.0 = STRING: ex3400-48t
JUNIPER-VIRTUALCHASSIS-MIB::jnxVirtualChassisMemberModel.1 = STRING: ex3400-48t

Also reported previously via the community forums:
https://community.librenms.org/t/pr-9546-results-in-junos-platform-detection-quirks-in-combination-with-virtual-chassis/6537

+ fixed a random comment typo I stumbled upon while investigating something else.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
