### PR TITLE
Replace color indicator near uptime counter with colored text and change color of status indicator to black on disabled devices instead of gray (matches availablity map with show ignored/disabled enabled)

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -120,7 +120,7 @@ class DeviceController extends TableController
     {
         return [
             'extra' => $this->getLabel($device),
-            'status' => $device->statusName(),
+            'status' => $this->getStatus($device),
             'icon' => '<img src="' . asset($device->icon) . '" title="' . pathinfo($device->icon, PATHINFO_FILENAME) . '">',
             'hostname' => $this->getHostname($device),
             'metrics' => $this->getMetrics($device),
@@ -133,21 +133,42 @@ class DeviceController extends TableController
     }
 
     /**
+     * Get the device up/down status
+     * @param Device $device
+     * @return string
+     */
+    private function getStatus($device)
+    {
+        if ($device->disabled == 1) {
+            return 'disabled';
+        } elseif ($device->status == 0) {
+            return 'down';
+        }
+
+        return 'up';
+    }
+
+    /**
      * Get the status label class
      * @param Device $device
      * @return string
      */
     private function getLabel($device)
     {
-        if ($device->disabled) {
+        if ($device->disabled == 1) {
+            return 'blackbg';
+        } elseif ($device->ignore == 1) {
             return 'label-default';
-        }
+        } elseif ($device->status == 0) {
+            return 'label-danger';
+        } else {
+            $warning_time = \LibreNMS\Config::get('uptime_warning', 84600);
+            if ($device->uptime < $warning_time && $device->uptime != 0) {
+                return 'label-warning';
+            }
 
-        if ($device->ignore) {
-            return 'label-default';
+            return 'label-success';
         }
-
-        return $device->status ? 'label-success' : 'label-danger';
     }
 
     /**

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -341,27 +341,6 @@ class Device extends BaseModel
         $this->save();
     }
 
-    /**
-     * @return string
-     */
-    public function statusName()
-    {
-        if ($this->disabled == 1) {
-            return 'disabled';
-        } elseif ($this->ignore == 1) {
-            return 'ignore';
-        } elseif ($this->status == 0) {
-            return 'down';
-        } else {
-            $warning_time = \LibreNMS\Config::get('uptime_warning', 84600);
-            if ($this->uptime < $warning_time && $this->uptime != 0) {
-                return 'warn';
-            }
-
-            return 'up';
-        }
-    }
-
     // ---- Accessors/Mutators ----
 
     public function getIconAttribute($icon)

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -31,7 +31,7 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
     $component_count = $component->getComponentCount($device['device_id']);
 
     $alert_class = '';
-    if ($device['disabled'] == '1' || $device['ignore'] == '1') {
+    if ($device['disabled'] == '1') {
         $alert_class = 'alert-info';
     } elseif ($device['status'] == '0') {
         $alert_class = 'alert-danger';

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -281,7 +281,7 @@ if ($format == "graph") {
         </div>
     </div>
     <div class="table-responsive">
-        <table id="devices" class="table table-hover table-condensed table-striped">  
+        <table id="devices" class="table table-hover table-condensed table-striped">
             <thead>
                 <tr>
                     <th data-column-id="status" data-formatter="status" data-width="7px" data-searchable="false">&nbsp;</th>
@@ -314,12 +314,12 @@ if ($format == "graph") {
                     return "<span>" + row.hostname + "</span>";
                 },
                 "uptime": function (column, row) {
-                    if (isNaN(row.uptime.charAt(0))) {
-                        return row.uptime;
-                    } else if (row.status == 'down') {
-                        return "<span class='alert-status-small label-danger'></span><span>" + row.uptime + "</span>";
+                    if (row.status == 'down') {
+                        return "<span class='red'>" + row.uptime + "</span>"
+                    } else if(row.status == 'disabled') {
+                        return '';
                     } else {
-                        return "<span class='alert-status-small label-success'></span><span>" + row.uptime + "</span>";
+                        return row.uptime;
                     }
                 },
             },


### PR DESCRIPTION
Replace color indicator near uptime counter with colored text and change color of status indicator to black on disabled devices instead of gray (matches availablity map with show ignored/disabled enabled).

* Brings back header color for ignored devices on device's own page (https://u.gensokyo.re/d/nCpaBasc (down) / https://u.gensokyo.re/d/Ya16kBvJ (up) / https://u.gensokyo.re/d/WVakwOxH (disabled))
* Change color of left indicator status for disabled devices from gray to black to match availability map (https://u.gensokyo.re/d/scsXvQuE)
* Remove color indicator near uptime counter on the right, instead use red text to mark downtime (https://u.gensokyo.re/d/5dGnUsx4)
* Do not display uptime counter for disabled devices (https://u.gensokyo.re/d/scsXvQuE)
* Update logic to change left counter to orange if device is within reboot warning period as previously only uptime counter indicator changed color and it is now removed (https://u.gensokyo.re/d/8xgyJhIq)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
