### PR TITLE
fix getOutput, collect all buffer for sync process

### DIFF
--- a/LibreNMS/Proc.php
+++ b/LibreNMS/Proc.php
@@ -159,14 +159,16 @@ class Proc
             $stderr_buf = stream_get_contents($this->_pipes[2]);
             $stderr .= $stderr_buf;
             if (empty($stdout_buf) && empty($stderr_buf)) {
-                break;
+                $do_get = false;
+            } else {
+                $stream_end = microtime(true);
+                $stream_time = round(($stream_end - $stream_start) * 1000);
+                if ($stream_time>$timeout) {
+                    $do_get = false;
+                } else {
+                    usleep($delay);
+                }
             }
-            $stream_end = microtime(true);
-            $stream_time = round(($stream_end - $stream_start) * 1000);
-            if ($stream_time>$timeout) {
-                break;
-            }
-            usleep($delay);
         }
         return [$stdout, $stderr];
     }

--- a/LibreNMS/Proc.php
+++ b/LibreNMS/Proc.php
@@ -147,30 +147,21 @@ class Proc
 
             stream_select($pipes, $w, $x, $timeout);
         }
-
-        $stdout = '';
-        $stderr = '';
-        $do_get = true;
+        list($stdout, $stderr) = array('', '');
         $stream_start = microtime(true);
