### PR TITLE
Fix: Remove ambiguity in Component filter query

### DIFF
--- a/LibreNMS/Component.php
+++ b/LibreNMS/Component.php
@@ -112,11 +112,11 @@ class Component
                 // Only add valid fields to the query
                 if (in_array($field, $validFields)) {
                     if ($array[0] == 'LIKE') {
-                        $SQL .= "`".$field."` LIKE ? AND ";
+                        $SQL .= "`C`.`".$field."` LIKE ? AND ";
                         $array[1] = "%".$array[1]."%";
                     } else {
                         // Equals operator is the default
-                        $SQL .= "`".$field."` = ? AND ";
+                        $SQL .= "`C`.`".$field."` = ? AND ";
                     }
                     array_push($PARAM, $array[1]);
                 }


### PR DESCRIPTION
In case we try to filter the component by it's `id`, we ran into ambiguity issue because both `component` and `component_prefs` tables have column `id`. Fixed by filtering explicitly on `component` table.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
