### PR TITLE
Don't display INF% for percentage of used transfer when billing is CDR

### DIFF
--- a/includes/html/pages/bill/transfer.inc.php
+++ b/includes/html/pages/bill/transfer.inc.php
@@ -42,7 +42,11 @@ if ($bill_data['bill_type'] == 'quota') {
 
 $total['ave'] = format_bytes_billing(($bill_data['total_data'] / $cur_days));
 $total['est'] = format_bytes_billing(($bill_data['total_data'] / $cur_days * $total_days));
-$total['per'] = round(($bill_data['total_data'] / $bill_data['bill_quota'] * 100), 2);
+if ($bill_data['bill_type'] == 'quota') {
+    $total['per'] = round(($bill_data['total_data'] / $bill_data['bill_quota'] * 100), 2);
+} else {
+    $total['per'] = round(($bill_data['total_data'] / ($bill_data['total_data'] / $cur_days * $total_days) * 100), 2);
+}
 $total['bg']  = get_percentage_colours($total['per']);
 
 $in['data']  = format_bytes_billing($bill_data['total_data_in']);


### PR DESCRIPTION
This changes calculation used to get total transfer usage percentage if billing type is 95th CDR - instead of bill_quote (which would be 0 in such case) it uses estimated usage.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
