### PR TITLE
Handle edge case in graph view for Munin plugins

### DIFF
--- a/app/Http/Controllers/Widgets/GraphController.php
+++ b/app/Http/Controllers/Widgets/GraphController.php
@@ -160,15 +160,16 @@ class GraphController extends WidgetController
         }
 
         $type = $this->getGraphType();
-        $param = '';
+        $params = [];
 
         if ($type == 'device') {
-            $param = 'device='.$settings['graph_device'];
+            $params[] = 'device='.$settings['graph_device'];
         } elseif ($type == 'application') {
-            $param = 'id='.$settings['graph_application'];
+            $params[] = 'id='.$settings['graph_application'];
         } elseif ($type == 'munin') {
             if ($mplug = MuninPlugin::find($settings['graph_munin'])) {
-                $param = 'device='.$mplug->device_id.'&plugin='.$mplug->mplug_type;
+                $params[] = 'device='.$mplug->device_id;
+                $params[] = 'plugin='.$mplug->mplug_type;
             }
         } elseif ($type == 'aggregate') {
             $aggregate_type = $this->getGraphType(false);
@@ -196,14 +197,14 @@ class GraphController extends WidgetController
                 })->pluck('port_id')->all();
             }
 
-            $param = 'id=' . implode(',', $port_ids);
+            $params[] = 'id=' . implode(',', $port_ids);
             $settings['graph_type'] = 'multiport_bits_separate';
         } else {
-            $param = 'id='.$settings['graph_'.$type];
+            $params[] = 'id='.$settings['graph_'.$type];
         }
 
         $data = $settings;
-        $data['param'] = $param;
+        $data['params'] = $params;
         $data['dimensions'] = $request->get('dimensions');
         $data['from'] = Carbon::now()->subSeconds(Time::legacyTimeSpecToSecs($settings['graph_range']))->timestamp;
         $data['to'] = Carbon::now()->timestamp;

--- a/resources/views/widgets/graph.blade.php
+++ b/resources/views/widgets/graph.blade.php
@@ -1,9 +1,9 @@
 <div class="dashboard-graph">
-    <a href="graphs/{{ $param }}/type={{ $graph_type }}/from={{ $from }}">
+    <a href="graphs/{{ implode($params, '/') }}/type={{ $graph_type }}/from={{ $from }}">
         <img class="minigraph-image"
              width="{{ $dimensions['x'] }}"
              height="{{ $dimensions['y'] }}"
-             src="graph.php?{{ $param }}&from={{ $from }}&to={{ $to }}&width={{ $dimensions['x'] }}&height={{ $dimensions['y'] }}&type={{ $graph_type }}&legend={{ $graph_legend }}&absolute=1"
+             src="graph.php?{{ implode($params, '&') }}&from={{ $from }}&to={{ $to }}&width={{ $dimensions['x'] }}&height={{ $dimensions['y'] }}&type={{ $graph_type }}&legend={{ $graph_legend }}&absolute=1"
         />
     </a>
 </div>


### PR DESCRIPTION
Munin plugins have set param in Graph Controller as 'device=x&plugin=y', which works fine for graph.php call, however it does not work as link to graph page, which expects 'device=x/plugin=y'. This commit adds str_replace in blade view for graph to ensure that '&' is replaced by '/' in param.

The reason why this logic is in view instead of controller is that Munin is the only one that uses this particular type of param 'hack' and creating separate variable in controller to fix what is essentially a 'hack' for single case seems unnecessary.

If this is not acceptable, I will update this PR to create separate variable in controller and then use @isset statement in blade template to decide whether it should use $param or separate variable for link, however in my opinion it would be harder to understand.

This fixes behavior reported on https://community.librenms.org/t/dashboard-munin-graph-links/3626

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
