### PR TITLE
Check correct path for config in the installer

### DIFF
--- a/html/install.php
+++ b/html/install.php
@@ -80,7 +80,7 @@ if ($stage == 4) {
     }
 } elseif ($stage == 6) {
     // If we get here then let's do some final checks.
-    if (!file_exists("config.php") && !file_exists("{$librenms_dir}/config.php")) {
+    if (!file_exists("{$librenms_dir}/config.php")) {
         // config.php file doesn't exist. go back to that stage
         $msg = "config.php still doesn't exist";
         $stage = 5;
@@ -394,7 +394,7 @@ $config_file = <<<"EOD"
 #\$config\['update'\] = 0;  # uncomment to completely disable updates
 EOD;
 
-if (!file_exists("config.php") && !file_exists("{$librenms_dir}/config.php")) {
+if (!file_exists("{$librenms_dir}/config.php")) {
     $conf = fopen("config.php", 'w');
     if ($conf != false) {
         if (fwrite($conf, "<?php\n") === false) {

--- a/html/install.php
+++ b/html/install.php
@@ -2,9 +2,11 @@
 use LibreNMS\Authentication\LegacyAuth;
 
 session_start();
+$librenms_dir = realpath(__DIR__ . '/..');
+
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;
-} elseif (!file_exists("config.php") && !file_exists('../config.php')) {
+} elseif (!file_exists("config.php") && !file_exists("{$librenms_dir}/config.php")) {
     $allowed_vars = array('stage','build-ok','dbhost','dbuser','dbpass','dbname','dbport','dbsocket','add_user','add_pass','add_email');
     foreach ($allowed_vars as $allowed) {
         if (isset($_POST[$allowed])) {
@@ -16,7 +18,7 @@ if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
 $stage = isset($_POST['stage']) ? $_POST['stage'] : 0;
 
 // Before we do anything, if we see config.php, redirect back to the homepage.
-if ((file_exists('../config.php') || file_exists('config.php')) && $stage != 6) {
+if ((file_exists('config.php') || file_exists("{$librenms_dir}/config.php")) && $stage != 6) {
     unset($_SESSION['stage']);
     header("Location: /");
     exit;
@@ -78,7 +80,7 @@ if ($stage == 4) {
     }
 } elseif ($stage == 6) {
     // If we get here then let's do some final checks.
-    if (!file_exists("config.php") && !file_exists('../config.php')) {
+    if (!file_exists("config.php") && !file_exists("{$librenms_dir}/config.php")) {
         // config.php file doesn't exist. go back to that stage
         $msg = "config.php still doesn't exist";
         $stage = 5;
@@ -392,7 +394,7 @@ $config_file = <<<"EOD"
 #\$config\['update'\] = 0;  # uncomment to completely disable updates
 EOD;
 
-if (!file_exists("config.php") && !file_exists('../config.php')) {
+if (!file_exists("config.php") && !file_exists("{$librenms_dir}/config.php")) {
     $conf = fopen("config.php", 'w');
     if ($conf != false) {
         if (fwrite($conf, "<?php\n") === false) {

--- a/html/install.php
+++ b/html/install.php
@@ -4,7 +4,7 @@ use LibreNMS\Authentication\LegacyAuth;
 session_start();
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;
-} elseif (!file_exists("config.php")) {
+} elseif (!file_exists("config.php") && !file_exists('../config.php')) {
     $allowed_vars = array('stage','build-ok','dbhost','dbuser','dbpass','dbname','dbport','dbsocket','add_user','add_pass','add_email');
     foreach ($allowed_vars as $allowed) {
         if (isset($_POST[$allowed])) {
@@ -16,7 +16,7 @@ if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
 $stage = isset($_POST['stage']) ? $_POST['stage'] : 0;
 
 // Before we do anything, if we see config.php, redirect back to the homepage.
-if (file_exists('config.php') && $stage != 6) {
+if ((file_exists('../config.php') || file_exists('config.php')) && $stage != 6) {
     unset($_SESSION['stage']);
     header("Location: /");
     exit;
@@ -78,7 +78,7 @@ if ($stage == 4) {
     }
 } elseif ($stage == 6) {
     // If we get here then let's do some final checks.
-    if (!file_exists("config.php")) {
+    if (!file_exists("config.php") && !file_exists('../config.php')) {
         // config.php file doesn't exist. go back to that stage
         $msg = "config.php still doesn't exist";
         $stage = 5;
@@ -392,7 +392,7 @@ $config_file = <<<"EOD"
 #\$config\['update'\] = 0;  # uncomment to completely disable updates
 EOD;
 
-if (!file_exists("config.php")) {
+if (!file_exists("config.php") && !file_exists('../config.php')) {
     $conf = fopen("config.php", 'w');
     if ($conf != false) {
         if (fwrite($conf, "<?php\n") === false) {

--- a/html/install.php
+++ b/html/install.php
@@ -6,7 +6,7 @@ $librenms_dir = realpath(__DIR__ . '/..');
 
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;
-} elseif (!file_exists("config.php") && !file_exists("{$librenms_dir}/config.php")) {
+} elseif (!file_exists("{$librenms_dir}/config.php")) {
     $allowed_vars = array('stage','build-ok','dbhost','dbuser','dbpass','dbname','dbport','dbsocket','add_user','add_pass','add_email');
     foreach ($allowed_vars as $allowed) {
         if (isset($_POST[$allowed])) {
@@ -18,7 +18,7 @@ if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
 $stage = isset($_POST['stage']) ? $_POST['stage'] : 0;
 
 // Before we do anything, if we see config.php, redirect back to the homepage.
-if ((file_exists('config.php') || file_exists("{$librenms_dir}/config.php")) && $stage != 6) {
+if (file_exists("{$librenms_dir}/config.php") && $stage != 6) {
     unset($_SESSION['stage']);
     header("Location: /");
     exit;


### PR DESCRIPTION
For older installations, install.php is still available for installations that have the configuration file in the parent directory. This PR fixes this.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
