### PR TITLE
Don't show warning when ignored device is online (pingable)

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -144,7 +144,7 @@ class DeviceController extends TableController
         }
 
         if ($device->ignore) {
-            return $device->status ? 'label-warning' : 'label-default';
+            return 'label-default';
         }
 
         return $device->status ? 'label-success' : 'label-danger';

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -36,8 +36,6 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
     } else {
         if ($device['status'] == '0') {
             $alert_class = 'alert-danger';
-        } elseif ($device['ignore'] == '1') {
-            $alert_class = 'alert-warning';
         }
     }
 

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -33,7 +33,7 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
     $alert_class = '';
     if ($device['disabled'] == '1' || $device['ignore'] == '1') {
         $alert_class = 'alert-info';
-    } else if ($device['status'] == '0') {
+    } elseif ($device['status'] == '0') {
         $alert_class = 'alert-danger';
     }
 

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -31,12 +31,10 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
     $component_count = $component->getComponentCount($device['device_id']);
 
     $alert_class = '';
-    if ($device['disabled'] == '1') {
+    if ($device['disabled'] == '1' || $device['ignore'] == '1') {
         $alert_class = 'alert-info';
-    } else {
-        if ($device['status'] == '0') {
-            $alert_class = 'alert-danger';
-        }
+    } else if ($device['status'] == '0') {
+        $alert_class = 'alert-danger';
     }
 
     echo '<div class="panel panel-default">';


### PR DESCRIPTION
Current logic seems counter-intuitive - it shows gray color when ignored device is down and warning when ignored device is up. User should definitely not be shown warning when device is online - if anything it should be shown when device is offline, however that seems incorrect too since they chose to ignore this device. Further, device name is color-coded gray when ignored device is offline and green when ignored device is online which doesn't match with gray offline and yellow online colors for alert- and label- elements. This PR makes it so that ignored device is always shown as gray for label- and alert- elements in WebUI.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
