### PR TITLE
Show Alert Detail for Applications

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -993,8 +993,14 @@ function alert_details($details)
         }
 
         if (in_array('app_id', array_keys($tmp_alerts))) {
-            $metric = str_replace("_", " ", $tmp_alerts['metric']);
-            $fault_detail .= $metric ." => ". $tmp_alerts['value'];
+            $fault_detail .= "<a href='" . generate_url(array('page' => 'device',
+                                                              'device' => $tmp_alerts['device_id'],
+                                                              'tab' => 'apps',
+                                                              'app' => $tmp_alerts['app_type'])) . "'>";
+            $fault_detail .= $tmp_alerts['metric'];
+            $fault_detail .= "</a>";
+
+            $fault_detail .= " => ". $tmp_alerts['value'];
             $fallback = false;
         }
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -969,6 +969,7 @@ function alert_details($details)
             $fault_detail .= generate_sensor_link($tmp_alerts, $tmp_alerts['name']) . ';&nbsp; <br>' . $details;
             $fallback = false;
         }
+
         if ($tmp_alerts['bgpPeer_id']) {
             // If we have a bgpPeer_id, we format the data accordingly
             $fault_detail .= "BGP peer <a href='" .
@@ -981,12 +982,19 @@ function alert_details($details)
             $fault_detail .= ", State " . $tmp_alerts['bgpPeerState'];
             $fallback = false;
         }
+
         if ($tmp_alerts['type'] && $tmp_alerts['label']) {
             if ($tmp_alerts['error'] == "") {
                 $fault_detail .= ' ' . $tmp_alerts['type'] . ' - ' . $tmp_alerts['label'] . ';&nbsp;';
             } else {
                 $fault_detail .= ' ' . $tmp_alerts['type'] . ' - ' . $tmp_alerts['label'] . ' - ' . $tmp_alerts['error'] . ';&nbsp;';
             }
+            $fallback = false;
+        }
+
+        if (in_array('app_id', array_keys($tmp_alerts))) {
+            $metric = str_replace("_", " ", $tmp_alerts['metric']);
+            $fault_detail .= $metric ." => ". $tmp_alerts['value'];
             $fallback = false;
         }
 


### PR DESCRIPTION
shows `metric => value` for every Alert match for all Applications,
instead of unusable `'app_id' => app_id`

Example for OS Update:
before:
`#1: app_id => '45'`
after:
`#1: packages => 1`

other Example for Smart Temperature:
before: 
```
#1: app_id => '44'
#2: app_id => '44'
#3: app_id => '44'
```
after: 
```
#1: 1917E1FD8BFB id194 => 45
#2: 2EKZLG5X id194 => 39
#3: JEJY8SWN id194 => 39
```

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
