### PR TITLE
Fix .env with number symbols

### DIFF
--- a/LibreNMS/ComposerHelper.php
+++ b/LibreNMS/ComposerHelper.php
@@ -146,6 +146,8 @@ class ComposerHelper
             }
         }
 
+        $content = self::fixComments($content);
+
         // only write if the content has changed
         if ($content !== $original_content) {
             file_put_contents($file, $content);
@@ -171,5 +173,23 @@ class ComposerHelper
     {
         $cmd = "set -v\n" . implode(PHP_EOL, (array)$cmds);
         passthru($cmd);
+    }
+
+    /**
+     * Fix .env with # in them without a space before it
+     */
+    private static function fixComments($dotenv)
+    {
+        return implode(PHP_EOL, array_map(function ($line) {
+            $parts = explode('=', $line, 2);
+            if (isset($parts[1])
+                && preg_match('/(?<! )#/', $parts[1]) // number symbol without a space before it
+                && !preg_match('/^(".*"|\'.*\')$/', $parts[1]) // not already quoted
+            ) {
+                return $parts[0] . '="' . $parts[1] . '"';
+            }
+
+            return $line;
+        }, explode(PHP_EOL, $dotenv)));
     }
 }

--- a/LibreNMS/ComposerHelper.php
+++ b/LibreNMS/ComposerHelper.php
@@ -183,10 +183,10 @@ class ComposerHelper
         return implode(PHP_EOL, array_map(function ($line) {
             $parts = explode('=', $line, 2);
             if (isset($parts[1])
-                && preg_match('/(?<! )#/', $parts[1]) // number symbol without a space before it
+                && preg_match('/(?<!\s)#/', $parts[1]) // number symbol without a space before it
                 && !preg_match('/^(".*"|\'.*\')$/', $parts[1]) // not already quoted
             ) {
-                return $parts[0] . '="' . $parts[1] . '"';
+                return trim($parts[0]) . '="' . trim($parts[1]) . '"';
             }
 
             return $line;


### PR DESCRIPTION
Wraps env values that contain # in quotes.  Tries to avoid ones that are comments.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
