### PR TITLE
Fix power consumption detection on Dell servers

### DIFF
--- a/includes/discovery/sensors/power/dell.inc.php
+++ b/includes/discovery/sensors/power/dell.inc.php
@@ -24,7 +24,7 @@
  */
 
 $temp = snmpwalk_cache_multi_oid($device, 'amperageProbeTableEntry', [], 'MIB-Dell-10892');
-$cur_oid = '.1.3.6.1.4.1.674.10892.1.600.30.1.6.1.';
+$cur_oid = '.1.3.6.1.4.1.674.10892.1.600.30.1.6.';
 
 foreach ((array)$temp as $index => $entry) {
     $descr = $entry['amperageProbeLocationName'];


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

#### Description

This PR fixes the detection of power consumption on Dell servers when this information is exposed via SNMP (using Dell OpenManage).

The issue was caused by the base oid which had one spurious index `1` at the end; the generated oid related to the power consumption was then `.1.3.6.1.4.1.674.10892.1.600.30.1.6.1.1.3` instead of `.1.3.6.1.4.1.674.10892.1.600.30.1.6.1.3`.

The wrong oid was causing the poller to raise a warning (`Warning: A non-numeric value encountered in /opt/librenms/includes/polling/functions.inc.php on line 167`) leaving the graph always at zero.

Before:

```
SNMP['/usr/bin/snmpget' '-v2c' '-c' 'COMMUNITY' '-OUQnte' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/supermicro:/opt/librenms/mibs/dell' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.674.10892.1.600.30.1.6.1.1.3']

.*.4.1.674.10892.1.6*.1.1.3 = No Such Instance currently exists at this OID  

  

Checking (snmp) power System Board Pwr Consumption... 


Warning: A non-numeric value encountered in /opt/librenms/includes/polling/functions.inc.php on line 167

0 
```

After

```
SNMP['/usr/bin/snmpget' '-v2c' '-c' 'COMMUNITY' '-OUQnte' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/supermicro:/opt/librenms/mibs/dell' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.674.10892.1.600.30.1.6.1.3']

Checking (snmp) power System Board Pwr Consumption... 
196 
RRD[update /opt/librenms/rrd/wilson.gem.lan/sensor-power-dell-1.3.rrd N:196]
[RRD Disabled]
.*.4.1.674.10892.1.6*.1.3 = 196  
  

SQL[UPDATE `sensors` set `sensor_current`=?,`sensor_prev`=?,`lastupdate`=NOW() WHERE `sensor_class` = ? AND `sensor_id` = ? [196,0,"Power",219] 2.6ms] 
```
