### PR TITLE
Added Graylog to device overview and log level filter mechanism

### DIFF
--- a/app/Http/Controllers/Table/GraylogController.php
+++ b/app/Http/Controllers/Table/GraylogController.php
@@ -58,6 +58,7 @@ class GraylogController extends SimpleTableController
             'stream' => 'nullable|alpha_num',
             'device' => 'nullable|int',
             'range' => 'nullable|int',
+            'maxLevel' => 'nullable|int|min:0|max:7',
         ]);
 
         $search = $request->get('searchPhrase');
@@ -67,7 +68,9 @@ class GraylogController extends SimpleTableController
         $limit = $request->get('rowCount', 10);
         $page = $request->get('current', 1);
         $offset = ($page - 1) * $limit;
-        $query = $api->buildSimpleQuery($search, $device);
+        $maxLevel = $request->get('maxLevel', 7);
+        $query = $api->buildSimpleQuery($search, $device).
+            ($maxLevel !== null ? ' AND level: <='. $maxLevel : '');
 
         $sort = null;
         foreach ($request->get('sort', []) as $field => $direction) {

--- a/app/Http/Controllers/Widgets/GraylogController.php
+++ b/app/Http/Controllers/Widgets/GraylogController.php
@@ -38,6 +38,7 @@ class GraylogController extends WidgetController
         'device' => null,
         'range' => null,
         'limit' => 15,
+        'maxLevel' => null,
     ];
 
     /**

--- a/doc/Extensions/Graylog.md
+++ b/doc/Extensions/Graylog.md
@@ -47,6 +47,11 @@ If you want to match the source address of the log entries against any IP addres
 the primary address and the host name to assign the log entries to a device, you can activate this function using
 $config['graylog']['match-any-address'] = 'true';
 
+There are 2 configuration parameters to influence the behaviour of the "Recent Graylog" table on the overview page of the devices.
+$config['graylog']['device-page']['rowCount'] sets the maximum number of rows to be displayed (default: 10)
+With $config['graylog']['device-page']['maxLevel'] you can set which loglevels should be displayed on the overview page. (default: 7, min: 0, max: 7)
+$config['graylog']['device-page']['maxLevel'] = 4 shows only entries with a log level less than or equal to 4 (Emergency, Alert, Critical, Error, Warning).
+
 ## Suppressing/enabling the domain part of a hostname for specific platforms
 You should see if what you get in syslog/Graylog matches up with your configured hosts first. If you need to modify the syslog messages from specific platforms, this may be of assistance:
 

--- a/includes/html/common/graylog.inc.php
+++ b/includes/html/common/graylog.inc.php
@@ -80,6 +80,18 @@ if (\LibreNMS\Config::has('graylog.timezone')) {
 }
 
 $tmp_output .= '
+                "<div class=\"form-group\">"+
+                "<select name=\"maxLevel\" id=\"maxLevel\" class=\"form-control\">"+
+                "<option value=\"\" disabled selected>Max Level</option>"+
+                "<option value=\"0\">'.("(0) " . __("syslog.severity.0")).'</option>"+
+                "<option value=\"1\">'.("(1) " . __("syslog.severity.1")).'</option>"+
+                "<option value=\"2\">'.("(2) " . __("syslog.severity.2")).'</option>"+
+                "<option value=\"3\">'.("(3) " . __("syslog.severity.3")).'</option>"+
+                "<option value=\"4\">'.("(4) " . __("syslog.severity.4")).'</option>"+
+                "<option value=\"5\">'.("(5) " . __("syslog.severity.5")).'</option>"+
+                "<option value=\"6\">'.("(6) " . __("syslog.severity.6")).'</option>"+
+                "<option value=\"7\">'.("(7) " . __("syslog.severity.7")).'</option>"+
+                "</select>&nbsp;</div>"+
                 "<div class=\"form-group\"><select name=\"range\" class=\"form-control\">"+
                 "<option value=\"0\">Search all time</option>"+
                 "<option value=\"300\">Search last 5 minutes</option>"+
@@ -97,7 +109,7 @@ $tmp_output .= '
                 "</select>&nbsp;</div>"+
                 "<button type=\"submit\" class=\"btn btn-success\">Filter</button>&nbsp;"+
                 "</form></div>"+
-                "<div class=\"col-sm-4 actionBar\"><p class=\"{{css.search}}\"></p><p class=\"{{css.actions}}\"></p></div></div></div>"
+                "<div class=\"col-sm-4 actionBar\"><p class=\"{{css.search}}\"></p><p class=\"{{css.actions}}\"></p></div></div></div>";
 
     var graylog_grid = $("#graylog").bootgrid({
         ajax: true,
@@ -123,7 +135,8 @@ $tmp_output .= '
             return {
                 stream: "' . (isset($_POST['stream']) ? mres($_POST['stream']) : '') . '",
                 device: "' . (isset($filter_device) ? $filter_device : '') . '",
-                range: "' . (isset($_POST['range']) ? mres($_POST['range']) : '')  . '"
+                range: "' . (isset($_POST['range']) ? mres($_POST['range']) : '')  . '",
+                maxLevel: "' . (isset($_POST['maxLevel']) ? mres($_POST['maxLevel']) : '')  . '",
             };
         },
         url: "' . url('/ajax/table/graylog') . '",

--- a/includes/html/pages/device/overview.inc.php
+++ b/includes/html/pages/device/overview.inc.php
@@ -66,7 +66,7 @@ require 'overview/sensors/waterflow.inc.php';
 require 'overview/eventlog.inc.php';
 require 'overview/services.inc.php';
 require 'overview/syslog.inc.php';
-
+require 'overview/graylog.inc.php';
 echo('</div></div></div>');
 
 #require 'overview/current.inc.php");

--- a/includes/html/pages/device/overview/graylog.inc.php
+++ b/includes/html/pages/device/overview/graylog.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if (\LibreNMS\Config::get('graylog.server')) {
-    echo 
+    echo
         '<div class="row" id="graylog-card">'.
         '  <div class="col-md-12">'.
         '    <div class="panel panel-default panel-condensed">'.
@@ -17,7 +17,7 @@ if (\LibreNMS\Config::get('graylog.server')) {
     require_once 'includes/html/print-graylog.inc.php';
     echo implode('', $common_output);
     unset($no_form);
-    echo 
+    echo
         '      </table>'.
         '    </div>'.
         '  </div>'.

--- a/includes/html/pages/device/overview/graylog.inc.php
+++ b/includes/html/pages/device/overview/graylog.inc.php
@@ -1,0 +1,31 @@
+<?php
+
+if (\LibreNMS\Config::get('graylog.server')) {
+/*    $syslog = dbFetchRows("SELECT *, DATE_FORMAT(timestamp, '" . \LibreNMS\Config::get('dateformat.mysql.compact') . "') AS date from syslog WHERE device_id = ? ORDER BY timestamp DESC LIMIT 20", [$device['device_id']]);
+    if (count($syslog)) {*/
+        echo '<div class="row">
+            <div class="col-md-12">
+            <div class="panel panel-default panel-condensed">
+              <div class="panel-heading">';
+        echo '<a href="device/device='.$device['device_id'].
+            '/tab=logs/section=syslog/"><i class="fa fa-clone fa-lg icon-theme"'.
+            ' aria-hidden="true"></i> <strong>Recent Graylog</strong></a>';
+        echo '        </div>
+              <table class="table table-hover table-condensed table-striped">';
+  /*      foreach ($syslog as $entry) {
+            unset($syslog_output);
+            include 'includes/html/print-syslog.inc.php';
+            echo $syslog_output;
+        }*/
+
+        $filter_device = $device["device_id"];
+        $no_form = true;
+        require_once 'includes/html/print-graylog.inc.php';
+        echo implode('', $common_output);
+        unset($no_form);
+        echo '</table>';
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+//    }
+}

