### PR TITLE
Comparison fix in slas.inc.php

### DIFF
--- a/includes/html/pages/device/slas.inc.php
+++ b/includes/html/pages/device/slas.inc.php
@@ -70,7 +70,7 @@ foreach ($slas as $sla) {
         continue;
     }
 
-    $opstatus = ($sla['opstatus'] === '0') ? 'up' : 'down';
+    $opstatus = ($sla['opstatus'] === 0) ? 'up' : 'down';
     d_echo("<br>Opstatus :: var: ".$vars['opstatus'].", db: ".$sla['opstatus'].", name: ".$opstatus."<br>");
     if ($vars['opstatus'] != 'all' && $vars['opstatus'] != $opstatus) {
         continue;


### PR DESCRIPTION
In the 'slas' table, the column 'opstatus' is of type int. The current
comparison does not work correctly - in the web-interface all sla-probes are
displayed as 'down', even if the status = 0 in the table (0 is OK).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
