### PR TITLE
Don't indicate that host is always up on uptime counter when host is ignored

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -348,8 +348,6 @@ class Device extends BaseModel
     {
         if ($this->disabled == 1) {
             return 'disabled';
-        } elseif ($this->ignore == 1) {
-            return 'ignore';
         } elseif ($this->status == 0) {
             return 'down';
         } else {

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -31,7 +31,7 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
     $component_count = $component->getComponentCount($device['device_id']);
 
     $alert_class = '';
-    if ($device['disabled'] == '1' || $device['ignore'] == '1') {
+    if ($device['disabled'] == '1') {
         $alert_class = 'alert-info';
     } elseif ($device['status'] == '0') {
         $alert_class = 'alert-danger';


### PR DESCRIPTION
Have statusName return proper status (up or down) even when device is ignored. Previously discussed at https://github.com/librenms/librenms/pull/10285

For what it's worth - these colors should be standardized somehow. On devices page gray is used for disabled devices and ignored near device name but gray near uptime never shows up (this is a bug actually, another PR will handle it). On the other hand, on Availability Map gray is for ignored and black for disabled.

Attached screenshots shows how weird these colors are
![chrome_2019-06-23_00-16-10](https://user-images.githubusercontent.com/1447794/59969387-72590300-954c-11e9-825a-52bfce840e68.png)
![chrome_2019-06-23_00-18-48](https://user-images.githubusercontent.com/1447794/59969389-7d139800-954c-11e9-94e6-fcf63d891d05.png)

Check https://github.com/librenms/librenms/pull/10366 for solution I propose to fix this.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
