### PR TITLE
Move Alert State Color Definition to config_defintion

### DIFF
--- a/LibreNMS/Alert/Transport.php
+++ b/LibreNMS/Alert/Transport.php
@@ -3,6 +3,7 @@
 namespace LibreNMS\Alert;
 
 use LibreNMS\Interfaces\Alert\Transport as TransportInterface;
+use LibreNMS\Config;
 
 abstract class Transport implements TransportInterface
 {
@@ -46,12 +47,13 @@ abstract class Transport implements TransportInterface
     public static function getColorForState($state)
     {
         $colors = array(
-            0 => '#00FF00', // OK - green
-            1 => '#FF0000', // Bad - red
-            2 => '#337AB7', // Acknowledged - blue
-            3 => '#FF0000', // Worse - red
-            4 => '#F0AD4E', // Better - yellow
+            0 => Config::get('alert_colour.ok'),
+            1 => Config::get('alert_colour.bad'),
+            2 => Config::get('alert_colour.acknowledged'),
+            3 => Config::get('alert_colour.worse'),
+            4 => Config::get('alert_colour.better'),
         );
+
         return isset($colors[$state]) ? $colors[$state] : '#337AB7';
     }
 }

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -27,6 +27,26 @@
             "order": 1,
             "type": "boolean"
         },
+        "alert_colour.ok": {
+            "default": "#00ff00",
+            "type": "color"
+        },
+        "alert_colour.bad": {
+            "default": "#ff0000",
+            "type": "color"
+        },
+        "alert_colour.acknowledged": {
+            "default": "#337ab7",
+            "type": "color"
+        },
+        "alert_colour.worse": {
+            "default": "#ff0000",
+            "type": "color"
+        },
+        "alert_colour.better": {
+            "default": "#f0ad4e",
+            "type": "color"
+        },
         "alert.default_copy": {
             "default": true,
             "group": "alerting",


### PR DESCRIPTION
Color Definition of Alert States should be defined in configuration file

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
