### PR TITLE
Relax validation for smseagle hostname

### DIFF
--- a/LibreNMS/Alert/Transport/Smseagle.php
+++ b/LibreNMS/Alert/Transport/Smseagle.php
@@ -64,9 +64,9 @@ class Smseagle extends Transport
         return [
             'config' => [
                 [
-                    'title' => 'SMSEagle URL',
+                    'title' => 'SMSEagle Host',
                     'name' => 'smseagle-url',
-                    'descr' => 'SMSEagle URL',
+                    'descr' => 'SMSEagle Host',
                     'type' => 'text',
                 ],
                 [

--- a/LibreNMS/Alert/Transport/Smseagle.php
+++ b/LibreNMS/Alert/Transport/Smseagle.php
@@ -89,7 +89,7 @@ class Smseagle extends Transport
                 ],
             ],
             'validation' => [
-                'smseagle-url'     => 'required|url',
+                'smseagle-url'     => 'required|string',
                 'smseagle-user'    => 'required|string',
                 'smseagle-pass'    => 'required|string',
                 'smseagle-mobiles' => 'required',

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -415,7 +415,7 @@ Destination numbers are one per line, with no spaces. They can be in either loca
 
 | Config | Example |
 | ------ | ------- |
-| SMSEagle URL | ip.add.re.ss |
+| SMSEagle Host | ip.add.re.ss |
 | User | smseagle_user |
 | Password | smseagle_user_password |
 | Mobiles | +3534567890 |


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

When trying to setup the smseagle transport, the validator was checking for a vaild URL in the form validation. However, the transport expects a hostname not a URL because it constructs the URL itself: https://github.com/librenms/librenms/blob/5e1994a39d268382ac99bd4e0cc01fbe1fc05547/LibreNMS/Alert/Transport/Smseagle.php#L47

This pull request relaxes the validation to accept a string so IP addresses and Hostnames are accepted by the form.