### PR TITLE
Update $rancid_map For Mikrotik

### DIFF
--- a/scripts/gen_rancid.php
+++ b/scripts/gen_rancid.php
@@ -41,6 +41,7 @@ $rancid_map['pfsense']    = 'pfsense';
 $rancid_map['procurve']   = 'hp';
 $rancid_map['nxos']       = 'cisco-nx';
 $rancid_map['mikrotik']   = 'mikrotik';
+$rancid_map['routeros']   = 'mikrotik';
 $rancid_map['screenos']   = 'netscreen';
 $rancid_map['xos']        = 'extreme';
 $rancid_map['ciscosb']    = 'cisco-sb';


### PR DESCRIPTION
Mikrotik's in LibreNMS have an OS of 'routeros'.  Added it to the rancid mapping so the generated router.db file includes Mikrotiks as expected.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
