### PR TITLE
Update devices last_ping along with device_perf

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2253,6 +2253,16 @@ function device_is_up($device, $record_perf = false)
         }
         $device_perf['debug'] = json_encode($trace_debug);
         dbInsert($device_perf, 'device_perf');
+
+        // if device_perf is inserted and the ping was successful then update device last_ping timestamp
+        if (!empty($ping_response['last_ping_timetaken']) && $ping_response['last_ping_timetaken'] != "0") {
+            dbUpdate(
+                array('last_ping' => NOW(), 'last_ping_timetaken' => $ping_response['last_ping_timetaken']),
+                'devices',
+                'device_id=?',
+                array($device['device_id'])
+            );
+        }
     }
     $response              = array();
     $response['ping_time'] = $ping_response['last_ping_timetaken'];


### PR DESCRIPTION
* As a user, I want to know when a device has long ping latency whether its SNMP is functioning or not.
* The device_perf timestamp is always updated regardless.  This leads to inconsistencies and confusion.  Why isn't devices.last_ping_timetaken updated every time too?
* As it is, last_ping timestamp for SNMP devices does not get updated when the device is 'down'. 
* If device_perf is inserted and the ping was successful then updating the devices last_ping timestamp is consistent.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
