### PR TITLE
Fix Capture Debug page symfony timeout error

### DIFF
--- a/includes/html/output/capture.inc.php
+++ b/includes/html/output/capture.inc.php
@@ -54,6 +54,8 @@ switch ($type) {
 
 // ---- Output ----
 $proc = new \Symfony\Component\Process\Process($cmd);
+$proc->setTimeout(Config::get('snmp.exec_timeout', 1200));
+
 if ($_GET['format'] == 'text') {
     header("Content-type: text/plain");
     header('X-Accel-Buffering: no');


### PR DESCRIPTION
Override symfony 60s execution timeout. Allows the capture page to output discovery and poller process results, if the process lasts longer than 60s.

Similar fix to commit https://github.com/murrant/librenms/commit/561e2fb6e26bc272550dd52684f0733afa0673e9

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
