### PR TITLE
List ungrouped devices on group management page

### DIFF
--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -26,11 +26,12 @@ class DeviceGroupController extends Controller
     {
         $this->authorize('manage', DeviceGroup::class);
 
-        $device_groups = DeviceGroup::orderBy('name')->with('devices:devices.device_id')->withCount('devices')->get();
-        $ungrouped_devices = Device::orderBy('hostname')->whereNotIn('device_id', function ($q) { $q->select('device_id')->from('device_group_device'); })->get();
+        $ungrouped_devices = Device::orderBy('hostname')->whereNotIn('device_id', function ($query) {
+            $query->select('device_id')->from('device_group_device');
+        })->get();
 
         return view('device-group.index', [
-            'device_groups' => $device_groups,
+            'device_groups' => DeviceGroup::orderBy('name')->withCount('devices')->get(),
             'ungrouped_devices' => $ungrouped_devices,
         ]);
     }

--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -26,13 +26,13 @@ class DeviceGroupController extends Controller
     {
         $this->authorize('manage', DeviceGroup::class);
 
-        $devices = DeviceGroup::orderBy('name')->withCount('devices')->get();
-        $grouped_device_ids = $this->grouped_devices_device_id($devices);
+        $device_groups = DeviceGroup::orderBy('name')->with('devices:devices.device_id')->withCount('devices')->get();
+        $grouped_device_ids = $this->groupedDevicesDeviceId($device_groups);
 
         $ungrouped_devices = Device::orderby('hostname')->whereNotIn('device_id', $grouped_device_ids)->get();
 
         return view('device-group.index', [
-            'device_groups' => DeviceGroup::orderBy('name')->withCount('devices')->get(),
+            'device_groups' => $device_groups,
             'ungrouped_devices' => $ungrouped_devices,
         ]);
     }
@@ -42,7 +42,7 @@ class DeviceGroupController extends Controller
      *
      * @return Array with grouped device_ids
      */