-        $delay = 10000; // 0.01 ms
-        while ($do_get) {
-            $stdout_buf = stream_get_contents($this->_pipes[1]);
+        $stream_time = 0;
+        while ($stream_time < $timeout) {
+            list($stdout_buf, $stderr_buf) = array(stream_get_contents($this->_pipes[1]), stream_get_contents($this->_pipes[2]));
             $stdout .= $stdout_buf;
-            $stderr_buf = stream_get_contents($this->_pipes[2]);
             $stderr .= $stderr_buf;
             if (empty($stdout_buf) && empty($stderr_buf)) {
-                $do_get = false;
-            } else {
-                $stream_end = microtime(true);
-                $stream_time = round(($stream_end - $stream_start) * 1000);
-                if ($stream_time>$timeout) {
-                    $do_get = false;
-                } else {
-                    usleep($delay);
-                }
+                break;
             }
+            $stream_end = microtime(true);
+            $stream_time = round(($stream_end - $stream_start) * 1000);
+            usleep(10000); // 10ms
         }
-        return [$stdout, $stderr];
+        return array($stdout, $stderr);
     }
 
     /**

--- a/LibreNMS/Proc.php
+++ b/LibreNMS/Proc.php
@@ -147,7 +147,28 @@ class Proc
 
             stream_select($pipes, $w, $x, $timeout);
         }
-        return array(stream_get_contents($this->_pipes[1]), stream_get_contents($this->_pipes[2]));
+
+        $stdout = '';
+        $stderr = '';
+        $do_get = true;
+        $stream_start = microtime(true);
+        $delay = 10000; // 0.01 ms
+        while ($do_get) {
+            $stdout_buf = stream_get_contents($this->_pipes[1]);
+            $stdout .= $stdout_buf;
+            $stderr_buf = stream_get_contents($this->_pipes[2]);
+            $stderr .= $stderr_buf;
+            if (empty($stdout_buf) && empty($stderr_buf)) {
+                break;
+            }
+            $stream_end = microtime(true);
+            $stream_time = round(($stream_end - $stream_start) * 1000);
+            if ($stream_time>$timeout) {
+                break;
+            }
+            usleep($delay);
+        }
+        return [$stdout, $stderr];
     }
 
     /**


### PR DESCRIPTION
fix getOutput, collect all buffer.

before changed, when get graph, got red bar, because getOutput is not completed.
output of debug graph.php
https://x.y.z/graph.php?height=45&debug=1
```
SQL[SELECT `devices`.*, `location`, `lat`, `lng` FROM `devices` LEFT JOIN locations ON `devices`.location_id=`locations`.`id` WHERE `device_id` = ? ["1"] 0.78ms] SQL[SELECT * FROM devices_attribs WHERE `device_id` = ? [1] 0.3ms] SQL[SELECT * FROM `vrf_lite_cisco` WHERE `device_id` = ? ["1"] 0.32ms] SQL[SELECT attrib_value FROM devices_attribs WHERE `device_id` = ? AND `attrib_type` = ? [1,"poll_mib"] 0.29ms] SQL[SELECT * FROM `processors` where `device_id` = ? [1] 2.95ms] RRD[last 10.10.0.1/processor-hr-196608.rrd --daemon rrdcached:42217] RRD[last 10.10.0.1/processor-hr-196609.rrd --daemon rrdcached:42217] 
Warning: substr_count(): Invalid length value in /opt/librenms/includes/rrdtool.inc.php on line 284
graph /tmp/xEaKh3bU2U7yrExX -g -l 0 -u 100 -E --start 1552416900 --end 1552503300 --width 150 --height 45 -c BACK#EEEEEE00 -c SHADEA#EEEEEE00 -c SHADEB#EEEEEE00 -c FONT#000000 -c CANVAS#FFFFFF00 -c GRID#a5a5a5 -c MGRID#FF9999 -c FRAME#5e5e5e -c ARROW#5e5e5e -R normal -c CANVAS#FFFFFF00 --only-graph --font LEGEND:7:DejaVuSansMono --font AXIS:6:DejaVuSansMono --font-render-mode normal COMMENT:'Load % Now Min Max Avg\l' DEF:usage0=10.10.0.1/processor-hr-196608.rrd:usage:AVERAGE DEF:usage0min=10.10.0.1/processor-hr-196608.rrd:usage:MIN DEF:usage0max=10.10.0.1/processor-hr-196608.rrd:usage:MAX CDEF:usage_cdef0=usage0,2,/ CDEF:usage_cdef0min=usage0min,2,/ CDEF:usage_cdef0max=usage0max,2,/ AREA:usage_cdef0#E43C00:'Intel Xeon E5-26 ' GPRINT:usage0:LAST:%5.2lf%s GPRINT:usage0min:MIN:%5.2lf%s GPRINT:usage0max:MAX:%5.2lf%s GPRINT:usage0:AVERAGE:'%5.2lf%s\n' COMMENT:'\n' DEF:usage1=10.10.0.1/processor-hr-196609.rrd:usage:AVERAGE DEF:usage1min=10.10.0.1/processor-hr-196609.rrd:usage:MIN DEF:usage1max=10.10.0.1/processor-hr-196609.rrd:usage:MAX CDEF:usage_cdef1=usage1,2,/ CDEF:usage_cdef1min=usage1min,2,/ CDEF:usage_cdef1max=usage1max,2,/ AREA:usage_cdef1#E74B00:'Intel Xeon E5-26 ':STACK GPRINT:usage1:LAST:%5.2lf%s GPRINT:usage1min:MIN:%5.2lf%s GPRINT:usage1max:MAX:%5.2lf%s GPRINT:usage1:AVERAGE:'%5.2lf%s\n' COMMENT:'\n' --daemon rrdcached:42217

command returned (1552503300 OK u:0.01 s:0.00 r:0.00 )

graph /tmp/xEaKh3bU2U7yrExX -g --alt-autoscale-max --rigid -E --start 1552416900 --end 1552503300 --width 150 --height 45 -c BACK#EEEEEE00 -c SHADEA#EEEEEE00 -c SHADEB#EEEEEE00 -c FONT#000000 -c CANVAS#FFFFFF00 -c GRID#a5a5a5 -c MGRID#FF9999 -c FRAME#5e5e5e -c ARROW#5e5e5e -R normal -c CANVAS#FFFFFF00 --only-graph --font LEGEND:7:DejaVuSansMono --font AXIS:6:DejaVuSansMono --font-render-mode normal HRULE:0#555555 --title='Draw Error' --daemon rrdcached:42217

command returned (150x45 OK u:0.01 s:0.00 r:0.01 )
```
after changed, getOutput always get completed, graph is normal.
```
SQL[SELECT `devices`.*, `location`, `lat`, `lng` FROM `devices` LEFT JOIN locations ON `devices`.location_id=`locations`.`id` WHERE `device_id` = ? ["1"] 0.78ms] SQL[SELECT * FROM devices_attribs WHERE `device_id` = ? [1] 0.3ms] SQL[SELECT * FROM `vrf_lite_cisco` WHERE `device_id` = ? ["1"] 0.3ms] SQL[SELECT attrib_value FROM devices_attribs WHERE `device_id` = ? AND `attrib_type` = ? [1,"poll_mib"] 0.28ms] SQL[SELECT * FROM `processors` where `device_id` = ? [1] 1.16ms] RRD[last 10.10.0.1/processor-hr-196608.rrd --daemon rrdcached:42217] RRD[last 10.10.0.1/processor-hr-196609.rrd --daemon rrdcached:42217] 
Warning: substr_count(): Invalid length value in /opt/librenms/includes/rrdtool.inc.php on line 284
graph /tmp/z2YLFtVAH7ZtRzF9 -g -l 0 -u 100 -E --start 1552416900 --end 1552503300 --width 150 --height 45 -c BACK#EEEEEE00 -c SHADEA#EEEEEE00 -c SHADEB#EEEEEE00 -c FONT#000000 -c CANVAS#FFFFFF00 -c GRID#a5a5a5 -c MGRID#FF9999 -c FRAME#5e5e5e -c ARROW#5e5e5e -R normal -c CANVAS#FFFFFF00 --only-graph --font LEGEND:7:DejaVuSansMono --font AXIS:6:DejaVuSansMono --font-render-mode normal COMMENT:'Load % Now Min Max Avg\l' DEF:usage0=10.10.0.1/processor-hr-196608.rrd:usage:AVERAGE DEF:usage0min=10.10.0.1/processor-hr-196608.rrd:usage:MIN DEF:usage0max=10.10.0.1/processor-hr-196608.rrd:usage:MAX CDEF:usage_cdef0=usage0,2,/ CDEF:usage_cdef0min=usage0min,2,/ CDEF:usage_cdef0max=usage0max,2,/ AREA:usage_cdef0#E43C00:'Intel Xeon E5-26 ' GPRINT:usage0:LAST:%5.2lf%s GPRINT:usage0min:MIN:%5.2lf%s GPRINT:usage0max:MAX:%5.2lf%s GPRINT:usage0:AVERAGE:'%5.2lf%s\n' COMMENT:'\n' DEF:usage1=10.10.0.1/processor-hr-196609.rrd:usage:AVERAGE DEF:usage1min=10.10.0.1/processor-hr-196609.rrd:usage:MIN DEF:usage1max=10.10.0.1/processor-hr-196609.rrd:usage:MAX CDEF:usage_cdef1=usage1,2,/ CDEF:usage_cdef1min=usage1min,2,/ CDEF:usage_cdef1max=usage1max,2,/ AREA:usage_cdef1#E74B00:'Intel Xeon E5-26 ':STACK GPRINT:usage1:LAST:%5.2lf%s GPRINT:usage1min:MIN:%5.2lf%s GPRINT:usage1max:MAX:%5.2lf%s GPRINT:usage1:AVERAGE:'%5.2lf%s\n' COMMENT:'\n' --daemon rrdcached:42217

command returned (150x45 OK u:0.01 s:0.00 r:0.04 )

-rw-rw-r-- 1 librenms librenms 2165 Mar 14 01:56 /tmp/z2YLFtVAH7ZtRzF9 graph
Runtime 0.079s
SNMP [0/0.00s]: Get[0/0.00s] Getnext[0/0.00s] Walk[0/0.00s] MySQL [5/0.00s]: Cell[0/0.00s] Row[2/0.00s] Rows[-1/0.00s] Column[4/0.00s] Update[0/0.00s] Insert[0/0.00s] Delete[0/0.00s] RRD [2/0.04s]: Update[0/0.00s] Create [0/0.00s] Other[2/0.04s]
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
