### PR TITLE
Use OSM for Map button if variable is set

### DIFF
--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -126,9 +126,15 @@ if ($device['location_id']) {
         <div class="col-sm-8"><span id="coordinates-text">' . $location_coords . '</span><div class="pull-right">';
 
     echo '<button type="button" id="toggle-map-button" class="btn btn-primary btn-xs" data-toggle="collapse" data-target="#toggle-map"><i class="fa fa-map" style="color:white" aria-hidden="true"></i> <span>View</span></button>';
-    if ($location_valid) {
-        echo ' <a id="map-it-button" href="https://maps.google.com/?q=' . $location->lat . ',' . $location->lng . '" target="_blank" class="btn btn-success btn-xs" role="button"><i class="fa fa-map-marker" style="color:white" aria-hidden="true"></i> Map</a>';
+
+   # Display Map button which will take you to Google or OSM depending on the setting map_provider in config.php
+    echo ' <a id="map-it-button" href="';
+    if ($location_valid && (Config::get('map_provider') != 'osm')) {
+        echo 'https://maps.google.com/?q=' . $location->lat . ',' . $location->lng;
+    } elseif ($location_valid && (Config::get('map_provider') == 'osm')) {
+        echo 'https://www.openstreetmap.org/#map=19/' . $location->lat . '/' . $location->lng;
     }
+    echo '" target="_blank" class="btn btn-success btn-xs" role="button"><i class="fa fa-map-marker" style="color:white" aria-hidden="true"></i> Map</a>';
     echo '</div>
         </div>
     </div>


### PR DESCRIPTION
If the "map_provider" variable is set to OSM, use OpenStreetMap instead of Google.
Google will still be default so not to confuse people when they upgrade.
This should be linked with Chewie9999-patch-1 which changes config.php.default to use the variable.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
