### PR TITLE
Add csv of groups a device belongs to in alert object

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -108,6 +108,14 @@ class RunAlerts
         $obj['proc']          = $alert['proc'];
         $obj['status']        = $device['status'];
         $obj['status_reason'] = $device['status_reason'];
+        
+        $device_groups = dbFetchRows("SELECT name FROM device_groups dg INNER JOIN device_group_device dgd ON dgd.device_group_id=dg.id WHERE dgd.device_id = ? ORDER BY name ASC", array($alert['device_id']));
+        $obj['groups'] = "";
+        foreach ($device_groups as $group) {
+            $obj['groups'] .= $group['name'] . ',';
+        }
+        $obj['groups'] = substr($obj['groups'], 0, -1);
+        
         if (can_ping_device($attribs)) {
             $ping_stats = DevicePerf::where('device_id', $alert['device_id'])->latest('timestamp')->first();
             $obj['ping_timestamp'] = $ping_stats->template;


### PR DESCRIPTION
Query for the groups being alerted on and build a csv string of groups a device belongs to and add it to the alert object for use in the transports.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
