### PR TITLE
Update alert rules with backticks

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -117,7 +117,7 @@
     "name": "Interface Errors Rate greater than 100"
   },
   {
-    "rule": "eventlog.type = \"discovery\" && eventlog.message ~ \"@autodiscovered@\" && eventlog.datetime >= macros.past_60m",
+    "rule": "eventlog.type = \"discovery\" && eventlog.message ~ \"@autodiscovered@\" && eventlog.datetime >= `macros.past_60m`",
     "name": "Device discovered within the last 60 minutes"
   },
   {
@@ -125,7 +125,7 @@
     "name": "Too many wireless clients"
   },
   {
-    "rule": "syslog.timestamp >= macros.past_5m && syslog.msg ~ \"@authentication failure@\"",
+    "rule": "syslog.timestamp >= `macros.past_5m` && syslog.msg ~ \"@authentication failure@\"",
     "name": "Syslog, Authentication failure on Device"
   },
   {
@@ -137,15 +137,15 @@
     "name": "Service critical"
   },
   {
-    "rule": "syslog.timestamp >= macros.past_5m && syslog.priority ~ \"alert\"",
+    "rule": "syslog.timestamp >= `macros.past_5m` && syslog.priority ~ \"alert\"",
     "name": "Syslog, received Alert Priority Message"
   },
   {
-    "rule": "syslog.timestamp >= macros.past_5m && syslog.priority ~ \"emergency\"",
+    "rule": "syslog.timestamp >= `macros.past_5m` && syslog.priority ~ \"emergency\"",
     "name": "Syslog, received Emergency Priority Message"
   },
   {
-    "rule": "syslog.timestamp = macros.past_5m && syslog.msg ~ \"@arp table is full@\"",
+    "rule": "syslog.timestamp = `macros.past_5m` && syslog.msg ~ \"@arp table is full@\"",
     "name": "Syslog, ARP table is full check on device "
   },
   {

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -145,7 +145,7 @@
     "name": "Syslog, received Emergency Priority Message"
   },
   {
-    "rule": "syslog.timestamp = `macros.past_5m` && syslog.msg ~ \"@arp table is full@\"",
+    "rule": "syslog.timestamp >= `macros.past_5m` && syslog.msg ~ \"@arp table is full@\"",
     "name": "Syslog, ARP table is full check on device "
   },
   {


### PR DESCRIPTION
added back ticks to all rules (syslog) where the macro is on the right side of the compare operator (greater than/less than/etc). also corrected a missing greater-than from a syslog rule

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
