### PR TITLE
Bugfix the snmpsim collector: use the correct mibdir

### DIFF
--- a/LibreNMS/Util/ModuleTestHelper.php
+++ b/LibreNMS/Util/ModuleTestHelper.php
@@ -149,11 +149,11 @@ class ModuleTestHelper
 
             $snmp_options = ['-OUneb', '-Ih'];
             if ($oid_data['method'] == 'walk') {
-                $data = snmp_walk($device, $oid_data['oid'], $snmp_options, $oid_data['mib']);
+                $data = snmp_walk($device, $oid_data['oid'], $snmp_options, $oid_data['mib'], $oid_data['mibdir']);
             } elseif ($oid_data['method'] == 'get') {
-                $data = snmp_get($device, $oid_data['oid'], $snmp_options, $oid_data['mib']);
+                $data = snmp_get($device, $oid_data['oid'], $snmp_options, $oid_data['mib'], $oid_data['mibdir']);
             } elseif ($oid_data['method'] == 'getnext') {
-                $data = snmp_getnext($device, $oid_data['oid'], $snmp_options, $oid_data['mib']);
+                $data = snmp_getnext($device, $oid_data['oid'], $snmp_options, $oid_data['mib'], $oid_data['mibdir']);
             }
 
             if (isset($data) && $data !== false) {
@@ -203,6 +203,8 @@ class ModuleTestHelper
         foreach ($snmp_matches[0] as $index => $line) {
             preg_match("/'-m' '\+?([a-zA-Z0-9:\-]+)'/", $line, $mib_matches);
             $mib = $mib_matches[1];
+            preg_match("/'-M' '\+?([a-zA-Z0-9:\-\/]+)'/", $line, $mibdir_matches);
+            $mibdir = $mibdir_matches[1];
             $method = $snmp_matches[1][$index];
             $oids = explode("' '", trim($snmp_matches[2][$index]));
 
@@ -210,6 +212,7 @@ class ModuleTestHelper
                 $snmp_oids["{$oid}_$method"] = [
                     'oid' => $oid,
                     'mib' => $mib,
+                    'mibdir' => $mibdir,
                     'method' => $method,
                 ];
             }


### PR DESCRIPTION
The captureFromDevice() function was only able to return data for named oids when the MIB lived in the root mibdir because the mibdir parameter was omitted from its snmp function call - as such it couldn't retrieve data from most vendor-specific MIBs, which generally live in sub-directories. The missing MIB reference meant that snmp commands for the snmpsim data collector didn't return usable data, and as a result test data was incomplete for many discovery components.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 11003`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
