### PR TITLE
Catch exceptions generated by alert transports

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * RunAlerts.php
- * 
+ *
  * Copyright (C) 2014 Daniel Preussker <f0o@devilcode.org>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@
  *
  * Modified by:
  * @author Heath Barnhart <barnhart@kanren.net>
- * 
+ *
  */
 
 namespace LibreNMS\Alert;
@@ -524,8 +524,12 @@ class RunAlerts
                 $obj['msg']       = $type->getBody($obj);
                 c_echo(" :: $transport_title => ");
                 $instance = new $class($item['transport_id']);
-                $tmp = $instance->deliverAlert($obj, $item['opts']);
-                $this->alertLog($tmp, $obj, $obj['transport']);
+                try {
+                    $tmp = $instance->deliverAlert($obj, $item['opts']);
+                    $this->alertLog($tmp, $obj, $obj['transport']);
+                } catch (\Exception $e) {
+                    $this->alertLog($e, $obj, $obj['transport']);
+                }
                 unset($instance);
                 echo PHP_EOL;
             }

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -523,8 +523,8 @@ class RunAlerts
                 $obj['alert']['title'] = $obj['title'];
                 $obj['msg']       = $type->getBody($obj);
                 c_echo(" :: $transport_title => ");
-                $instance = new $class($item['transport_id']);
                 try {
+                    $instance = new $class($item['transport_id']);
                     $tmp = $instance->deliverAlert($obj, $item['opts']);
                     $this->alertLog($tmp, $obj, $obj['transport']);
                 } catch (\Exception $e) {


### PR DESCRIPTION
The alert.php script would completely die if a single alert
transport generated an exception. For example the API transport
if CURL couldn't connect to the api endpoint. The script
should attempt to send alerts to all working transports and not
die because a single transport fails.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
