### PR TITLE
Show the plugin's name in the title rather than just "Plugin"

### DIFF
--- a/includes/html/pages/plugin.inc.php
+++ b/includes/html/pages/plugin.inc.php
@@ -4,11 +4,11 @@ use LibreNMS\Config;
 
 $link_array = array('page' => 'plugin');
 
-$pagetitle[] = 'Plugin';
-
 if ($vars['view'] == 'admin') {
     include_once Config::get('install_dir') . '/includes/html/pages/plugin/admin.inc.php';
+    $pagetitle[] = 'Plugins';
 } else {
+    $pagetitle[] = $vars['p'];
     $plugin = dbFetchRow("SELECT `plugin_name` FROM `plugins` WHERE `plugin_name` = ? AND `plugin_active`='1'", [$vars['p']]);
     if (!empty($plugin)) {
         $plugin_path = Config::get('plugin_dir').'/'.$plugin['plugin_name'].'/'.$plugin['plugin_name'].'.inc.php';


### PR DESCRIPTION
Quick change to show a plugin's name in the browser window title instead of just the word "Plugin".

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
