### PR TITLE
rrdtool.inc.php: in rrdtool_escape(), fix invalid length

### DIFF
--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -275,10 +275,34 @@ function rrdtool_update($filename, $data)
  */
 function rrdtool_escape($string, $length = null)
 {
+    global $debug;
+
+    if ($debug) {
+        echo "<p>". __FUNCTION__ . "() backtrace:<p>";
+        echo "<pre>";
+        debug_print_backtrace();
+        echo "</pre>";
+    }
+
     $result = shorten_interface_type($string);
     $result = str_replace("'", '', $result);            # remove quotes
     if (is_numeric($length)) {
-        $extra = substr_count($string, ':', 0, $length);
+
+        # preserve original $length for str_pad()
+
+        # determine correct strlen() for substr_count()
+        $string_length=strlen($string);
+        if ($length > $string_length) {
+            $substr_count_length=$string_length; # If $length is greater than the haystack length, then substr_count() will produce a warning; fix warnings.
+        } else {
+            $substr_count_length=$length;
+        }
+
+        if ($debug) {
+            echo "<p>". __FUNCTION__ . "() string=$string,length=$length,string_length=$string_length,substr_count_length=$substr_count_length</p>";
+        }
+
+        $extra = substr_count($string, ':', 0, $substr_count_length);
         $result = substr(str_pad($result, $length), 0, ($length + $extra));
         if ($extra > 0) {
             $result = substr($result, 0, (-1 * $extra));
@@ -286,6 +310,11 @@ function rrdtool_escape($string, $length = null)
     }
 
     $result = str_replace(':', '\:', $result);          # escape colons
+
+    if ($debug) {
+        echo "<p>". __FUNCTION__ . "() final result='$result'<p>";
+    }
+
     return $result.' ';
 } // rrdtool_escape
 

--- a/includes/rrdtool.inc.php
+++ b/includes/rrdtool.inc.php
@@ -275,31 +275,18 @@ function rrdtool_update($filename, $data)
  */
 function rrdtool_escape($string, $length = null)
 {
-    global $debug;
-
-    if ($debug) {
-        echo "<p>". __FUNCTION__ . "() backtrace:<p>";
-        echo "<pre>";
-        debug_print_backtrace();
-        echo "</pre>";
-    }
-
     $result = shorten_interface_type($string);
     $result = str_replace("'", '', $result);            # remove quotes
-    if (is_numeric($length)) {
 
+    if (is_numeric($length)) {
         # preserve original $length for str_pad()
 
         # determine correct strlen() for substr_count()
         $string_length=strlen($string);
+        $substr_count_length=$length;
+
         if ($length > $string_length) {
             $substr_count_length=$string_length; # If $length is greater than the haystack length, then substr_count() will produce a warning; fix warnings.
-        } else {
-            $substr_count_length=$length;
-        }
-
-        if ($debug) {
-            echo "<p>". __FUNCTION__ . "() string=$string,length=$length,string_length=$string_length,substr_count_length=$substr_count_length</p>";
         }
 
         $extra = substr_count($string, ':', 0, $substr_count_length);
@@ -310,10 +297,6 @@ function rrdtool_escape($string, $length = null)
     }
 
     $result = str_replace(':', '\:', $result);          # escape colons
-
-    if ($debug) {
-        echo "<p>". __FUNCTION__ . "() final result='$result'<p>";
-    }
 
     return $result.' ';
 } // rrdtool_escape


### PR DESCRIPTION
For graph description lengths < 12 (i.e. 'Load %'), rrdtool_escape() produces ...

Warning: substr_count(): Invalid length value in /opt/librenms/includes/rrdtool.inc.php on line 281

... as per ...

https://www.php.net/manual/en/function.substr-count.php

This patch will calculate a separate length of $string for use with substr_count().  The original $length is still used for str_pad().