### PR TITLE
re-enable LDAP debugging wip

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -12,6 +12,9 @@ class LdapAuthorizer extends AuthorizerBase
 
     public function authenticate($credentials)
     {
+        if (Config::get('auth_ldap_debug')) {
+            ldap_set_option(null, LDAP_OPT_DEBUG_LEVEL, 7);
+        }
         $connection = $this->getLdapConnection(true);
 
         if (!empty($credentials['username'])) {


### PR DESCRIPTION
Fix to re-enable LDAP debugging when set.

Without :
```
./scripts/auth_test.php -u XXXX -d -v 
Authentication Method: ldap
Password: 
Authenticate user XX: 
AUTH SUCCESS

User (5001):
  username => XX
  realname => XX
  user_id => 5001
  email => XX@XX
  level => 10
Groups: cn=librenms_group,ou=Users,o=XXX,dc=jumpcloud,dc=com
```
With the fix :

```
./scripts/auth_test.php -u XXX -d -v
Authentication Method: ldap
Password: stty: 

Authenticate user XXX: 
ldap_url_parse_ext(ldap://XXX/)
ldap_init: trying /etc/openldap/ldap.conf
ldap_init: using /etc/openldap/ldap.conf
ldap_url_parse_ext(ldaps://ldXX2)
ldap_url_parse_ext(ldaps://ldap-XX)
ldap_init: HOME env is /root
ldap_init: trying /root/ldaprc
ldap_init: trying /root/.ldaprc
ldap_init: LDAPCONF env is NULL
ldap_init: LDAPRC env is NULL
ldap_create
ldap_url_parse_ext(ldaps://ldap.jumpcloud.com)
ldap_sasl_bind_s
ldap_sasl_bind
(...)
```


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
