### PR TITLE
Graphical alerts update (text/icon alignment)

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -1817,10 +1817,11 @@ label {
 .badge-navbar-user {
    border-radius: 40%;
    font-size: 65%;
-   padding: 5px;
+   padding: 4px;
    position: relative;
    top: -10px;
-   left: -5px;
+   left: -11px;
+   margin-right: -14px;
 }
 .badge-default {
   background-color: #777;

--- a/resources/views/layouts/librenmsv1.blade.php
+++ b/resources/views/layouts/librenmsv1.blade.php
@@ -41,7 +41,7 @@
     <link href="{{ asset('css/select2.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('css/select2-bootstrap.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('css/query-builder.default.min.css') }}" rel="stylesheet" type="text/css" />
-    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=20190912" rel="stylesheet" type="text/css" />
+    <link href="{{ asset(LibreNMS\Config::get('stylesheet', 'css/styles.css')) }}?ver=20191124" rel="stylesheet" type="text/css" />
     <link href="{{ asset('css/' . LibreNMS\Config::get('applied_site_style', 'light') . '.css?ver=632417642') }}" rel="stylesheet" type="text/css" />
     @foreach(LibreNMS\Config::get('webui.custom_css', []) as $custom_css)
         <link href="{{ $custom_css }}" rel="stylesheet" type="text/css" />

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -27,7 +27,7 @@
                     <ul class="dropdown-menu multi-level" role="menu">
                         <li><a href="{{ url('overview') }}"><i class="fa fa-tv fa-fw fa-lg"
                                                                aria-hidden="true"></i> @lang('Dashboard')</a></li>
-                        <li class="dropdown-submenu">
+                        <li class="dropdown-submenu">F
                             <a><i class="fa fa-map fa-fw fa-lg"
                                                                aria-hidden="true"></i> @lang('Maps')</a>
                             <ul class="dropdown-menu">
@@ -472,7 +472,7 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown">
                         <i class="fa fa-user fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i>
-                        <span class="badge badge-navbar-user count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count ? $notification_count : '' }}</span>
+                        <span class="badge badge-navbar-user count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count ?: '' }}</span>
                         <span class="hidden-sm"><small>{{ Auth::user()->username }}</small></span>
                         <span class="visible-xs-inline-block">@lang('User')</span>
                     </a>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -472,7 +472,7 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown">
                         <i class="fa fa-user fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i>
-                        <span class="badge badge-navbar-user count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count }}</span>
+                        <span class="badge badge-navbar-user count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count ? $notification_count : '' }}</span>
                         <span class="hidden-sm"><small>{{ Auth::user()->username }}</small></span>
                         <span class="visible-xs-inline-block">@lang('User')</span>
                     </a>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -472,7 +472,7 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><i class="fa fa-user fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i><span class="hidden-sm"><small>{{ Auth::user()->username }}</small></span>
                         <span class="visible-xs-inline-block">@lang('User')</span><span
-                            class="badge badge-navbar-user count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count }}</span></a>
+                            class="badge count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count }}</span></a>
                     <ul class="dropdown-menu">
                         <li><a href="{{ url('preferences') }}"><i class="fa fa-cog fa-fw fa-lg"
                                                                   aria-hidden="true"></i> @lang('My Settings')</a></li>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -27,7 +27,7 @@
                     <ul class="dropdown-menu multi-level" role="menu">
                         <li><a href="{{ url('overview') }}"><i class="fa fa-tv fa-fw fa-lg"
                                                                aria-hidden="true"></i> @lang('Dashboard')</a></li>
-                        <li class="dropdown-submenu">F
+                        <li class="dropdown-submenu">
                             <a><i class="fa fa-map fa-fw fa-lg"
                                                                aria-hidden="true"></i> @lang('Maps')</a>
                             <ul class="dropdown-menu">

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -470,9 +470,12 @@
             </form>
             <ul class="nav navbar-nav navbar-right">
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><i class="fa fa-user fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i><span class="hidden-sm"><small>{{ Auth::user()->username }}</small></span>
-                        <span class="visible-xs-inline-block">@lang('User')</span><span
-                            class="badge count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count }}</span></a>
+                    <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown">
+                        <i class="fa fa-user fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i>
+                        <span class="badge badge-navbar-user count-notif {{ $notification_count ? 'badge-danger' : 'badge-default' }}">{{ $notification_count }}</span>
+                        <span class="hidden-sm"><small>{{ Auth::user()->username }}</small></span>
+                        <span class="visible-xs-inline-block">@lang('User')</span>
+                    </a>
                     <ul class="dropdown-menu">
                         <li><a href="{{ url('preferences') }}"><i class="fa fa-cog fa-fw fa-lg"
                                                                   aria-hidden="true"></i> @lang('My Settings')</a></li>


### PR DESCRIPTION
The goal is to have the UserName and the alert number correctly aligned.

Before: 
![Capture d’écran 2019-11-20 à 11 18 57](https://user-images.githubusercontent.com/38363551/69230901-6ff4e680-0b88-11ea-9528-943c9b2393e2.png)

After: 
![Capture d’écran 2019-11-20 à 11 19 29](https://user-images.githubusercontent.com/38363551/69230895-6d928c80-0b88-11ea-8b80-4f70d3f7b649.png)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
