### PR TITLE
Fix regression after fc281ccc4b5f2fb0a0bbc46a8285fcec18771d66

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -431,7 +431,7 @@ class Device extends BaseModel
 
     public function scopeInDeviceGroup($query, $deviceGroup)
     {
-        return $query->whereIn('device_id', function ($query) use ($deviceGroup) {
+        return $query->whereIn($query->qualifyColumn('device_id'), function ($query) use ($deviceGroup) {
             $query->select('device_id')
                 ->from('device_group_device')
                 ->where('device_group_id', $deviceGroup);

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -36,7 +36,7 @@ class DeviceRelatedModel extends BaseModel
 
     public function scopeInDeviceGroup($query, $deviceGroup)
     {
-        return $query->whereIn('device_id', function ($query) use ($deviceGroup) {
+        return $query->whereIn($query->qualifyColumn('device_id'), function ($query) use ($deviceGroup) {
             $query->select('device_id')
                 ->from('device_group_device')
                 ->where('device_group_id', $deviceGroup);


### PR DESCRIPTION
Top device widget with `memory usage` and a device group generates this sql:
```sql
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'device_id' in IN/ALL/ANY subquery is ambiguous (SQL: select mempools.device_id from mempools left join devices on mempools.device_id = devices.device_id where devices.last_polled > 2019-08-08 10:03:35 and device_id in (select device_group_device.device_id from device_group_device where device_group_device.device_group_id = 10) group by mempools.device_id order by mempool_perc desc limit 5)
```
By prefixing the `device_id` with the current table, like for example `mempools.device_id` we avoid this problem. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
