### PR TITLE
Fix device groups not using cached joins sometimes

### DIFF
--- a/LibreNMS/Alerting/QueryBuilderFluentParser.php
+++ b/LibreNMS/Alerting/QueryBuilderFluentParser.php
@@ -152,7 +152,7 @@ class QueryBuilderFluentParser extends QueryBuilderParser
      */
     protected function joinTables($query)
     {
-        if (empty($this->builder['joins'])) {
+        if (!isset($this->builder['joins'])) {
             $this->generateJoins();
         }
 


### PR DESCRIPTION
for device groups that only reference the devices table

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
