### PR TITLE
Reduce discovery snmp load of Cisco VTP vlans module

### DIFF
--- a/includes/discovery/vlans/cisco-vtp.inc.php
+++ b/includes/discovery/vlans/cisco-vtp.inc.php
@@ -3,15 +3,16 @@
 if ($device['os_group'] == 'cisco') {
     echo "Cisco VLANs:\n";
 
-    $native_vlans = snmpwalk_cache_oid($device, 'vlanTrunkPortNativeVlan', array(), 'CISCO-VTP-MIB');
+    $native_vlans = snmpwalk_cache_oid($device, 'vlanTrunkPortNativeVlan', [], 'CISCO-VTP-MIB');
     $native_vlans = snmpwalk_cache_oid($device, 'vmVlan', $native_vlans, 'CISCO-VLAN-MEMBERSHIP-MIB');
 
     // Not sure why we check for VTP, but this data comes from that MIB, so...
     $vtpversion = snmp_get($device, 'vtpVersion.0', '-OnvQ', 'CISCO-VTP-MIB');
     if ($vtpversion == '1' || $vtpversion == '2' || $vtpversion == '3' || $vtpversion == 'one' || $vtpversion == 'two' || $vtpversion == 'three' || $vtpversion == 'none') {
         // FIXME - can have multiple VTP domains.
-        $vtpdomains = snmpwalk_cache_oid($device, 'vlanManagementDomains', array(), 'CISCO-VTP-MIB');
-        $vlans      = snmpwalk_cache_twopart_oid($device, 'vtpVlanEntry', array(), 'CISCO-VTP-MIB');
+        $vtpdomains = snmpwalk_cache_oid($device, 'vlanManagementDomains', [], 'CISCO-VTP-MIB');
+        $vlans      = snmpwalk_cache_twopart_oid($device, 'vtpVlanName', [], 'CISCO-VTP-MIB');
+        $vlans      = snmpwalk_cache_twopart_oid($device, 'vtpVlanType', $vlans, 'CISCO-VTP-MIB');
 
         foreach ($vtpdomains as $vtpdomain_id => $vtpdomain) {
             echo 'VTP Domain '.$vtpdomain_id.' '.$vtpdomain['managementDomainName'].' ';
@@ -37,7 +38,9 @@ if ($device['os_group'] == 'cisco') {
                     // Ignore reserved VLAN IDs
                     // get dot1dStpPortEntry within the vlan context
                     $vlan_device = array_merge($device, array('community' => $device['community'] . '@' . $vlan_id, 'context_name' => "vlan-$vlan_id"));
-                    $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dStpPortEntry', array(), 'BRIDGE-MIB');
+                    $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dStpPortPriority', [], 'BRIDGE-MIB');
+                    $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dStpPortState', $tmp_vlan_data, 'BRIDGE-MIB');
+                    $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dStpPortPathCost', $tmp_vlan_data, 'BRIDGE-MIB');
 
                     // may need to fetch additional dot1dBasePortIfIndex mappings
                     $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dBasePortIfIndex', $tmp_vlan_data, 'BRIDGE-MIB');

--- a/includes/discovery/vlans/cisco-vtp.inc.php
+++ b/includes/discovery/vlans/cisco-vtp.inc.php
@@ -8,7 +8,7 @@ if ($device['os_group'] == 'cisco') {
 
     // Not sure why we check for VTP, but this data comes from that MIB, so...
     $vtpversion = snmp_get($device, 'vtpVersion.0', '-OnvQ', 'CISCO-VTP-MIB');
-    if ($vtpversion == '1' || $vtpversion == '2' || $vtpversion == '3' || $vtpversion == 'one' || $vtpversion == 'two' || $vtpversion == 'three' || $vtpversion == 'none') {
+    if (in_array($vtpversion, ['1', '2', '3', 'one', 'two', 'three', 'none'])) {
         // FIXME - can have multiple VTP domains.
         $vtpdomains = snmpwalk_cache_oid($device, 'vlanManagementDomains', [], 'CISCO-VTP-MIB');
         $vlans      = snmpwalk_cache_twopart_oid($device, 'vtpVlanName', [], 'CISCO-VTP-MIB');
@@ -44,7 +44,7 @@ if ($device['os_group'] == 'cisco') {
 
                     // may need to fetch additional dot1dBasePortIfIndex mappings
                     $tmp_vlan_data = snmpwalk_cache_oid($vlan_device, 'dot1dBasePortIfIndex', $tmp_vlan_data, 'BRIDGE-MIB');
-                    $vlan_data = array();
+                    $vlan_data = [];
                     // flatten the array, use ifIndex instead of dot1dBasePortId
                     foreach ($tmp_vlan_data as $index => $array) {
                         if (isset($array['dot1dBasePortIfIndex'])) {


### PR DESCRIPTION
Current 'vlans' discovery does load the complete vtpVlanEntry and dot1dStpPortEntry table even if it only uses very few OIDs in them. 
This patch reduces the snmp requests to only the necessary OIDs -> quicker vlan discovery and less CPU pressure on the device. 

Some nexus 55xx devices have a buggy SNMP implementation and get killed (CPU goes high, and forwarding can even be impacted). 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 10510`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
