### PR TITLE
Fix path in Smokeping conf file

### DIFF
--- a/doc/Extensions/Smokeping.md
+++ b/doc/Extensions/Smokeping.md
@@ -42,7 +42,7 @@ cgiurl   = http://yourlibrenms/cgi-bin/smokeping.cgi
 Add the following line to `/etc/smokeping/config` config file:
 
 ```bash
-@include /opt/smokeping/etc/librenms.conf
+@include /etc/smokeping/config.d/librenms.conf
 ```
 
 We will generate the conf file in the next step. 


### PR DESCRIPTION
Wrong path is given for including the librenms.conf file into the SmokePing config.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
