### PR TITLE
Fix error when deleting alert maintenance schedules

### DIFF
--- a/includes/html/forms/schedule-maintenance.inc.php
+++ b/includes/html/forms/schedule-maintenance.inc.php
@@ -203,7 +203,6 @@ if ($sub_type == 'new-maintenance') {
     );
 } elseif ($sub_type == 'del-maintenance') {
     $schedule_id = mres($_POST['del_schedule_id']);
-    dbDelete('alert_schedule_items', '`schedule_id`=?', array($schedule_id));
     dbDelete('alert_schedule', '`schedule_id`=?', array($schedule_id));
     dbDelete('alert_schedulables', '`schedule_id`=?', array($schedule_id));
     $status   = 'ok';


### PR DESCRIPTION
* the table named alert_schedule_items was renamed to alert_schedulables
* see migration 277

stops messages like these from showing up in the production logs ...

```
[2020-03-02 12:39:48] production.ERROR: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'librenms.alert_schedule_items' doesn't exist (SQL: DELETE FROM `alert_schedule_items` WHERE `schedule_id`=7) (SQL: DELETE FROM `alert_schedule_items` WHERE `schedule_id`=7)#0 /opt/librenms/includes/html/forms/schedule-maintenance.inc.php(206): ...
```

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
