### PR TITLE
Fix service overview

### DIFF
--- a/includes/html/pages/device/overview/services.inc.php
+++ b/includes/html/pages/device/overview/services.inc.php
@@ -6,6 +6,7 @@ if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
     $colors = collect(['green', 'yellow', 'red']);
     $output = \App\Models\Service::query()
         ->where('device_id', $device['device_id'])
+        ->orderBy('service_type')
         ->get(['service_type', 'service_status', 'service_message'])
         ->map(function ($service) use ($colors) {
             $message = str_replace(' ', '&nbsp;', $service->service_message);

--- a/includes/html/pages/device/overview/services.inc.php
+++ b/includes/html/pages/device/overview/services.inc.php
@@ -3,26 +3,17 @@
 use LibreNMS\Util\ObjectCache;
 
 if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
-    // Build the string.
-    $break = '';
-    $output = '';
-    foreach (service_get($device['device_id']) as $data) {
-        if ($data['service_status'] == '0') {
-            // Ok
-            $status = 'green';
-        } elseif ($data['service_status'] == '1') {
-            // Warning
-            $status = 'red';
-        } elseif ($data['service_status'] == '2') {
-            // Critical
-            $status = 'red';
-        } else {
-            // Unknown
-            $status = 'grey';
-        }
-        $output .= $break . '<div title=' . str_replace(' ', '&nbsp;&nbsp;', $data['service_message']) . '><a class=' . $status . '>' . strtolower($data['service_type']) . '</a></div>';
-        $break = ', ';
-    }
+    $colors = collect(['green', 'yellow', 'red']);
+    $output = \App\Models\Service::query()
+        ->where('device_id', $device['device_id'])
+        ->get(['service_type', 'service_status', 'service_message'])
+        ->map(function ($service) use ($colors) {
+            $message = str_replace(' ', '&nbsp;', $service->service_message);
+            $color = $colors->get($service->service_status, 'grey');
+            $type = strtolower($service->service_type);
+
+            return "<span title='$message' class='$color'>$type</span>";
+        })->implode(', ');
 
     $services = ObjectCache::serviceCounts(['total', 'ok', 'warning', 'critical'], $device['device_id']);
     ?>
@@ -34,7 +25,7 @@ if (ObjectCache::serviceCounts(['total'], $device['device_id'])['total'] > 0) {
                     </div>
                     <table class="table table-hover table-condensed table-striped">
                         <tr>
-                            <td title="Total"><i class="fa fa-cog" style="color:#0080FF" aria-hidden="true"></i> <?php echo $services['total']?></td>
+                            <td title="Total"><i class="fa fa-cog" aria-hidden="true"></i> <?php echo $services['total']?></td>
                             <td title="Status - Ok"><i class="fa fa-cog" style="color:green" aria-hidden="true"></i> <?php echo $services['ok']?></td>
                             <td title="Status - Warning"><i class="fa fa-cog" style="color:orange" aria-hidden="true"></i> <?php echo $services['warning']?></td>
                             <td title="Status - Critical"><i class="fa fa-cog" style="color:red" aria-hidden="true"></i> <?php echo $services['critical']?></td>


### PR DESCRIPTION
Now lists them all on one line instead of each on their own line.
Correct color for warning
Total is now grey instead of blue

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
