### PR TITLE
Reduce DB polling while getting SNMP data

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -106,19 +106,26 @@ class Device extends BaseModel
     /**
      * Returns IP/Hostname where polling will be targeted to
      *
-     * @param string $hostname hostname which will be triggered
+     * @param string $device hostname which will be triggered
+     *        array  $device associative array with device data
      * @return string IP/Hostname to which Device polling is targeted
      */
-    public static function pollerTarget($hostname)
+    public static function pollerTarget($device)
     {
-        $ret = static::where('hostname', $hostname)->first(['hostname', 'overwrite_ip']);
-        if (empty($ret)) {
-            return $hostname;
+        if (! is_array($device)) {
+            $ret = static::where('hostname', $device)->first(['hostname', 'overwrite_ip']);
+            if (empty($ret)) {
+                return $device;
+            }
+            $overwrite_ip = $ret->overwrite_ip;
+            $hostname = $ret->hostname;
+        } elseif (array_key_exists('overwrite_ip', $device)) {
+            $overwrite_ip = $device['overwrite_ip'];
+            $hostname = $device['hostname'];
+        } else {
+            return $device['hostname'];
         }
-        $_overwrite_ip = $ret->overwrite_ip;
-        $_hostname = $ret->hostname;
-
-        return $_overwrite_ip ?: $_hostname;
+        return $overwrite_ip ?: $hostname;
     }
 
     public static function findByIp($ip)

--- a/includes/snmp.inc.php
+++ b/includes/snmp.inc.php
@@ -172,7 +172,7 @@ function gen_snmp_cmd($cmd, $device, $oids, $options = null, $mib = null, $mibdi
         array_push($cmd, '-r', $retries);
     }
 
-    $pollertarget = Device::pollerTarget($device['hostname']);
+    $pollertarget = Device::pollerTarget($device);
     $cmd[] = $device['transport'].':'.$pollertarget.':'.$device['port'];
     $cmd = array_merge($cmd, (array)$oids);
 


### PR DESCRIPTION
"optimizing" function `pollerTarget` to reduce calls against Database 
on polling for snmp data down to 1:

**### BEFORE:**
same db request is called many times for the same polling
Example : one devices polling. Called 213 times.

```
$ ./poller.php -h 2 -d &>/dev/stdout | grep overwrite_ip | wc -l
213
```
**### AFTER**
```
$ ./poller.php -h 2 -d &>/dev/stdout | grep overwrite_ip | wc -l
1
```
thanks to @louis-oui for pointing on it

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
