### PR TITLE
Cast alert ID to string for PD API

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -57,7 +57,7 @@ class Pagerduty extends Transport
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],
-            'dedup_key'    => $obj['alert_id'],
+            'dedup_key'    => (string)$obj['alert_id'],
             'payload'    => [
                 'custom_details'  => substr(implode(PHP_EOL, array_column($obj['faults'], 'string')), 0, 1020) . '....' ?: 'Test',
                 'source'   => $obj['hostname'],


### PR DESCRIPTION
This is a simple one.  The PagerDuty API expects the Alert ID to be a string, and currently it is not.  It seems that it may have been a change on PagerDuty's end to start enforcing the type as this _used_ to work, but it suddenly broke one day and I don't think it was because of LibreNMS.

PagerDuty docs reference: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
