### PR TITLE
Equalize default Poller Group Naming

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -240,12 +240,13 @@ if (\LibreNMS\Config::get('distributed_poller') === true) {
        <label for="poller_group" class="col-sm-2 control-label">Poller Group</label>
        <div class="col-sm-6">
            <select name="poller_group" id="poller_group" class="form-control input-sm">
-               <option value="0"> Default poller group</option>
+           <option value="0">General<?=\LibreNMS\Config::get('distributed_poller_group') == 0 ? ' (default Poller)': ''?></option>
 <?php
 foreach (dbFetchRows('SELECT `id`,`group_name` FROM `poller_groups` ORDER BY `group_name`') as $group) {
-    echo '<option value="'.$group['id'].'"'.
-        ($device_model->poller_group == $group['id'] ? " selected": "").
-        '>'.$group['group_name'].'</option>';
+    echo ('<option value="'.$group['id'].'"'.
+        ($device_model->poller_group == $group['id'] ? " selected": "").'>'.$group['group_name']);
+    echo (\LibreNMS\Config::get('distributed_poller_group') == $group['id'] ? ' (default Poller)': '');
+    echo ('</option>');
 }
 ?>
            </select>


### PR DESCRIPTION
equailze default Poller Group Naming between Poller Group View and Device Edit View:

Poller Group Management:
![image](https://user-images.githubusercontent.com/7978916/74604484-c659be80-50be-11ea-8aeb-bb469db5a793.png)

Device Edit (before):
![image](https://user-images.githubusercontent.com/7978916/74604491-d8d3f800-50be-11ea-9799-f6eaa7123bab.png)

Device Edit (after):
![image](https://user-images.githubusercontent.com/7978916/74604497-e8ebd780-50be-11ea-818f-2dcdf8f333c4.png)



#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
