### PR TITLE
Avoid unnecessary net-snmp long options for version info

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -1143,7 +1143,7 @@ function version_info($remote = false)
         Config::get('rrdtool', 'rrdtool') . ' --version |head -n1'
     )), 1, 1)));
     $output['netsnmp_ver'] = str_replace('version: ', '', rtrim(shell_exec(
-        Config::get('snmpget', 'snmpget') . ' --version 2>&1'
+        Config::get('snmpget', 'snmpget') . ' -V 2>&1'
     )));
 
     return $output;


### PR DESCRIPTION
Long option support in net-snmp relies on non-portable usage of getopt(3) with "-:" in the argument string, this doesn't work on all OS. Replace with the alternative -V which works everywhere.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
