### PR TITLE
MPLS Route discovery - Wrong variable assignation order

### DIFF
--- a/includes/discovery/route.inc.php
+++ b/includes/discovery/route.inc.php
@@ -258,9 +258,9 @@ if ($mpls_skip != 1) {
                         $entry['inetCidrRouteNextHop'] = normalize_snmp_ip_address($inetCidrRouteNextHop);
                         $entry['context_name'] = $vpnId;
                         $entry['device_id'] = $device['device_id'];
+                        $entry['inetCidrRouteIfIndex'] = $entry['mplsL3VpnVrfRteInetCidrIfIndex'];
                         $entry['port_id'] = Device::find($device['device_id'])->ports()->where('ifIndex', '=', $entry['inetCidrRouteIfIndex'])->first()->port_id;
                         $entry['updated_at'] = $update_timestamp;
-                        $entry['inetCidrRouteIfIndex'] = $entry['mplsL3VpnVrfRteInetCidrIfIndex'];
                         $entry['inetCidrRouteType'] = $entry['mplsL3VpnVrfRteInetCidrType'];
                         $entry['inetCidrRouteProto'] = $entry['mplsL3VpnVrfRteInetCidrProto'];
                         $entry['inetCidrRouteMetric1'] = $entry['mplsL3VpnVrfRteInetCidrMetric1'];


### PR DESCRIPTION
Interfaces are not discovered for MPLS routes because of wrong order in the commands (read before variable being initilized)
It results in NextHop Port_ID not being defined for the route in DB, and in fine, the NextHop interface link not being displayed in the WebUI. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
