### PR TITLE
Open Links to external Urls (Docs) in new tab

### DIFF
--- a/includes/html/modal/alert_template.inc.php
+++ b/includes/html/modal/alert_template.inc.php
@@ -22,7 +22,7 @@ if (!Auth::user()->hasGlobalAdmin()) {
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="Create">Alert Template :: <a href="https://docs.librenms.org/Alerting/Templates/"><i class="fa fa-book fa-1x"></i> Docs</a></h4>
+                <h4 class="modal-title" id="Create">Alert Template :: <a target="_blank" href="https://docs.librenms.org/Alerting/Templates/"><i class="fa fa-book fa-1x"></i> Docs</a></h4>
             </div>
             <div class="modal-body">
                 <div class="row">

--- a/includes/html/modal/edit_alert_transport.inc.php
+++ b/includes/html/modal/edit_alert_transport.inc.php
@@ -22,7 +22,7 @@ if (Auth::user()->hasGlobalAdmin()) {
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h5 class="modal-title" id="Edit-transport">Alert Transport :: <a href="https://docs.librenms.org/Alerting/">Docs <i class="fa fa-book fa-1x"></i></a> </h5>
+                    <h5 class="modal-title" id="Edit-transport">Alert Transport :: <a target="_blank" href="https://docs.librenms.org/Alerting/">Docs <i class="fa fa-book fa-1x"></i></a> </h5>
                 </div>
                 <div class="modal-body">
                     <form method="post" role="form" id="transports" class="form-horizontal transports-form">

--- a/includes/html/modal/edit_transport_group.inc.php
+++ b/includes/html/modal/edit_transport_group.inc.php
@@ -20,7 +20,7 @@ if (Auth::user()->hasGlobalAdmin()) {
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h5 class="modal-title" id="Edit-transport">Alert Transport Groups :: <a href="https://docs.librenms.org/Alerting/">Docs <i class="fa fa-book fa-1x"></i></a> </h5>
+                    <h5 class="modal-title" id="Edit-transport">Alert Transport Groups :: <a target="_blank" href="https://docs.librenms.org/Alerting/">Docs <i class="fa fa-book fa-1x"></i></a> </h5>
                 </div>
                 <div class="modal-body">
                     <form method="post" role="form" id="transport-group" class="form-horizontal transport-group-form">

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -35,7 +35,7 @@ if (Auth::user()->hasGlobalAdmin()) {
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h5 class="modal-title" id="Create">Alert Rule :: <a href="https://docs.librenms.org/Alerting/"><i class="fa fa-book fa-1x"></i> Docs</a> </h5>
+                    <h5 class="modal-title" id="Create">Alert Rule :: <a target="_blank" href="https://docs.librenms.org/Alerting/"><i class="fa fa-book fa-1x"></i> Docs</a> </h5>
                 </div>
                 <div class="modal-body">
                     <ul class="nav nav-tabs" role="tablist">

--- a/includes/html/modal/new_customoid.inc.php
+++ b/includes/html/modal/new_customoid.inc.php
@@ -11,7 +11,7 @@ if (!(Auth::user()->hasGlobalAdmin())) {
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h5 class="modal-title" id="Create">Custom OID :: <a href="https://docs.librenms.org/">Docs <i class="fa fa-book fa-1x"></i></a> </h5>
+                <h5 class="modal-title" id="Create">Custom OID :: <a target="_blank" href="https://docs.librenms.org/">Docs <i class="fa fa-book fa-1x"></i></a> </h5>
             </div>
             <div class="modal-body">
                 <form method="post" role="form" id="coids" class="form-horizontal coid_form">

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -56,14 +56,14 @@
             <h3>@lang('LibreNMS is a community-based project')</h3>
             @lang('Please feel free to join us and contribute code, documentation, and bug reports:')
             <br>
-              <a href="http://www.librenms.org/">@lang('Web site')</a> |
-              <a href="https://docs.librenms.org/">@lang('Docs')</a> |
-              <a href="https://github.com/librenms/">@lang('GitHub')</a> |
-              <a href="https://community.librenms.org/c/help">@lang('Bug tracker')</a> |
-              <a href="https://community.librenms.org">@lang('Community Forum')</a> |
-              <a href="http://twitter.com/librenms">@lang('Twitter')</a> |
-              <a href="http://www.librenms.org/changelog.html">@lang('Changelog')</a> |
-              <a href="#" data-toggle="modal" data-target="#git_log">@lang('Local git log')</a>
+              <a target="_blank" href="http://www.librenms.org/">@lang('Web site')</a> |
+              <a target="_blank" href="https://docs.librenms.org/">@lang('Docs')</a> |
+              <a target="_blank" href="https://github.com/librenms/">@lang('GitHub')</a> |
+              <a target="_blank" href="https://community.librenms.org/c/help">@lang('Bug tracker')</a> |
+              <a target="_blank" href="https://community.librenms.org">@lang('Community Forum')</a> |
+              <a target="_blank" href="http://twitter.com/librenms">@lang('Twitter')</a> |
+              <a target="_blank" href="http://www.librenms.org/changelog.html">@lang('Changelog')</a> |
+              <a target="_blank" href="#" data-toggle="modal" data-target="#git_log">@lang('Local git log')</a>
           </p>
 
           <h3>@lang('Contributors')</h3>
@@ -94,7 +94,7 @@
                     </span>
                     <input type="checkbox" id="callback" data-size="normal" name="statistics" @if($callback_status) checked @endif>
                     <br />
-                    @lang('Online stats:') <a href='https://stats.librenms.org/'>stats.librenms.org</a>
+                    @lang('Online stats:') <a target="_blank" href='https://stats.librenms.org/'>stats.librenms.org</a>
                 </td>
             </tr>
 
@@ -185,7 +185,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>.</pre>
+along with this program.  If not, see <a target="_blank" href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>.</pre>
 
         </div>
     </div>

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -63,7 +63,7 @@
               <a target="_blank" href="https://community.librenms.org">@lang('Community Forum')</a> |
               <a target="_blank" href="http://twitter.com/librenms">@lang('Twitter')</a> |
               <a target="_blank" href="http://www.librenms.org/changelog.html">@lang('Changelog')</a> |
-              <a target="_blank" href="#" data-toggle="modal" data-target="#git_log">@lang('Local git log')</a>
+              <a href="#" data-toggle="modal" data-target="#git_log">@lang('Local git log')</a>
           </p>
 
           <h3>@lang('Contributors')</h3>

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -28,7 +28,7 @@
             <table class='table table-condensed table-hover'>
                 <tr>
                     <td><b>@lang('Version')</b></td>
-                    <td><a href='http://www.librenms.org/changelog.html'>{{ $version_local }}<span id='version_date' style="display: none;">{{ $git_date }}</span></a></td>
+                    <td><a target="_blank" href='http://www.librenms.org/changelog.html'>{{ $version_local }}<span id='version_date' style="display: none;">{{ $git_date }}</span></a></td>
                 </tr>
                 <tr>
                     <td><b>@lang('Database Schema')</b></td>

--- a/resources/views/errors/static/file_permissions.html
+++ b/resources/views/errors/static/file_permissions.html
@@ -72,7 +72,7 @@
     <hr class="separator"/>
     <p>Check your log for more details.  (<i>!!!!LOG_FILE!!!!</i>)</p>
 
-    <p>If that doesn't fix the issue. You can find how to get help at <a href="https://docs.librenms.org/Support">https://docs.librenms.org/Support</a>.</p>
+    <p>If that doesn't fix the issue. You can find how to get help at <a target="_blank" href="https://docs.librenms.org/Support">https://docs.librenms.org/Support</a>.</p>
 </div>
 
 </body>

--- a/resources/views/layouts/error.blade.php
+++ b/resources/views/layouts/error.blade.php
@@ -70,7 +70,7 @@
     <hr class="separator"/>
     <p>@lang("Check your log for more details.") ({{ isset($log_file) ? $log_file : 'librenms.log' }})</p>
 
-    <p>@lang("If you need additional help, you can find how to get help at") <a href="https://docs.librenms.org/Support">https://docs.librenms.org/Support</a>.</p>
+    <p>@lang("If you need additional help, you can find how to get help at") <a target="_blank" href="https://docs.librenms.org/Support">https://docs.librenms.org/Support</a>.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Not really useful if a Doc Link opens in same tab.
Now Doc opens in new tab, so LibreNMS stays open and Doc can be viewed in parallel tab

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
