### PR TITLE
Invalidate 'Wrong Type' snmp_walk() data

### DIFF
--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -386,8 +386,7 @@ function snmp_walk($device, $oid, $options = null, $mib = null, $mibdir = null)
     $data = str_replace('"', '', $data);
     $data = str_replace('End of MIB', '', $data);
 
-
-    if (is_string($data) && (preg_match('/No Such (Object|Instance)/i', $data) || preg_match('/Wrong Type(.*)should be/',$data))) {
+    if (is_string($data) && (preg_match('/No Such (Object|Instance)/i', $data) || preg_match('/Wrong Type(.*)should be/', $data))) {
         d_echo("Invalid snmp_walk() data = " . print_r($data, true));
         $data = false;
     } else {

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -386,7 +386,9 @@ function snmp_walk($device, $oid, $options = null, $mib = null, $mibdir = null)
     $data = str_replace('"', '', $data);
     $data = str_replace('End of MIB', '', $data);
 
-    if (is_string($data) && (preg_match('/No Such (Object|Instance)/i', $data))) {
+
+    if (is_string($data) && (preg_match('/No Such (Object|Instance)/i', $data) || preg_match('/Wrong Type(.*)should be/',$data))) {
+        d_echo("Invalid snmp_walk() data = " . print_r($data, true));
         $data = false;
     } else {
         if (ends_with($data, '(It is past the end of the MIB tree)')) {


### PR DESCRIPTION
Certain, invalid, values must not be passed by snmp_walk() or they will end up being discovered as present when they are, in fact, not present (e.g. Temperature, Fan, & Voltage sensors).

This patch adds 'Wrong Type' to the existing snmp_walk() preg_match() condition to invalidate the $data.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
