### PR TITLE
Fix auth_test script does not do ldap bind

### DIFF
--- a/scripts/auth_test.php
+++ b/scripts/auth_test.php
@@ -45,6 +45,11 @@ if (Config::get('auth_mechanism') == 'ldap' || Config::get('auth_mechanism') == 
 try {
     $authorizer = LegacyAuth::get();
 
+    // ldap based auth we should bind before using, otherwise searches may fail due to anonymous bind
+    if (method_exists($authorizer, 'bind')) {
+        $authorizer->bind([]);
+    }
+
     // AD bind tests
     if ($authorizer instanceof \LibreNMS\Authentication\ActiveDirectoryAuthorizer) {
         // peek inside the class


### PR DESCRIPTION
Fix auth_test script does not do ldap bind

Add ldap bind stage in auth_test script. Stage is present in webUI login (see LegacyProvider.php).

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
