### PR TITLE
Removal of IP address validation for ip field in add_service_for_host API call

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -963,7 +963,7 @@ function list_alerts(\Illuminate\Http\Request $request)
             $sql .= ' AND `R`.severity=?';
         }
     }
-    
+
     $order = 'timestamp desc';
 
     if ($request->has('order')) {
@@ -2119,9 +2119,6 @@ function add_service_for_host(\Illuminate\Http\Request $request)
     // Print error if required fields are missing
     if (!empty($missing_fields)) {
         return api_error(400, sprintf("Service field%s %s missing: %s.", ((sizeof($missing_fields)>1)?'s':''), ((sizeof($missing_fields)>1)?'are':'is'), implode(', ', $missing_fields)));
-    }
-    if (!filter_var($data['ip'], FILTER_VALIDATE_IP)) {
-        return api_error(400, 'service_ip is not a valid IP address.');
     }
 
     // Check if service type exists


### PR DESCRIPTION
This pull request is to remove the IP validation against the ip field in the 'add_service_for_host' call. Enforcing it doesn't allow https service checks to be added correctly, as these have to be added as an FQDN.

This restriction is not in the Web front end when adding a service, and it is possible to add service monitoring with FQDNs.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
