### PR TITLE
Typo in Spelling prevented new services from being added.

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -46,7 +46,7 @@ function add_service($device, $type, $desc, $ip = 'localhost', $param = "", $ign
         $ip = $device['hostname'];
     }
 
-    $insert = array('device_id' => $device['device_id'], 'service_ip' => $ip, 'service_type' => $type, 'service_changed' => array('UNIX_TIMESTAMP(NOW())'), 'service_desc' => $desc, 'service_param' => $param, 'service_ignore' => $ignore, 'service_status' => 3, 'service_message' => 'Service not yet checked', 'service_ds' => '{}', 'servcie_disabled' => $disabled);
+    $insert = array('device_id' => $device['device_id'], 'service_ip' => $ip, 'service_type' => $type, 'service_changed' => array('UNIX_TIMESTAMP(NOW())'), 'service_desc' => $desc, 'service_param' => $param, 'service_ignore' => $ignore, 'service_status' => 3, 'service_message' => 'Service not yet checked', 'service_ds' => '{}', 'service_disabled' => $disabled);
     return dbInsert($insert, 'services');
 }
 


### PR DESCRIPTION
When attempting to add a new services this was showing up in the logs:
[2019-07-07 09:44:53] production.ERROR: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'servcie_disabled' in 'field list' (SQL: INSERT IGNORE INTO `services` (`device_id`,`service_ip`,`service_type`,`service_changed`,`service_desc`,`service_param`,`service_ignore`,`service_status`,`service_message`,`service_ds`,`servcie_disabled`)


No error was presented in the gui, it said the service was added but in fact it was not and when you went back to the list of all services the one you tried to add was not present.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
