### PR TITLE
Missing 'use LibreNMS\Config' in route discovery

### DIFF
--- a/includes/discovery/route.inc.php
+++ b/includes/discovery/route.inc.php
@@ -1,6 +1,8 @@
 <?php
-
-/* Copyright (C) 2014 Nicolas Armando <nicearma@yahoo.com> and Mathieu Millet <htam-net@github.net>
+/* Copyright (C) 2014 Nicolas Armando <nicearma@yahoo.com>
+ * Copyright (C) 2014 Mathieu Millet <htam-net@github.net>
+ * Copyright (C) 2019 PipoCanaja <pipocanaja@github.net>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -12,7 +14,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>. */
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 //We can use RFC1213 or IP-FORWARD-MIB or MPLS-L3VPN-STD-MIB
 

--- a/includes/discovery/route.inc.php
+++ b/includes/discovery/route.inc.php
@@ -18,6 +18,7 @@
 
 use App\Models\Device;
 use LibreNMS\Util\IPv4;
+use LibreNMS\Config;
 
 $ipForwardMibRoutesNumber = snmp_get($device, 'IP-FORWARD-MIB::inetCidrRouteNumber.0', '-Osqn');
 


### PR DESCRIPTION
Seems that this one escaped the tests :) 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
