### PR TITLE
Graph CPU Steal and IO Wait

### DIFF
--- a/includes/html/graphs/device/ucd_cpu_steal.inc.php
+++ b/includes/html/graphs/device/ucd_cpu_steal.inc.php
@@ -1,0 +1,17 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'ucd_ssCpuRawSteal');
+
+$ds = 'value';
+
+$colour_area = '1111BB';
+$colour_line = '0000CC';
+
+$colour_area_max = 'cc9999';
+
+// $graph_max = 1;
+$scale_min = 0;
+
+$unit_text = 'CPU Steal';
+
+require 'includes/html/graphs/generic_simplex.inc.php';

--- a/includes/html/graphs/device/ucd_io_wait.inc.php
+++ b/includes/html/graphs/device/ucd_io_wait.inc.php
@@ -1,0 +1,17 @@
+<?php
+
+$rrd_filename = rrd_name($device['hostname'], 'ucd_ssCpuRawWait');
+
+$ds = 'value';
+
+$colour_area = '1111BB';
+$colour_line = '0000CC';
+
+$colour_area_max = 'cc9999';
+
+// $graph_max = 1;
+$scale_min = 0;
+
+$unit_text = 'IO Wait';
+
+require 'includes/html/graphs/generic_simplex.inc.php';

--- a/includes/polling/ucd-mib.inc.php
+++ b/includes/polling/ucd-mib.inc.php
@@ -28,6 +28,9 @@ use LibreNMS\RRD\RrdDefinition;
 // UCD-SNMP-MIB::ssCpuRawSoftIRQ.0 = Counter32: 2605010
 // UCD-SNMP-MIB::ssRawSwapIn.0 = Counter32: 602002
 // UCD-SNMP-MIB::ssRawSwapOut.0 = Counter32: 937422
+// UCD-SNMP-MIB::ssCpuRawWait.0
+// UCD-SNMP-MIB::ssCpuRawSteal.0
+
 $ss = snmpwalk_cache_oid($device, 'systemStats', array(), 'UCD-SNMP-MIB');
 $ss = $ss[0];
 
@@ -67,6 +70,8 @@ $collect_oids = array(
     'ssRawContexts',
     'ssRawSwapIn',
     'ssRawSwapOut',
+    'ssCpuRawWait',
+    'ssCpuRawSteal',
 );
 
 foreach ($collect_oids as $oid) {
@@ -100,6 +105,14 @@ if (is_numeric($ss['ssRawContexts'])) {
 
 if (is_numeric($ss['ssRawInterrupts'])) {
     $graphs['ucd_interrupts'] = true;
+}
+
+if (is_numeric($ss['ssCpuRawWait'])) {
+    $graphs['ucd_io_wait'] = true;
+}
+
+if (is_numeric($ss['ssCpuRawSteal'])) {
+    $graphs['ucd_cpu_steal'] = true;
 }
 
 // #

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -2964,11 +2964,27 @@
             },
             "type": "graph"
         },
+        "graph_types.device.ucd_cpu_steal": {
+            "default": {
+                "section": "system",
+                "order": 0,
+                "descr": "CPU Steal"
+            },
+            "type": "graph"
+        },
         "graph_types.device.ucd_interrupts": {
             "default": {
                 "section": "system",
                 "order": 0,
                 "descr": "Interrupts"
+            },
+            "type": "graph"
+        },
+        "graph_types.device.ucd_io_wait": {
+            "default": {
+                "section": "system",
+                "order": 0,
+                "descr": "I/0 Wait"
             },
             "type": "graph"
         },


### PR DESCRIPTION
Idea based on #10682 
but instead of running this as Application still transfered UCD MIB Data will be used and graphed. So everything @Munzy want's to be graphed is graphed, but with much less code and even faster handling.

UCD-SNMP-MIB::ssCpuRawWait.0  (IO Wait)
UCD-SNMP-MIB::ssCpuRawSteal.0 (CPU Steal)

This Graphs are printed if numeric data are fetched, like all other Graphs in 
**Device->Graphs**
![image](https://user-images.githubusercontent.com/7978916/75728565-77c83900-5ce8-11ea-8715-ad172f7308b9.png)

Nevertheless thanks for your Contribution @Munzy , i hope this PR will match your needs

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
