### PR TITLE
VPN sensors Fortigate name: phase1 - phase2 (remote_ip)

### DIFF
--- a/includes/definitions/discovery/fortigate.yaml
+++ b/includes/definitions/discovery/fortigate.yaml
@@ -11,6 +11,7 @@ modules:
             data:
                 -   oid:
                       - fgVpnTunEntPhase1Name
+                      - fgVpnTunEntPhase2Name
                       - fgVpnTunEntRemGwyIp
         state:
             data:
@@ -27,7 +28,7 @@ modules:
                     oid: fgVpnTunEntStatus
                     num_oid: '.1.3.6.1.4.1.12356.101.12.2.2.1.20.{{ $index }}'
                     index: 'fgVpnTunEntIndex.{{ $index }}'
-                    descr: "{{ $fgVpnTunEntPhase1Name }} ({{ $fgVpnTunEntRemGwyIp }})"
+                    descr: "{{ $fgVpnTunEntPhase1Name }} - {{ $fgVpnTunEntPhase2Name }} ({{ $fgVpnTunEntRemGwyIp }})"
                     group: IPSEC VPN
                     value: fgVpnTunEntStatus
                     states:


### PR DESCRIPTION
Change name of sensor to get useful name when more than one phase2 exist in a VPN.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
