### PR TITLE
Fixed validator for rrd folder permissions

### DIFF
--- a/LibreNMS/Validations/Rrd.php
+++ b/LibreNMS/Validations/Rrd.php
@@ -63,7 +63,7 @@ class Rrd extends BaseValidation
             }
 
             if (substr(sprintf('%o', fileperms($rrd_dir)), -3) != 775) {
-                $validator->warn('Your RRD directory is not set to 0775', "chmod 775 $rrd_dir}");
+                $validator->warn('Your RRD directory is not set to 0775', "chmod 775 $rrd_dir");
             }
         }
     }


### PR DESCRIPTION
Had an issue with RRD and noticed the } in the command on the WebUI.
Thought I'd correct it. Sorry it is rather minor

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
