### PR TITLE
automatically cleanup plugin-table from removed plugins

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1144,6 +1144,26 @@ function scan_new_plugins()
     return( $installed );
 }
 
+function scan_removed_plugins()
+{
+    $removed = 0; # Track how many plugins will be removed from database
+
+    if (file_exists(Config::get('plugin_dir'))) {
+        $plugin_files = scandir(Config::get('plugin_dir'));
+        $installed_plugins = dbFetchColumn("SELECT `plugin_name` FROM `plugins`");
+        foreach ($installed_plugins as $name) {
+            if (in_array($name, $plugin_files)) {
+                continue;
+            }
+            if (dbDelete('plugins', "`plugin_name` = ?", $name)) {
+                $removed++;
+            }
+        }
+    }
+
+    return( $removed );
+}
+
 function validate_device_id($id)
 {
     if (empty($id) || !is_numeric($id)) {

--- a/includes/html/pages/plugin/admin.inc.php
+++ b/includes/html/pages/plugin/admin.inc.php
@@ -3,6 +3,7 @@
 if (Auth::user()->hasGlobalAdmin()) {
     // Scan for new plugins and add to the database
     $new_plugins = scan_new_plugins();
+    $removed_plugins = scan_removed_plugins();
 
 
     // Check if we have to toggle enabled / disable a particular module
@@ -43,6 +44,13 @@ if ($new_plugins > 0) {
     echo '<div class="panel-body">
     <div class="alert alert-warning">
       We have found '.$new_plugins.' new plugins that need to be configured and enabled
+    </div>
+  </div>';
+}
+if ($removed_plugins > 0) {
+    echo '<div class="panel-body">
+    <div class="alert alert-warning">
+      We have found '.$removed_plugins.' removed plugins
     </div>
   </div>';
 }


### PR DESCRIPTION
if a plugin was removed from plugin-directory it stays in plugin-table in database
this patch runs a scan function to remove this orphaned entries from database