### PR TITLE
Add a space for times like '1 minute'

### DIFF
--- a/LibreNMS/Util/Time.php
+++ b/LibreNMS/Util/Time.php
@@ -70,7 +70,7 @@ class Time
                 } elseif ($diff > 1) {
                     $result .= ' ' . $k;
                 } else {
-                    $result .= substr($k, 0, -1);
+                    $result .= ' ' . substr($k, 0, -1);
                 }
 
                 $interval -= $v * $diff;

--- a/LibreNMS/Util/Time.php
+++ b/LibreNMS/Util/Time.php
@@ -67,9 +67,13 @@ class Time
                 $result .= " $diff";
                 if ($format == 'short') {
                     $result .= substr($k, 0, 1);
-                } elseif ($diff > 1) {
+                }
+
+                if ($format != 'short' && $diff > 1) {
                     $result .= ' ' . $k;
-                } else {
+                }
+
+                if ($format != 'short' && $diff < 2) {
                     $result .= ' ' . substr($k, 0, -1);
                 }
 


### PR DESCRIPTION
* Times like '1 minute' get displayed as '1minute' which is inconsistent with the other times that display with a space after the integer.
* This patch adds a space for short times like '1 minute'

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
