### PR TITLE
Fix transport options when edited on Windows

### DIFF
--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -19,4 +19,22 @@ abstract class Transport implements TransportInterface
             $this->config = json_decode(dbFetchCell($sql, [$transport_id]), true);
         }
     }
+
+    /**
+     * Helper function to parse free form text box defined in ini style to key value pairs
+     *
+     * @param string $input
+     * @return array
+     */
+    protected function parseUserOptions($input)
+    {
+        $options = [];
+        foreach (explode(PHP_EOL, $input) as $option) {
+            if (str_contains($option, '=')) {
+                list($k,$v) = explode('=', $option, 2);
+                $options[$k] = trim($v);
+            }
+        }
+        return $options;
+    }
 }

--- a/LibreNMS/Alert/Transport/Alertmanager.php
+++ b/LibreNMS/Alert/Transport/Alertmanager.php
@@ -29,12 +29,9 @@ class Alertmanager extends Transport
 {
     public function deliverAlert($obj, $opts)
     {
-        $alertmanager_opts = [];
+        $alertmanager_opts = $this->parseUserOptions($this->config['alertmanager-options']);
         $alertmanager_opts['url'] = $this->config['alertmanager-url'];
-        foreach (explode(PHP_EOL, $this->config['alertmanager-options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $alertmanager_opts[$k] = $v;
-        }
+
         return $this->contactAlertmanager($obj, $alertmanager_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Boxcar.php
+++ b/LibreNMS/Alert/Transport/Boxcar.php
@@ -48,11 +48,9 @@ class Boxcar extends Transport
         if (empty($this->config)) {
             return $this->deliverAlertOld($obj, $opts);
         }
+        $boxcar_opts = $this->parseUserOptions($this->config['options']);
         $boxcar_opts['access_token'] = $this->config['boxcar-token'];
-        foreach (explode(PHP_EOL, $this->config['options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $boxcar_opts[$k] = $v;
-        }
+
         return $this->contactBoxcar($obj, $boxcar_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Discord.php
+++ b/LibreNMS/Alert/Transport/Discord.php
@@ -37,11 +37,12 @@ class Discord extends Transport
         if (empty($this->config)) {
             return $this->deliverAlertOld($obj, $opts);
         }
-        $discord_opts['url'] = $this->config['url'];
-        foreach (explode(PHP_EOL, $this->config['options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $discord_opts['options'][$k] = $v;
-        }
+
+        $discord_opts = [
+            'url' => $this->config['url'],
+            'options' => $this->parseUserOptions($this->config['options']),
+        ];
+
         return $this->contactDiscord($obj, $discord_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Hipchat.php
+++ b/LibreNMS/Alert/Transport/Hipchat.php
@@ -32,13 +32,11 @@ class Hipchat extends Transport
         if (empty($this->config)) {
             return $this->deliverAlertOld($obj, $opts);
         }
+        $hipchat_opts = $this->parseUserOptions($this->config['hipchat-options']);
         $hipchat_opts['url'] = $this->config['hipchat-url'];
         $hipchat_opts['room_id'] = $this->config['hipchat-room-id'];
         $hipchat_opts['from'] = $this->config['hipchat-from-name'];
-        foreach (explode(PHP_EOL, $this->config['hipchat-options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $hipchat_opts[$k] = $v;
-        }
+
         return $this->contactHipchat($obj, $hipchat_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Pushover.php
+++ b/LibreNMS/Alert/Transport/Pushover.php
@@ -47,11 +47,8 @@ class Pushover extends Transport
             return $this->deliverAlertOld($obj, $opts);
         }
         $pushover_opts = $this->config;
-        unset($pushover_opts['options']);
-        foreach (explode(PHP_EOL, $this->config['options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $pushover_opts['options'][$k] = trim($v);
-        }
+        $pushover_opts['options'] = $this->parseUserOptions($this->config['options']);
+
         return $this->contactPushover($obj, $pushover_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Rocket.php
+++ b/LibreNMS/Alert/Transport/Rocket.php
@@ -32,11 +32,9 @@ class Rocket extends Transport
         if (empty($this->config)) {
             return $this->deliverAlertOld($obj, $opts);
         }
+        $rocket_opts = $this->parseUserOptions($this->config['rocket-options']);
         $rocket_opts['url'] = $this->config['rocket-url'];
-        foreach (explode(PHP_EOL, $this->config['rocket-options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $rocket_opts[$k] = $v;
-        }
+
         return $this->contactRocket($obj, $rocket_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Slack.php
+++ b/LibreNMS/Alert/Transport/Slack.php
@@ -32,11 +32,9 @@ class Slack extends Transport
         if (empty($this->config)) {
             return $this->deliverAlertOld($obj, $opts);
         }
+        $slack_opts = $this->parseUserOptions($this->config['slack-options']);
         $slack_opts['url'] = $this->config['slack-url'];
-        foreach (explode(PHP_EOL, $this->config['slack-options']) as $option) {
-            list($k,$v) = explode('=', $option);
-            $slack_opts[$k] = $v;
-        }
+
         return $this->contactSlack($obj, $slack_opts);
     }
 

--- a/LibreNMS/Alert/Transport/Smseagle.php
+++ b/LibreNMS/Alert/Transport/Smseagle.php
@@ -32,10 +32,10 @@ class Smseagle extends Transport
         if (empty($this->config)) {
             return $this->deliverAlertOld($obj, $opts);
         }
-        $smseagle_opts['url']   = $this->config['playsms-url'];
-        $smseagle_opts['user']  = $this->config['playsms-user'];
-        $smseagle_opts['token'] = $this->config['playsms-pass'];
-        $smseagle_opts['to']    = preg_split('/([,\r\n]+)/', $this->config['playsms-mobiles']);
+        $smseagle_opts['url']   = $this->config['smseagle-url'];
+        $smseagle_opts['user']  = $this->config['smseagle-user'];
+        $smseagle_opts['token'] = $this->config['smseagle-pass'];
+        $smseagle_opts['to']    = preg_split('/([,\r\n]+)/', $this->config['smseagle-mobiles']);
         return $this->contactSmseagle($obj, $smseagle_opts);
     }
 


### PR DESCRIPTION
Windows puts line returns as \r\n, when parsing LibreNMS previously left the \r, which could cause issues
Centralize the code so we just have one place to fix.
Try to fix SMSEagle, it had the options wrong (copied from another transport)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
