### PR TITLE
Fix issue when non-existent plugin is enabled

### DIFF
--- a/LibreNMS/Plugins.php
+++ b/LibreNMS/Plugins.php
@@ -104,12 +104,14 @@ class Plugins
         chdir(Config::get('install_dir') . '/html');
         $plugin = self::getInstance($file, $pluginName);
 
-        $class = get_class($plugin);
-        $hooks = get_class_methods($class);
+        if (!is_null($plugin)) {
+            $class = get_class($plugin);
+            $hooks = get_class_methods($class);
 
-        foreach ((array)$hooks as $hookName) {
-            if ($hookName[0] != '_') {
-                self::$plugins[$hookName][] = $class;
+            foreach ((array)$hooks as $hookName) {
+                if ($hookName[0] != '_') {
+                    self::$plugins[$hookName][] = $class;
+                }
             }
         }
 


### PR DESCRIPTION
Calling get_class(null) is now a warning in PHP 7.2

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
