### PR TITLE
Fix includes/defaults.inc.php references

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -1,6 +1,6 @@
 <?php
 
-## Have a look in includes/defaults.inc.php for examples of settings you can set here. DO NOT EDIT defaults.inc.php!
+## Have a look in misc/config_definitions.json for examples of settings you can set here. DO NOT EDIT misc/config_definitions.json!
 
 ### Database config
 $config['db_host'] = 'localhost';

--- a/doc/Developing/os/Initial-Detection.md
+++ b/doc/Developing/os/Initial-Detection.md
@@ -77,7 +77,7 @@ mib_dir:
 ```
 
 `poller_modules`: This is a list of poller modules to either enable
-(1) or disable (0). Check `includes/defaults.inc.php` to see which
+(1) or disable (0). Check `misc/config_definitions.json` to see which
 modules are enabled/disabled by default.
 
 ```yaml
@@ -87,7 +87,7 @@ poller_modules:
 ```
 
 `discovery_modules`: This is the list of discovery modules to either
-enable (1) or disable (0). Check `includes/defaults.inc.php` to see
+enable (1) or disable (0). Check `misc/config_definitions.json` to see
 which modules are enabled/disabled by default.
 
 ```yaml

--- a/tests/config/config.test.php
+++ b/tests/config/config.test.php
@@ -1,6 +1,6 @@
 <?php
 
-## Have a look in includes/defaults.inc.php for examples of settings you can set here. DO NOT EDIT defaults.inc.php!
+## Have a look in misc/config_definitions.json for examples of settings you can set here. DO NOT EDIT misc/config_definitions.json!
 
 ### Database config
 $config['db_host'] = '127.0.0.1';


### PR DESCRIPTION
Now that includes/defaults.inc.php has gone away, refer to
misc/config_definitions.json instead.

Fixes #11242

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
