### PR TITLE
Added PPPoE Sessions Graph for Mikrotik

### DIFF
--- a/html/includes/graphs/device/routeros_pppoe_sessions.inc.php
+++ b/html/includes/graphs/device/routeros_pppoe_sessions.inc.php
@@ -1,0 +1,19 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'routeros_pppoe_sessions');
+
+require 'includes/graphs/common.inc.php';
+
+$ds = 'pppoe_sessions';
+
+$colour_area = '99cc99';
+$colour_line = '00cc00';
+
+$colour_area_max = '99cc99';
+$scale_min = '0';
+$graph_max = 1;
+$graph_min = 0;
+
+$unit_text = 'PPPoE Sessions';
+
+require 'includes/graphs/generic_simplex.inc.php';

--- a/includes/definitions.inc.php
+++ b/includes/definitions.inc.php
@@ -503,6 +503,10 @@ $config['graph_types']['device']['routeros_leases']['section'] = 'network';
 $config['graph_types']['device']['routeros_leases']['order'] = 0;
 $config['graph_types']['device']['routeros_leases']['descr'] = 'DHCP Lease Count';
 
+$config['graph_types']['device']['routeros_pppoe_sessions']['section'] = 'network';
+$config['graph_types']['device']['routeros_pppoe_sessions']['order'] = 0;
+$config['graph_types']['device']['routeros_pppoe_sessions']['descr'] = 'PPPoE Session Count';
+
 
 //CheckPoint SPLAT specific graphs
 $config['graph_types']['device']['secureplatform_sessions']['section'] = 'firewall';

--- a/includes/polling/os/routeros.inc.php
+++ b/includes/polling/os/routeros.inc.php
@@ -26,3 +26,19 @@ if (is_numeric($leases)) {
 }
 
 unset($leases);
+
+$pppoe_sessions = snmp_get($device, '1.3.6.1.4.1.9.9.150.1.1.1.0', '-OQv', '', '');
+
+if (is_numeric($pppoe_sessions)) {
+    $rrd_def = RrdDefinition::make()->addDataset('pppoe_sessions', 'GAUGE', 0);
+
+    $fields = array(
+        'pppoe_sessions' => $pppoe_sessions,
+    );
+
+    $tags = compact('rrd_def');
+    data_update($device, 'routeros_pppoe_sessions', $tags, $fields);
+    $graphs['routeros_pppoe_sessions'] = true;
+}
+
+unset($pppoe_sessions);


### PR DESCRIPTION
Added PPPoE Sessions Graph for Mikrotik. Cli command to get session count: /interface pppoe-server print count-only

Coding style and implement idea from 9f553af71e2f4bea70a3a9a1002ecaaa0969d765.

Tested on Mikrotik Firmware version 6.23-6.44, but should work with all firmware versions.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
