### PR TITLE
Remove also Associations by deleting Scheduled Maintenance

### DIFF
--- a/includes/html/forms/schedule-maintenance.inc.php
+++ b/includes/html/forms/schedule-maintenance.inc.php
@@ -199,6 +199,7 @@ if ($sub_type == 'new-maintenance') {
     $schedule_id = mres($_POST['del_schedule_id']);
     dbDelete('alert_schedule_items', '`schedule_id`=?', array($schedule_id));
     dbDelete('alert_schedule', '`schedule_id`=?', array($schedule_id));
+    dbDelete('alert_schedulables', '`schedule_id`=?', array($schedule_id));
     $status   = 'ok';
     $message  = 'Maintenance schedule has been removed';
     $response = array(


### PR DESCRIPTION
On deleting a scheduled maintenance table `alert_schedulables` kept untouched.
So rows in which Devices, Groups, Locations, where associated to schedulede maintenance will stay as data garbage.

@Reviewer A little confused about this line:
`dbDelete('alert_schedule_items', '`schedule_id`=?', array($schedule_id));`
Because cannot find table `alert_schedule_items`. Is it absolete/old code?

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
