### PR TITLE
Fix to display minimum values in uptime graphs.

### DIFF
--- a/html/includes/graphs/application/memcached_uptime.inc.php
+++ b/html/includes/graphs/application/memcached_uptime.inc.php
@@ -12,5 +12,5 @@ $rrd_options .= ' CDEF:cuptime=uptime,86400,/';
 $rrd_options .= " 'COMMENT:Days      Current  Minimum  Maximum  Average\\n'";
 $rrd_options .= ' AREA:cuptime#EEEEEE:Uptime';
 $rrd_options .= ' LINE1.25:cuptime#36393D:';
-$rrd_options .= ' GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:AVERAGE:%6.2lf';
+$rrd_options .= ' GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:MIN:%6.2lf';
 $rrd_options .= " GPRINT:cuptime:MAX:%6.2lf  'GPRINT:cuptime:AVERAGE:%6.2lf\\n'";

--- a/html/includes/graphs/device/uptime.inc.php
+++ b/html/includes/graphs/device/uptime.inc.php
@@ -11,5 +11,5 @@ $rrd_options .= ' CDEF:cuptime=uptime,86400,/';
 $rrd_options .= " 'COMMENT:Days      Current  Minimum  Maximum  Average\\n'";
 $rrd_options .= ' AREA:cuptime#00FF0022:Uptime';
 $rrd_options .= ' LINE1.25:cuptime#36393D:';
-$rrd_options .= ' GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:AVERAGE:%6.2lf';
+$rrd_options .= ' GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:MIN:%6.2lf';
 $rrd_options .= " GPRINT:cuptime:MAX:%6.2lf  'GPRINT:cuptime:AVERAGE:%6.2lf\\n'";

--- a/includes/services/check_mysql.inc.php
+++ b/includes/services/check_mysql.inc.php
@@ -62,7 +62,7 @@ $check_graph['mysqluptime'] .= " CDEF:cuptime=DS0,86400,/";
 $check_graph['mysqluptime'] .= " 'COMMENT:Days      Current  Minimum  Maximum  Average\\n'";
 $check_graph['mysqluptime'] .= " AREA:cuptime#EEEEEE:Uptime";
 $check_graph['mysqluptime'] .= " LINE1.25:cuptime#36393D:";
-$check_graph['mysqluptime'] .= " GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:AVERAGE:%6.2lf";
+$check_graph['mysqluptime'] .= " GPRINT:cuptime:LAST:%6.2lf  GPRINT:cuptime:MIN:%6.2lf";
 $check_graph['mysqluptime'] .= " GPRINT:cuptime:MAX:%6.2lf  GPRINT:cuptime:AVERAGE:%6.2lf\\l";
 
 $check_graph['mysqlQcache'] = " DEF:DS0=" . $rrd_filename . ":Qcache_free_memory:AVERAGE ";


### PR DESCRIPTION
Fixes an issue with several uptime graphs using the average value when it should be using the minimum value.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
