### PR TITLE
Fixed issue with SNMP contexts using vlan 1002-1005 on IOS devices

### DIFF
--- a/LibreNMS/Component.php
+++ b/LibreNMS/Component.php
@@ -354,7 +354,7 @@ class Component
                     dbUpdate($DATA, 'component_prefs', '`component` = ? AND `attribute` = ?', array($COMPONENT, $ATTR));
 
                     // Add the modification to the Eventlog.
-                    log_event("Component: " . $AVP[$COMPONENT]['type'] . "(" . $COMPONENT . "). Attribute: " . $ATTR . ", was modified from: " . $OLD[$COMPONENT][$ATTR] . ", to: " . $VALUE, $device_id, 'component', 3, $COMPONENT);
+                    log_event("Component: " . $AVP[$COMPONENT]['type'] . "(" . $COMPONENT . "). Attribute: " . $ATTR . ", was modified from: " . $OLD[$device_id][$COMPONENT][$ATTR] . ", to: " . $VALUE, $device_id, 'component', 3, $COMPONENT);
                 }
             } // End Foreach AVP
 

--- a/includes/discovery/fdb-table/ios.inc.php
+++ b/includes/discovery/fdb-table/ios.inc.php
@@ -18,7 +18,7 @@ foreach ($vtpdomains as $vtpdomain_id => $vtpdomain) {
             $vlans_dict[$vlan_raw] = $newvlan_id;
         }
 
-        if ($vlan['vtpVlanState'] === '1') {
+        if (($vlan['vtpVlanState'] === '1') && ($vlan_raw < 1002 || $vlan_raw > 1005)) {
             $device_vlan = array_merge($device, array('community' => $device['community'] . '@' . $vlan_raw, 'context_name' => "vlan-$vlan_raw"));
 
             $fdbPort_table = snmpwalk_group($device_vlan, 'dot1dTpFdbPort', 'BRIDGE-MIB', 0);


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

This pull request fixes an issue in IOS devices where the SNMP context for vlans 1002-1005 are not accessible on devices.  Cisco IOS does not support these vlans and have been effectively blocked from polling.  Polling against this context yields an SNMP auth trap message.

Please see https://github.com/librenms/librenms/issues/11004 for further details.
