### PR TITLE
Graylog fix query with multiple items

### DIFF
--- a/app/ApiClients/GraylogApi.php
+++ b/app/ApiClients/GraylogApi.php
@@ -129,7 +129,7 @@ class GraylogApi
             return '*';
         }
 
-        return implode('&&', $query);
+        return implode(' && ', $query);
     }
 
     public function getAddresses(Device $device)


### PR DESCRIPTION
Added Space before and after && in app/ApiClients/GraylogApi.php:132
Missing spaces resulting in "<query1>&&<query2>" can cause problems when searching. 
For example `message:"test" && source: ("192.168.1.1")` returns all log messages from 192.168.1.1 containing "test", but `message:"test"&&source: ("192.168.1.1")` returns all log messages from all devices containing "test"

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
