### PR TITLE
Fix aruba controller + ap polling; acces_points table schema updates

### DIFF
--- a/database/migrations/2019_03_07_223433_add_columns_to_access_points_table.php
+++ b/database/migrations/2019_03_07_223433_add_columns_to_access_points_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddColumnsToAccessPointsTable extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('access_points', function (Blueprint $table) {
+            $table->string('extchannel', 24);
+            $table->string('htchannel', 6);
+            $table->string('htmode', 16);
+            $table->string('mode', 32);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('access_points', function (Blueprint $table) {
+            $table->dropColumn('extchannel');
+            $table->dropColumn('htchannel');
+            $table->dropColumn('htmode');
+            $table->dropColumn('mode');
+        });
+    }
+}

--- a/includes/polling/aruba-controller.inc.php
+++ b/includes/polling/aruba-controller.inc.php
@@ -40,12 +40,12 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
 
     foreach ($switch_apinfo_oids as $oid) {
         echo "$oid ";
-        $aruba_apstats = snmpwalk_cache_oid_num($device, $oid, $aruba_apstats, 'WLSX-WLAN-MIB');
+        $aruba_apstats = snmpwalk_cache_numerical_oid($device, $oid, $aruba_apstats, 'WLSX-WLAN-MIB');
     }
 
     foreach ($switch_apname_oids as $oid) {
         echo "$oid ";
-        $aruba_apnames = snmpwalk_cache_oid_num($device, $oid, $aruba_apnames, 'WLSX-WLAN-MIB');
+        $aruba_apnames = snmpwalk_cache_numerical_oid($device, $oid, $aruba_apnames, 'WLSX-WLAN-MIB');
     }
 
 
