### PR TITLE
fix typos for instructions for ubuntu 16.04

### DIFF
--- a/doc/Extensions/RRDCached.md
+++ b/doc/Extensions/RRDCached.md
@@ -79,8 +79,8 @@ WRITE_TIMEOUT=1800
 WRITE_JITTER=1800
 BASE_PATH=/opt/librenms/rrd/
 JOURNAL_PATH=/var/lib/rrdcached/journal/
-PIDFILE=/run/rrdcached.pid
-SOCKFILE=/run/rrdcached.sock
+PIDFILE=/var/run/rrdcached.pid
+SOCKFILE=/var/run/rrdcached.sock
 SOCKGROUP=librenms
 BASE_OPTIONS="-B -F -R"
 ```


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ X ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

This PR fixes a typo in the instructions for installing on rrdcache on ubuntu

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
