### PR TITLE
Fix missing background on progress-bar for 95th bills

### DIFF
--- a/includes/html/pages/bill.inc.php
+++ b/includes/html/pages/bill.inc.php
@@ -187,6 +187,7 @@ if ($vars['view'] == 'edit' && LegacyAuth::user()->hasGlobalAdmin()) {
             $cdr       = $bill_data['bill_cdr'];
             $rate_95th = round($rate_95th, 2);
             $percent = round((($rate_95th) / $cdr * 100), 2);
+            $background = get_percentage_colours($percent);
             $type = '&amp;95th=yes';
 ?>
         <td>


### PR DESCRIPTION
Before:
https://u.gensokyo.re/d/XQkqDp0s

After:
https://u.gensokyo.re/d/Ki3OSjxT

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
