### PR TITLE
Add a deprecated warning to the front pages

### DIFF
--- a/includes/html/pages/front/default.php
+++ b/includes/html/pages/front/default.php
@@ -1,3 +1,9 @@
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <?php
 
 use LibreNMS\Config;

--- a/includes/html/pages/front/demo.php
+++ b/includes/html/pages/front/demo.php
@@ -1,3 +1,9 @@
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <table border=0 cellpadding=10 cellspacing=10 width=100%>
   <tr>
     <td colspan=2>

--- a/includes/html/pages/front/example2.php
+++ b/includes/html/pages/front/example2.php
@@ -1,4 +1,9 @@
-
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <table border=0 cellpadding=10 cellspacing=10 width=100%>
   <tr>
     <td bgcolor=#e5e5e5 valign=top>

--- a/includes/html/pages/front/globe.php
+++ b/includes/html/pages/front/globe.php
@@ -1,3 +1,9 @@
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <?php
 /* Copyright (C) 2014 Daniel Preussker <f0o@devilcode.org>
  * This program is free software: you can redistribute it and/or modify

--- a/includes/html/pages/front/jt.php
+++ b/includes/html/pages/front/jt.php
@@ -1,3 +1,9 @@
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <table border=0 cellpadding=10 cellspacing=10 width=100%>
   <tr>
     <td bgcolor=#e5e5e5 valign=top>

--- a/includes/html/pages/front/map.php
+++ b/includes/html/pages/front/map.php
@@ -1,3 +1,9 @@
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <?php
 /* Copyright (C) 2014 Daniel Preussker <f0o@devilcode.org>
  * This program is free software: you can redistribute it and/or modify

--- a/includes/html/pages/front/traffic.php
+++ b/includes/html/pages/front/traffic.php
@@ -1,3 +1,9 @@
+<div class="row">
+    <div class="alert alert-info text-center" role="alert">
+        Overview pages have changed to a new format, this page will not be converted to the new format and will be removed in the next release (1.59).
+        <br>For more info, see: <a href="https://t.libren.ms/overview">https://t.libren.ms/overview</a>
+    </div>
+</div>
 <table border=0 cellpadding=10 cellspacing=10 width=100%>
   <tr>
     <td bgcolor=#e5e5e5 valign=top>


### PR DESCRIPTION
This is a preparation for https://github.com/librenms/librenms/pull/10757

Looks like this:
![image](https://user-images.githubusercontent.com/759887/68297355-01e3f600-0097-11ea-9cb8-4e6f48dab59c.png)

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
