### PR TITLE
Improve Huawei BGP polling + BGP webui & graphs patches

### DIFF
--- a/html/includes/graphs/bgp/prefixes.inc.php
+++ b/html/includes/graphs/bgp/prefixes.inc.php
@@ -2,15 +2,19 @@
 
 $scale_min = '0';
 
-$ds = 'AcceptedPrefixes';
+$ds_in  = 'AcceptedPrefixes';
+$ds_out = 'AdvertisedPrefixes';
 
-$colour_area = 'AA66AA';
-$colour_line = 'FFDD88';
+$colour_area_in  = 'AA66AA';
+$colour_line_in  = '330033';
+$colour_area_out = 'FF6600';
+$colour_line_out = 'FFDD88';
 
-$colour_area_max = 'FFEE99';
+$colour_area_in_max  = 'FFEE99';
+$colour_area_out_max = 'FF7711';
 
 $graph_max = 1;
 
 $unit_text = 'Prefixes';
 
-require 'includes/graphs/generic_simplex.inc.php';
+require 'includes/graphs/generic_duplex.inc.php';

--- a/html/pages/device/routing/bgp.inc.php
+++ b/html/pages/device/routing/bgp.inc.php
@@ -53,12 +53,12 @@ if ($vars['view'] == 'prefixes_ipv4unicast') {
 
 echo ' | ';
 
-if ($vars['view'] == 'prefixes_vpnv4unicast') {
+if ($vars['view'] == 'prefixes_ipv4vpn') {
     echo "<span class='pagemenu-selected'>";
 }
 
-echo generate_link('VPNv4', $link_array, array('view' => 'prefixes_vpnv4unicast'));
-if ($vars['view'] == 'prefixes_vpnv4unicast') {
+echo generate_link('VPNv4 Ucast', $link_array, array('view' => 'prefixes_ipv4vpn'));
+if ($vars['view'] == 'prefixes_ipv4vpn') {
     echo '</span>';
 }
 
@@ -71,6 +71,18 @@ if ($vars['view'] == 'prefixes_ipv6unicast') {
 
 echo generate_link('IPv6', $link_array, array('view' => 'prefixes_ipv6unicast'));
 if ($vars['view'] == 'prefixes_ipv6unicast') {
+    echo '</span>';
+}
+
+echo ' | ';
+
+if ($vars['view'] == 'prefixes_ipv6vpn') {
+    echo "<span class='pagemenu-selected'>";
+    $extra_sql = " AND `bgpPeerIdentifier` LIKE '%:%'";
+}
+
+echo generate_link('VPNv6 Ucast', $link_array, array('view' => 'prefixes_ipv6vpn'));
+if ($vars['view'] == 'prefixes_ipv6vpn') {
     echo '</span>';
 }
 

--- a/html/pages/routing/bgp.inc.php
+++ b/html/pages/routing/bgp.inc.php
@@ -142,6 +142,17 @@ if (!LegacyAuth::user()->hasGlobalRead()) {
         echo '</span>';
     }
 
+    echo '|';
+
+    if ($vars['graph'] == 'prefixes_ipv6vpn') {
+        echo "<span class='pagemenu-selected'>";
+    }
+
+    echo generate_link('VPNv6', $vars, array('view' => 'graphs', 'graph' => 'prefixes_ipv6vpn'));
+    if ($vars['graph'] == 'prefixes_ipv6vpn') {
+        echo '</span>';
+    }
+
     echo ')';
 
     echo ' | Multicast (';

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -5,8 +5,6 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IP;
 
 if (Config::get('enable_bgp')) {
-
-
     if ($device['os'] == 'timos') {
         $bgpPeersCache =snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
         foreach ($bgpPeersCache as $key => $value) {

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -5,6 +5,28 @@ use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IP;
 
 if (Config::get('enable_bgp')) {
+
+
+    if ($device['os'] == 'vrp') {
+        d_echo("VRP:");
+        $hwBgpPeers = snmpwalk_group($device, 'hwBgpPeers', 'HUAWEI-BGP-VPN-MIB', 6, $hwBgpPeers);
+        d_echo($hwBgpPeers);
+
+        foreach ($hwBgpPeers as $hwInstance => $hwBgpPeersInst) {
+            foreach ($hwBgpPeersInst as $hwAfi => $hwBgpPeersAfi) {
+                foreach ($hwBgpPeersAfi as $hwSafi1 => $hwBgpPeersType) {
+                    foreach ($hwBgpPeersType as $hwPeerType => $hwBgpPeersIP) {
+                        foreach ($hwBgpPeersIP as $hwPeer => $hwPeerValues) {
+                        $peer['ip']=$hwPeer;
+                        add_cbgp_peer($device, $peer, $hwAfi, $hwSafi1);
+                        unset($peer);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     if ($device['os'] == 'timos') {
         $bgpPeersCache =snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
         foreach ($bgpPeersCache as $key => $value) {

--- a/includes/discovery/bgp-peers.inc.php
+++ b/includes/discovery/bgp-peers.inc.php
@@ -7,26 +7,6 @@ use LibreNMS\Util\IP;
 if (Config::get('enable_bgp')) {
 
 
-    if ($device['os'] == 'vrp') {
-        d_echo("VRP:");
-        $hwBgpPeers = snmpwalk_group($device, 'hwBgpPeers', 'HUAWEI-BGP-VPN-MIB', 6, $hwBgpPeers);
-        d_echo($hwBgpPeers);
-
-        foreach ($hwBgpPeers as $hwInstance => $hwBgpPeersInst) {
-            foreach ($hwBgpPeersInst as $hwAfi => $hwBgpPeersAfi) {
-                foreach ($hwBgpPeersAfi as $hwSafi1 => $hwBgpPeersType) {
-                    foreach ($hwBgpPeersType as $hwPeerType => $hwBgpPeersIP) {
-                        foreach ($hwBgpPeersIP as $hwPeer => $hwPeerValues) {
-                        $peer['ip']=$hwPeer;
-                        add_cbgp_peer($device, $peer, $hwAfi, $hwSafi1);
-                        unset($peer);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     if ($device['os'] == 'timos') {
         $bgpPeersCache =snmpwalk_cache_multi_oid($device, 'tBgpPeerNgTable', [], 'TIMETRA-BGP-MIB', 'nokia');
         foreach ($bgpPeersCache as $key => $value) {
@@ -162,6 +142,11 @@ if (Config::get('enable_bgp')) {
 
                 // build the list
                 if (!empty($af_data)) {
+                    $af_list = build_cbgp_peers($device, $peer, $af_data, $peer2);
+                }
+                if ($device['os'] == 'vrp') {
+                    d_echo("VRP:");
+                    $af_data = snmpwalk_cache_oid($device, 'hwBgpPeers', $af_data, 'HUAWEI-BGP-VPN-MIB');
                     $af_list = build_cbgp_peers($device, $peer, $af_data, $peer2);
                 }
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1195,6 +1195,7 @@ function build_bgp_peers($device, $data, $peer2)
         'ARISTA-BGP4V2-MIB::aristaBgp4V2PeerRemoteAs.1.',
         'CISCO-BGP4-MIB::cbgpPeer2RemoteAs.',
         'BGP4-MIB::bgpPeerRemoteAs.',
+        'HUAWEI-BGP-VPN-MIB::hwBgpPeerRemoteAs.',
         '.1.3.6.1.4.1.2636.5.1.1.2.1.1.1.13.',
     );
     $peers = trim(str_replace($remove, '', $data));
@@ -1250,11 +1251,19 @@ function build_cbgp_peers($device, $peer, $af_data, $peer2)
         d_echo("AFISAFI = $k\n");
 
         $afisafi_tmp = explode('.', $k);
-        $safi        = array_pop($afisafi_tmp);
-        $afi         = array_pop($afisafi_tmp);
-        $bgp_ip      = str_replace(".$afi.$safi", '', $k);
-        if ($device['os_group'] === 'arista') {
-            $bgp_ip      = str_replace("$afi.", '', $bgp_ip);
+        if ($device['os_group'] === 'vrp') {
+            array_shift($afisafi_tmp); //remove 1st value
+            $afi         = array_shift($afisafi_tmp);
+            $safi        = array_shift($afisafi_tmp);
+            array_shift($afisafi_tmp); //type 
+            $bgp_ip      = implode('.', $afisafi_tmp);
+        } else {
+            $safi        = array_pop($afisafi_tmp);
+            $afi         = array_pop($afisafi_tmp);
+            $bgp_ip      = str_replace(".$afi.$safi", '', $k);
+            if ($device['os_group'] === 'arista') {
+                $bgp_ip      = str_replace("$afi.", '', $bgp_ip);
+            }
         }
         $bgp_ip      = preg_replace('/:/', ' ', $bgp_ip);
         $bgp_ip      = preg_replace('/(\S+\s+\S+)\s/', '$1:', $bgp_ip);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1252,10 +1252,10 @@ function build_cbgp_peers($device, $peer, $af_data, $peer2)
 
         $afisafi_tmp = explode('.', $k);
         if ($device['os_group'] === 'vrp') {
-            array_shift($afisafi_tmp); //remove 1st value
+            array_shift($afisafi_tmp); //remove 1st value, always 0 so far
             $afi         = array_shift($afisafi_tmp);
             $safi        = array_shift($afisafi_tmp);
-            array_shift($afisafi_tmp); //type 
+            array_shift($afisafi_tmp); //type, always ipv4 so far
             $bgp_ip      = implode('.', $afisafi_tmp);
         } else {
             $safi        = array_pop($afisafi_tmp);

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -390,12 +390,9 @@ if ($config['enable_bgp']) {
 
                     if ($device['os_group'] === 'vrp') {
                         $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixRcvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
-                        //$vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixActiveCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
                         $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixAdvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
                         
-                        d_echo($vrpPrefixes);
                         $key = '0.'.$afi.'.'.$safi.'.ipv4.'.$peer['bgpPeerIdentifier'];
-                        d_echo($key);
                         $cbgpPeerAcceptedPrefixes = $vrpPrefixes[$key]['hwBgpPeerPrefixRcvCounter'];
                         $cbgpPeerAdvertisedPrefixes  = $vrpPrefixes[$key]['hwBgpPeerPrefixAdvCounter'];
                         
@@ -479,7 +476,6 @@ if ($config['enable_bgp']) {
                         'rrd_name' => $cbgp_rrd_name,
                         'rrd_def' => $cbgp_rrd_def
                     );
-                    d_echo($fields);
                     data_update($device, 'cbgp', $tags, $fields);
                 } //end foreach
             } //end if

--- a/includes/polling/bgp-peers.inc.php
+++ b/includes/polling/bgp-peers.inc.php
@@ -387,7 +387,6 @@ if ($config['enable_bgp']) {
                         $cbgpPeerAcceptedPrefixes = $a_prefixes["1.$afi.$tmp_peer.$afi.$safi"]['aristaBgp4V2PrefixInPrefixesAccepted'];
                     }
 
-
                     if ($device['os_group'] === 'vrp') {
                         $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixRcvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
                         $vrpPrefixes = snmpwalk_cache_multi_oid($device, 'hwBgpPeerPrefixAdvCounter', $vrpPrefixes, 'HUAWEI-BGP-VPN-MIB', null, '-OQUs');
@@ -395,7 +394,6 @@ if ($config['enable_bgp']) {
                         $key = '0.'.$afi.'.'.$safi.'.ipv4.'.$peer['bgpPeerIdentifier'];
                         $cbgpPeerAcceptedPrefixes = $vrpPrefixes[$key]['hwBgpPeerPrefixRcvCounter'];
                         $cbgpPeerAdvertisedPrefixes  = $vrpPrefixes[$key]['hwBgpPeerPrefixAdvCounter'];
-                        
                     }
 
                     // Validate data


### PR DESCRIPTION
In an attempt to improve Huawei VRP BGP support, I patched the webui as well (AFI & SAFI were not always correct). Currently testing it with both Cisco & Huawei. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 10010`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