--- a/includes/html/pages/device/overview/graylog.inc.php
+++ b/includes/html/pages/device/overview/graylog.inc.php
@@ -1,31 +1,25 @@
 <?php
 
 if (\LibreNMS\Config::get('graylog.server')) {
-/*    $syslog = dbFetchRows("SELECT *, DATE_FORMAT(timestamp, '" . \LibreNMS\Config::get('dateformat.mysql.compact') . "') AS date from syslog WHERE device_id = ? ORDER BY timestamp DESC LIMIT 20", [$device['device_id']]);
-    if (count($syslog)) {*/
-        echo '<div class="row">
-            <div class="col-md-12">
-            <div class="panel panel-default panel-condensed">
-              <div class="panel-heading">';
-        echo '<a href="device/device='.$device['device_id'].
-            '/tab=logs/section=syslog/"><i class="fa fa-clone fa-lg icon-theme"'.
-            ' aria-hidden="true"></i> <strong>Recent Graylog</strong></a>';
-        echo '        </div>
-              <table class="table table-hover table-condensed table-striped">';
-  /*      foreach ($syslog as $entry) {
-            unset($syslog_output);
-            include 'includes/html/print-syslog.inc.php';
-            echo $syslog_output;
-        }*/
+    echo 
+        '<div class="row" id="graylog-card">'.
+        '  <div class="col-md-12">'.
+        '    <div class="panel panel-default panel-condensed">'.
+        '      <div class="panel-heading">'.
+        '        <a href="device/device='.$device['device_id'].
+        '/tab=logs/section=syslog/"><i class="fa fa-clone fa-lg icon-theme"'.
+        ' aria-hidden="true"></i> <strong>Recent Graylog</strong></a>'.
+        '      </div>'.
+        '      <table class="table table-hover table-condensed table-striped">';
 
-        $filter_device = $device["device_id"];
-        $no_form = true;
-        require_once 'includes/html/print-graylog.inc.php';
-        echo implode('', $common_output);
-        unset($no_form);
-        echo '</table>';
-        echo '</div>';
-        echo '</div>';
-        echo '</div>';
-//    }
+    $filter_device = $device["device_id"];
+    $no_form = true;
+    require_once 'includes/html/print-graylog.inc.php';
+    echo implode('', $common_output);
+    unset($no_form);
+    echo 
+        '      </table>'.
+        '    </div>'.
+        '  </div>'.
+        '</div>';
 }

