### PR TITLE
sensors sometime not clean up

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1159,9 +1159,9 @@ function dynamic_discovery_get_value($name, $index, $discovery_data, $pre_cache,
  */
 function sensors($types, $device, $valid, $pre_cache = array())
 {
-    foreach ((array)$types as $sensor_type) {
-        echo ucfirst($sensor_type) . ': ';
-        $dir = Config::get('install_dir') . '/includes/discovery/sensors/' . $sensor_type .'/';
+    foreach ((array)$types as $sensor_class) {
+        echo ucfirst($sensor_class) . ': ';
+        $dir = Config::get('install_dir') . '/includes/discovery/sensors/' . $sensor_class .'/';
 
         if (is_file($dir . $device['os_group'] . '.inc.php')) {
             include $dir . $device['os_group'] . '.inc.php';
@@ -1174,9 +1174,9 @@ function sensors($types, $device, $valid, $pre_cache = array())
                 include $dir . '/rfc1628.inc.php';
             }
         }
-        discovery_process($valid, $device, $sensor_type, $pre_cache);
-        d_echo($valid['sensor'][$sensor_type]);
-        check_valid_sensors($device, $sensor_type, $valid['sensor']);
+        discovery_process($valid, $device, $sensor_class, $pre_cache);
+        d_echo($valid['sensor'][$sensor_class]);
+        check_valid_sensors($device, $sensor_class, $valid['sensor']);
         echo "\n";
     }
 }

--- a/includes/discovery/sensors/dbm/raisecom.inc.php
+++ b/includes/discovery/sensors/dbm/raisecom.inc.php
@@ -9,8 +9,8 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
         if (($key == 'txPower') && is_numeric($value['raisecomOpticalTransceiverParameterValue']) && ($value['raisecomOpticalTransceiverDDMValidStatus'] == 1)) {
             $oid = '.1.3.6.1.4.1.8886.1.18.2.2.1.1.2.'.$index.'.3';
             $sensor_type = 'raisecomOpticalTransceiverTxPower';
-            $port_descr = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
-            $descr = $port_descr['ifDescr'] . ' Transmit Power';
+            $port = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
+            $descr = $port['ifDescr'] . ' Transmit Power';
             $low_limit  = $value['raisecomOpticalTransceiverParamLowAlarmThresh'] / $divisor;
             $low_warn_limit = $value['raisecomOpticalTransceiverParamLowWarningThresh'] / $divisor;
             $warn_limit = $value['raisecomOpticalTransceiverParamHighWarningThresh'] / $divisor;
@@ -18,13 +18,15 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $current = $value['raisecomOpticalTransceiverParameterValue'] / $divisor;
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
-            discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+            if ($port['ifAdminStatus'] == 'up') {
+                discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+            }
         }
         if (($key == 'rxPower') && is_numeric($value['raisecomOpticalTransceiverParameterValue']) && ($value['raisecomOpticalTransceiverDDMValidStatus'] != 0)) {
             $oid = '.1.3.6.1.4.1.8886.1.18.2.2.1.1.2.'.$index.'.4';
             $sensor_type = 'raisecomOpticalTransceiverRxPower';
-            $port_descr = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
-            $descr = $port_descr['ifDescr'] . ' Receive Power';
+            $port = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
+            $descr = $port['ifDescr'] . ' Receive Power';
             $low_limit  = $value['raisecomOpticalTransceiverParamLowAlarmThresh'] / $divisor;
             $low_warn_limit = $value['raisecomOpticalTransceiverParamLowWarningThresh'] / $divisor;
             $warn_limit = $value['raisecomOpticalTransceiverParamHighWarningThresh'] / $divisor;
@@ -32,7 +34,9 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $current = $value['raisecomOpticalTransceiverParameterValue'] / $divisor;
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
-            discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+            if ($port['ifAdminStatus'] == 'up') {
+                discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
+            }
         }
     }
 }

--- a/includes/discovery/sensors/dbm/raisecom.inc.php
+++ b/includes/discovery/sensors/dbm/raisecom.inc.php
@@ -9,8 +9,8 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
         if (($key == 'txPower') && is_numeric($value['raisecomOpticalTransceiverParameterValue']) && ($value['raisecomOpticalTransceiverDDMValidStatus'] == 1)) {
             $oid = '.1.3.6.1.4.1.8886.1.18.2.2.1.1.2.'.$index.'.3';
             $sensor_type = 'raisecomOpticalTransceiverTxPower';
-            $port = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
-            $descr = $port['ifDescr'] . ' Transmit Power';
+            $port_descr = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
+            $descr = $port_descr['ifDescr'] . ' Transmit Power';
             $low_limit  = $value['raisecomOpticalTransceiverParamLowAlarmThresh'] / $divisor;
             $low_warn_limit = $value['raisecomOpticalTransceiverParamLowWarningThresh'] / $divisor;
             $warn_limit = $value['raisecomOpticalTransceiverParamHighWarningThresh'] / $divisor;
@@ -18,15 +18,13 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $current = $value['raisecomOpticalTransceiverParameterValue'] / $divisor;
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
-            if ($port['ifAdminStatus'] == 'up') {
-                discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
-            }
+            discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'tx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
         }
         if (($key == 'rxPower') && is_numeric($value['raisecomOpticalTransceiverParameterValue']) && ($value['raisecomOpticalTransceiverDDMValidStatus'] != 0)) {
             $oid = '.1.3.6.1.4.1.8886.1.18.2.2.1.1.2.'.$index.'.4';
             $sensor_type = 'raisecomOpticalTransceiverRxPower';
-            $port = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
-            $descr = $port['ifDescr'] . ' Receive Power';
+            $port_descr = get_port_by_index_cache($device['device_id'], str_replace('1.', '', $index));
+            $descr = $port_descr['ifDescr'] . ' Receive Power';
             $low_limit  = $value['raisecomOpticalTransceiverParamLowAlarmThresh'] / $divisor;
             $low_warn_limit = $value['raisecomOpticalTransceiverParamLowWarningThresh'] / $divisor;
             $warn_limit = $value['raisecomOpticalTransceiverParamHighWarningThresh'] / $divisor;
@@ -34,9 +32,7 @@ foreach ($pre_cache['raisecomOpticalTransceiverDDMTable'] as $index => $data) {
             $current = $value['raisecomOpticalTransceiverParameterValue'] / $divisor;
             $entPhysicalIndex = $index;
             $entPhysicalIndex_measured = 'ports';
-            if ($port['ifAdminStatus'] == 'up') {
-                discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
-            }
+            discover_sensor($valid['sensor'], 'dbm', $device, $oid, 'rx-'.$index, $sensor_type, $descr, $divisor, $multiplier, $low_limit, $low_warn_limit, $warn_limit, $high_limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured);
         }
     }
 }


### PR DESCRIPTION
In some legacy sensors discovery code located at includes/discovery/sensors/*/*inc.php a variable $sensor_type is set.
That interfere with using the same variable in includes/discovery/functions.inc.php and prevent old sensors from delete.
Rename to avoiding confusion here.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
