### PR TITLE
Fixed ports_vlans bulk delete from crashing MySQL

### DIFF
--- a/includes/discovery/vlans.inc.php
+++ b/includes/discovery/vlans.inc.php
@@ -91,8 +91,11 @@ foreach ($vlans_db as $domain_id => $vlans) {
 
 // remove non-existent port-vlan mappings
 if (!empty($valid_vlan_port)) {
-    $num = dbDelete('ports_vlans', '`device_id`=? AND `port_vlan_id` NOT IN ' . dbGenPlaceholders(count($valid_vlan_port)), array_merge([$device['device_id']], $valid_vlan_port));
-    d_echo("Deleted $num vlan mappings\n");
+    $del_vlan_chunks = array_chunk($valid_vlan_port, 50, true);
+    foreach ($del_vlan_chunks as $del_vlan_chunk) {
+        $num = dbDelete('ports_vlans', '`device_id`=? AND `port_vlan_id` NOT IN ' . dbGenPlaceholders(count($del_vlan_chunk)), array_merge([$device['device_id']], $del_vlan_chunk));
+        d_echo("Deleted $num vlan mappings\n");
+    }
 }
 
 unset($device['vlans']);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

This should fix: https://community.librenms.org/t/vlan-discovery-crashes-mysql-database-after-update-to-v1-43/5394

We've been seeing the same thing where our MySQL instance was restarting twice an hour. So far, 1 hour later it's been stable. Will report back if we see issues.

I chose 50 as an arbitrary number. I couldn't find any data on max size for queries other than packet size which is a per install. We can increase / decrease that number if need to.