### PR TITLE
Add inbit and outbit rate to auxiliary datastores.

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -868,6 +868,10 @@ foreach ($ports as $port) {
             $fields['ifInOctets_rate'] = $port['ifInOctets_rate'];
             $fields['ifOutOctets_rate'] = $port['ifOutOctets_rate'];
 
+            // Add delta rate between current poll and last poll.
+            $fields['ifInBits_rate'] = $port['stats']['ifInBits_rate'];
+            $fields['ifOutBits_rate'] = $port['stats']['ifOutBits_rate'];
+            
             prometheus_push($device, 'ports', rrd_array_filter($tags), $fields);
             influx_update($device, 'ports', rrd_array_filter($tags), $fields);
             graphite_update($device, 'ports|' . $ifName, $tags, $fields);


### PR DESCRIPTION
This change allows for the ifInBit and ifOutBit rates to be captured in auxiliary datastores (Influx, Prometheus, graphite and opentsdb).  We need this so that the data returned from these datastores reflects the same usage stats we see in the RRD file/graphs.

Specifically we use this to capture the peak port utilization of any given device.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
