### PR TITLE
Remove default 'temp_dir' value '/tmp'

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4188,6 +4188,9 @@
             "order": 2,
             "type": "integer"
         },
+        "temp_dir": {
+            "type": "text"
+        },
         "top_devices": {
             "default": true,
             "type": "boolean"

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4188,10 +4188,6 @@
             "order": 2,
             "type": "integer"
         },
-        "temp_dir": {
-            "default": "/tmp",
-            "type": "text"
-        },
         "top_devices": {
             "default": true,
             "type": "boolean"


### PR DESCRIPTION
This fixes https://github.com/librenms/librenms/pull/10428 again again.
Removed fixed '/tmp' value for 'temp_dir' since `LibreNMS/Config.php` sets temp dir if no default exists, giving a chance for 'temp_dir' to become the value set by the system.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
