### PR TITLE
Poller Group Management - Device Count

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -52,6 +52,7 @@ class DeviceController extends TableController
             'ignore' => 'nullable|in:0,1',
             'disable_notify' => 'nullable|in:0,1',
             'group' => 'nullable|int',
+            'poller_group' => 'nullable|int',
         ];
     }
 
@@ -86,6 +87,10 @@ class DeviceController extends TableController
             $query->whereHas('groups', function ($query) use ($group) {
                 $query->where('id', $group);
             });
+        }
+
+        if ($request->get('poller_group') !== null) {
+            $query->where('poller_group', $request->get('poller_group'));
         }
 
         return $query;

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -186,6 +186,10 @@ if ($format == "graph") {
     if (!empty($vars['location'])) {
         $location_filter = $vars['location'];
     }
+    if (isset($vars['poller_group'])) {
+        $where .= " AND `poller_group`= ?";
+        $sql_param[] = $vars['poller_group'];
+    }
     if (!empty($vars['group'])) {
         $where .= " AND ( ";
         foreach (DB::table('device_group_device')->where('device_group_id', $vars['group'])->pluck('device_id') as $dev) {
@@ -350,6 +354,7 @@ if ($format == "graph") {
                     ignore: '<?php echo mres($vars['ignore']); ?>',
                     disable_notify: '<?php echo mres($vars['disable_notify']); ?>',
                     group: '<?php echo mres($vars['group']); ?>',
+                    poller_group: '<?php echo mres($vars['poller_group']); ?>',
                 };
             },
             url: "<?php echo url('/ajax/table/device') ?>"

--- a/includes/html/pages/pollers/groups.inc.php
+++ b/includes/html/pages/pollers/groups.inc.php
@@ -25,20 +25,32 @@ require_once 'includes/html/modal/poller_groups.inc.php';
         <tr>
             <th>ID</th>
             <th>Group Name</th>
+            <th>Devices</th>
             <th>Description</th>
             <th>Action</th>
         </tr>
-
 <?php
-$query = 'SELECT * FROM `poller_groups`';
 
-foreach (dbFetchRows($query) as $group) {
+$default_group = ['id' => 0,
+                  'group_name' =>'(default poller group)',
+                  'descr' => 'Devices which are not assigned to a poller group will be handled by this poller'];
+
+$group_list = dbFetchRows('SELECT * FROM `poller_groups`');
+array_unshift($group_list, $default_group);
+
+foreach ($group_list as $group) {
+    $group_device_count = dbFetchCell('SELECT COUNT(*) FROM devices WHERE `poller_group`=?', $group['id']);
     echo '
         <tr id="'.$group['id'].'">
             <td>'.$group['id'].'</td>
             <td>'.$group['group_name'].'</td>
-            <td>'.$group['descr'].'</td>
-            <td><button type="button" class="btn btn-success btn-xs" id="'.$group['id'].'" data-group_id="'.$group['id'].'" data-toggle="modal" data-target="#poller-groups">Edit</button> <button type="button" class="btn btn-danger btn-xs" id="'.$group['id'].'" data-group_id="'.$group['id'].'" data-toggle="modal" data-target="#confirm-delete">Delete</button></td>
+            <td><a href="/devices/poller_group='.$group['id'].'")">'.$group_device_count.'</a></td>
+            <td>'.$group['descr'].'</td>';
+    echo '<td>';
+    if ($group['id']) {
+        echo '<button type="button" class="btn btn-success btn-xs" id="'.$group['id'].'" data-group_id="'.$group['id'].'" data-toggle="modal" data-target="#poller-groups">Edit</button> <button type="button" class="btn btn-danger btn-xs" id="'.$group['id'].'" data-group_id="'.$group['id'].'" data-toggle="modal" data-target="#confirm-delete">Delete</button>';
+    }
+    echo '</td>
         </tr>
 ';
 }


### PR DESCRIPTION
Poller Group Management enhanced.
Show's count of assigned devices per Poller Group, also default Poller Group.
Device Count is clickable and show's assigned Devices filtered by poller group, like in Device Group Management.

![image](https://user-images.githubusercontent.com/7978916/73140585-da3f7100-407a-11ea-9b6e-5c83b4aad2a7.png)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
