### PR TITLE
Bug: Fixed Incorrect device match in Graylog

### DIFF
--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -141,15 +141,15 @@ class GraylogApi
         ]);
 
         if (Config::get('graylog.match-any-address')) {
-            $addresses = $addresses->merge($device->ipv4->pluck('ipv4_address'))
+            $addresses = $addresses->merge($device->ipv4->pluck('ipv4_address')
                 ->filter(
-                    function($address) {
+                    function ($address) {
                         return $address != "127.0.0.1";
                     }
-                ))->merge($device->ipv6->pluck('ipv6_address'))
+                ))->merge($device->ipv6->pluck('ipv6_address')
                 ->filter(
-                    function($address) {
-                        return $address != "0000:0000:0000:0000:0000:0000:0000:0001"; 
+                    function ($address) {
+                        return $address != "0000:0000:0000:0000:0000:0000:0000:0001";
                     }
                 ));
         }

--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -142,14 +142,19 @@ class GraylogApi
 
         if (Config::get('graylog.match-any-address')) {
             $addresses = $addresses->merge($device->ipv4->pluck('ipv4_address'))
-                ->merge($device->ipv6->pluck('ipv6_address'));
+                ->filter(
+                    function($address) {
+                        return $address != "127.0.0.1";
+                    }
+                ))->merge($device->ipv6->pluck('ipv6_address'))
+                ->filter(
+                    function($address) {
+                        return $address != "0000:0000:0000:0000:0000:0000:0000:0001"; 
+                    }
+                ));
         }
 
-        return $addresses->filter(
-            function ($address) {
-                return $address != "127.0.0.1" && $address != "::1";
-            }
-        )->unique();
+        return $addresses->filter()->unique();
     }
 
     public function isConfigured()

--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -145,7 +145,11 @@ class GraylogApi
                 ->merge($device->ipv6->pluck('ipv6_address'));
         }
 
-        return $addresses->filter()->unique();
+        return $addresses->filter(
+            function ($address) {
+                return $address != "127.0.0.1" && $address != "::1";
+            }
+        )->unique();
     }
 
     public function isConfigured()


### PR DESCRIPTION
Incorrect device match fixed. Because getAddresses(Device $device) also returned 127.0.0.1 and ::1, always matched the first device with a loopback address. Introduced in https://github.com/librenms/librenms/pull/10458

Filtered 127.0.0.1 and ::1 in return statement of getAddresses(Device $device)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
