### PR TITLE
Url.php: Allow findOsImage() to also use the first two words of $feature

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -382,7 +382,14 @@ class Url
 
         if ($os) {
             if ($os == "linux") {
+                // first, prefer the first word of $feature
                 $distro = Str::before(strtolower(trim($feature)), ' ');
+                $possibilities[] = "$distro.svg";
+                $possibilities[] = "$distro.png";
+
+                // second, prefer the first two words of $feature (i.e. 'Red Hat' becomes 'redhat')
+                $distro = Str::replaceFirst(' ', '', strtolower(trim($feature)), ' ');
+                $distro = Str::before($distro, ' ');
                 $possibilities[] = "$distro.svg";
                 $possibilities[] = "$distro.png";
             }

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -388,7 +388,7 @@ class Url
                 $possibilities[] = "$distro.png";
 
                 // second, prefer the first two words of $feature (i.e. 'Red Hat' becomes 'redhat')
-                $distro = Str::replaceFirst(' ', '', strtolower(trim($feature)), ' ');
+                $distro = Str::replaceFirst(' ', null, strtolower(trim($feature)), ' ');
                 $distro = Str::before($distro, ' ');
                 $possibilities[] = "$distro.svg";
                 $possibilities[] = "$distro.png";

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -388,10 +388,12 @@ class Url
                 $possibilities[] = "$distro.png";
 
                 // second, prefer the first two words of $feature (i.e. 'Red Hat' becomes 'redhat')
-                $distro = Str::replaceFirst(' ', null, strtolower(trim($feature)), ' ');
-                $distro = Str::before($distro, ' ');
-                $possibilities[] = "$distro.svg";
-                $possibilities[] = "$distro.png";
+                if (strpos($feature, ' ') !== false) {
+                    $distro = Str::replaceFirst(' ', null, strtolower(trim($feature)));
+                    $distro = Str::before($distro, ' ');
+                    $possibilities[] = "$distro.svg";
+                    $possibilities[] = "$distro.png";
+                }
             }
             $os_icon = Config::getOsSetting($os, 'icon', $os);
             $possibilities[] = "$os_icon.svg";


### PR DESCRIPTION
* LibreNMS is not always using the bunded redhat.svg.
* Modern RHEL has /etc/os-release and distro ends up using it.
* The lsb release is correct, i.e. 'Red Hat Enterprise Linux Server 7.6'
* Previously, findOsImage() only considered the first word of $feature as a possibility for the icon.
* This patch also allows using the first two words (with the space removed)
* i.e. 'Red Hat' becomes 'redhat' and findOsImage uses the bundled redhat.svg