### PR TITLE
Fixing PHP incompatibility issue with PHP 7.4

### DIFF
--- a/resources/views/widgets/graph.blade.php
+++ b/resources/views/widgets/graph.blade.php
@@ -1,9 +1,9 @@
 <div class="dashboard-graph">
-    <a href="graphs/{{ implode($params, '/') }}/type={{ $graph_type }}/from={{ $from }}/to={{ $to }}">
+    <a href="graphs/{{ implode('/', $params) }}/type={{ $graph_type }}/from={{ $from }}/to={{ $to }}">
         <img class="minigraph-image"
              width="{{ $dimensions['x'] }}"
              height="{{ $dimensions['y'] }}"
-             src="graph.php?{{ implode($params, '&') }}&from={{ $from }}&to={{ $to }}&width={{ $dimensions['x'] }}&height={{ $dimensions['y'] }}&type={{ $graph_type }}&legend={{ $graph_legend }}&absolute=1"
+             src="graph.php?{{ implode('&', $params) }}&from={{ $from }}&to={{ $to }}&width={{ $dimensions['x'] }}&height={{ $dimensions['y'] }}&type={{ $graph_type }}&legend={{ $graph_legend }}&absolute=1"
         />
     </a>
 </div>


### PR DESCRIPTION
The PHP implode function has deprecated the glue after pieces method of calling the function as from PHP 7.4
Fixing this to ensure librenms works in PHP 7.4

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
