### PR TITLE
Beautify port health

### DIFF
--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1685,3 +1685,44 @@ function get_sensor_label_color($sensor)
 
     return $current_label_color;
 }
+
+/**
+ * Get the unit for the sensor class given as parameter
+ * @param $class
+ * @return string The unit
+ */
+function get_unit_for_sensor_class($class)
+{
+    $units_by_classes = array(
+        'ber'                  => '',
+        'charge'               => '%',
+        'chromatic_dispersion' => 'ps/nm',
+        'cooling'              => 'W',
+        'count'                => '',
+        'current'              => '',
+        'dbm'                  => 'dBm',
+        'delay'                => 's',
+        'eer'                  => '',
+        'fanspeed'             => 'rpm',
+        'frequency'            => 'Hz',
+        'humidity'             => '%',
+        'load'                 => '%',
+        'power'                => 'W',
+        'power_consumed'       => 'kWh',
+        'power_factor'         => '',
+        'pressure'             => 'kPa',
+        'quality_factor'       => 'dB',
+        'signal'               => 'dBm',
+        'snr'                  => 'dB',
+        'state'                => '',
+        'temperature'          => '&deg;C',
+        'voltage'              => 'V',
+        'waterflow'            => 'l/m',
+    );
+
+    if (!array_key_exists($class, $units_by_classes)) {
+        return '';
+    }
+
+    return $units_by_classes[$class];
+}

--- a/html/includes/functions.inc.php
+++ b/html/includes/functions.inc.php
@@ -1699,7 +1699,7 @@ function get_unit_for_sensor_class($class)
         'chromatic_dispersion' => 'ps/nm',
         'cooling'              => 'W',
         'count'                => '',
-        'current'              => '',
+        'current'              => 'A',
         'dbm'                  => 'dBm',
         'delay'                => 's',
         'eer'                  => '',

