### PR TITLE
Show when a device was added and last discovered

### DIFF
--- a/database/migrations/2020_02_05_093457_add_inserted_to_devices.php
+++ b/database/migrations/2020_02_05_093457_add_inserted_to_devices.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddInsertedToDevices extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            // add inserted column after device id with a default of current_timestamp
+            $table->timestamp('inserted')->default(DB::raw('CURRENT_TIMESTAMP'))->after('device_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            // revert add inserted column after device id with a default of current_timestamp
+            $table->dropColumn('inserted');
+        });
+    }
+}

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -23,9 +23,6 @@ echo '</div><div class="panel-body">';
 echo '<script src="js/leaflet.js"></script>';
 echo '<script src="js/L.Control.Locate.min.js"></script>';
 
-$uptime = (Time::formatInterval($device['status'] ? $device['uptime'] : time() - strtotime($device['last_polled'])));
-$uptime_text = ($device['status'] ? 'Uptime' : 'Downtime');
-
 if ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
     formatCiscoHardware($device);
 }
@@ -103,11 +100,23 @@ if ($device['sysContact']) {
       </div>';
 }
 
+if (!empty($device['inserted'])) {
+    $inserted_text = "Device Added";
+    $inserted = (Time::formatInterval(time() - strtotime($device['inserted'])) . " ago");
+    echo "<div class='row'><div class='col-sm-4'>$inserted_text</div><div class='col-sm-8' title='$inserted_text on " . $device['inserted'] . "'>$inserted</div></div>";
+}
+
+if (!empty($device['last_discovered'])) {
+    $last_discovered_text = "Last Discovered";
+    $last_discovered = (empty($device['last_discovered']) ? "Never" : Time::formatInterval(time() - strtotime($device['last_discovered'])) . " ago");
+    echo "<div class='row'><div class='col-sm-4'>$last_discovered_text</div><div class='col-sm-8' title='$last_discovered_text at " . $device['last_discovered'] . "'>$last_discovered</div></div>";
+}
+
+$uptime = (Time::formatInterval($device['status'] ? $device['uptime'] : time() - strtotime($device['last_polled'])));
+$uptime_text = ($device['status'] ? 'Uptime' : 'Downtime');
+
 if ($uptime) {
-    echo "<div class='row'>
-        <div class='col-sm-4'>$uptime_text</div>
-        <div class='col-sm-8'>$uptime</div>
-      </div>";
+    echo "<div class='row'><div class='col-sm-4'>$uptime_text</div><div class='col-sm-8'>$uptime</div></div>";
 }
 
 if ($device['location_id']) {

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -117,6 +117,10 @@
     "name": "Interface Errors Rate greater than 100"
   },
   {
+    "rule": "devices.inserted >= `macros.past_60m`",
+    "name": "Device added within the last 60 minutes"
+  },
+  {
     "rule": "eventlog.type = \"discovery\" && eventlog.message ~ \"@autodiscovered@\" && eventlog.datetime >= `macros.past_60m`",
     "name": "Device discovered within the last 60 minutes"
   },

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -451,6 +451,7 @@ dbSchema:
 devices:
   Columns:
     - { Field: device_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
+    - { Field: inserted, Type: timestamp, 'Null': false, Extra: '', Default: CURRENT_TIMESTAMP }
     - { Field: hostname, Type: varchar(128), 'Null': false, Extra: '' }
     - { Field: sysName, Type: varchar(128), 'Null': true, Extra: '' }
     - { Field: ip, Type: varbinary(16), 'Null': true, Extra: '' }


### PR DESCRIPTION
* As an admin or a user, I want to know exactly when a device was added and more easily determine the last time it was discovered.
* Add a new column named 'inserted' to the devices table that automatically updates when a new row is added.
* Updated device overview page to show this information.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
