### PR TITLE
Fixed foreach loop throwing errors when no vlans present

### DIFF
--- a/includes/discovery/vlans/junos.inc.php
+++ b/includes/discovery/vlans/junos.inc.php
@@ -99,7 +99,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
             }
         } else {
             d_echo("JunOS: No tag/untagged interfaces found for L2 associated" .
-                   " with vlanID: $vlan_id - Index $vlan_index");            
+                   " with vlanID: $vlan_id - Index $vlan_index");
         }
     }
 }

--- a/includes/discovery/vlans/junos.inc.php
+++ b/includes/discovery/vlans/junos.inc.php
@@ -87,7 +87,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
 
 
         d_echo("");
-        if( isset($tagness_by_vlan_index[$vlan_index]) ) {
+        if (isset($tagness_by_vlan_index[$vlan_index])) {
             d_echo("JunOS: vlanID $vlan_id, index $vlan_index");
 
             foreach ($tagness_by_vlan_index[$vlan_index] as $ifIndex => $tag) {

--- a/includes/discovery/vlans/junos.inc.php
+++ b/includes/discovery/vlans/junos.inc.php
@@ -93,10 +93,13 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
             foreach ($tagness_by_vlan_index[$vlan_index] as $ifIndex => $tag) {
                 $f_portType = $tag['tag'] ? 'access' : 'trunk';
 
-                d_echo("JunOS:  port-ifIndex $ifIndex - is a $f_portType port");
+                d_echo("JunOS:  port-ifIndex $ifIndex - $f_portType port");
  
                 $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = $tag['tag'];
             }
+        } else {
+            d_echo("JunOS: No tag/untagged interfaces found for L2 associated" .
+                   " with vlanID: $vlan_id - Index $vlan_index");            
         }
     }
 }

--- a/includes/discovery/vlans/junos.inc.php
+++ b/includes/discovery/vlans/junos.inc.php
@@ -62,7 +62,7 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
     }
     foreach ($vlans as $vlan_index => $vlan) {
         $vlan_id = $vlan_tag[$vlan_index][$tmp_tag];
-        d_echo(" $vlan_id");
+        d_echo("VLAN --> $vlan_id");
         if (is_array($vlans_db[$vtpdomain_id][$vlan_id])) {
             $vlan_data = $vlans_db[$vtpdomain_id][$vlan_id];
             if ($vlan_data['vlan_name'] != $vlan[$tmp_name]) {
@@ -84,8 +84,19 @@ if ($vlanversion == 'version1' || $vlanversion == '2') {
             echo '+';
         }
         $device['vlans'][$vtpdomain_id][$vlan_id] = $vlan_id;
-        foreach ($tagness_by_vlan_index[$vlan_index] as $ifIndex => $tag) {
-            $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = $tag['tag'];
+
+
+        d_echo("");
+        if( isset($tagness_by_vlan_index[$vlan_index]) ) {
+            d_echo("JunOS: vlanID $vlan_id, index $vlan_index");
+
+            foreach ($tagness_by_vlan_index[$vlan_index] as $ifIndex => $tag) {
+                $f_portType = $tag['tag'] ? 'access' : 'trunk';
+
+                d_echo("JunOS:  port-ifIndex $ifIndex - is a $f_portType port");
+ 
+                $per_vlan_data[$vlan_id][$ifIndex]['untagged'] = $tag['tag'];
+            }
         }
     }
 }


### PR DESCRIPTION
…d post 9528

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.



This pull requests helps fix the following error that was seen when running discovery against an MX system with no vlans:

```
QL[INSERT IGNORE INTO `vlans` (`device_id`,`vlan_domain`,`vlan_vlan`,`vlan_name`,`vlan_type`)  VALUES (:device_id,:vlan_domain,:vlan_vlan,:vlan_name,NULL) {"device_id":12,"vlan_domain":"1","vlan_vlan":"0","vlan_name":"____juniper_private1____"} 1ms]

+
Warning: Invalid argument supplied for foreach() in /opt/librenms/includes/discovery/vlans/junos.inc.php on line 87
VLAN 0

>> Runtime for discovery module 'vlans': 0.4520 seconds with 4456 bytes
```

When running against a QFX there were no issues as vlans existed.
ref: https://community.librenms.org/t/junos-discovery-error-line87-foreach-invalid-argument/9528

