### PR TITLE
Fixed sysName can't display because newline character

### DIFF
--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -94,9 +94,9 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != "hide") || !isset($vars[
     $output .= "<option value=''>All Devices</option>";
 
     if (LegacyAuth::user()->hasGlobalRead()) {
-        $results = dbFetchRows("SELECT `device_id`,`hostname`, `sysName` FROM `devices` ORDER BY `hostname`");
+        $results = dbFetchRows("SELECT `device_id`,`hostname`, replace(`sysName`,`\n`,``) FROM `devices` ORDER BY `hostname`");
     } else {
-        $results = dbFetchRows("SELECT `D`.`device_id`,`D`.`hostname`, `D`.`sysname` FROM `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` ORDER BY `hostname`", array(LegacyAuth::id()));
+        $results = dbFetchRows("SELECT `D`.`device_id`,`D`.`hostname`, replace(`D`.`sysname`,`\n`,``) FROM `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` ORDER BY `hostname`", array(LegacyAuth::id()));
     }
     foreach ($results as $data) {
         if ($data['device_id'] == $vars['device_id']) {
@@ -109,7 +109,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != "hide") || !isset($vars[
     }
 
     if (!LegacyAuth::user()->hasGlobalRead()) {
-        $results = dbFetchRows("SELECT `D`.`device_id`,`D`.`hostname`, `D`.`sysName` FROM `ports` AS `I` JOIN `devices` AS `D` ON `D`.`device_id`=`I`.`device_id` JOIN `ports_perms` AS `PP` ON `PP`.`port_id`=`I`.`port_id` WHERE `PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` ORDER BY `hostname`", array(LegacyAuth::id()));
+        $results = dbFetchRows("SELECT `D`.`device_id`,`D`.`hostname`, replace(`D`.`sysName`,`\n`,``) FROM `ports` AS `I` JOIN `devices` AS `D` ON `D`.`device_id`=`I`.`device_id` JOIN `ports_perms` AS `PP` ON `PP`.`port_id`=`I`.`port_id` WHERE `PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` ORDER BY `hostname`", array(LegacyAuth::id()));
     } else {
         $results = array();
     }

--- a/html/pages/search/arp.inc.php
+++ b/html/pages/search/arp.inc.php
@@ -33,7 +33,7 @@ var grid = $("#arp-search").bootgrid({
 use LibreNMS\Authentication\LegacyAuth;
 
 // Select the devices only with ARP tables
-$sql = 'SELECT D.device_id AS device_id, `hostname`, `D`.`sysName` AS `sysName` FROM `ipv4_mac` AS M, `ports` AS P, `devices` AS D';
+$sql = 'SELECT D.device_id AS device_id, `hostname`, replace(`D`.`sysName`,`\n`,``) AS `sysName` FROM `ipv4_mac` AS M, `ports` AS P, `devices` AS D';
 
 if (!LegacyAuth::user()->hasGlobalRead()) {
     $sql    .= ' LEFT JOIN `devices_perms` AS `DP` ON `D`.`device_id` = `DP`.`device_id`';

--- a/html/pages/search/arp.inc.php
+++ b/html/pages/search/arp.inc.php
@@ -33,7 +33,7 @@ var grid = $("#arp-search").bootgrid({
 use LibreNMS\Authentication\LegacyAuth;
 
 // Select the devices only with ARP tables
-$sql = 'SELECT D.device_id AS device_id, `hostname`, replace(`D`.`sysName`,`\n`,``) AS `sysName` FROM `ipv4_mac` AS M, `ports` AS P, `devices` AS D';
+$sql = 'SELECT D.device_id AS device_id, `hostname`, `D`.`sysName` AS `sysName` FROM `ipv4_mac` AS M, `ports` AS P, `devices` AS D';
 
 if (!LegacyAuth::user()->hasGlobalRead()) {
     $sql    .= ' LEFT JOIN `devices_perms` AS `DP` ON `D`.`device_id` = `DP`.`device_id`';

--- a/html/pages/search/ipv4.inc.php
+++ b/html/pages/search/ipv4.inc.php
@@ -30,7 +30,7 @@ var grid = $("#ipv4-search").bootgrid({
 
 use LibreNMS\Authentication\LegacyAuth;
 
-$sql = 'SELECT `devices`.`device_id`,`hostname`,`sysName` FROM `devices`';
+$sql = 'SELECT `devices`.`device_id`,`hostname`,replace(`sysName`,`\n`,``) FROM `devices`';
 
 if (!LegacyAuth::user()->hasGlobalRead()) {
     $sql    .= ' LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`';

--- a/html/pages/search/ipv6.inc.php
+++ b/html/pages/search/ipv6.inc.php
@@ -29,7 +29,7 @@ var grid = $("#ipv6-search").bootgrid({
 
 use LibreNMS\Authentication\LegacyAuth;
 
-$sql = 'SELECT `devices`.`device_id`,`hostname`, `sysName` FROM `devices`';
+$sql = 'SELECT `devices`.`device_id`,`hostname`, replace(`sysName`,`\n`,``) FROM `devices`';
 
 if (!LegacyAuth::user()->hasGlobalRead()) {
     $sql    .= ' LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`';

--- a/html/pages/search/mac.inc.php
+++ b/html/pages/search/mac.inc.php
@@ -30,7 +30,7 @@ var grid = $("#mac-search").bootgrid({
 
 use LibreNMS\Authentication\LegacyAuth;
 
-$sql = 'SELECT `devices`.`device_id`,`hostname`, `sysName` FROM `devices`';
+$sql = 'SELECT `devices`.`device_id`,`hostname`, replace(`sysName`,`\n`,``) FROM `devices`';
 
 if (!LegacyAuth::user()->hasGlobalRead()) {
     $sql    .= ' LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`';


### PR DESCRIPTION
Fixed sysName can't display because newline character.
The reason is that the sysName retrieved by SNMP has a newline character

See forum for details:
https://community.librenms.org/t/ipv4-ipv6-mac-address-arp-table-page-empty/7524/6




DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
