### PR TITLE
Fix the menu that filters out erroring ports

### DIFF
--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -241,13 +241,13 @@
                                                             aria-hidden="true"></i> @lang('All Ports')</a></li>
 
                         @if($port_counts['errored'] > 0)
-                            <li><a href="{{ url('ports/errors=yes') }}"><i class="fa fa-exclamation-circle fa-fw fa-lg"
+                            <li><a href="{{ url('ports/errors=1') }}"><i class="fa fa-exclamation-circle fa-fw fa-lg"
                                                                            aria-hidden="true"></i> @lang('Errored :port_count', ['port_count' => $port_counts['errored']])
                                 </a></li>
                         @endif
 
                         @if($port_counts['ignored'] > 0)
-                            <li><a href="{{ url('ports/ignore=yes') }}"><i class="fa fa-question-circle fa-fw fa-lg"
+                            <li><a href="{{ url('ports/ignore=1') }}"><i class="fa fa-question-circle fa-fw fa-lg"
                                                                            aria-hidden="true"></i> @lang('Ignored :port_count', ['port_count' => $port_counts['ignored']])
                                 </a></li>
                         @endif
@@ -304,7 +304,7 @@
                             <li role="presentation" class="divider"></li>
 
                             @if($port_counts['alerted'])
-                                <li><a href="{{ url('ports/alerted=yes') }}"><i
+                                <li><a href="{{ url('ports/alerted=1') }}"><i
                                             class="fa fa-exclamation-circle fa-fw fa-lg"
                                             aria-hidden="true"></i> @lang('Alerts :port_count', ['port_count' => $port_counts['alerted']])
                                     </a></li>
@@ -319,7 +319,7 @@
                                 </a></li>
 
                             @if($port_counts['deleted'])
-                                <li><a href="{{ url('ports/deleted=yes') }}"><i class="fa fa-minus-circle fa-fw fa-lg"
+                                <li><a href="{{ url('ports/deleted=1') }}"><i class="fa fa-minus-circle fa-fw fa-lg"
                                                                                 aria-hidden="true"></i> @lang('Deleted :port_count', ['port_count' => $port_counts['deleted']])
                                     </a></li>
                             @endif


### PR DESCRIPTION
`inclues/html/pages/ports.inc.php` expects the value to be 1, not 'yes'.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
