### PR TITLE
Improving Health limits display

### DIFF
--- a/html/includes/table/sensors-common.php
+++ b/html/includes/table/sensors-common.php
@@ -130,8 +130,10 @@ foreach (dbFetchRows($sql, $param) as $sensor) {
         'graph'            => overlib_link($link_graph, $sensor_minigraph, $overlib_content, null),
         'alert'            => $alert,
         'sensor_current'   => $sensor_current,
-        'sensor_limit_low' => is_null($sensor['sensor_limit_low']) ? '-' : round($sensor['sensor_limit_low'], 2).$unit,
-        'sensor_limit'     => is_null($sensor['sensor_limit']) ? '-' : round($sensor['sensor_limit'], 2).$unit,
+        'sensor_limit_low' => is_null($sensor['sensor_limit_low']) ? '-' :
+            '<span class=\'label label-default\'>' . trim(format_si($sensor['sensor_limit_low']) . $unit) . '</span>',
+        'sensor_limit'     => is_null($sensor['sensor_limit']) ? '-' :
+            '<span class=\'label label-default\'>' . trim(format_si($sensor['sensor_limit']) . $unit) . '</span>',
     );
 
     if ($vars['view'] == 'graphs') {


### PR DESCRIPTION
Improve the display of the health limit values for the sensors under the Health menu :
- Limit values are normalized with SI prefixes
- Limit values are displayed with "label label-default" classes.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
