### PR TITLE
Reimplemented filtering of devices under maintenance when displaying …

### DIFF
--- a/resources/views/widgets/worldmap.blade.php
+++ b/resources/views/widgets/worldmap.blade.php
@@ -40,11 +40,13 @@
         });
 
         @foreach($devices as $device)
-            var title = '<a href="{{ \LibreNMS\Util\Url::deviceUrl($device) }}"><img src="{{ $device->icon }}" width="32" height="32" alt=""> {{ $device->displayName() }}</a>';
-            var tooltip = '{{ $device->displayName() }}';
-            var marker = L.marker(new L.LatLng('{{ $device->location->lat }}', '{{ $device->location->lng }}'), {title: tooltip, icon: {{ $device->markerIcon }}, zIndexOffset: {{ $device->zOffset }}});
-            marker.bindPopup(title);
-            markers.addLayer(marker);
+            @if($status != '0' or !$device->isUnderMaintenance())
+                var title = '<a href="{{ \LibreNMS\Util\Url::deviceUrl($device) }}"><img src="{{ $device->icon }}" width="32" height="32" alt=""> {{ $device->displayName() }}</a>';
+                var tooltip = '{{ $device->displayName() }}';
+                var marker = L.marker(new L.LatLng('{{ $device->location->lat }}', '{{ $device->location->lng }}'), {title: tooltip, icon: {{ $device->markerIcon }}, zIndexOffset: {{ $device->zOffset }}});
+                marker.bindPopup(title);
+                markers.addLayer(marker);
+            @endif
         @endforeach
 
         map.addLayer(markers);


### PR DESCRIPTION
…only Down devices in the WorldMap

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
