### PR TITLE
fix port_usage_perc macro matches in but not out

### DIFF
--- a/doc/Alerting/Macros.md
+++ b/doc/Alerting/Macros.md
@@ -84,9 +84,9 @@ Source: `(ports.ifOperStatus = "down" AND ports.ifAdminStatus != "down" AND macr
 
 Entity: `macros.port_usage_perc`
 
-Description: Return port-usage in percent.
+Description: Return port-usage (max value of in and out) in percent.
 
-Source: `((ports.ifInOctets_rate*8) / ports.ifSpeed)*100`
+Source: `((SELECT IF(ports.ifOutOctets_rate>ports.ifInOctets_rate, ports.ifOutOctets_rate, ports.ifInOctets_rate)*8) / ports.ifSpeed)*100`
 
 ## Time
 

--- a/misc/macros.json
+++ b/misc/macros.json
@@ -21,7 +21,11 @@
     "port": "(%ports.deleted = 0 && %ports.ignore = 0 && %ports.disabled = 0)",
     "port_down": "(%ports.ifOperStatus = \"down\" && %ports.ifAdminStatus != \"down\" && %macros.port)",
     "port_up": "(%ports.ifOperStatus = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port)",
-    "port_usage_perc": "(((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100 OR ((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100)",
+<<<<<<< HEAD
+    "port_usage_perc": "((SELECT IF(%ports.ifOutOctets_rate>%ports.ifInOctets_rate, %ports.ifOutOctets_rate, %ports.ifInOctets_rate)*8) \/ %ports.ifSpeed)*100",
+=======
+    "port_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
+>>>>>>> parent of c573091... port_usage_perc macros matches in or out
     "port_in_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_out_usage_perc": "((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_now_down": "%ports.ifOperStatus != %ports.ifOperStatus_prev && %ports.ifOperStatus_prev = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port",

--- a/misc/macros.json
+++ b/misc/macros.json
@@ -21,11 +21,7 @@
     "port": "(%ports.deleted = 0 && %ports.ignore = 0 && %ports.disabled = 0)",
     "port_down": "(%ports.ifOperStatus = \"down\" && %ports.ifAdminStatus != \"down\" && %macros.port)",
     "port_up": "(%ports.ifOperStatus = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port)",
-<<<<<<< HEAD
     "port_usage_perc": "((SELECT IF(%ports.ifOutOctets_rate>%ports.ifInOctets_rate, %ports.ifOutOctets_rate, %ports.ifInOctets_rate)*8) \/ %ports.ifSpeed)*100",
-=======
-    "port_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
->>>>>>> parent of c573091... port_usage_perc macros matches in or out
     "port_in_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_out_usage_perc": "((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_now_down": "%ports.ifOperStatus != %ports.ifOperStatus_prev && %ports.ifOperStatus_prev = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port",

--- a/misc/macros.json
+++ b/misc/macros.json
@@ -21,7 +21,7 @@
     "port": "(%ports.deleted = 0 && %ports.ignore = 0 && %ports.disabled = 0)",
     "port_down": "(%ports.ifOperStatus = \"down\" && %ports.ifAdminStatus != \"down\" && %macros.port)",
     "port_up": "(%ports.ifOperStatus = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port)",
-    "port_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
+    "port_usage_perc": "(((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100 OR ((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100)",
     "port_in_usage_perc": "((%ports.ifInOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_out_usage_perc": "((%ports.ifOutOctets_rate*8) \/ %ports.ifSpeed)*100",
     "port_now_down": "%ports.ifOperStatus != %ports.ifOperStatus_prev && %ports.ifOperStatus_prev = \"up\" && %ports.ifAdminStatus = \"up\" && %macros.port",


### PR DESCRIPTION
Misleading port_usage_perc macro. Was same as port_in_usage_perc and was only matching in.

The patch is effective after editing and saving all the rules with port_usage_perc so that related alert_rules entries in database will be updated

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
