### PR TITLE
Fix alert follow up for custom queries

### DIFF
--- a/includes/alerts.inc.php
+++ b/includes/alerts.inc.php
@@ -674,7 +674,7 @@ function loadAlerts($where)
     $alerts = [];
     foreach (dbFetchRows("SELECT alerts.id, alerts.device_id, alerts.rule_id, alerts.state, alerts.note, alerts.info FROM alerts WHERE $where") as $alert_status) {
         $alert = dbFetchRow(
-            'SELECT alert_log.id,alert_log.rule_id,alert_log.device_id,alert_log.state,alert_log.details,alert_log.time_logged,alert_rules.rule,alert_rules.severity,alert_rules.extra,alert_rules.name,alert_rules.builder FROM alert_log,alert_rules WHERE alert_log.rule_id = alert_rules.id && alert_log.device_id = ? && alert_log.rule_id = ? && alert_rules.disabled = 0 ORDER BY alert_log.id DESC LIMIT 1',
+            'SELECT alert_log.id,alert_log.rule_id,alert_log.device_id,alert_log.state,alert_log.details,alert_log.time_logged,alert_rules.rule,alert_rules.severity,alert_rules.extra,alert_rules.name,alert_rules.query,alert_rules.builder FROM alert_log,alert_rules WHERE alert_log.rule_id = alert_rules.id && alert_log.device_id = ? && alert_log.rule_id = ? && alert_rules.disabled = 0 ORDER BY alert_log.id DESC LIMIT 1',
             array($alert_status['device_id'], $alert_status['rule_id'])
         );
 


### PR DESCRIPTION
`RunFollowUp` checks if there is a custom sql query attached to the alert and uses this before invoking `GenSQL` to build the query. However, the custom query column was not included when selecting
alerts so the `GenSQL` function was always invoked.

This patch includes the alert_rules.query in the `loadAlerts` function used by `RunFollowUp`.


See `$alert['query']` is checked here: https://github.com/librenms/librenms/blob/master/includes/alerts.inc.php#L630-L632
But this will never be set as it's not included in the `loadAlerts` query

This only caused a problem because I built a custom query which returned multiple rows, where the number of rows returned represents the number of instances of the alert on the device. This fix also allows the libre to detect if an alert has got better/worse when using a custom query.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
