### PR TITLE
Add overlib link css class for changing background color - Update Url.php

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -252,7 +252,7 @@ class Url
 
     public static function overlibLink($url, $text, $contents, $class = null)
     {
-        $contents = "<div class=\'lib_overlib\'>" . $contents . '</div>';
+        $contents = "<div class=\'overlib-contents\'>" . $contents . '</div>';
         $contents = str_replace('"', "\'", $contents);
         if ($class === null) {
             $output = '<a href="' . $url . '"';

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -252,7 +252,7 @@ class Url
 
     public static function overlibLink($url, $text, $contents, $class = null)
     {
-        $contents = "<div style=\'background-color: #FFFFFF;\'>" . $contents . '</div>';
+        $contents = "<div class=\'lib_overlib\'>" . $contents . '</div>';
         $contents = str_replace('"', "\'", $contents);
         if ($class === null) {
             $output = '<a href="' . $url . '"';

--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1534,6 +1534,10 @@ tr.search:nth-child(odd) {
   font-weight: bold;
 }
 
+.overlib-contents {
+    background-color: #fff;
+}
+
 .minigraph-image {
   margin: 2px;
 }

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -40,7 +40,7 @@
     <link href="{{ asset('css/select2.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('css/select2-bootstrap.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet" type="text/css" />
-    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=20190123" rel="stylesheet" type="text/css" />
+    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=20190603" rel="stylesheet" type="text/css" />
     <link href="{{ asset('css/' . LibreNMS\Config::get('site_style', 'light') . '.css?ver=632417642') }}" rel="stylesheet" type="text/css" />
     @foreach(LibreNMS\Config::get('webui.custom_css', []) as $custom_css)
         <link href="{{ $custom_css }}" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Add css class "lib_overlib" onmouserover event for "overlib" link, easyer to change color of background ex.: for a dark theme vs bg color hardcoded

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
