### PR TITLE
SNMP counters validation

### DIFF
--- a/poll-billing.php
+++ b/poll-billing.php
@@ -105,12 +105,11 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
             if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
                 $fields['bill_id'] = $bill_id;
                 $fields['port_id'] = $port_id;
-
                 dbInsert($fields, 'bill_port_counters');
             }
         } else {
             echo "WATCH out! - Wrong counters. Table 'bill_port_counters' not updated\n";
-            logfile("WATCH out! - Wrong counters. Table 'bill_port_counters' not updated");         
+            logfile("WATCH out! - Wrong counters. Table 'bill_port_counters' not updated");
         }
         ////////////////////////////////EndCountersValidation&DB-Update
         $delta     = ($delta + $port_data['in_delta'] + $port_data['out_delta']);

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -89,14 +89,31 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
             $port_data['out_delta'] = '0';
         }
 
-        // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
-        $fields = array('timestamp' => $now, 'in_counter' => (string)set_numeric($port_data['in_measurement']), 'out_counter' => (string)set_numeric($port_data['out_measurement']), 'in_delta' => (string)set_numeric($port_data['in_delta']), 'out_delta' => (string)set_numeric($port_data['out_delta']));
-        if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
-            $fields['bill_id'] = $bill_id;
-            $fields['port_id'] = $port_id;
-            dbInsert($fields, 'bill_port_counters');
-        }
+//////////////////////////////////CountersValidation$DB-Update
+echo "\nDB SNMP counters received.\n";
+echo " in_measurement: ",$port_data['in_measurement']," out_measurement: ",$port_data['out_measurement'],"\n";
+echo " The data types are --> in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement'])."\n";
+//For debugging
+logfile("\n****$now: ".$bill->bill_name."\nDB SNMP counters received.");
+logfile("in_measurement: ".$port_data['in_measurement']."  out_measurement: ".$port_data['out_measurement']."\nThe data types are. in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement']));
+logfile("IN_delta: ".$port_data['in_delta']." OUT_delta: ".$port_data['out_delta']."\nLast_IN_delta: ".$port_data['last_in_delta']." last_OUT_delta: ".$port_data['last_out_delta']);
 
+if(is_numeric($port_data['in_measurement']) && is_numeric($port_data['out_measurement'])){
+// NOTE: casting to string for mysqli bug (fixed by mysqlnd)
+    $fields = array('timestamp' => $now, 'in_counter' => (string)set_numeric($port_data['in_measurement']), 'out_counter' => (string)set_numeric($port_data['out_measurement']), 'in_delta' => (string)set_numeric($port_data['in_delta']), 'out_delta' => (string)set_numeric($port_data['out_delta']));
+if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
+        $fields['bill_id'] = $bill_id;
+        $fields['port_id'] = $port_id;
+
+        dbInsert($fields, 'bill_port_counters');
+            echo "Nice, valid counter 'in/out_measurement', lets use it\n";
+            logfile("Nice, valid counter 'in/out_measurement', lets use it");
+    }
+echo "WATCH out! - Wrong counters. Used 'last_in/out_measurement' instead\n";
+logfile("WATCH out! - Wrong counters. Avoid to update 'bill_port_counter'");
+}
+////////////////////////////////EndCountersValidation&DB-Update
+        
         $delta     = ($delta + $port_data['in_delta'] + $port_data['out_delta']);
         $in_delta  = ($in_delta + $port_data['in_delta']);
         $out_delta = ($out_delta + $port_data['out_delta']);

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -110,10 +110,9 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
             }
         } else {
             echo "WATCH out! - Wrong counters. Table 'bill_port_counters' not updated\n";
-            logfile("WATCH out! - Wrong counters. Table 'bill_port_counters' not updated");
-            
+            logfile("WATCH out! - Wrong counters. Table 'bill_port_counters' not updated");         
         }
-        ////////////////////////////////EndCountersValidation&DB-Update        
+        ////////////////////////////////EndCountersValidation&DB-Update
         $delta     = ($delta + $port_data['in_delta'] + $port_data['out_delta']);
         $in_delta  = ($in_delta + $port_data['in_delta']);
         $out_delta = ($out_delta + $port_data['out_delta']);

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -89,30 +89,32 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
             $port_data['out_delta'] = '0';
         }
 
