### PR TITLE
Fix for device config file identification

### DIFF
--- a/includes/html/pages/device/showconfig.inc.php
+++ b/includes/html/pages/device/showconfig.inc.php
@@ -17,12 +17,15 @@ if (Auth::user()->hasGlobalAdmin()) {
 
             if (is_file($configs.$device['hostname'])) {
                 $file = $configs.$device['hostname'];
+                break;
             } elseif (is_file($configs.strtok($device['hostname'], '.'))) { // Strip domain
                 $file = $configs.strtok($device['hostname'], '.');
+                break;
             } else {
                 if (!empty(Config::get('mydomain'))) { // Try with domain name if set
                     if (is_file($configs.$device['hostname'].'.'.Config::get('mydomain'))) {
                         $file = $configs.$device['hostname'].'.'.Config::get('mydomain');
+                        break;
                     }
                 }
             } // end if


### PR DESCRIPTION
Stop looping after the file is found, otherwise $config might contain another path then the one where te file is found. This causes problems when $config is used as working directory for fetching changes in git.

Also, this is a small performance improvement.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
