### PR TITLE
Corrected active_count for Alert icon color

### DIFF
--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -222,7 +222,6 @@ class MenuComposer
         $alert_status = AlertRule::select('severity')
             ->isActive()
             ->hasAccess($user)
-            ->groupBy('severity')
             ->leftJoin('devices', 'alerts.device_id', '=', 'devices.device_id')
             ->where('devices.disabled', '=', '0')
             ->where('devices.ignore', '=', '0')

--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -223,6 +223,10 @@ class MenuComposer
             ->isActive()
             ->hasAccess($user)
             ->groupBy('severity')
+            ->leftJoin('devices', 'alerts.device_id', '=', 'devices.device_id')
+            ->where('devices.disabled', '=', '0')
+            ->where('devices.ignore', '=', '0')
+            ->groupBy('severity')
             ->pluck('severity');
 
         if ($alert_status->contains('critical')) {

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -52,7 +52,7 @@ class AlertRule extends BaseModel
     {
         return $query->enabled()
             ->join('alerts', 'alerts.rule_id', 'alert_rules.id')
-            ->whereIn('alerts.state', [1, 3, 4]);
+            ->whereNotIn('alerts.state', [0, 2]);
     }
 
     /**

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -52,7 +52,7 @@ class AlertRule extends BaseModel
     {
         return $query->enabled()
             ->join('alerts', 'alerts.rule_id', 'alert_rules.id')
-            ->where('alerts.state', 1);
+            ->whereIn('alerts.state', [1, 3, 4]);
     }
 
     /**

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -39,7 +39,7 @@ class AlertRule extends BaseModel
      */
     public function scopeEnabled($query)
     {
-        return $query->where('disabled', 0);
+        return $query->where('alert_rules.disabled', 0);
     }
 
     /**

--- a/includes/caches/alerts.inc.php
+++ b/includes/caches/alerts.inc.php
@@ -3,10 +3,10 @@
 use LibreNMS\Authentication\LegacyAuth;
 
 if (LegacyAuth::user()->hasGlobalRead()) {
-    $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2)');
+    $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2) AND `devices`.`disabled` = 0');
 } else {
     $data['active_count'] = array(
-        'query'  => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id` LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2) AND `DP`.`user_id`=?',
+        'query'  => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id` LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2)  AND `devices`.`disabled` = 0 AND `DP`.`user_id`=?',
         'params' => array(LegacyAuth::id()),
     );
 }

--- a/includes/caches/alerts.inc.php
+++ b/includes/caches/alerts.inc.php
@@ -3,10 +3,10 @@
 use LibreNMS\Authentication\LegacyAuth;
 
 if (LegacyAuth::user()->hasGlobalRead()) {
-    $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2) AND `devices`.`disabled` = 0');
+    $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2) AND `devices`.`disabled` = 0 AND `devices`.`ignore` = 0');
 } else {
     $data['active_count'] = array(
-        'query'  => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id` LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2)  AND `devices`.`disabled` = 0 AND `DP`.`user_id`=?',
+        'query'  => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id` LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2)  AND `devices`.`disabled` = 0 AND `devices`.`ignore` = 0 AND `DP`.`user_id`=?',
         'params' => array(LegacyAuth::id()),
     );
 }

--- a/includes/caches/alerts.inc.php
+++ b/includes/caches/alerts.inc.php
@@ -3,10 +3,10 @@
 use LibreNMS\Authentication\LegacyAuth;
 
 if (LegacyAuth::user()->hasGlobalRead()) {
-    $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,1)');
+    $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2)');
 } else {
     $data['active_count'] = array(
-        'query'  => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id` LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,1) AND `DP`.`user_id`=?',
+        'query'  => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id` LEFT JOIN `devices_perms` AS `DP` ON `devices`.`device_id` = `DP`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,2) AND `DP`.`user_id`=?',
         'params' => array(LegacyAuth::id()),
     );
 }


### PR DESCRIPTION
Hi,

I did receive questions from my colleagues on the Alert Icon color in the menubar. Red or green does not follow the implicit logic.

After a check, it seems that the SQL calculating it is wrong. As far as I see it, we want:
- Green if all alerts in DB are OK (status 0) or ACK (status 2)
- Red in any other cases. 

That means : ```AND `alerts`.`state` NOT IN (0,2)'``` instead of ```AND `alerts`.`state` NOT IN (0,1)' ```as it is now. 
Moreover, Devices with disabled or ignore state should not be taken into account.

Here is a patch for legacy and laravel icon coloring. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
