### PR TITLE
Added skip_values operator and documentation

### DIFF
--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -150,6 +150,16 @@ $index="1.20", then $subindex0="1" and $subindex1="20".
 > =, !=, ==, !==, <=, >=, <, >,
 > starts, ends, contains, regex, in_array, not_starts,
 > not_ends, not_contains, not_regex, not_in_array
+>
+> Example:
+
+```yaml
+                    skip_values:
+                    -
+                      oid: sensorName
+                      op: 'not_in_array'
+                      value: ['sensor1', 'sensor2']
+```
 
 If you aren't able to use yaml to perform the sensor discovery, you
 will most likely need to use Advanced health discovery.

--- a/doc/Developing/os/Health-Information.md
+++ b/doc/Developing/os/Health-Information.md
@@ -145,6 +145,12 @@ $index="1.20", then $subindex0="1" and $subindex1="20".
                       value: 4
 ```
 
+> ``` op ``` can be any of the following operators :
+>
+> =, !=, ==, !==, <=, >=, <, >,
+> starts, ends, contains, regex, in_array, not_starts,
+> not_ends, not_contains, not_regex, not_in_array
+
 If you aren't able to use yaml to perform the sensor discovery, you
 will most likely need to use Advanced health discovery.
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -314,12 +314,24 @@ function compare_var($a, $b, $comparison = '=')
             return $a < $b;
         case "contains":
             return str_contains($a, $b);
+        case "not_contains":
+            return !str_contains($a, $b);
         case "starts":
             return starts_with($a, $b);
+        case "not_starts":
+            return !starts_with($a, $b);
         case "ends":
             return ends_with($a, $b);
+        case "not_ends":
+            return !ends_with($a, $b);
         case "regex":
             return (bool)preg_match($b, $a);
+        case "not regex":
+            return !((bool)preg_match($b, $a));
+        case "in_array":
+            return in_array($a, $b);
+        case "not_in_array":
+            return !in_array($a, $b);
         default:
             return false;
     }

--- a/misc/discovery_schema.json
+++ b/misc/discovery_schema.json
@@ -444,7 +444,13 @@
                 "starts",
                 "ends",
                 "contains",
-                "regex"
+                "regex",
+                "not_starts",
+                "not_ends",
+                "not_contains",
+                "not_regex",
+                "in_array",
+                "not_in_array"
             ]
         }
     }

--- a/misc/os_schema.json
+++ b/misc/os_schema.json
@@ -502,7 +502,13 @@
                 "starts",
                 "ends",
                 "contains",
-                "regex"
+                "regex",
+                "not_starts",
+                "not_ends",
+                "not_contains",
+                "not_regex",
+                "in_array",
+                "not_in_array"
             ]
         }
     }


### PR DESCRIPTION
The goal of this PR was to add in_array and not_in_array operator to help filter tables during YAML discovery. A few other "not_xxxxxx" operator were added and the list of the available operators is now added in the documentation.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
