### PR TITLE
Fix - Crash in Device Group on some Operator

### DIFF
--- a/LibreNMS/Alerting/QueryBuilderParser.php
+++ b/LibreNMS/Alerting/QueryBuilderParser.php
@@ -61,6 +61,8 @@ class QueryBuilderParser implements \JsonSerializable
         'is_not_null' => "IS NOT NULL",
         'regex' => 'REGEXP',
         'not_regex' => 'NOT REGEXP',
+        'in' => 'IN',
+        'not_in' => 'NOT IN',
     ];
 
     protected static $values = [


### PR DESCRIPTION
fix missing Operator 'not' 'not in'
Now this Operators in Device Group handling are working now

Crash Example can be seen [here](https://community.librenms.org/t/cannot-access-manage-groups-section/11115/12)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
