### PR TITLE
Python service: Reconnect to MySQL server when connection is lost

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -1,8 +1,8 @@
 import threading
 
-from logging import critical, info, debug, exception
+from logging import critical, warning, info, debug, exception
 from math import ceil
-from time import time
+from time import time, sleep
 
 from .service import Service, ServiceConfig
 from .queuemanager import QueueManager, TimedQueueManager, BillingQueueManager
@@ -68,7 +68,14 @@ class DB:
         if threading.get_ident() not in self._db.keys():
             self.connect()
 
-        return self._db[threading.get_ident()]
+        conn = self._db[threading.get_ident()]
+        try:
+            conn.ping()
+        except:
+            warning("WARNING: Lost connection to MySQL server, retrying in 10 seconds")
+            sleep(10)
+            conn.ping()
+        return conn
 
     def query(self, query, args=None):
         """


### PR DESCRIPTION
Currently, the Poller service simply hangs when it looses the connection
to the MySQL server. With this patch, it pings the server before making
a request, which will automatically reconnect if the connection died. If
the new connection cannot be established, a second try is done after 10
seconds.

Whether 10 seconds and only retrying once obviously is up for debate, and could probably even be made configurable. So feedback is appreciated.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
