### PR TITLE
UI bug fix - Scroll disabled on "new rule from collection" modal

### DIFF
--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -83,9 +83,12 @@ if (!Auth::user()->hasGlobalAdmin()) {
                                     dataType: "json",
                                     success: function (data) {
                                         if (data.status == 'ok') {
+                                            $("#search_rule_modal").on('hidden.bs.modal', function(event) {
+                                                loadRule(data);
+                                                $('#create-alert').modal('show');
+                                                $("#search_rule_modal").off(event);
+                                            });
                                             $("#search_rule_modal").modal('hide');
-                                            loadRule(data);
-                                            $('#create-alert').modal('show');
                                         } else {
                                             toastr.error(data.message);
                                         }

--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -83,10 +83,9 @@ if (!Auth::user()->hasGlobalAdmin()) {
                                     dataType: "json",
                                     success: function (data) {
                                         if (data.status == 'ok') {
-                                            $("#search_rule_modal").on('hidden.bs.modal', function(event) {
+                                            $("#search_rule_modal").one('hidden.bs.modal', function(event) {
                                                 loadRule(data);
                                                 $('#create-alert').modal('show');
-                                                $("#search_rule_modal").off(event);
                                             });
                                             $("#search_rule_modal").modal('hide');
                                         } else {


### PR DESCRIPTION
How to reproduce:
- Reduce browser window height (so that view-port is smaller than 700px)
- Go to Alert Rules
- Click "Create rule from collection" button
- The new modal can be scrolled
- Click any rule's "select"
- The new modal is does not scroll, instead the hole page scrolls while the modal stay fixed

How to fix the bug:

To fix this bug, you need to wait the first modal to close (wait the animations too), before opening the second modal. This can be done by listening for the `hidden.bs.modal` event ~~(and then instantly removing the event handler by calling the `.off(event)`)~~ once.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
