### PR TITLE
Fix FatalThrowableError in forgetAttrib()

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -401,8 +401,11 @@ class Device extends BaseModel
         });
 
         if ($attrib_index !== false) {
+            $deleted=(bool)$this->attribs->get($attrib_index)->delete();
+            // only forget the attrib_index after delete, otherwise delete() will fail fatally with:
+            // Symfony\\Component\\Debug\Exception\\FatalThrowableError(code: 0):  Call to a member function delete() on null
             $this->attribs->forget($attrib_index);
-            return (bool)$this->attribs->get($attrib_index)->delete();
+            return $deleted;
         }
 
         return false;


### PR DESCRIPTION
* From a device's SNMP edit form, when attempting to remove previously set Max Repeaters or Max OIDs values, a fatal error was being thrown.

* Fix Call to a member function delete() on null {"userId":2,"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to a member function delete() on null at /opt/librenms/app/Models/Device.php:406)

* This patch corrects the ability to use the device's SNMP edit form to remove device attributes that had been previously set.  The values of Max Repeaters or MaxOIDs can now be deleted from the database.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
