### PR TITLE
New permissions code

### DIFF
--- a/LibreNMS/Permissions.php
+++ b/LibreNMS/Permissions.php
@@ -2,7 +2,7 @@
 /**
  * Permissions.php
  *
- * -Description-
+ * Class to check the direct permissions on devices, ports, and bills for normal users (not global read only and admin)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/LibreNMS/Permissions.php
+++ b/LibreNMS/Permissions.php
@@ -39,6 +39,9 @@ class Permissions
     private $billPermissions;
 
     /**
+     * Check if a device can be accessed by user (non-global read/admin)
+     * If no user is given, use the logged in user
+     *
      * @param Device|int $device
      * @param User|int $user
      * @return boolean
@@ -52,6 +55,9 @@ class Permissions
     }
 
     /**
+     * Check if a access can be accessed by user (non-global read/admin)
+     * If no user is given, use the logged in user
+     *
      * @param Port|int $port
      * @param User|int $user
      * @return boolean
@@ -65,6 +71,9 @@ class Permissions
     }
 
     /**
+     * Check if a bill can be accessed by user (non-global read/admin)
+     * If no user is given, use the logged in user
+     *
      * @param Bill|int $bill
      * @param User|int $user
      * @return boolean
@@ -77,6 +86,12 @@ class Permissions
             ->isNotEmpty();
     }
 
+    /**
+     * Get the user_id of users that have been granted access to device
+     *
+     * @param Device|int $device
+     * @return \Illuminate\Support\Collection
+     */
     public function usersForDevice($device)
     {
         return $this->getDevicePermissions()
@@ -84,6 +99,12 @@ class Permissions
             ->pluck('user_id');
     }
 
+    /**
+     * Get the user_id of users that have been granted access to port
+     *
+     * @param Port|int $port
+     * @return \Illuminate\Support\Collection
+     */
     public function usersForPort($port)
     {
         return $this->getPortPermissions()
@@ -91,6 +112,12 @@ class Permissions
             ->pluck('user_id');
     }
 
+    /**
+     * Get the user_id of users that have been granted access to bill
+     *
+     * @param Bill|int $bill
+     * @return \Illuminate\Support\Collection
+     */
     public function usersForBill($bill)
     {
         return $this->getBillPermissions()
@@ -98,6 +125,12 @@ class Permissions
             ->pluck('user_id');
     }
 
+    /**
+     * Get a list of device_id of all devices the user can access
+     *
+     * @param User|int $user
+     * @return \Illuminate\Support\Collection
+     */
     public function devicesForUser($user = null)
     {
         return $this->getDevicePermissions()
@@ -105,6 +138,12 @@ class Permissions
             ->pluck('device_id');
     }
 
+    /**
+     * Get a list of port_id of all ports the user can access
+     *
+     * @param User|int $user
+     * @return \Illuminate\Support\Collection
+     */
     public function portsForUser($user = null)
     {
         return $this->getPortPermissions()
@@ -112,6 +151,12 @@ class Permissions
             ->pluck('port_id');
     }
 
+    /**
+     * Get a list of bill_id of all bills the user can access
+     *
+     * @param User|int $user
+     * @return \Illuminate\Support\Collection
+     */
     public function billsForUser($user = null)
     {
         return $this->getBillPermissions()
@@ -120,6 +165,8 @@ class Permissions
     }
 
     /**
+     * Get the cached data for device permissions.  Use helpers instead.
+     *
      * @return \Illuminate\Support\Collection
      */
     public function getDevicePermissions()
@@ -132,6 +179,8 @@ class Permissions
     }
 
     /**
+     * Get the cached data for port permissions.  Use helpers instead.
+     *
      * @return \Illuminate\Support\Collection
      */
     public function getPortPermissions()
@@ -144,6 +193,8 @@ class Permissions
     }
 
     /**
+     * Get the cached data for bill permissions.  Use helpers instead.
+     *
      * @return \Illuminate\Support\Collection
      */
     public function getBillPermissions()

--- a/LibreNMS/Permissions.php
+++ b/LibreNMS/Permissions.php
@@ -98,21 +98,21 @@ class Permissions
             ->pluck('user_id');
     }
 
-    public function devicesForUser($user)
+    public function devicesForUser($user = null)
     {
         return $this->getDevicePermissions()
             ->where('user_id', $this->getUserId($user))
             ->pluck('device_id');
     }
 
