### PR TITLE
Fix mysql bug in cisco-sla module

### DIFF
--- a/includes/discovery/cisco-sla.inc.php
+++ b/includes/discovery/cisco-sla.inc.php
@@ -84,7 +84,7 @@ if (Config::get('enable_sla') && $device['os_group'] == 'cisco') {
 
     // Mark all remaining SLAs as deleted
     foreach ($existing_slas as $existing_sla) {
-        dbUpdate(array(‘deleted’ => 1), 'slas', 'sla_id = ?', [$existing_sla]);
+        dbUpdate(['deleted' => 1], 'slas', 'sla_id = ?', [$existing_sla]);
         echo '-';
     }
 

--- a/includes/discovery/cisco-sla.inc.php
+++ b/includes/discovery/cisco-sla.inc.php
@@ -77,14 +77,14 @@ if (Config::get('enable_sla') && $device['os_group'] == 'cisco') {
             // Remove from the list
             $existing_slas = array_diff($existing_slas, array($sla_id));
 
-            dbUpdate($data, 'slas', '`sla_id` = :sla_id', array('sla_id' => $sla_id));
+            dbUpdate($data, ‘slas’, ’sla_id = ?’, array($sla_id));
             echo '.';
         }
     }//end foreach
 
     // Mark all remaining SLAs as deleted
     foreach ($existing_slas as $existing_sla) {
-        dbUpdate(array('deleted' => 1), 'slas', '`sla_id` = :sla_id', array('sla_id' => $existing_sla));
+        dbUpdate(array(‘deleted’ => 1), ‘slas’, ’sla_id = ?’, array($existing_sla));
         echo '-';
     }
 

--- a/includes/discovery/cisco-sla.inc.php
+++ b/includes/discovery/cisco-sla.inc.php
@@ -77,14 +77,14 @@ if (Config::get('enable_sla') && $device['os_group'] == 'cisco') {
             // Remove from the list
             $existing_slas = array_diff($existing_slas, array($sla_id));
 
-            dbUpdate($data, ‘slas’, ’sla_id = ?’, array($sla_id));
+            dbUpdate($data, 'slas', 'sla_id = ?', [$sla_id]);
             echo '.';
         }
     }//end foreach
 
     // Mark all remaining SLAs as deleted
     foreach ($existing_slas as $existing_sla) {
-        dbUpdate(array(‘deleted’ => 1), ‘slas’, ’sla_id = ?’, array($existing_sla));
+        dbUpdate(array(‘deleted’ => 1), 'slas', 'sla_id = ?', [$existing_sla]);
         echo '-';
     }
 


### PR DESCRIPTION
Fix SQL error during discovery of cisco-sla.
This error points to /opt/librenms/includes/discovery/cisco-sla.inc.php(80).

LOG ERROR:
[2019-06-18 07:07:01] production.ERROR: SQLSTATE[HY093]: Invalid parameter number: mixed named and positional parameters (SQL: UPDATE slas set device_id=39,sla_nr=1,owner=,tag=xxx.xxx.xxx.xxx,rtt_type=echo,status=1,opstatus=0,deleted=0 WHERE sla_id = 5) (SQL: UPDATE slas set device_id=39,sla_nr=1,owner=,tag=xxx.xxx.xxx.xxx,rtt_type=echo,status=1,opstatus=0,deleted=0 WHERE sla_id = 5)#0 /opt/librenms/includes/discover
y/cisco-sla.inc.php(80): dbUpdate(Array, ‘slas’, ’sla_id = :sla…’, Array)
#1 /opt/librenms/includes/discovery/functions.inc.php(179): include(’/opt/librenms/i…’)
#2 /opt/librenms/discovery.php(120): discover_device(Array, false)
#3 {main}

I suggest to change this lines of code in cisco-sla.inc.php to avoid this error:

line 80: dbUpdate($data, ‘slas’, ’sla_id = :sla_id’, array(‘sla_id’ => $sla_id));
change to: dbUpdate($data, ‘slas’, ’sla_id = ?’, array($sla_id));

line 87: dbUpdate(array(‘deleted’ => 1), ‘slas’, ’sla_id = :sla_id’, array(‘sla_id’ => $existing_sla));
change to: dbUpdate(array(‘deleted’ => 1), ‘slas’, ’sla_id = ?’, array($existing_sla));

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
