### PR TITLE
Port exists check in eventlog

### DIFF
--- a/app/Http/Controllers/Table/EventlogController.php
+++ b/app/Http/Controllers/Table/EventlogController.php
@@ -80,7 +80,9 @@ class EventlogController extends TableController
         if ($eventlog->type == 'interface') {
             if (is_numeric($eventlog->reference)) {
                 $port = $eventlog->related;
-                return '<b>' . Url::portLink($port, $port->getShortLabel()) . '</b>';
+                if (isset($port)) {
+                    return '<b>' . Url::portLink($port, $port->getShortLabel()) . '</b>';
+                }
             }
         }
 


### PR DESCRIPTION
Check if port exists before getting the label as some ports may have events but then removed and this can break eventlog page.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
