### PR TITLE
Removed broken POE graphing code

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -351,7 +351,7 @@ if ($device['xdsl_count'] > '0') {
 if ($config['enable_ports_poe']) {
     // Code by OS device
 
-    if ($device['os'] == 'ios') {
+    if ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
         echo 'cpeExtPsePortEntry';
         $port_stats_poe = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', array(), 'CISCO-POWER-ETHERNET-EXT-MIB');
         $port_ent_to_if = snmpwalk_cache_oid($device, 'portIfIndex', array(), 'CISCO-STACK-MIB');

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -395,9 +395,10 @@ if ($config['enable_ports_poe']) {
             $port_stats[$if_id] = array_merge($port_stats[$if_id], $value);
         }
     } else {
-        //Any other device, generic polling
-        $port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
-        $port_stats = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', $port_stats, 'CISCO-POWER-ETHERNET-EXT-MIB');
+        //Any other device, there is no 'generic' polling available to graph POE port consumption
+        //the table below can only say if yes or no POE is currently enabled and active.
+        //nothing really helpful for the moment. 
+        //$port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
     }
 }
 

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -394,11 +394,6 @@ if ($config['enable_ports_poe']) {
             [$group_id, $if_id] = explode(".", $key);
             $port_stats[$if_id] = array_merge($port_stats[$if_id], $value);
         }
-    } else {
-        //Any other device, there is no 'generic' polling available to graph POE port consumption
-        //the table below can only say if yes or no POE is currently enabled and active.
-        //nothing really helpful for the moment. 
-        //$port_stats = snmpwalk_cache_oid($device, 'pethPsePortEntry', $port_stats, 'POWER-ETHERNET-MIB');
     }
 }
 

--- a/includes/polling/ports/port-poe.inc.php
+++ b/includes/polling/ports/port-poe.inc.php
@@ -59,24 +59,4 @@ if (($device['os'] == 'vrp')) {
         data_update($device, 'poe', $tags, $fields);
         echo 'PoE(IOS) ';
     }//end if
-} else {
-    //This is the legacy code, to be tested against devices. This code looks terribly broken. There is
-    //most probably no device that can show anything out of this ...
-
-    if ($this_port['dot3StatsIndex'] && $port['ifType'] == 'ethernetCsmacd') {
-        $upd = "$polled:".$port['cpeExtPsePortPwrAllocated'].':'.$port['cpeExtPsePortPwrAvailable'].':'.
-            $port['cpeExtPsePortPwrConsumption'].':'.$port['cpeExtPsePortMaxPwrDrawn'];
-
-        $fields = array(
-                'PortPwrAllocated'   => $port['cpeExtPsePortPwrAllocated'],
-                'PortPwrAvailable'   => $port['cpeExtPsePortPwrAvailable'],
-                'PortConsumption'    => $port['cpeExtPsePortPwrConsumption'],
-                'PortMaxPwrDrawn'    => $port['cpeExtPsePortMaxPwrDrawn'],
-                   );
-
-        $tags = compact('ifName', 'rrd_name', 'rrd_def');
-        data_update($device, 'poe', $tags, $fields);
-
-        echo 'PoE(generic) ';
-    }//end if
 }


### PR DESCRIPTION
Hello

Currently, there is no way to poll POE values and graph them with standard MIB. The only standard info we can get is "do we have POE available and active" but this information is not used in LibreNMS so far. 
The removed code did use some specific Cisco MIBS for the values, which obviously do not return any value for non Cisco devices. 
This PR is removing the code to avoid unnecessary polling of useless values. And also, currently, unnecessary creation of empty RRD (waste of space). 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
