### PR TITLE
Typo VDSL2-LINE-MIB

### DIFF
--- a/mibs/VDSL2-LINE-MIB
+++ b/mibs/VDSL2-LINE-MIB
@@ -19,8 +19,8 @@ IMPORTS
    SnmpAdminString
       FROM SNMP-FRAMEWORK-MIB
 	  
-	noDefect, allowTransitionsToIdle, allowTransitionsToLowPower
-		FROM ADSL2-LINE-TC-MIB
+   Adsl2LConfProfPmMode
+      FROM ADSL2-LINE-TC-MIB
 
    HCPerfIntervalThreshold,
    HCPerfTimeElapsed

--- a/mibs/VDSL2-LINE-MIB
+++ b/mibs/VDSL2-LINE-MIB
@@ -72,7 +72,8 @@ IMPORTS
    Xdsl2LineTxRefVnUs,
    Xdsl2BitsAlloc,
    Xdsl2MrefPsdDs,
-   Xdsl2MrefPsdUs,
+   Xdsl2MrefPsdUs
+   
           FROM   VDSL2-LINE-TC-MIB       -- [This document]
 
    MODULE-COMPLIANCE,

--- a/mibs/VDSL2-LINE-MIB
+++ b/mibs/VDSL2-LINE-MIB
@@ -73,9 +73,6 @@ IMPORTS
    Xdsl2BitsAlloc,
    Xdsl2MrefPsdDs,
    Xdsl2MrefPsdUs,
-   
-   profile8a, profile8b, profile8c, profile8d,  profile12a, profile12b, profile17a, profile30a
-
           FROM   VDSL2-LINE-TC-MIB       -- [This document]
 
    MODULE-COMPLIANCE,


### PR DESCRIPTION
Remove typo. These values are part of Xdsl2LineProfiles, so only Xdsl2LineProfiles should be imported.
Idem for  Adsl2LConfProfPmMode

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
