### PR TITLE
Allow adding custom quick links to device navigation

### DIFF
--- a/doc/Extensions/Customizing-the-Web-UI.md
+++ b/doc/Extensions/Customizing-the-Web-UI.md
@@ -28,3 +28,18 @@ Example contents:
     </ul>
 </li>
 ```
+  
+  
+## Custom device menu entry
+
+You can add custom external system link in the menu on the device page, and you can take the device information as a parameter to the url, such as hostname, sysName.
+  
+This feature allows you to easily link applications to related systems, as shown in the example of Open-audIT.
+  
+Open the file `config.php`:
+
+```php
+$config['html']['device']['links'] = [['url' => 'http://atssrv/open-audit/index/devices/{{ $device[\'sysName\'] }}', 'title' => 'Open-AudIT']];
+```
+  
+If you want to add more external system links, add them to the array of values.

--- a/doc/Extensions/Customizing-the-Web-UI.md
+++ b/doc/Extensions/Customizing-the-Web-UI.md
@@ -32,14 +32,14 @@ Example contents:
   
 ## Custom device menu entry
 
-You can add custom external system link in the menu on the device page, and you can take the device information as a parameter to the url, such as hostname, sysName.
-  
+You can add custom external links in the menu on the device page.
+
 This feature allows you to easily link applications to related systems, as shown in the example of Open-audIT.
-  
-Open the file `config.php`:
+
+The Links value is parsed by Laravel Blade's templating engine so you can use Device variables such as `hostname`, `sysName` and more.
+
+`config.php:`
 
 ```php
-$config['html']['device']['links'] = [['url' => 'http://atssrv/open-audit/index/devices/{{ $device[\'sysName\'] }}', 'title' => 'Open-AudIT']];
+$config['html']['device']['links'][] = ['url' => 'http://atssrv/open-audit/index/devices/{{ $device[\'sysName\'] }}', 'title' => 'Open-AudIT'];
 ```
-  
-If you want to add more external system links, add them to the array of values.

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -456,10 +456,9 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
                   <ul class="dropdown-menu">
                     <li><a href="https://'.$device['hostname'].'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme"  aria-hidden="true"></i> Web</a></li>';
 
-        if (Config::has('openaudit_web_device')) {
-            if (!empty(Config::get('openaudit_web_device'))） {
-                echo '<li><a href="'.Config::get('openaudit_web_device').$device['sysName'].'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme"  aria-hidden="true"></i> Open-AudIT</a></li>';
-            }
+        foreach (Config::get('html.device.links') as $links) {
+            $html_link = view(['template' => $links['url']], ['device' => $device])->__toString();
+ 	    echo '<li><a href="'.$html_link.'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme" aria-hidden="true"></i> '.$links['title'].'</a></li>';
         }
 
         if (Config::has('gateone.server')) {

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -455,6 +455,13 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
                   <span class="caret"></span></button>
                   <ul class="dropdown-menu">
                     <li><a href="https://'.$device['hostname'].'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme"  aria-hidden="true"></i> Web</a></li>';
+
+        if (Config::has('openaudit_web_device')) {
+            if (!empty(Config::get('openaudit_web_device'))） {
+                echo '<li><a href="'.Config::get('openaudit_web_device').$device['sysName'].'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme"  aria-hidden="true"></i> Open-AudIT</a></li>';
+            }
+        }
+
         if (Config::has('gateone.server')) {
             if (Config::get('gateone.use_librenms_user') == true) {
                 echo '<li><a href="' . Config::get('gateone.server') . '?ssh=ssh://' . LegacyAuth::user()->username . '@' . $device['hostname'] . '&location=' . $device['hostname'] . '" target="_blank" rel="noopener"><i class="fa fa-lock fa-lg icon-theme" aria-hidden="true"></i> SSH</a></li>';

--- a/includes/html/pages/device.inc.php
+++ b/includes/html/pages/device.inc.php
@@ -458,7 +458,7 @@ if (device_permitted($vars['device']) || $permitted_by_port) {
 
         foreach (Config::get('html.device.links') as $links) {
             $html_link = view(['template' => $links['url']], ['device' => $device])->__toString();
- 	    echo '<li><a href="'.$html_link.'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme" aria-hidden="true"></i> '.$links['title'].'</a></li>';
+            echo '<li><a href="'.$html_link.'" onclick="http_fallback(this); return false;" target="_blank" rel="noopener"><i class="fa fa-globe fa-lg icon-theme" aria-hidden="true"></i> '.$links['title'].'</a></li>';
         }
 
         if (Config::has('gateone.server')) {


### PR DESCRIPTION
In the device page menu, I add a link to open-audit to show the device asset details.

To enable this feature, you need to add a setting value in `config.php`, such as:
`$config['openaudit_web_device'] = "http://atssrv.com/open-audit/index.php/devices/";`

The display results are shown as follows:

![2019-07-02 13_25_46-vm-014 - LibreNMS](https://user-images.githubusercontent.com/30381035/60484758-313fbc00-9ccd-11e9-8d9e-dd4a8440cb63.png)
![2019-07-02 13_26_57-Open-AudIT](https://user-images.githubusercontent.com/30381035/60484762-31d85280-9ccd-11e9-93fd-5db3ccc36569.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
