### PR TITLE
removed the ksort block as it was not working

### DIFF
--- a/LibreNMS/Component.php
+++ b/LibreNMS/Component.php
@@ -158,14 +158,6 @@ class Component
             foreach ($this->reserved as $k => $v) {
                 $RESULT[$component_device_id][$COMPONENT['id']][$k] = $COMPONENT[$k];
             }
-
-            // Sort each component array so the attributes are in order.
-            if (is_array($RESULT[$RESULT[$component_device_id][$COMPONENT['id']]])) {
-                ksort($RESULT[$RESULT[$component_device_id][$COMPONENT['id']]]);
-            }
-            if (is_array($RESULT[$RESULT[$component_device_id]])) {
-                ksort($RESULT[$RESULT[$component_device_id]]);
-            }
         }
 
         // limit    array(start,count)


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

#### Info about the PR

Running ./discovery.php -h device_d -m ntp -d, I had some warnings : 
`Warning: Illegal offset type in /opt/librenms/LibreNMS/Component.php on line 163 & 166`

As suggested by murrant :

> $RESULT[$component_device_id] is an array, but the code tries to use that as an index...
> just delete that block of code...
> I'm guessing this $RESULT[$RESULT[ is supposed to just be this $RESULT[, but that means that the ksorts have never done anything, so they can be removed.