@@ -68,93 +68,150 @@ if ($device['type'] == 'wireless' && $device['os'] == 'arubaos') {
     $ap_db = dbFetchRows('SELECT * FROM `access_points` WHERE `device_id` = ?', array($device['device_id']));
 
 
-    foreach ($aruba_apnames as $key => $value) {
-        $radioid       = str_replace('1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.16.', '', $key);
-        $name          = $value[''];
-        $type          = $aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.2.$radioid"][''];
-        $channel       = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.3.$radioid"][''] + 0);
-        $txpow         = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.4.$radioid"][''] + 0);
-        $radioutil     = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.6.$radioid"][''] + 0);
-        $numasoclients = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.7.$radioid"][''] + 0);
-        $nummonclients = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.8.$radioid"][''] + 0);
-        $numactbssid   = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.9.$radioid"][''] + 0);
-        $nummonbssid   = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.10.$radioid"][''] + 0);
-        $interference  = ($aruba_apstats["1.3.6.1.4.1.14823.2.2.1.5.3.1.6.1.11.$radioid"][''] + 0);
+    foreach ($aruba_apnames as $key1 => $value1) {
+        foreach ($value1 as $key => $value) {
+            $radioid       = str_replace('.1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.16.', '', $key);
+            $name          = $value;
+            $type          = $aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.2.$radioid"];
+            $radiomode     = $aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.5.$radioid"];
+            $htchannel     = $aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.15.$radioid"];
+            $radiohtmode   = $aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.13.$radioid"];
+            $extchannel    = $aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.14.$radioid"];
+            $channel       = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.3.$radioid"] + 0);
+            $txpow         = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.4.$radioid"] + 0);
+            $radioutil     = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.6.$radioid"] + 0);
+            $numasoclients = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.7.$radioid"] + 0);
+            $nummonclients = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.8.$radioid"] + 0);
+            $numactbssid   = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.9.$radioid"] + 0);
+            $nummonbssid   = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.2.1.5.1.10.$radioid"] + 0);
+            $interference  = ($aruba_apstats[$key1][".1.3.6.1.4.1.14823.2.2.1.5.3.1.6.1.11.$radioid"] + 0);
 
-        $radionum = substr($radioid, (strlen($radioid) - 1), 1);
+            $radionum = substr($radioid, (strlen($radioid) - 1), 1);
 
-        if ($debug) {
-            echo "* radioid: $radioid\n";
-            echo "  radionum: $radionum\n";
-            echo "  name: $name\n";
-            echo "  type: $type\n";
-            echo "  channel: $channel\n";
-            echo "  txpow: $txpow\n";
-            echo "  radioutil: $radioutil\n";
-            echo "  numasoclients: $numasoclients\n";
-            echo "  interference: $interference\n";
-        }
-
-        // if there is a numeric channel, assume the rest of the data is valid, I guess
-        if (is_numeric($channel)) {
-            $rrd_name = array('arubaap',  $name.$radionum);
-
-            $rrd_def = RrdDefinition::make()
-                ->addDataset('channel', 'GAUGE', 0, 200)
-                ->addDataset('txpow', 'GAUGE', 0, 200)
-                ->addDataset('radioutil', 'GAUGE', 0, 100)
-                ->addDataset('nummonclients', 'GAUGE', 0, 500)
-                ->addDataset('nummonbssid', 'GAUGE', 0, 200)
-                ->addDataset('numasoclients', 'GAUGE', 0, 500)
-                ->addDataset('interference', 'GAUGE', 0, 2000);
-
-            $fields = array(
-                'channel'         => $channel,
-                'txpow'           => $txpow,
-                'radioutil'       => $radioutil,
-                'nummonclients'   => $nummonclients,
-                'nummonbssid'     => $nummonbssid,
-                'numasoclients'   => $numasoclients,
-                'interference'    => $interference,
-            );
-
-            $tags = array(
-                'name' => $name,
-                'radionum' => $radionum,
-                'rrd_name' => $rrd_name,
-                'rrd_def' => $rrd_def
-            );
-
-            data_update($device, 'aruba', $tags, $fields);
-        }
-
-        // generate the mac address
-        $macparts = explode('.', $radioid, -1);
-        $mac      = '';
-        foreach ($macparts as $part) {
-            $mac .= sprintf('%02x', $part).':';
-        }
-
-        $mac = rtrim($mac, ':');
-
-
-        $foundid = 0;
-
-        for ($z = 0; $z < sizeof($ap_db); $z++) {
-            if ($ap_db[$z]['name'] == $name && $ap_db[$z]['radio_number'] == $radionum) {
-                $foundid           = $ap_db[$z]['accesspoint_id'];
-                $ap_db[$z]['seen'] = 1;
-                continue;
+            if ($debug) {
+                echo "$key\n";
+                echo "$value\n";
+                echo "* radioid:        $radioid\n";
+                echo "  radionum:       $radionum\n";
+                echo "  name:           $name\n";
+                echo "  mode:           $radiomode\n";
+                echo "  type:           $type\n";
+                echo "  radiohtmode:    $radiohtmode\n";
+                echo "  channel:        $channel\n";
+                echo "  htchannel:      $htchannel\n";
+                echo "  extchannel:     $extchannel\n";
+                echo "  txpow:          $txpow\n";
+                echo "  radioutil:      $radioutil\n";
+                echo "  numasoclients:  $numasoclients\n";
+                echo "  interference:   $interference\n";
             }
-        }
+
+            // if there is a numeric channel, assume the rest of the data is valid, I guess
+            if (is_numeric($channel)) {
+                $rrd_name = array('arubaap',  $name.$radionum);
+
+                $rrd_def = RrdDefinition::make()
+                    ->addDataset('channel', 'GAUGE', 0, 200)
+                    ->addDataset('txpow', 'GAUGE', 0, 200)
+                    ->addDataset('radioutil', 'GAUGE', 0, 100)
+                    ->addDataset('nummonclients', 'GAUGE', 0, 500)
+                    ->addDataset('nummonbssid', 'GAUGE', 0, 200)
+                    ->addDataset('numasoclients', 'GAUGE', 0, 500)
+                    ->addDataset('interference', 'GAUGE', 0, 2000);
+
+                $fields = array(
+                    'channel'         => $channel,
+                    'txpow'           => $txpow,
+                    'radioutil'       => $radioutil,
+                    'nummonclients'   => $nummonclients,
+                    'nummonbssid'     => $nummonbssid,
+                    'numasoclients'   => $numasoclients,
+                    'interference'    => $interference,
+                );
+
+                $tags = array(
+                    'name' => $name,
+                    'radionum' => $radionum,
+                    'rrd_name' => $rrd_name,
+                    'rrd_def' => $rrd_def
+                );
+
+                data_update($device, 'aruba', $tags, $fields);
+            }
+
+            // generate the mac address
+            $macparts = explode('.', $radioid, -1);
+            $mac      = '';
+            foreach ($macparts as $part) {
+                $mac .= sprintf('%02x', $part).':';
+            }
+
+            $mac = rtrim($mac, ':');
+
+
+            $foundid = 0;
+
+            for ($z = 0; $z < sizeof($ap_db); $z++) {
+                if ($ap_db[$z]['name'] == $name && $ap_db[$z]['radio_number'] == $radionum) {
+                    $foundid           = $ap_db[$z]['accesspoint_id'];
+                    $ap_db[$z]['seen'] = 1;
+                    continue;
+                }
+            }
 
 
 
-        if ($foundid == 0) {
-            $ap_id = dbInsert(array('device_id' => $device['device_id'], 'name' => $name, 'radio_number' => $radionum, 'type' => $type, 'mac_addr' => $mac, 'channel' => $channel, 'txpow' => $txpow, 'radioutil' => $radioutil, 'numasoclients' => $numasoclients, 'nummonclients' => $nummonclients, 'numactbssid' => $numactbssid, 'nummonbssid' => $nummonbssid, 'interference' => $interference), 'access_points');
-        } else {
-            dbUpdate(array('mac_addr' => $mac, 'deleted' => 0, 'channel' => $channel, 'txpow' => $txpow, 'radioutil' => $radioutil, 'numasoclients' => $numasoclients, 'nummonclients' => $nummonclients, 'numactbssid' => $numactbssid, 'nummonbssid' => $nummonbssid, 'interference' => $interference), 'access_points', '`accesspoint_id` = ?', array($foundid));
-        }
+            if ($foundid == 0) {
+                $ap_id = dbInsert(
+                    array(
+                        'channel'       => $channel,
+                        'deleted'       => 0,
+                        'device_id'     => $device['device_id'],
+                        'extchannel'    => $extchannel,
+                        'htchannel'     => $htchannel,
+                        'htmode'        => $radiohtmode,
+                        'interference'  => $interference,
+                        'mac_addr'      => $mac,
+                        'mode'          => $radiomode,
+                        'name'          => $name,
+                        'numactbssid'   => $numactbssid,
+                        'numasoclients' => $numasoclients,
+                        'nummonbssid'   => $nummonbssid,
+                        'nummonclients' => $nummonclients,
+                        'radio_number'  => $radionum,
+                        'radioutil'     => $radioutil,
+                        'txpow'         => $txpow,
+                        'type'          => $type
+                    ),
+                    'access_points'
+                );
+            } else {
+                dbUpdate(
+                    array(
+                        'channel'       => $channel,
+                        'deleted'       => 0,
+                        'extchannel'    => $extchannel,
+                        'htchannel'     => $htchannel,
+                        'htmode'        => $radiohtmode,
+                        'interference'  => $interference,
+                        'mac_addr'      => $mac,
+                        'mode'          => $radiomode,
+                        'name'          => $name,
+                        'numactbssid'   => $numactbssid,
+                        'numasoclients' => $numasoclients,
+                        'nummonbssid'   => $nummonbssid,
+                        'nummonclients' => $nummonclients,
+                        'radio_number'  => $radionum,
+                        'radioutil'     => $radioutil,
+                        'txpow'         => $txpow,
+                        'type'          => $type
+                    ),
+                    'access_points',
+                    '`accesspoint_id` = ?',
+                    array($foundid)
+                );
+            }
+        }//end foreach
     }//end foreach
 
     // mark APs which are not on this controller anymore as deleted

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -15,6 +15,10 @@ access_points:
     - { Field: numactbssid, Type: tinyint(4), 'Null': false, Extra: '', Default: '0' }
     - { Field: nummonbssid, Type: tinyint(4), 'Null': false, Extra: '', Default: '0' }
     - { Field: interference, Type: 'tinyint(3) unsigned', 'Null': false, Extra: '' }
+    - { Field: extchannel, Type: varchar(24), 'Null': false, Extra: '' }
+    - { Field: htchannel, Type: varchar(6), 'Null': false, Extra: '' }
+    - { Field: htmode, Type: varchar(16), 'Null': false, Extra: '' }
+    - { Field: mode, Type: varchar(32), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [accesspoint_id], Unique: true, Type: BTREE }
     deleted: { Name: deleted, Columns: [deleted], Unique: false, Type: BTREE }


### PR DESCRIPTION
Fix Aruba Controller + AP polling
update access_points table to allow for storage of AP mode, HT mode, HT channel, and Ext channel information

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
