### PR TITLE
Remove function report_this_text()

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -787,11 +787,6 @@ function generate_ap_url($ap, $vars = array())
     return generate_url(array('page' => 'device', 'device' => $ap['device_id'], 'tab' => 'accesspoint', 'ap' => $ap['accesspoint_id']), $vars);
 }//end generate_ap_url()
 
-function report_this_text($message)
-{
-    return $message . '\nPlease report this to the ' . Config::get('project_name') . ' developers at ' . Config::get('project_issues') . '\n';
-}//end report_this_text()
-
 
 // Find all the files in the given directory that match the pattern
 

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -267,7 +267,7 @@ function snmp_get($device, $oid, $options = null, $mib = null, $mibdir = null)
     $time_start = microtime(true);
 
     if (strstr($oid, ' ')) {
-        echo report_this_text("snmp_get called for multiple OIDs: $oid");
+        throw new Exception("snmp_get called for multiple OIDs: $oid");
     }
 
     $cmd = gen_snmpget_cmd($device, $oid, $options, $mib, $mibdir);


### PR DESCRIPTION
This function is only called at a single place, and it wasn't even working there (see #10704)
Lets remove it, we could add a similar text to Laravels exception handler if we wanted.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
