### PR TITLE
Added fix for escaping underscore while using Markdown

### DIFF
--- a/LibreNMS/Alert/Transport/Telegram.php
+++ b/LibreNMS/Alert/Transport/Telegram.php
@@ -44,6 +44,9 @@ class Telegram extends Transport
         $format="";
         if ($data['format']) {
                 $format="&parse_mode=" . $data['format'];
+                if ($data['format'] == 'Markdown') {
+                    $text = urlencode(preg_replace("/([a-z0-9]+)_([a-z0-9]+)/", "$1\_$2", $obj['msg']));
+                }
         }
         curl_setopt($curl, CURLOPT_URL, ("https://api.telegram.org/bot{$data['token']}/sendMessage?chat_id={$data['chat_id']}&text=$text{$format}"));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);

--- a/LibreNMS/Alert/Transport/Telegram.php
+++ b/LibreNMS/Alert/Transport/Telegram.php
@@ -44,9 +44,9 @@ class Telegram extends Transport
         $format="";
         if ($data['format']) {
                 $format="&parse_mode=" . $data['format'];
-                if ($data['format'] == 'Markdown') {
-                    $text = urlencode(preg_replace("/([a-z0-9]+)_([a-z0-9]+)/", "$1\_$2", $obj['msg']));
-                }
+            if ($data['format'] == 'Markdown') {
+                $text = urlencode(preg_replace("/([a-z0-9]+)_([a-z0-9]+)/", "$1\_$2", $obj['msg']));
+            }
         }
         curl_setopt($curl, CURLOPT_URL, ("https://api.telegram.org/bot{$data['token']}/sendMessage?chat_id={$data['chat_id']}&text=$text{$format}"));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
When Markdown is being used for Telegram and there is an _ in the field name you will sometimes get a 400 error because there are unbalanced _ in the text, this fix will escape all _ that have text/numbers directly in front/after.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
