### PR TITLE
"Disable alerting" on device disables alert rules check (not just alert transport)

### DIFF
--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -44,12 +44,16 @@ class AlertRules
 
         //Check to see if under maintenance
         if (AlertUtil::isMaintenance($device_id) > 0) {
-            echo "Under Maintenance, Skipping alerts.\r\n";
+            echo "Under Maintenance, skipping alert rules check.\r\n";
             return false;
         }
         //Check to see if disable alerting is set
         if (AlertUtil::hasDisableNotify($device_id)) {
-            echo "Disable alerting is set, Skipping alerts.\r\n";
+            echo "Disable alerting is set, Clearing active alerts and skipping alert rules check\r\n";
+            $device_alert['state'] = 0;
+            $device_alert['alerted'] = 0;
+            $device_alert['open'] = 0;
+            dbUpdate($device_alert, 'alerts', '`device_id` = ?', array($device['device_id']));
             return false;
         }
         //Checks each rule.

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -53,7 +53,7 @@ class AlertRules
             $device_alert['state'] = 0;
             $device_alert['alerted'] = 0;
             $device_alert['open'] = 0;
-            dbUpdate($device_alert, 'alerts', '`device_id` = ?', array($device['device_id']));
+            dbUpdate($device_alert, 'alerts', '`device_id` = ?', array($device_id));
             return false;
         }
         //Checks each rule.

--- a/LibreNMS/Alert/AlertRules.php
+++ b/LibreNMS/Alert/AlertRules.php
@@ -47,6 +47,11 @@ class AlertRules
             echo "Under Maintenance, Skipping alerts.\r\n";
             return false;
         }
