### PR TITLE
Watchguard Fireware is FirewareOS in oxidized

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1322,6 +1322,7 @@ function list_oxidized()
             'arista_eos' => 'eos',
             'vyos'       => 'vyatta',
             'slms'       => 'zhoneolt',
+            'fireware'   => 'firewareos',
         ];
 
         $device['os'] = str_replace(array_keys($models), array_values($models), $device['os']);


### PR DESCRIPTION
As discussed in https://github.com/ytti/oxidized/pull/1868, Watchguard OS is named fireware or firewareos, the latter being used by Oxidized.
As suggested by @laf, renaming this in the API.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