-    public function portsForUser($user)
+    public function portsForUser($user = null)
     {
         return $this->getPortPermissions()
             ->where('user_id', $this->getUserId($user))
             ->pluck('port_id');
     }
 
-    public function billsForUser($user)
+    public function billsForUser($user = null)
     {
         return $this->getBillPermissions()
             ->where('user_id', $this->getUserId($user))

--- a/LibreNMS/Permissions.php
+++ b/LibreNMS/Permissions.php
@@ -38,11 +38,6 @@ class Permissions
     private $portPermissions;
     private $billPermissions;
 
-    public function __construct()
-    {
-
-    }
-
     /**
      * @param Device|int $device
      * @param User|int $user
@@ -82,40 +77,46 @@ class Permissions
             ->isNotEmpty();
     }
 
-    public function usersFromDevice($device)
+    public function usersForDevice($device)
     {
         return $this->getDevicePermissions()
-            ->where('device_id', $this->getDeviceId($device));
+            ->where('device_id', $this->getDeviceId($device))
+            ->pluck('user_id');
     }
 
-    public function usersFromPort($port)
+    public function usersForPort($port)
     {
         return $this->getPortPermissions()
-            ->where('port_id', $this->getPortId($port));
+            ->where('port_id', $this->getPortId($port))
+            ->pluck('user_id');
     }
 
-    public function usersFromBill($bill)
+    public function usersForBill($bill)
     {
         return $this->getBillPermissions()
-            ->where('bill_id', $this->getBillId($bill));
+            ->where('bill_id', $this->getBillId($bill))
+            ->pluck('user_id');
     }
 
-    public function devicesFromUser($user)
+    public function devicesForUser($user)
     {
         return $this->getDevicePermissions()
-            ->where('user_id', $this->getUserId($user));
+            ->where('user_id', $this->getUserId($user))
+            ->pluck('device_id');
     }
 
-    public function portsFromUser($user)
+    public function portsForUser($user)
     {
         return $this->getPortPermissions()
-            ->where('user_id', $this->getUserId($user));
+            ->where('user_id', $this->getUserId($user))
+            ->pluck('port_id');
     }
 
-    public function billsFromUser($user)
+    public function billsForUser($user)
     {
         return $this->getBillPermissions()
-            ->where('user_id', $this->getUserId($user));
+            ->where('user_id', $this->getUserId($user))
+            ->pluck('bill_id');
     }
 
     /**

--- a/LibreNMS/Permissions.php
+++ b/LibreNMS/Permissions.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Permissions.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2019 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS;
+
+use App\Models\Bill;
+use App\Models\Device;
+use App\Models\Port;
+use App\Models\User;
+use Auth;
+use DB;
+
+class Permissions
+{
+    private $devicePermissions;
+    private $portPermissions;
+    private $billPermissions;
+
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * @param Device|int $device
+     * @param User|int $user
+     * @return boolean
+     */
+    public function canAccessDevice($device, $user = null)
+    {
+        return $this->getDevicePermissions()
+            ->where('user_id', $this->getUserId($user))
+            ->where('device_id', $this->getDeviceId($device))
+            ->isNotEmpty();
+    }
+
+    /**
+     * @param Port|int $port
+     * @param User|int $user
+     * @return boolean
+     */
+    public function canAccessPort($port, $user = null)
+    {
+        return $this->getPortPermissions()
+            ->where('user_id', $this->getUserId($user))
+            ->where('port_id', $this->getPortId($port))
+            ->isNotEmpty();
+    }
+
+    /**
+     * @param Bill|int $bill
+     * @param User|int $user
+     * @return boolean
+     */
+    public function canAccessBill($bill, $user = null)
+    {
+        return $this->getBillPermissions()
+            ->where('user_id', $this->getUserId($user))
+            ->where('bill_id', $this->getBillId($bill))
+            ->isNotEmpty();
+    }
+
+    public function usersFromDevice($device)
+    {
+        return $this->getDevicePermissions()
+            ->where('device_id', $this->getDeviceId($device));
+    }
+
+    public function usersFromPort($port)
+    {
+        return $this->getPortPermissions()
+            ->where('port_id', $this->getPortId($port));
+    }
+
+    public function usersFromBill($bill)
+    {
+        return $this->getBillPermissions()
+            ->where('bill_id', $this->getBillId($bill));
+    }
+
+    public function devicesFromUser($user)
+    {
+        return $this->getDevicePermissions()
+            ->where('user_id', $this->getUserId($user));
+    }
+
+    public function portsFromUser($user)
+    {
+        return $this->getPortPermissions()
+            ->where('user_id', $this->getUserId($user));
+    }
+
+    public function billsFromUser($user)
+    {
+        return $this->getBillPermissions()
+            ->where('user_id', $this->getUserId($user));
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getDevicePermissions()
+    {
+        if (is_null($this->devicePermissions)) {
+            $this->devicePermissions = DB::table('devices_perms')->get();
+        }
+
+        return $this->devicePermissions;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getPortPermissions()
+    {
+        if (is_null($this->portPermissions)) {
+            $this->portPermissions = DB::table('ports_perms')->get();
+        }
+
+        return $this->portPermissions;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getBillPermissions()
+    {
+        if (is_null($this->billPermissions)) {
+            $this->billPermissions = DB::table('bill_ports')->get();
+        }
+
+        return $this->billPermissions;
+    }
+
+    /**
+     * @param $user
+     * @return int|null
+     */
+    private function getUserId($user)
+    {
+        return $user instanceof User ? $user->user_id : (is_int($user) ? $user : Auth::id());
+    }
+
+    /**
+     * @param $device
+     * @return int
+     */
+    private function getDeviceId($device)
+    {
+        return $device instanceof Device ? $device->device_id : (is_int($device) ? $device : 0);
+    }
+
+    /**
+     * @param $port
+     * @return int
+     */
+    private function getPortId($port)
+    {
+        return $port instanceof Port ? $port->port_id : (is_int($port) ? $port : 0);
+    }
+
+    /**
+     * @param $bill
+     * @return int
+     */
+    private function getBillId($bill)
+    {
+        return $bill instanceof Bill ? $bill->bill_id : (is_int($bill) ? $bill : 0);
+    }
+}

--- a/app/Facades/Permissions.php
+++ b/app/Facades/Permissions.php
@@ -29,5 +29,8 @@ use Illuminate\Support\Facades\Facade;
 
 class Permissions extends Facade
 {
-    protected static function getFacadeAccessor() { return 'permissions'; }
+    protected static function getFacadeAccessor()
+    {
+        return 'permissions';
+    }
 }

--- a/app/Facades/Permissions.php
+++ b/app/Facades/Permissions.php
@@ -25,7 +25,9 @@
 
 namespace App\Facades;
 
-class Permissions
+use Illuminate\Support\Facades\Facade;
+
+class Permissions extends Facade
 {
     protected static function getFacadeAccessor() { return 'permissions'; }
 }

--- a/app/Facades/Permissions.php
+++ b/app/Facades/Permissions.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Permissions.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2019 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace App\Facades;
+
+class Permissions
+{
+    protected static function getFacadeAccessor() { return 'permissions'; }
+}

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -26,7 +26,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder;
 
 abstract class BaseModel extends Model
 {
@@ -69,8 +69,7 @@ abstract class BaseModel extends Model
             $table = $this->getTable();
         }
 
-        return $query->join('devices_perms', 'devices_perms.device_id', "$table.device_id")
-            ->where('devices_perms.user_id', $user->user_id);
+        return $query->whereIn("$table.device_id", \Permissions::devicesForUser($user));
     }
 
     /**
@@ -91,11 +90,9 @@ abstract class BaseModel extends Model
             $table = $this->getTable();
         }
 
-        return $query->join('ports_perms', 'ports_perms.port_id', "$table.port_id")
-            ->join('devices_perms', 'devices_perms.device_id', "$table.device_id")
-            ->where(function ($query) use ($user) {
-                $query->where('ports_perms.user_id', $user->user_id)
-                    ->orWhere('devices_perms.user_id', $user->user_id);
-            });
+        return $query->where(function ($query) use ($table, $user) {
+            return $query->whereIn("$table.port_id", \Permissions::portsForUser($user))
+                ->orWhereIn("$table.device_id", \Permissions::devicesForUser($user));
+        });
     }
 }

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -25,8 +25,6 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Builder;
-
 class DeviceRelatedModel extends BaseModel
 {
     // ---- Query Scopes ----

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -24,7 +24,7 @@ class AppServiceProvider extends ServiceProvider
         $this->registerFacades();
         $this->registerGeocoder();
 
-        $this->app->singleton('permissions', function($app) {
+        $this->app->singleton('permissions', function ($app) {
             return new Permissions();
         });
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,21 +15,6 @@ use Validator;
 class AppServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->app->booted('\LibreNMS\DB\Eloquent::initLegacyListeners');
-        $this->app->booted('\LibreNMS\Config::load');
-
-        $this->bootCustomBladeDirectives();
-        $this->bootCustomValidators();
-        $this->configureMorphAliases();
-    }
-
-    /**
      * Register any application services.
      *
      * @return void
@@ -42,6 +27,21 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton('permissions', function($app) {
             return new Permissions();
         });
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->app->booted('\LibreNMS\DB\Eloquent::initLegacyListeners');
+        $this->app->booted('\LibreNMS\Config::load');
+
+        $this->bootCustomBladeDirectives();
+        $this->bootCustomValidators();
+        $this->configureMorphAliases();
     }
 
     private function bootCustomBladeDirectives()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use LibreNMS\Config;
+use LibreNMS\Permissions;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\Validate;
 use Validator;
@@ -37,6 +38,10 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->registerFacades();
         $this->registerGeocoder();
+
+        $this->app->singleton('permissions', function($app) {
+            return new Permissions();
+        });
     }
 
     private function bootCustomBladeDirectives()

--- a/config/app.php
+++ b/config/app.php
@@ -237,7 +237,7 @@ return [
         'Toastr' => Kamaln7\Toastr\Facades\Toastr::class,
 
         // LibreNMS
-//        'LibreConfig' => \LibreNMS\Config::class,
+        'Permissions' => \App\Facades\Permissions::class,
     ],
 
 ];

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -40,6 +40,12 @@ $factory->state(App\Models\User::class, 'read', function ($faker) {
     ];
 });
 
+$factory->define(\App\Models\Bill::class, function (Faker\Generator $faker) {
+    return [
+        'bill_name' => $faker->text
+    ];
+});
+
 $factory->define(\App\Models\Device::class, function (Faker\Generator $faker) {
     return [
         'hostname'      => $faker->domainWord.'.'.$faker->domainName,

--- a/html/includes/api_functions.inc.php
+++ b/html/includes/api_functions.inc.php
@@ -18,8 +18,6 @@ use LibreNMS\Config;
 
 function authToken(\Slim\Route $route)
 {
-    global $permissions;
-
     if (Auth::check()) {
         $user = Auth::user();
 
@@ -29,7 +27,6 @@ function authToken(\Slim\Route $route)
             'user_id' => $user->user_id,
             'userlevel' => $user->level
         ];
-        $permissions = permissions_cache($user->user_id);
 
         return;
     }

--- a/includes/init.php
+++ b/includes/init.php
@@ -30,7 +30,7 @@
 use LibreNMS\Authentication\LegacyAuth;
 use LibreNMS\Config;
 
-global $config, $permissions, $vars, $console_color;
+global $config, $vars, $console_color;
 
 error_reporting(E_ERROR|E_PARSE|E_CORE_ERROR|E_COMPILE_ERROR);
 ini_set('display_errors', 1);
@@ -153,28 +153,3 @@ if (module_selected('web', $init_modules)) {
 }
 
 $console_color = new Console_Color2();
-
-if (module_selected('auth', $init_modules) ||
-    (
-        module_selected('graphs', $init_modules) &&
-        isset($config['allow_unauth_graphs']) &&
-        $config['allow_unauth_graphs'] != true
-    )
-) {
-    // populate the permissions cache TODO: remove?
-    $permissions = [];
-
-    $user_id = LegacyAuth::id();
-    foreach (dbFetchColumn('SELECT device_id FROM devices_perms WHERE user_id=?', [$user_id]) as $device_id) {
-        $permissions['device'][$device_id] = 1;
-    }
-
-    foreach (dbFetchColumn('SELECT port_id FROM ports_perms WHERE user_id=?', [$user_id]) as $port_id) {
-        $permissions['port'][$port_id] = 1;
-    }
-
-    foreach (dbFetchColumn('SELECT bill_id FROM bill_perms WHERE user_id=?', [$user_id]) as $bill_id) {
-        $permissions['bill'][$bill_id] = 1;
-    }
-    unset($user_id, $device_id, $port_id, $bill_id);
-}

--- a/tests/Unit/PermissionsTest.php
+++ b/tests/Unit/PermissionsTest.php
@@ -25,7 +25,34 @@
 
 namespace LibreNMS\Tests\Unit;
 
-class PermissionsTest
-{
+use App\Models\Device;
+use App\Models\User;
+use LibreNMS\Tests\LaravelTestCase;
+use Mockery\Mock;
 
+class PermissionsTest extends LaravelTestCase
+{
+    public function testUserCanAccessDevice()
+    {
+        $perms = \Mockery::mock(\LibreNMS\Permissions::class)->makePartial();
+        $perms->shouldReceive('getDevicePermissions')->andReturn(collect([(object)['user_id' => 43, 'device_id' => 54]]));
+
+        $device = new Device();
+        $device->device_id = 54;
+        $user = new User();
+        $user->user_id = 43;
+        $this->assertTrue($perms->canAccessDevice($device, 43));
+        $this->assertTrue($perms->canAccessDevice($device, $user));
+        $this->assertTrue($perms->canAccessDevice(54, $user));
+        $this->assertTrue($perms->canAccessDevice(54, 43));
+        $this->assertTrue($perms->canAccessDevice(54, 43));
+        $this->assertFalse($perms->canAccessDevice(54, 23));
+        $this->assertFalse($perms->canAccessDevice(23, 43));
+        $this->assertFalse($perms->canAccessDevice(54));
+
+        \Auth::shouldReceive('id')->once()->andReturn(43);
+        $this->assertTrue($perms->canAccessDevice(54));
+        \Auth::shouldReceive('id')->once()->andReturn(23);
+        $this->assertFalse($perms->canAccessDevice(54));
+    }
 }

--- a/tests/Unit/PermissionsTest.php
+++ b/tests/Unit/PermissionsTest.php
@@ -35,12 +35,12 @@ class PermissionsTest extends LaravelTestCase
     public function testUserCanAccessDevice()
     {
         $perms = \Mockery::mock(\LibreNMS\Permissions::class)->makePartial();
-        $perms->shouldReceive('getDevicePermissions')->andReturn(collect([(object)['user_id' => 43, 'device_id' => 54]]));
+        $perms->shouldReceive('getDevicePermissions')->andReturn(collect([
+            (object)['user_id' => 43, 'device_id' => 54],
+        ]));
 
-        $device = new Device();
-        $device->device_id = 54;
-        $user = new User();
-        $user->user_id = 43;
+        $device = factory(Device::class)->make(['device_id', 54]);
+        $user = factory(User::class)->make(['user_id', 43]);
         $this->assertTrue($perms->canAccessDevice($device, 43));
         $this->assertTrue($perms->canAccessDevice($device, $user));
         $this->assertTrue($perms->canAccessDevice(54, $user));
@@ -54,5 +54,19 @@ class PermissionsTest extends LaravelTestCase
         $this->assertTrue($perms->canAccessDevice(54));
         \Auth::shouldReceive('id')->once()->andReturn(23);
         $this->assertFalse($perms->canAccessDevice(54));
+    }
+
+    public function testDevicesForUser()
+    {
+        $perms = \Mockery::mock(\LibreNMS\Permissions::class)->makePartial();
+        $perms->shouldReceive('getDevicePermissions')->andReturn(collect([
+            (object)['user_id' => 3, 'device_id' => 7],
+            (object)['user_id' => 3, 'device_id' => 2],
+            (object)['user_id' => 4, 'device_id' => 5],
+        ]));
+
+        $this->assertEquals([7,2], $perms->devicesForUser(3));
+        $user = factory(User::class)->make(['user_id' => 3]);
+        $this->assertEquals([7,2], $perms->devicesForUser($user));
     }
 }

--- a/tests/Unit/PermissionsTest.php
+++ b/tests/Unit/PermissionsTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PermissionsTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2019 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace LibreNMS\Tests\Unit;
+
+class PermissionsTest
+{
+
+}


### PR DESCRIPTION
Removes global
Caches permissions per request
Uses whereIn for Eloquent permissions checks instead of joins.  That way we don't cause side effects.

Needed for an upcoming PR.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
