### PR TITLE
APC NetBotz 200 - doesn't add not available temperature sensors

### DIFF
--- a/includes/discovery/sensors/temperature/apc.inc.php
+++ b/includes/discovery/sensors/temperature/apc.inc.php
@@ -31,7 +31,10 @@ foreach (array_keys($apc_env_data) as $index) {
         $high_warn_limit = ($apc_env_data[$index]['iemConfigProbeHighTempEnable'] != 1 ? $apc_env_data[$index]['iemConfigProbeHighTempThreshold'] : null);
         $high_limit      = ($apc_env_data[$index]['iemConfigProbeMaxTempEnable'] != 1 ? $apc_env_data[$index]['iemConfigProbeMaxTempThreshold'] : null);
 
-        discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, $sensorType, $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+        if ($current > 0) {
+            // Temperature = 0 -> Sensor not available
+            discover_sensor($valid['sensor'], 'temperature', $device, $oid, $index, $sensorType, $descr, 1, 1, $low_limit, $low_warn_limit, $high_warn_limit, $high_limit, $current);
+        }
     }
 }
 


### PR DESCRIPTION
I just added the condition available in humidity/apc.inc.php 

without this condition discovery would add a sensor even if not available (nothing connected) without this fix, I had 1 valid sensor and 9 without value. 

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
