### PR TITLE
Port usage perc CI/CD fix 

### DIFF
--- a/tests/data/misc/querybuilder.json
+++ b/tests/data/misc/querybuilder.json
@@ -157,8 +157,8 @@
         "%macros.port_usage_perc > 80",
         {"condition":"AND","rules":[{"id":"macros.port_usage_perc","field":"macros.port_usage_perc","type":"integer","input":"text","operator":"greater","value":"80"}],"valid":true},
         "macros.port_usage_perc > 80",
-        "SELECT * FROM devices,ports WHERE (devices.device_id = ? AND devices.device_id = ports.device_id) AND (((ports.ifInOctets_rate*8) / ports.ifSpeed)*100) > 80",
-        ["select * from `devices` left join `ports` on `devices`.`device_id` = `ports`.`device_id` where ((((ports.ifInOctets_rate*8) / ports.ifSpeed)*100) > ?)", ["80"]]],
+        "SELECT * FROM devices,ports WHERE (devices.device_id = ? AND devices.device_id = ports.device_id) AND (((SELECT IF(ports.ifOutOctets_rate>ports.ifInOctets_rate, ports.ifOutOctets_rate, ports.ifInOctets_rate)*8) / ports.ifSpeed)*100) > 80",
+        ["select * from `devices` left join `ports` on `devices`.`device_id` = `ports`.`device_id` where (((((SELECT IF(ports.ifOutOctets_rate>ports.ifInOctets_rate, ports.ifOutOctets_rate, ports.ifInOctets_rate)*8) / ports.ifSpeed)*100) > ?)", ["80"]]],
     [
         "%devices.sysName ~ \"..domain.com\" || %devices.sysName ~ \"switch.\" &&",
         {"condition":"OR","rules":[{"id":"devices.sysName","field":"devices.sysName","type":"string","input":"text","operator":"regex","value":"..domain.com"},{"id":"devices.sysName","field":"devices.sysName","type":"string","input":"text","operator":"regex","value":"switch."}],"valid":true},


### PR DESCRIPTION
Fix CI/CD test that failed after merging https://github.com/librenms/librenms/pull/10932

1) LibreNMS\Tests\QueryBuilderTest::testQueryConversion with data set #22 ('%macros.port_usage_perc > 80', array('AND', array(array('macros.port_usage_perc', 'macros.port_usage_perc', 'integer', 'text', 'greater', '80')), true), 'macros.port_usage_perc > 80', 'SELECT * FROM devices,ports W...) > 80', array('select * from `devices` left ...) > ?)', array('80')))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'SELECT * FROM devices,ports WHERE (devices.device_id = ? AND devices.device_id = ports.device_id) AND (((ports.ifInOctets_rate*8) / ports.ifSpeed)*100) > 80'
+'SELECT * FROM devices,ports WHERE (devices.device_id = ? AND devices.device_id = ports.device_id) AND (((SELECT IF(ports.ifOutOctets_rate>ports.ifInOctets_rate, ports.ifOutOctets_rate, ports.ifInOctets_rate)*8) / ports.ifSpeed)*100) > 80'
/home/travis/build/librenms/librenms/tests/QueryBuilderTest.php:60
FAILURES!
Tests: 1591, Assertions: 4954, Failures: 1.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
