### PR TITLE
Allow filtering of getUserlist LDAP function

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -152,8 +152,8 @@ class LdapAuthorizer extends AuthorizerBase
             }
 
             $filter = '(' . Config::get('auth_ldap_prefix') . '*)';
-	    if (Config::get('auth_ldap_Userlist_filter') != NULL) {
-                    $filter = '(' . Config::get('auth_ldap_Userlist_filter') . ')';
+            if (Config::get('auth_ldap_Userlist_filter') != null) {
+                $filter = '(' . Config::get('auth_ldap_Userlist_filter') . ')';
             }
 
             // build group filter

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -152,8 +152,8 @@ class LdapAuthorizer extends AuthorizerBase
             }
 
             $filter = '(' . Config::get('auth_ldap_prefix') . '*)';
-            if (Config::get('auth_ldap_Userlist_filter') != null) {
-                $filter = '(' . Config::get('auth_ldap_Userlist_filter') . ')';
+            if (Config::get('auth_ldap_userlist_filter') != null) {
+                $filter = '(' . Config::get('auth_ldap_userlist_filter') . ')';
             }
 
             // build group filter

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -152,6 +152,9 @@ class LdapAuthorizer extends AuthorizerBase
             }
 
             $filter = '(' . Config::get('auth_ldap_prefix') . '*)';
+	    if (Config::get('auth_ldap_Userlist_filter') != NULL) {
+                    $filter = '(' . Config::get('auth_ldap_Userlist_filter') . ')';
+            }
 
             // build group filter
             $group_filter = '';

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -162,6 +162,7 @@ $config['auth_ldap_groupmemberattr'] = 'memberUid'; // attribute to use to see i
 $config['auth_ldap_uid_attribute'] = 'uidnumber';   // attribute for unique id
 $config['auth_ldap_debug'] = false;                 // enable for verbose debug messages
 $config['auth_ldap_userdn'] = true;                 // Uses a users full DN as the value of the member attribute in a group instead of member: username. (it’s member: uid=username,ou=groups,dc=domain,dc=com)
+$config[‘auth_ldap_Userlist_filter’] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users
 ```
 
 ### LDAP bind user (optional)

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -162,7 +162,7 @@ $config['auth_ldap_groupmemberattr'] = 'memberUid'; // attribute to use to see i
 $config['auth_ldap_uid_attribute'] = 'uidnumber';   // attribute for unique id
 $config['auth_ldap_debug'] = false;                 // enable for verbose debug messages
 $config['auth_ldap_userdn'] = true;                 // Uses a users full DN as the value of the member attribute in a group instead of member: username. (it’s member: uid=username,ou=groups,dc=domain,dc=com)
-$config['auth_ldap_Userlist_filter'] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users
+$config['auth_ldap_userlist_filter'] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users
 ```
 
 ### LDAP bind user (optional)

--- a/doc/Extensions/Authentication.md
+++ b/doc/Extensions/Authentication.md
@@ -162,7 +162,7 @@ $config['auth_ldap_groupmemberattr'] = 'memberUid'; // attribute to use to see i
 $config['auth_ldap_uid_attribute'] = 'uidnumber';   // attribute for unique id
 $config['auth_ldap_debug'] = false;                 // enable for verbose debug messages
 $config['auth_ldap_userdn'] = true;                 // Uses a users full DN as the value of the member attribute in a group instead of member: username. (it’s member: uid=username,ou=groups,dc=domain,dc=com)
-$config[‘auth_ldap_Userlist_filter’] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users
+$config['auth_ldap_Userlist_filter'] = 'service=informatique'; // Replace 'service=informatique' by your ldap filter to limit the number of responses if you have an ldap directory with thousand of users
 ```
 
 ### LDAP bind user (optional)


### PR DESCRIPTION
I have an openldap directory with several thousand of accounts.
so when I try to use the ldap authentification in Librenms, it does not work.

I found this solution (add an ldap filter to limit the number of results) :

I have added $config[‘auth_ldap_Userlist_filter’] = ‘service=informatique’; in the config.php

I have modified the source code of the getUserlist() function in the file librenms/LibreNMS/Authentication/LdapAuthorizer.php like this :

$filter = ‘(’ . Config::get(‘auth_ldap_prefix’) . ‘*)’;
if (Config::get(‘auth_ldap_Userlist_filter’) != NULL) {
    $filter = ‘(’ . Config::get(‘auth_ldap_Userlist_filter’) . ‘)’;
}

Now with this modification, the ldap authentification working fine.


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
