### PR TITLE
Serial number and more robust OS version for Netgear switches

### DIFF
--- a/includes/polling/os/netgear.inc.php
+++ b/includes/polling/os/netgear.inc.php
@@ -1,9 +1,8 @@
 <?php
-
 // sysDescr.0 = XS712T ProSafe 12-Port 10 Gigabit Ethernet (10GbE) Smart Switch, 6.1.0.12, B6.1.0.1
 list($hardware, ) = explode(' ', $device['sysDescr']);
 list(,$version, ) = explode(',', $device['sysDescr']);
-if(!$version) {
+if (!$version) {
     $version = trim(snmp_get($device, 'entPhysicalSoftwareRev.1', '-OQv', 'ENTITY-MIB', ''), '"');
 }
 $serial = trim(snmp_get($device, 'entPhysicalSerialNum.1', '-OQv', 'ENTITY-MIB', ''), '"');

--- a/includes/polling/os/netgear.inc.php
+++ b/includes/polling/os/netgear.inc.php
@@ -3,3 +3,5 @@
 // sysDescr.0 = XS712T ProSafe 12-Port 10 Gigabit Ethernet (10GbE) Smart Switch, 6.1.0.12, B6.1.0.1
 list($hardware, ) = explode(' ', $device['sysDescr']);
 list(,$version, ) = explode(',', $device['sysDescr']);
+if(!$version) $version = trim(snmp_get($device, 'entPhysicalSoftwareRev.1', '-OQv', 'ENTITY-MIB', ''), '"');
+$serial = trim(snmp_get($device, 'entPhysicalSerialNum.1', '-OQv', 'ENTITY-MIB', ''), '"');

--- a/includes/polling/os/netgear.inc.php
+++ b/includes/polling/os/netgear.inc.php
@@ -3,5 +3,7 @@
 // sysDescr.0 = XS712T ProSafe 12-Port 10 Gigabit Ethernet (10GbE) Smart Switch, 6.1.0.12, B6.1.0.1
 list($hardware, ) = explode(' ', $device['sysDescr']);
 list(,$version, ) = explode(',', $device['sysDescr']);
-if(!$version) $version = trim(snmp_get($device, 'entPhysicalSoftwareRev.1', '-OQv', 'ENTITY-MIB', ''), '"');
+if(!$version) {
+    $version = trim(snmp_get($device, 'entPhysicalSoftwareRev.1', '-OQv', 'ENTITY-MIB', ''), '"');
+}
 $serial = trim(snmp_get($device, 'entPhysicalSerialNum.1', '-OQv', 'ENTITY-MIB', ''), '"');


### PR DESCRIPTION
Some Netgear switches don't report their software version in description, instead they report it in entPhysicalSoftwareRev. 

This PR also adds support for fetching serial number from entPhysicalSerialNum.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
