### PR TITLE
WEB UI Changed color of Non Unicast Packets

### DIFF
--- a/includes/html/graphs/port/nupkts.inc.php
+++ b/includes/html/graphs/port/nupkts.inc.php
@@ -16,16 +16,16 @@ if (1) {
     $rrd_list[2]['ds_in']           = 'INBROADCASTPKTS';
     $rrd_list[2]['ds_out']          = 'OUTBROADCASTPKTS';
     $rrd_list[2]['descr']           = 'Broadcast';
-    $rrd_list[2]['colour_area_in']  = 'aa37BB';
-    $rrd_list[2]['colour_area_out'] = 'ee9D88';
+    $rrd_list[2]['colour_area_in']  = '085F63';
+    $rrd_list[2]['colour_area_out'] = '49BEB7';
 
     $rrd_list[4]['filename']        = $rrd_file;
     $rrd_list[4]['descr']           = $int['ifDescr'];
     $rrd_list[4]['ds_in']           = 'INMULTICASTPKTS';
     $rrd_list[4]['ds_out']          = 'OUTMULTICASTPKTS';
     $rrd_list[4]['descr']           = 'Multicast';
-    $rrd_list[4]['colour_area_in']  = '905090';
-    $rrd_list[4]['colour_area_out'] = 'c0a060';
+    $rrd_list[4]['colour_area_in']  = 'FACF5A';
+    $rrd_list[4]['colour_area_out'] = 'FF5959';
 
     $units       = '';
     $units_descr = 'Packets';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

I believe that this PR helps to see better Non Unicast Packets on Port view.
Maybe we can use other colors maybe not.

Before:
![image](https://user-images.githubusercontent.com/36922215/58695867-b2d2c000-8396-11e9-9bbf-4286450421cb.png)

After:
![image](https://user-images.githubusercontent.com/36922215/58695633-27f1c580-8396-11e9-8c4e-ba6ebb4265ac.png)
