### PR TITLE
Allow getCacheByIndex snmpflags

### DIFF
--- a/LibreNMS/OS.php
+++ b/LibreNMS/OS.php
@@ -106,9 +106,10 @@ class OS implements ProcessorDiscovery
      *
      * @param string $oid textual oid
      * @param string $mib mib for this oid
+     * @param string $snmpflags snmpflags for this oid
      * @return array array indexed by the snmp index with the value as the data returned by snmp
      */
-    public function getCacheByIndex($oid, $mib = null, $snmpflags)
+    public function getCacheByIndex($oid, $mib = null, $snmpflags = '-OQUs')
     {
         if (str_contains($oid, '.')) {
             echo "Error: don't use this with numeric oids!\n";
@@ -116,7 +117,7 @@ class OS implements ProcessorDiscovery
         }
 
         if (!isset($this->cache[$oid])) {
-            $data = snmpwalk_cache_oid($this->getDevice(), $oid, $snmpflags, array(), $mib);
+            $data = snmpwalk_cache_oid($this->getDevice(), $oid, array(), $mib, null, $snmpflags);
             $this->cache[$oid] = array_map('current', $data);
         }
 

--- a/LibreNMS/OS.php
+++ b/LibreNMS/OS.php
@@ -108,7 +108,7 @@ class OS implements ProcessorDiscovery
      * @param string $mib mib for this oid
      * @return array array indexed by the snmp index with the value as the data returned by snmp
      */
-    public function getCacheByIndex($oid, $mib = null)
+    public function getCacheByIndex($oid, $mib = null, $snmpflags)
     {
         if (str_contains($oid, '.')) {
             echo "Error: don't use this with numeric oids!\n";
@@ -116,7 +116,7 @@ class OS implements ProcessorDiscovery
         }
 
         if (!isset($this->cache[$oid])) {
-            $data = snmpwalk_cache_oid($this->getDevice(), $oid, array(), $mib);
+            $data = snmpwalk_cache_oid($this->getDevice(), $oid, $snmpflags, array(), $mib);
             $this->cache[$oid] = array_map('current', $data);
         }
 


### PR DESCRIPTION
Just allowing snmpflags on the getCacheByIndex function.

Had a problem with with snmp getting the wrong index, "-Ob" fixed it for me, but no way to pass this currently to getCacheByIndex

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
