### PR TITLE
Fix database validation for MySQL 8

### DIFF
--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -184,6 +184,12 @@ class Database extends BaseValidation
 
                 foreach ($data['Columns'] as $index => $cdata) {
                     $column = $cdata['Field'];
+
+                    // MySQL 8 fix, remove DEFAULT_GENERATED from timestamp extra columns
+                    if ($cdata['Type'] == 'timestamp') {
+                         $current_columns[$column]['Extra'] = preg_replace("/DEFAULT_GENERATED[ ]*/", '', $current_columns[$column]['Extra']);
+                    }
+
                     if (empty($current_columns[$column])) {
                         $validator->fail("Database: missing column ($table/$column)");
                         $primary = false;


### PR DESCRIPTION
The validate script reports all timestamp columns as non-compliant because MySQL introduced a new schema in version 8. The extra field now adds "DEFAULT_GENERATED for columns that have an expression default value.". See https://dev.mysql.com/doc/refman/8.0/en/columns-table.html

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
