### PR TITLE
Dont't show ' - ' on ping only Devices in Availability Widget

### DIFF
--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -23,7 +23,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="{{ \LibreNMS\Util\Url::deviceUrl($device) }}" title="{{ $device->displayName() }} - {{ $device->formatUptime(true) }}">
+    <a href="{{ \LibreNMS\Util\Url::deviceUrl($device) }}" title="{{ $device->displayName() }}@if($device->formatUptime(true)) - @endif{{ $device->formatUptime(true) }}">
         @if($type == 0)
             @if($color_only_select)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>


### PR DESCRIPTION
Before Tooltip in Availability Map Widget was `www.mydomain.com - `, now it's `www.mydomain.com` if Device has no uptime.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
