### PR TITLE
Added yum-config-manager to Remi install

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -29,9 +29,15 @@ There are multiple ways to install php 7.x on CentOS 7, like Webtatic, Remi or S
 ```
 yum localinstall http://rpms.remirepo.net/enterprise/remi-release-7.rpm
 ```
+Install the yum-config-manager to change to Remi PHP 7.3 Repo.
+```
+yum install yum-utils
+yum-config-manager --enable remi-php73
+```
+Install the required packages
 
 ```
-yum install php73-mod_php php73-php-cli php73-php-common php73-php-curl php73-php-gd php73-php-mbstring php73-php-process php73-php-snmp php73-php-xml php73-php-zip php73-php-memcached php73-php-mysqlnd
+yum install mod_php php-cli php-common php-curl php-gd php-mbstring php-process php-snmp php-xml php-zip php-memcached php-mysqlnd
 ```
 
 #### Running with Webtatic PHP


### PR DESCRIPTION
Hello,

If you follow the original Rumi config, the path to the binaries are not changed, so you cannot do php -v after the yum install line. 

If you install the yum-package-manager then apply the repo, all php packages become rumi php packages.

I hope the yum install line is correct, as i've tried to edit it and i hope i didnt miss any packages.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
