### PR TITLE
Add conditions for bgp admin status = stop

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -11,7 +11,7 @@
     "default": true
   },
   {
-    "rule": "bgpPeers.bgpPeerState != \"established\" && macros.device_up = \"1\"",
+    "rule": "bgpPeers.bgpPeerState != \"established\" && macros.device_up = \"1\" && bgpPeers.bgpPeerAdminStatus != \"stop\"",
     "name": "BGP Session down",
     "extra": "{\"count\": 1}",
     "default": true


### PR DESCRIPTION
I propose this change so that bgp sessions down volunteer is not on alert

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


I propose this change so that bgp sessions down volunteer is not on alert
