### PR TITLE
Fix unescaped variables in ajax_search.php

### DIFF
--- a/html/ajax_search.php
+++ b/html/ajax_search.php
@@ -15,7 +15,7 @@ if (!LegacyAuth::check()) {
 $device = array();
 $ports  = array();
 $bgp    = array();
-$limit  = $config['webui']['global_search_result_limit'];
+$limit  = (int)\LibreNMS\Config::get('webui.global_search_result_limit');
 
 if (isset($_REQUEST['search'])) {
     $search = mres($_REQUEST['search']);
@@ -25,7 +25,7 @@ if (isset($_REQUEST['search'])) {
 
         if ($_REQUEST['type'] == 'group') {
             include_once '../includes/device-groups.inc.php';
-            foreach (dbFetchRows("SELECT id,name FROM device_groups WHERE name LIKE '%".$search."%'") as $group) {
+            foreach (dbFetchRows("SELECT id,name FROM device_groups WHERE name LIKE ?", ["%$search%"]) as $group) {
                 if ($_REQUEST['map']) {
                     $results[] = array(
                         'name'     => 'g:'.$group['name'],
@@ -38,7 +38,7 @@ if (isset($_REQUEST['search'])) {
 
             die(json_encode($results));
         } elseif ($_REQUEST['type'] == 'alert-rules') {
-            foreach (dbFetchRows("SELECT name FROM alert_rules WHERE name LIKE '%".$search."%'") as $rules) {
+            foreach (dbFetchRows("SELECT name FROM alert_rules WHERE name LIKE ?", ["%$search%"]) as $rules) {
                 $results[] = array('name' => $rules['name']);
             }
 
@@ -46,9 +46,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'device') {
             // Device search
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT * FROM `devices` LEFT JOIN `locations` ON `locations`.`id` = `devices`.`location_id` WHERE `devices`.`hostname` LIKE '%".$search."%' OR `locations`.`location` LIKE '%".$search."%' OR `devices`.`sysName` LIKE '%".$search."%' OR `devices`.`purpose` LIKE '%".$search."%' OR `devices`.`notes` LIKE '%".$search."%' ORDER BY `devices`.hostname LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT * FROM `devices` LEFT JOIN `locations` ON `locations`.`id` = `devices`.`location_id` WHERE `devices`.`hostname` LIKE ? OR `locations`.`location` LIKE ? OR `devices`.`sysName` LIKE ? OR `devices`.`purpose` LIKE ? OR `devices`.`notes` LIKE ? ORDER BY `devices`.hostname LIMIT " . $limit,
+                    ["%$search%", "%$search%", "%$search%", "%$search%", "%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT * FROM `devices` AS `D` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` LEFT JOIN `locations` ON `locations`.`id` = `D`.`location_id` WHERE `P`.`user_id` = ? AND (D.`hostname` LIKE '%".$search."%' OR D.`sysName` LIKE '%".$search."%' OR `locations`.`location` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT * FROM `devices` AS `D` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` LEFT JOIN `locations` ON `locations`.`id` = `D`.`location_id` WHERE `P`.`user_id` = ? AND (D.`hostname` LIKE ? OR D.`sysName` LIKE ? OR `locations`.`location` LIKE ?) ORDER BY hostname LIMIT " . $limit,
+                    [LegacyAuth::id(), "%$search%", "%$search%", "%$search%"]
+                );
             }
 
             if (count($results)) {
@@ -71,9 +77,9 @@ if (isset($_REQUEST['search'])) {
                     }
 
                     if (LegacyAuth::user()->hasGlobalRead()) {
-                        $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ?', array($result['device_id']));
+                        $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ?', [$result['device_id']]);
                     } else {
-                        $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND `I`.`device_id` = `D`.`device_id` AND D.device_id = ?', array(LegacyAuth::id(), $result['device_id']));
+                        $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND `I`.`device_id` = `D`.`device_id` AND D.device_id = ?', [LegacyAuth::id(), $result['device_id']]);
                     }
 
                     $device[] = array(
@@ -96,9 +102,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'ports') {
             // Search ports
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT `ports`.*,`devices`.* FROM `ports` LEFT JOIN `devices` ON  `ports`.`device_id` =  `devices`.`device_id` WHERE `ifAlias` LIKE '%".$search."%' OR `ifDescr` LIKE '%".$search."%' OR `ifName` LIKE '%".$search."%' ORDER BY ifDescr LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT `ports`.*,`devices`.* FROM `ports` LEFT JOIN `devices` ON  `ports`.`device_id` =  `devices`.`device_id` WHERE `ifAlias` LIKE ? OR `ifDescr` LIKE ? OR `ifName` LIKE ? ORDER BY ifDescr LIMIT ".$limit,
+                    ["%$search%", "%$search%", "%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT DISTINCT(`I`.`port_id`), `I`.*, `D`.`hostname` FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifAlias` LIKE '%".$search."%' OR `ifDescr` LIKE '%".$search."%' OR `ifName` LIKE '%".$search."%') ORDER BY ifDescr LIMIT ".$limit, array(LegacyAuth::id(), LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT DISTINCT(`I`.`port_id`), `I`.*, `D`.`hostname` FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifAlias` LIKE ? OR `ifDescr` LIKE ? OR `ifName` LIKE ?) ORDER BY ifDescr LIMIT ".$limit,
+                    [LegacyAuth::id(), LegacyAuth::id(), "%$search%", "%$search%", "%$search%"]
+                );
             }
 
             if (count($results)) {
@@ -130,7 +142,7 @@ if (isset($_REQUEST['search'])) {
                         'url'         => generate_port_url($result),
                         'name'        => $name,
                         'description' => $description,
-                        'colours'     => $highlight_colour,
+                        'colours'     => $port_colour,
                         'hostname'    => $result['hostname'],
                         'port_id'     => $result['port_id'],
                     );
@@ -142,9 +154,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'bgp') {
             // Search bgp peers
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT `bgpPeers`.*,`devices`.* FROM `bgpPeers` LEFT JOIN `devices` ON  `bgpPeers`.`device_id` =  `devices`.`device_id` WHERE `astext` LIKE '%".$search."%' OR `bgpPeerIdentifier` LIKE '%".$search."%' OR `bgpPeerRemoteAs` LIKE '%".$search."%' ORDER BY `astext` LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT `bgpPeers`.*,`devices`.* FROM `bgpPeers` LEFT JOIN `devices` ON  `bgpPeers`.`device_id` =  `devices`.`device_id` WHERE `astext` LIKE ? OR `bgpPeerIdentifier` LIKE ? OR `bgpPeerRemoteAs` LIKE ? ORDER BY `astext` LIMIT " . $limit,
+                    ["%$search%", "%$search%", "%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT `bgpPeers`.*,`D`.* FROM `bgpPeers`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND  `bgpPeers`.`device_id`=`D`.`device_id` AND  (`astext` LIKE '%".$search."%' OR `bgpPeerIdentifier` LIKE '%".$search."%' OR `bgpPeerRemoteAs` LIKE '%".$search."%') ORDER BY `astext` LIMIT ".$limit, array(LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT `bgpPeers`.*,`D`.* FROM `bgpPeers`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND  `bgpPeers`.`device_id`=`D`.`device_id` AND  (`astext` LIKE ? OR `bgpPeerIdentifier` LIKE ? OR `bgpPeerRemoteAs` LIKE ?) ORDER BY `astext` LIMIT ".$limit,
+                    [LegacyAuth::id(), "%$search%", "%$search%", "%$search%"]
+                );
             }
 
             if (count($results)) {
@@ -192,9 +210,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'applications') {
             // Device search
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT * FROM `applications` INNER JOIN `devices` ON devices.device_id = applications.device_id WHERE `app_type` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%' ORDER BY hostname LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT * FROM `applications` INNER JOIN `devices` ON devices.device_id = applications.device_id WHERE `app_type` LIKE ? OR `hostname` LIKE ? ORDER BY hostname LIMIT ".$limit,
+                    ["%$search%", "%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT * FROM `applications` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `applications`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`app_type` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT * FROM `applications` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `applications`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`app_type` LIKE ? OR `hostname` LIKE ?) ORDER BY hostname LIMIT ".$limit,
+                    [LegacyAuth::id(), "%$search%", "%$search%"]
+                );
             }
 
             if (count($results)) {
@@ -233,9 +257,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'munin') {
             // Device search
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT * FROM `munin_plugins` INNER JOIN `devices` ON devices.device_id = munin_plugins.device_id WHERE `mplug_type` LIKE '%".$search."%' OR `mplug_title` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%' ORDER BY hostname LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT * FROM `munin_plugins` INNER JOIN `devices` ON devices.device_id = munin_plugins.device_id WHERE `mplug_type` LIKE ? OR `mplug_title` LIKE ? OR `hostname` LIKE ? ORDER BY hostname LIMIT ".$limit,
+                    ["%$search%", "%$search%", "%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT * FROM `munin_plugins` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `munin_plugins`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`mplug_type` LIKE '%".$search."%' OR `mplug_title` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT * FROM `munin_plugins` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `munin_plugins`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`mplug_type` LIKE ? OR `mplug_title` LIKE ? OR `hostname` LIKE ?) ORDER BY hostname LIMIT ".$limit,
+                    [LegacyAuth::id(), "%$search%", "%$search%", "%$search%"]
+                );
             }
 
             if (count($results)) {
@@ -274,9 +304,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'iftype') {
             // Device search
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT `ports`.ifType FROM `ports` WHERE `ifType` LIKE '%".$search."%' GROUP BY ifType ORDER BY ifType LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT `ports`.ifType FROM `ports` WHERE `ifType` LIKE ? GROUP BY ifType ORDER BY ifType LIMIT ".$limit,
+                    ["%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT `I`.ifType FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifType` LIKE '%".$search."%') GROUP BY ifType ORDER BY ifType LIMIT ".$limit, array(LegacyAuth::id(), LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT `I`.ifType FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifType` LIKE ?) GROUP BY ifType ORDER BY ifType LIMIT ".$limit,
+                    [LegacyAuth::id(), LegacyAuth::id(), "%$search%"]
+                );
             }
             if (count($results)) {
                 $found   = 1;
@@ -294,9 +330,15 @@ if (isset($_REQUEST['search'])) {
         } elseif ($_REQUEST['type'] == 'bill') {
             // Device search
             if (LegacyAuth::user()->hasGlobalRead()) {
-                $results = dbFetchRows("SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` WHERE `bill_name` LIKE '%".$search."%' OR `bill_notes` LIKE '%".$search."%' LIMIT ".$limit);
+                $results = dbFetchRows(
+                    "SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` WHERE `bill_name` LIKE ? OR `bill_notes` LIKE ? LIMIT ".$limit,
+                    ["%$search%", "%$search%"]
+                );
             } else {
-                $results = dbFetchRows("SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` INNER JOIN `bill_perms` ON `bills`.bill_id = `bill_perms`.bill_id WHERE `bill_perms`.user_id = ? AND (`bill_name` LIKE '%".$search."%' OR `bill_notes` LIKE '%".$search."%') LIMIT ".$limit, array(LegacyAuth::id()));
+                $results = dbFetchRows(
+                    "SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` INNER JOIN `bill_perms` ON `bills`.bill_id = `bill_perms`.bill_id WHERE `bill_perms`.user_id = ? AND (`bill_name` LIKE ? OR `bill_notes` LIKE ?) LIMIT ".$limit,
+                    [LegacyAuth::id(), "%$search%", "%$search%"]
+                );
             }
             $json = json_encode($results);
             die($json);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
