### PR TITLE
Fix entity-state polling/discovery

### DIFF
--- a/includes/discovery/entity-state.inc.php
+++ b/includes/discovery/entity-state.inc.php
@@ -57,7 +57,7 @@ if (!empty($entPhysical)) {
 
             if (isset($db_states[$id])) { // update the db
                 $db_state = $db_states[$id];
-                $update = array_diff($state, $db_state);
+                $update = array_diff_assoc($state, $db_state);
 
                 if (!empty($update)) {
                     if (array_key_exists('entStateLastChanged', $update) && is_null($update['entStateLastChanged'])) {

--- a/includes/polling/entity-state.inc.php
+++ b/includes/polling/entity-state.inc.php
@@ -65,7 +65,7 @@ if (!empty($entityStatesIndexes)) {
                         ->format('Y-m-d H:i:s');
 
                     // check if anything has changed
-                    $update = array_diff(
+                    $update = array_diff_assoc(
                         $new_states,
                         dbFetchRow(
                             'SELECT * FROM entityState WHERE entity_state_id=?',


### PR DESCRIPTION
array_diff doesn't work as expected with associatiave arrays,
use array_diff_assoc instead

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
