### PR TITLE
Better handling disabled devices on devices list page

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -140,7 +140,7 @@ class DeviceController extends TableController
     private function getLabel($device)
     {
         if ($device->disabled) {
-            return 'label-default';
+            return 'blackbg';
         }
 
         if ($device->ignore) {

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -314,12 +314,14 @@ if ($format == "graph") {
                     return "<span>" + row.hostname + "</span>";
                 },
                 "uptime": function (column, row) {
-                    if (isNaN(row.uptime.charAt(0))) {
-                        return row.uptime;
-                    } else if (row.status == 'down') {
+                    if (row.status == 'down') {
                         return "<span class='alert-status-small label-danger'></span><span>" + row.uptime + "</span>";
-                    } else {
+                    } else if(row.status == 'up') {
                         return "<span class='alert-status-small label-success'></span><span>" + row.uptime + "</span>";
+                    } else if(row.status == 'disabled') {
+                        return '';
+                    } else {
+                        return row.uptime;
                     }
                 },
             },


### PR DESCRIPTION
Differentiates between ignored device (gray) and disabled device (black) and fixes disabled hosts showing always as up on uptime counter by removing uptime counter for disabled devices.

![chrome_2019-06-23_00-31-33](https://user-images.githubusercontent.com/1447794/59969493-4b033580-954e-11e9-92ee-bc3bf0fd4d2c.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
