### PR TITLE
Allow Add_Device API to set sysName

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -397,6 +397,7 @@ function add_device()
     $snmp_disable = ($data['snmp_disable']);
     if ($snmp_disable) {
         $additional = array(
+            'sysName'      => $data['sysName'] ? mres($data['sysName']) : '',
             'os'           => $data['os'] ? mres($data['os']) : 'ping',
             'hardware'     => $data['hardware'] ? mres($data['hardware']) : '',
             'snmp_disable' => 1,


### PR DESCRIPTION
sysName is a valid option via the WebGUI to set when SNMP is turned off. Currently you cannot set this via the API add device. This is to enable setting the sysName via the API.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
