### PR TITLE
Documentation: Fix broken links and anchors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -212,6 +212,7 @@ LibreNMS contributors:
 - Rémy Jacquin <remy@remyj.fr> (remyj38)
 - PipoCanaja <pipocanaja@gmail.com> [pipocanaja](https://github.com/pipocanaja/)
 - Tim de Boer <tim+github@tim427.net> (tim427)
+- Pavle Obradovic <pobradovic08@gmail.com> (pobradovic08)
 
 Observium was written by:
 - Adam Armstrong

--- a/doc/Alerting/Transports.md
+++ b/doc/Alerting/Transports.md
@@ -51,13 +51,13 @@ It is possible to configure as much label values as required in Alertmanager Opt
 ## API
 API transports definitions are a bit more complex than the E-Mail configuration.
 
-The URL can have the same placeholders as defined in the [Template-Syntax](Templates#syntax).
+The URL can have the same placeholders as defined in the [Template-Syntax](Templates.md#syntax).
 
 If the `Api Method` is `get`, all placeholders will be URL-Encoded.
 
 The API transport uses cURL to call the APIs, therefore you might need to install `php curl` to make it work.
 
-__Note__: it is highly recommended to define your own [Templates](Templates) when you want to use the API transport. The default template might exceed URL-length for GET requests and therefore cause all sorts of errors.
+__Note__: it is highly recommended to define your own [Templates](Templates.md) when you want to use the API transport. The default template might exceed URL-length for GET requests and therefore cause all sorts of errors.
 
 **Example:**
 

--- a/doc/Extensions/Fast-Ping-Check.md
+++ b/doc/Extensions/Fast-Ping-Check.md
@@ -11,7 +11,7 @@ Some users may want to know if devices stop responding to ping more quickly than
 to run ping checks as quickly as possible without increasing snmp load on your devices by switching to 1 minute polling.
 
 > **WARNING**: If you do not have an alert rule that alerts on device status, enabling this will be a waste of resources.
-> You can find one in the [Alert Rules Collection](../Alerting/Rules.md#Alert Rules Collection).
+> You can find one in the [Alert Rules Collection](../Alerting/Rules.md#alert-rules-collection).
                          
 
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -427,7 +427,7 @@ The varying options after that are to support the different transports.
 
 ### Alerting
 
-[Alerting](../Alerting/Rules.md)
+[Alerting](../Alerting/index.md)
 
 ### Billing
 


### PR DESCRIPTION
1. Fixed broken link in `Transports.md` that points to nonexistant:
`https://docs.librenms.org/Alerting/Transports/Templates#syntax` 
instead of:
`https://docs.librenms.org/Alerting/Templates/#syntax`

2. Changed Alerting link in `Configuration.md` to point to Alerting Intro instead of Alerting Rules.

3. Fixed broken anchor in `Fast-Ping-Check.md`

4. Took the chance to add myself to AUTHORS.md

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
