### PR TITLE
WIP - Allow 'count' sensors to adapt RRD type (COUNTER, DERIVE, instead of GAUGE)

### DIFF
--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -109,8 +109,8 @@ The only sensor we have defined here is airflow. The available options are as fo
   identify this sensor. `{{ $index }}` will be replaced by the `index`
   from the snmp walk.
   For the 'count' sensor class, it is possible to prefix the index with
-  ```counter__``` or ```derive__``` to change the RRD file type from
-  default GAUGE type. 
+  ``` counter__ ``` or ``` derive__ ``` to change the RRD file type from
+  default GAUGE type.
 - `skip_values` (optional): This is an array of values we should skip
   over (see note below).
 - `skip_value_lt` (optional): If sensor value is less than this, skip the discovery.

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -108,6 +108,9 @@ The only sensor we have defined here is airflow. The available options are as fo
 - `index` (optional): This is the index value we use to uniquely
   identify this sensor. `{{ $index }}` will be replaced by the `index`
   from the snmp walk.
+  For the 'count' sensor class, it is possible to prefix the index with
+  ```counter__``` or ```derive__``` to change the RRD file type from
+  default GAUGE type. 
 - `skip_values` (optional): This is an array of values we should skip
   over (see note below).
 - `skip_value_lt` (optional): If sensor value is less than this, skip the discovery.

--- a/includes/common.php
+++ b/includes/common.php
@@ -200,10 +200,10 @@ function get_sensor_rrd($device, $sensor)
 
 function get_sensor_rrd_type($device, $sensor)
 {
-    if (strpos($sensor['sensor_index'], "derive__") === 0) {
+    if ($sensor['sensor_class'] == 'count' && strpos($sensor['sensor_index'], "derive__") === 0) {
         return 'DERIVE';
     }
-    if (strpos($sensor['sensor_index'], "counter__") === 0) {
+    if ($sensor['sensor_class'] == 'count' && strpos($sensor['sensor_index'], "counter__") === 0) {
         return 'COUNTER';
     }
     return 'GAUGE';

--- a/includes/common.php
+++ b/includes/common.php
@@ -198,6 +198,17 @@ function get_sensor_rrd($device, $sensor)
     return rrd_name($device['hostname'], get_sensor_rrd_name($device, $sensor));
 }
 
+function get_sensor_rrd_type($device, $sensor)
+{
+    if (strpos($sensor['sensor_index'], "derive__") === 0) {
+        return 'DERIVE';
+    }
+    if (strpos($sensor['sensor_index'], "counter__") === 0) {
+        return 'COUNTER';
+    }
+    return 'GAUGE';
+}
+
 function get_sensor_rrd_name($device, $sensor)
 {
     # For IPMI, sensors tend to change order, and there is no index, so we prefer to use the description as key here.

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -1639,5 +1639,14 @@ function get_sensor_label_color($sensor, $type = 'sensors')
         $label_style = "label-danger";
     }
     $unit = __("$type.{$sensor['sensor_class']}.unit");
-    return "<span class='label $label_style'>".trim(format_si($sensor['sensor_current']).$unit)."</span>";
+    $sensor_current = $sensor['sensor_current'];
+    if (strpos($sensor['sensor_index'], "derive__") === 0 || strpos($sensor['sensor_index'], "counter__") === 0) {
+        $sensor_current = $sensor['sensor_current'] - (is_null($sensor['sensor_prev'])?$sensor['sensor_current']:$sensor['sensor_prev']);
+        $sensor_current = $sensor_current / Config::get('rrd.step', 300);
+        $unit .= " /s";
+        if (strpos($sensor['sensor_index'], "counter__") === 0) {
+            $sensor_current = max($sensor_current, 0);
+        }
+    }
+    return "<span class='label $label_style'>".trim(format_si($sensor_current).$unit)."</span>";
 }

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -176,8 +176,9 @@ function record_sensor_data($device, $all_sensors)
         }
 
         $rrd_name = get_sensor_rrd_name($device, $sensor);
+        $rrd_type = get_sensor_rrd_type($device, $sensor);
 
-        $rrd_def = RrdDefinition::make()->addDataset('sensor', 'GAUGE');
+        $rrd_def = RrdDefinition::make()->addDataset('sensor', $rrd_type);
 
         echo "$sensor_value $unit\n";
 


### PR DESCRIPTION
This PR allows the 'count' sensor to use RRDs with COUNTER and DERIVE instead of GAUGE which remains the default. 
Type can be changed by prefixing the 'sensor_index' with `counter__` or `derive__`.

Both of #10410 and #10413 will allow sensors from EfficientIP devices to be loaded. 

![Capture d’écran 2019-07-05 à 13 00 41](https://user-images.githubusercontent.com/38363551/60718531-2ed79f00-9f25-11e9-9950-086155ecde51.png)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
