### PR TITLE
Fix billing showing estimated transfer based on total of 1 days if billing day is first

### DIFF
--- a/includes/html/pages/bill/transfer.inc.php
+++ b/includes/html/pages/bill/transfer.inc.php
@@ -31,7 +31,7 @@ $yesterday      = dbFetchCell('SELECT UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 1 
 $rightnow       = date('U');
 
 $cur_days   = date('d', (strtotime('now') - strtotime($datefrom)));
-$total_days = date('d', (strtotime($dateto) - strtotime($datefrom)));
+$total_days = round((strtotime($dateto) - strtotime($datefrom)) / (60 * 60 * 24));
 
 $total['data'] = format_bytes_billing($bill_data['total_data']);
 if ($bill_data['bill_type'] == 'quota') {


### PR DESCRIPTION
Fixes billing showing estimated transfer being same as average if billing start day is 1st.
```date('d', (strtotime($dateto) - strtotime($datefrom)));``` 
would return 1 if in such case.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
