### PR TITLE
Fixed sysName can't display because newline character

### DIFF
--- a/includes/polling/core.inc.php
+++ b/includes/polling/core.inc.php
@@ -18,9 +18,9 @@ use LibreNMS\RRD\RrdDefinition;
 $snmpdata = snmp_get_multi_oid($device, ['sysUpTime.0', 'sysLocation.0', 'sysContact.0', 'sysName.0', 'sysObjectID.0', 'sysDescr.0'], '-OQnUt', 'SNMPv2-MIB');
 
 $poll_device['sysUptime']   = $snmpdata['.1.3.6.1.2.1.1.3.0'];
-$poll_device['sysLocation'] = $snmpdata['.1.3.6.1.2.1.1.6.0'];
-$poll_device['sysContact']  = $snmpdata['.1.3.6.1.2.1.1.4.0'];
-$poll_device['sysName']     = strtolower($snmpdata['.1.3.6.1.2.1.1.5.0']);
+$poll_device['sysLocation'] = str_replace("\n", '', $snmpdata['.1.3.6.1.2.1.1.6.0']);
+$poll_device['sysContact']  = str_replace("\n", '', $snmpdata['.1.3.6.1.2.1.1.4.0']);
+$poll_device['sysName']     = str_replace("\n", '', strtolower($snmpdata['.1.3.6.1.2.1.1.5.0']));
 $poll_device['sysObjectID'] = $snmpdata['.1.3.6.1.2.1.1.2.0'];
 $poll_device['sysDescr']    = $snmpdata['.1.3.6.1.2.1.1.1.0'];
 


### PR DESCRIPTION
Fixed sysName can't display because newline character.
The reason is that the sysName retrieved by SNMP has a newline character

See forum for details:
https://community.librenms.org/t/ipv4-ipv6-mac-address-arp-table-page-empty/7524/6

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
