### PR TITLE
Use $_SERVER['HOST_NAME'] instead of $_SERVER['SERVER_NAME']

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -80,12 +80,12 @@ $config['rrd_rra'] .= ' RRA:LAST:0.5:1:1440 ';
 // $config['rrdcached']    = "unix:/var/run/rrdcached.sock";
 
 // Web Interface Settings
-if (isset($_SERVER['HOST_NAME']) && isset($_SERVER['SERVER_PORT'])) {
-    if (strpos($_SERVER['HOST_NAME'], ':')) {
+if (isset($_SERVER['HTTP_HOST']) && isset($_SERVER['SERVER_PORT'])) {
+    if (strpos($_SERVER['HTTP_HOST'], ':')) {
         // Literal IPv6
-        $config['base_url'] = 'http://['.$_SERVER['HOST_NAME'].']'.($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
+        $config['base_url'] = 'http://['.$_SERVER['HTTP_HOST'].']'.($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
     } else {
-        $config['base_url'] = 'http://'.$_SERVER['HOST_NAME'].($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
+        $config['base_url'] = 'http://'.$_SERVER['HTTP_HOST'].($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
     }
 }
 

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -80,12 +80,12 @@ $config['rrd_rra'] .= ' RRA:LAST:0.5:1:1440 ';
 // $config['rrdcached']    = "unix:/var/run/rrdcached.sock";
 
 // Web Interface Settings
-if (isset($_SERVER['SERVER_NAME']) && isset($_SERVER['SERVER_PORT'])) {
-    if (strpos($_SERVER['SERVER_NAME'], ':')) {
+if (isset($_SERVER['HOST_NAME']) && isset($_SERVER['SERVER_PORT'])) {
+    if (strpos($_SERVER['HOST_NAME'], ':')) {
         // Literal IPv6
-        $config['base_url'] = 'http://['.$_SERVER['SERVER_NAME'].']'.($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
+        $config['base_url'] = 'http://['.$_SERVER['HOST_NAME'].']'.($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
     } else {
-        $config['base_url'] = 'http://'.$_SERVER['SERVER_NAME'].($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
+        $config['base_url'] = 'http://'.$_SERVER['HOST_NAME'].($_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '').'/';
     }
 }
 


### PR DESCRIPTION
Use $_SERVER['HOST_NAME'] instead of $_SERVER['SERVER_NAME'] to make the webinterface… reachable over several domain names. This didn't work previously, even if the HTTP server was configured with several server names that pointed at librenms.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
