### PR TITLE
Improve VRP stack state discovery with one member only to avoid unnecessary alarms

### DIFF
--- a/includes/definitions/discovery/vrp.yaml
+++ b/includes/definitions/discovery/vrp.yaml
@@ -21,6 +21,7 @@ modules:
             data:
                 - oid:
                     - entPhysicalName
+                    - hwStackPortTable
         temperature:
             data:
                 -
@@ -156,14 +157,4 @@ modules:
                          - { descr: Master, graph: 1, value: 1, generic: 0 }
                          - { descr: Standby, graph: 1, value: 2, generic: 0 }
                          - { descr: Slave, graph: 1, value: 3, generic: 0 }
-                -
-                    oid: hwStackPortTable
-                    value: hwStackPortStatus
-                    num_oid: '.1.3.6.1.4.1.2011.5.25.183.1.21.1.5.{{ $index }}'
-                    descr: 'Stack Port {{ $index }} Status'
-                    group: Stack
-                    state_name: hwStackPortStatus
-                    states:
-                         - { descr: Up, graph: 1, value: 1, generic: 0 }
-                         - { descr: Down, graph: 1, value: 2, generic: 2 }
 

--- a/includes/discovery/sensors/state/vrp.inc.php
+++ b/includes/discovery/sensors/state/vrp.inc.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * vrp.inc.php
+ *
+ * LibreNMS sensors state discovery module for HP Procurve
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2019 PipoCanaja
+ * @author     PipoCanaja
+ */
+
+//d_echo($pre_cache);
+
+//exit;
+
+$stacked_device = count(array_keys($pre_cache['hwStackMemberInfoTable']));
+// If we have more than 1 device in the stack, then we should alert on stack ports not up
+
+if ($stacked_device > 1) {
+    $state_name    = "hwStackPortStatus";
+    $states = [
+        ['value' => 1, 'generic' => 0, 'graph' => 0, 'descr' => 'Up'],
+        ['value' => 2, 'generic' => 2, 'graph' => 0, 'descr' => 'Down'],
+    ];
+} else {
+    $state_name    = "hwStackPortStatusNotStacked";
+    $states = [
+        ['value' => 1, 'generic' => 3, 'graph' => 0, 'descr' => 'Up'],
+        ['value' => 2, 'generic' => 3, 'graph' => 0, 'descr' => 'Down'],
+    ];
+}
+
+foreach ($pre_cache['hwStackPortTable'] as $index => $data) {
+    $subindex = explode('.', $index);
+    $state_oid     = '.1.3.6.1.4.1.2011.5.25.183.1.21.1.5.' . $index;
+    $state_descr   = "Unit " . $subindex[0] . " stack-port " . $subindex[1] . " Status";
+    $state          = $data['hwStackPortStatus'];
+    $state_index      = $index;
+
+    create_state_index($state_name, $states);
+
+    discover_sensor($valid['sensor'], 'state', $device, $state_oid, $state_index, $state_name, $state_descr, '1', '1', null, null, null, null, $state, 'snmp', null, null, null, 'Stack');
+    create_sensor_to_state_index($device, $state_name, $state_index);
+}

--- a/includes/discovery/sensors/state/vrp.inc.php
+++ b/includes/discovery/sensors/state/vrp.inc.php
@@ -23,10 +23,6 @@
  * @author     PipoCanaja
  */
 
-//d_echo($pre_cache);
-
-//exit;
-
 $stacked_device = count(array_keys($pre_cache['hwStackMemberInfoTable']));
 // If we have more than 1 device in the stack, then we should alert on stack ports not up
 

--- a/tests/data/vrp_5720-vrf.json
+++ b/tests/data/vrp_5720-vrf.json
@@ -34646,7 +34646,7 @@
                     "sensor_oid": ".1.3.6.1.4.1.2011.5.25.183.1.21.1.5.1.0",
                     "sensor_index": "1.0",
                     "sensor_type": "hwStackPortStatus",
-                    "sensor_descr": "Stack Port 1.0 Status",
+                    "sensor_descr": "Unit 1 stack-port 0 Status",
                     "group": "Stack",
                     "sensor_divisor": 1,
                     "sensor_multiplier": 1,
@@ -34670,7 +34670,7 @@
                     "sensor_oid": ".1.3.6.1.4.1.2011.5.25.183.1.21.1.5.1.1",
                     "sensor_index": "1.1",
                     "sensor_type": "hwStackPortStatus",
-                    "sensor_descr": "Stack Port 1.1 Status",
+                    "sensor_descr": "Unit 1 stack-port 1 Status",
                     "group": "Stack",
                     "sensor_divisor": 1,
                     "sensor_multiplier": 1,
@@ -34694,7 +34694,7 @@
                     "sensor_oid": ".1.3.6.1.4.1.2011.5.25.183.1.21.1.5.2.0",
                     "sensor_index": "2.0",
                     "sensor_type": "hwStackPortStatus",
-                    "sensor_descr": "Stack Port 2.0 Status",
+                    "sensor_descr": "Unit 2 stack-port 0 Status",
                     "group": "Stack",
                     "sensor_divisor": 1,
                     "sensor_multiplier": 1,
@@ -34718,7 +34718,7 @@
                     "sensor_oid": ".1.3.6.1.4.1.2011.5.25.183.1.21.1.5.2.1",
                     "sensor_index": "2.1",
                     "sensor_type": "hwStackPortStatus",
-                    "sensor_descr": "Stack Port 2.1 Status",
+                    "sensor_descr": "Unit 2 stack-port 1 Status",
                     "group": "Stack",
                     "sensor_divisor": 1,
                     "sensor_multiplier": 1,
@@ -34977,14 +34977,14 @@
                 {
                     "state_name": "hwStackPortStatus",
                     "state_descr": "Up",
-                    "state_draw_graph": 1,
+                    "state_draw_graph": 0,
                     "state_value": 1,
                     "state_generic_value": 0
                 },
                 {
                     "state_name": "hwStackPortStatus",
                     "state_descr": "Down",
-                    "state_draw_graph": 1,
+                    "state_draw_graph": 0,
                     "state_value": 2,
                     "state_generic_value": 2
                 }


### PR DESCRIPTION
The YAML implementation cannot identify a device non stacked cause VRP reports it as a stack with 1 member.

So this patch replaces YAML with PHP for this sensor.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
