### PR TITLE
Renovated Alert Rules

### DIFF
--- a/includes/html/forms/delete-alert-rule.inc.php
+++ b/includes/html/forms/delete-alert-rule.inc.php
@@ -22,15 +22,23 @@ if (!is_numeric($vars['alert_id'])) {
     echo 'ERROR: No alert selected';
     exit;
 } else {
+    $alert_name = dbFetchCell('SELECT name FROM alert_rules WHERE id=?', [$vars['alert_id']]);
+    $alert_msg_prefix = 'Alert rule';
+    if ($alert_name) {
+        $alert_msg_prefix .= ' ' . $alert_name;
+    }
+    if (!$alert_name) {
+        $alert_msg_prefix .= ' id ' . $vars['alert_id'];
+    }
     if (dbDelete('alert_rules', '`id` =  ?', array($vars['alert_id']))) {
         dbDelete('alert_device_map', 'rule_id=?', [$vars['alert_id']]);
         dbDelete('alert_group_map', 'rule_id=?', [$vars['alert_id']]);
         dbDelete('alert_transport_map', 'rule_id=?', [$vars['alert_id']]);
         dbDelete('alert_template_map', 'alert_rule_id=?', [$vars['alert_id']]);
-        echo 'Alert rule has been deleted.';
+        echo $alert_msg_prefix . ' has been deleted.';
         exit;
     } else {
-        echo 'ERROR: Alert rule has not been deleted.';
+        echo 'ERROR: ' . $alert_msg_prefix . ' has not been deleted.';
         exit;
     }
 }

--- a/includes/html/modal/delete_alert_rule.inc.php
+++ b/includes/html/modal/delete_alert_rule.inc.php
@@ -61,8 +61,8 @@ $('#alert-rule-removal').click('', function(event) {
             toastr.success(msg);
             $("#confirm-delete").modal('hide');
         },
-        error: function() {
-            toastr.error('The alert rule could not be deleted.');
+        error: function(msg) {
+            toastr.error(msg);
             $("#confirm-delete").modal('hide');
         }
     });

--- a/includes/html/modal/delete_alert_rule.inc.php
+++ b/includes/html/modal/delete_alert_rule.inc.php
@@ -56,16 +56,13 @@ $('#alert-rule-removal').click('', function(event) {
         dataType: "html",
         success: function(msg) {
             if(msg.indexOf("ERROR:") <= -1) {
-                $("#row_"+alert_id).remove();
-                setTimeout(function() {
-                    location.reload(1);
-                }, 1000);
+                $("#rule_id_"+alert_id).remove();
             }
-            $("#message").html('<div class="alert alert-info">'+msg+'</div>');
+            toastr.success(msg);
             $("#confirm-delete").modal('hide');
         },
         error: function() {
-            $("#message").html('<div class="alert alert-info">The alert rule could not be deleted.</div>');
+            toastr.error('The alert rule could not be deleted.');
             $("#confirm-delete").modal('hide');
         }
     });

