### PR TITLE
Added issue between rrdcached and smokeping

### DIFF
--- a/doc/Extensions/RRDCached.md
+++ b/doc/Extensions/RRDCached.md
@@ -94,6 +94,9 @@ SOCKGROUP=librenms
 BASE_OPTIONS="-B -F -R"
 ```
 
+Note: there's an issue between RRDCached and Smokeping:
+https://docs.librenms.org/Extensions/Smokeping/#Issues
+
 2: Fix permissions
 
 ```bash


### PR DESCRIPTION
You need other base_options when using smokeping. Made notice of it in the documentation of rrdcached as well (bi-directional)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
