### PR TITLE
Ignore empty IPv4 addresses in discovery on buggy devices

### DIFF
--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -17,6 +17,9 @@ foreach ($vrfs_lite_cisco as $vrf) {
         list($oid,$ifIndex) = explode(' ', $data);
         $mask               = trim(snmp_get($device, "ipAdEntNetMask.$oid", '-Oqv', 'IP-MIB'));
         $cidr               = IPv4::netmask2cidr($mask);
+        if(!$oid || $cidr == 0) {
+            continue;
+        }
         $ipv4               = new IPv4("$oid/$cidr");
         $network            = $ipv4->getNetworkAddress() . '/' . $ipv4->cidr;
 

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -17,7 +17,7 @@ foreach ($vrfs_lite_cisco as $vrf) {
         list($oid,$ifIndex) = explode(' ', $data);
         $mask               = trim(snmp_get($device, "ipAdEntNetMask.$oid", '-Oqv', 'IP-MIB'));
         $cidr               = IPv4::netmask2cidr($mask);
-        if(!$oid || $cidr == 0) {
+        if (!$oid || $cidr == 0) {
             continue;
         }
         $ipv4               = new IPv4("$oid/$cidr");

--- a/includes/discovery/ipv4-addresses.inc.php
+++ b/includes/discovery/ipv4-addresses.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 use LibreNMS\Util\IPv4;
+use LibreNMS\Exceptions\InvalidIpException;
 
 if (key_exists('vrf_lite_cisco', $device) && (count($device['vrf_lite_cisco'])!= 0)) {
     $vrfs_lite_cisco = $device['vrf_lite_cisco'];
@@ -17,10 +18,11 @@ foreach ($vrfs_lite_cisco as $vrf) {
         list($oid,$ifIndex) = explode(' ', $data);
         $mask               = trim(snmp_get($device, "ipAdEntNetMask.$oid", '-Oqv', 'IP-MIB'));
         $cidr               = IPv4::netmask2cidr($mask);
-        if (!$oid || $cidr == 0) {
+        try {
+            $ipv4               = new IPv4("$oid/$cidr");
+        } catch (InvalidIpException $e) {
             continue;
         }
-        $ipv4               = new IPv4("$oid/$cidr");
         $network            = $ipv4->getNetworkAddress() . '/' . $ipv4->cidr;
 
 


### PR DESCRIPTION
Reported on Discord:

```
Error in ipv4-addresses module. /0 is not a valid ipv4 address
#0 /opt/librenms/includes/discovery/ipv4-addresses.inc.php(20): LibreNMS\Util\IPv4->__construct('/0')
#1 /opt/librenms/includes/discovery/functions.inc.php(179): include('/opt/librenms/i...')
#2 /opt/librenms/discovery.php(120): discover_device(Array, false)
#3 {main}
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