+        //Check to see if disable alerting is set
+        if (AlertUtil::hasDisableNotify($device_id)) {
+            echo "Disable alerting is set, Skipping alerts.\r\n";
+            return false;
+        }
         //Checks each rule.
         foreach (AlertUtil::getRules($device_id) as $rule) {
             c_echo('Rule %p#'.$rule['id'].' (' . $rule['name'] . '):%n ');

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -196,6 +196,17 @@ class AlertUtil
     }
 
     /**
+     * Check if device is set to ignore alerts
+     * @param int $device_id Device-ID
+     * @return bool
+     */
+    public static function hasDisableNotify($device_id)
+    {
+        $device = Device::find($device_id);
+        return !is_null($device) && $device->disable_notify;
+    }
+
+    /**
      * Process Macros
      * @param string $rule Rule to process
      * @param int $x Recursion-Anchor

--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -260,10 +260,6 @@ class RunAlerts
      */
     public function issueAlert($alert)
     {
-        if (dbFetchCell('SELECT attrib_value FROM devices_attribs WHERE attrib_type = "disable_notify" && device_id = ?', array($alert['device_id'])) == '1') {
-            return true;
-        }
-
         if (Config::get('alert.fixed-contacts') == false) {
             if (empty($alert['query'])) {
                 $alert['query'] = AlertDB::genSQL($alert['rule'], $alert['builder']);

--- a/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
+++ b/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
@@ -22,8 +22,6 @@ class MigrateDevicesAttribsTable extends Migration
     }
 }
 
-    }
-
     /**
      * Reverse the migrations.
      *

--- a/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
+++ b/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
@@ -15,7 +15,6 @@ class MigrateDevicesAttribsTable extends Migration
     {
         Schema::table('devices', function (Blueprint $table) {
             $table->boolean('disable_notify')->default(0);
-            $table->boolean('override_sysContact')->default(0);
         });
         // migrate disable_notify data into devices table
         \DB::statement("UPDATE devices d, devices_attribs da SET d.disable_notify=1  WHERE da.attrib_type='disable_notify' AND da.attrib_value=1 AND d.device_id = da.device_id;");
@@ -34,6 +33,10 @@ class MigrateDevicesAttribsTable extends Migration
     {
         // revert migrate disable_notify data into devices table
         \DB::statement("INSERT INTO devices_attribs (device_id, attrib_type, attrib_value) SELECT DISTINCT d.device_id, 'disable_notify', 1 FROM devices_attribs da INNER JOIN devices d WHERE d.device_id = da.device_id AND d.disable_notify=1;");
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('disable_notify');
+        });
+
     }
 
 }

--- a/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
+++ b/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
@@ -20,7 +20,6 @@ class MigrateDevicesAttribsTable extends Migration
         \DB::statement("UPDATE devices d, devices_attribs da SET d.disable_notify=1  WHERE da.attrib_type='disable_notify' AND da.attrib_value=1 AND d.device_id = da.device_id;");
         \DB::statement("DELETE FROM devices_attribs WHERE attrib_type='disable_notify' AND attrib_value=1;");
     }
-}
 
     /**
      * Reverse the migrations.
@@ -34,7 +33,5 @@ class MigrateDevicesAttribsTable extends Migration
         Schema::table('devices', function (Blueprint $table) {
             $table->dropColumn('disable_notify');
         });
-
     }
-
 }

--- a/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
+++ b/database/migrations/2020_01_09_1300_migrate_devices_attribs_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class MigrateDevicesAttribsTable extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->boolean('disable_notify')->default(0);
+            $table->boolean('override_sysContact')->default(0);
+        });
+        // migrate disable_notify data into devices table
+        \DB::statement("UPDATE devices d, devices_attribs da SET d.disable_notify=1  WHERE da.attrib_type='disable_notify' AND da.attrib_value=1 AND d.device_id = da.device_id;");
+        \DB::statement("DELETE FROM devices_attribs WHERE attrib_type='disable_notify' AND attrib_value=1;");
+    }
+}
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // revert migrate disable_notify data into devices table
+        \DB::statement("INSERT INTO devices_attribs (device_id, attrib_type, attrib_value) SELECT DISTINCT d.device_id, 'disable_notify', 1 FROM devices_attribs da INNER JOIN devices d WHERE d.device_id = da.device_id AND d.disable_notify=1;");
+    }
+
+}

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -680,7 +680,7 @@ function devclass($device)
         $class = 'list-device';
     }
 
-    if (isset($device['ignore']) && $device['ignore'] == '1') {
+    if (isset($device['disable_notify']) && $device['disable_notify'] == '1') {
         $class = 'list-device-ignored';
         if (isset($device['status']) && $device['status'] == '1') {
             $class = 'list-device-ignored-up';

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -32,6 +32,7 @@ if ($_POST['editing']) {
         $device_model->purpose = $_POST['descr'];
         $device_model->ignore = (int)isset($_POST['ignore']);
         $device_model->disabled = (int)isset($_POST['disabled']);
+        $device_model->disable_notify = (int)isset($_POST['disable_notify']);
         $device_model->type = $_POST['type'];
 
         if ($device_model->isDirty('type')) {
@@ -70,8 +71,6 @@ if ($_POST['editing']) {
             $override_sysContact_string = mres($_POST['sysContact']);
         }
 
-        $disable_notify = mres($_POST['disable_notify']);
-
         if ($override_sysContact_bool) {
             set_dev_attrib($device, 'override_sysContact_bool', '1');
         } else {
@@ -81,14 +80,7 @@ if ($_POST['editing']) {
         if (isset($override_sysContact_string)) {
             set_dev_attrib($device, 'override_sysContact_string', $override_sysContact_string);
         };
-        if ($disable_notify) {
-            set_dev_attrib($device, 'disable_notify', '1');
-        } else {
-            set_dev_attrib($device, 'disable_notify', '0');
-        }
 
-        //$update_message = 'Device alert settings updated.';
-        //$updated        = 1;
     } else {
         include 'includes/html/error-no-perm.inc.php';
     }

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -249,12 +249,11 @@ $disable_notify             = get_dev_attrib($device, 'disable_notify');
       <label for="disable_notify" class="col-sm-2 control-label">Disable alerting:</label>
       <div class="col-sm-6">
         <input id="disable_notify" type="checkbox" name="disable_notify" data-size="small"
-    <?php
-    if ($disable_notify) {
-        echo ' checked="1"';
-    };
-    ?>
-   />
+                <?php
+                if ($device_model->disable_notify) {
+                    echo("checked=checked");
+                }
+                ?> />
       </div>
     </div>
     <div class="form-group">

--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -79,8 +79,7 @@ if ($_POST['editing']) {
 
         if (isset($override_sysContact_string)) {
             set_dev_attrib($device, 'override_sysContact_string', $override_sysContact_string);
-        };
-
+        }
     } else {
         include 'includes/html/error-no-perm.inc.php';
     }

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -497,6 +497,7 @@ devices:
     - { Field: notes, Type: text, 'Null': true, Extra: '' }
     - { Field: port_association_mode, Type: int(11), 'Null': false, Extra: '', Default: '1' }
     - { Field: max_depth, Type: int(11), 'Null': false, Extra: '', Default: '0' }
+    - { Field: disable_notify, Type: tinyint(1), 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [device_id], Unique: true, Type: BTREE }
     hostname: { Name: hostname, Columns: [hostname], Unique: false, Type: BTREE }


### PR DESCRIPTION
Related to this device setting:
![image](https://user-images.githubusercontent.com/47607835/72083529-4774a780-3302-11ea-8e91-1bdefba6ce8b.png)

"Disable alerting" setting behaviour on device is currently: 

- avoiding sending alert to external if alert transport is set. 
- Alert rules are still checked and can be viewed in menu alerts -> notifications. And their log in alerts ->alert history.

This behaviour is misleading because active alerts are still in alerts -> notifications. In this PR, I suggest "Disable alerting" setting on device **avoids checking alert rules and clears active alerts**. As a consequence:

- Active alerts are cleared and no more seen menu alerts -> notification
- New alerts are not logged in alerts ->alert history
- Sending alert to external if alert transport is set is not done

For code coherence with settings in database devices.disabled and devices.ignore, this PR also migrate disable_notify data from devices_attribs table to devices.disable_notify 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
