### PR TITLE
Add an option to hide Location column in Alerts widget

### DIFF
--- a/app/Http/Controllers/Widgets/AlertsController.php
+++ b/app/Http/Controllers/Widgets/AlertsController.php
@@ -40,6 +40,7 @@ class AlertsController extends WidgetController
         'state' => null,
         'group' => null,
         'proc' => 0,
+        'location' => 1,
         'sort' => 1,
     ];
 

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -12,7 +12,7 @@
             <th data-column-id="rule">Rule</th>
             <th data-column-id="details" data-sortable="false"></th>
             <th data-column-id="hostname">Hostname</th>
-            <th data-column-id="location">Location</th>
+            <th data-column-id="location" data-visible="{{ $location ? 'true' : 'false' }}">Location</th>
             <th data-column-id="ack_ico" data-sortable="false">ACK</th>
             <th data-column-id="notes" data-sortable="false">Notes</th>
             <th data-column-id="proc" data-sortable="false" data-visible="{{ $proc ? 'true' : 'false' }}">URL</th>

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -54,6 +54,13 @@
         </select>
     </div>
     <div class="form-group row">
+        <label for="location-{{ $id }}" class="control-label">@lang('Show Location field'):</label>
+        <select class="form-control" name="location" id="location-{{ $id }}">
+            <option value="1" @if($location == 1) selected @endif>@lang('show')</option>
+            <option value="0" @if($location == 0) selected @endif>@lang('hide')</option>
+        </select>
+    </div>
+    <div class="form-group row">
         <label for="sort-{{ $id }}" class="control-label">@lang('Sort alerts by'):</label>
         <select class="form-control" name="sort" id="sort-{{ $id }}">
             <option value="" @if($sort == 1) selected @endif>@lang('timestamp, descending')</option>


### PR DESCRIPTION
Add an option to hide Location column in Alerts widget.

Default value is to show Location column.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
