### PR TITLE
Update SNMP-Configuration-Examples

### DIFF
--- a/doc/Support/SNMP-Configuration-Examples.md
+++ b/doc/Support/SNMP-Configuration-Examples.md
@@ -266,7 +266,7 @@ extend .1.3.6.1.4.1.2021.7890.1 distro /usr/bin/distro
 #extend .1.3.6.1.4.1.2021.7890.4 serial '/bin/cat /sys/devices/virtual/dmi/id/product_serial'
 ```
 
-**NOTE**: On some systems the snmpd is running as its own user, which means it can't read `/sys/devices/virtual/dmi/id/product_serial` which is mode 0400. One solution is to `chmod 444 /sys/devices/virtual/dmi/id/product_serial` in `/etc/rc.local` or equivalent.
+**NOTE**: On some systems the snmpd is running as its own user, which means it can't read `/sys/devices/virtual/dmi/id/product_serial` which is mode 0400. One solution is to include `@reboot chmod 444 /sys/devices/virtual/dmi/id/product_serial` in the crontab for root or equivalent. 
 
 The LibreNMS server include a copy of this example here:
 


### PR DESCRIPTION
Update snmpd instructions for Linux to reflect the ability to use @reboot declaration in the crontab. This is probably preferable to rc.local, which is apparently not supported or possibly deprecated in Ubuntu and CentOS7.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
