### PR TITLE
Added VRP SFPs thresholds and map entPhysical to ifIndexes

### DIFF
--- a/includes/definitions/discovery/vrp.yaml
+++ b/includes/definitions/discovery/vrp.yaml
@@ -21,6 +21,7 @@ modules:
             data:
                 - oid:
                     - entPhysicalName
+                    - hwEntityAdminStatus
                     - hwStackPortTable
         temperature:
             data:

--- a/includes/definitions/discovery/vrp.yaml
+++ b/includes/definitions/discovery/vrp.yaml
@@ -63,6 +63,10 @@ modules:
                             oid: hwEntityOpticalRxPower
                             op: '<='
                             value: 0
+                        -
+                            oid: hwEntityAdminStatus
+                            op: '='
+                            value: 12
                 -
                     oid: hwOpticalModuleInfoTable
                     value: hwEntityOpticalTxPower
@@ -78,6 +82,10 @@ modules:
                             oid: hwEntityOpticalTxPower
                             op: '<='
                             value: 0
+                        -
+                            oid: hwEntityAdminStatus
+                            op: '='
+                            value: 12
                 -
                     oid: hwOpticalModuleInfoTable
                     value: hwEntityOpticalLaneRxPower
@@ -88,11 +96,17 @@ modules:
                     index: 'lane-rx-{{ $index }}'
                     divisor: 100
                     group: '{{ $entPhysicalName }}'
+                    high_limit: hwEntityOpticalRxHighThreshold
+                    low_limit: hwEntityOpticalRxLowThreshold
                     skip_values:
                         -
                             oid: hwEntityOpticalRxPower
                             op: '>'
                             value: 0
+                        -
+                            oid: hwEntityAdminStatus
+                            op: '='
+                            value: 12
                 -
                     oid: hwOpticalModuleInfoTable
                     value: hwEntityOpticalLaneTxPower
@@ -102,11 +116,17 @@ modules:
                     entPhysicalIndex_measured: ports
                     index: 'lane-tx-{{ $index }}'
                     group: '{{ $entPhysicalName }}'
+                    high_limit: hwEntityOpticalTxHighThreshold
+                    low_limit: hwEntityOpticalTxLowThreshold
                     skip_values:
                         -
                             oid: hwEntityOpticalTxPower
                             op: '>'
                             value: 0
+                        -
+                            oid: hwEntityAdminStatus
+                            op: '='
+                            value: 12
                     divisor: 100
         voltage:
             data:

