### PR TITLE
mock.snmp.inc.php: Fix snmptranslate exception

### DIFF
--- a/tests/mocks/mock.snmp.inc.php
+++ b/tests/mocks/mock.snmp.inc.php
@@ -138,7 +138,7 @@ function snmp_translate_number($oid, $mib = null, $mibdir = null)
         return ltrim($oid, '.');
     }
 
-    $cmd = "snmptranslate -IR -On $oid";
+    $cmd = "snmptranslate -IR -On '$oid'";
     $cmd .= ' -M ' . (isset($mibdir) ? Config::get('mib_dir') . ":" . Config::get('mib_dir') . "/$mibdir" : Config::get('mib_dir'));
     if (isset($mib) && $mib) {
         $cmd .= " -m $mib";


### PR DESCRIPTION
* Running ./scripts/pre-commit.php -p -u [-m applications] fails all tests that have 1.3.6.1.4.1.8072 with messages similar to ...
```
Exception: Could not translate oid: NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."distro"
Tried: snmptranslate -IR -On NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."distro" -M /opt/librenms/mibs
```
* OIDs with double quotes must be single quoted.  All OID translations work with single quotes, regardless.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
