### PR TITLE
OpenGear OS remove single quote around type OOB Management

### DIFF
--- a/includes/definitions/opengear.yaml
+++ b/includes/definitions/opengear.yaml
@@ -1,6 +1,6 @@
 os: opengear
 text: Opengear
-type: 'OOB Management'
+type: OOB Management
 icon: opengear
 mib_dir:
     - opengear


### PR DESCRIPTION
This is just something i noticed while looking up all the device types.

1. I remove the Single quotes around Device type OOB Management
2. Is OOB Management a correct device type? Should this be something else? 