### PR TITLE
Fix the divisor error found in routeros.yaml.

### DIFF
--- a/includes/definitions/discovery/routeros.yaml
+++ b/includes/definitions/discovery/routeros.yaml
@@ -16,13 +16,11 @@ modules:
                 -
                     oid: mtxrHlSensorTemperature
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.5.{{ $index }}'
-                    divisor: 10
                     descr: 'Sensor chip'
                     index: 'mtxrHlSensorTemperature.{{ $index }}'
                 -
                     oid: mtxrHlCpuTemperature
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.6.{{ $index }}'
-                    divisor: 10
                     descr: 'Processor'
                     index: 'mtxrHlCpuTemperature.{{ $index }}'
                 -
@@ -35,7 +33,6 @@ modules:
                     oid: mtxrHlTemperature
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.10.{{ $index }}'
                     index: 0
-                    divisor: 10
                     descr: 'Temperature {{ $index }}'
                     low_limit: -40
                     low_warn_limit: -35
@@ -45,7 +42,6 @@ modules:
                     oid: mtxrHlProcessorTemperature
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.11.{{ $index }}'
                     index: 1
-                    divisor: 10
                     descr: 'Processor Temperature {{ $index }}'
         voltage:
             data:
@@ -53,14 +49,12 @@ modules:
                     oid: mtxrOpticalTable
                     value: mtxrOpticalSupplyVoltage
                     num_oid: '.1.3.6.1.4.1.14988.1.1.19.1.1.7.{{ $index }}'
-                    divisor: 1000
                     descr: mtxrOpticalName
                     index: 'mtxrOpticalSupplyVoltage.{{ $index }}'
                 -
                     oid: mtxrPOETable
                     value: mtxrPOEVoltage
                     num_oid: '.1.3.6.1.4.1.14988.1.1.15.1.1.4.{{ $index }}'
-                    divisor: 10
                     descr: '{{ $mtxrPOEName }} POE'
                     index: 'mtxrPOEVoltage.{{ $index }}'
                 -
@@ -86,7 +80,6 @@ modules:
                 -
                     oid: mtxrHlVoltage
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.8.{{ $index }}'
-                    divisor: 10
                     descr: 'Voltage {{ $index }}'
         current:
             data:
@@ -94,20 +87,17 @@ modules:
                     oid: mtxrOpticalTable
                     value: mtxrOpticalTxBiasCurrent
                     num_oid: '.1.3.6.1.4.1.14988.1.1.19.1.1.8.{{ $index }}'
-                    divisor: 1000
                     descr: '{{ $mtxrOpticalName }} Tx'
                     index: 'mtxrOpticalTxBiasCurrent.{{ $index }}'
                 -
                     oid: mtxrPOETable
                     value: mtxrPOECurrent
                     num_oid: '.1.3.6.1.4.1.14988.1.1.15.1.1.5.{{ $index }}'
-                    divisor: 1000
                     descr: '{{ $mtxrPOEName }} POE'
                     index: 'mtxrPOECurrent.{{ $index }}'
                 -
                     oid: mtxrHlCurrent
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.13.{{ $index }}'
-                    divisor: 1000
                     descr: 'Current'
                     index: '0'
         dbm:
@@ -116,14 +106,12 @@ modules:
                     oid: mtxrOpticalTable
                     value: mtxrOpticalTxPower
                     num_oid: '.1.3.6.1.4.1.14988.1.1.19.1.1.9.{{ $index }}'
-                    divisor: 1000
                     descr: '{{ $mtxrOpticalName }} Tx'
                     index: 'mtxrOpticalTxPower.{{ $index }}'
                 -
                     oid: mtxrOpticalTable
                     value: mtxrOpticalRxPower
                     num_oid: '.1.3.6.1.4.1.14988.1.1.19.1.1.10.{{ $index }}'
-                    divisor: 1000
                     descr: '{{ $mtxrOpticalName }} Rx'
                     index: 'mtxrOpticalRxPower.{{ $index }}'
         state:
@@ -194,13 +182,11 @@ modules:
                     oid: mtxrPOETable
                     value: mtxrPOEPower
                     num_oid: '.1.3.6.1.4.1.14988.1.1.15.1.1.6.{{ $index }}'
-                    divisor: 10
                     descr: '{{ $mtxrPOEName }} POE'
                     index: 'mtxrPOEPower.{{ $index }}'
                 -
                     oid: mtxrHlPower
                     num_oid: '.1.3.6.1.4.1.14988.1.1.3.12.{{ $index }}'
-                    divisor: 10
                     descr: 'Power Usage'
                     index: '1'
         fanspeed:


### PR DESCRIPTION
RouterOS device returns the data in the correct form, thus there's no
need to use divisor.

Tested against RouterOS 6.43 and 6.42 (current long-term and stable branch), and can confirm the behavior change.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
