### PR TITLE
Fix rrd graph draw errors

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -96,7 +96,8 @@ function rrdtool_close()
  * @param $command The command to send to the rrdtool process
  * @return array The output of stdout and stderr in an array
  */
-function rrdtool_sync_command($cmd) {
+function rrdtool_sync_command($cmd) 
+{
     global $debug, $rrd_sync_process;
     /** @var Proc $rrd_sync_process */
 

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -278,7 +278,7 @@ function rrdtool_escape($string, $length = null)
     $result = shorten_interface_type($string);
     $result = str_replace("'", '', $result);            # remove quotes
     if (is_numeric($length)) {
-        $extra = substr_count($string, ':', 0, $length);
+        $extra = substr_count($string, ':', 0, min(strlen($string), $length));
         $result = substr(str_pad($result, $length), 0, ($length + $extra));
         if ($extra > 0) {
             $result = substr($result, 0, (-1 * $extra));


### PR DESCRIPTION
- Found the `rrdtool_escape` warning when using `...&debug=1` on the graphs.
- The rrdtool response parsing was broken due to `Proc->getOutput` being broken by design

I think i followed the code guidelines, but the check script doesn't work in the docker container I'm running the code in.

---

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
