### PR TITLE
Fix inventory page hostname/sysname and default generate_device_link behaviour

### DIFF
--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -18,7 +18,8 @@ use LibreNMS\Config;
  * Compare $t with the value of $vars[$v], if that exists
  * @param string $v Name of the var to test
  * @param string $t Value to compare $vars[$v] to
- * @return boolean true, if values are the same, false if $vars[$v] is unset or values differ
+ * @return boolean true, if values are the same, false if $vars[$v] 
+ * is unset or values differ
  */
 function var_eq($v, $t)
 {

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -175,9 +175,6 @@ function generate_device_link($device, $text = null, $vars = array(), $start = 0
     }
 
     $class = devclass($device);
-    if (!$text) {
-        $text = format_hostname($device['hostname']);
-    }
 
     $text = format_hostname($device, $text);
 

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -18,7 +18,7 @@ use LibreNMS\Config;
  * Compare $t with the value of $vars[$v], if that exists
  * @param string $v Name of the var to test
  * @param string $t Value to compare $vars[$v] to
- * @return boolean true, if values are the same, false if $vars[$v] 
+ * @return boolean true, if values are the same, false if $vars[$v]
  * is unset or values differ
  */
 function var_eq($v, $t)

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -175,7 +175,7 @@ function generate_device_link($device, $text = null, $vars = array(), $start = 0
 
     $class = devclass($device);
     if (!$text) {
-        $text = $device['hostname'];
+        $text = format_hostname($device['hostname']);
     }
 
     $text = format_hostname($device, $text);

--- a/includes/html/table/inventory.inc.php
+++ b/includes/html/table/inventory.inc.php
@@ -61,11 +61,11 @@ if ($rowCount != -1) {
     $sql .= " LIMIT $limit_low,$limit_high";
 }
 
-$sql = "SELECT `D`.`device_id` AS `device_id`, `D`.`hostname` AS `hostname`,`entPhysicalDescr` AS `description`, `entPhysicalName` AS `name`, `entPhysicalModelName` AS `model`, `entPhysicalSerialNum` AS `serial` $sql";
+$sql = "SELECT `D`.`device_id` AS `device_id`, `D`.`hostname` AS `hostname`, `D`.`sysName` AS `sysName`,`entPhysicalDescr` AS `description`, `entPhysicalName` AS `name`, `entPhysicalModelName` AS `model`, `entPhysicalSerialNum` AS `serial` $sql";
 
 foreach (dbFetchRows($sql, $param) as $invent) {
     $response[] = array(
-                   'hostname'    => generate_device_link($invent, shortHost($invent['hostname'])),
+                   'hostname'    => generate_device_link($invent),
                    'description' => $invent['description'],
                    'name'        => $invent['name'],
                    'model'       => $invent['model'],


### PR DESCRIPTION
Simplification of generate_device_link with the use of format_hostname.
Fix the inventory page to use use it.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
