### PR TITLE
Allowed more characters in graph legend for interface names

### DIFF
--- a/html/includes/graphs/generic_multi_seperated.inc.php
+++ b/html/includes/graphs/generic_multi_seperated.inc.php
@@ -15,9 +15,11 @@
 
 require 'includes/graphs/common.inc.php';
 
+$rrddescr_len = 14; // length of the padded rrd_descr in legend
+
 $stacked = generate_stacked_graphs();
 
-$units_descr = substr(str_pad($units_descr, 18), 0, 18);
+$units_descr = substr(str_pad($units_descr, $rrddescr_len + 9), 0, $rrddescr_len + 9);
 
 if ($format == 'octets' || $format == 'bytes') {
     $units = 'Bps';
@@ -87,7 +89,7 @@ foreach ($rrd_list as $rrd) {
         $stack = ':STACK';
     }
 
-    $rrd_options .= ' AREA:inbits' . $i . '#' . $colour_in . $stacked['transparency'] . ":'" . rrdtool_escape($rrd['descr'], 9) . "In '$stack";
+    $rrd_options .= ' AREA:inbits' . $i . '#' . $colour_in . $stacked['transparency'] . ":'" . rrdtool_escape($rrd['descr'], $rrddescr_len) . "In '$stack";
     $rrd_options .= ' GPRINT:inbits' . $i . ':LAST:%6.2lf%s';
     $rrd_options .= ' GPRINT:inbits' . $i . ':AVERAGE:%6.2lf%s';
     $rrd_options .= ' GPRINT:inbits' . $i . ':MAX:%6.2lf%s';
@@ -98,7 +100,7 @@ foreach ($rrd_list as $rrd) {
 
     $rrd_options .= " COMMENT:'\\n'";
     $rrd_optionsb .= ' AREA:outbits' . $i . '_neg#' . $colour_out . $stacked['transparency'] . ":$stack";
-    $rrd_options .= ' HRULE:999999999999999#' . $colour_out . ":'" . str_pad('', 10) . "Out'";
+    $rrd_options .= ' HRULE:999999999999999#' . $colour_out . ":'" . str_pad('', $rrddescr_len + 1) . "Out'";
     $rrd_options .= ' GPRINT:outbits' . $i . ':LAST:%6.2lf%s';
     $rrd_options .= ' GPRINT:outbits' . $i . ':AVERAGE:%6.2lf%s';
     $rrd_options .= ' GPRINT:outbits' . $i . ':MAX:%6.2lf%s';
@@ -160,21 +162,21 @@ if (!$args['nototal']) {
 
     $rrd_options .= " COMMENT:' \\n'";
 
-    $rrd_options .= " HRULE:999999999999999#FFFFFF:'" . str_pad('Total', 10) . "In '";
+    $rrd_options .= " HRULE:999999999999999#FFFFFF:'" . str_pad('Total', $rrddescr_len + 1) . "In '";
     $rrd_options .= ' GPRINT:inbits:LAST:%6.2lf%s';
     $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.2lf%s';
     $rrd_options .= ' GPRINT:inbits:MAX:%6.2lf%s';
     $rrd_options .= " GPRINT:totin:%6.2lf%s$total_units";
     $rrd_options .= " COMMENT:'\\n'";
 
-    $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', 10) . "Out'";
+    $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', $rrddescr_len + 1) . "Out'";
     $rrd_options .= ' GPRINT:outbits:LAST:%6.2lf%s';
     $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.2lf%s';
     $rrd_options .= ' GPRINT:outbits:MAX:%6.2lf%s';
     $rrd_options .= " GPRINT:totout:%6.2lf%s$total_units";
     $rrd_options .= " COMMENT:'\\n'";
 
-    $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', 10) . "Agg'";
+    $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', $rrddescr_len + 1) . "Agg'";
     $rrd_options .= ' GPRINT:bits:LAST:%6.2lf%s';
     $rrd_options .= ' GPRINT:bits:AVERAGE:%6.2lf%s';
     $rrd_options .= ' GPRINT:bits:MAX:%6.2lf%s';


### PR DESCRIPTION
- Added a variable to store the target length for rrd[descr]. 
- Extended current value from 9 to 14.

Following this forum post : 
https://community.librenms.org/t/correct-interface-name-truncated-in-total-traffic-graphs/7528/7


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
