### PR TITLE
fix an issue where the order may be random when adding values to the UPS-APC RRD

### DIFF
--- a/includes/polling/applications/ups-apcups.inc.php
+++ b/includes/polling/applications/ups-apcups.inc.php
@@ -64,7 +64,15 @@ $rrd_def = RrdDefinition::make()
     ->addDataset('nominal_voltage', 'GAUGE', 0)
     ->addDataset('load', 'GAUGE', 0, 100);
 
-$fields = $json_return{'data'};
+$fields = array(
+                'charge' => $json_return['data']['charge'],
+                'time_remaining' => $json_return['data']['time_remaining'],
+                'battery_nominal' => $json_return['data']['battery_nominal'],
+                'battery_voltage' => $json_return['data']['battery_voltage'],
+                'input_voltage' => $json_return['data']['input_voltage'],
+                'nominal_voltage' => $json_return['data']['nominal_voltage'],
+                'load' => $json_return['data']['load'],
+                );
 
 $tags = compact('name', 'app_id', 'rrd_name', 'rrd_def');
 data_update($device, 'app', $tags, $fields);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

I have no clue what is going on here as correct data is returned, but this fixes the problem.

Came across while investigating https://github.com/librenms/librenms-agent/issues/229 .