### PR TITLE
Fixed Alertmanager transport

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -41,16 +41,16 @@ class Alertmanager extends Transport
     public static function contactAlertmanager($obj, $api)
     {
         if ($obj['state'] == 0) {
-            $alertmanager_status = 'resolved';
+            $alertmanager_status = 'endsAt';
         } else {
-            $alertmanager_status = 'firing';
+            $alertmanager_status = 'startsAt';
         }
         $gen_url          = (Config::get('base_url') . 'device/device=' . $obj['device_id']);
         $host             = ($api['url'] . '/api/v1/alerts');
         $curl             = curl_init();
         $alertmanager_msg = strip_tags($obj['msg']);
         $data             = [[
-            'status' => $alertmanager_status,
+            $alertmanager_status => date("c"),
             'generatorURL' => $gen_url,
             'annotations' => [
                 'summary' => $obj['name'],


### PR DESCRIPTION
This is a fix for [9637](https://github.com/librenms/librenms/pull/9637) pull request, which offered Alertmanager transport integration. What we did achieve is correct processing of resolved alerts - in my playground it was only a coincidence they were processed normally. After setting this up in a pre-prod environment, we saw alert resolutions are only processed after timeout in Alertmanager itself. 

This fix changes JSON layout according to this article: https://prometheus.io/docs/alerting/clients/

The only thing I remain uncertain with - if `date` function use is correct considering movement to Laravel. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