--- a/html/pages/device/port/sensors.inc.php
+++ b/html/pages/device/port/sensors.inc.php
@@ -3,7 +3,7 @@
 $sensors = dbFetchRows("SELECT * FROM `sensors` WHERE `device_id` = ? AND `entPhysicalIndex` = ? AND entPhysicalIndex_measured = 'ports' ORDER BY `sensor_type` ASC", array($device['device_id'],$port['ifIndex']));
 
 foreach ($sensors as $sensor) {
-    if ($sensor['poller_type'] == "ipmi") {
+    if ($sensor['poller_type'] == 'ipmi') {
         $sensor_descr = ipmiSensorName($device['hardware'], $sensor['sensor_descr']);
     } else {
         $sensor_descr = $sensor['sensor_descr'];
@@ -19,7 +19,7 @@ foreach ($sensors as $sensor) {
     echo "<div class='panel-body'>";
 
     $graph_array['id']   = $sensor['sensor_id'];
-    $graph_array['type'] = "sensor_" . $sensor['sensor_class'];
+    $graph_array['type'] = 'sensor_' . $sensor['sensor_class'];
 
     include 'includes/print-graphrow.inc.php';
     echo '</div></div>';

--- a/html/pages/device/port/sensors.inc.php
+++ b/html/pages/device/port/sensors.inc.php
@@ -3,6 +3,8 @@
 $sensors = dbFetchRows("SELECT * FROM `sensors` WHERE `device_id` = ? AND `entPhysicalIndex` = ? AND entPhysicalIndex_measured = 'ports' ORDER BY `sensor_type` ASC", array($device['device_id'],$port['ifIndex']));
 
 foreach ($sensors as $sensor) {
+    $unit = get_unit_for_sensor_class($sensor['sensor_class']);
+
     $state_translation = array();
     if (($graph_type == 'sensor_state')) {
         $state_translation = dbFetchRows('SELECT * FROM state_translations as ST, sensors_to_state_indexes as SSI WHERE ST.state_index_id=SSI.state_index_id AND SSI.sensor_id = ? AND ST.state_value = ? ', array($sensor['sensor_id'], $sensor['sensor_current']));

--- a/html/pages/device/port/sensors.inc.php
+++ b/html/pages/device/port/sensors.inc.php
@@ -2,14 +2,7 @@
 
 $sensors = dbFetchRows("SELECT * FROM `sensors` WHERE `device_id` = ? AND `entPhysicalIndex` = ? AND entPhysicalIndex_measured = 'ports' ORDER BY `sensor_type` ASC", array($device['device_id'],$port['ifIndex']));
 
-$row = 0;
 foreach ($sensors as $sensor) {
-    if (!is_integer($row / 2)) {
-        $row_colour = $config['list_colour']['even'];
-    } else {
-        $row_colour = $config['list_colour']['odd'];
-    }
-
     if ($sensor['poller_type'] == "ipmi") {
         $sensor_descr = ipmiSensorName($device['hardware'], $sensor['sensor_descr']);
     } else {
@@ -30,7 +23,4 @@ foreach ($sensors as $sensor) {
 
     include 'includes/print-graphrow.inc.php';
     echo '</div></div>';
-
-    $row++;
 }
-unset($row);

--- a/html/pages/device/port/sensors.inc.php
+++ b/html/pages/device/port/sensors.inc.php
@@ -9,9 +9,9 @@ foreach ($sensors as $sensor) {
         $sensor_descr = $sensor['sensor_descr'];
     }
 
-    $sensor_current = format_si($sensor['sensor_current']).$unit;
-    $sensor_limit = format_si($sensor['sensor_limit']).$unit;
-    $sensor_limit_low = format_si($sensor['sensor_limit_low']).$unit;
+    $sensor_current = format_si($sensor['sensor_current']) . $unit;
+    $sensor_limit = format_si($sensor['sensor_limit']) . $unit;
+    $sensor_limit_low = format_si($sensor['sensor_limit_low']) . $unit;
     echo "<div class='panel panel-default'>
             <div class='panel-heading'>
                 <h3 class='panel-title'>$sensor_descr <div class='pull-right'>$sensor_current | $sensor_limit_low <> $sensor_limit</div></h3>

--- a/html/pages/device/port/sensors.inc.php
+++ b/html/pages/device/port/sensors.inc.php
@@ -12,15 +12,18 @@ foreach ($sensors as $sensor) {
     $sensor_current = format_si($sensor['sensor_current']) . $unit;
     $sensor_limit = format_si($sensor['sensor_limit']) . $unit;
     $sensor_limit_low = format_si($sensor['sensor_limit_low']) . $unit;
-    echo "<div class='panel panel-default'>
-            <div class='panel-heading'>
-                <h3 class='panel-title'>$sensor_descr <div class='pull-right'>$sensor_current | $sensor_limit_low <> $sensor_limit</div></h3>
-            </div>";
-    echo "<div class='panel-body'>";
+
+    echo "<div class='panel panel-default'>\n" .
+         "    <div class='panel-heading'>\n" .
+         "        <h3 class='panel-title'>$sensor_descr <div class='pull-right'>$sensor_current | $sensor_limit_low <> $sensor_limit</div></h3>" .
+         "    </div>\n" .
+         "    <div class='panel-body'>\n";
 
     $graph_array['id']   = $sensor['sensor_id'];
     $graph_array['type'] = 'sensor_' . $sensor['sensor_class'];
 
     include 'includes/print-graphrow.inc.php';
-    echo '</div></div>';
+
+    echo "    </div>\n" .
+         "</div>\n";
 }

--- a/html/pages/device/port/sensors.inc.php
+++ b/html/pages/device/port/sensors.inc.php
@@ -3,19 +3,48 @@
 $sensors = dbFetchRows("SELECT * FROM `sensors` WHERE `device_id` = ? AND `entPhysicalIndex` = ? AND entPhysicalIndex_measured = 'ports' ORDER BY `sensor_type` ASC", array($device['device_id'],$port['ifIndex']));
 
 foreach ($sensors as $sensor) {
+    $state_translation = array();
+    if (($graph_type == 'sensor_state')) {
+        $state_translation = dbFetchRows('SELECT * FROM state_translations as ST, sensors_to_state_indexes as SSI WHERE ST.state_index_id=SSI.state_index_id AND SSI.sensor_id = ? AND ST.state_value = ? ', array($sensor['sensor_id'], $sensor['sensor_current']));
+    }
+
     if ($sensor['poller_type'] == 'ipmi') {
         $sensor_descr = ipmiSensorName($device['hardware'], $sensor['sensor_descr']);
     } else {
         $sensor_descr = $sensor['sensor_descr'];
     }
 
-    $sensor_current = format_si($sensor['sensor_current']) . $unit;
-    $sensor_limit = format_si($sensor['sensor_limit']) . $unit;
-    $sensor_limit_low = format_si($sensor['sensor_limit_low']) . $unit;
+    if (($graph_type == 'sensor_state') && !empty($state_translation['0']['state_descr'])) {
+        $sensor_current = get_state_label($sensor['state_generic_value'], $state_translation[0]['state_descr'] . ' (' . $sensor['sensor_current'] . ')');
+    } else {
+        $current_label = get_sensor_label_color($sensor);
+        $sensor_current = "<span class='label $current_label'>" . trim(format_si($sensor['sensor_current']) . $unit). '</span>';
+    }
+
+    $sensor_limit = trim(format_si($sensor['sensor_limit']) . $unit);
+    $sensor_limit_low = trim(format_si($sensor['sensor_limit_low']) . $unit);
+    $sensor_limit_warn = trim(format_si($sensor['sensor_limit_warn']) . $unit);
+    $sensor_limit_low_warn = trim(format_si($sensor['sensor_limit_low_warn']) . $unit);
 
     echo "<div class='panel panel-default'>\n" .
          "    <div class='panel-heading'>\n" .
-         "        <h3 class='panel-title'>$sensor_descr <div class='pull-right'>$sensor_current | $sensor_limit_low <> $sensor_limit</div></h3>" .
+         "        <h3 class='panel-title'>$sensor_descr <div class='pull-right'>$sensor_current";
+
+    //Display low and high limit if they are not null (format_si() is changing null to '0')
+    if (!is_null($sensor['sensor_limit_low'])) {
+        echo " <span class='label label-default'>low: $sensor_limit_low</span>";
+    }
+    if (!is_null($sensor['sensor_limit_low_warn'])) {
+        echo " <span class='label label-default'>low_warn: $sensor_limit_low_warn</span>";
+    }
+    if (!is_null($sensor['sensor_limit_warn'])) {
+        echo " <span class='label label-default'>high_warn: $sensor_limit_warn</span>";
+    }
+    if (!is_null($sensor['sensor_limit'])) {
+        echo " <span class='label label-default'>high: $sensor_limit</span>";
+    }
+
+    echo "        </div></h3>" .
          "    </div>\n" .
          "    <div class='panel-body'>\n";
 


### PR DESCRIPTION
The presentation of the graphs (display of current and limit values) under Device / Port / Health not as beautiful than the one on Device / Health.

This PR proposes to provide the same "look" on the Device / Port / Health.

This PR also takes the opportunity to do some clean-up in the code / perform minor changes.

Addition of a new helper function "get_unit_for_sensor_class" to get the unit for the different sensor classes.

Capture of the change :
![image](https://user-images.githubusercontent.com/37099668/54490095-41b15f80-48b3-11e9-9791-7a2eaa8e8bf4.png)
![image](https://user-images.githubusercontent.com/37099668/54490106-4fff7b80-48b3-11e9-9e2e-e0e5b400be32.png)
![image](https://user-images.githubusercontent.com/37099668/54490115-5857b680-48b3-11e9-9ef0-7b8315c467f7.png)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
