### PR TITLE
Fix alert icons wrongly defaults to blue info level

### DIFF
--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -148,6 +148,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
 
     $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($alert['id']) . '" class="collapse">' . $fault_detail . '</div></div>';
 
+    $severity = $alert['severity'];
     switch ($severity) {
         case 'critical':
             $severity_ico = '<span class="alert-status label-danger">&nbsp;</span>';
@@ -162,8 +163,7 @@ foreach (dbFetchRows($sql, $param) as $alert) {
             $severity_ico = '<span class="alert-status label-info">&nbsp;</span>';
             break;
     }
-    
-    $severity = $alert['severity'];
+
     if ($alert['state'] == 3) {
         $severity .= ' <strong>+</strong>';
     } elseif ($alert['state'] == 4) {

--- a/includes/html/table/alerts.inc.php
+++ b/includes/html/table/alerts.inc.php
@@ -146,13 +146,6 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         }
     }
 
-    $severity = $alert['severity'];
-    if ($alert['state'] == 3) {
-        $severity .= ' <strong>+</strong>';
-    } elseif ($alert['state'] == 4) {
-        $severity .= ' <strong>-</strong>';
-    }
-
     $hostname = '<div class="incident">' . generate_device_link($alert, format_hostname($alert, shorthost($alert['hostname']))) . '<div id="incident' . ($alert['id']) . '" class="collapse">' . $fault_detail . '</div></div>';
 
     switch ($severity) {
@@ -168,6 +161,13 @@ foreach (dbFetchRows($sql, $param) as $alert) {
         default:
             $severity_ico = '<span class="alert-status label-info">&nbsp;</span>';
             break;
+    }
+    
+    $severity = $alert['severity'];
+    if ($alert['state'] == 3) {
+        $severity .= ' <strong>+</strong>';
+    } elseif ($alert['state'] == 4) {
+        $severity .= ' <strong>-</strong>';
     }
 
     if ((int)$alert['state'] === 2) {


### PR DESCRIPTION
Fix alert icons. Level info blue color should be red
![image](https://user-images.githubusercontent.com/47607835/70227768-7459fb80-1753-11ea-89b8-512b3a5c5107.png)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
