### PR TITLE
Speed up canAccessDevice/devicesForUser

### DIFF
--- a/LibreNMS/Permissions.php
+++ b/LibreNMS/Permissions.php
@@ -50,10 +50,8 @@ class Permissions
      */
     public function canAccessDevice($device, $user = null)
     {
-        return $this->getDevicePermissions()
-            ->where('user_id', $this->getUserId($user))
-            ->where('device_id', $this->getDeviceId($device))
-            ->isNotEmpty();
+        return $this->getDevicePermissions($user)
+            ->contains('device_id', $this->getDeviceId($device));
     }
 
     /**
@@ -94,13 +92,14 @@ class Permissions
      * @param Device|int $device
      * @return \Illuminate\Support\Collection
      */
+/*
     public function usersForDevice($device)
     {
         return $this->getDevicePermissions()
             ->where('device_id', $this->getDeviceId($device))
             ->pluck('user_id');
     }
-
+*/
     /**
      * Get the user_id of users that have been granted access to port
      *
@@ -135,8 +134,7 @@ class Permissions
      */
     public function devicesForUser($user = null)
     {
-        return $this->getDevicePermissions()
-            ->where('user_id', $this->getUserId($user))
+        return $this->getDevicePermissions($user)
             ->pluck('device_id');
     }
 
@@ -180,6 +178,7 @@ class Permissions
         if (!isset($this->deviceGroupMap[$user_id])) {
             $this->deviceGroupMap[$user_id] = DB::table('device_group_device')
                 ->whereIn('device_id', $this->devicesForUser($user))
+                ->distinct('device_group_id')
                 ->pluck('device_group_id');
         }
 
@@ -189,17 +188,20 @@ class Permissions
     /**
      * Get the cached data for device permissions.  Use helpers instead.
      *
+     * @param User|int $user
      * @return \Illuminate\Support\Collection
      */
-    public function getDevicePermissions()
+    public function getDevicePermissions($user = null)
     {
-        if (is_null($this->devicePermissions)) {
-            $this->devicePermissions = DB::table('devices_perms')
-                ->union($this->getDeviceGroupPermissionsQuery())
+        $user_id = $this->getUserId($user);
+
+        if (!isset($this->devicePermissions[$user_id])) {
+            $this->devicePermissions[$user_id] = DB::table('devices_perms')->where('user_id', $user_id)
+                ->union($this->getDeviceGroupPermissionsQuery()->where('user_id', $user_id))
                 ->get();
         }
 
-        return $this->devicePermissions;
+        return $this->devicePermissions[$user_id];
     }
 
     /**


### PR DESCRIPTION
Calling `Permission::canAccessDevice($device)` on 1000 devices (User have access to 1500 devices):
Current version: 28s
This version: 5s

Had to remove `usersForDevice()` since it's no longer possible to return with this solution, no code seems to use that function tho.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
