### PR TITLE
Ensure that sysName is trimmed on discovery

### DIFF
--- a/includes/discovery/core.inc.php
+++ b/includes/discovery/core.inc.php
@@ -4,7 +4,7 @@ $snmpdata = snmp_get_multi_oid($device, ['sysName.0', 'sysObjectID.0', 'sysDescr
 
 $core_update = array(
     'sysObjectID' => $snmpdata['.1.3.6.1.2.1.1.2.0'],
-    'sysName' => strtolower($snmpdata['.1.3.6.1.2.1.1.5.0']),
+    'sysName' => strtolower(trim($snmpdata['.1.3.6.1.2.1.1.5.0'])),
     'sysDescr' => $snmpdata['.1.3.6.1.2.1.1.1.0'],
 );
 


### PR DESCRIPTION
some devices like NetAgent report sysName with newline at the end causing LibreNMS to try to update sysName on every discovery run as it compares value with newline at the end to trimmed value from SQL.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
