### PR TITLE
Fix inconsistent <h3> closed by </div>

### DIFF
--- a/html/pages/device/health/sensors.inc.php
+++ b/html/pages/device/health/sensors.inc.php
@@ -49,7 +49,7 @@ foreach (dbFetchRows('SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `devi
         echo " <span class='label label-default'>high: $sensor_limit</span>";
     }
 
-    echo "</div></div>
+    echo "</div></h3>
         </div>";
     echo "<div class='panel-body'>";
 


### PR DESCRIPTION
Working on #9981, it was discovered an inconsistency in HTML tags : &lt;h3&gt; tag was closed by &lt;/div&gt;.

This PR fixes this.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
