### PR TITLE
Fix structure of network_map_legend default

### DIFF
--- a/includes/defaults.inc.php
+++ b/includes/defaults.inc.php
@@ -369,19 +369,15 @@ $config['network_map_legend'] = array(
     '90'           => '#d12300',
     '95'           => '#cc0000',
     '100'          => '#cc0000',
-    [
-        'di' => [
-            'edge' => '#dddddd88',
-            'border' => '#cccccc',
-            'node' => '#eeeeee',
-        ]
+    'di' => [
+        'edge' => '#dddddd88',
+        'border' => '#cccccc',
+        'node' => '#eeeeee',
     ],
-    [
-        'dn' => [
-            'edge' => '#ff777788',
-            'border' => '#ff5555',
-            'node' => '#ffdddd',
-        ]
+    'dn' => [
+        'edge' => '#ff777788',
+        'border' => '#ff5555',
+        'node' => '#ffdddd',
     ]
 );
 


### PR DESCRIPTION
Fix array to allow `Config::get('network_map_legend.dn.node')` in `print-map.inc.php` to work properly.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ X ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
