### PR TITLE
Don't overwrite real port ids with zeros in the FDB

### DIFF
--- a/includes/discovery/fdb-table.inc.php
+++ b/includes/discovery/fdb-table.inc.php
@@ -41,7 +41,7 @@ if (!empty($insert)) {
                 $new_port = $entry['port_id'];
                 $port_fdb_id = $existing_fdbs[$vlan_id][$mac_address_entry]['ports_fdb_id'];
 
-                // Sometimes new_port ends up as 0 if we didn't get a complete dot1dBasePort 
+                // Sometimes new_port ends up as 0 if we didn't get a complete dot1dBasePort
                 // dictionary from BRIDGE-MIB - don't write a 0 over a previously known port
                 if ($existing_fdbs[$vlan_id][$mac_address_entry]['port_id'] != $new_port && $new_port != 0) {
                     DB::table('ports_fdb')

--- a/includes/discovery/fdb-table.inc.php
+++ b/includes/discovery/fdb-table.inc.php
@@ -41,7 +41,9 @@ if (!empty($insert)) {
                 $new_port = $entry['port_id'];
                 $port_fdb_id = $existing_fdbs[$vlan_id][$mac_address_entry]['ports_fdb_id'];
 
-                if ($existing_fdbs[$vlan_id][$mac_address_entry]['port_id'] != $new_port) {
+                // Sometimes new_port ends up as 0 if we didn't get a complete dot1dBasePort 
+                // dictionary from BRIDGE-MIB - don't write a 0 over a previously known port
+                if ($existing_fdbs[$vlan_id][$mac_address_entry]['port_id'] != $new_port && $new_port != 0) {
                     DB::table('ports_fdb')
                         ->where('ports_fdb_id', $port_fdb_id)
                         ->update([


### PR DESCRIPTION
I have found occasionally that busy switches only return a partial dot1dBasePortTable when doing FDB discovery (includes/discovery/fdb-table/bridge.inc.php). This results in some FDB entries being given a port_id of zero and this gets written over any valid port IDs from previous runs in the database ports_fdb table.

This PR is to avoid doing that and just update the timestamp, on the assumption that the FDB entry is really still on the same port as before and this is just a transient issue reading the dot1dBasePortTable that will resolve soon.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
