### PR TITLE
hostname mouseover fix - only show location name instead of its array

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -85,7 +85,7 @@ class Url
         }
 
         if ($device->location_id) {
-            $contents .= ' - ' . htmlentities($device->location);
+            $contents .= ' - ' . htmlentities($device->location->location);
         }
 
         $contents .= '</div>';


### PR DESCRIPTION
on mouseover on a device, now location name will be displayed instead the location associative array