### PR TITLE
Always sort indexes in dump_db_schema 

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2382,7 +2382,7 @@ function dump_db_schema()
             $output[$table]['Columns'][] = $def;
         }
 
-        foreach (dbFetchRows("SHOW INDEX FROM `$table`") as $key) {
+        foreach (array_sort_by_column(dbFetchRows("SHOW INDEX FROM `$table`"), 'Key_name') as $key) {
             $key_name = $key['Key_name'];
             if (isset($output[$table]['Indexes'][$key_name])) {
                 $output[$table]['Indexes'][$key_name]['Columns'][] = $key['Column_name'];

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -32,9 +32,9 @@ alerts:
     - { Field: info, Type: text, 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
-    unique_alert: { Name: unique_alert, Columns: [device_id, rule_id], Unique: true, Type: BTREE }
-    rule_id: { Name: rule_id, Columns: [rule_id], Unique: false, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    rule_id: { Name: rule_id, Columns: [rule_id], Unique: false, Type: BTREE }
+    unique_alert: { Name: unique_alert, Columns: [device_id, rule_id], Unique: true, Type: BTREE }
 alert_device_map:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -61,8 +61,8 @@ alert_log:
     - { Field: time_logged, Type: timestamp, 'Null': false, Extra: '', Default: CURRENT_TIMESTAMP }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
-    rule_id: { Name: rule_id, Columns: [rule_id], Unique: false, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    rule_id: { Name: rule_id, Columns: [rule_id], Unique: false, Type: BTREE }
     time_logged: { Name: time_logged, Columns: [time_logged], Unique: false, Type: BTREE }
 alert_rules:
   Columns:
@@ -86,8 +86,8 @@ alert_schedulables:
     - { Field: alert_schedulable_type, Type: varchar(255), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [item_id], Unique: true, Type: BTREE }
-    schedule_id: { Name: schedule_id, Columns: [schedule_id], Unique: false, Type: BTREE }
     schedulable_morph_index: { Name: schedulable_morph_index, Columns: [alert_schedulable_type, alert_schedulable_id], Unique: false, Type: BTREE }
+    schedule_id: { Name: schedule_id, Columns: [schedule_id], Unique: false, Type: BTREE }
 alert_schedule:
   Columns:
     - { Field: schedule_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -233,8 +233,8 @@ bgpPeers_cbgp:
     - { Field: WithdrawnPrefixes_prev, Type: int(11), 'Null': false, Extra: '' }
     - { Field: context_name, Type: varchar(128), 'Null': true, Extra: '' }
   Indexes:
-    unique_index: { Name: unique_index, Columns: [device_id, bgpPeerIdentifier, afi, safi], Unique: true, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id, bgpPeerIdentifier, context_name], Unique: false, Type: BTREE }
+    unique_index: { Name: unique_index, Columns: [device_id, bgpPeerIdentifier, afi, safi], Unique: true, Type: BTREE }
 bills:
   Columns:
     - { Field: bill_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -296,8 +296,8 @@ bill_history:
     - { Field: pdf, Type: longblob, 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [bill_hist_id], Unique: true, Type: BTREE }
-    unique_index: { Name: unique_index, Columns: [bill_id, bill_datefrom, bill_dateto], Unique: true, Type: BTREE }
     bill_id: { Name: bill_id, Columns: [bill_id], Unique: false, Type: BTREE }
+    unique_index: { Name: unique_index, Columns: [bill_id, bill_datefrom, bill_dateto], Unique: true, Type: BTREE }
 bill_perms:
   Columns:
     - { Field: user_id, Type: 'int(10) unsigned', 'Null': false, Extra: '' }
@@ -476,12 +476,12 @@ devices:
     - { Field: max_depth, Type: int(11), 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [device_id], Unique: true, Type: BTREE }
-    status: { Name: status, Columns: [status], Unique: false, Type: BTREE }
     hostname: { Name: hostname, Columns: [hostname], Unique: false, Type: BTREE }
-    sysName: { Name: sysName, Columns: [sysName], Unique: false, Type: BTREE }
-    os: { Name: os, Columns: [os], Unique: false, Type: BTREE }
-    last_polled: { Name: last_polled, Columns: [last_polled], Unique: false, Type: BTREE }
     last_poll_attempted: { Name: last_poll_attempted, Columns: [last_poll_attempted], Unique: false, Type: BTREE }
+    last_polled: { Name: last_polled, Columns: [last_polled], Unique: false, Type: BTREE }
+    os: { Name: os, Columns: [os], Unique: false, Type: BTREE }
+    status: { Name: status, Columns: [status], Unique: false, Type: BTREE }
+    sysName: { Name: sysName, Columns: [sysName], Unique: false, Type: BTREE }
 devices_attribs:
   Columns:
     - { Field: attrib_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -643,9 +643,9 @@ graph_types:
     - { Field: graph_order, Type: int(11), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [graph_type, graph_subtype, graph_section], Unique: true, Type: BTREE }
-    graph_type: { Name: graph_type, Columns: [graph_type], Unique: false, Type: BTREE }
-    graph_subtype: { Name: graph_subtype, Columns: [graph_subtype], Unique: false, Type: BTREE }
     graph_section: { Name: graph_section, Columns: [graph_section], Unique: false, Type: BTREE }
+    graph_subtype: { Name: graph_subtype, Columns: [graph_subtype], Unique: false, Type: BTREE }
+    graph_type: { Name: graph_type, Columns: [graph_type], Unique: false, Type: BTREE }
 hrDevice:
   Columns:
     - { Field: hrDevice_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -691,8 +691,8 @@ ipv4_mac:
     - { Field: ipv4_address, Type: varchar(32), 'Null': false, Extra: '' }
     - { Field: context_name, Type: varchar(128), 'Null': false, Extra: '' }
   Indexes:
-    port_id: { Name: port_id, Columns: [port_id], Unique: false, Type: BTREE }
     mac_address: { Name: mac_address, Columns: [mac_address], Unique: false, Type: BTREE }
+    port_id: { Name: port_id, Columns: [port_id], Unique: false, Type: BTREE }
 ipv4_networks:
   Columns:
     - { Field: ipv4_network_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -743,9 +743,9 @@ links:
     - { Field: remote_version, Type: varchar(256), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
-    src_if: { Name: src_if, Columns: [local_port_id], Unique: false, Type: BTREE }
     dst_if: { Name: dst_if, Columns: [remote_port_id], Unique: false, Type: BTREE }
     local_device_id: { Name: local_device_id, Columns: [local_device_id, remote_device_id], Unique: false, Type: BTREE }
+    src_if: { Name: src_if, Columns: [local_port_id], Unique: false, Type: BTREE }
 loadbalancer_rservers:
   Columns:
     - { Field: rserver_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1180,8 +1180,8 @@ packages:
     - { Field: size, Type: bigint(20), 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [pkg_id], Unique: true, Type: BTREE }
-    unique_key: { Name: unique_key, Columns: [device_id, name, manager, arch, version, build], Unique: true, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    unique_key: { Name: unique_key, Columns: [device_id, name, manager, arch, version, build], Unique: true, Type: BTREE }
 pdb_ix:
   Columns:
     - { Field: pdb_ix_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1377,8 +1377,8 @@ ports_fdb:
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [ports_fdb_id], Unique: true, Type: BTREE }
     mac_address: { Name: mac_address, Columns: [mac_address], Unique: false, Type: BTREE }
-    ports_fdb_port_id_index: { Name: ports_fdb_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
     ports_fdb_device_id_index: { Name: ports_fdb_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
+    ports_fdb_port_id_index: { Name: ports_fdb_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
     ports_fdb_vlan_id_index: { Name: ports_fdb_vlan_id_index, Columns: [vlan_id], Unique: false, Type: BTREE }
 ports_nac:
   Columns:
@@ -1592,8 +1592,8 @@ sensors:
     - { Field: user_func, Type: varchar(100), 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sensor_id], Unique: true, Type: BTREE }
-    sensor_host: { Name: sensor_host, Columns: [device_id], Unique: false, Type: BTREE }
     sensor_class: { Name: sensor_class, Columns: [sensor_class], Unique: false, Type: BTREE }
+    sensor_host: { Name: sensor_host, Columns: [device_id], Unique: false, Type: BTREE }
     sensor_type: { Name: sensor_type, Columns: [sensor_type], Unique: false, Type: BTREE }
   Constraints:
     sensors_device_id_foreign: { name: sensors_device_id_foreign, foreign_key: device_id, table: devices, key: device_id, extra: 'ON DELETE CASCADE' }
@@ -1650,8 +1650,8 @@ slas:
     - { Field: deleted, Type: tinyint(1), 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sla_id], Unique: true, Type: BTREE }
-    unique_key: { Name: unique_key, Columns: [device_id, sla_nr], Unique: true, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    unique_key: { Name: unique_key, Columns: [device_id, sla_nr], Unique: true, Type: BTREE }
 state_indexes:
   Columns:
     - { Field: state_index_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1688,8 +1688,8 @@ storage:
     - { Field: storage_deleted, Type: tinyint(1), 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [storage_id], Unique: true, Type: BTREE }
-    index_unique: { Name: index_unique, Columns: [device_id, storage_mib, storage_index], Unique: true, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    index_unique: { Name: index_unique, Columns: [device_id, storage_mib, storage_index], Unique: true, Type: BTREE }
 stp:
   Columns:
     - { Field: stp_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1728,9 +1728,9 @@ syslog:
     PRIMARY: { Name: PRIMARY, Columns: [seq], Unique: true, Type: BTREE }
     datetime: { Name: datetime, Columns: [timestamp], Unique: false, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
-    program: { Name: program, Columns: [program], Unique: false, Type: BTREE }
-    priority_level: { Name: priority_level, Columns: [priority, level], Unique: false, Type: BTREE }
     device_id-timestamp: { Name: device_id-timestamp, Columns: [device_id, timestamp], Unique: false, Type: BTREE }
+    priority_level: { Name: priority_level, Columns: [priority, level], Unique: false, Type: BTREE }
+    program: { Name: program, Columns: [program], Unique: false, Type: BTREE }
 tnmsneinfo:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1862,10 +1862,10 @@ vrf_lite_cisco:
     - { Field: vrf_name, Type: varchar(128), 'Null': true, Extra: '', Default: Default }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [vrf_lite_cisco_id], Unique: true, Type: BTREE }
-    vrf: { Name: vrf, Columns: [vrf_name], Unique: false, Type: BTREE }
     context: { Name: context, Columns: [context_name], Unique: false, Type: BTREE }
     device: { Name: device, Columns: [device_id], Unique: false, Type: BTREE }
     mix: { Name: mix, Columns: [device_id, context_name, vrf_name], Unique: false, Type: BTREE }
+    vrf: { Name: vrf, Columns: [vrf_name], Unique: false, Type: BTREE }
 widgets:
   Columns:
     - { Field: widget_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }


### PR DESCRIPTION
Currently when I run `./scripts/build-schema.php` it moves around the order of the columns, which creates a unnecessary diff.  
This PR makes the output sorted, which avoids the issue in the future.
```diff
diff --git a/misc/db_schema.yaml b/misc/db_schema.yaml
index 30b0af89b..11c595a2c 100644
--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -17,8 +17,8 @@ access_points:
     - { Field: interference, Type: 'tinyint(3) unsigned', 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [accesspoint_id], Unique: true, Type: BTREE }
-    deleted: { Name: deleted, Columns: [deleted], Unique: false, Type: BTREE }
     name: { Name: name, Columns: [name, radio_number], Unique: false, Type: BTREE }
+    deleted: { Name: deleted, Columns: [deleted], Unique: false, Type: BTREE }
 alerts:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -33,8 +33,8 @@ alerts:
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     unique_alert: { Name: unique_alert, Columns: [device_id, rule_id], Unique: true, Type: BTREE }
-    rule_id: { Name: rule_id, Columns: [rule_id], Unique: false, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    rule_id: { Name: rule_id, Columns: [rule_id], Unique: false, Type: BTREE }
 alert_device_map:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -86,8 +86,8 @@ alert_schedulables:
     - { Field: alert_schedulable_type, Type: varchar(255), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [item_id], Unique: true, Type: BTREE }
-    schedule_id: { Name: schedule_id, Columns: [schedule_id], Unique: false, Type: BTREE }
     schedulable_morph_index: { Name: schedulable_morph_index, Columns: [alert_schedulable_type, alert_schedulable_id], Unique: false, Type: BTREE }
+    schedule_id: { Name: schedule_id, Columns: [schedule_id], Unique: false, Type: BTREE }
 alert_schedule:
   Columns:
     - { Field: schedule_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -476,10 +476,10 @@ devices:
     - { Field: max_depth, Type: int(11), 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [device_id], Unique: true, Type: BTREE }
-    status: { Name: status, Columns: [status], Unique: false, Type: BTREE }
     hostname: { Name: hostname, Columns: [hostname], Unique: false, Type: BTREE }
     sysName: { Name: sysName, Columns: [sysName], Unique: false, Type: BTREE }
     os: { Name: os, Columns: [os], Unique: false, Type: BTREE }
+    status: { Name: status, Columns: [status], Unique: false, Type: BTREE }
     last_polled: { Name: last_polled, Columns: [last_polled], Unique: false, Type: BTREE }
     last_poll_attempted: { Name: last_poll_attempted, Columns: [last_poll_attempted], Unique: false, Type: BTREE }
 devices_attribs:
@@ -492,6 +492,14 @@ devices_attribs:
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [attrib_id], Unique: true, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
 devices_perms:
   Columns:
     - { Field: user_id, Type: 'int(10) unsigned', 'Null': false, Extra: '' }
@@ -632,8 +640,8 @@ eventlog:
     - { Field: severity, Type: tinyint(4), 'Null': false, Extra: '', Default: '2' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [event_id], Unique: true, Type: BTREE }
-    datetime: { Name: datetime, Columns: [datetime], Unique: false, Type: BTREE }
     device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    datetime: { Name: datetime, Columns: [datetime], Unique: false, Type: BTREE }
 graph_types:
   Columns:
     - { Field: graph_type, Type: varchar(32), 'Null': false, Extra: '' }
@@ -743,9 +751,9 @@ links:
     - { Field: remote_version, Type: varchar(256), 'Null': false, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
+    local_device_id: { Name: local_device_id, Columns: [local_device_id, remote_device_id], Unique: false, Type: BTREE }
     src_if: { Name: src_if, Columns: [local_port_id], Unique: false, Type: BTREE }
     dst_if: { Name: dst_if, Columns: [remote_port_id], Unique: false, Type: BTREE }
-    local_device_id: { Name: local_device_id, Columns: [local_device_id, remote_device_id], Unique: false, Type: BTREE }
 loadbalancer_rservers:
   Columns:
     - { Field: rserver_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1376,10 +1384,10 @@ ports_fdb:
     - { Field: updated_at, Type: timestamp, 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [ports_fdb_id], Unique: true, Type: BTREE }
-    mac_address: { Name: mac_address, Columns: [mac_address], Unique: false, Type: BTREE }
     ports_fdb_port_id_index: { Name: ports_fdb_port_id_index, Columns: [port_id], Unique: false, Type: BTREE }
-    ports_fdb_device_id_index: { Name: ports_fdb_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
+    mac_address: { Name: mac_address, Columns: [mac_address], Unique: false, Type: BTREE }
     ports_fdb_vlan_id_index: { Name: ports_fdb_vlan_id_index, Columns: [vlan_id], Unique: false, Type: BTREE }
+    ports_fdb_device_id_index: { Name: ports_fdb_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
 ports_nac:
   Columns:
     - { Field: ports_nac_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1401,8 +1409,8 @@ ports_nac:
     - { Field: time_elapsed, Type: varchar(50), 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [ports_nac_id], Unique: true, Type: BTREE }
-    ports_nac_device_id_index: { Name: ports_nac_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
     ports_nac_port_id_mac_address_index: { Name: ports_nac_port_id_mac_address_index, Columns: [port_id, mac_address], Unique: false, Type: BTREE }
+    ports_nac_device_id_index: { Name: ports_nac_device_id_index, Columns: [device_id], Unique: false, Type: BTREE }
 ports_perms:
   Columns:
     - { Field: user_id, Type: 'int(10) unsigned', 'Null': false, Extra: '' }
@@ -1592,8 +1600,8 @@ sensors:
     - { Field: user_func, Type: varchar(100), 'Null': true, Extra: '' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [sensor_id], Unique: true, Type: BTREE }
-    sensor_host: { Name: sensor_host, Columns: [device_id], Unique: false, Type: BTREE }
     sensor_class: { Name: sensor_class, Columns: [sensor_class], Unique: false, Type: BTREE }
+    sensor_host: { Name: sensor_host, Columns: [device_id], Unique: false, Type: BTREE }
     sensor_type: { Name: sensor_type, Columns: [sensor_type], Unique: false, Type: BTREE }
   Constraints:
     sensors_device_id_foreign: { name: sensors_device_id_foreign, foreign_key: device_id, table: devices, key: device_id, extra: 'ON DELETE CASCADE' }
@@ -1726,11 +1734,11 @@ syslog:
     - { Field: seq, Type: 'bigint(20) unsigned', 'Null': false, Extra: auto_increment }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [seq], Unique: true, Type: BTREE }
-    datetime: { Name: datetime, Columns: [timestamp], Unique: false, Type: BTREE }
-    device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
-    program: { Name: program, Columns: [program], Unique: false, Type: BTREE }
     priority_level: { Name: priority_level, Columns: [priority, level], Unique: false, Type: BTREE }
     device_id-timestamp: { Name: device_id-timestamp, Columns: [device_id, timestamp], Unique: false, Type: BTREE }
+    device_id: { Name: device_id, Columns: [device_id], Unique: false, Type: BTREE }
+    datetime: { Name: datetime, Columns: [timestamp], Unique: false, Type: BTREE }
+    program: { Name: program, Columns: [program], Unique: false, Type: BTREE }
 tnmsneinfo:
   Columns:
     - { Field: id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
@@ -1862,10 +1870,10 @@ vrf_lite_cisco:
     - { Field: vrf_name, Type: varchar(128), 'Null': true, Extra: '', Default: Default }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [vrf_lite_cisco_id], Unique: true, Type: BTREE }
-    vrf: { Name: vrf, Columns: [vrf_name], Unique: false, Type: BTREE }
-    context: { Name: context, Columns: [context_name], Unique: false, Type: BTREE }
-    device: { Name: device, Columns: [device_id], Unique: false, Type: BTREE }
     mix: { Name: mix, Columns: [device_id, context_name, vrf_name], Unique: false, Type: BTREE }
+    device: { Name: device, Columns: [device_id], Unique: false, Type: BTREE }
+    context: { Name: context, Columns: [context_name], Unique: false, Type: BTREE }
+    vrf: { Name: vrf, Columns: [vrf_name], Unique: false, Type: BTREE }
 widgets:
   Columns:
     - { Field: widget_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