--- a/includes/html/print-graylog.inc.php
+++ b/includes/html/print-graylog.inc.php
@@ -38,14 +38,23 @@ $tmp_output = '
 <script>
 ';
 
+$rowCount = \LibreNMS\Config::get('graylog.device-page.rowCount');
+$maxLevel = \LibreNMS\Config::get('graylog.device-page.maxLevel');
+
 $tmp_output .= '
     $.ajax({
         type: "post",
         data: {
-            device: "' . (isset($filter_device) ? $filter_device : '') . '"
+            device: "' . (isset($filter_device) ? $filter_device : '') . '",
+            '. ($rowCount? 'rowCount: '.$rowCount .',' : '') .'
+            '. ($maxLevel? 'maxLevel: '.$maxLevel .',' : '') .'
         },
         url: "' . url('/ajax/table/graylog') . '",
         success: function(data){
+            if (data.rowCount == 0) {
+                $("#graylog-card").remove();
+                return;
+            }
             var html = "<tbody>";
             $("#graylog").append("<tbody></tbody>");
             $.each(data.rows, function(i,v){

--- a/includes/html/print-graylog.inc.php
+++ b/includes/html/print-graylog.inc.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * LibreNMS
+ *
+ * Copyright (c) 2014 Neil Lathwood <https://github.com/laf/ http://www.lathwood.co.uk/fa>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.  Please see LICENSE.txt at the top level of
+ * the source code distribution for details.
+ *
+ * @package    LibreNMS
+ * @subpackage webui
+ * @link       http://librenms.org
+ * @copyright  2017 LibreNMS
+ * @author     LibreNMS Contributors
+*/
+
+#use App\Models\Device;
+
+$tmp_output = '
+
+<div class="table-responsive">
+    <table id="graylog" class="table table-hover table-condensed table-striped">
+        <thead>
+            <tr>
+            <th data-column-id="severity"></th>
+            <th data-column-id="timestamp">Timestamp</th>
+            <th data-column-id="level">Level</th>
+            <th data-column-id="message">Message</th>
+            <th data-column-id="facility">Facility</th>
+            </tr>
+        </thead>
+    </table>
+</div>
+
+<script>
+';
+
+$tmp_output .= '
+    $.ajax({
+        type: "post",
+        data: {
+            device: "' . (isset($filter_device) ? $filter_device : '') . '"
+        },
+        url: "' . url('/ajax/table/graylog') . '",
+        success: function(data){
+            var html = "<tbody>";
+            $("#graylog").append("<tbody></tbody>");
+            $.each(data.rows, function(i,v){
+                html = html + "<tr><td>"+v.severity+"</td><td>"+
+                    v.timestamp+"</td><td>"+v.level+"</td><td>"+
+                    v.message+"</td><td>"+v.facility+"</td></tr>";
+            });
+            html = html + "</tbody>";
+            $("#graylog").append(html);
+        }
+    });
+';
+
+$tmp_output .= '
+</script>
+
+';
+
+$common_output[] = $tmp_output;

--- a/resources/views/widgets/graylog.blade.php
+++ b/resources/views/widgets/graylog.blade.php
@@ -31,7 +31,8 @@
             return {
                 stream: "{{ $stream }}",
                 device: "{{ $device }}",
-                range: "{{ $range }}"
+                range: "{{ $range }}",
+                maxLevel: "{{ $maxLevel }}",
             };
         },
         url: "{{ url('/ajax/table/graylog') }}"

--- a/resources/views/widgets/settings/graylog.blade.php
+++ b/resources/views/widgets/settings/graylog.blade.php
@@ -30,6 +30,22 @@
     </div>
 
     <div class="form-group">
+        <label for="maxLevel-{{ $id }}" class="control-label">@lang('Max Level')</label>
+        <select name="maxLevel" id="maxLevel-{{ $id }}" class="form-control">
+            <option value="" disabled @if($maxLevel == null) selected @endif>@lang('Max Level')</option>
+            <option value="0" @if($maxLevel === 0) selected @endif>@lang('(0) Emergency')</option>
+            <option value="1" @if($maxLevel == 1) selected @endif>@lang('(1) Alert')</option>
+            <option value="2" @if($maxLevel == 2) selected @endif>@lang('(2) Critical')</option>
+            <option value="3" @if($maxLevel == 3) selected @endif>@lang('(3) Error')</option>
+            <option value="4" @if($maxLevel == 4) selected @endif>@lang('(4) Warning')</option>
+            <option value="5" @if($maxLevel == 5) selected @endif>@lang('(5) Notice')</option>
+            <option value="6" @if($maxLevel == 6) selected @endif>@lang('(6) Informational')</option>
+            <option value="7" @if($maxLevel == 7) selected @endif>@lang('(7) Debug')</option>
+        </select>
+    </div>
+
+
+    <div class="form-group">
         <label for="range-{{ $id }}" class="control-label">@lang('Time Range')</label>
         <select name="range" id="range-{{ $id }}" class="form-control">
             <option value="0" @if($range == 0) selected @endif>@lang('Search all time')</option>


### PR DESCRIPTION
I added Recent Graylog Entries to device overview like Recent Syslog or Events and 2 Config options to influence the behaviour of the "Recent Graylog" table on the overview page of the devices (row count and maximum log level to show).
Also added a log level dropdown to filter existing Graylog Pages (device subpage and graylog overview) and a graylog widget setting to set the maximum log level for the widget.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
