### PR TITLE
Create device groups via API

### DIFF
--- a/doc/API/Alerts.md
+++ b/doc/API/Alerts.md
@@ -36,7 +36,7 @@ Output:
    "alerted": "1",
    "open": "1",
    "timestamp": "2014-12-11 14:40:02"
-  },
+  }]
 }
 ```
 
@@ -140,7 +140,7 @@ Output:
    "alerted": "1",
    "open": "1",
    "timestamp": "2014-12-11 14:40:02"
-  }
+  }]
 }
 ```
 
@@ -247,7 +247,7 @@ Output:
    "extra": "{\"mute\":false,\"count\":\"15\",\"delay\":\"300\",\"invert\":false}",
    "disabled": "0",
    "name": "A test rule"
-  },
+  }]
 }
 ```
 

--- a/doc/API/DeviceGroups.md
+++ b/doc/API/DeviceGroups.md
@@ -37,6 +37,67 @@ Output:
 ]
 ```
 
+### `add_devicegroup`
+
+Add a new device group. Upon success, the ID of the new device group is returned
+and the HTTP response code is `201`.
+
+Route: `/api/v0/devicegroups`
+
+Input (JSON):
+
+- `name`: *required* - The name of the device group
+- `type`: *required* - should be `static` or `dynamic`. Setting this to static
+  requires that the devices input be provided
+- `desc`: *optional* - Description of the device group
+- `rules`: *required if type == dynamic* - A set of rules to determine which
+  devices should be included in this device group
+- `devices`: *required if type == static* - A list of devices that should be
+  included in this group. This is a static list of devices
+
+Examples:
+
+Dynamic Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' \
+  -d '{"name": "New Device Group", \
+       "desc": "A very fancy dynamic group", \
+       "type": "dynamic",
+       "rules": "{\"condition\":\"AND\",\"rules\":[{\"id\":\"access_points.name\",\"field\":\"access_points.name\",\"type\":\"string\",\"input\":\"text\",\"operator\":\"equal\",\"value\":\"accesspoint1\"}],\"valid\":true}"}' \
+  https://librenms.org/api/v0/devicegroups
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "id": 86,
+    "message": "Device group New Device Group created"
+}
+```
+
+Static Example:
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' \
+  -X POST \
+  -d '{"name":"New Device Group","type":"static","devices":[261,271]}' \
+  https://librenms.org/api/v0/devicegroups
+```
+
+Output:
+
+```json
+{
+    "status": "ok",
+    "id": 86,
+    "message": "Device group New Device Group created"
+}
+```
+
+
 ### `get_devices_by_group`
 
 List all devices matching the group provided.

--- a/routes/api.php
+++ b/routes/api.php
@@ -74,6 +74,7 @@ Route::group(['prefix' => 'v0', 'namespace' => '\App\Api\Controllers'], function
         Route::delete('rules/{id}', 'LegacyApiController@delete_rule')->name('delete_rule');
         Route::post('services/{hostname}', 'LegacyApiController@add_service_for_host')->name('add_service_for_host');
         Route::get('oxidized/config/search/{searchstring}', 'LegacyApiController@search_oxidized')->name('search_oxidized');
+        Route::post('devicegroups', 'LegacyApiController@add_device_group')->name('add_device_group');
     });
 
     // restricted by access


### PR DESCRIPTION
This PR adds POST to the devicegroups API endpoint to enable adding a device group via the API.

It has been tested and working. It returns the ID of the newly generated device group and supports the typical static/dynamic rule generation.

Testing of the rule is rudimentary, but follows the same as the `add_alert` API endpoint. It's reasonably easy to break things by messing the rule up though. Is there any better rule validation that we can do here? (And add to the `add_alert` endpoint?) If not, we can improve that later.

I would also like to add DELETE and GET methods for individual device groups so the API is more complete. We can do that in future PRs.

Please review and let me know your feedback. It should be good to go. The documentation may need a little re-formatting as I deviated slightly to include the *optional* and *required* notes in.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
