### PR TITLE
Default alert rules remove Devices up/down

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -2,7 +2,6 @@
   {
     "rule": "macros.device_down = \"1\"",
     "name": "Devices up/down",
-    "default": true
   },
   {
     "rule": "macros.device_down = \"1\" && devices.status_reason = \"icmp\"",

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -2,6 +2,7 @@
   {
     "rule": "macros.device_down = \"1\"",
     "name": "Devices up/down",
+    "default": false
   },
   {
     "rule": "macros.device_down = \"1\" && devices.status_reason = \"icmp\"",


### PR DESCRIPTION
removed the Devices up/down as the default alert rule. This can be confusing to new users. We already have the alert for SNMP and one for ICMP defaulted.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
