### PR TITLE
More appropriate state colours for MS Teams alerts

### DIFF
--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -24,33 +24,13 @@ class Msteams extends Transport
         return $this->contactMsteams($obj, $opts);
     }
 
-    public function contactMsteams($obj, $opts)
+    public function contactMsteams($obj, $opts) 
     {
         $url   = $opts['url'];
         
-        switch ($obj['state']) {
-            case 0: // OK - green
-                $color = '#00FF00';
-                break;
-            case 1: // Bad - red
-                $color = '#FF0000';
-                break;
-            case 2: // Acknowledged - blue
-                $color = '#337AB7';
-                break;
-            case 3: // Worse - red
-                $color = '#FF0000';
-                break;
-            case 4: // Better - yellow
-                $color = '#F0AD4E';
-                break;
-            default: // Anything else - blue
-                $color = '#337AB7';
-        }
-        
         $data  = array(
             'title' => $obj['title'],
-            'themeColor' => $color,
+            'themeColor' => self::getColorForState($obj['state']),
             'text' => strip_tags($obj['msg'], '<strong><em><h1><h2><h3><strike><ul><ol><li><pre><blockquote><a><img><p>')
         );
         $curl  = curl_init();
@@ -70,6 +50,24 @@ class Msteams extends Transport
             return false;
         }
         return true;
+    }
+    
+    /**
+     * Get the hex color string for a particular state
+     * @param integer $state State code from alert
+     * @return string Hex color, default to #337AB7 blue if state unrecognised
+     */
+    public static function getColorForState($state)
+    {
+        $colors = array( 
+            0 => '#00FF00', // OK - green
+            1 => '#FF0000', // Bad - red
+            2 => '#337AB7', // Acknowledged - blue
+            3 => '#FF0000', // Worse - red
+            4 => '#F0AD4E', // Better - yellow
+        );
+        
+        return isset($colors[$state]) ? $colors[$state] : '#337AB7';
     }
 
     public static function configTemplate()

--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -27,7 +27,27 @@ class Msteams extends Transport
     public function contactMsteams($obj, $opts)
     {
         $url   = $opts['url'];
-        $color = ($obj['state'] == 0 ? '#00FF00' : '#FF0000');
+        
+        switch ($obj['state']) {
+            case 0: // OK - green
+                $color = '#00FF00';
+                break;
+            case 1: // Bad - red
+                $color = '#FF0000';
+                break;
+            case 2: // Acknowledged - blue
+                $color = '#337AB7';
+                break;
+            case 3: // Worse - red
+                $color = '#FF0000';
+                break;
+            case 4: // Better - yellow
+                $color = '#F0AD4E';
+                break;
+            default: // Anything else - blue
+                $color = '#337AB7';
+        }
+        
         $data  = array(
             'title' => $obj['title'],
             'themeColor' => $color,

--- a/LibreNMS/Alert/Transport/Msteams.php
+++ b/LibreNMS/Alert/Transport/Msteams.php
@@ -24,7 +24,7 @@ class Msteams extends Transport
         return $this->contactMsteams($obj, $opts);
     }
 
-    public function contactMsteams($obj, $opts) 
+    public function contactMsteams($obj, $opts)
     {
         $url   = $opts['url'];
         
@@ -59,7 +59,7 @@ class Msteams extends Transport
      */
     public static function getColorForState($state)
     {
-        $colors = array( 
+        $colors = array(
             0 => '#00FF00', // OK - green
             1 => '#FF0000', // Bad - red
             2 => '#337AB7', // Acknowledged - blue


### PR DESCRIPTION
Currently the alerting into MS Teams uses only two accent colours on the messages - green for OK (recovery) and red for everything else. I think it would be more appropriate to use something neutral (like blue) for acknowledgements, and something less bad (like yellow) for "got better" alerts.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
