### PR TITLE
Fix fail2ban jails eventlog spam

### DIFF
--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use LibreNMS\Exceptions\JsonAppParsingFailedException;
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\RRD\RrdDefinition;
@@ -92,7 +93,7 @@ if (empty($f2b['jails'])) {
 
     $id = $component->getFirstComponentID($f2bc);
     $f2bc[$id]['label'] = 'Fail2ban Jails';
-    $f2bc[$id]['jails'] = json_encode(array_keys($f2b['jails']));
+    $f2bc[$id]['jails'] = json_encode(Arr::sort(array_keys($f2b['jails'])));
 
     $component->setComponentPrefs($device_id, $f2bc);
 }


### PR DESCRIPTION
Sort the jails before saving so it always matches.
Not sure why it would be different order, but this fixes the spam in any case.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
