### PR TITLE
Syslog hostname translation broken

### DIFF
--- a/includes/syslog.php
+++ b/includes/syslog.php
@@ -57,7 +57,7 @@ function process_syslog($entry, $update)
     }
 
     $entry['host'] = preg_replace("/^::ffff:/", "", $entry['host']);
-    if ($new_host = Config::get('syslog_xlate.' . $entry['host'])) {
+    if ($new_host = Config::get("syslog_xlate")[$entry['host']]) {
         $entry['host'] = $new_host;
     }
     $entry['device_id'] = get_cache($entry['host'], 'device_id');


### PR DESCRIPTION
For some reason, this is now broken. Accessing the array this way fixes it. I suspect it has something to do with the periods in the host names

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
