### PR TITLE
Fix htmlspecialchars for route table

### DIFF
--- a/app/Http/Controllers/Table/RoutesTablesController.php
+++ b/app/Http/Controllers/Table/RoutesTablesController.php
@@ -170,7 +170,7 @@ class RoutesTablesController extends TableController
         }
         $item['inetCidrRouteIfIndex'] = 'ifIndex ' . $item['inetCidrRouteIfIndex'];
         if ($port = $route_entry->port()->first()) {
-            $item['inetCidrRouteIfIndex'] = Url::portLink($port, $port->getShortLabel());
+            $item['inetCidrRouteIfIndex'] = Url::portLink($port, htmlspecialchars($port->getShortLabel()));
         }
         $device = Device::findByIp($route_entry->inetCidrRouteNextHop);
         if ($device) {
@@ -188,7 +188,7 @@ class RoutesTablesController extends TableController
         }
         $item['context_name'] = '[global]';
         if ($route_entry->context_name != '') {
-            $item['context_name'] = '<a href="' . Url::generate(['page' => 'routing', 'protocol' => 'vrf', 'vrf' => $route_entry->context_name]) . '">' . $route_entry->context_name . '</a>' ;
+            $item['context_name'] = '<a href="' . Url::generate(['page' => 'routing', 'protocol' => 'vrf', 'vrf' => $route_entry->context_name]) . '">' . htmlspecialchars($route_entry->context_name) . '</a>' ;
         }
         return $item;
     }


### PR DESCRIPTION
Fix funny html chars in interface names. Mikrotik L2TP connections appear in ```< xxxx >``` which of course does not play well in HTML page ... 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
