### PR TITLE
alert.inc.php: Fix missing ACK & Notes modals on device alert page

### DIFF
--- a/includes/html/pages/device/alert.inc.php
+++ b/includes/html/pages/device/alert.inc.php
@@ -47,6 +47,8 @@ echo '<div style="width:99%;margin:0 auto;">';
 
 switch ($vars['section']) {
     case 'alerts':
+        include 'includes/html/modal/alert_notes.inc.php';
+        include 'includes/html/modal/alert_ack.inc.php';
         include 'includes/html/common/alerts.inc.php';
         echo implode('', $common_output);
         break;


### PR DESCRIPTION
* BUG: From a device page, click Alerts and attempt to ACK or add a Note.  Nothing happens because the modals are not on the page.
* This patch corrects pages/device/alert.inc.php to include both modal/alert_notes.inc.php and modal/alert_ack.inc.php

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
