### PR TITLE
Remove redundant data from Alert fallback detail

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -991,11 +991,16 @@ function alert_details($details)
         }
 
         if ($fallback === true) {
+            $fault_detail_data = [];
             foreach ($tmp_alerts as $k => $v) {
-                if (!empty($v) && $k != 'device_id' && (stristr($k, 'id') || stristr($k, 'desc') || stristr($k, 'msg')) && substr_count($k, '_') <= 1) {
-                    $fault_detail .= "$k => '$v', ";
+                if (in_array($k, ['device_id', 'sysObjectID', 'sysDescr', 'location_id'])) {
+                    continue;
+                }
+                if (!empty($v) && (stristr($k, 'id') || stristr($k, 'desc') || stristr($k, 'msg')) && substr_count($k, '_') <= 1) {
+                    $fault_detail_data[] = "$k => '$v'";
                 }
             }
+            $fault_detail .= count($fault_detail_data) ? implode('<br>&nbsp;&nbsp;&nbsp', $fault_detail_data) : '';
 
             $fault_detail = rtrim($fault_detail, ', ');
         }


### PR DESCRIPTION
fallback Alerts details looks like this:
`#1: sysObjectID => '.1.3.6.1.4.1.8072.3.2.10', sysDescr => 'Linux testsystem 4.19.0-6-amd64 #1 SMP Debian 4.19.67-2+deb10u2 (2019-11-11) x86_64', location_id => '1', app_id => '31'`
This is a detail view associated to the device where the alert happens.

So following data are redundand (often also confusing) and will be not displayed in detail view anymore, similar to other alert detail view types.
- sysObjectID
- sysDescr
- location_id


#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
