### PR TITLE
Use PHP sys_temp_dir by default

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -461,6 +461,7 @@ class Config
         self::setDefault('log_dir', '%s/logs', ['install_dir']);
         self::setDefault('log_file', '%s/%s.log', ['log_dir', 'project_id']);
         self::setDefault('plugin_dir', '%s/plugins', ['html_dir']);
+        self::setDefault('temp_dir', sys_get_temp_dir() ?: '/tmp');
 //        self::setDefault('email_from', '"%s" <%s@' . php_uname('n') . '>', ['project_name', 'email_user']);  // FIXME email_from set because alerting config
 
         // deprecated variables

--- a/html/install.php
+++ b/html/install.php
@@ -4,7 +4,6 @@ use LibreNMS\Config;
 
 session_start();
 $librenms_dir = realpath(__DIR__ . '/..');
-$php_temp_dir = sys_get_temp_dir() ? sys_get_temp_dir() : '/tmp';
 
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;
@@ -212,7 +211,7 @@ if ($status == 'no') {
 }
 echo "</td></tr>";
     
-if (is_writable($php_temp_dir)) {
+if (is_writable(Config::get('temp_dir'))) {
     $status = 'yes';
     $row_class = 'success';
 } else {
@@ -223,7 +222,7 @@ if (is_writable($php_temp_dir)) {
 
 echo "<tr class='$row_class'><td>Temporary directory writable</td><td>$status</td><td>";
 if ($status == 'no') {
-    echo "$php_temp_dir is not writable";
+    echo Config::get('temp_dir') . ' is not writable';
     if (function_exists('posix_getgrgid')) {
         $group_info = posix_getgrgid(filegroup(session_save_path()));
         if ($group_info['gid'] !== 0) {  // don't suggest adding users to the root group

--- a/html/install.php
+++ b/html/install.php
@@ -391,9 +391,6 @@ $config_file = <<<"EOD"
 //Please ensure this user is created and has the correct permissions to your install
 \$config['user'] = 'librenms';
 
-// This is the temporary directory used by php, set by php_admin_value[sys_temp_dir], defaults to /tmp when not set.
-\$config['temp_dir'] = '$php_temp_dir';
-
 ### Locations - it is recommended to keep the default
 #\$config\['install_dir'\]  = "$install_dir";
 

--- a/html/install.php
+++ b/html/install.php
@@ -4,6 +4,7 @@ use LibreNMS\Config;
 
 session_start();
 $librenms_dir = realpath(__DIR__ . '/..');
+$php_temp_dir = sys_get_temp_dir();
 
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;
@@ -210,6 +211,29 @@ if ($status == 'no') {
     }
 }
 echo "</td></tr>";
+    
+if (is_writeable($php_temp_dir)) {
+    $status = 'yes';
+    $row_class = 'success';
+} else {
+    $status = 'no';
+    $row_class = 'danger';
+    $complete = false;
+}
+
+echo "<tr class='$row_class'><td>Temporary directory writable</td><td>$status</td><td>";
+if ($status == 'no') {
+    echo "$php_temp_dir is not writable";
+    if (function_exists('posix_getgrgid')) {
+        $group_info = posix_getgrgid(filegroup(session_save_path()));
+        if ($group_info['gid'] !== 0) {  // don't suggest adding users to the root group
+            $group = $group_info['name'];
+            $user = get_current_user();
+            echo ", suggested fix <strong>chown $user:$group $php_temp_dir</strong>";
+        }
+    }
+}
+echo "</td></tr>";
 ?>
         </table>
       </div>
@@ -366,6 +390,9 @@ $config_file = <<<"EOD"
 // This is the user LibreNMS will run as
 //Please ensure this user is created and has the correct permissions to your install
 \$config['user'] = 'librenms';
+
+// This is the temporary directory used by php, set by php_admin_value[sys_temp_dir], defaults to /tmp when not set.
+\$config['temp_dir'] = '$php_temp_dir';
 
 ### Locations - it is recommended to keep the default
 #\$config\['install_dir'\]  = "$install_dir";

--- a/html/install.php
+++ b/html/install.php
@@ -212,7 +212,7 @@ if ($status == 'no') {
 }
 echo "</td></tr>";
     
-if (is_writeable($php_temp_dir)) {
+if (is_writable($php_temp_dir)) {
     $status = 'yes';
     $row_class = 'success';
 } else {

--- a/html/install.php
+++ b/html/install.php
@@ -4,7 +4,7 @@ use LibreNMS\Config;
 
 session_start();
 $librenms_dir = realpath(__DIR__ . '/..');
-$php_temp_dir = sys_get_temp_dir();
+$php_temp_dir = sys_get_temp_dir() ? sys_get_temp_dir() : '/tmp';
 
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -25,7 +25,7 @@
 $config['project_name'] = 'LibreNMS';
 $config['project_id']   = strtolower($config['project_name']);
 
-$config['temp_dir']    = '/tmp';
+$config['temp_dir']    = sys_get_temp_dir() ? sys_get_temp_dir() : '/tmp';
 $config['log_dir']     = $config['install_dir'].'/logs';
 
 // MySQL Debug level

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -25,7 +25,7 @@
 $config['project_name'] = 'LibreNMS';
 $config['project_id']   = strtolower($config['project_name']);
 
-$config['temp_dir']    = sys_get_temp_dir() ? sys_get_temp_dir() : '/tmp';
+$config['temp_dir']    = sys_get_temp_dir() ?: '/tmp';
 $config['log_dir']     = $config['install_dir'].'/logs';
 
 // MySQL Debug level

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -25,6 +25,7 @@
 $config['project_name'] = 'LibreNMS';
 $config['project_id']   = strtolower($config['project_name']);
 
+$config['temp_dir']    = '/tmp';
 $config['log_dir']     = $config['install_dir'].'/logs';
 
 // MySQL Debug level

--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -25,7 +25,6 @@
 $config['project_name'] = 'LibreNMS';
 $config['project_id']   = strtolower($config['project_name']);
 
-$config['temp_dir']    = sys_get_temp_dir() ?: '/tmp';
 $config['log_dir']     = $config['install_dir'].'/logs';
 
 // MySQL Debug level


### PR DESCRIPTION
This fixes a usecase when open_basedir is set, not allowing php to write to default temp directory /tmp.
In that case, temp directory is set by `php_admin_value[sys_temp_dir] = /var/www/site/tmp`
Without setting config['temp_dir'] in generated config.php, LibreNMS will use /tmp regardless of what is set in fpm configuration.
This will set config['temp_dir'] to /tmp if not if no special sys_temp_dir directive is configured in php-fpm pool.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
