### PR TITLE
API Transport - Empty lines handling

### DIFF
--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -48,7 +48,7 @@ class Api extends Transport
         $host = explode("?", $api, 2)[0]; //we don't use the parameter part, cause we build it out of options.
 
         //get each line of key-values and process the variables;
-        foreach (preg_split("/\\r\\n|\\r|\\n/", $options, -1, PREG_SPLIT_NO_EMPTY)) as $current_line) {
+        foreach (preg_split("/\\r\\n|\\r|\\n/", $options, -1, PREG_SPLIT_NO_EMPTY) as $current_line) {
             list($u_key, $u_val) = explode('=', $current_line, 2);
 
             // Replace the values

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -50,7 +50,9 @@ class Api extends Transport
         //get each line of key-values and process the variables;
         foreach (preg_split("/\\r\\n|\\r|\\n/", $options) as $current_line) {
             list($u_key, $u_val) = explode('=', $current_line, 2);
-
+            if (empty($u_key)) {
+                continue;
+            }
             // Replace the values
             foreach ($obj as $p_key => $p_val) {
                 $u_val = str_replace("{{ $" . $p_key . ' }}', $p_val, $u_val);

--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -48,11 +48,9 @@ class Api extends Transport
         $host = explode("?", $api, 2)[0]; //we don't use the parameter part, cause we build it out of options.
 
         //get each line of key-values and process the variables;
-        foreach (preg_split("/\\r\\n|\\r|\\n/", $options) as $current_line) {
+        foreach (preg_split("/\\r\\n|\\r|\\n/", $options, -1, PREG_SPLIT_NO_EMPTY)) as $current_line) {
             list($u_key, $u_val) = explode('=', $current_line, 2);
-            if (empty($u_key)) {
-                continue;
-            }
+
             // Replace the values
             foreach ($obj as $p_key => $p_val) {
                 $u_val = str_replace("{{ $" . $p_key . ' }}', $p_val, $u_val);


### PR DESCRIPTION
Issue when dealing with empty line in API options, resulting in bad option formatting. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
