### PR TITLE
Set up variable to give a choice of using OSM in Device Overview

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -49,3 +49,6 @@ $config['enable_billing'] = 1;
 
 # Enable the in-built services support (Nagios plugins)
 $config['show_services'] = 1;
+
+# Uncomment the following line to use OpenStreetMap instead of Google for the "Map" button in the device overview screen
+#$config['map_provider'] = "osm";


### PR DESCRIPTION
At the moment, although the small map window in Device Overview uses OpenStreetMap, the "Map" button opens Google Maps.
Create a commented-out variable to use in html/includes/dev-overview-data.inc.php so the user can choose to swap to using OSM instead.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