-//////////////////////////////////CountersValidation$DB-Update
-echo "\nDB SNMP counters received.\n";
-echo " in_measurement: ",$port_data['in_measurement']," out_measurement: ",$port_data['out_measurement'],"\n";
-echo " The data types are --> in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement'])."\n";
-//For debugging
-logfile("\n****$now: ".$bill->bill_name."\nDB SNMP counters received.");
-logfile("in_measurement: ".$port_data['in_measurement']."  out_measurement: ".$port_data['out_measurement']."\nThe data types are. in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement']));
-logfile("IN_delta: ".$port_data['in_delta']." OUT_delta: ".$port_data['out_delta']."\nLast_IN_delta: ".$port_data['last_in_delta']." last_OUT_delta: ".$port_data['last_out_delta']);
+        //////////////////////////////////CountersValidation$DB-Update
+        echo "\nDB SNMP counters received.\n";
+        echo " in_measurement: ",$port_data['in_measurement']," out_measurement: ",$port_data['out_measurement'],"\n";
+        echo " The data types are --> in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement'])."\n";
+        //For debugging
+        logfile("\n****$now: ".$bill->bill_name."\nDB SNMP counters received.");
+        logfile("in_measurement: ".$port_data['in_measurement']."  out_measurement: ".$port_data['out_measurement']."\nThe data types are. in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement']));
+        logfile("IN_delta: ".$port_data['in_delta']." OUT_delta: ".$port_data['out_delta']."\nLast_IN_delta: ".$port_data['last_in_delta']." last_OUT_delta: ".$port_data['last_out_delta']);
 
-if(is_numeric($port_data['in_measurement']) && is_numeric($port_data['out_measurement'])){
-// NOTE: casting to string for mysqli bug (fixed by mysqlnd)
-    $fields = array('timestamp' => $now, 'in_counter' => (string)set_numeric($port_data['in_measurement']), 'out_counter' => (string)set_numeric($port_data['out_measurement']), 'in_delta' => (string)set_numeric($port_data['in_delta']), 'out_delta' => (string)set_numeric($port_data['out_delta']));
-if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
-        $fields['bill_id'] = $bill_id;
-        $fields['port_id'] = $port_id;
+        if(is_numeric($port_data['in_measurement']) && is_numeric($port_data['out_measurement'])){
+            echo "Nice, valid counters 'in/out_measurement', lets use them\n";
+            logfile("Nice, valid counters 'in/out_measurement', lets use them");
+            // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
+            $fields = array('timestamp' => $now, 'in_counter' => (string)set_numeric($port_data['in_measurement']), 'out_counter' => (string)set_numeric($port_data['out_measurement']), 'in_delta' => (string)set_numeric($port_data['in_delta']), 'out_delta' => (string)set_numeric($port_data['out_delta']));
+            if (dbUpdate($fields, 'bill_port_counters', "`port_id`='" . mres($port_id) . "' AND `bill_id`='$bill_id'") == 0) {
+                $fields['bill_id'] = $bill_id;
+                $fields['port_id'] = $port_id;
 
-        dbInsert($fields, 'bill_port_counters');
-            echo "Nice, valid counter 'in/out_measurement', lets use it\n";
-            logfile("Nice, valid counter 'in/out_measurement', lets use it");
-    }
-echo "WATCH out! - Wrong counters. Used 'last_in/out_measurement' instead\n";
-logfile("WATCH out! - Wrong counters. Avoid to update 'bill_port_counter'");
-}
-////////////////////////////////EndCountersValidation&DB-Update
+                dbInsert($fields, 'bill_port_counters');
+            }
+        }else{
+            echo "WATCH out! - Wrong counters. Table 'bill_port_counters' not updated\n";
+            logfile("WATCH out! - Wrong counters. Table 'bill_port_counters' not updated");
+            
+        }
+        ////////////////////////////////EndCountersValidation&DB-Update
         
         $delta     = ($delta + $port_data['in_delta'] + $port_data['out_delta']);
         $in_delta  = ($in_delta + $port_data['in_delta']);

--- a/poll-billing.php
+++ b/poll-billing.php
@@ -88,7 +88,6 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
             $port_data['in_delta'] = '0';
             $port_data['out_delta'] = '0';
         }
