### PR TITLE
Fixed missing PoE graphs for Cisco devices

### DIFF
--- a/includes/polling/ports.inc.php
+++ b/includes/polling/ports.inc.php
@@ -352,22 +352,15 @@ if (Config::get('enable_ports_poe')) {
 
     if ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
         echo 'cpeExtPsePortEntry';
-        $port_stats_poe = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', array(), 'CISCO-POWER-ETHERNET-EXT-MIB');
-        $port_ent_to_if = snmpwalk_cache_oid($device, 'portIfIndex', array(), 'CISCO-STACK-MIB');
+        $port_stats_poe = snmpwalk_cache_oid($device, 'cpeExtPsePortEntry', [], 'CISCO-POWER-ETHERNET-EXT-MIB');
+        $port_ent_to_if = snmpwalk_cache_oid($device, 'portIfIndex', [], 'CISCO-STACK-MIB');
 
         if (!$port_ent_to_if) {
-            $ifTable_ifDescr = snmpwalk_cache_oid($device,
-                                                 'ifDescr',
-                                                 array(),
-                                                 'IF-MIB');
-            $port_ent_to_if = array();
+            $ifTable_ifDescr = snmpwalk_cache_oid($device, 'ifDescr', [], 'IF-MIB');
+            $port_ent_to_if = [];
             foreach ($ifTable_ifDescr as $if_index => $if_descr) {
-                if (preg_match('/^[[:alpha:]]+ethernet([0-9\/.]+)$/i',
-                               $if_descr['ifDescr'],
-                               $matches)) {
-                    $port_ent_to_if[str_replace('/', '.', $matches[1])] = array(
-                        'portIfIndex' => $if_index
-                    );
+                if (preg_match('/^[[:alpha:]]+ethernet([0-9\/.]+)$/i', $if_descr['ifDescr'], $matches)) {
+                    $port_ent_to_if[str_replace('/', '.', $matches[1])] = ['portIfIndex' => $if_index];
                 }
             }
         }


### PR DESCRIPTION
Fixed missing PoE graphs for Cisco devices where portIfIndex can't retrieved from CISCO-STACK-MIB.

Various PoE capable Cisco switches, like the Catalyst 4500 series, didn't show PoE graphs although enable_ports_poe=1 was set. On these devices, the poller isn't able to retrieve the interface name<->interface index table from CISCO-STACK-MIB, i.e. portIfIndex.
This mapping is also available in IF-MIB. The added code will walk the ifTable from this MIB to build the interface entry to interface index array.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
