### PR TITLE
Hide devices added for devices that existed before #11104

### DIFF
--- a/database/migrations/2020_02_05_224042_device_inserted_null.php
+++ b/database/migrations/2020_02_05_224042_device_inserted_null.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DeviceInsertedNull extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            // inserted column will not default null to CURRENT_TIMESTAMP
+            \DB::statement("alter table `devices` change `inserted` `inserted` timestamp NULL default CURRENT_TIMESTAMP;");
+            \DB::statement("update `devices` set `inserted`=NULL;"); // set all existing (legacy) rows to null
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            // inserted column will default null to CURRENT_TIMESTAMP
+            \DB::statement("alter table `devices` change `inserted` `inserted` timestamp default CURRENT_TIMESTAMP;");
+            \DB::statement("update `devices` set `inserted`=NULL"); // timestamp all existing (legacy) rows to now()
+        });
+    }
+}

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -100,7 +100,7 @@ if ($device['sysContact']) {
       </div>';
 }
 
-if (!empty($device['inserted'])) {
+if (!empty($device['inserted']) && $device['inserted'] != "0000-00-00 00:00:00") {
     $inserted_text = "Device Added";
     $inserted = (Time::formatInterval(time() - strtotime($device['inserted'])) . " ago");
     echo "<div class='row'><div class='col-sm-4'>$inserted_text</div><div class='col-sm-8' title='$inserted_text on " . $device['inserted'] . "'>$inserted</div></div>";

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -100,7 +100,7 @@ if ($device['sysContact']) {
       </div>';
 }
 
-if (!empty($device['inserted']) && $device['inserted'] != "0000-00-00 00:00:00") {
+if (!empty($device['inserted']) && preg_match("/^0/", $device['inserted']) == 0) {
     $inserted_text = "Device Added";
     $inserted = (Time::formatInterval(time() - strtotime($device['inserted'])) . " ago");
     echo "<div class='row'><div class='col-sm-4'>$inserted_text</div><div class='col-sm-8' title='$inserted_text on " . $device['inserted'] . "'>$inserted</div></div>";

--- a/misc/db_schema.yaml
+++ b/misc/db_schema.yaml
@@ -451,7 +451,7 @@ dbSchema:
 devices:
   Columns:
     - { Field: device_id, Type: 'int(10) unsigned', 'Null': false, Extra: auto_increment }
-    - { Field: inserted, Type: timestamp, 'Null': false, Extra: '', Default: CURRENT_TIMESTAMP }
+    - { Field: inserted, Type: timestamp, 'Null': true, Extra: '', Default: CURRENT_TIMESTAMP }
     - { Field: hostname, Type: varchar(128), 'Null': false, Extra: '' }
     - { Field: sysName, Type: varchar(128), 'Null': true, Extra: '' }
     - { Field: ip, Type: varbinary(16), 'Null': true, Extra: '' }


### PR DESCRIPTION
* Prior to https://github.com/librenms/librenms/pull/11104 it was impossible to know exactly when a device was added.
* This patch contains a migration for the devices.inserted column to allow NULL values and resets all preexisting rows to NULL, so there is not a false timestamp.
* Additionally, the Device Overview page was modified to _not_ display the Device Added timestamp for devices with a null (or /^0/) value for devices.inserted.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
