### PR TITLE
Add more detail to webgui alerts

### DIFF
--- a/includes/html/common/alerts.inc.php
+++ b/includes/html/common/alerts.inc.php
@@ -229,6 +229,7 @@ if (defined('SHOW_SETTINGS')) {
                 <th data-column-id="rule">Rule</th>
                 <th data-column-id="details" data-sortable="false"></th>
                 <th data-column-id="hostname">Hostname</th>
+                <th data-column-id="location">Location</th>
                 <th data-column-id="ack_ico" data-sortable="false">ACK</th>
                 <th data-column-id="notes" data-sortable="false">Notes</th>';
 

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -138,7 +138,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
     } elseif ((int)$alert['state'] === 1 || (int)$alert['state'] === 3 || (int)$alert['state'] === 4) {
         if ((int)$alert['state'] === 3) {
             $msg = '<i class="fa fa-angle-double-down" style="font-size:20px;" aria-hidden="true" title="Status got worse"></i>';
-         } elseif ((int)$alert['state'] === 4) {
+        } elseif ((int)$alert['state'] === 4) {
             $msg = '<i class="fa fa-angle-double-up" style="font-size:20px;" aria-hidden="true" title="Status got better"></i>';
         }
     } elseif ((int)$alert['state'] === 2) {

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -203,6 +203,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         'rule' => '<i title="' . htmlentities($alert['rule']) . '"><a href="' . generate_url(array('page' => 'alert-rules')) . '">' . htmlentities($alert['name']) . '</a></i>',
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . ($rulei) . '" data-parent="#alerts"></a>',
         'hostname' => $hostname,
+        'location' => $alert['location'],
         'timestamp' => ($alert['timestamp'] ? $alert['timestamp'] : 'N/A'),
         'severity' => $severity_ico,
         'state' => $alert['state'],

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -14,6 +14,7 @@
 */
 
 use LibreNMS\Authentication\LegacyAuth;
+use LibreNMS\Config;
 
 $where = ' `devices`.`disabled` = 0';
 
@@ -155,7 +156,11 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         $severity .= ' <strong>-</strong>';
     }
 
-    $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
+    if (Config::get('alert_sysname')) {
+        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<br />' . $alert['sysName'] . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
+    } else {
+        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
+    }
 
     switch ($severity) {
         case 'critical':

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -156,10 +156,10 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         $severity .= ' <strong>-</strong>';
     }
 
-    if (Config::get('alert_sysname')) {
-        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<br />' . $alert['sysName'] . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
+    if (Config::get('force_ip_to_sysname')) {
+        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['sysName'])) . '<br />' . $alert['hostname'] . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
     } else {
-        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
+        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<br />' . $alert['sysName'] . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
     }
 
     switch ($severity) {

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -138,7 +138,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
     } elseif ((int)$alert['state'] === 1 || (int)$alert['state'] === 3 || (int)$alert['state'] === 4) {
         if ((int)$alert['state'] === 3) {
             $msg = '<i class="fa fa-angle-double-down" style="font-size:20px;" aria-hidden="true" title="Status got worse"></i>';
-        } elseif ((int)$alert['state'] === 4) {
+         } elseif ((int)$alert['state'] === 4) {
             $msg = '<i class="fa fa-angle-double-up" style="font-size:20px;" aria-hidden="true" title="Status got better"></i>';
         }
     } elseif ((int)$alert['state'] === 2) {
@@ -203,7 +203,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         'rule' => '<i title="' . htmlentities($alert['rule']) . '"><a href="' . generate_url(array('page' => 'alert-rules')) . '">' . htmlentities($alert['name']) . '</a></i>',
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . ($rulei) . '" data-parent="#alerts"></a>',
         'hostname' => $hostname,
-        'location' => $alert['location'],
+        'location' => generate_link($alert['location'], array('page' => 'devices', 'location' => $alert['location'])),
         'timestamp' => ($alert['timestamp'] ? $alert['timestamp'] : 'N/A'),
         'severity' => $severity_ico,
         'state' => $alert['state'],

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -156,11 +156,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         $severity .= ' <strong>-</strong>';
     }
 
-    if (Config::get('force_ip_to_sysname')) {
-        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['sysName'])) . '<br />' . $alert['hostname'] . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
-    } else {
-        $hostname = '<div class="incident">' . generate_device_link($alert, shorthost($alert['hostname'])) . '<br />' . $alert['sysName'] . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
-    }
+    $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($rulei + 1) . '" class="collapse">' . $fault_detail . '</div></div>';
 
     switch ($severity) {
         case 'critical':

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -12,6 +12,7 @@
             <th data-column-id="rule">Rule</th>
             <th data-column-id="details" data-sortable="false"></th>
             <th data-column-id="hostname">Hostname</th>
+            <th data-column-id="location">Location</th>
             <th data-column-id="ack_ico" data-sortable="false">ACK</th>
             <th data-column-id="notes" data-sortable="false">Notes</th>
             <th data-column-id="proc" data-sortable="false" data-visible="{{ $proc ? 'true' : 'false' }}">URL</th>


### PR DESCRIPTION
I add everything via IP address's, this works fine, but the alert tables only display the hostname(IP). This PR is to add a little more detail to the alert, by adding the sysname under the hostname. A couple of other places do this such as "device dependence's"

Made this a config option in case someone is already doing $config['force_ip_to_sysname'] = false;

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
