### PR TITLE
Don't enable secure cookies when they won't work

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -442,8 +442,8 @@ class Config
             self::set('email_from', '"' . self::get('project_name') . '" <' . self::get('email_user') . '@' . php_uname('n') . '>');
         }
 
-        if (self::get('secure_cookies')) {
-            @ini_set('session.cookie_secure', 1);
+        if (self::get('secure_cookies') && isset($_SERVER["HTTPS"])) {
+            ini_set('session.cookie_secure', 1);
         }
 
         // If we're on SSL, let's properly detect it

--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -442,10 +442,6 @@ class Config
             self::set('email_from', '"' . self::get('project_name') . '" <' . self::get('email_user') . '@' . php_uname('n') . '>');
         }
 
-        if (self::get('secure_cookies') && isset($_SERVER["HTTPS"])) {
-            ini_set('session.cookie_secure', 1);
-        }
-
         // If we're on SSL, let's properly detect it
         if (isset($_SERVER['HTTPS'])) {
             self::set('base_url', preg_replace('/^http:/', 'https:', self::get('base_url')));

--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -443,7 +443,7 @@ class Config
         }
 
         if (self::get('secure_cookies')) {
-            ini_set('session.cookie_secure', 1);
+            @ini_set('session.cookie_secure', 1);
         }
 
         // If we're on SSL, let's properly detect it

--- a/doc/General/Security.md
+++ b/doc/General/Security.md
@@ -13,9 +13,6 @@ a firewall or VPN.
 It is also highly recommended that the Web interface is protected with an SSL certificate such as ones 
 provided by [LetsEncrypt](http://www.letsencrypt.org).
 
-When using HTTPS, it is recommended that you use secure, encrypted cookies to prevent session
-hijacking attacks. Set ``$config['secure_cookies'] = true;`` in ``config.php`` to enable these.
-
 Please ensure you keep your install [up to date](Updating.md).
 
 ### Reporting vulnerabilities

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -982,13 +982,6 @@ $config['xirrus_disable_stations']  = false;
 // Graphite default port
 $config['graphite']['port']         = 2003;
 
-// Whether to enable secure cookies. Setting this to true enable secure cookies
-// and only send them over HTTPS. Setting this to false will send cookies over
-// HTTP and HTTPS, but they will be insecure. Setting this to $_SERVER["HTTPS"]
-// will send secure cookies when the site is being accessed over HTTPS, and
-// send insecure cookies when the site is being accessed over HTTP.
-$config['secure_cookies'] = isset($_SERVER["HTTPS"]) ? $_SERVER["HTTPS"] : false;
-
 // API config
 $config['api']['cors']['enabled'] = false;
 $config['api']['cors']['origin'] = '*';


### PR DESCRIPTION
secure cookies only work when accessing the page via https.
That is done automatically already...
So users setting the config setting essentially were breaking their installs for now benefit.
Don't allow that to happen anymore.  The only valid secure_cookies setting now is false, which will disable them.

Again, this setting will be unused once we fully remove the php session.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
