### PR TITLE
unix.inc.php: correct preg_match() pattern on line 5

### DIFF
--- a/includes/polling/os/unix.inc.php
+++ b/includes/polling/os/unix.inc.php
@@ -2,7 +2,7 @@
 
 if (in_array($device['os'], array("linux", "endian", "proxmox", "recoveryos"))) {
     list(,,$version) = explode(" ", $device['sysDescr']);
-    if (preg_match('[3-6]86', $device['sysDescr'])) {
+    if (preg_match('/[3-6]86/', $device['sysDescr'])) {
         $hardware = "Generic x86";
     } elseif (strstr($device['sysDescr'], "x86_64")) {
         $hardware = "Generic x86 64-bit";


### PR DESCRIPTION
Without this patch, poller.php produces ...

Warning: preg_match(): Unknown modifier '8' in /opt/librenms/includes/polling/os/unix.inc.php on line 5

... on every poll of of a device matching array("linux", "endian", "proxmox", "recoveryos").