### PR TITLE
Format the Device Module Naming like in global Settings

### DIFF
--- a/includes/html/pages/device/edit/modules.inc.php
+++ b/includes/html/pages/device/edit/modules.inc.php
@@ -21,12 +21,19 @@
 
 use LibreNMS\Config;
 
+$language = \config('app.locale');
+$settings = (include Config::get('install_dir').'/resources/lang/'.$language.'/settings.php')['settings'];
+
+$poller_module_names = $settings['poller_modules'];
+$discovery_module_names = $settings['discovery_modules'];
+
 $poller_modules = Config::get('poller_modules');
 ksort($poller_modules);
 foreach ($poller_modules as $module => $module_status) {
+    $module_name = $poller_module_names[$module]['description'] ?: $module;
     echo('
       <tr>
-        <td><strong>'.$module.'</strong></td>
+        <td><strong>'.$module_name.'</strong></td>
         <td>
         ');
 
@@ -107,10 +114,11 @@ foreach ($poller_modules as $module => $module_status) {
 $discovery_modules = Config::get('discovery_modules');
 ksort($discovery_modules);
 foreach ($discovery_modules as $module => $module_status) {
+    $module_name = $discovery_module_names[$module]['description'] ?: $module;
     echo('
       <tr>
         <td>
-          <strong>'.$module.'</strong>
+          <strong>'.$module_name.'</strong>
         </td>
         <td>
         ');


### PR DESCRIPTION
Refresh the naming on Device specific Poller/Discovery Module Settings,
Naming is equal to global Setting Module Control (has the same Source)

before:

![image](https://user-images.githubusercontent.com/7978916/72947577-b7634300-3d82-11ea-8aad-48ca0207e717.png)

after (like in global Settings):
![image](https://user-images.githubusercontent.com/7978916/72947589-c5b15f00-3d82-11ea-829c-7cc7b7190b75.png)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
