### PR TITLE
Fix graphs for ASA announcing all interfaces in type l2vlan (by default filtered)

### DIFF
--- a/html/includes/graphs/device/bits.inc.php
+++ b/html/includes/graphs/device/bits.inc.php
@@ -8,6 +8,12 @@ foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled`
     $ignore = 0;
     if (is_array($config['device_traffic_iftype'])) {
         foreach ($config['device_traffic_iftype'] as $iftype) {
+            if ($iftype == '/l2vlan/' && $device['os']=='asa') {
+                // ASA (at least in multicontext) reports all interfaces as l2vlan even if they are l3 
+                // so every context has no graph displayed unless l2vlan are accepted for all.
+                // This patch will ignore l2vlan for ASA.
+                continue;
+            }
             if (preg_match($iftype.'i', $port['ifType'])) {
                 $ignore = 1;
             }

--- a/html/includes/graphs/device/bits.inc.php
+++ b/html/includes/graphs/device/bits.inc.php
@@ -9,7 +9,7 @@ foreach (dbFetchRows('SELECT * FROM `ports` WHERE `device_id` = ? AND `disabled`
     if (is_array($config['device_traffic_iftype'])) {
         foreach ($config['device_traffic_iftype'] as $iftype) {
             if ($iftype == '/l2vlan/' && $device['os']=='asa') {
-                // ASA (at least in multicontext) reports all interfaces as l2vlan even if they are l3 
+                // ASA (at least in multicontext) reports all interfaces as l2vlan even if they are l3
                 // so every context has no graph displayed unless l2vlan are accepted for all.
                 // This patch will ignore l2vlan for ASA.
                 continue;


### PR DESCRIPTION
Cisco ASA announces all its interfaces in l2vlan type (at least in multi-context mode). Or by default these are ignored in graphs (which is good generally speaking). Which gives an empty errored device_bits overall graph for each ASA contexts. 
 
In order to avoid this, this PR add a condition to ignore the l2vlan filtering for ASA.

The other option would be to create a filter list "per os" but it seems a little bit overkill only for this ASA issue. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
