### PR TITLE
Fix maps display only one link if multiple links are present between …

### DIFF
--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -288,13 +288,14 @@ foreach ($list as $items) {
 
     // If mac is choosen to graph, ensure only one link exists between any two ports, or any two devices.
     // else ensure only one link exists between any two ports
-    if ((in_array('mac',$config['network_map_items']) &&
+    if ((in_array('mac', Config::get('network_map_items')) &&
         !array_key_exists($link_id1, $link_assoc_seen) &&
         !array_key_exists($link_id2, $link_assoc_seen) &&
         !array_key_exists($device_id1, $device_assoc_seen) &&
         !array_key_exists($device_id2, $device_assoc_seen)) ||
-        (!array_key_exists($link_id1, $link_assoc_seen)
-         & !array_key_exists($link_id2, $link_assoc_seen))) {
+        (!in_array('mac', Config::get('network_map_items')) &&
+        !array_key_exists($link_id1, $link_assoc_seen) &&
+        !array_key_exists($link_id2, $link_assoc_seen))) {
         $local_port = cleanPort($local_port);
         $remote_port = cleanPort($remote_port);
         $links[] = array_merge(

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -288,14 +288,11 @@ foreach ($list as $items) {
 
     // If mac is choosen to graph, ensure only one link exists between any two ports, or any two devices.
     // else ensure only one link exists between any two ports
-    if ((in_array('mac', Config::get('network_map_items')) &&
-        !array_key_exists($link_id1, $link_assoc_seen) &&
+    if (!array_key_exists($link_id1, $link_assoc_seen) &&
         !array_key_exists($link_id2, $link_assoc_seen) &&
-        !array_key_exists($device_id1, $device_assoc_seen) &&
-        !array_key_exists($device_id2, $device_assoc_seen)) ||
-        (!in_array('mac', Config::get('network_map_items')) &&
-        !array_key_exists($link_id1, $link_assoc_seen) &&
-        !array_key_exists($link_id2, $link_assoc_seen))) {
+        (!in_array('mac', Config::get('network_map_items')) ||
+        (!array_key_exists($device_id1, $device_assoc_seen) &&
+        !array_key_exists($device_id2, $device_assoc_seen)))) {
         $local_port = cleanPort($local_port);
         $remote_port = cleanPort($remote_port);
         $links[] = array_merge(

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -286,11 +286,15 @@ foreach ($list as $items) {
     $device_id1 = $items['local_device_id'].':'.$items['remote_device_id'];
     $device_id2 = $items['remote_device_id'].':'.$items['local_device_id'];
 
-    // Ensure only one link exists between any two ports, or any two devices.
-    if (!array_key_exists($link_id1, $link_assoc_seen) &&
+    // If mac is choosen to graph, ensure only one link exists between any two ports, or any two devices.
+    // else ensure only one link exists between any two ports
+    if ((in_array('mac',$config['network_map_items']) &&
+        !array_key_exists($link_id1, $link_assoc_seen) &&
         !array_key_exists($link_id2, $link_assoc_seen) &&
         !array_key_exists($device_id1, $device_assoc_seen) &&
-        !array_key_exists($device_id2, $device_assoc_seen)) {
+        !array_key_exists($device_id2, $device_assoc_seen)) ||
+        (!array_key_exists($link_id1, $link_assoc_seen)
+         & !array_key_exists($link_id2, $link_assoc_seen))) {
         $local_port = cleanPort($local_port);
         $remote_port = cleanPort($remote_port);
         $links[] = array_merge(


### PR DESCRIPTION
…devices.

Recreate pull request for https://github.com/librenms/librenms/pull/10687

If mac is selected, to graph, only graph one link to avoid unreadable map that was noticed on this post : https://community.librenms.org/t/network-map-w-port-channels-or-multiple-links/2467/3

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
