### PR TITLE
Allow filtering of Health sensor discovery

### DIFF
--- a/doc/Developing/os/Settings.md
+++ b/doc/Developing/os/Settings.md
@@ -21,25 +21,29 @@ $config['os']['ios']['icon'] = 'fuzzybunny';
 It is possible to filter some sensors from the configuration:
 
 - Filter all 'current' sensors for Operating System 'vrp'.
-```
+
+```php
 $config['os']['vrp']['disabled_sensors']['current'] = true;
 ```
 
-- Filter all sensors matching regexp ``` '/PEM Iout/' ``` for Operating System iosxe. 
-```
+- Filter all sensors matching regexp ``` '/PEM Iout/' ``` for
+Operating System iosxe.
+
+```php
 $config['os']['iosxe']['disabled_sensors_regex'][] = '/PEM Iout/';
 ```
 
 - Ignore all temperature sensors
-```
+
+```php
 $config['disabled_sensors']['current'] = true;
 ```
 
 - Filter all sensors matching regexp ``` '/PEM Iout/' ```.
-```
+
+```php
 $config['disabled_sensors_regex'][] = '/PEM Iout/';
 ```
-
 
 ### Ignoring Interfaces
 See also: [Global Ignoring Interfaces Config](../../Support/Configuration.md#interfaces-to-be-ignored)

--- a/doc/Developing/os/Settings.md
+++ b/doc/Developing/os/Settings.md
@@ -16,6 +16,31 @@ For example, to set an alternate icon for ios:
 $config['os']['ios']['icon'] = 'fuzzybunny';
 ```
 
+### Ignoring Sensors
+
+It is possible to filter some sensors from the configuration:
+
+- Filter all 'current' sensors for Operating System 'vrp'.
+```
+$config['os']['vrp']['disabled_sensors']['current'] = true;
+```
+
+- Filter all sensors matching regexp ``` '/PEM Iout/' ``` for Operating System iosxe. 
+```
+$config['os']['iosxe']['disabled_sensors_regex'][] = '/PEM Iout/';
+```
+
+- Ignore all temperature sensors
+```
+$config['disabled_sensors']['current'] = true;
+```
+
+- Filter all sensors matching regexp ``` '/PEM Iout/' ```.
+```
+$config['disabled_sensors_regex'][] = '/PEM Iout/';
+```
+
+
 ### Ignoring Interfaces
 See also: [Global Ignoring Interfaces Config](../../Support/Configuration.md#interfaces-to-be-ignored)
 

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -721,6 +721,30 @@ these are not provided by the vendor, the guess method can be disabled:
 $config['sensors']['guess_limits'] = false;
 ```
 
+# Ignoring Health Sensors
+
+It is possible to filter some sensors from the configuration:
+
+- Ignore all temperature sensors
+```
+$config['disabled_sensors']['current'] = true;
+```
+
+- Filter all sensors matching regexp ``` '/PEM Iout/' ```.
+```
+$config['disabled_sensors_regex'][] = '/PEM Iout/';
+```
+
+- Filter all 'current' sensors for Operating System 'vrp'.
+```
+$config['os']['vrp']['disabled_sensors']['current'] = true;
+```
+
+- Filter all sensors matching regexp ``` '/PEM Iout/' ``` for Operating System iosxe.
+```
+$config['os']['iosxe']['disabled_sensors_regex'][] = '/PEM Iout/';
+```
+
 # Storage configuration
 
 Mounted storage / mount points to ignore in discovery and polling.

--- a/doc/Support/Configuration.md
+++ b/doc/Support/Configuration.md
@@ -726,22 +726,27 @@ $config['sensors']['guess_limits'] = false;
 It is possible to filter some sensors from the configuration:
 
 - Ignore all temperature sensors
-```
+
+```php
 $config['disabled_sensors']['current'] = true;
 ```
 
 - Filter all sensors matching regexp ``` '/PEM Iout/' ```.
-```
+
+```php
 $config['disabled_sensors_regex'][] = '/PEM Iout/';
 ```
 
 - Filter all 'current' sensors for Operating System 'vrp'.
-```
+
+```php
 $config['os']['vrp']['disabled_sensors']['current'] = true;
 ```
 
-- Filter all sensors matching regexp ``` '/PEM Iout/' ``` for Operating System iosxe.
-```
+- Filter all sensors matching regexp ``` '/PEM Iout/' ``` for 
+Operating System iosxe.
+
+```php
 $config['os']['iosxe']['disabled_sensors_regex'][] = '/PEM Iout/';
 ```
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1328,9 +1328,6 @@ function add_cbgp_peer($device, $peer, $afi, $safi)
  */
 function can_skip_sensor($device, $sensor_type = '', $sensor_descr = '')
 {
-    if (! $device) {
-        return false;
-    }
     if (! empty($sensor_type) && Config::getCombined($device['os'], "disabled_sensors.$sensor_type", false)) {
         return true;
     }

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1331,7 +1331,7 @@ function can_skip_sensor($device, $sensor_type = '', $sensor_descr = '')
     if (! $device) {
         return false;
     }
-    if (! empty($sensor_type) && Config::getCombined($device['os'], "disabled_sensors.$sensor_type",false)) {
+    if (! empty($sensor_type) && Config::getCombined($device['os'], "disabled_sensors.$sensor_type", false)) {
         return true;
     }
     foreach (Config::getCombined($device['os'], "disabled_sensors_regex", []) as $skipRegex) {


### PR DESCRIPTION
Some LibreNMS users might not want to discover all the supported sensors for an OS. But it is not possible to change the YAML file (prevents upgrades). 
This PR allows filtering to occur during the discovery process, from config.php, using the same principles than other filtering already implemented in LibreNMS

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
