### PR TITLE
Always update widget seeds when db update

### DIFF
--- a/includes/sql-schema/update.php
+++ b/includes/sql-schema/update.php
@@ -103,6 +103,7 @@ try {
     }
 
     if ($db_rev == 1000) {
+        $migrate_opts['--seed'] = true;
         $return = Artisan::call('migrate', $migrate_opts);
         echo Artisan::output();
     }

--- a/includes/sql-schema/update.php
+++ b/includes/sql-schema/update.php
@@ -103,7 +103,7 @@ try {
     }
 
     if ($db_rev == 1000) {
-        $migrate_opts['--seed'] = true;
+        Artisan::call('db:seed', ['--force' => true, '--ansi' => true, '--class' => DefaultWidgetSeeder::class]);
         $return = Artisan::call('migrate', $migrate_opts);
         echo Artisan::output();
     }


### PR DESCRIPTION
Related to https://github.com/librenms/librenms/pull/10901#discussion_r353790598

Avoid doing seeds manually : https://docs.librenms.org/Support/FAQ/#faq31

Script includes/sql-schema/update.php is called by daily.sh (in case of automatic upgrade) or build-base.php (for manual upgrade)

daily.sh
```
        case $arg in
            no-code-update)
                # Updates of the code are disabled, just check for schema updates
                # and clean up the db.
                status_run 'Updating SQL-Schema' 'php includes/sql-schema/update.php'
```

build-base.php
`require __DIR__ . '/includes/sql-schema/update.php';`

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
