### PR TITLE
Workaround of bad SNMP implementation in EDS device.

### DIFF
--- a/includes/polling/sensors/state/eds.inc.php
+++ b/includes/polling/sensors/state/eds.inc.php
@@ -1,0 +1,6 @@
+<?php
+//Workaround for bad behaviour of the SNMP engine in EDS device
+//a ".0" is added in snmpget compared to snmpwalk of the same table. 
+if(!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
+    $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].".0"]));
+}

--- a/includes/polling/sensors/state/eds.inc.php
+++ b/includes/polling/sensors/state/eds.inc.php
@@ -1,5 +1,5 @@
 <?php
-//Workaround for bad behaviour of the SNMP engine in EDS device
+//Workaround for bad behaviour of the SNMP engine in EDS device.
 //a ".0" is added in snmpget compared to snmpwalk of the same table. 
 if (!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
     $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].".0"]));

--- a/includes/polling/sensors/state/eds.inc.php
+++ b/includes/polling/sensors/state/eds.inc.php
@@ -1,6 +1,6 @@
 <?php
 //Workaround for bad behaviour of the SNMP engine in EDS device
 //a ".0" is added in snmpget compared to snmpwalk of the same table. 
-if(!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
+if (!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
     $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].".0"]));
 }

--- a/includes/polling/sensors/temperature/eds.inc.php
+++ b/includes/polling/sensors/temperature/eds.inc.php
@@ -1,0 +1,6 @@
+<?php
+//Workaround for bad behaviour of the SNMP engine in EDS device
+//a ".0" is added in snmpget compared to snmpwalk of the same table. 
+if(!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
+    $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].".0"]));
+}

--- a/includes/polling/sensors/temperature/eds.inc.php
+++ b/includes/polling/sensors/temperature/eds.inc.php
@@ -1,5 +1,5 @@
 <?php
-//Workaround for bad behaviour of the SNMP engine in EDS device
+//Workaround for bad behaviour of the SNMP engine in EDS device.
 //a ".0" is added in snmpget compared to snmpwalk of the same table. 
 if (!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
     $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].".0"]));

--- a/includes/polling/sensors/temperature/eds.inc.php
+++ b/includes/polling/sensors/temperature/eds.inc.php
@@ -1,6 +1,6 @@
 <?php
 //Workaround for bad behaviour of the SNMP engine in EDS device
 //a ".0" is added in snmpget compared to snmpwalk of the same table. 
-if(!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
+if (!array_key_exists($sensor['sensor_oid'], $snmp_data) && array_key_exists($sensor['sensor_oid'].".0", $snmp_data)) {
     $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].".0"]));
 }


### PR DESCRIPTION
The EDS devices are sometimes replying to snmpget with an extra ".0" after the index. This patch checks this situation and extracts the correct value if available. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