-    private function grouped_devices_device_id($grouped_devices)
+    private function groupedDevicesDeviceId($grouped_devices)
     {
         $device_ids = array();
         foreach ($grouped_devices as $device_group) {

--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -26,12 +26,13 @@ class DeviceGroupController extends Controller
     {
         $this->authorize('manage', DeviceGroup::class);
 
-        $device_groups = DeviceGroup::orderBy('name')->withCount('devices')->get();
-        $ungrouped_device_ids = $this->groupedDevicesDeviceId($device_groups);
-        $ungrouped_devices = Device::orderby('hostname')->whereNotIn('device_id', $ungrouped_device_ids)->get();
+        $devices = DeviceGroup::orderBy('name')->withCount('devices')->get();
+        $grouped_device_ids = $this->grouped_devices_device_id($devices);
+
+        $ungrouped_devices = Device::orderby('hostname')->whereNotIn('device_id', $grouped_device_ids)->get();
 
         return view('device-group.index', [
-            'device_groups' => $device_groups,
+            'device_groups' => DeviceGroup::orderBy('name')->withCount('devices')->get(),
             'ungrouped_devices' => $ungrouped_devices,
         ]);
     }
@@ -39,16 +40,17 @@ class DeviceGroupController extends Controller
     /**
      * get all grouped devices
      *
-     * @return Array with device_ids of all grouped devices
+     * @return Array with grouped device_ids
      */
-    private function groupedDevicesDeviceId($device_groups)
+    private function grouped_devices_device_id($grouped_devices)
     {
         $device_ids = array();
-        foreach ($device_groups as $device_group) {
+        foreach ($grouped_devices as $device_group) {
             foreach ($device_group->devices as $device) {
                 $device_ids[] = $device->device_id;
             }
         }
+
         return array_unique($device_ids);
     }
 

--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -28,7 +28,7 @@ class DeviceGroupController extends Controller
 
         $device_groups = DeviceGroup::orderBy('name')->withCount('devices')->get();
         $ungrouped_device_ids = $this->groupedDevicesDeviceId($device_groups);
-        $ungrouped_devices = Device::orderby('hostname')->whereNotIn('device_id', $ungrouped_device_ids);
+        $ungrouped_devices = Device::orderby('hostname')->whereNotIn('device_id', $ungrouped_device_ids)->get();
 
         return view('device-group.index', [
             'device_groups' => $device_groups,

--- a/app/Http/Controllers/DeviceGroupController.php
+++ b/app/Http/Controllers/DeviceGroupController.php
@@ -27,31 +27,12 @@ class DeviceGroupController extends Controller
         $this->authorize('manage', DeviceGroup::class);
 
         $device_groups = DeviceGroup::orderBy('name')->with('devices:devices.device_id')->withCount('devices')->get();
-        $grouped_device_ids = $this->groupedDevicesDeviceId($device_groups);
-
-        $ungrouped_devices = Device::orderby('hostname')->whereNotIn('device_id', $grouped_device_ids)->get();
+        $ungrouped_devices = Device::orderBy('hostname')->whereNotIn('device_id', function ($q) { $q->select('device_id')->from('device_group_device'); })->get();
 
         return view('device-group.index', [
             'device_groups' => $device_groups,
             'ungrouped_devices' => $ungrouped_devices,
         ]);
-    }
-
-    /**
-     * get all grouped devices
-     *
-     * @return Array with grouped device_ids
-     */
-    private function groupedDevicesDeviceId($grouped_devices)
-    {
-        $device_ids = array();
-        foreach ($grouped_devices as $device_group) {
-            foreach ($device_group->devices as $device) {
-                $device_ids[] = $device->device_id;
-            }
-        }
-
-        return array_unique($device_ids);
     }
 
     /**

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -55,6 +55,37 @@
                     </table>
                 </div>
             </div>
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                @lang('ungrouped Devices') (<?php echo(count($ungrouped_devices))?>)
+                </h4>
+            </div>
+            <div class="panel-body">
+                <div class="table-responsive">
+                    <table id="ungrouped-devices-table" class="table table-condensed table-hover">
+                        <thead>
+                        <tr>
+                            <th>@lang('Vendor')</th>
+                            <th>@lang('Device')</th>
+                            <th>@lang('Platform')</th>
+                            <th>@lang('Operating System')</th>
+                            <th>@lang('Location')</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($ungrouped_devices as $device)
+                            <tr id="row_{{ $device->device_id }}">
+                                <td><img alt="{{ $device->os }} "src="{{ asset($device->icon) }}" width="32px" height="32px" title="{{ $device->os }}"></td>
+                                <td><a class="list-device" href="device/device={{$device->device_id}}"><b>{{ $device->hostname }}</b></a><br>{{$device->sysName}}</td>
+                                <td>{{ $device->hardware }}</td>
+                                <td>{{ $device->os }} {{ $device->version }} ({{ $device->features }})</td>
+                                <td>{{ $device->location->location }}</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -55,6 +55,10 @@
                     </table>
                 </div>
             </div>
+        </div>
+    </div>
+    <div class="container-fluid">
+        <div id="manage-device-groups-panel" class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
                 @lang('ungrouped Devices') ({{ $ungrouped_devices->count() }})

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -81,11 +81,7 @@
                                 <td><img alt="{{ $device->os }}" src="{{ asset($device->icon) }}" width="32px" height="32px" title="{{ $device->os }}"></td>
                                 <td>{!! \LibreNMS\Util\Url::deviceLink($device) !!}<br />{{ $device->sysName }}</td>
                                 <td>{{ $device->hardware }}</td>
-                                @if ($device->features)
-                                <td>{{ $device->os }} {{ $device->version }} ({{ $device->features }})</td>
-                                                                @else
-                                <td>{{ $device->os }} {{ $device->version }}</td>
-                                                                @endif
+                                <td>{{ $device->os }} {{ $device->version }} @if($device->features) ({{ $device->features }}) @endif </td>
                             </tr>
                         @endforeach
                         </tbody>

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -57,7 +57,7 @@
             </div>
             <div class="panel-heading">
                 <h4 class="panel-title">
-                @lang('ungrouped Devices') (<?php echo(count($ungrouped_devices))?>)
+                @lang('ungrouped Devices') ({{ $ungrouped_devices->count() }})
                 </h4>
             </div>
             <div class="panel-body">
@@ -69,7 +69,6 @@
                             <th>@lang('Device')</th>
                             <th>@lang('Platform')</th>
                             <th>@lang('Operating System')</th>
-                            <th>@lang('Location')</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -79,7 +78,6 @@
                                 <td><a class="list-device" href="device/device={{$device->device_id}}"><b>{{ $device->hostname }}</b></a><br>{{$device->sysName}}</td>
                                 <td>{{ $device->hardware }}</td>
                                 <td>{{ $device->os }} {{ $device->version }} ({{ $device->features }})</td>
-                                <td>{{ $device->location->location }}</td>
                             </tr>
                         @endforeach
                         </tbody>

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -61,7 +61,7 @@
         <div id="manage-device-groups-panel" class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                @lang('ungrouped Devices') ({{ $ungrouped_devices->count() }})
+                @lang('Ungrouped Devices') ({{ $ungrouped_devices->count() }})
                 </h4>
             </div>
             <div class="panel-body">

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -75,7 +75,7 @@
                         @foreach($ungrouped_devices as $device)
                             <tr id="row_{{ $device->device_id }}">
                                 <td><img alt="{{ $device->os }} "src="{{ asset($device->icon) }}" width="32px" height="32px" title="{{ $device->os }}"></td>
-                                <td><a class="list-device" href="device/device={{$device->device_id}}"><b>{{ $device->hostname }}</b></a><br>{{$device->sysName}}</td>
+                                <td><a class="list-device" href="{{ url("device/device=$device->device_id") }}"><b>{{ $device->hostname }}</b></a><br>{{$device->sysName}}</td>
                                 <td>{{ $device->hardware }}</td>
                                 <td>{{ $device->os }} {{ $device->version }} ({{ $device->features }})</td>
                             </tr>

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -56,8 +56,6 @@
                 </div>
             </div>
         </div>
-    </div>
-    <div class="container-fluid">
         <div id="unmanaged-devices-panel" class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">

--- a/resources/views/device-group/index.blade.php
+++ b/resources/views/device-group/index.blade.php
@@ -58,7 +58,7 @@
         </div>
     </div>
     <div class="container-fluid">
-        <div id="manage-device-groups-panel" class="panel panel-default">
+        <div id="unmanaged-devices-panel" class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
                 @lang('Ungrouped Devices') ({{ $ungrouped_devices->count() }})
@@ -69,7 +69,7 @@
                     <table id="ungrouped-devices-table" class="table table-condensed table-hover">
                         <thead>
                         <tr>
-                            <th>@lang('Vendor')</th>
+                            <th style="width:32px">@lang('Vendor')</th>
                             <th>@lang('Device')</th>
                             <th>@lang('Platform')</th>
                             <th>@lang('Operating System')</th>
@@ -78,10 +78,14 @@
                         <tbody>
                         @foreach($ungrouped_devices as $device)
                             <tr id="row_{{ $device->device_id }}">
-                                <td><img alt="{{ $device->os }} "src="{{ asset($device->icon) }}" width="32px" height="32px" title="{{ $device->os }}"></td>
-                                <td><a class="list-device" href="{{ url("device/device=$device->device_id") }}"><b>{{ $device->hostname }}</b></a><br>{{$device->sysName}}</td>
+                                <td><img alt="{{ $device->os }}" src="{{ asset($device->icon) }}" width="32px" height="32px" title="{{ $device->os }}"></td>
+                                <td>{!! \LibreNMS\Util\Url::deviceLink($device) !!}<br />{{ $device->sysName }}</td>
                                 <td>{{ $device->hardware }}</td>
+                                @if ($device->features)
                                 <td>{{ $device->os }} {{ $device->version }} ({{ $device->features }})</td>
+                                                                @else
+                                <td>{{ $device->os }} {{ $device->version }}</td>
+                                                                @endif
                             </tr>
                         @endforeach
                         </tbody>


### PR DESCRIPTION
list all devices which doesn't match to a Device Group.
This table can be viewed on "Manage Groups" page
Target is to see all ungrouped devices at once and avoid searching them manually.
