### PR TITLE
Fixed Junos port/vlan relationships for els and non-els based software

### DIFF
--- a/includes/discovery/vlans/junos.inc.php
+++ b/includes/discovery/vlans/junos.inc.php
@@ -10,19 +10,58 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
     $vlans        = snmpwalk_cache_oid($device, 'jnxExVlanName', array(), 'JUNIPER-VLAN-MIB');
     if (empty($vlans)) {
         $vlans      = snmpwalk_cache_oid($device, 'jnxL2aldVlanName', array(), 'JUNIPER-L2ALD-MIB');
-        $tagoruntag = snmpwalk_cache_oid($device, 'jnxL2aldVlanTag', array(), 'JUNIPER-L2ALD-MIB', null, ['-OQUs', '--hexOutputLength=0']);
+        $vlan_tag   = snmpwalk_cache_oid($device, 'jnxL2aldVlanTag', array(), 'JUNIPER-L2ALD-MIB', null, ['-OQUs', '--hexOutputLength=0']);
         $untag      = snmpwalk_cache_oid($device, 'jnxExVlanPortTagness', array(), 'JUNIPER-VLAN-MIB', null, ['-OQeUs', '--hexOutputLength=0']);
         $tmp_tag    = 'jnxL2aldVlanTag';
         $tmp_name   = 'jnxL2aldVlanName';
     } else {
-        $tagoruntag = snmpwalk_cache_oid($device, 'jnxExVlanTag', array(), 'JUNIPER-VLAN-MIB', null, ['-OQUs', '--hexOutputLength=0']);
+        $vlan_tag   = snmpwalk_cache_oid($device, 'jnxExVlanTag', array(), 'JUNIPER-VLAN-MIB', null, ['-OQUs', '--hexOutputLength=0']);
         $untag      = snmpwalk_cache_oid($device, 'jnxExVlanPortTagness', array(), 'JUNIPER-VLAN-MIB', null, ['-OQeUs', '--hexOutputLength=0']);
         $tmp_tag    = 'jnxExVlanTag';
         $tmp_name   = 'jnxExVlanName';
     }
 
-    foreach ($vlans as $vlan_id => $vlan) {
-        $vlan_id = $tagoruntag[$vlan_id][$tmp_tag];
+    if (empty($untag)) {
+	# If $untag is empty, device is based on Junipers ELS software
+    	$untag       = snmpwalk_cache_oid($device, 'dot1qVlanStaticUntaggedPorts', array(), 'Q-BRIDGE-MIB', null, ['-OQUs', '--hexOutputLength=0']);
+	$taganduntag = snmpwalk_cache_oid($device, 'dot1qVlanStaticEgressPorts', array(), 'Q-BRIDGE-MIB', null, ['-OQUs', '--hexOutputLength=0']);
+	$vlan_tag    = snmpwalk_cache_oid($device, 'jnxL2aldVlanTag', array(), 'JUNIPER-L2ALD-MIB', null, ['-OQUs', '--hexOutputLength=0']);
+        $tmp_tag     = 'jnxL2aldVlanTag';
+	$tmp_name    = 'jnxL2aldVlanName'; 
+	$temp_vlan   = array();
+	foreach ($vlan_tag as $key => $value) {
+		$temp_vlan[$key] = $value['jnxL2aldVlanTag'];
+	}
+	#set all port vlan relationships to be tagged	
+	foreach ($taganduntag as $key => $taganduntag) {
+	    $vlan_index = array_search($key, $temp_vlan);
+	    $port_on_vlan = explode(',', $taganduntag['dot1qVlanStaticEgressPorts']);
+	    foreach ($port_on_vlan as $port) {
+                $tagness_by_vlan_index[$vlan_index][$base_to_index[$port]]['tag'] = 0;
+		unset($tagness_by_vlan_index[$vlan_index]['']);
+	    }
+        }
+	# correct all untagged ports to be untagged
+	foreach ($untag as $key => $untag) {
+            $vlan_index = array_search($key, $temp_vlan);
+            $port_on_vlan = explode(',', $untag['dot1qVlanStaticUntaggedPorts']);
+            foreach ($port_on_vlan as $port) {
+		$tagness_by_vlan_index[$vlan_index][$base_to_index[$port]]['tag'] = 1;
+		unset($tagness_by_vlan_index[$vlan_index]['']);
+            }
+	}
+    } else {
+        foreach ($untag as $key => $tagness) {
+    	    $key = explode('.', $key);
+            if ($tagness['jnxExVlanPortTagness'] == 2) {
+                $tagness_by_vlan_index[$key[0]][$base_to_index[$key[1]]]['tag'] = 1;
+            } else {
+    	        $tagness_by_vlan_index[$key[0]][$base_to_index[$key[1]]]['tag'] = 0;
+            }
+        }
+    }
+    foreach ($vlans as $vlan_index => $vlan) {
+        $vlan_id = $vlan_tag[$vlan_index][$tmp_tag];
         d_echo(" $vlan_id");
         if (is_array($vlans_db[$vtpdomain_id][$vlan_id])) {
             $vlan_data = $vlans_db[$vtpdomain_id][$vlan_id];
@@ -44,13 +83,9 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
             ), 'vlans');
             echo '+';
         }
-
         $device['vlans'][$vtpdomain_id][$vlan_id] = $vlan_id;
-        $egress_ids = $tagoruntag[$vlan_id][$tmp_tag];
-
-        foreach ($egress_ids as $port_id) {
-            $ifIndex = $base_to_index[$port_id];
-            $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = $untagged_ids;
-        }
+        foreach ($tagness_by_vlan_index[$vlan_index] as $ifIndex => $tag) {
+	        $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = $tag['tag'];
+	}
     }
 }


### PR DESCRIPTION
Hi,

i tried to fix port / vlan relationship detection for juniper based devices, as it wasnt working. For non-els based software it was only detecting untagged ports and for els based software just vlans. 
Hopefully it will met all requirements, as i'm not a professional developer.

Result:
![Uploading Bildschirmfoto 2019-06-07 um 14.06.18.png…]()



DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
