### PR TITLE
Don't indicate that host is always up on uptime counter when host is ignored

### DIFF
--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -318,6 +318,8 @@ if ($format == "graph") {
                         return row.uptime;
                     } else if (row.status == 'down') {
                         return "<span class='alert-status-small label-danger'></span><span>" + row.uptime + "</span>";
+                    } else if (row.status == 'ignore') {
+                        return "<span class='alert-status-small label-default'></span><span>" + row.uptime + "</span>";
                     } else {
                         return "<span class='alert-status-small label-success'></span><span>" + row.uptime + "</span>";
                     }


### PR DESCRIPTION
When host is ignored, near up/down counter, don't show green, instead show gray.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
