### PR TITLE
Update includes/polling/os/unix.inc.php to detect aarch64/ARM64/ARMv8

### DIFF
--- a/includes/polling/os/unix.inc.php
+++ b/includes/polling/os/unix.inc.php
@@ -19,6 +19,8 @@ if (in_array($device['os'], array("linux", "endian", "proxmox", "recoveryos"))) 
         $hardware = "Generic ARMv6";
     } elseif (strstr($device['sysDescr'], "armv7")) {
         $hardware = "Generic ARMv7";
+    } elseif (strstr($device['sysDescr'], "aarch64")) {
+        $hardware = "Generic ARMv8 64-bit";
     } elseif (strstr($device['sysDescr'], "armv")) {
         $hardware = "Generic ARM";
     }


### PR DESCRIPTION
What it says on the tin. 30-second, 2-line fix to detect Unix OSes running in 64-bit mode on ARM. Tested against Ubuntu 18.04 ARM64 on Raspberry Pi 4 and KVM virtualization.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
