### PR TITLE
Alertmanager fix 2

### DIFF
--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -46,7 +46,7 @@ class Alertmanager extends Transport
             $alertmanager_status = 'startsAt';
         }
         $gen_url          = (Config::get('base_url') . 'device/device=' . $obj['device_id']);
-        $host             = ($api['url'] . '/api/v1/alerts');
+        $host             = ($api['url'] . '/api/v22/alerts');
         $curl             = curl_init();
         $alertmanager_msg = strip_tags($obj['msg']);
         $data             = [[
@@ -61,9 +61,13 @@ class Alertmanager extends Transport
                     'alertname' => $obj['name'],
                     'severity' => $obj['severity'],
                     'instance' => $obj['hostname'],
-                    'source' => $api['source'],
                 ],
         ]];
+
+        unset($api['url']);
+        foreach($api as $label => $value){
+            $data[0]['labels'][$label] = $value;
+        };
 
         $alert_message = json_encode($data);
         curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -65,7 +65,7 @@ class Alertmanager extends Transport
         ]];
 
         unset($api['url']);
-        foreach($api as $label => $value){
+        foreach ($api as $label => $value) {
             $data[0]['labels'][$label] = $value;
         };
 

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -46,7 +46,7 @@ class Alertmanager extends Transport
             $alertmanager_status = 'startsAt';
         }
         $gen_url          = (Config::get('base_url') . 'device/device=' . $obj['device_id']);
-        $host             = ($api['url'] . '/api/v22/alerts');
+        $host             = ($api['url'] . '/api/v2/alerts');
         $curl             = curl_init();
         $alertmanager_msg = strip_tags($obj['msg']);
         $data             = [[

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -36,7 +36,7 @@ It has built-in functionality for deduplicating, grouping and routing alerts bas
 
 LibreNMS uses alert grouping by alert rule, which can produce an array of alerts of similar content for an array of hosts, whereas Alertmanager can group them by alert meta, ideally producing one single notice in case an issue occurs. 
 
-The one and only possible parameter to be passed is `source` - this is required to distinguish LibreNMS alerts from alerts coming from different sources. 
+It is possible to configure as much label values as required in Alertmanager Options section. Every label and it's value should be entered as a new line.
 
 [Alertmanager Docs](https://prometheus.io/docs/alerting/alertmanager/)
 
@@ -46,6 +46,7 @@ The one and only possible parameter to be passed is `source` - this is required 
 | ------ | ------- |
 | Alertmanager URL      | http://alertmanager.example.com |
 | Alertmanager Options: | source=librenms |
+| | customlabel=value |
 
 ## API
 API transports definitions are a bit more complex than the E-Mail configuration.


### PR DESCRIPTION
This is once again a small fix for Alertmanager transport. We found ourselves in a situation where we need to pass two label/value pairs from LibreNMS to Alertmanager, so rewrote the Transport to offer multiple labels to be specified. This has also been documented.
Also due to [latest release](https://github.com/prometheus/alertmanager/releases/tag/v0.16.0) Alertmanager V1 HTTP API endpoint has been deprecated, so it had to be changed as well. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
