### PR TITLE
Store IPv4 networks as network address and fix address search page showing networks not addresses

### DIFF
--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -17,7 +17,8 @@ foreach ($vrfs_lite_cisco as $vrf) {
         list($oid,$ifIndex) = explode(' ', $data);
         $mask               = trim(snmp_get($device, "ipAdEntNetMask.$oid", '-Oqv', 'IP-MIB'));
         $cidr               = IPv4::netmask2cidr($mask);
-        $network            = "$oid/$cidr";
+        $ipv4               = new IPv4("$oid/$cidr");
+        $network            = $ipv4->getNetworkAddress() . '/' . $ipv4->cidr;
 
 
         if (dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ? AND `ifIndex` = ?', array($device['device_id'], $ifIndex)) != '0' && $oid != '0.0.0.0' && $oid != 'ipAdEntIfIndex') {

--- a/includes/html/table/address-search.inc.php
+++ b/includes/html/table/address-search.inc.php
@@ -85,11 +85,11 @@ foreach (dbFetchRows($sql, $param) as $interface) {
     $type  = humanmedia($interface['ifType']);
 
     if ($vars['search_type'] == 'ipv6') {
-        $address = (string)IP::parse($interface['ipv6_network'], true);
+        $address = (string)IP::parse($interface['ipv6_address'], true) . '/' . $interface['ipv6_prefixlen'];
     } elseif ($vars['search_type'] == 'mac') {
         $address = formatMac($interface['ifPhysAddress']);
     } else {
-        $address = (string)IP::parse($interface['ipv4_network'], true);
+        $address = (string)IP::parse($interface['ipv4_address'], true) . '/' . $interface['ipv4_prefixlen'];
     }
 
     if ($interface['in_errors'] > 0 || $interface['out_errors'] > 0) {


### PR DESCRIPTION
I am not sure how LibreNMS will handle it for existing addresses, possibly there needs to be some logic added to sort them out?

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
