### PR TITLE
Allow OS to define config highlighting (pfSense)

### DIFF
--- a/includes/definitions/pfsense.yaml
+++ b/includes/definitions/pfsense.yaml
@@ -3,6 +3,7 @@ type: firewall
 group: unix
 text: pfSense
 processor_stacked: true
+config_highlighting: xml
 over:
     - { graph: device_processor, text: 'Processor Usage' }
     - { graph: device_ucd_memory, text: 'Memory Usage' }

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -318,6 +318,8 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
     if (!empty($text)) {
         if (isset($previous_config)) {
             $language = 'diff';
+        } else if ($device['os'] == 'pfsense') {
+            $language = 'xml';
         } else {
             $language = 'ios';
         }
@@ -327,7 +329,7 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
         // $geshi->set_line_style('color: #999999');
         echo '<div class="config">';
         echo '<input id="linenumbers" class="btn btn-primary" type="submit" value="Hide line numbers"/>';
-        echo htmlspecialchars_decode($geshi->parse_code());
+        echo $geshi->parse_code();
         echo '</div>';
     }
 }//end if

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -318,8 +318,8 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
     if (!empty($text)) {
         if (isset($previous_config)) {
             $language = 'diff';
-        } elseif (isset($device['config_highlighting'])) {
-            $language = $device['config_highlighting'];
+        } elseif (isset(Config::get('os')[$device['os']]['config_highlighting'])) {
+            $language = Config::get('os')[$device['os']]['config_highlighting'];
         } else {
             $language = 'ios';
         }

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -323,7 +323,7 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
         } else {
             $language = 'ios';
         }
-        $geshi = new GeSHi($text, $language);
+        $geshi = new GeSHi(htmlspecialchars_decode($text), $language);
         $geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
         $geshi->set_overall_style('color: black;');
         // $geshi->set_line_style('color: #999999');

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -316,13 +316,7 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
                           </div>';
     }
     if (!empty($text)) {
-        if (isset($previous_config)) {
-            $language = 'diff';
-        } elseif (isset(Config::get('os')[$device['os']]['config_highlighting'])) {
-            $language = Config::get('os')[$device['os']]['config_highlighting'];
-        } else {
-            $language = 'ios';
-        }
+        $language = isset($previous_config) ? 'diff' : Config::getOsSetting($device['os'], 'config_highlighting', 'ios');
         $geshi = new GeSHi(htmlspecialchars_decode($text), $language);
         $geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
         $geshi->set_overall_style('color: black;');

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -318,7 +318,7 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
     if (!empty($text)) {
         if (isset($previous_config)) {
             $language = 'diff';
-        } else if ($device['os'] == 'pfsense') {
+        } elseif ($device['os'] == 'pfsense') {
             $language = 'xml';
         } else {
             $language = 'ios';

--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -318,8 +318,8 @@ if (LegacyAuth::user()->hasGlobalAdmin()) {
     if (!empty($text)) {
         if (isset($previous_config)) {
             $language = 'diff';
-        } elseif ($device['os'] == 'pfsense') {
-            $language = 'xml';
+        } elseif (isset($device['config_highlighting'])) {
+            $language = $device['config_highlighting'];
         } else {
             $language = 'ios';
         }

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -53,6 +53,9 @@
         "icon": {
             "type": "string"
         },
+        "config_highlighting": {
+            "type": "string"
+        },
         "poller_modules": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Fix display for pfsense config files.
 - use xml language formatting for pfsense os
 - don't use htmlspecialchars_decode as xml tags won't show

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