--- a/includes/html/modal/delete_alert_rule.inc.php
+++ b/includes/html/modal/delete_alert_rule.inc.php
@@ -57,6 +57,9 @@ $('#alert-rule-removal').click('', function(event) {
         success: function(msg) {
             if(msg.indexOf("ERROR:") <= -1) {
                 $("#row_"+alert_id).remove();
+                setTimeout(function() {
+                    location.reload(1);
+                }, 1000);
             }
             $("#message").html('<div class="alert alert-info">'+msg+'</div>');
             $("#confirm-delete").modal('hide');

--- a/includes/html/modal/delete_alert_rule.inc.php
+++ b/includes/html/modal/delete_alert_rule.inc.php
@@ -33,6 +33,7 @@ if (!Auth::user()->hasGlobalAdmin()) {
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                     <button type="submit" class="btn btn-danger danger" id="alert-rule-removal" data-target="alert-rule-removal">Delete</button>
                     <input type="hidden" name="alert_id" id="alert_id" value="">
+                    <input type="hidden" name="alert_name" id="alert_name" value="">
                     <input type="hidden" name="confirm" id="confirm" value="yes">
                 </form>
             </div>
@@ -43,12 +44,16 @@ if (!Auth::user()->hasGlobalAdmin()) {
 <script>
 $('#confirm-delete').on('show.bs.modal', function(event) {
     alert_id = $(event.relatedTarget).data('alert_id');
+    alert_name = $(event.relatedTarget).data('alert_name');
     $("#alert_id").val(alert_id);
+    $("#alert_name").val(alert_name);
+    $( "p" ).first().text( 'If you would like to remove the alert rule named \''+alert_name+'\' then please click Delete.' );
 });
 
 $('#alert-rule-removal').click('', function(event) {
     event.preventDefault();
     var alert_id = $("#alert_id").val();
+    var alert_name = $("#alert_name").val();
     $.ajax({
         type: 'POST',
         url: 'ajax_form.php',
@@ -57,12 +62,14 @@ $('#alert-rule-removal').click('', function(event) {
         success: function(msg) {
             if(msg.indexOf("ERROR:") <= -1) {
                 $("#rule_id_"+alert_id).remove();
+                toastr.success(msg);
+            } else {
+                toastr.error(msg);
             }
-            toastr.success(msg);
             $("#confirm-delete").modal('hide');
         },
-        error: function(msg) {
-            toastr.error(msg);
+        error: function() {
+            toastr.error('ERROR: ajax post failed; unable to delete alert rule');
             $("#confirm-delete").modal('hide');
         }
     });

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -44,9 +44,9 @@ if (Auth::user()->hasGlobalAdmin()) {
                         <div class="tab-content">
                             <div role="tabpanel" class="tab-pane active" id="main">
                                 <div class='form-group' title="The description of this alert rule.">
-                                    <label for='name' class='col-sm-3 col-md-2 control-label'>Rule name: </label>
+                                    <label for='rule_name' class='col-sm-3 col-md-2 control-label'>Rule name: </label>
                                     <div class='col-sm-9 col-md-10'>
-                                        <input type='text' id='name' name='name' class='form-control validation' maxlength='200' required>
+                                        <input type='text' id='rule_name' name='name' class='form-control validation' maxlength='200' required>
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -316,7 +316,7 @@ if (Auth::user()->hasGlobalAdmin()) {
         });
 
         function loadRule(rule) {
-            $('#name').val(rule.name);
+            $('#rule_name').val(rule.name);
             $('#proc').val(rule.proc);
             $('#builder').queryBuilder("setRules", rule.builder);
             $('#severity').val(rule.severity).trigger('change');

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -261,7 +261,7 @@ foreach ($rule_list as $rule) {
         $except_device_or_group = '<strong><em>EXCEPT</em></strong> ';
     }
 
-    $devices_and_groups_popover='left';
+    $devices_and_groups_popover='right';
 
     $groups=null;
     if ($group_count) {

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -5,7 +5,6 @@ use LibreNMS\Alerting\QueryBuilderParser;
 $no_refresh = true;
 
 ?>
-
 <div class="row">
     <div class="col-sm-12">
         <span id="message"></span>
@@ -50,9 +49,8 @@ if (isset($_POST['create-default'])) {
 require_once 'includes/html/modal/new_alert_rule.inc.php';
 require_once 'includes/html/modal/delete_alert_rule.inc.php';
 require_once 'includes/html/modal/alert_rule_collection.inc.php';
-?>
-<form method="post" action="" id="result_form">
-<?php
+
+echo '<form method="post" action="" id="result_form">';
 echo csrf_field();
 if (isset($_POST['results_amount']) && $_POST['results_amount'] > 0) {
     $results = $_POST['results'];
@@ -60,27 +58,17 @@ if (isset($_POST['results_amount']) && $_POST['results_amount'] > 0) {
     $results = 50;
 }
 
-echo '<div class="table-responsive">
-    <table class="table table-hover table-condensed" width="100%">
-    <tr>
-    <th>#</th>
-    <th>Name</th>
-    <th>Rule</th>
-    <th>Severity</th>
-    <th>Status</th>
-    <th>Extra</th>
-    <th>Enabled</th>
-    <th style="width:86px;">Action</th>
-    </tr>';
-
-echo '<td colspan="7">';
+echo '<div class="table-responsive">';
+echo '<div class="col pull-left">';
 if (Auth::user()->hasGlobalAdmin()) {
     echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#create-alert" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create new alert rule</button>';
     echo '<i> - OR - </i>';
     echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#search_rule_modal" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create rule from collection</button>';
 }
-echo '</td>
-    <td><select name="results" id="results" class="form-control input-sm" onChange="updateResults(this);">';
+echo '</div>';
+
+echo '<div class="col pull-right">';
+echo '<select title="results per page" name="results" id="results" class="form-control input-sm" onChange="updateResults(this);">';
 $result_options = array(
     '10',
     '50',
@@ -95,11 +83,14 @@ foreach ($result_options as $option) {
     if ($results == $option) {
         echo ' selected';
     }
-
     echo ">$option</option>";
 }
+echo '</select>';
+echo '</div>';
 
-echo '</select></td>';
+echo '</div>';
+
+echo '<br>';
 
 $param = [];
 if (isset($device['device_id']) && $device['device_id'] > 0) {
@@ -132,6 +123,26 @@ if (isset($_POST['page_number']) && $_POST['page_number'] > 0 && $_POST['page_nu
 
 $start = (($page_number - 1) * $results);
 
+?>
+<div class="table-responsive">
+<table id="alert-rules-table" class="table table-condensed table-hover table-striped">
+<thead>
+    <tr>
+        <th data-column-id="Type">Type<th>
+        <th data-column-id="Name">Name</th>
+        <th data-column-id="Devices">Devices<th>
+        <th data-column-id="Transports">Transports<th>
+        <th data-column-id="Extra">Extra</th>
+        <th data-column-id="Rule">Rule</th>
+        <th data-column-id="Severity">Severity</th>
+        <th data-column-id="Status">Status</th>
+        <th data-column-id="Enabled">Enabled</th>
+        <th data-column-id="Action" style="width:86px;">Action</th>
+    </tr>
+</thead>
+<tbody>
+<?php
+
 $index = 0;
 foreach ($rule_list as $rule) {
     $index++;
@@ -147,15 +158,19 @@ foreach ($rule_list as $rule) {
     $ico   = 'check';
     $col   = 'success';
     $extra = '';
+    $status_title = '';
     if (sizeof($sub) == 1) {
         $sub = $sub[0];
         if ((int) $sub['state'] === 0) {
             $ico = 'check';
             $col = 'success';
-        } elseif ((int) $sub['state'] === 1 || (int) $sub['state'] === 2) {
+            $status_title = "all devices matching " . $rule['name'] . "  are OK";
+        }
+        if ((int) $sub['state'] === 1 || (int) $sub['state'] === 2) {
             $ico   = 'exclamation';
             $col   = 'danger';
             $extra = 'danger';
+            $status_title = "some devices matching " . $rule['name'] . " are alerting";
         }
     }
 
@@ -167,6 +182,7 @@ foreach ($rule_list as $rule) {
         $ico   = 'pause';
         $col   = '';
         $extra = 'active';
+        $status_title = $rule['name'] . " is OFF";
     } else {
         $alert_checked = 'checked';
     }
@@ -175,23 +191,89 @@ foreach ($rule_list as $rule) {
 
     $device_count = dbFetchCell('SELECT COUNT(*) FROM alert_device_map WHERE rule_id=?', [$rule['id']]);
     $group_count = dbFetchCell('SELECT COUNT(*) FROM alert_group_map WHERE rule_id=?', [$rule['id']]);
-    if ($device_count && $group_count) {
-        $popover_msg = 'Restricted rule';
-        $icon_indicator = 'fa fa-connectdevelop fa-fw text-primary';
-    } elseif ($device_count) {
-        $popover_msg = 'Device restricted rule';
+    if ($device_count) {
+        $popover_msg = 'Device restricted rule #' . $rule['id'];
         $icon_indicator = 'fa fa-server fa-fw text-primary';
-    } elseif ($group_count) {
-        $popover_msg = 'Group restricted rule';
+    }
+    if ($group_count) {
+        $popover_msg = 'Group restricted rule #' . $rule['id'];
         $icon_indicator = 'fa fa-th fa-fw text-primary';
-    } else {
-        $popover_msg = 'Global alert rule';
+    }
+    if ($device_count && $group_count) {
+        $popover_msg = 'Device and Group restricted rule #' . $rule['id'];
+        $icon_indicator = 'fa fa-connectdevelop fa-fw text-primary';
+    }
+    if (!$device_count && !$group_count) {
+        $popover_msg = 'Global alert rule #' . $rule['id'];
         $icon_indicator = 'fa fa-globe fa-fw text-success';
     }
 
-    echo "<tr class='".$extra."' id='row_".$rule['id']."'>";
-    echo "<td><i>#".((int) $rule['id'])."</i><br /><i class=\"$icon_indicator\"></i></td>";
+    echo "<tr class='".$extra."' id='rule_id_".$rule['id']."'>";
+
+    // Type
+    echo "<td colspan=\"2\"><div title=\"$popover_msg\" class=\"$icon_indicator\"></div></td>";
+
+    // Name
     echo '<td>'.$rule['name'].'</td>';
+
+    // Devices
+    $devices=null;
+    if ($group_count) {
+        $group_maps = dbFetchRows('SELECT device_groups.name FROM alert_group_map, device_groups WHERE alert_group_map.rule_id=? and alert_group_map.group_id = device_groups.id ORDER BY name', [$rule['id']]);
+        foreach ($group_maps as $group_map) {
+            $groups_title = '';
+            if ($rule['invert_map'] == 0) {
+                $groups_title = 'This rule is restricted to devices in the group named ' . $group_map['name'];
+            }
+            if ($rule['invert_map'] == 1) {
+                $groups_title = 'This rule is restricted to devices NOT in the group named ' . $group_map['name'];
+                $group_map['name'] = '<strong><em>NOT</em></strong> ' . $group_map['name'];
+            }
+            $devices .= "<p title='$groups_title'>";
+            $devices .= $group_map['name'];
+            $devices .= "</p>";
+        }
+    }
+    if ($device_count) {
+        $devices_maps = dbFetchRows('SELECT devices.hostname FROM alert_device_map, devices WHERE alert_device_map.rule_id=? and alert_device_map.device_id = devices.device_id ORDER BY hostname', [$rule['id']]);
+        foreach ($devices_maps as $device_map) {
+            $devices_title = '';
+            if ($rule['invert_map'] == 0) {
+                $devices_title = 'This rule is restricted to the device named ' . $device_map['hostname'];
+            }
+            if ($rule['invert_map'] == 1) {
+                $devices_title = 'This rule is restricted to devices NOT named ' . $device_map['hostname'];
+                $device_map['hostname'] = '<strong><em>NOT</em></strong> ' . $device_map['hostname'];
+            }
+            $devices .= "<p title='$devices_title'>";
+            $devices .= $device_map['hostname'];
+            $devices .= "</p>";
+        }
+    }
+    echo "<td colspan='2'>$devices</td>";
+
+    // Transports
+    $transport_count = dbFetchCell('SELECT COUNT(*) FROM alert_transport_map WHERE rule_id=?', [$rule['id']]);
+    $transports=null;
+    if ($transport_count) {
+        $transport_maps = dbFetchRows('SELECT transport_or_group_id,target_type FROM alert_transport_map WHERE alert_transport_map.rule_id=? ORDER BY target_type', [$rule['id']]);
+        foreach ($transport_maps as $transport_map) {
+            $transport_name=null;
+            if ($transport_map['target_type'] == "group" ) {
+                $transport_name = dbFetchCell('SELECT transport_group_name FROM alert_transport_groups WHERE transport_group_id=?', [$transport_map['transport_or_group_id']]);
+            }
+            if ($transport_map['target_type'] == "single" ) {
+                $transport_name = dbFetchCell('SELECT transport_name FROM alert_transports WHERE transport_id=?', [$transport_map['transport_or_group_id']]);
+            }
+            $transports .= "<p>" . $transport_name . "</p>";
+        }
+    }
+    echo "<td colspan='2'>$transports</td>";
+
+    // Extra
+    echo '<td><small>Max: '.$rule_extra['count'].'<br />Delay: '.$rule_extra['delay'].'<br />Interval: '.$rule_extra['interval'].'</small></td>';
+
+    // Rule
     echo "<td class='col-sm-4'>";
     if ($rule_extra['invert'] === true) {
         echo '<strong><em>Inverted</em></strong> ';
@@ -206,63 +288,94 @@ foreach ($rule_list as $rule) {
     }
     echo '<i>'.htmlentities($rule_display).'</i></td>';
 
-    echo '<td>'.$rule['severity'].'</td>';
-    echo "<td><span id='alert-rule-".$rule['id']."' class='fa fa-fw fa-2x fa-".$ico.' text-'.$col."'></span> ";
+    // Severity
+    echo '<td>'.($rule['severity'] == "ok" ? strtoupper($rule['severity']) : ucwords($rule['severity'])).'</td>';
+
+    // Status
+    echo "<td><span title='$status_title' id='alert-rule-".$rule['id']."' class='fa fa-fw fa-2x fa-".$ico.' text-'.$col."'></span> ";
     if ($rule_extra['mute'] === true) {
-        echo "<i class='fa fa-fw fa-2x fa-volume-off text-primary' aria-hidden='true'></i></td>";
+        echo "<i title='alerts for " . $rule['name'] . " are muted' class='fa fa-fw fa-2x fa-volume-off text-primary' aria-hidden='true'></i></td>";
     }
 
-    echo '<td><small>Max: '.$rule_extra['count'].'<br />Delay: '.$rule_extra['delay'].'<br />Interval: '.$rule_extra['interval'].'</small></td>';
+    // Enabled
     echo '<td>';
-    if (Auth::user()->hasGlobalAdmin()) {
-        echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' ".$alert_checked." data-size='small' data-content='".$popover_msg."' data-toggle='modal'>";
+    if ($rule['disabled']) {
+        $enabled_title = $rule['name'] . " is OFF";
     }
-
+    if (!$rule['disabled']) {
+        $enabled_title = $rule['name'] . " is ON";
+    }
+    if (!Auth::user()->hasGlobalAdmin()) {
+        if ($rule['disabled']) {
+            echo "<div title='" . $enabled_title . "' class='fa fa-fw fa-2x fa-pause'></div>";
+        }
+        if (!$rule['disabled']) {
+            echo "<div title='" . $enabled_title . "' class='fa fa-fw fa-2x fa-check text-success'></div>";
+        }
+    }
+    if (Auth::user()->hasGlobalAdmin()) {
+        echo "<div class='btn-group btn-group-sm' role='group'>";
+        echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' ".$alert_checked." data-size='small' data-content='".$enabled_title."' data-toggle='modal'>";
+        echo "</div>";
+    }
     echo '</td>';
+
+    // Action
     echo '<td>';
     if (Auth::user()->hasGlobalAdmin()) {
         echo "<div class='btn-group btn-group-sm' role='group'>";
-        echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-target='#create-alert' data-rule_id='".$rule['id']."' name='edit-alert-rule' data-content='".$popover_msg."' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-        echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule' data-content='".$popover_msg."' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+        echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-target='#create-alert' data-rule_id='".$rule['id']."' name='edit-alert-rule' data-content='Edit " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
+        echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule' data-content=' Delete " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
     }
-
     echo '</td>';
+
     echo "</tr>\r\n";
 }//end foreach
 
-if (($count % $results) > 0) {
-    echo '    <tr>
-        <td colspan="8" align="center">'.generate_pagination($count, $results, $page_number).'</td>
-        </tr>';
-}
-
-echo '</table>
-    <input type="hidden" name="page_number" id="page_number" value="'.$page_number.'">
-    <input type="hidden" name="results_amount" id="results_amount" value="'.$results.'">
-    </form>
-    </div>';
-
-if ($count < 1) {
-    if (Auth::user()->hasGlobalAdmin()) {
-        echo '<div class="row">
-            <div class="col-sm-12">
-            <form role="form" method="post">
-            ' . csrf_field() . '
-            <p class="text-center">
-            <button type="submit" class="btn btn-success btn-lg" id="create-default" name="create-default"><i class="fa fa-plus"></i> Click here to create the default alert rules!</button>
-            </p>
-            </form>
-            </div>
-            </div>';
-    }
-}
-
 ?>
+</tbody>
+</table>
+</div>
+<?php
+// Pagination
 
+if (($count % $results) > 0) {
+    echo '<div class="table-responsive">';
+    echo '<div class="col pull-left">';
+    echo generate_pagination($count, $results, $page_number);
+    echo '</div>';
+    echo '<div class="col pull-right">';
+    $showing_start=($page_number*$results)-$results+1;
+    $showing_end=$page_number*$results;
+    if ($showing_end > $count) $showing_end=$count;
+    echo "<p class=\"pagination\">Showing $showing_start to $showing_end of $count alert rules</p>";
+    echo '</div>';
+    echo '</div>';
+}
+
+echo '<input type="hidden" name="page_number" id="page_number" value="'.$page_number.'">
+    <input type="hidden" name="results_amount" id="results_amount" value="'.$results.'">
+    </form>';
+
+        if ($count < 1) {
+            if (Auth::user()->hasGlobalAdmin()) {
+                echo '<div class="row">
+                    <div class="col-sm-12">
+                    <form role="form" method="post">
+                    ' . csrf_field() . '
+                    <p class="text-center">
+                    <button type="submit" class="btn btn-success btn-lg" id="create-default" name="create-default"><i class="fa fa-plus"></i> Click here to create the default alert rules!</button>
+                    </p>
+                    </form>
+                    </div>
+                    </div>';
+            }
+        }
+?>
 <script>
 $("[data-toggle='modal'], [data-toggle='popover']").popover({
     trigger: 'hover',
-        'placement': 'top'
+    'placement': 'top'
 });
 $('#ack-alert').click('', function(e) {
     event.preventDefault();
@@ -305,15 +418,15 @@ $('input[name="alert-rule"]').on('switchChange.bootstrapSwitch',  function(event
                         $('#alert-rule-'+alert_id).addClass('fa-'+orig_state);
                         $('#alert-rule-'+alert_id).removeClass('text-default');
                         $('#alert-rule-'+alert_id).addClass('text-'+orig_colour);
-                        $('#row_'+alert_id).removeClass('active');
-                        $('#row_'+alert_id).addClass(orig_class);
+                        $('#rule_id_'+alert_id).removeClass('active');
+                        $('#rule_id_'+alert_id).addClass(orig_class);
                     } else {
                         $('#alert-rule-'+alert_id).removeClass('fa-'+orig_state);
                         $('#alert-rule-'+alert_id).addClass('fa-pause');
                         $('#alert-rule-'+alert_id).removeClass('text-'+orig_colour);
                         $('#alert-rule-'+alert_id).addClass('text-default');
-                        $('#row_'+alert_id).removeClass('warning');
-                        $('#row_'+alert_id).addClass('active');
+                        $('#rule_id_'+alert_id).removeClass('warning');
+                        $('#rule_id_'+alert_id).addClass('active');
                     }
                 } else {
                     $("#message").html('<div class="alert alert-info">'+msg+'</div>');
@@ -338,5 +451,4 @@ function changePage(page,e) {
     $('#page_number').val(page);
     $('#result_form').submit();
 }
-
 </script>

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -285,6 +285,10 @@ foreach ($rule_list as $rule) {
         }
     }
 
+    if (!$devices_and_groups) {
+        $devices_and_groups .= "<a href=\"/devices\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='View All Devices' target=\"_blank\">All Devices</a><br>";
+    }
+
     echo "<td colspan='2'>";
     echo $devices_and_groups;
     echo "</td>";

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -247,11 +247,11 @@ foreach ($rule_list as $rule) {
         $maps = dbFetchRows($device_and_group_query, [$rule['id']]);
         foreach ($maps as $map) {
             // Groups first
-            if (preg_match("/^SELECT device_groups.name/i",$device_and_group_query) == 1) {
+            if (preg_match("/^SELECT device_groups.name/i", $device_and_group_query) == 1) {
                 $devices_and_groups .= "$except_device_or_group<a href=\"/device-groups/" . $map['id'] . "/edit\" data-container='body' data-toggle='popover' data-content='Edit device group " . $map['name'] . "' title='$groups_title' target=\"_blank\">" . $map['name'] . "</a><br>";
             }
             // Devices last
-            if (preg_match("/^SELECT devices.device_id/i",$device_and_group_query) == 1) {
+            if (preg_match("/^SELECT devices.device_id/i", $device_and_group_query) == 1) {
                 $devices_and_groups .= "$except_device_or_group<a href=\"/device/device=" . $map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-content='Edit device " . $map['hostname'] . "' title='$devices_title' target=\"_blank\">" . $map['hostname'] . "</a>";
             }
         }

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -379,7 +379,7 @@ foreach ($rule_list as $rule) {
     echo '<td>';
     echo "<div class='btn-group btn-group-sm' role='group'>";
     echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-placement='$action_popover' data-target='#create-alert' data-rule_id='".$rule['id']."' name='edit-alert-rule' data-content='Edit alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-    echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-placement='$action_popover' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule' data-content=' Delete alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+    echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-placement='$action_popover' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' data-alert_name='".$rule['name']."' name='delete-alert-rule' data-content=' Delete alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
     echo '</td>';
 
     echo "</tr>\r\n";

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -187,19 +187,19 @@ foreach ($rule_list as $rule) {
     $ico   = 'check';
     $col   = 'success';
     $extra = '';
-    $status_title = '';
+    $status_msg = '';
     if (sizeof($sub) == 1) {
         $sub = $sub[0];
         if ((int) $sub['state'] === 0) {
             $ico = 'check';
             $col = 'success';
-            $status_title = "All devices matching " . $rule['name'] . "  are OK";
+            $status_msg = "All devices matching " . $rule['name'] . "  are OK";
         }
         if ((int) $sub['state'] === 1 || (int) $sub['state'] === 2) {
             $ico   = 'exclamation';
             $col   = 'danger';
             $extra = 'danger';
-            $status_title = "Some devices matching " . $rule['name'] . " are currently alerting";
+            $status_msg = "Some devices matching " . $rule['name'] . " are currently alerting";
         }
     }
 
@@ -211,7 +211,7 @@ foreach ($rule_list as $rule) {
         $ico   = 'pause';
         $col   = '';
         $extra = 'active';
-        $status_title = $rule['name'] . " is OFF";
+        $status_msg = $rule['name'] . " is OFF";
     } else {
         $alert_checked = 'checked';
     }
@@ -240,22 +240,24 @@ foreach ($rule_list as $rule) {
     echo "<tr class='".$extra."' id='rule_id_".$rule['id']."'>";
 
     // Type
+
     echo "<td colspan=\"2\"><div data-toggle='popover' data-placement='top' data-content=\"$popover_msg\" class=\"$icon_indicator\"></div></td>";
 
     // Name
+
     echo '<td>'.$rule['name'].'</td>';
 
     // Devices (and Groups)
 
     if ($rule['invert_map'] == 0) {
-        $groups_title = 'Only devices in this group.';
-        $devices_title = 'Only this device.';
+        $groups_msg = 'Only devices in this group.';
+        $devices_msg = 'Only this device.';
         $except_device_or_group = null;
     }
 
     if ($rule['invert_map'] == 1) {
-        $devices_title = 'All devices EXCEPT this device. ';
-        $groups_title = 'All devices EXCEPT this group.';
+        $devices_msg = 'All devices EXCEPT this device. ';
+        $groups_msg = 'All devices EXCEPT this group.';
         $except_device_or_group = '<strong><em>EXCEPT</em></strong> ';
     }
 
@@ -276,11 +278,11 @@ foreach ($rule_list as $rule) {
         foreach ($maps as $map) {
             // Groups first
             if (preg_match("/^SELECT device_groups.name/i", $device_and_group_query) == 1) {
-                $devices_and_groups .= "$except_device_or_group<a href=\"/device-groups/" . $map['id'] . "/edit\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='Edit device group " . $map['name'] . "' title='$groups_title' target=\"_blank\">" . $map['name'] . "</a><br>";
+                $devices_and_groups .= "$except_device_or_group<a href=\"/device-groups/" . $map['id'] . "/edit\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='Edit device group " . $map['name'] . "' title='$groups_msg' target=\"_blank\">" . $map['name'] . "</a><br>";
             }
             // Devices last
             if (preg_match("/^SELECT devices.device_id/i", $device_and_group_query) == 1) {
-                $devices_and_groups .= "$except_device_or_group<a href=\"/device/device=" . $map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='Edit device " . $map['hostname'] . "' title='$devices_title' target=\"_blank\">" . $map['hostname'] . "</a><br>";
+                $devices_and_groups .= "$except_device_or_group<a href=\"/device/device=" . $map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='Edit device " . $map['hostname'] . "' title='$devices_msg' target=\"_blank\">" . $map['hostname'] . "</a><br>";
             }
         }
     }
@@ -330,9 +332,11 @@ foreach ($rule_list as $rule) {
     echo "<td colspan='2'>$transports</td>";
 
     // Extra
+
     echo '<td><small>Max: '.$rule_extra['count'].'<br />Delay: '.$rule_extra['delay'].'<br />Interval: '.$rule_extra['interval'].'</small></td>';
 
     // Rule
+
     echo "<td class='col-sm-4'>";
     if ($rule_extra['invert'] === true) {
         echo '<strong><em>Inverted</em></strong> ';
@@ -354,9 +358,9 @@ foreach ($rule_list as $rule) {
 
     $status_popover='top';
 
-    echo "<td><span data-toggle='popover' data-placement='$status_popover' data-content='$status_title' id='alert-rule-".$rule['id']."' class='fa fa-fw fa-2x fa-".$ico.' text-'.$col."'></span> ";
+    echo "<td><span data-toggle='popover' data-placement='$status_popover' data-content='$status_msg' id='alert-rule-".$rule['id']."' class='fa fa-fw fa-2x fa-".$ico.' text-'.$col."'></span> ";
     if ($rule_extra['mute'] === true) {
-        echo "<div data-toggle='popover' data-placement='$status_popover' data-content='Alerts for " . $rule['name'] . " are muted' class='fa fa-fw fa-2x fa-volume-off text-primary' aria-hidden='true'></div></td>";
+        echo "<div data-toggle='popover' data-content='Alerts for " . $rule['name'] . " are muted' class='fa fa-fw fa-2x fa-volume-off text-primary' aria-hidden='true'></div></td>";
     }
 
     // Enabled
@@ -365,14 +369,14 @@ foreach ($rule_list as $rule) {
 
     echo '<td>';
     if ($rule['disabled']) {
-        $enabled_title = $rule['name'] . " is OFF";
+        $enabled_msg = $rule['name'] . " is OFF";
     }
     if (!$rule['disabled']) {
-        $enabled_title = $rule['name'] . " is ON";
+        $enabled_msg = $rule['name'] . " is ON";
     }
 
-    echo "<div data-toggle='popover' data-placement='$enabled_popover' data-content='" . $enabled_title . "' class='btn-group btn-group-sm' role='group'>";
-    echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' ".$alert_checked." data-size='small' data-content='".$enabled_title."' data-toggle='modal'>";
+    echo "<div id='on-off-checkbox-" .$rule['id']. "' data-toggle='popover' data-placement='$enabled_popover' data-content='" . $enabled_msg . "' class='btn-group btn-group-sm' role='group'>";
+    echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' data-alert_name='".$rule['name']."' data-alert_status='". $status_msg. "' ".$alert_checked." data-size='small' data-toggle='modal'>";
     echo "</div>";
     echo '</td>';
 
@@ -383,7 +387,7 @@ foreach ($rule_list as $rule) {
     echo '<td>';
     echo "<div class='btn-group btn-group-sm' role='group'>";
     echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-placement='$action_popover' data-target='#create-alert' data-rule_id='".$rule['id']."' name='edit-alert-rule' data-content='Edit alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-    echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-placement='$action_popover' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' data-alert_name='".$rule['name']."' name='delete-alert-rule' data-content=' Delete alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
+    echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-placement='$action_popover' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' data-alert_name='".$rule['name']."' name='delete-alert-rule' data-content='Delete alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
     echo '</td>';
 
     echo "</tr>\r\n";
@@ -459,6 +463,8 @@ $('input[name="alert-rule"]').on('switchChange.bootstrapSwitch',  function(event
     event.preventDefault();
     var $this = $(this);
     var alert_id = $(this).data("alert_id");
+    var alert_name = $(this).data("alert_name");
+    var alert_status = $(this).data("alert_status");
     var orig_state = $(this).data("orig_state");
     var orig_colour = $(this).data("orig_colour");
     var orig_class = $(this).data("orig_class");
@@ -474,6 +480,8 @@ $('input[name="alert-rule"]').on('switchChange.bootstrapSwitch',  function(event
                         $('#alert-rule-'+alert_id).addClass('fa-'+orig_state);
                         $('#alert-rule-'+alert_id).removeClass('text-default');
                         $('#alert-rule-'+alert_id).addClass('text-'+orig_colour);
+                        $('#alert-rule-'+alert_id).attr('data-content', alert_status);
+                        $('#on-off-checkbox-'+alert_id).attr('data-content', alert_name+' is ON');
                         $('#rule_id_'+alert_id).removeClass('active');
                         $('#rule_id_'+alert_id).addClass(orig_class);
                     } else {
@@ -481,6 +489,8 @@ $('input[name="alert-rule"]').on('switchChange.bootstrapSwitch',  function(event
                         $('#alert-rule-'+alert_id).addClass('fa-pause');
                         $('#alert-rule-'+alert_id).removeClass('text-'+orig_colour);
                         $('#alert-rule-'+alert_id).addClass('text-default');
+                        $('#alert-rule-'+alert_id).attr('data-content', alert_name+' is OFF');
+                        $('#on-off-checkbox-'+alert_id).attr('data-content', alert_name+' is OFF');
                         $('#rule_id_'+alert_id).removeClass('warning');
                         $('#rule_id_'+alert_id).addClass('active');
                     }

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -236,27 +236,32 @@ foreach ($rule_list as $rule) {
         $except_device_or_group = '<strong><em>EXCEPT</em></strong> ';
     }
 
+    $device_and_group_queries=array();
     if ($group_count) {
-        $group_maps = dbFetchRows('SELECT device_groups.name, device_groups.id FROM alert_group_map, device_groups WHERE alert_group_map.rule_id=? and alert_group_map.group_id = device_groups.id ORDER BY name', [$rule['id']]);
-        foreach ($group_maps as $group_map) {
-            $groups .= "$except_device_or_group<a href=\"/device-groups/" . $group_map['id'] . "/edit\" data-container='body' data-toggle='popover' data-content='Edit device group " . $group_map['name'] . "' title='$groups_title' target=\"_blank\">" . $group_map['name'] . "</a><br>";
-        }
+        $device_and_group_queries[] = 'SELECT device_groups.name, device_groups.id FROM alert_group_map, device_groups WHERE alert_group_map.rule_id=? and alert_group_map.group_id = device_groups.id ORDER BY name';
     }
 
     if ($device_count) {
-        $devices_maps = dbFetchRows('SELECT devices.device_id,devices.hostname FROM alert_device_map, devices WHERE alert_device_map.rule_id=? and alert_device_map.device_id = devices.device_id ORDER BY hostname', [$rule['id']]);
-        foreach ($devices_maps as $device_map) {
-            $devices .= "$except_device_or_group<a href=\"/device/device=" . $device_map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-content='Edit device " . $device_map['hostname'] . "' title='$devices_title' target=\"_blank\">" . $device_map['hostname'] . "</a>";
+        $device_and_group_queries[] = 'SELECT devices.device_id,devices.hostname FROM alert_device_map, devices WHERE alert_device_map.rule_id=? and alert_device_map.device_id = devices.device_id ORDER BY hostname';
+    }
+
+    $devices_and_groups=null;
+    foreach ($device_and_group_queries as $device_and_group_query) {
+        $maps = dbFetchRows($device_and_group_query, [$rule['id']]);
+        foreach ($maps as $map) {
+            // Groups first
+            if (preg_match("/^SELECT device_groups.name/i",$device_and_group_query) == 1) {
+                $devices_and_groups .= "$except_device_or_group<a href=\"/device-groups/" . $map['id'] . "/edit\" data-container='body' data-toggle='popover' data-content='Edit device group " . $map['name'] . "' title='$groups_title' target=\"_blank\">" . $map['name'] . "</a><br>";
+            }
+            // Devices last
+            if (preg_match("/^SELECT devices.device_id/i",$device_and_group_query) == 1) {
+                $devices_and_groups .= "$except_device_or_group<a href=\"/device/device=" . $map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-content='Edit device " . $map['hostname'] . "' title='$devices_title' target=\"_blank\">" . $map['hostname'] . "</a>";
+            }
         }
     }
 
     echo "<td colspan='2'>";
-    if ($groups) {
-        echo $groups;
-    }
-    if ($devices) {
-        echo $devices;
-    }
+    echo $devices_and_groups;
     echo "</td>";
 
     // Transports

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -233,17 +233,19 @@ foreach ($rule_list as $rule) {
         $not_device_or_group = '<strong><em>NOT</em></strong> ';
     }
 
+    // i.e. /device-groups/4/edit
     if ($group_count) {
-        $group_maps = dbFetchRows('SELECT device_groups.name FROM alert_group_map, device_groups WHERE alert_group_map.rule_id=? and alert_group_map.group_id = device_groups.id ORDER BY name', [$rule['id']]);
+        $group_maps = dbFetchRows('SELECT device_groups.name, device_groups.id FROM alert_group_map, device_groups WHERE alert_group_map.rule_id=? and alert_group_map.group_id = device_groups.id ORDER BY name', [$rule['id']]);
         foreach ($group_maps as $group_map) {
-            $groups .= "<p title='$groups_title ". $group_map['name'] . "'>" . $not_device_or_group . $group_map['name'] . "</p>";
+            $groups .= "$not_device_or_group<a href=\"/device-groups/" . $group_map['id'] . "/edit\" title='$groups_title ". $group_map['name'] . "' target=\"_blank\">" . $group_map['name'] . "</a><br>";
         }
     }
 
+    // i.e. /device/device=24477/tab=edit/
     if ($device_count) {
-        $devices_maps = dbFetchRows('SELECT devices.hostname FROM alert_device_map, devices WHERE alert_device_map.rule_id=? and alert_device_map.device_id = devices.device_id ORDER BY hostname', [$rule['id']]);
+        $devices_maps = dbFetchRows('SELECT devices.device_id,devices.hostname FROM alert_device_map, devices WHERE alert_device_map.rule_id=? and alert_device_map.device_id = devices.device_id ORDER BY hostname', [$rule['id']]);
         foreach ($devices_maps as $device_map) {
-            $devices .= "<p title='$devices_title ". $device_map['hostname'] . "'>" . $not_device_or_group . $device_map['hostname'] . "</p>";
+            $devices .= "$not_device_or_group<a href=\"/device/device=" . $device_map['device_id'] . "/tab=edit/\" title='$devices_title ". $device_map['hostname'] . "' target=\"_blank\">" . $device_map['hostname'] . "</a>";
         }
     }
 

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -233,11 +233,11 @@ foreach ($rule_list as $rule) {
         $not_device_or_group = '<strong><em>NOT</em></strong> ';
     }
 
-    // i.e. /device-groups/4/edit
+    // i.e. /device-groups/4/edit/
     if ($group_count) {
         $group_maps = dbFetchRows('SELECT device_groups.name, device_groups.id FROM alert_group_map, device_groups WHERE alert_group_map.rule_id=? and alert_group_map.group_id = device_groups.id ORDER BY name', [$rule['id']]);
         foreach ($group_maps as $group_map) {
-            $groups .= "$not_device_or_group<a href=\"/device-groups/" . $group_map['id'] . "/edit\" title='$groups_title ". $group_map['name'] . "' target=\"_blank\">" . $group_map['name'] . "</a><br>";
+            $groups .= "$not_device_or_group<a href=\"/device-groups/" . $group_map['id'] . "/edit/\" title='$groups_title ". $group_map['name'] . "' target=\"_blank\">" . $group_map['name'] . "</a><br>";
         }
     }
 

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -119,7 +119,7 @@ if (isset($device['device_id']) && $device['device_id'] > 0) {
     $full_query = 'SELECT alert_rules.* FROM alert_rules';
 }
 
-$full_query .= ' ORDER BY id ASC';
+$full_query .= ' ORDER BY name ASC';
 
 $rule_list = dbFetchRows($full_query, $param);
 $count = count($rule_list);

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -280,7 +280,7 @@ foreach ($rule_list as $rule) {
             }
             // Devices last
             if (preg_match("/^SELECT devices.device_id/i", $device_and_group_query) == 1) {
-                $devices_and_groups .= "$except_device_or_group<a href=\"/device/device=" . $map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='Edit device " . $map['hostname'] . "' title='$devices_title' target=\"_blank\">" . $map['hostname'] . "</a>";
+                $devices_and_groups .= "$except_device_or_group<a href=\"/device/device=" . $map['device_id'] . "/tab=edit/\" data-container='body' data-toggle='popover' data-placement='$devices_and_groups_popover' data-content='Edit device " . $map['hostname'] . "' title='$devices_title' target=\"_blank\">" . $map['hostname'] . "</a><br>";
             }
         }
     }

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -263,10 +263,10 @@ foreach ($rule_list as $rule) {
         $transport_maps = dbFetchRows('SELECT transport_or_group_id,target_type FROM alert_transport_map WHERE alert_transport_map.rule_id=? ORDER BY target_type', [$rule['id']]);
         foreach ($transport_maps as $transport_map) {
             $transport_name=null;
-            if ($transport_map['target_type'] == "group" ) {
+            if ($transport_map['target_type'] == "group") {
                 $transport_name = dbFetchCell('SELECT transport_group_name FROM alert_transport_groups WHERE transport_group_id=?', [$transport_map['transport_or_group_id']]);
             }
-            if ($transport_map['target_type'] == "single" ) {
+            if ($transport_map['target_type'] == "single") {
                 $transport_name = dbFetchCell('SELECT transport_name FROM alert_transports WHERE transport_id=?', [$transport_map['transport_or_group_id']]);
             }
             $transports .= "<p>" . $transport_name . "</p>";

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -221,9 +221,6 @@ foreach ($rule_list as $rule) {
 
     // Devices (and Groups)
 
-    $groups=null;
-    $devices=null;
-
     if ($rule['invert_map'] == 0) {
         $groups_title = 'Only devices in this group.';
         $devices_title = 'Only this device.';

--- a/includes/html/print-alert-rules.php
+++ b/includes/html/print-alert-rules.php
@@ -1,4 +1,32 @@
 <?php
+/**
+ * print-alert-rules.inc.php
+ *
+ * LibreNMS print alert rules table
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2020 The LibreNMS Community
+ * @author     Original Author <unknown>
+ * @author     Joseph Tingiris <joseph.tingiris@gmail.com>
+ */
+
+if (!Auth::user()->hasGlobalAdmin()) {
+    die('ERROR: You need to be admin');
+}
 
 use LibreNMS\Alerting\QueryBuilderParser;
 
@@ -47,8 +75,8 @@ if (isset($_POST['create-default'])) {
 }
 
 require_once 'includes/html/modal/new_alert_rule.inc.php';
-require_once 'includes/html/modal/delete_alert_rule.inc.php';
-require_once 'includes/html/modal/alert_rule_collection.inc.php';
+require_once 'includes/html/modal/delete_alert_rule.inc.php'; // Also dies if !Auth::user()->hasGlobalAdmin()
+require_once 'includes/html/modal/alert_rule_collection.inc.php'; // Also dies if !Auth::user()->hasGlobalAdmin()
 
 require_once 'includes/html/modal/edit_transport_group.inc.php';
 require_once 'includes/html/modal/edit_alert_transport.inc.php';
@@ -63,11 +91,9 @@ if (isset($_POST['results_amount']) && $_POST['results_amount'] > 0) {
 
 echo '<div class="table-responsive">';
 echo '<div class="col pull-left">';
-if (Auth::user()->hasGlobalAdmin()) {
-    echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#create-alert" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create new alert rule</button>';
-    echo '<i> - OR - </i>';
-    echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#search_rule_modal" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create rule from collection</button>';
-}
+echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#create-alert" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create new alert rule</button>';
+echo '<i> - OR - </i>';
+echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#search_rule_modal" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create rule from collection</button>';
 echo '</div>';
 
 echo '<div class="col pull-right">';
@@ -275,11 +301,11 @@ foreach ($rule_list as $rule) {
             $transport_name=null;
             if ($transport_map['target_type'] == "group") {
                 $transport_name = dbFetchCell('SELECT transport_group_name FROM alert_transport_groups WHERE transport_group_id=?', [$transport_map['transport_or_group_id']]);
-                $transport_edit = "<a href='' data-toggle='modal' data-target='#edit-transport-group' data-group_id='" . $transport_map['transport_or_group_id'] . "' data-container='body' data-toggle='popover' data-placement='$transports_popover' data-content='Edit transport group  $transport_name'>" . $transport_name. "</a>";
+                $transport_edit = "<a href='' data-toggle='modal' data-target='#edit-transport-group' data-group_id='" . $transport_map['transport_or_group_id'] . "' data-container='body' data-toggle='popover' data-placement='$transports_popover' data-content='Edit transport group  $transport_name'>" . $transport_name . "</a>";
             }
             if ($transport_map['target_type'] == "single") {
                 $transport_name = dbFetchCell('SELECT transport_name FROM alert_transports WHERE transport_id=?', [$transport_map['transport_or_group_id']]);
-                $transport_edit = "<a href='' data-toggle='modal' data-target='#edit-alert-transport' data-transport_id='" . $transport_map['transport_or_group_id'] . "' data-container='body' data-toggle='popover' data-placement='$transports_popover' data-content='Edit transport $transport_name'>" . $transport_name. "</a>";
+                $transport_edit = "<a href='' data-toggle='modal' data-target='#edit-alert-transport' data-transport_id='" . $transport_map['transport_or_group_id'] . "' data-container='body' data-toggle='popover' data-placement='$transports_popover' data-content='Edit transport $transport_name'>" . $transport_name . "</a>";
             }
             $transports .= $transport_edit . "<br>";
         }
@@ -341,20 +367,9 @@ foreach ($rule_list as $rule) {
         $enabled_title = $rule['name'] . " is ON";
     }
 
-    if (!Auth::user()->hasGlobalAdmin()) {
-        if ($rule['disabled']) {
-            echo "<div data-toggle='popover' data-placement='$enabled_popover' data-content='" . $enabled_title . "' class='fa fa-fw fa-2x fa-pause'></div>";
-        }
-        if (!$rule['disabled']) {
-            echo "<div data-toggle='popover' data-placement='$enabled_popover' data-content='" . $enabled_title . "' class='fa fa-fw fa-2x fa-check text-success'></div>";
-        }
-    }
-
-    if (Auth::user()->hasGlobalAdmin()) {
-        echo "<div data-toggle='popover' data-placement='$enabled_popover' data-content='" . $enabled_title . "' class='btn-group btn-group-sm' role='group'>";
-        echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' ".$alert_checked." data-size='small' data-content='".$enabled_title."' data-toggle='modal'>";
-        echo "</div>";
-    }
+    echo "<div data-toggle='popover' data-placement='$enabled_popover' data-content='" . $enabled_title . "' class='btn-group btn-group-sm' role='group'>";
+    echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' ".$alert_checked." data-size='small' data-content='".$enabled_title."' data-toggle='modal'>";
+    echo "</div>";
     echo '</td>';
 
     // Action
@@ -362,11 +377,9 @@ foreach ($rule_list as $rule) {
     $action_popover='left';
 
     echo '<td>';
-    if (Auth::user()->hasGlobalAdmin()) {
-        echo "<div class='btn-group btn-group-sm' role='group'>";
-        echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-placement='$action_popover' data-target='#create-alert' data-rule_id='".$rule['id']."' name='edit-alert-rule' data-content='Edit alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
-        echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-placement='$action_popover' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule' data-content=' Delete alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
-    }
+    echo "<div class='btn-group btn-group-sm' role='group'>";
+    echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-placement='$action_popover' data-target='#create-alert' data-rule_id='".$rule['id']."' name='edit-alert-rule' data-content='Edit alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
+    echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-placement='$action_popover' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule' data-content=' Delete alert rule " . $rule['name'] . "' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
     echo '</td>';
 
     echo "</tr>\r\n";
@@ -400,18 +413,16 @@ echo '<input type="hidden" name="page_number" id="page_number" value="'.$page_nu
     </form>';
 
 if ($count < 1) {
-    if (Auth::user()->hasGlobalAdmin()) {
-        echo '<div class="row">
-            <div class="col-sm-12">
-            <form role="form" method="post">
-            ' . csrf_field() . '
-            <p class="text-center">
-            <button type="submit" class="btn btn-success btn-lg" id="create-default" name="create-default"><i class="fa fa-plus"></i> Click here to create the default alert rules!</button>
-            </p>
-            </form>
-            </div>
-            </div>';
-    }
+    echo '<div class="row">
+        <div class="col-sm-12">
+        <form role="form" method="post">
+        ' . csrf_field() . '
+        <p class="text-center">
+        <button type="submit" class="btn btn-success btn-lg" id="create-default" name="create-default"><i class="fa fa-plus"></i> Click here to create the default alert rules!</button>
+        </p>
+        </form>
+        </div>
+        </div>';
 }
 ?>
 <script>

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -5,6 +5,16 @@
     "default": true
   },
   {
+    "rule": "macros.device_down = \"1\" && devices.status_reason = \"icmp\"",
+    "name": "Device Down! Due to no ICMP response.",
+    "default": true
+  },
+  {
+    "rule": "macros.device_down = \"1\" && devices.status_reason = \"snmp\"",
+    "name": "SNMP not responding on Device - Check on SNMP Service - Device marked Down!",
+    "default": true
+  },
+  {
     "rule": "devices.uptime < \"300\" && macros.device = \"1\"",
     "name": "Device rebooted",
     "extra": "{\"count\": 1}",


### PR DESCRIPTION
* As an admin or user, it makes more sense to sort the alert rules by name and have additional information on the table view.
* Defaulted alert rules to sort by name
* Moved top buttons and results selector outside of table and aligned them with pull-left and pull-right
* Collapsed '#' (ID) into 'Type' and added popovers for the icons
* Added Devices and Transports columns for each rule
* Added additional links to edit devices, device groups, transports, and transport groups
* Added additional link to view all devices
* Fixed #name property conflict (so transport and alert modals can be used on the same page)
* Moved Extra column next to transports
* Fail faster for users without global admin rights
* Changed row_# variable to rule_id_# to avoid confusion
* Some 'else' & 'elseif' cleanup; code climate conformance (except DRY)
* Added various popover & title attributes for more information when hovering
* Moved pagination outside of table & aligned it with pull-left
* Added pagination summary pulled-right (similar to bootgrid)
* Added table & th attributes for bootgrid (but didn't turn it on)
* Deleting a rule now uses toastr and has more informative feedback

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
