### PR TITLE
Mark Devices in Maintenance Mode

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -32,6 +32,7 @@ use LibreNMS\Config;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;
 use LibreNMS\Util\Time;
+use LibreNMS\Alert\AlertUtil;
 
 class DeviceController extends TableController
 {
@@ -127,6 +128,7 @@ class DeviceController extends TableController
         return [
             'extra' => $this->getLabel($device),
             'status' => $this->getStatus($device),
+            'maintenance' => AlertUtil::isMaintenance($device->device_id),
             'icon' => '<img src="' . asset($device->icon) . '" title="' . pathinfo($device->icon, PATHINFO_FILENAME) . '">',
             'hostname' => $this->getHostname($device),
             'metrics' => $this->getMetrics($device),

--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -106,7 +106,7 @@ class AvailabilityMapController extends WidgetController
 
         // process status
         $uptime_warn = Config::get('uptime_warning', 84600);
-        $totals = ['warn' => 0, 'up' => 0, 'down' => 0, 'ignored' => 0, 'disabled' => 0];
+        $totals = ['warn' => 0, 'up' => 0, 'down' => 0, 'maintenance' => 0, 'ignored' => 0, 'disabled' => 0];
         foreach ($devices as $device) {
             if ($device->disabled) {
                 $totals['disabled']++;
@@ -130,6 +130,11 @@ class AvailabilityMapController extends WidgetController
                 $totals['down']++;
                 $device->stateName = 'down';
                 $device->labelClass = 'label-danger';
+            }
+
+            if ($device->isUnderMaintenance()) {
+                $device->labelClass = 'label-default';
+                $totals['maintenance']++;
             }
         }
         return [$devices, $totals];

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -391,9 +391,9 @@ if (defined('SHOW_SETTINGS')) {
                 <span class="label label-success label-font-border label-border">up: '.$host_up_count.'</span>
                 <span class="label label-warning label-font-border label-border">warn: '.$host_warn_count.'</span>
                 <span class="label label-danger label-font-border label-border">down: '.$host_down_count.'</span>';
-   if ($host_maintenance_count) {
-        $temp_header[] = '<span class="label label-default label-font-border label-border">maintenance: '.$host_maintenance_count.'</span>';
-   }
+        if ($host_maintenance_count) {
+            $temp_header[] = '<span class="label label-default label-font-border label-border">maintenance: '.$host_maintenance_count.'</span>';
+        }
         $temp_header[] = $disabled_ignored_header.'
             </div>';
     }

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -12,6 +12,7 @@
  * the source code distribution for details.
  */
 
+use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Config;
 
 $mode = Session::get('map_view', 0);
@@ -146,6 +147,7 @@ if (defined('SHOW_SETTINGS')) {
     $host_up_count = 0;
     $host_warn_count = 0;
     $host_down_count = 0;
+    $host_maintenance_count = 0;
     $host_disable_notify_count = 0;
     $host_disabled_count = 0;
     $service_up_count = 0;
@@ -221,6 +223,12 @@ if (defined('SHOW_SETTINGS')) {
                 $deviceLabelOld = 'availability-map-oldview-box-down';
                 $host_down_count++;
             }
+
+            if (AlertUtil::isMaintenance($device['device_id'])) {
+                $deviceLabel = 'label-default';
+                $host_maintenance_count++;
+            }
+
             $device_system_name = format_hostname($device);
 
             if (Config::get('webui.availability_map_compact') == 0) {
@@ -382,8 +390,11 @@ if (defined('SHOW_SETTINGS')) {
                 <span>Total hosts</span>
                 <span class="label label-success label-font-border label-border">up: '.$host_up_count.'</span>
                 <span class="label label-warning label-font-border label-border">warn: '.$host_warn_count.'</span>
-                <span class="label label-danger label-font-border label-border">down: '.$host_down_count.'</span>
-                '.$disabled_ignored_header.'
+                <span class="label label-danger label-font-border label-border">down: '.$host_down_count.'</span>';
+   if ($host_maintenance_count) {
+        $temp_header[] = '<span class="label label-default label-font-border label-border">maintenance: '.$host_maintenance_count.'</span>';
+   }
+        $temp_header[] = $disabled_ignored_header.'
             </div>';
     }
 

--- a/includes/html/device-header.inc.php
+++ b/includes/html/device-header.inc.php
@@ -1,5 +1,6 @@
 <?php
 
+use LibreNMS\Alert\AlertUtil;
 use LibreNMS\Config;
 
 echo getLogoTag($device, 'device-icon-header pull-left') .'
@@ -9,6 +10,10 @@ $host_id = get_vm_parent_id($device);
 if ($host_id > 0) {
     echo '
 <a href="'.generate_url(array('page'=>'device','device'=>$host_id)).'"><i class="fa fa-server fa-fw fa-lg"></i></a>';
+}
+
+if (AlertUtil::isMaintenance($device['device_id'])) {
+    echo ('<span title="Scheduled Maintenance" class="glyphicon glyphicon-wrench"></span>');
 }
 
 echo '

--- a/includes/html/pages/devices.inc.php
+++ b/includes/html/pages/devices.inc.php
@@ -13,6 +13,8 @@
  * @author     LibreNMS Contributors
 */
 
+use LibreNMS\Alert\AlertUtil;
+
 $pagetitle[] = "Devices";
 
 if (!isset($vars['format'])) {
@@ -298,6 +300,7 @@ if ($format == "graph") {
                 <tr>
                     <th data-column-id="status" data-formatter="status" data-width="7px" data-searchable="false">&nbsp;</th>
                     <th data-column-id="icon" data-width="70px" data-searchable="false" data-formatter="icon" data-visible="<?php echo $detailed  ? 'true' : 'false'; ?>">Vendor</th>
+                    <th data-column-id="maintenance" data-width="5px" data-searchable="false" data-formatter="maintenance" data-visible="<?php echo $detailed  ? 'true' : 'false'; ?>"></th>
                     <th data-column-id="hostname" data-order="asc" <?php echo $detailed ? 'data-formatter="device"' : ''; ?>>Device</th>
                     <th data-column-id="metrics" data-width="<?php echo $detailed ? '100px' : '150px'; ?>" data-sortable="false" data-searchable="false" data-visible="<?php echo $detailed  ? 'true' : 'false'; ?>">Metrics</th>
                     <th data-column-id="hardware">Platform</th>
@@ -321,6 +324,12 @@ if ($format == "graph") {
                 },
                 "icon": function (column, row) {
                     return "<span class=\"device-table-icon\">" + row.icon + "</span>";
+                },
+                "maintenance": function (column, row) {
+                    if (row.maintenance) {
+                        return "<span title=\"Scheduled Maintenance\" class=\"glyphicon glyphicon-wrench\"></span>";
+                    }
+                    return '';
                 },
                 "device": function (column, row) {
                     return "<span>" + row.hostname + "</span>";

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -8,6 +8,9 @@
     <a href="{{ url('devices/state=up') }}"><span class="label label-success label-font-border label-border">@lang('up'): {{ $device_totals['up'] }}</span></a>
     <span class="label label-warning label-font-border label-border">@lang('warn'): {{ $device_totals['warn'] }}</span>
     <a href="{{ url('devices/state=down') }}"><span class="label label-danger label-font-border label-border">@lang('down'): {{ $device_totals['down'] }}</span></a>
+    @if($device_totals['maintenance'])
+    <span class="label label-default label-font-border label-border">@lang('maintenance'): {{ $device_totals['maintenance'] }}</span>
+    @endif
 </div>
 @endif
 


### PR DESCRIPTION
This PR marks Devices, which are in Maintenance Mode

Dashboard - Alert Widget (Colour Overwrite and additional Counter):
![image](https://user-images.githubusercontent.com/7978916/73601379-b25f7a00-4560-11ea-89b7-0f0671f865eb.png)

Map - Availability Map (Colour Overwrite and additional Counter):
![image](https://user-images.githubusercontent.com/7978916/73601389-e044be80-4560-11ea-851c-5b9f8dbeb1b8.png)

Devices - All Devices (additional Icon):
![image](https://user-images.githubusercontent.com/7978916/73601398-20a43c80-4561-11ea-9c74-c9f06792e840.png)

Device View (additional Icon):
![image](https://user-images.githubusercontent.com/7978916/73601420-97d9d080-4561-11ea-9599-da7590a4a410.png)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
