### PR TITLE
Fix Nan value broken maps network graph

### DIFF
--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -259,7 +259,9 @@ foreach ($list as $items) {
     if ($link_used > 100) {
         $link_used = 100;
     }
-
+    if (is_nan($link_used)) {
+        $link_used = 0;
+    }
     $link_style = [
         'color' => [
             'border' => Config::get("network_map_legend.$link_used"),


### PR DESCRIPTION
UI Error message:
Uncaught TypeError: Cannot read property 'indexOf' of null
at Object.e.overrideOpacity (vis.js:1085)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
