### PR TITLE
Fixes constraint 'poller_cluster_node_id_unique'.

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -708,7 +708,7 @@ class Service:
                            .format(self.config.node_id, self.config.name, "librenms-service", ','.join(str(g) for g in self.config.group), 1 if self.is_master else 0))
 
             # Find our ID
-            self._db.query('SELECT id INTO @parent_poller_id FROM poller_cluster WHERE node_id="{0}"; '.format(self.config.node_id))
+            self._db.query('SELECT id INTO @parent_poller_id FROM poller_cluster WHERE node_id="{0}" AND poller_name="{1}"; '.format(self.config.node_id, self.config.name))
 
             for worker_type, counter in self.performance_stats.items():
                 worker_seconds, devices = counter.reset()

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1112,7 +1112,7 @@ poller_cluster:
     - { Field: master, Type: tinyint(1), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
-    poller_cluster_node_id_unique: { Name: poller_cluster_node_id_unique, Columns: [node_id], Unique: true, Type: BTREE }
+    poller_cluster_node_id_poller_name_unique: { Name: poller_cluster_node_id_poller_name_unique, Columns: [node_id, poller_name], Unique: true, Type: BTREE }
 poller_cluster_stats:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }

--- a/sql-schema/282.sql
+++ b/sql-schema/282.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `poller_cluster` DROP INDEX `poller_cluster_node_id_unique`;
+ALTER TABLE `poller_cluster` ADD UNIQUE `poller_cluster_node_id_poller_name_unique` (`node_id`, `poller_name`);


### PR DESCRIPTION
While the `poller_cluster_stats` table will support accounting for poller clusters where the number of participating poller instances N > 2, the `poller_cluster` table will always fold registrations from pollers into a single row for its parent cluster.

The `poller_cluster_stats` table may be populated as expected only once `poller_cluster` has a mapping for the corresponding `(node_id, poller_name)` pair.

Therefore, the underlying constraint `poller_cluster_node_id_unique` is redefined as unique with respect to both `poller_cluster.node_id` as well as `poller_cluster.poller_name`.

Additionally, relevant code paths in `Service.log_performance_stats` are updated to select `parent_poller_id` accordingly.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
