### PR TITLE
Fixes Zyxel MIB product definition

### DIFF
--- a/mibs/zyxel/ZYXEL-MIB
+++ b/mibs/zyxel/ZYXEL-MIB
@@ -243,11 +243,34 @@
 	ges2104			OBJECT IDENTIFIER ::= { gesSeries 2 }
 	ges1116			OBJECT IDENTIFIER ::= { gesSeries 3 }
 
-
-
 	-- DSLAM products
 	dslamCommon             OBJECT IDENTIFIER ::= { dslam 1 }
-		
+
+	-- ZyWALL series
+	zywallCommon       	OBJECT IDENTIFIER ::= { zywall 1 }
+	zywall1		      	OBJECT IDENTIFIER ::= { zywall 2 }
+	zywall2		        OBJECT IDENTIFIER ::= { zywall 3 }
+	zywall2w	      	OBJECT IDENTIFIER ::= { zywall 4 }
+	zywall10	       	OBJECT IDENTIFIER ::= { zywall 5 }
+	zywall10ii		    OBJECT IDENTIFIER ::= { zywall 6 }
+	zywall10w		    OBJECT IDENTIFIER ::= { zywall 7 }
+	zywall50	      	OBJECT IDENTIFIER ::= { zywall 8 }
+	zywall100	      	OBJECT IDENTIFIER ::= { zywall 9 }
+	zywall200	       	OBJECT IDENTIFIER ::= { zywall 10 }
+	zywallidp10        	OBJECT IDENTIFIER ::= { zywall 11 }
+	zywall5           	OBJECT IDENTIFIER ::= { zywall 12 }
+	zywall30w         	OBJECT IDENTIFIER ::= { zywall 13 }
+	zywall35           	OBJECT IDENTIFIER ::= { zywall 14 }
+	zywall70           	OBJECT IDENTIFIER ::= { zywall 15 }
+	zywall1000         	OBJECT IDENTIFIER ::= { zywall 16 }
+	zywallCHT1         	OBJECT IDENTIFIER ::= { zywall 17 }
+	zywallM70          	OBJECT IDENTIFIER ::= { zywall 18 }
+	zywallP1           	OBJECT IDENTIFIER ::= { zywall 19 }
+    zywallP2           	OBJECT IDENTIFIER ::= { zywall 20 }
+	zywallM110         	OBJECT IDENTIFIER ::= { zywall 21 }
+
+	-- ZyWALL ZLD series
+	zywallZLDCommon		OBJECT IDENTIFIER ::= { zywall 22 }
 	-- Service Gateway products
 	serviceGWCommon			OBJECT IDENTIFIER ::= { serviceGateway 1 }
 	vsg1000				OBJECT IDENTIFIER ::= { serviceGateway 2 }


### PR DESCRIPTION
Some definitions disappeared in newer ZYXEL-MIB file, leading to broken dependant mibfiles.

After #10789 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
