### PR TITLE
Panos - ActiveSession Fix and SSLProxy Sensor

### DIFF
--- a/includes/definitions/discovery/panos.yaml
+++ b/includes/definitions/discovery/panos.yaml
@@ -38,3 +38,10 @@ modules:
                     group: Sessions
                     descr: Active Sessions
                     high_limit: panSessionMax
+        load:
+            data:
+                -
+                    oid: panSessionSslProxyUtilization
+                    num_oid: '.1.3.6.1.4.1.25461.2.1.2.3.8.{{ $index }}'
+                    descr: SSL Proxy Utilization
+                    group: Sessions

--- a/includes/definitions/discovery/panos.yaml
+++ b/includes/definitions/discovery/panos.yaml
@@ -32,12 +32,11 @@ modules:
         count:
             data:
                 -
-                    oid: panSession
-                    value: panSessionActive
-                    num_oid: '.1.3.6.1.4.1.25461.2.1.2.3.{{ $index }}'
+                    oid: panSessionActive
+                    num_oid: '.1.3.6.1.4.1.25461.2.1.2.3.3.{{ $index }}'
                     group: Sessions
                     descr: Active Sessions
-                    high_limit: panSessionMax
+                    high_limit: '.1.3.6.1.4.1.25461.2.1.2.3.2.{{ $index }}'
         load:
             data:
                 -


### PR DESCRIPTION
Primary contribution is adding a new SSLProxyUtilization, while I was doing this I noticed that the active session sensor on our install hasn't worked for over a year. Specifying the OID an additional level as well as the max level by OID seemed to resolve it for me. Not sure if there is a better way to fix it. I don't quite understand the index value as these values are not out of a table that I can tell but it is now reporting correctly.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
