### PR TITLE
Add alert rule option to invert devices and groups "map to" list

### DIFF
--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -181,7 +181,7 @@ class AlertUtil
         WHERE a.disabled = 0 AND (
             (d.device_id IS NULL AND g.group_id IS NULL)
             OR (a.invert_map = 0 AND (d.device_id=? OR dg.device_id=?))
-            OR (a.invert_map = 1 AND ? NOT IN (SELECT d.device_id) AND ? NOT IN (SELECT dg.device_id))
+            OR (a.invert_map = 1 AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR dg.device_id IS NULL))
         )";
 
         $params = [$device_id, $device_id, $device_id, $device_id, $device_id, $device_id];

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -181,7 +181,7 @@ class AlertUtil
         WHERE a.disabled = 0 AND (
             (d.device_id IS NULL AND g.group_id IS NULL)
             OR (a.invert_map = 0 AND (d.device_id=? OR dg.device_id=?))
-            OR (a.invert_map = 1 AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR dg.device_id IS NULL))
+            OR (a.invert_map = 1 AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR (dg.device_id IS NULL AND g.group_id is NULL)))
         )";
 
         $params = [$device_id, $device_id, $device_id, $device_id, $device_id, $device_id];

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -176,12 +176,12 @@ class AlertUtil
     {
         $query = "SELECT DISTINCT a.* FROM alert_rules a
         LEFT JOIN alert_device_map d ON a.id=d.rule_id AND d.device_id = ?
-        LEFT JOIN alert_group_map g ON a.id=g.rule_id
+        LEFT JOIN alert_group_map g ON a.id=g.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND g.group_id IN (SELECT DISTINCT device_group_id FROM device_group_device WHERE device_id = ?))
         LEFT JOIN device_group_device dg ON g.group_id=dg.device_group_id AND dg.device_id = ?
         WHERE a.disabled = 0 AND (
             (d.device_id IS NULL AND g.group_id IS NULL)
             OR (a.invert_map = 0 AND (d.device_id=? OR dg.device_id=?))
-            OR (a.invert_map = 1 AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR (dg.device_id IS NULL AND g.group_id is NULL)))
+            OR (a.invert_map = 1  AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR dg.device_id IS NULL))
         )";
 
         $params = [$device_id, $device_id, $device_id, $device_id, $device_id, $device_id];

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -184,7 +184,7 @@ class AlertUtil
             OR (a.invert_map = 1  AND (d.device_id != ? OR d.device_id IS NULL) AND (dg.device_id != ? OR dg.device_id IS NULL))
         )";
 
