### PR TITLE
Fix missing to-parameter in dashboard graph widget link

### DIFF
--- a/resources/views/widgets/graph.blade.php
+++ b/resources/views/widgets/graph.blade.php
@@ -1,5 +1,5 @@
 <div class="dashboard-graph">
-    <a href="graphs/{{ implode($params, '/') }}/type={{ $graph_type }}/from={{ $from }}">
+    <a href="graphs/{{ implode($params, '/') }}/type={{ $graph_type }}/from={{ $from }}/to={{ $to }}">
         <img class="minigraph-image"
              width="{{ $dimensions['x'] }}"
              height="{{ $dimensions['y'] }}"


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

#### Description
If you add a generic-graph widget to a dashboard the image links to a bigger version of the graph (under `https://librenms/graphs/`). This link doesn't include a `/to=${timestamp}/` parameter in the URL.
Updating the time range in the graph view uses `submitCustomRange()` from [librenms.js](https://github.com/librenms/librenms/blob/master/html/js/librenms.js#L138) to replace the `from` and `to` parameters in the URL using regular expressions. If there is no `to` parameter in the URL, it won't be added - so unless you click on one of the predefined time ranges first or add it yourself you can't change the `to` parameter.

It might be a better idea to rewrite the `submitCustomRange()` function, but as I don't know enough about javascript, I just added the `to` parameter in the generic-graph widget code.