### PR TITLE
PHP hashes are case sensitive. 

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -489,7 +489,7 @@ function delete_device($id)
 
     $db_name = dbFetchCell('SELECT DATABASE()');
     foreach ($fields as $field) {
-        foreach (dbFetch("SELECT table_name FROM information_schema.columns WHERE table_schema = ? AND column_name = ?", [$db_name, $field]) as $table) {
+        foreach (dbFetch("SELECT TABLE_NAME FROM information_schema.columns WHERE table_schema = ? AND column_name = ?", [$db_name, $field]) as $table) {
             $table = $table['TABLE_NAME'];
             $entries = (int) dbDelete($table, "`$field` =  ?", array($id));
             if ($entries > 0 && $debug === true) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -490,7 +490,7 @@ function delete_device($id)
     $db_name = dbFetchCell('SELECT DATABASE()');
     foreach ($fields as $field) {
         foreach (dbFetch("SELECT table_name FROM information_schema.columns WHERE table_schema = ? AND column_name = ?", [$db_name, $field]) as $table) {
-            $table = $table['table_name'];
+            $table = $table['TABLE_NAME'];
             $entries = (int) dbDelete($table, "`$field` =  ?", array($id));
             if ($entries > 0 && $debug === true) {
                 $ret .= "$field@$table = #$entries\n";


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.

#### Reason

We were unable to delete devices. When looking in `logs/librenms.log` we could see 70 instances of:

```[2020-02-12 17:11:26] production.ERROR: SQLSTATE[42000]: Syntax error or access violation: 1103 Incorrect table name '' (SQL: DELETE FROM `` WHERE `device_id` =  58) (SQL: DELETE FROM `` WHERE `device_id` =  58)#0 /opt/librenms/includes/functions.php(494): dbDelete(NULL, '`device_id` =  ...', Array)```

When executing the same query LibreNMS uses to find all tables containing the columns `device_id` and `host`

```
SELECT table_name FROM information_schema.columns WHERE table_schema = 'librenms' AND column_name = 'device_id';

SELECT table_name FROM information_schema.columns WHERE table_schema = 'librenms' AND column_name = 'host';
```
we got a total of 70 tables back.

When checking the value of `$table` after Line 493 in `includes/functions.php`, `$table`was null. After changing the line to `$table = $table['TABLE_NAME'];` the column names were correctly returned and the devices were able to be deleted.