### PR TITLE
Add index to notifications_attribs to resolve poor performance on mysql 5.7

### DIFF
--- a/database/migrations/2019_09_05_153524_create_notifications_attribs_index.php
+++ b/database/migrations/2019_09_05_153524_create_notifications_attribs_index.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateNotificationsAttribsIndex extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('notifications_attribs', function (Blueprint $table) {
+            $table->index(['notifications_id','user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('notifications_attribs', function (Blueprint $table) {
+            $table->dropIndex(['notifications_id','user_id']);
+        });
+    }
+}

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -1082,6 +1082,7 @@ notifications_attribs:
     - { Field: value, Type: varchar(255), 'Null': false, Extra: '', Default: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [attrib_id], Unique: true, Type: BTREE }
+    notifications_attribs_notifications_id_user_id_index: { Name: notifications_attribs_notifications_id_user_id_index, Columns: [notifications_id, user_id], Unique: false, Type: BTREE }
 ospf_areas:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }


### PR DESCRIPTION
Hitting the same issue described here: https://github.com/librenms/librenms/issues/10337 I've got a forum post here describing my specific issue in greater detail https://community.librenms.org/t/slow-database-queries-after-server-migration/9483 

TL;DR mariadb and mysql have different behaviours with how they process subqueries, in this specific situation a query which takes milliseconds on mariadb takes about 15s on mysql.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
