### PR TITLE
Categorise Cisco WLC as wireless, like the other controller-based wireless platforms

### DIFF
--- a/includes/definitions/ciscowlc.yaml
+++ b/includes/definitions/ciscowlc.yaml
@@ -1,6 +1,6 @@
 os: ciscowlc
 text: 'Cisco WLC'
-type: network
+type: wireless
 ifname: true
 over:
     - { graph: device_bits, text: 'Device Traffic' }

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -71,7 +71,7 @@
   <item>
     <title>Cisco Wireless Controller classified as Wireless</title>
     <description>Cisco WLC is now classified as type "Wireless" instead of "Network".  Update any alert rules you may have.</description>
-    <pubDate>Thu, 20 Dec 2019 00:00:00 +0000</pubDate>
+    <pubDate>Wed, 18 Dec 2019 00:00:00 +0000</pubDate>
   </item>
 </channel>
 </rss>

--- a/misc/notifications.rss
+++ b/misc/notifications.rss
@@ -68,5 +68,10 @@
     <description>RutOS 2xx pinState renamed to rutos2xx_pinState.  Update any alert rules you may have.</description>
     <pubDate>Thu, 10 Oct 2019 00:00:00 +0000</pubDate>
   </item>
+  <item>
+    <title>Cisco Wireless Controller classified as Wireless</title>
+    <description>Cisco WLC is now classified as type "Wireless" instead of "Network".  Update any alert rules you may have.</description>
+    <pubDate>Thu, 20 Dec 2019 00:00:00 +0000</pubDate>
+  </item>
 </channel>
 </rss>


### PR DESCRIPTION
Just a tweak of category for Cisco WLC, so it shows up in the Wireless group instead of plain old Network.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
