### PR TITLE
Add class for overlib background 

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1534,6 +1534,10 @@ tr.search:nth-child(odd) {
   font-weight: bold;
 }
 
+.lib_overlib {
+    background-color: #fff;
+}
+
 .minigraph-image {
   margin: 2px;
 }


### PR DESCRIPTION
Add class for overlib background  see https://github.com/librenms/librenms/pull/10300
class css for changing the background color of overlib instead of hardcoded color

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
