### PR TITLE
Extra daily.sh safety

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -211,7 +211,7 @@ main () {
             status_run 'Updating to latest codebase' 'git pull --quiet' 'update'
             update_res=$?
             new_ver=$(git rev-parse --short HEAD)
-        elif [[ "$up" == "3" ]]; then
+        else
             # Update to last Tag
             old_ver=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
             status_run 'Updating to latest release' 'git fetch --tags && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))' 'update'


### PR DESCRIPTION
If the php update channel check fails, it returns an error code 255...
This isn't handled by daily.sh, so it doesn't update code at all.

If updates are disabled (0), skip.
If master (1) or in the php version jail do a git pull update
Otherwise update to the latest tagged release

This should give a "safe" fallback if php isn't working.  Might cause flipping back and forth if the user's error isn't (or can't be) fixed by code changes.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
