### PR TITLE
API bugfix to correctly handle health graphs for sensor names containing underscores

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -802,7 +802,7 @@ function list_available_health_graphs()
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     check_device_permission($device_id);
     if (isset($router['type'])) {
-        list($dump, $type) = explode('_', $router['type']);
+        list($dump, $type) = explode('device_', $router['type']);
     }
     $sensor_id = $router['sensor_id'] ?: null;
     $graphs    = array();


### PR DESCRIPTION
When a health sensor name contains underscores - e.g. cases such as "power_consumed" or "power_factor" - the LibreNMS API only considers the first part of the name. In the given example it then returns the "power" graph data when something else was requested. By setting a more specific delimiter in the explode function ("device_" rather than just "_") we solve this problem and get the data we wanted.

Example of a call which is broken:

curl -X GET -k -H 'X-Auth-Token: redacted' -i 'https://domainname-removed/api/v0/devices/779/health/device_power_consumed'

It returns the same data as:

curl -X GET -k -H 'X-Auth-Token: redacted' -i 'https://domainname-removed/api/v0/devices/779/health/device_power'

All credits for finding and fixing this one go to my colleague Seyed Mostafavi, who didn't have a github account and asked me to open the pull request on his behalf. :)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
