### PR TITLE
correct and cleanup the mysql socket python code

### DIFF
--- a/discovery-wrapper.py
+++ b/discovery-wrapper.py
@@ -89,22 +89,20 @@ discovery_path = config['install_dir'] + '/discovery.php'
 log_dir = config['log_dir']
 db_username = config['db_user']
 db_password = config['db_pass']
-db_port = int(config['db_port'])
 
 if config['db_socket']:
-    db_server = config['db_host']
     db_socket = config['db_socket']
 else:
     db_server = config['db_host']
-    db_socket = None
+    db_port = int(config['db_port'])
 
 db_dbname = config['db_name']
 
 
 def db_open():
     try:
-        if db_socket:
-            db = MySQLdb.connect(host=db_server, unix_socket=db_socket, user=db_username, passwd=db_password, db=db_dbname)
+        if config['db_socket']:
+            db = MySQLdb.connect(unix_socket=db_socket, user=db_username, passwd=db_password, db=db_dbname)
         else:
             db = MySQLdb.connect(host=db_server, port=db_port, user=db_username, passwd=db_password, db=db_dbname)
         return db

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -79,22 +79,20 @@ poller_path = config['install_dir'] + '/poller.php'
 log_dir = config['log_dir']
 db_username = config['db_user']
 db_password = config['db_pass']
-db_port = int(config['db_port'])
 
 if config['db_socket']:
-    db_server = config['db_host']
     db_socket = config['db_socket']
 else:
     db_server = config['db_host']
-    db_socket = None
+    db_port = int(config['db_port'])
 
 db_dbname = config['db_name']
 
 
 def db_open():
     try:
-        if db_socket:
-            db = MySQLdb.connect(host=db_server, unix_socket=db_socket, user=db_username, passwd=db_password, db=db_dbname)
+        if config['db_socket']:
+            db = MySQLdb.connect(unix_socket=db_socket, user=db_username, passwd=db_password, db=db_dbname)
         else:
             db = MySQLdb.connect(host=db_server, port=db_port, user=db_username, passwd=db_password, db=db_dbname)
         return db

--- a/services-wrapper.py
+++ b/services-wrapper.py
@@ -90,32 +90,26 @@ log_dir = config['log_dir']
 db_username = config['db_user']
 db_password = config['db_pass']
 
-if config['db_host'][:5].lower() == 'unix:':
-    db_server = config['db_host']
-    db_port = 0
-elif config['db_socket']:
-    db_server = config['db_socket']
-    db_port = 0
-elif ':' in config['db_host']:
-    db_server = config['db_host'].rsplit(':')[0]
-    db_port = int(config['db_host'].rsplit(':')[1])
+if config['db_socket']:
+    db_socket = config['db_socket']
 else:
     db_server = config['db_host']
-    db_port = 0
+    db_port = int(config['db_port'])
 
 db_dbname = config['db_name']
 
 
 def db_open():
     try:
-        if db_port == 0:
-            db = MySQLdb.connect(host=db_server, user=db_username, passwd=db_password, db=db_dbname)
+        if config['db_socket']:
+            db = MySQLdb.connect(unix_socket=db_socket, user=db_username, passwd=db_password, db=db_dbname)
         else:
             db = MySQLdb.connect(host=db_server, port=db_port, user=db_username, passwd=db_password, db=db_dbname)
         return db
     except:
         print "ERROR: Could not connect to MySQL database!"
         sys.exit(2)
+
 
 # (c) 2015, GPLv3, Daniel Preussker <f0o@devilcode.org> <<<EOC1
 if 'distributed_poller_group' in config:


### PR DESCRIPTION
This PR fixes the mysql connect socket code and ensures constant behavior across all the python scripts that behaves as described in the  documentation - https://docs.librenms.org/Support/Configuration/.

1. if mysql is listening on a socket, you don't need to specify host or port in the connect string
2. setting `db_host` to a socket path and the port to 0 will still cause MySql-python to use TCP
3. usage of the `unix:` syntax in the host field is undocumented
4. The MySQL-python package has opinionated defaults that might warrant further documentation to avoid confusion
  - setting `localhost` as the `db_host` will result in a socket connection
  - setting `127.0.0.1` as the `db_host` will result in a TCP connection
  - setting `db_socket` will result in a socket connection even if `db_host` is set

config_to_json.php will default config[db_socket] to `null` if its not explicitly set, so it makes sense to use that as the tcp / socket connection determination.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
