### PR TITLE
webui: Allow admins to add/remove/create sticky notifications

### DIFF
--- a/html/includes/forms/notifications.inc.php
+++ b/html/includes/forms/notifications.inc.php
@@ -33,7 +33,7 @@ if (isset($_REQUEST['notification_id']) && isset($_REQUEST['action'])) {
         $status  = 'ok';
         $message = 'Set as Read';
     } elseif (LegacyAuth::user()->hasGlobalAdmin() || LegacyAuth::user()->isDemoUser()) {
-        if( $_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'sticky','value'=>1), 'notifications_attribs')) {
+        if ($_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'sticky','value'=>1), 'notifications_attribs')) {
             $status  = 'ok';
             $message = 'Set as Sticky';
         } elseif ($_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", array($_REQUEST['notification_id'],LegacyAuth::id()))) {

--- a/html/includes/forms/notifications.inc.php
+++ b/html/includes/forms/notifications.inc.php
@@ -32,17 +32,21 @@ if (isset($_REQUEST['notification_id']) && isset($_REQUEST['action'])) {
     if ($_REQUEST['action'] == 'read' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'read','value'=>1), 'notifications_attribs')) {
         $status  = 'ok';
         $message = 'Set as Read';
-    } elseif ((!LegacyAuth::user()->hasGlobalAdmin() || LegacyAuth::user()->isDemoUser()) && $_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'sticky','value'=>1), 'notifications_attribs')) {
-        $status  = 'ok';
-        $message = 'Set as Sticky';
-    } elseif ((!LegacyAuth::user()->hasGlobalAdmin() || LegacyAuth::user()->isDemoUser()) && $_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", array($_REQUEST['notification_id'],LegacyAuth::id()))) {
-        $status  = 'ok';
-        $message = 'Removed Sticky';
-    }
-} elseif ($_REQUEST['action'] == 'create' && (!LegacyAuth::user()->hasGlobalAdmin() || LegacyAuth::user()->isDemoUser()) && (isset($_REQUEST['title']) && isset($_REQUEST['body']))) {
-    if (dbInsert(array('title'=>$_REQUEST['title'],'body'=>$_REQUEST['body'],'checksum'=>hash('sha512', LegacyAuth::id().'.LOCAL.'.$_REQUEST['title']),'source'=>LegacyAuth::id()), 'notifications')) {
-        $status  = 'ok';
-        $message = 'Created';
+    } elseif (LegacyAuth::user()->hasGlobalAdmin() || LegacyAuth::user()->isDemoUser()) {
+        if( $_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'sticky','value'=>1), 'notifications_attribs')) {
+            $status  = 'ok';
+            $message = 'Set as Sticky';
+        } elseif ($_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", array($_REQUEST['notification_id'],LegacyAuth::id()))) {
+            $status  = 'ok';
+            $message = 'Removed Sticky';
+        } elseif ($_REQUEST['action'] == 'create' && (isset($_REQUEST['title']) && isset($_REQUEST['body']))) {
+            if (dbInsert(array('title'=>$_REQUEST['title'],'body'=>$_REQUEST['body'],'checksum'=>hash('sha512', LegacyAuth::id().'.LOCAL.'.$_REQUEST['title']),'source'=>LegacyAuth::id()), 'notifications')) {
+                $status  = 'ok';
+                $message = 'Created';
+            }
+        }
+    } else {
+        $message = 'ERROR: Need to be GlobalAdmin or DemoUser';
     }
 } elseif (isset($_REQUEST['action']) && $_REQUEST['action'] == 'read-all-notif') {
     $unread = dbFetchColumn("SELECT `notifications_id` FROM `notifications` AS N WHERE NOT EXISTS ( SELECT 1 FROM `notifications_attribs` WHERE `notifications_id` = N.`notifications_id` AND `user_id`=? AND `key`='read' AND `value`=1)", array(LegacyAuth::id()));

--- a/html/includes/forms/notifications.inc.php
+++ b/html/includes/forms/notifications.inc.php
@@ -29,18 +29,18 @@ header('Content-type: application/json');
 $status    = 'error';
 $message   = 'unknown error';
 if (isset($_REQUEST['notification_id']) && isset($_REQUEST['action'])) {
-    if ($_REQUEST['action'] == 'read' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'read','value'=>1), 'notifications_attribs')) {
+    if ($_REQUEST['action'] == 'read' && dbInsert(['notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'read','value'=>1], 'notifications_attribs')) {
         $status  = 'ok';
         $message = 'Set as Read';
-    } elseif (LegacyAuth::user()->hasGlobalAdmin() || LegacyAuth::user()->isDemoUser()) {
-        if ($_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'sticky','value'=>1), 'notifications_attribs')) {
+    } elseif (LegacyAuth::user()->hasGlobalAdmin()) {
+        if ($_REQUEST['action'] == 'stick' && dbInsert(['notifications_id'=>$_REQUEST['notification_id'],'user_id'=>LegacyAuth::id(),'key'=>'sticky','value'=>1], 'notifications_attribs')) {
             $status  = 'ok';
             $message = 'Set as Sticky';
-        } elseif ($_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", array($_REQUEST['notification_id'],LegacyAuth::id()))) {
+        } elseif ($_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", [$_REQUEST['notification_id'],LegacyAuth::id()])) {
             $status  = 'ok';
             $message = 'Removed Sticky';
         } elseif ($_REQUEST['action'] == 'create' && (isset($_REQUEST['title']) && isset($_REQUEST['body']))) {
-            if (dbInsert(array('title'=>$_REQUEST['title'],'body'=>$_REQUEST['body'],'checksum'=>hash('sha512', LegacyAuth::id().'.LOCAL.'.$_REQUEST['title']),'source'=>LegacyAuth::id()), 'notifications')) {
+            if (dbInsert(['title'=>$_REQUEST['title'],'body'=>$_REQUEST['body'],'checksum'=>hash('sha512', LegacyAuth::id().'.LOCAL.'.$_REQUEST['title']),'source'=>LegacyAuth::id()], 'notifications')) {
                 $status  = 'ok';
                 $message = 'Created';
             }


### PR DESCRIPTION
Allow admins to add/remove/create sticky notifications
Added auth error to ajax form - notifications
	$status is already 'error'

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
