### PR TITLE
Split install steps into git clone and composer install

### DIFF
--- a/doc/Developing/Getting-Started.md
+++ b/doc/Developing/Getting-Started.md
@@ -14,7 +14,7 @@ Possible options:
  
 ### Set up your development git clone
  1. Follow the [documentation on using git](Using-Git.md)
- 2. Install development dependencies `./composer_wrapper.php install`
+ 2. Install development dependencies `./scripts/composer_wrapper.php install`
  3. Set variables in .env, including database settings.  Which could be a local or remote MySQL server including your production DB.
 ```dotenv
 APP_ENV=local

--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -17,10 +17,23 @@ path: blob/master/doc/
     useradd librenms -d /opt/librenms -M -r
     usermod -a -G librenms apache
 
-#### Install LibreNMS
+#### Download LibreNMS
 
     cd /opt
-    composer create-project --no-dev --keep-vcs librenms/librenms librenms dev-master
+    git clone https://github.com/librenms/librenms.git
+    
+#### Set permissions
+
+    chown -R librenms:librenms /opt/librenms
+    chmod 770 /opt/librenms
+    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+
+#### Install PHP dependencies
+
+    su - librenms
+    ./composer_wrapper.php install --no-dev
+    exit
 
 ## DB Server ##
 
@@ -163,12 +176,6 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
 LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
 
     cp /opt/librenms/misc/librenms.logrotate /etc/logrotate.d/librenms
-
-### Set permissions
-
-    chown -R librenms:librenms /opt/librenms
-    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
-    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
 
 ## Web installer ##
 

--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -32,7 +32,7 @@ path: blob/master/doc/
 #### Install PHP dependencies
 
     su - librenms
-    ./composer_wrapper.php install --no-dev
+    ./scripts/composer_wrapper.php install --no-dev
     exit
 
 ## DB Server ##

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -33,7 +33,7 @@ path: blob/master/doc/
 #### Install PHP dependencies
 
     su - librenms
-    ./composer_wrapper.php install --no-dev
+    ./scripts/composer_wrapper.php install --no-dev
     exit
 
 ## DB Server ##

--- a/doc/Installation/Installation-CentOS-7-Nginx.md
+++ b/doc/Installation/Installation-CentOS-7-Nginx.md
@@ -20,7 +20,21 @@ path: blob/master/doc/
 #### Download LibreNMS
 
     cd /opt
-    composer create-project --no-dev --keep-vcs librenms/librenms librenms dev-master
+    git clone https://github.com/librenms/librenms.git
+    
+#### Set permissions
+
+    chown -R librenms:librenms /opt/librenms
+    chmod 770 /opt/librenms
+    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+    chgrp apache /var/lib/php/session/
+
+#### Install PHP dependencies
+
+    su - librenms
+    ./composer_wrapper.php install --no-dev
+    exit
 
 ## DB Server ##
 
@@ -193,13 +207,6 @@ Edit the text which says `RANDOMSTRINGGOESHERE` and set your own community strin
 LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large and be rotated out.  To rotate out the old logs you can use the provided logrotate config file:
 
     cp /opt/librenms/misc/librenms.logrotate /etc/logrotate.d/librenms
-
-### Set permissions
-
-    chown -R librenms:librenms /opt/librenms
-    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
-    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
-    chgrp apache /var/lib/php/session/
 
 ## Web installer ##
 

--- a/doc/Installation/Installation-Ubuntu-1804-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1804-Apache.md
@@ -15,11 +15,23 @@ path: blob/master/doc/
     useradd librenms -d /opt/librenms -M -r
     usermod -a -G librenms www-data
 
-#### Install LibreNMS
+#### Download LibreNMS
 
     cd /opt
-    composer create-project --no-dev --keep-vcs librenms/librenms librenms dev-master
+    git clone https://github.com/librenms/librenms.git
+    
+#### Set permissions
 
+    chown -R librenms:librenms /opt/librenms
+    chmod 770 /opt/librenms
+    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+
+#### Install PHP dependencies
+
+    su - librenms
+    ./composer_wrapper.php install --no-dev
+    exit
 
 ## DB Server ##
 
@@ -109,11 +121,6 @@ LibreNMS keeps logs in `/opt/librenms/logs`. Over time these can become large an
 
     cp /opt/librenms/misc/librenms.logrotate /etc/logrotate.d/librenms
 
-### Set permissions
-
-    chown -R librenms:librenms /opt/librenms
-    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
-    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
 
 ## Web installer ##
 

--- a/doc/Installation/Installation-Ubuntu-1804-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1804-Apache.md
@@ -30,7 +30,7 @@ path: blob/master/doc/
 #### Install PHP dependencies
 
     su - librenms
-    ./composer_wrapper.php install --no-dev
+    ./scripts/composer_wrapper.php install --no-dev
     exit
 
 ## DB Server ##

--- a/doc/Installation/Installation-Ubuntu-1804-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1804-Nginx.md
@@ -15,10 +15,23 @@ path: blob/master/doc/
     useradd librenms -d /opt/librenms -M -r
     usermod -a -G librenms www-data
 
-#### Install LibreNMS
+#### Download LibreNMS
 
     cd /opt
-    composer create-project --no-dev --keep-vcs librenms/librenms librenms dev-master
+    git clone https://github.com/librenms/librenms.git
+    
+#### Set permissions
+
+    chown -R librenms:librenms /opt/librenms
+    chmod 770 /opt/librenms
+    setfacl -d -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+    setfacl -R -m g::rwx /opt/librenms/rrd /opt/librenms/logs /opt/librenms/bootstrap/cache/ /opt/librenms/storage/
+
+#### Install PHP dependencies
+
+    su - librenms
+    ./composer_wrapper.php install --no-dev
+    exit
 
 ## DB Server ##
 

--- a/doc/Installation/Installation-Ubuntu-1804-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1804-Nginx.md
@@ -30,7 +30,7 @@ path: blob/master/doc/
 #### Install PHP dependencies
 
     su - librenms
-    ./composer_wrapper.php install --no-dev
+    ./scripts/composer_wrapper.php install --no-dev
     exit
 
 ## DB Server ##

--- a/doc/Installation/index.md
+++ b/doc/Installation/index.md
@@ -22,7 +22,7 @@ If you want to install manually then we have some documentation which should mak
 - [RHEL / CentOS 7 Nginx](http://docs.librenms.org/Installation/Installation-CentOS-7-Nginx/)
 
 ### Old Install Docs
-These install docs are longer updated and may result in an unsuccessful install.
+These install docs are no longer updated and may result in an unsuccessful install.
 
 - [Ubuntu 16.04 Apache](http://docs.librenms.org/Installation/Installation-Ubuntu-1604-Apache/)
 - [Ubuntu 16.04 Nginx](http://docs.librenms.org/Installation/Installation-Ubuntu-1604-Nginx/)


### PR DESCRIPTION
This gives the admin a little more knowledge about how to maintain the system, showing them composer_wrapper.php and su - librenms
They will get errors if composer_wrapper doesn't work because of a proxy or no internet connection

We lose stats on packagist.org (https://packagist.org/packages/librenms/librenms/stats)
If we wanted to keep stats, we could use:
```
COMPOSER_ALLOW_SUPERUSER=1 composer create-project --no-dev --no-install --keep-vcs librenms/librenms librenms dev-master
```
not sure that is worth it.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
