### PR TITLE
Use format_hostname for graph default title

### DIFF
--- a/includes/html/graphs/graph.inc.php
+++ b/includes/html/graphs/graph.inc.php
@@ -34,6 +34,9 @@ $graphfile = Config::get('temp_dir') . '/' . strgen();
 
 require Config::get('install_dir') . "/includes/html/graphs/$type/auth.inc.php";
 
+//set default graph title
+$graph_title = format_hostname($device);
+
 if ($auth && is_custom_graph($type, $subtype, $device)) {
     include(Config::get('install_dir') . "/includes/html/graphs/custom.inc.php");
 } elseif ($auth && is_mib_graph($type, $subtype)) {


### PR DESCRIPTION
Use format_hostname for default graphe title. Useful for librenms setups with ``` $config['force_ip_to_sysname'] = true;```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