-
         //////////////////////////////////CountersValidation$DB-Update
         echo "\nDB SNMP counters received.\n";
         echo " in_measurement: ",$port_data['in_measurement']," out_measurement: ",$port_data['out_measurement'],"\n";
@@ -98,7 +97,7 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
         logfile("in_measurement: ".$port_data['in_measurement']."  out_measurement: ".$port_data['out_measurement']."\nThe data types are. in_measurement:".gettype($port_data['in_measurement'])." and out_measurement: ".gettype($port_data['out_measurement']));
         logfile("IN_delta: ".$port_data['in_delta']." OUT_delta: ".$port_data['out_delta']."\nLast_IN_delta: ".$port_data['last_in_delta']." last_OUT_delta: ".$port_data['last_out_delta']);
 
-        if(is_numeric($port_data['in_measurement']) && is_numeric($port_data['out_measurement'])){
+        if (is_numeric($port_data['in_measurement']) && is_numeric($port_data['out_measurement'])) {
             echo "Nice, valid counters 'in/out_measurement', lets use them\n";
             logfile("Nice, valid counters 'in/out_measurement', lets use them");
             // NOTE: casting to string for mysqli bug (fixed by mysqlnd)
@@ -109,13 +108,12 @@ foreach ($query->get(['bill_id', 'bill_name']) as $bill) {
 
                 dbInsert($fields, 'bill_port_counters');
             }
-        }else{
+        } else {
             echo "WATCH out! - Wrong counters. Table 'bill_port_counters' not updated\n";
             logfile("WATCH out! - Wrong counters. Table 'bill_port_counters' not updated");
             
         }
-        ////////////////////////////////EndCountersValidation&DB-Update
-        
+        ////////////////////////////////EndCountersValidation&DB-Update        
         $delta     = ($delta + $port_data['in_delta'] + $port_data['out_delta']);
         $in_delta  = ($in_delta + $port_data['in_delta']);
         $out_delta = ($out_delta + $port_data['out_delta']);


### PR DESCRIPTION
Validation step added before counters are updated in table 'bill_port_counters'.

Avoid wrong data to be added to the table in case the SNMP polling function return an invalid value.

check --> https://community.librenms.org/t/wrong-billing-record-in-delta/8540

Scenarios encountered (No1 resolved - 2 and 3 to discuss)

1. If both SNMP polling queries fail (64/32) value returned is nor numeric --> is assumed as 0 --> this is overcome on the first calculation but the value is stored as a legit counter. The problem arises on the next calculation where the delta will be calculated against the 0 value… high delta as result.
Solution:
If both queries failed (64b and 32b) the value returned is FALSE. In this case conditional needs to be created in poll-billing.php to evaluate this condition and avoid DB update on 'bill_port_counters' table.

2.SNMP function used getValue() and snmp_get() uses RFC-2665 starting querying for 64counter and querying 32bit if the 64 fails --> Case No1 --> this is a problem when the current counter is over 2^32 (max counter value), in this case the counter (32bit) returned is not relevant…calculation would then give a big Delta.
Comment:
Dependent on 3 to add conditional and determine which query to use. --> In our case we use 64b counters only, we commented 32b query for the time being (function getValue())? --> Added a debug in this scenario to query the 64b again and try to capture the error returned by the snmp query --> No success.

3.Poll-billing.php --> Delta calculation does not discriminate if value obtained from counter was 32 or 64 --> this is a problem when the previous counter value (variable retained in the DB is over 2^32), in this case the counter (32bit) returned is not relevant…calculation would then give a big Delta.
Comment:
Modify getValue() function to receive port counter (64 or 32) and poll that one only. However, there is not seem to be currently a value on the tables that flag this case. This could be taken when the adding process is completed maybe?

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
