### PR TITLE
Ports API: Workaround for ifNames with slashes

### DIFF
--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -469,16 +469,13 @@ Output:
     "count": 3,
     "ports": [
         {
-            "ifName": "lo",
-            "port_id": 1
+            "ifName": "lo"
         },
         {
-            "ifName": "eth0",
-            "port_id": 2
+            "ifName": "eth0"
         },
         {
-            "ifName": "eth1",
-            "port_id": 14
+            "ifName": "eth1"
         }
     ]
 }
@@ -750,11 +747,10 @@ Get information about a particular port for a device.
 Route: `/api/v0/devices/:hostname/ports/:ifname`
 
 - hostname can be either the device hostname or id
-- port_id or ifname of any of the interfaces of the device which can be
-  obtained using [`get_port_graphs`](#function-get_port_graphs).
->  If ifName contains `/`, you must pass it as the ifName GET variable
-  and put a dummy value in ifname. For example: 
-  `/api/v0/devices/1/ports/none?ifName=Gi0/1/0`
+- ifname can be any of the interface names for the device which can be
+  obtained using
+  [`get_port_graphs`](#function-get_port_graphs). Please ensure that
+  the ifname is urlencoded if it needs to be (i.e Gi0/1/0 would need to be urlencoded.
 
 Input:
 
@@ -788,12 +784,11 @@ Get a graph of a port for a particular device.
 Route: `/api/v0/devices/:hostname/ports/:ifname/:type`
 
 - hostname can be either the device hostname or id
-- port_id or ifname of any of the ports of the device which can be
-  obtained using [`get_port_graphs`](#function-get_port_graphs). 
->  If ifName contains `/`, you must pass it as the ifName GET variable
-  and put a dummy value in ifname. For example: 
-  `/api/v0/devices/1/ports/none/port_bits?ifName=Gi0/1/0`
-
+- ifname can be any of the interface names for the device which can be
+  obtained using
+  [`get_port_graphs`](#function-get_port_graphs). Please ensure that
+  the ifname is urlencoded if it needs to be (i.e Gi0/1/0 would need
+  to be urlencoded.
 - type is the port type you want the graph for, you can request a list
   of ports for a device with [`get_port_graphs`](#function-get_port graphs).
 

--- a/doc/API/Devices.md
+++ b/doc/API/Devices.md
@@ -469,13 +469,16 @@ Output:
     "count": 3,
     "ports": [
         {
-            "ifName": "lo"
+            "ifName": "lo",
+            "port_id": 1
         },
         {
-            "ifName": "eth0"
+            "ifName": "eth0",
+            "port_id": 2
         },
         {
-            "ifName": "eth1"
+            "ifName": "eth1",
+            "port_id": 14
         }
     ]
 }
@@ -747,10 +750,11 @@ Get information about a particular port for a device.
 Route: `/api/v0/devices/:hostname/ports/:ifname`
 
 - hostname can be either the device hostname or id
-- ifname can be any of the interface names for the device which can be
-  obtained using
-  [`get_port_graphs`](#function-get_port_graphs). Please ensure that
-  the ifname is urlencoded if it needs to be (i.e Gi0/1/0 would need to be urlencoded.
+- port_id or ifname of any of the interfaces of the device which can be
+  obtained using [`get_port_graphs`](#function-get_port_graphs).
+>  If ifName contains `/`, you must pass it as the ifName GET variable
+  and put a dummy value in ifname. For example: 
+  `/api/v0/devices/1/ports/none?ifName=Gi0/1/0`
 
 Input:
 
@@ -784,11 +788,12 @@ Get a graph of a port for a particular device.
 Route: `/api/v0/devices/:hostname/ports/:ifname/:type`
 
 - hostname can be either the device hostname or id
-- ifname can be any of the interface names for the device which can be
-  obtained using
-  [`get_port_graphs`](#function-get_port_graphs). Please ensure that
-  the ifname is urlencoded if it needs to be (i.e Gi0/1/0 would need
-  to be urlencoded.
+- port_id or ifname of any of the ports of the device which can be
+  obtained using [`get_port_graphs`](#function-get_port_graphs). 
+>  If ifName contains `/`, you must pass it as the ifName GET variable
+  and put a dummy value in ifname. For example: 
+  `/api/v0/devices/1/ports/none/port_bits?ifName=Gi0/1/0`
+
 - type is the port type you want the graph for, you can request a list
   of ports for a device with [`get_port_graphs`](#function-get_port graphs).
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -455,6 +455,18 @@ function generate_entity_link($type, $entity, $text = null, $graph_type = null)
     return ($link);
 }//end generate_entity_link()
 
+/**
+ * Extract type and subtype from a complex graph type, also makes sure variables are file name safe.
+ * @param string $type
+ * @return array [type, subtype]
+ */
+function extract_graph_type($type): array
+{
+    preg_match('/^(?P<type>[A-Za-z0-9]+)_(?P<subtype>.+)/', $type, $graphtype);
+    $type = basename($graphtype['type']);
+    $subtype = basename($graphtype['subtype']);
+    return [$type, $subtype];
+}
 
 function generate_port_link($port, $text = null, $type = null, $overlib = 1, $single_graph = 0)
 {

--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -7,9 +7,7 @@ foreach ($_GET as $name => $value) {
     $vars[$name] = $value;
 }
 
-preg_match('/^(?P<type>[A-Za-z0-9]+)_(?P<subtype>.+)/', $vars['type'], $graphtype);
-$type    = basename($graphtype['type']);
-$subtype = basename($graphtype['subtype']);
+list($type, $subtype) = extract_graph_type($vars['type']);
 
 if (is_numeric($vars['device'])) {
     $device = device_by_id_cache($vars['device']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,7 +91,8 @@ Route::group(['prefix' => 'v0', 'namespace' => '\App\Api\Controllers'], function
         Route::get('{hostname}/port_stack', 'LegacyApiController@get_port_stack')->name('get_port_stack');
         Route::get('{hostname}/components', 'LegacyApiController@get_components')->name('get_components');
         Route::get('{hostname}/groups', 'LegacyApiController@get_device_groups')->name('get_device_groups');
-        Route::get('{hostname}/ports/{ifname}', 'LegacyApiController@get_port_stats_by_port_hostname')->name('get_port_stats_by_port_hostname');
+        // consumes the route below, but passes to it when detected
+        Route::get('{hostname}/ports/{ifname}', 'LegacyApiController@get_port_stats_by_port_hostname')->name('get_port_stats_by_port_hostname')->where('ifname', '.*');
         Route::get('{hostname}/ports/{ifname}/{type}', 'LegacyApiController@get_graph_by_port_hostname')->name('get_graph_by_port_hostname');
 
         Route::get('{hostname}/{type}', 'LegacyApiController@get_graph_generic_by_hostname')->name('get_graph_generic_by_hostname');


### PR DESCRIPTION
Basically,

/api/v0/devices/3/ports/0%2f4 -> /api/v0/devices/3/ports/ifName?ifName=0/4
/api/v0/devices/3/ports/0%2f4/port_bits -> /api/v0/devices/3/ports/ifName/port_bits?ifName=0/4

Or you can just use port_id. If ifName doesn't contain / it will still work.

Also adds port_id to the default output for the ports list.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