-        $params = [$device_id, $device_id, $device_id, $device_id, $device_id, $device_id];
+        $params = [$device_id, $device_id, $device_id, $device_id, $device_id, $device_id, $device_id];
         return dbFetchRows($query, $params);
     }
 

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -174,6 +174,7 @@ class AlertUtil
 
     public static function getRules($device_id)
     {
+        // cfdfs
         $query = "SELECT DISTINCT a.* FROM alert_rules a
         LEFT JOIN alert_device_map d ON a.id=d.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND d.device_id = ?)
         LEFT JOIN alert_group_map g ON a.id=g.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND g.group_id IN (SELECT DISTINCT device_group_id FROM device_group_device WHERE device_id = ?))

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -174,7 +174,6 @@ class AlertUtil
 
     public static function getRules($device_id)
     {
-        // cfdfs
         $query = "SELECT DISTINCT a.* FROM alert_rules a
         LEFT JOIN alert_device_map d ON a.id=d.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND d.device_id = ?)
         LEFT JOIN alert_group_map g ON a.id=g.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND g.group_id IN (SELECT DISTINCT device_group_id FROM device_group_device WHERE device_id = ?))

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -175,7 +175,7 @@ class AlertUtil
     public static function getRules($device_id)
     {
         $query = "SELECT DISTINCT a.* FROM alert_rules a
-        LEFT JOIN alert_device_map d ON a.id=d.rule_id AND d.device_id = ?
+        LEFT JOIN alert_device_map d ON a.id=d.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND d.device_id != ?)
         LEFT JOIN alert_group_map g ON a.id=g.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND g.group_id IN (SELECT DISTINCT device_group_id FROM device_group_device WHERE device_id = ?))
         LEFT JOIN device_group_device dg ON g.group_id=dg.device_group_id AND dg.device_id = ?
         WHERE a.disabled = 0 AND (

--- a/LibreNMS/Alert/AlertUtil.php
+++ b/LibreNMS/Alert/AlertUtil.php
@@ -175,7 +175,7 @@ class AlertUtil
     public static function getRules($device_id)
     {
         $query = "SELECT DISTINCT a.* FROM alert_rules a
-        LEFT JOIN alert_device_map d ON a.id=d.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND d.device_id != ?)
+        LEFT JOIN alert_device_map d ON a.id=d.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND d.device_id = ?)
         LEFT JOIN alert_group_map g ON a.id=g.rule_id AND (a.invert_map = 0 OR a.invert_map = 1 AND g.group_id IN (SELECT DISTINCT device_group_id FROM device_group_device WHERE device_id = ?))
         LEFT JOIN device_group_device dg ON g.group_id=dg.device_group_id AND dg.device_id = ?
         WHERE a.disabled = 0 AND (

--- a/database/migrations/2019_12_17_151314_add_invert_map_to_alert_rules.php
+++ b/database/migrations/2019_12_17_151314_add_invert_map_to_alert_rules.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class addInvertMapToAlertRules extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('alert_rules', function (Blueprint $table) {
+            $table->boolean('invert_map')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('alert_rules', function (Blueprint $table) {
+            $table->dropColumn(['invert_map']);
+        });
+    }
+}

--- a/database/migrations/2019_12_17_151314_add_invert_map_to_alert_rules.php
+++ b/database/migrations/2019_12_17_151314_add_invert_map_to_alert_rules.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class addInvertMapToAlertRules extends Migration
+class AddInvertMapToAlertRules extends Migration
 {
 
     /**

--- a/includes/html/forms/alert-rules.inc.php
+++ b/includes/html/forms/alert-rules.inc.php
@@ -136,7 +136,8 @@ if (is_numeric($rule_id) && $rule_id > 0) {
             'name' => $name,
             'proc' => $proc,
             'query' => $query,
-            'builder' => $builder_json
+            'builder' => $builder_json,
+            'invert_map' => $invert_map
         ), 'alert_rules');
 
         if ($rule_id) {

--- a/includes/html/forms/alert-rules.inc.php
+++ b/includes/html/forms/alert-rules.inc.php
@@ -58,6 +58,7 @@ $invert       = mres(isset($_POST['invert']) ? $_POST['invert'] : null);
 $name         = mres($_POST['name']);
 $proc         = mres($_POST['proc']);
 $recovery     = ($vars['recovery']);
+$invert_map   = mres(isset($_POST['invert_map']) ? $_POST['invert_map'] : null);
 $severity     = mres($_POST['severity']);
 
 if (!is_numeric($count)) {
@@ -81,6 +82,12 @@ if ($invert == 'on') {
 
 $recovery = empty($recovery) ? $recovery = false : true;
 
+if ($invert_map == 'on') {
+    $invert_map = true;
+} else {
+    $invert_map = false;
+}
+
 $extra = array(
     'mute'     => $mute,
     'count'    => $count,
@@ -101,7 +108,8 @@ if (is_numeric($rule_id) && $rule_id > 0) {
             'name' => $name,
             'proc' => $proc,
             'query' => $query,
-            'builder' => $builder_json
+            'builder' => $builder_json,
+            'invert_map' => $invert_map
         ),
         'alert_rules',
         'id=?',

--- a/includes/html/forms/parse-alert-rule.inc.php
+++ b/includes/html/forms/parse-alert-rule.inc.php
@@ -77,5 +77,6 @@ if (is_array($rule)) {
         'builder'    => $builder,
         'severity'   => $rule['severity'],
         'adv_query'  => $rule['query'],
+        'invert_map'  => $rule['invert_map'],
     ]);
 }

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -98,7 +98,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                                     <div class='col-sm-2' title="Show alert status in the webui, but do not issue notifications.">
                                         <input type="checkbox" name="mute" id="mute">
                                     </div>
-                                    <label for='invert' class='col-sm-3 col-md-3 control-label' title="Alert when this rule doesn't match." style="vertical-align: top;">Invert alert match: </label>
+                                    <label for='invert' class='col-sm-3 col-md-3 control-label' title="Alert when this rule doesn't match." style="vertical-align: top;">Invert rule match: </label>
                                     <div class='col-sm-2' title="Alert when this rule doesn't match.">
                                         <input type='checkbox' name='invert' id='invert'>
                                     </div>
@@ -111,11 +111,11 @@ if (Auth::user()->hasGlobalAdmin()) {
                                 </div>
                                 <div class="form-group form-inline">
                                     <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices and groups.">Match devices and groups list: </label>
-                                    <div class="col-sm-7 col-md-7">
+                                    <div class="col-sm-7" style="width: 56%;">
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                                     </div>
                                     <div>
-                                        <label for='invert_map' class=' control-label' text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">Invert list: </label>
+                                        <label for='invert_map' class=' control-label' text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">Invert list match: </label>
                                         <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
                                 </div>

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -109,14 +109,12 @@ if (Auth::user()->hasGlobalAdmin()) {
                                         <input type='checkbox' name='recovery' id='recovery'>
                                     </div>
                                 </div>
-                                <div class="form-group" title="Restricts this alert rule to the selected devices or groups.">
-                                    <label for='maps' class='col-sm-3 col-md-2 control-label'>Map to: </label>
-                                    <div class="col-sm-9 col-md-10">
+                                <div class="form-group form-inline">
+                                    <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices or groups.">Match devices and groups list: </label>
+                                    <div class="col-sm-9 col-md-6">
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                                     </div>
-                                </div>
-                                <div class="form-group" title="If ON, alert rule won't match any device in map to ">
-                                    <label for='invert_map' class='col-sm-3 col-md-2 control-label'>Invert map to: </label>
+                                    <label for='invert_map' class='col-sm-2 col-md-2 control-label' title="If ON, alert rule won't match any device in map to">Not in list: </label>
                                     <div class='col-sm-2'>
                                         <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
@@ -372,6 +370,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                 if (extra.adv_query) {
                     $('#adv_query').val(extra.adv_query);
                 }
+                
                 $("[name='mute']").bootstrapSwitch('state', extra.mute);
                 $("[name='invert']").bootstrapSwitch('state', extra.invert);
                 if (typeof extra.recovery == 'undefined') {
@@ -385,13 +384,13 @@ if (Auth::user()->hasGlobalAdmin()) {
                     extra.options.override_query = false;
                 }
                 $("[name='recovery']").bootstrapSwitch('state', extra.recovery);
-
+                
                 if (rule.invert_map == 1) {
                     $("[name='invert_map']").bootstrapSwitch('state', true);
                 }else{
                     $("[name='invert_map']").bootstrapSwitch('state', false);
                 }
-
+                
                 $("[name='override_query']").bootstrapSwitch('state', extra.options.override_query);
             } else {
                 $('#count').val('-1');

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -110,9 +110,15 @@ if (Auth::user()->hasGlobalAdmin()) {
                                     </div>
                                 </div>
                                 <div class="form-group" title="Restricts this alert rule to the selected devices or groups.">
-                                    <label for='maps' class='col-sm-3 col-md-2 control-label'>Map To: </label>
+                                    <label for='maps' class='col-sm-3 col-md-2 control-label'>Map to: </label>
                                     <div class="col-sm-9 col-md-10">
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
+                                    </div>
+                                </div>
+                                <div class="form-group" title="If ON, alert rule won't match any device in map to ">
+                                    <label for='invert_map' class='col-sm-3 col-md-2 control-label'>Invert map to: </label>
+                                    <div class='col-sm-2'>
+                                        <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
                                 </div>
                                 <div class="form-group" title="Restricts this alert rule to specified transports.">
@@ -292,6 +298,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                 $("#invert").bootstrapSwitch('state', false);
                 $("#recovery").bootstrapSwitch('state', true);
                 $("#override_query").bootstrapSwitch('state', false);
+                $("#invert_map").bootstrapSwitch('state', false);
                 $(this).find("input[type=text]").val("");
                 $('#count').val('-1');
                 $('#delay').val('1m');
@@ -365,12 +372,12 @@ if (Auth::user()->hasGlobalAdmin()) {
                 if (extra.adv_query) {
                     $('#adv_query').val(extra.adv_query);
                 }
-
                 $("[name='mute']").bootstrapSwitch('state', extra.mute);
                 $("[name='invert']").bootstrapSwitch('state', extra.invert);
                 if (typeof extra.recovery == 'undefined') {
                     extra.recovery = true;
                 }
+
                 if (typeof extra.options == 'undefined') {
                     extra.options = new Array();
                 }
@@ -378,6 +385,13 @@ if (Auth::user()->hasGlobalAdmin()) {
                     extra.options.override_query = false;
                 }
                 $("[name='recovery']").bootstrapSwitch('state', extra.recovery);
+
+                if (rule.invert_map == 1) {
+                    $("[name='invert_map']").bootstrapSwitch('state', true);
+                }else{
+                    $("[name='invert_map']").bootstrapSwitch('state', false);
+                }
+
                 $("[name='override_query']").bootstrapSwitch('state', extra.options.override_query);
             } else {
                 $('#count').val('-1');

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -115,7 +115,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                                     </div>
                                     <div>
-                                        <label for='invert_map' class=' control-label' text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">Invert list match: </label>
+                                        <label for='invert_map' class='col-md-1' style="width: 14.1333%;" text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">All devices except in list: </label>
                                         <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
                                 </div>

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -98,7 +98,7 @@ if (Auth::user()->hasGlobalAdmin()) {
                                     <div class='col-sm-2' title="Show alert status in the webui, but do not issue notifications.">
                                         <input type="checkbox" name="mute" id="mute">
                                     </div>
-                                    <label for='invert' class='col-sm-3 col-md-2 control-label' title="Alert when this rule doesn't match." style="vertical-align: top;">Invert match: </label>
+                                    <label for='invert' class='col-sm-3 col-md-3 control-label' title="Alert when this rule doesn't match." style="vertical-align: top;">Invert alert match: </label>
                                     <div class='col-sm-2' title="Alert when this rule doesn't match.">
                                         <input type='checkbox' name='invert' id='invert'>
                                     </div>
@@ -110,12 +110,12 @@ if (Auth::user()->hasGlobalAdmin()) {
                                     </div>
                                 </div>
                                 <div class="form-group form-inline">
-                                    <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices or groups.">Match devices and groups list: </label>
+                                    <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices and groups.">Match devices and groups list: </label>
                                     <div class="col-sm-7 col-md-7">
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                                     </div>
                                     <div>
-                                        <label for='invert_map' class=' control-label' text-align="left" title="If ON, alert rule won't match any device in map to">Not in list: </label>
+                                        <label for='invert_map' class=' control-label' text-align="left" title="If ON, alert rule check will run on all devices except the selected devices and groups.">Invert list: </label>
                                         <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
                                 </div>
@@ -370,7 +370,6 @@ if (Auth::user()->hasGlobalAdmin()) {
                 if (extra.adv_query) {
                     $('#adv_query').val(extra.adv_query);
                 }
-                
                 $("[name='mute']").bootstrapSwitch('state', extra.mute);
                 $("[name='invert']").bootstrapSwitch('state', extra.invert);
                 if (typeof extra.recovery == 'undefined') {
@@ -384,13 +383,13 @@ if (Auth::user()->hasGlobalAdmin()) {
                     extra.options.override_query = false;
                 }
                 $("[name='recovery']").bootstrapSwitch('state', extra.recovery);
-                
+
                 if (rule.invert_map == 1) {
                     $("[name='invert_map']").bootstrapSwitch('state', true);
                 }else{
                     $("[name='invert_map']").bootstrapSwitch('state', false);
                 }
-                
+
                 $("[name='override_query']").bootstrapSwitch('state', extra.options.override_query);
             } else {
                 $('#count').val('-1');

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -111,11 +111,11 @@ if (Auth::user()->hasGlobalAdmin()) {
                                 </div>
                                 <div class="form-group form-inline">
                                     <label for='maps' class='col-sm-3 col-md-2 control-label' title="Restricts this alert rule to the selected devices or groups.">Match devices and groups list: </label>
-                                    <div class="col-sm-9 col-md-6">
+                                    <div class="col-sm-7 col-md-7">
                                         <select id="maps" name="maps[]" class="form-control" multiple="multiple"></select>
                                     </div>
-                                    <label for='invert_map' class='col-sm-2 col-md-2 control-label' title="If ON, alert rule won't match any device in map to">Not in list: </label>
-                                    <div class='col-sm-2'>
+                                    <div>
+                                        <label for='invert_map' class=' control-label' text-align="left" title="If ON, alert rule won't match any device in map to">Not in list: </label>
                                         <input type='checkbox' name='invert_map' id='invert_map'>
                                     </div>
                                 </div>

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -75,6 +75,7 @@ alert_rules:
     - { Field: query, Type: text, 'Null': false, Extra: '' }
     - { Field: builder, Type: text, 'Null': false, Extra: '' }
     - { Field: proc, Type: varchar(80), 'Null': true, Extra: '' }
+    - { Field: invert_map, Type: tinyint(1), 'Null': false, Extra: '', Default: '0' }
   Indexes:
     PRIMARY: { Name: PRIMARY, Columns: [id], Unique: true, Type: BTREE }
     name: { Name: name, Columns: [name], Unique: true, Type: BTREE }


### PR DESCRIPTION
Fix previous PR https://github.com/librenms/librenms/pull/10954 that worked for group in alert rules "map to" but did not with devices

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
