### PR TITLE
Fix API Call not found Error Code

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -27,7 +27,7 @@ use LibreNMS\Util\IPv4;
 function api_success($result, $result_name, $message = null, $code = 200, $count = null, $extra = null)
 {
     if (isset($result) && !isset($result_name)) {
-        return api_error(500, 'Result name not specified');
+        return api_error(404, 'Result name not specified');
     }
 
     $output = ['status' => 'ok'];


### PR DESCRIPTION
Error Code 500 (internal Server Error) for not existing API Calls is the wrong number.
Changed it to 404 (not found)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
