### PR TITLE
Do not use $sensor[sensor_limit] if not available

### DIFF
--- a/html/includes/graphs/sensor/humidity.inc.php
+++ b/html/includes/graphs/sensor/humidity.inc.php
@@ -10,7 +10,9 @@ $rrd_options .= " COMMENT:'                                 Last   Max\\n'";
 $rrd_options .= " DEF:sensor=$rrd_filename:sensor:AVERAGE";
 $rrd_options .= " DEF:sensor_max=$rrd_filename:sensor:MAX";
 $rrd_options .= " DEF:sensor_min=$rrd_filename:sensor:MIN";
-$rrd_options .= ' CDEF:sensorwarm=sensor_max,'.$sensor['sensor_limit'].',GT,sensor,UNKN,IF';
+if (is_numeric($sensor['sensor_limit'])) {
+    $rrd_options .= ' CDEF:sensorwarm=sensor_max,'.$sensor['sensor_limit'].',GT,sensor,UNKN,IF';
+}
 $rrd_options .= ' CDEF:sensorcold=sensor_min,20,LT,sensor,UNKN,IF';
 $rrd_options .= ' AREA:sensor_max#c5c5c5';
 $rrd_options .= ' AREA:sensor_min#ffffffff';

--- a/html/includes/graphs/sensor/temperature.inc.php
+++ b/html/includes/graphs/sensor/temperature.inc.php
@@ -9,7 +9,9 @@ $rrd_options .= " COMMENT:'                          Min     Last   Max\\n'";
 $rrd_options .= " DEF:sensor=$rrd_filename:sensor:AVERAGE";
 $rrd_options .= " DEF:sensor_max=$rrd_filename:sensor:MAX";
 $rrd_options .= " DEF:sensor_min=$rrd_filename:sensor:MIN";
-$rrd_options .= ' CDEF:sensorwarm=sensor_max,'.$sensor['sensor_limit'].',GT,sensor,UNKN,IF';
+if (is_numeric($sensor['sensor_limit'])) {
+    $rrd_options .= ' CDEF:sensorwarm=sensor_max,'.$sensor['sensor_limit'].',GT,sensor,UNKN,IF';
+}
 $rrd_options .= ' CDEF:sensorcold=sensor_min,20,LT,sensor,UNKN,IF';
 $rrd_options .= ' CDEF:sensor_diff=sensor_max,sensor_min,-';
 $rrd_options .= ' AREA:sensor_min';


### PR DESCRIPTION
Following https://github.com/librenms/librenms/pull/9973, some graphs are using sensor_limit without checking if defined, which kills the RRD command. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