--- a/includes/discovery/entity-physical/entity-physical.inc.php
+++ b/includes/discovery/entity-physical/entity-physical.inc.php
@@ -117,6 +117,7 @@ if ($device['os'] == 'saf-cfm') {
 }
 
 foreach ($entity_array as $entPhysicalIndex => $entry) {
+    unset($ifIndex);
     if ($device['os'] == 'junos') {
         // Juniper's MIB doesn't have the same objects as the Entity MIB, so some values
         // are made up here.
@@ -190,6 +191,17 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
         $entPhysicalIsFRU        = $entry['entPhysicalIsFRU'];
         $entPhysicalAlias        = $entry['entPhysicalAlias'];
         $entPhysicalAssetID      = $entry['entPhysicalAssetID'];
+        if (array_key_exists('1', $entry) && array_key_exists('entAliasMappingIdentifier', $entry['1'])) {
+            $ifIndex = $entry['1']['entAliasMappingIdentifier'];
+        
+            if (!strpos($ifIndex, 'fIndex') || $ifIndex == '') {
+                unset($ifIndex);
+            } else {
+                $ifIndex_array = explode('.', $ifIndex);
+                $ifIndex       = $ifIndex_array[1];
+                unset($ifIndex_array);
+            }
+        }
     } else {
         $entPhysicalDescr        = array_key_exists('entPhysicalDescr', $entry)        ? $entry['entPhysicalDescr']        : '';
         $entPhysicalContainedIn  = array_key_exists('entPhysicalContainedIn', $entry)  ? $entry['entPhysicalContainedIn']  : '';
@@ -210,14 +222,13 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
 
     if (isset($entity_array[$entPhysicalIndex]['0']['entAliasMappingIdentifier'])) {
         $ifIndex = $entity_array[$entPhysicalIndex]['0']['entAliasMappingIdentifier'];
-    }
-
-    if (!strpos($ifIndex, 'fIndex') || $ifIndex == '') {
-        unset($ifIndex);
-    } else {
-        $ifIndex_array = explode('.', $ifIndex);
-        $ifIndex       = $ifIndex_array[1];
-        unset($ifIndex_array);
+        if (!strpos($ifIndex, 'fIndex') || $ifIndex == '') {
+            unset($ifIndex);
+        } else {
+            $ifIndex_array = explode('.', $ifIndex);
+            $ifIndex       = $ifIndex_array[1];
+            unset($ifIndex_array);
+        }
     }
 
     // List of real names for cisco entities

--- a/includes/discovery/entity-physical/entity-physical.inc.php
+++ b/includes/discovery/entity-physical/entity-physical.inc.php
@@ -191,8 +191,9 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
         $entPhysicalIsFRU        = $entry['entPhysicalIsFRU'];
         $entPhysicalAlias        = $entry['entPhysicalAlias'];
         $entPhysicalAssetID      = $entry['entPhysicalAssetID'];
-        
-        //VRP devices seems to use Logical '1' instead of '0' like the default code checks. 
+
+        //VRP devices seems to use LogicalEntity '1' instead of '0' like the default code checks.
+        //Standard code is still run after anyway.
         if (array_key_exists('1', $entry) && array_key_exists('entAliasMappingIdentifier', $entry['1'])) {
             $ifIndex = $entry['1']['entAliasMappingIdentifier'];
             if (!strpos($ifIndex, 'fIndex') || $ifIndex == '') {

--- a/includes/discovery/entity-physical/entity-physical.inc.php
+++ b/includes/discovery/entity-physical/entity-physical.inc.php
@@ -191,9 +191,10 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
         $entPhysicalIsFRU        = $entry['entPhysicalIsFRU'];
         $entPhysicalAlias        = $entry['entPhysicalAlias'];
         $entPhysicalAssetID      = $entry['entPhysicalAssetID'];
+        
+        //VRP devices seems to use Logical '1' instead of '0' like the default code checks. 
         if (array_key_exists('1', $entry) && array_key_exists('entAliasMappingIdentifier', $entry['1'])) {
             $ifIndex = $entry['1']['entAliasMappingIdentifier'];
-        
             if (!strpos($ifIndex, 'fIndex') || $ifIndex == '') {
                 unset($ifIndex);
             } else {

--- a/includes/discovery/entity-physical/entity-physical.inc.php
+++ b/includes/discovery/entity-physical/entity-physical.inc.php
@@ -194,15 +194,8 @@ foreach ($entity_array as $entPhysicalIndex => $entry) {
 
         //VRP devices seems to use LogicalEntity '1' instead of '0' like the default code checks.
         //Standard code is still run after anyway.
-        if (array_key_exists('1', $entry) && array_key_exists('entAliasMappingIdentifier', $entry['1'])) {
-            $ifIndex = $entry['1']['entAliasMappingIdentifier'];
-            if (!strpos($ifIndex, 'fIndex') || $ifIndex == '') {
-                unset($ifIndex);
-            } else {
-                $ifIndex_array = explode('.', $ifIndex);
-                $ifIndex       = $ifIndex_array[1];
-                unset($ifIndex_array);
-            }
+        if (isset($entry['1']['entAliasMappingIdentifier'])) {
+            $ifIndex = preg_replace('/ifIndex\.(\d+).*/', '$1', $entry['1']['entAliasMappingIdentifier']);
         }
     } else {
         $entPhysicalDescr        = array_key_exists('entPhysicalDescr', $entry)        ? $entry['entPhysicalDescr']        : '';

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -812,6 +812,9 @@ function discover_entity_physical(&$valid, $device, $entPhysicalIndex, $entPhysi
                 'entPhysicalAlias'        => $entPhysicalAlias,
                 'entPhysicalAssetID'      => $entPhysicalAssetID,
             );
+            if (!empty($ifIndex)) {
+                $update_data['ifIndex'] = $ifIndex;
+            }
             dbUpdate($update_data, 'entPhysical', '`device_id`=? AND `entPhysicalIndex`=?', array($device['device_id'], $entPhysicalIndex));
         }//end if
         $valid[$entPhysicalIndex] = 1;

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -811,10 +811,8 @@ function discover_entity_physical(&$valid, $device, $entPhysicalIndex, $entPhysi
                 'entPhysicalIsFRU'        => $entPhysicalIsFRU,
                 'entPhysicalAlias'        => $entPhysicalAlias,
                 'entPhysicalAssetID'      => $entPhysicalAssetID,
+                'ifIndex'                 => $ifIndex,
             );
-            if (!empty($ifIndex)) {
-                $update_data['ifIndex'] = $ifIndex;
-            }
             dbUpdate($update_data, 'entPhysical', '`device_id`=? AND `entPhysicalIndex`=?', array($device['device_id'], $entPhysicalIndex));
         }//end if
         $valid[$entPhysicalIndex] = 1;


### PR DESCRIPTION
A little bug appeared in the discover entity function, as the ifIndex was not taken into account during updates, only during initial insert.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
