### PR TITLE
Device groups list only related to the user permission

### DIFF
--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -214,13 +214,22 @@ function GetDevicesFromGroup($group_id, $nested = false, $full = '')
 }//end GetDevicesFromGroup()
 
 /**
- * Get all Device-Groups
+ * Get all the Device groups which the decive are associated to the current user
  * @return array
  */
 function GetDeviceGroups()
 {
-    return dbFetchRows('SELECT * FROM device_groups ORDER BY name');
-}//end GetDeviceGroups()
+    $user_id = '';
+    
+    if ((LegacyAuth::user()->hasGlobalRead()) or (LegacyAuth::user()->isAdmin())) {
+        return dbFetchRows('SELECT * FROM device_groups ORDER BY name');
+    }
+    else {
+        $user = (LegacyAuth::id());
+        return dbFetchRows("SELECT d.* from device_groups d join device_group_device d2 join devices_perms d1 WHERE d.id = d2.device_group_id and d2.device_id = d1.device_id and d1.user_id = {$user_id}");
+    }
+}
+//end GetDeviceGroups()
 
 /**
  * Run the group queries again to get fresh list of groups for this device

--- a/includes/device-groups.inc.php
+++ b/includes/device-groups.inc.php
@@ -225,7 +225,7 @@ function GetDeviceGroups()
         return dbFetchRows('SELECT * FROM device_groups ORDER BY name');
     }
     else {
-        $user = (LegacyAuth::id());
+        $user_id = (LegacyAuth::id());
         return dbFetchRows("SELECT d.* from device_groups d join device_group_device d2 join devices_perms d1 WHERE d.id = d2.device_group_id and d2.device_id = d1.device_id and d1.user_id = {$user_id}");
     }
 }


### PR DESCRIPTION
Modify the function GetDeviceGroups() to return the Device group list only according to the current user. This prevent to list a device group, if doesn't contain any device allowed to access.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
