### PR TITLE
Adds API to fetch all inventory items for a given device

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1199,16 +1199,7 @@ function get_inventory_for_device(\Illuminate\Http\Request $request)
     $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
     return check_device_permission($device_id, function ($device_id) use ($request) {
         $params    = [];
-        $sql = 'SELECT `D`.`device_id` AS `device_id`,
-                       `D`.`hostname` AS `hostname`,
-                       `entPhysicalDescr` AS `description`,
-                       `entPhysicalName` AS `name`,
-                       `entPhysicalModelName` AS `model`,
-                       `entPhysicalSerialNum` AS `serial`,
-                       `entPhysicalHardwareRev` as `revision`,
-                       `entPhysicalFirmwareRev` as `version`
-               FROM entPhysical AS E, devices AS D
-               WHERE `D`.`device_id`=? AND D.device_id = E.device_id';
+        $sql = 'SELECT * FROM `entPhysical` WHERE device_id = ?';
         $params[] = $device_id;
         $inventory = dbFetchRows($sql, $params);
         return api_success($inventory, 'inventory');

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1192,6 +1192,30 @@ function get_inventory(\Illuminate\Http\Request $request)
 }
 
 
+function get_inventory_for_device(\Illuminate\Http\Request $request)
+{
+    $hostname = $request->route('hostname');
+    // use hostname as device_id if it's all digits
+    $device_id = ctype_digit($hostname) ? $hostname : getidbyname($hostname);
+    return check_device_permission($device_id, function ($device_id) use ($request) {
+        $params    = [];
+        $sql = 'SELECT `D`.`device_id` AS `device_id`,
+                       `D`.`hostname` AS `hostname`,
+                       `entPhysicalDescr` AS `description`,
+                       `entPhysicalName` AS `name`,
+                       `entPhysicalModelName` AS `model`,
+                       `entPhysicalSerialNum` AS `serial`,
+                       `entPhysicalHardwareRev` as `revision`,
+                       `entPhysicalFirmwareRev` as `version`
+               FROM entPhysical AS E, devices AS D
+               WHERE `D`.`device_id`=? AND D.device_id = E.device_id';
+        $params[] = $device_id;
+        $inventory = dbFetchRows($sql, $params);
+        return api_success($inventory, 'inventory');
+    });
+}
+
+
 function search_oxidized(\Illuminate\Http\Request $request)
 {
     $search_in_conf_textbox = $request->route('searchstring');

--- a/routes/api.php
+++ b/routes/api.php
@@ -131,6 +131,7 @@ Route::group(['prefix' => 'v0', 'namespace' => '\App\Api\Controllers'], function
     });
 
     Route::get('inventory/{hostname}', 'LegacyApiController@get_inventory')->name('get_inventory');
+    Route::get('inventory/{hostname}/all', 'LegacyApiController@get_inventory_for_device')->name('get_inventory_for_device');
 
 
     // Route not found


### PR DESCRIPTION
The current inventory API takes 742 API calls, 1m43 and 1Mb traffic in 2467 packets
to fetch the inventory items for a very common use case (core switch/router).
This proposal to extend the inventory API closely reflects the UI and only takes 1 API call, 0.5s and 237Kb traffic in 76 packets

I understand the reasoning that went into the concept of the current inventory API, but this proposal performs better and won't hammer the server (and database) as much.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
