### PR TITLE
Enhance Prometheus tags processing

### DIFF
--- a/includes/prometheus.inc.php
+++ b/includes/prometheus.inc.php
@@ -23,19 +23,19 @@ function prometheus_push($device, $measurement, $tags, $fields)
                 set_curl_proxy($ch);
                 $vals = "";
 
-								# Format Prometheus tags for inclusion with metrics in the body
-								#
-								$promtags = array('measurement="' . $measurement . '"');
+                # Format Prometheus tags for inclusion with metrics in the body
+                #
+                $promtags = array('measurement="' . $measurement . '"');
                 foreach ($tags as $t => $v) {
                     if ($v !== null) {
                         $promtags[] = $t . '="' . $v .'"';
                     }
                 }
-								$tagline = "{" . join(",", $promtags) . "}";
+                $tagline = "{" . join(",", $promtags) . "}";
 
 
-								# Output metrics with their tags
-								#
+                # Output metrics with their tags
+                #
                 foreach ($fields as $k => $v) {
                     if ($v !== null) {
                         $vals = $vals . "$k$tagline $v\n";

--- a/includes/prometheus.inc.php
+++ b/includes/prometheus.inc.php
@@ -22,22 +22,27 @@ function prometheus_push($device, $measurement, $tags, $fields)
 
                 set_curl_proxy($ch);
                 $vals = "";
-                $promtags = "/measurement/".$measurement;
 
+								# Format Prometheus tags for inclusion with metrics in the body
+								#
+								$promtags = array('measurement="' . $measurement . '"');
+                foreach ($tags as $t => $v) {
+                    if ($v !== null) {
+                        $promtags[] = $t . '="' . $v .'"';
+                    }
+                }
+								$tagline = "{" . join(",", $promtags) . "}";
+
+
+								# Output metrics with their tags
+								#
                 foreach ($fields as $k => $v) {
                     if ($v !== null) {
-                        $vals = $vals . "$k $v\n";
+                        $vals = $vals . "$k$tagline $v\n";
                     }
                 }
                 
-                foreach ($tags as $t => $v) {
-                    if ($v !== null) {
-                        $v = urlencode(str_replace("/", "-", $v));
-                        $promtags = $promtags . "/$t/$v";
-                    }
-                }
-
-                $promurl = $config['prometheus']['url'].'/metrics/job/'.$config['prometheus']['job'].'/instance/'.$device['hostname'].$promtags;
+                $promurl = $config['prometheus']['url'].'/metrics/job/'.$config['prometheus']['job'].'/instance/'.$device['hostname'];
         
                 d_echo("\nPrometheus data:\n");
                 d_echo($measurement);

--- a/includes/prometheus.inc.php
+++ b/includes/prometheus.inc.php
@@ -32,12 +32,12 @@ function prometheus_push($device, $measurement, $tags, $fields)
                 
                 foreach ($tags as $t => $v) {
                     if ($v !== null) {
+                        $v = urlencode(str_replace("/", "-", $v));
                         $promtags = $promtags . "/$t/$v";
                     }
                 }
 
                 $promurl = $config['prometheus']['url'].'/metrics/job/'.$config['prometheus']['job'].'/instance/'.$device['hostname'].$promtags;
-                $promurl = str_replace(" ", "-", $promurl); // Prometheus doesn't handle tags with spaces in url
         
                 d_echo("\nPrometheus data:\n");
                 d_echo($measurement);


### PR DESCRIPTION
Tags provided via URLpath encoded values are now properly encoded.

Also, prometheus pushgateway can't handle `/` in tags (which is frequent in cisco interface names). This applies only when using this method (and the `%2f` tricks can't be done here either, because of Go's URL lib). All slashes are now replaced with `-`.

Proper solution would be to provide all the tags/labels in the request body with the metrics, ie:

```
INOCTETS{measurement="ports",ifName="Gi1/0/1",...} 10000
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
