### PR TITLE
Cisco Spark Do not strip tags when markdown is in use.

### DIFF
--- a/LibreNMS/Alert/Transport/Ciscospark.php
+++ b/LibreNMS/Alert/Transport/Ciscospark.php
@@ -29,14 +29,28 @@ class Ciscospark extends Transport
 
     public function contactCiscospark($obj, $room_id, $token)
     {
-        $text = strip_tags($obj['msg']);
+        $text = null;
         $data = array (
             'roomId' => $room_id
         );
 
         $akey = 'text';
         if ($this->config['use-markdown'] === 'on') {
+            $lines = explode("\n", $obj['msg']);
+            $mlines = [];
+            /* Remove blank lines as they create weird markdown
+             * behaviors.
+             */
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line != '') {
+                    array_push($mlines, $line);
+                }
+            }
+            $text = implode("\n", $mlines);
             $akey = 'markdown';
+        } else {
+            $text = strip_tags($obj['msg']);
         }
         $data[$akey] = $text;
 


### PR DESCRIPTION
Markdown supports limited HTML tags, which can help enrich messages.
Additionally, eliminate extra whitespace when markdown is used as that
will have weird output effects.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
