### PR TITLE
Fix missing to-parameter in graphRows

### DIFF
--- a/LibreNMS/Util/Html.php
+++ b/LibreNMS/Util/Html.php
@@ -27,6 +27,7 @@ namespace LibreNMS\Util;
 
 use HTMLPurifier;
 use HTMLPurifier_Config;
+use Carbon\Carbon;
 use LibreNMS\Config;
 
 class Html
@@ -78,6 +79,7 @@ class Html
         $graph_data = [];
         foreach ($periods as $period => $period_text) {
             $graph_array['from'] = Config::get("time.$period");
+            $graph_array['to'] = Carbon::now()->timestamp;
             $graph_array_zoom = $graph_array;
             $graph_array_zoom['height'] = '150';
             $graph_array_zoom['width'] = '400';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.


#### Description
This PR fixes the same problem as #10600 when graphRows() is used to generate multiple graphs of the same type (e.g. https://librenms.example.org/device/device=41/tab=graphs/).