### PR TITLE
Get Colors from getColorState function for Alert Transport Mattermost

### DIFF
--- a/LibreNMS/Alert/Transport/Mattermost.php
+++ b/LibreNMS/Alert/Transport/Mattermost.php
@@ -45,7 +45,7 @@ class Mattermost extends Transport
         $host = $api['url'];
         $curl = curl_init();
         $mattermost_msg = strip_tags($obj['msg']);
-        $color = ($obj['state'] == 0 ? '#00FF00' : '#FF0000');
+        $color = self::getColorForState($obj['state']);
         $data = [
             'attachments' => [
                 0 => [


### PR DESCRIPTION
use globalized function getColorState for colorizing Transport "Mattermost"

depends on PR #10944 

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
