### PR TITLE
[fix] edgeswitch v1.9 os detection

### DIFF
--- a/includes/definitions/edgeswitch.yaml
+++ b/includes/definitions/edgeswitch.yaml
@@ -15,6 +15,5 @@ discovery:
         - .1.3.6.1.4.1.41112
       sysDescr_regex:
         - '/^EdgeSwitch/'
-        - '/^ EdgeSwitch/'
         - '/^EdgePoint/'
         - '/^USW-/'

--- a/includes/definitions/edgeswitch.yaml
+++ b/includes/definitions/edgeswitch.yaml
@@ -10,8 +10,11 @@ over:
     - { graph: device_mempool, text: 'Memory Usage' }
 discovery:
     -
-      sysObjectID: .1.3.6.1.4.1.4413
+      sysObjectID:
+        - .1.3.6.1.4.1.4413
+        - .1.3.6.1.4.1.41112
       sysDescr_regex:
         - '/^EdgeSwitch/'
+        - '/^ EdgeSwitch/'
         - '/^EdgePoint/'
         - '/^USW-/'


### PR DESCRIPTION
EdgeSwitch v1.9 version could not be detected due to sysObjectID change from .1.3.6.1.4.1.4413 to .1.3.6.1.4.1.41112

before:
<img width="723" alt="screen shot 2019-02-24 at 9 47 29 pm" src="https://user-images.githubusercontent.com/3048315/53304438-d826ce00-387d-11e9-9223-f3ef2528c6d0.png">

after:
<img width="673" alt="screen shot 2019-02-24 at 9 46 50 pm" src="https://user-images.githubusercontent.com/3048315/53304440-dfe67280-387d-11e9-8571-195541c73c9f.png">

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
