### PR TITLE
Smoking outgoing graphs fix

### DIFF
--- a/includes/html/graphs/smokeping/in.inc.php
+++ b/includes/html/graphs/smokeping/in.inc.php
@@ -32,7 +32,7 @@ if ($width > '500') {
 $filename_dir = generate_smokeping_file($device);
 if ($src['hostname'] == Config::get('own_hostname')) {
     $filename = $filename_dir . $device['hostname'].'.rrd';
-    if (!rrdtool_check_rrd_exists($filename_dir.$device['hostname'].'.rrd')) {
+    if (!rrdtool_check_rrd_exists($filename)) {
         // Try with dots in hostname replaced by underscores
         $filename = $filename_dir . str_replace('.', '_', $device['hostname']).'.rrd';
     }

--- a/includes/html/graphs/smokeping/out.inc.php
+++ b/includes/html/graphs/smokeping/out.inc.php
@@ -29,17 +29,18 @@ if ($width > '500') {
     $rrd_options .= " COMMENT:'".substr(str_pad($unit_text, ($descr_len + 5)), 0, ($descr_len + 5))." RTT      Loss    SDev   RTT\:SDev                              \l'";
 }
 
+$filename_dir = generate_smokeping_file($device);
 if ($device['hostname'] == Config::get('own_hostname')) {
-    $filename = Config::get('smokeping.dir') . $dest['hostname'] . '.rrd';
+    $filename = $filename_dir . $dest['hostname'] . '.rrd';
     if (!rrdtool_check_rrd_exists($filename)) {
         // Try with dots in hostname replaced by underscores
-        $filename = Config::get('smokeping.dir') . str_replace('.', '_', $dest['hostname']) . '.rrd';
+        $filename = $filename_dir . str_replace('.', '_', $dest['hostname']) . '.rrd';
     }
 } else {
-    $filename = Config::get('smokeping.dir') . $dest['hostname'] . '~' . $device['hostname'] . '.rrd';
+    $filename = $filename_dir . $dest['hostname'] . '~' . $device['hostname'] . '.rrd';
     if (!rrdtool_check_rrd_exists($filename)) {
         // Try with dots in hostname replaced by underscores
-        $filename = Config::get('smokeping.dir') . str_replace('.', '_', $dest['hostname']) . '~' . $device['hostname'] . '.rrd';
+        $filename = $filename_dir . str_replace('.', '_', $dest['hostname']) . '~' . $device['hostname'] . '.rrd';
     }
 }
 

--- a/includes/html/pages/device/latency.inc.php
+++ b/includes/html/pages/device/latency.inc.php
@@ -87,13 +87,14 @@ if ($vars['view'] == 'incoming') {
         $graph_array['type']   = 'device_smokeping_out_all_avg';
         $graph_array['device'] = $device['device_id'];
         echo '<tr><td>';
-        echo '<h3>Aggregate</h3>';
+        echo '<h3>Average</h3>';
 
         include 'includes/html/print-graphrow.inc.php';
 
         echo '</td></tr>';
 
         $graph_array['type']   = 'device_smokeping_out_all';
+        $graph_array['device'] = $device['device_id'];
         $graph_array['legend'] = 'no';
         echo '<tr><td>';
         echo '<h3>Aggregate</h3>';
@@ -106,7 +107,7 @@ if ($vars['view'] == 'incoming') {
 
         asort($smokeping_files['out'][$device['hostname']]);
         foreach ($smokeping_files['out'][$device['hostname']] as $host) {
-            $hostname           = str_replace('.rrd', '', $host);
+            $hostname       = str_replace('_', '.', str_replace('.rrd', '', $host));
             list($hostname) = explode('~', $hostname);
             $host           = device_by_name($hostname);
             if (is_numeric($host['device_id'])) {


### PR DESCRIPTION
Smokeping outgoing graphs are not working because of looking in the wrong place when smokeping.integration is enabled, and because of not converting underscores in RRD filenames to dots.

This patch fixes that.

> DO NOT DELETE THIS TEXT

Ok

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

Done

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

Yes

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
