### PR TITLE
ajax_search.php: Fix & amend broken $num_ports query on line 83

### DIFF
--- a/html/ajax_search.php
+++ b/html/ajax_search.php
@@ -80,7 +80,7 @@ if (isset($_REQUEST['search'])) {
                         $highlight_colour = '#008000';
                     }
 
-                    $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` AS `I`, `devices` AS `D` WHERE $perms_sql AND `I`.`device_id` = `D`.`device_id` AND D.device_id = ?', array_merge($device_ids, [$result['device_id']]));
+                    $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` AS `I`, `devices` AS `D` WHERE ' . $perms_sql . ' AND `I`.`device_id` = `D`.`device_id` AND `I`.`ignore` = 0 AND `I`.`deleted` = 0 AND `D`.`device_id` = ?', array_merge($device_ids, [$result['device_id']]));
 
 
                     $device[] = array(


### PR DESCRIPTION
* When searching from the web interface, librenms produces
production.ERROR SQLSTATE: Column not found: 1054 Unknown column
'$perms_sql' in 'where clause'

* Above feeds resources/views/layouts/menu.blade.php which, because
of the failed query, has no device_ports as a value. Thus the search
results do not produce the expected 'name ... device with X port(s)'

* As well, the previous query did not exclude deleted and ignored
ports. Therefore, the value for X port(s) was incorrect and did not
correspond to the device's ports screen.