### PR TITLE
Netscaler vservers table update

### DIFF
--- a/includes/html/pages/device/loadbalancer/netscaler_vsvr.inc.php
+++ b/includes/html/pages/device/loadbalancer/netscaler_vsvr.inc.php
@@ -15,7 +15,11 @@ if (is_numeric($vars['vsvr'])) {
 
     $i = 0;
 
-    echo "<div style='margin: 5px;'><table border=0 cellspacing=0 cellpadding=5 width=100%>";
+    echo "<div style='margin: 0px;'><table class='table'>";
+    // Table header
+    echo "<tr><th width=320>VServer</th><th width=320>VIP and port</th><th width=100>State</th>";
+    echo "<th width=320>Type</th><th width=320>Inbound traffic</th><th width=320>Outbound traffic</th></tr>";
+    // Vserver graphs
     foreach (dbFetchRows('SELECT * FROM `netscaler_vservers` WHERE `device_id` = ? AND `vsvr_id` = ? ORDER BY `vsvr_name`', array($device['device_id'], $vars['vsvr'])) as $vsvr) {
         if (is_integer($i / 2)) {
             $bg_colour = $config['list_colour']['even'];
@@ -24,17 +28,20 @@ if (is_numeric($vars['vsvr'])) {
         }
 
         if ($vsvr['vsvr_state'] == 'up') {
-            $vsvr_class = 'green';
+            $vsvr_label = 'success';
+        } else if ($vsvr['vsvr_state'] == 'down') {
+            $vsvr_label = 'danger';
         } else {
-            $vsvr_class = 'red';
+            $vsvr_label = 'default';
         }
 
         echo "<tr bgcolor='$bg_colour'>";
-        echo '<td width=320 class=list-large><a href="'.generate_url($vars, array('vsvr' => $vsvr['vsvr_id'], 'view' => null, 'graph' => null)).'">'.$vsvr['vsvr_name'].'</a></td>';
-        echo '<td width=320 class=list-small>'.$vsvr['vsvr_ip'].':'.$vsvr['vsvr_port'].'</a></td>';
-        echo "<td width=100 class=list-small><span class='".$vsvr_class."'>".$vsvr['vsvr_state'].'</span></td>';
-        echo ('<td width=320 class=list-small>'.format_si(($vsvr['vsvr_bps_in'] * 8)).'bps</a></td>');
-        echo ('<td width=320 class=list-small>'.format_si(($vsvr['vsvr_bps_out'] * 8)).'bps</a></td>');
+        echo '<td><a href="'.generate_url($vars, array('vsvr' => $vsvr['vsvr_id'], 'view' => null, 'graph' => null)).'">'.$vsvr['vsvr_name'].'</a></td>';
+        echo '<td>' . $vsvr['vsvr_ip'] . ':' . $vsvr['vsvr_port'] . '</td>';
+        echo "<td><span class='label label-" . $vsvr_label . "'>" . $vsvr['vsvr_state'] . '</span></td>';
+        echo '<td><span class="label label-default">' . $vsvr['vsvr_type'] . '</span></td>';
+        echo ('<td>'.format_si(($vsvr['vsvr_bps_in'] * 8)).'bps</a></td>');
+        echo ('<td>'.format_si(($vsvr['vsvr_bps_out'] * 8)).'bps</a></td>');
         echo '</tr>';
 
         foreach ($graph_types as $graph_type => $graph_text) {
@@ -110,7 +117,11 @@ if (is_numeric($vars['vsvr'])) {
 
     print_optionbar_end();
 
-    echo "<div style='margin: 5px;'><table border=0 cellspacing=0 cellpadding=5 width=100%>";
+    echo "<div style='margin: 0px;'><table class='table'>";
+    // Table header
+    echo "<tr><th width=320>VServer</th><th width=320>VIP and port</th><th width=100>State</th>";
+    echo "<th width=320>Type</th><th width=320>Inbound traffic</th><th width=320>Outbound traffic</th></tr>";
+    // Vserver list
     $i = '0';
     foreach (dbFetchRows('SELECT * FROM `netscaler_vservers` WHERE `device_id` = ? ORDER BY `vsvr_name`', array($device['device_id'])) as $vsvr) {
         if (is_integer($i / 2)) {
@@ -120,17 +131,20 @@ if (is_numeric($vars['vsvr'])) {
         }
 
         if ($vsvr['vsvr_state'] == 'up') {
-            $vsvr_class = 'green';
+            $vsvr_label = 'success';
+        } else if ($vsvr['vsvr_state'] == 'down') {
+            $vsvr_label = 'danger';
         } else {
-            $vsvr_class = 'red';
+            $vsvr_label = 'default';
         }
 
         echo "<tr bgcolor='$bg_colour'>";
-        echo '<td width=320 class=list-large><a href="'.generate_url($vars, array('vsvr' => $vsvr['vsvr_id'], 'view' => null, 'graph' => null)).'">'.$vsvr['vsvr_name'].'</a></td>';
-        echo '<td width=320 class=list-small>'.$vsvr['vsvr_ip'].':'.$vsvr['vsvr_port'].'</a></td>';
-        echo "<td width=100 class=list-small><span class='".$vsvr_class."'>".$vsvr['vsvr_state'].'</span></td>';
-        echo ('<td width=320 class=list-small>'.format_si(($vsvr['vsvr_bps_in'] * 8)).'bps</a></td>');
-        echo ('<td width=320 class=list-small>'.format_si(($vsvr['vsvr_bps_out'] * 8)).'bps</a></td>');
+        echo '<td><a href="'.generate_url($vars, array('vsvr' => $vsvr['vsvr_id'], 'view' => null, 'graph' => null)).'">'.$vsvr['vsvr_name'].'</a></td>';
+        echo '<td>' . $vsvr['vsvr_ip'] . ':' . $vsvr['vsvr_port'] . '</td>';
+        echo "<td><span class='label label-" . $vsvr_label . "'>" . $vsvr['vsvr_state'] . '</span></td>';
+        echo '<td><span class="label label-default">' . $vsvr['vsvr_type'] . '</span></td>';
+        echo ('<td>'.format_si(($vsvr['vsvr_bps_in'] * 8)).'bps</a></td>');
+        echo ('<td>'.format_si(($vsvr['vsvr_bps_out'] * 8)).'bps</a></td>');
         echo '</tr>';
         if ($vars['view'] == 'graphs') {
             echo '<tr class="list-bold" bgcolor="'.$bg_colour.'">';


### PR DESCRIPTION
- Adjusted vservers table design to be more inline with general look and feel of LibreNMS
- Added header row
- Added vserver type column
- Added ability to sort by vserver name, inbound traffic or outbound traffic

Before:
![Before](http://pavle.aur.co.rs/librenms/1/librenms-vservers-table.png)

After:
![After](http://pavle.aur.co.rs/librenms/1/librenms-vservers-table-new.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
