### PR TITLE
Optimize DB update of ports and ports_statistics tables when polling

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -766,7 +766,7 @@ foreach ($ports as $port) {
         if (!empty($port['skipped'])) {
             // We don't care about statistics for skipped selective polling ports
             echo " $port_id skipped because selective polling ports is set.";
-        } elif ($port['ifOperStatus'] == "down" && $port['ifOperStatus_prev'] == "down" && $this_port['ifOperStatus'] == "down" && $this_port['ifLastChange'] == $port['ifLastChange'])) {
+        } elseif ($port['ifOperStatus'] == "down" && $port['ifOperStatus_prev'] == "down" && $this_port['ifOperStatus'] == "down" && $this_port['ifLastChange'] == $port['ifLastChange']) {
             // We don't care about statistics for down ports on which states did not change since last polling
             echo " $port_id skipped because port is still down since last polling.";
         } else {

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -764,7 +764,7 @@ foreach ($ports as $port) {
         }//end if
 
         // We don't care about statistics for skipped selective polling ports
-        if (!empty($port['skipped'])) {
+        if (!empty($port['skipped']) || ($port['ifOperStatus'] == "down" && $port['ifOperStatus_prev'] == "down" && $this_port['ifOperStatus'] == "down" && $this_port['ifLastChange'] == $port['ifLastChange'])) {
             echo " $port_id skipped.";
         } else {
             // End parse ifAlias

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -537,12 +537,7 @@ foreach ($port_stats as $ifIndex => $port) {
 echo "\n";
 
 // get last poll time to optimize poll_time, poll_prev and poll_period in table db
-$last_poll_time = 0;
-foreach ($ports as $port) {
-    if ($port['poll_time'] > $last_poll_time) {
-        $last_poll_time = $port['poll_time'];
-    }
-}
+$last_poll_time = max(array_column($ports, 'poll_time'));
 
 $device_global_ports = [];
 $device_global_ports['poll_time']  = $polled;

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -501,7 +501,6 @@ foreach ($port_stats as $ifIndex => $port) {
             dbInsert(array('port_id' => $port_id), 'ports_statistics');
             $ports[$port_id] = dbFetchRow('SELECT * FROM `ports` WHERE `port_id` = ?', array($port_id));
             echo 'Adding: '.$ifName.'('.$ifIndex.')('.$port_id.')';
-            // print_r($ports);
         } // Port re-discovered after previous deletion?
         elseif ($ports[$port_id]['deleted'] == 1) {
             dbUpdate(array('deleted' => '0'), 'ports', '`port_id` = ?', array($port_id));

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -783,10 +783,10 @@ foreach ($ports as $port) {
 
         if (!empty($port['skipped'])) {
             // We don't care about statistics for skipped selective polling ports
-            echo " $port_id skipped because selective polling ports is set.";
+            d_echo("$port_id skipped because selective polling ports is set.");
         } elseif ($port['ifOperStatus'] == "down" && $port['ifOperStatus_prev'] == "down" && $this_port['ifOperStatus'] == "down" && $this_port['ifLastChange'] == $port['ifLastChange']) {
             // We don't care about statistics for down ports on which states did not change since last polling
-            echo " $port_id skipped because port is still down since last polling.";
+            d_echo("$port_id skipped because port is still down since last polling.");
         } else {
             // End parse ifAlias
             // Update IF-MIB metrics

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -536,12 +536,11 @@ foreach ($port_stats as $ifIndex => $port) {
 echo "\n";
 
 // get last poll time to optimize poll_time, poll_prev and poll_period in table db
-$last_poll_time = max(array_column($ports, 'poll_time'));
-
-$device_global_ports = [];
-$device_global_ports['poll_time']  = $polled;
-$device_global_ports['poll_prev']  = $last_poll_time;
-$device_global_ports['poll_period']  = ($polled - $port['poll_time']);
+$device_global_ports = [
+    'poll_time' => $polled,
+    'poll_prev' => max(array_column($ports, 'poll_time')),
+    'poll_period' => ($polled - $port['poll_time']),
+];
 
 $port_ids = array();
 
@@ -589,7 +588,9 @@ foreach ($ports as $port) {
             $port['update']['ifIndex'] = $ifIndex;
         }
         
-        if ($last_poll_time != $port['poll_time']) {
+        // set $port['update'] times if different from $device_global_ports
+        // if $port['update'] times not set and $port['update'] is void, value would be replaced by $device_global_ports
+        if ($device_global_ports["poll_prev"] != $port['poll_time']) {
             $port['update']['poll_time'] = $polled;
             $port['update']['poll_prev'] = $port['poll_time'];
             $port['update']['poll_period'] = $polled_period;

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -763,9 +763,12 @@ foreach ($ports as $port) {
             }
         }//end if
 
-        // We don't care about statistics for skipped selective polling ports
-        if (!empty($port['skipped']) || ($port['ifOperStatus'] == "down" && $port['ifOperStatus_prev'] == "down" && $this_port['ifOperStatus'] == "down" && $this_port['ifLastChange'] == $port['ifLastChange'])) {
-            echo " $port_id skipped.";
+        if (!empty($port['skipped'])) {
+            // We don't care about statistics for skipped selective polling ports
+            echo " $port_id skipped because selective polling ports is set.";
+        } elif ($port['ifOperStatus'] == "down" && $port['ifOperStatus_prev'] == "down" && $this_port['ifOperStatus'] == "down" && $this_port['ifLastChange'] == $port['ifLastChange'])) {
+            // We don't care about statistics for down ports on which states did not change since last polling
+            echo " $port_id skipped because port is still down since last polling.";
         } else {
             // End parse ifAlias
             // Update IF-MIB metrics

--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -593,7 +593,7 @@ foreach ($ports as $port) {
             $port['update']['ifIndex'] = $ifIndex;
         }
         
-        if ($last_poll_time != $port['poll_time']){
+        if ($last_poll_time != $port['poll_time']) {
             $port['update']['poll_time'] = $polled;
             $port['update']['poll_prev'] = $port['poll_time'];
             $port['update']['poll_period'] = $polled_period;


### PR DESCRIPTION
Two optimizations to reduce useless update request in database : 
- table ports_statistics : Don't update ports stats in database when their ifOperStatus is down and their ifLastChange did not change - ports_statistics table
- table ports : Update the poll_time, poll_prev and poll_period of all ports in an unique request per device. Do not request update when iflastchange is the same.

This change optimizes the numbers of update request in database during port polling phase.

Gain for total polling time is significant when the disk activity in term of IO per second is saturated without the patch.

Significant gain in term of CPU usage

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
