### PR TITLE
.gitignore: Ignore some more commonly used files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ html/plugins/*
 !html/plugins/Test/
 includes/custom/*
 junk
-librenms-agent
 nbproject
 patches
 !/lib/yaml

--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,21 @@ __pycache__
 *.pyc
 *.swp
 Thumbs.db
+arch*
+backup
+bin
+certificate
 config.php
+etc
+httpd.conf*
 html/css/custom/*
 html/images/custom/*
+html/custom/*
 html/plugins/*
 !html/plugins/Test/
 includes/custom/*
 junk
+librenms-agent
 nbproject
 patches
 !/lib/yaml
@@ -36,6 +44,8 @@ _ide_helper.php
 _ide_helper_models.php
 resources/views/menu/custom.blade.php
 resources/js/vue-i18n-locales.generated.js
+sbin
+tmp
 
 # Docs #
 ########


### PR DESCRIPTION
Add the following ignores to the repo root's .gitignore ... 

+arch*
+backup
+bin
+certificate
+etc
+httpd.conf*
+html/custom/*
+sbin
+tmp