### PR TITLE
Fail2ban: properly set the component information when polling

### DIFF
--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -77,7 +77,7 @@ $component = new LibreNMS\Component();
 $f2b_components = $component->getComponents($device_id, $options);
 
 // if no jails, delete fail2ban components
-if (empty($jails)) {
+if (empty($f2b['jails'])) {
     if (isset($f2b_components[$device_id])) {
         foreach ($f2b_components[$device_id] as $component_id => $_unused) {
             $component->deleteComponent($component_id);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


When converted to JSON, the variable got renamed. Everything was updated except for the check to see if any jail information was returned or not. It now properly checks if the correct variable is empty or not.

Currently it just displays the totals graph with out display anything else. This fixes it so it displays all the graphs for jails on a device.