### PR TITLE
Allow num_oid to use OCTET STRING indexes

### DIFF
--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -85,7 +85,8 @@ The only sensor we have defined here is airflow. The available options are as fo
   the value. If not provided willuse `oid`
 - `num_oid` (required): This is the numerical OID that contains
   `value`. This should always include `{{ $index }}`.  snmptranslate
-  -On can help figure out the number
+  -On can help figure out the number.
+  In case the index is a string, `{{ $index_string }}` can be used instead.
 - `divisor` (optional): This is the divisor to use against the returned `value`.
 - `multiplier` (optional): This is the multiplier to use against the returned `value`.
 - `low_limit` (optional): This is the critical low threshold that

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1041,7 +1041,10 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
                 d_echo("Final sensor value: $value\n");
 
                 if (YamlDiscovery::canSkipItem($value, $index, $data, $sensor_options, $pre_cache) === false && is_numeric($value)) {
-                    $oid = str_replace('{{ $index }}', $index, $data['num_oid']);
+		    $oid = str_replace('{{ $index }}', $index, $data['num_oid']);
+		    // if index is a string, we need to convert it to OID
+		    // strlen($index) as first number, and each letter converted to a number, separated by dots
+                    $oid = str_replace('{{ $index_string }}', strlen($index) . '.' . implode(".", unpack("c*", $index)), $oid);
 
                     // process the description
                     $descr = YamlDiscovery::replaceValues('descr', $index, null, $data, $pre_cache);

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1041,9 +1041,9 @@ function discovery_process(&$valid, $device, $sensor_type, $pre_cache)
                 d_echo("Final sensor value: $value\n");
 
                 if (YamlDiscovery::canSkipItem($value, $index, $data, $sensor_options, $pre_cache) === false && is_numeric($value)) {
-		    $oid = str_replace('{{ $index }}', $index, $data['num_oid']);
-		    // if index is a string, we need to convert it to OID
-		    // strlen($index) as first number, and each letter converted to a number, separated by dots
+                    $oid = str_replace('{{ $index }}', $index, $data['num_oid']);
+                    // if index is a string, we need to convert it to OID
+                    // strlen($index) as first number, and each letter converted to a number, separated by dots
                     $oid = str_replace('{{ $index_string }}', strlen($index) . '.' . implode(".", unpack("c*", $index)), $oid);
 
                     // process the description


### PR DESCRIPTION
Hi,

This PR creates a new variable $index_string that contains the OID converted as OCTET_STRING. basically, it converts a string index into an OID, so it can be used for snmpgets.

Exemple for an efficient_ip appliance, which exposes DNS/DHCP statistics indexed by name : 

.1.3.6.1.4.1.2440.1.4.2.3.1.3.**3.116.99.112** = 0
.1.3.6.1.4.1.2440.1.4.2.3.1.3.**3.117.100.112** = 72

it represents : 

$ snmptranslate  '-M' '/opt/librenms/mibs:/opt/librenms/mibs/efficientip' -m all .1.3.6.1.4.1.2440.1.4.2.3.1.3.3.116.99.112 
EIP-STATS-MIB::eipDnsStatValue.**"tcp"**
$ snmptranslate  '-M' '/opt/librenms/mibs:/opt/librenms/mibs/efficientip' -m all .1.3.6.1.4.1.2440.1.4.2.3.1.3.3.117.100.112   
EIP-STATS-MIB::eipDnsStatValue.**"udp"**

In the YAML file, it is now possible to do the following for DNS stats : 
```
                    oid: eipDnsStatTable
                    value: eipDnsStatValue
                    num_oid: '.1.3.6.1.4.1.2440.1.4.2.3.1.3.{{ $index_string }}'
                    descr: '{{ $eipDnsStatName }}'
                    group: 'DNS'
```
#10413 is also necessary in order to load the COUNTER values and graph them correctly. Nobody cares of the absolut number of DNS requests (RRD GAUGE), but prefers the RRD COUNTER which derives it.
![Capture d’écran 2019-07-04 à 17 03 31](https://user-images.githubusercontent.com/38363551/60675990-05176d00-9e7e-11e9-9195-ba61b80f8a2f.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
