### PR TITLE
Add alert_rule filtering to API ROUTE "list_alerts"

### DIFF
--- a/doc/API/Alerts.md
+++ b/doc/API/Alerts.md
@@ -107,6 +107,7 @@ Input:
 
 - state: Filter the alerts by state, 0 = ok, 1 = alert, 2 = ack
 - severity: Filter the alerts by severity. Valid values are `ok`, `warning`, `critical`.
+- alert_rule: Filter alerts by alert rule ID.
 - order: How to order the output, default is by timestamp
   (descending). Can be appended by DESC or ASC to change the order.
 
@@ -123,6 +124,11 @@ curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/alerts?seve
 ```curl
 curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/alerts?order=timestamp%20ASC
 ```
+
+```curl
+curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/alerts?alert_rule=49
+```
+
 
 Output:
 

--- a/doc/API/Alerts.md
+++ b/doc/API/Alerts.md
@@ -129,7 +129,6 @@ curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/alerts?orde
 curl -H 'X-Auth-Token: YOURAPITOKENHERE' https://librenms.org/api/v0/alerts?alert_rule=49
 ```
 
-
 Output:
 
 ```json

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -988,9 +988,8 @@ function list_alerts(\Illuminate\Http\Request $request)
     }
 
     $order = 'timestamp desc';
-
     
-    $alert_rule = $_GET['alert_rule'];
+    $alert_rule= $request->get('alert_rule');
     if (isset($alert_rule)) {
         if (is_numeric($alert_rule)) {
             $param[] = $alert_rule;

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1000,6 +1000,14 @@ function list_alerts(\Illuminate\Http\Request $request)
     }
     $sql .= ' ORDER BY A.'.$order;
 
+    $alert_rule = $_GET['alert_rule'];
+    if (isset($alert_rule)) {
+        if (is_numeric($alert_rule)) {
+            $param[] = $alert_rule;
+            $sql .= ' AND `R`.id=?';
+        }
+    }
+
     $alerts = dbFetchRows($sql, $param);
     return api_success($alerts, 'alerts');
 }

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -989,6 +989,15 @@ function list_alerts(\Illuminate\Http\Request $request)
 
     $order = 'timestamp desc';
 
+    
+    $alert_rule = $_GET['alert_rule'];
+    if (isset($alert_rule)) {
+        if (is_numeric($alert_rule)) {
+            $param[] = $alert_rule;
+            $sql .= ' AND `R`.id=?';
+        }
+    }
+    
     if ($request->has('order')) {
         list($sort_column, $sort_order) = explode(' ', $request->get('order'), 2);
         if (($res = validate_column_list($sort_column, 'alerts')) !== true) {
@@ -999,14 +1008,6 @@ function list_alerts(\Illuminate\Http\Request $request)
         }
     }
     $sql .= ' ORDER BY A.'.$order;
-
-    $alert_rule = $_GET['alert_rule'];
-    if (isset($alert_rule)) {
-        if (is_numeric($alert_rule)) {
-            $param[] = $alert_rule;
-            $sql .= ' AND `R`.id=?';
-        }
-    }
 
     $alerts = dbFetchRows($sql, $param);
     return api_success($alerts, 'alerts');

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -989,7 +989,7 @@ function list_alerts(\Illuminate\Http\Request $request)
 
     $order = 'timestamp desc';
     
-    $alert_rule= $request->get('alert_rule');
+    $alert_rule = $request->get('alert_rule');
     if (isset($alert_rule)) {
         if (is_numeric($alert_rule)) {
             $param[] = $alert_rule;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

### Description
Add option to filter the current set of active alerts, by specifying the alre rule id on the API call

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
