### PR TITLE
Fix testing fping output when the LibreNMS user doesn't have a valid …

### DIFF
--- a/LibreNMS/Validator.php
+++ b/LibreNMS/Validator.php
@@ -251,7 +251,7 @@ class Validator
     public function execAsUser($command, &$output = null, &$code = null)
     {
         if (self::getUsername() === 'root') {
-            $command = 'su ' . Config::get('user') . ' -c "' . $command . '"';
+            $command = 'su ' . Config::get('user') . ' -s /bin/sh -c "' . $command . '"';
         }
         exec($command, $output, $code);
     }


### PR DESCRIPTION
…shell

Normally, the librenms user will not have a default shell (We don't want this user logging in to the system, etc.). But this breaks the `fping` tests because the lack of shell means we get no output from the tests. This simple pull requests sets a shell for the librenms user if the script is running as `root`.

For example:

```
[root@localhost ~]# cat /etc/passwd | grep librenms
librenms:x:991:986::/opt/librenms:/bin/false

[root@localhost ~]# su librenms -c "fping6 ::1"

[root@localhost ~]# su librenms -s /bin/sh -c "fping6 ::1"
::1 is alive
```

This results in `validate.php` running correctly for root as well as the librenms user.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
