### PR TITLE
Fix cisco temperature limit

### DIFF
--- a/includes/discovery/sensors/temperature/cisco.inc.php
+++ b/includes/discovery/sensors/temperature/cisco.inc.php
@@ -16,7 +16,7 @@ if (is_array($temp)) {
     foreach ($temp as $index => $entry) {
         if ($temp[$index]['ciscoEnvMonTemperatureState'] != 'notPresent' && !empty($temp[$index]['ciscoEnvMonTemperatureStatusDescr'])) {
             $descr = ucwords($temp[$index]['ciscoEnvMonTemperatureStatusDescr']);
-            discover_sensor($valid['sensor'], 'temperature', $device, $cur_oid.$index, $index, 'cisco', $descr, '1', '1', null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'], null, $temp[$index]['ciscoEnvMonTemperatureStatusValue'], 'snmp', $index);
+            discover_sensor($valid['sensor'], 'temperature', $device, $cur_oid . $index, $index, 'cisco', $descr, '1', '1', null, null, null, $temp[$index]['ciscoEnvMonTemperatureThreshold'], $temp[$index]['ciscoEnvMonTemperatureStatusValue'], 'snmp', $index);
         }
     }
 }

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -53,5 +53,10 @@
     <description>As described previously, Legacy Alert Templates and Transports have been removed.  You can find more info here: https://community.librenms.org/t/deprecation-notice-alerting-legacy-transports-and-templates/5915</description>
     <pubDate>Fri, 15 Feb 2017 23:00:00 +0000</pubDate>
   </item>
+    <item>
+      <title>Cisco Temperature Sensor Threshold Values Stored as High Limits</title>
+      <description>During discovery, some temperature sensors discovered on Cisco devices had their highest temperature value stored as warning high limit. For new discovered devices, this value is now stored as high limit.
+      <pubDate>Sun, 17 Mar 2019 21:00:00 +0100</pubDate>
+    </item>
 </channel>
 </rss>

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -55,7 +55,7 @@
   </item>
     <item>
       <title>Cisco Temperature Sensor Threshold Values Stored as High Limits</title>
-      <description>During discovery, some temperature sensors discovered on Cisco devices had their highest temperature value stored as warning high limit. For new discovered devices, this value is now stored as high limit.
+      <description>During discovery, some temperature sensors discovered on Cisco devices had their highest temperature value stored as warning high limit. For new discovered devices, this value is now stored as high limit.</description>
       <pubDate>Sun, 17 Mar 2019 21:00:00 +0100</pubDate>
     </item>
 </channel>


### PR DESCRIPTION
During discovery, some temperature sensors discovered on Cisco devices had their highest temperature value stored as warning high limit.

This patch fixes this behavior by storing this value as high limit, for new discovered devices.

The misc/notifications.rss is updated accordingly.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
