### PR TITLE
Add quotes around the word mail

### DIFF
--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -287,7 +287,7 @@ Conditional formatting example, will display a link to the host in
 email or just the hostname in any other transport:
 
 ```text
-@if ($alert->transport == mail)<a href="https://my.librenms.install/device/device={{ $alert->hostname }}/">{{ $alert->hostname }}</a>
+@if ($alert->transport == "mail")<a href="https://my.librenms.install/device/device={{ $alert->hostname }}/">{{ $alert->hostname }}</a>
 @else
 {{ $alert->hostname }}
 @endif

--- a/doc/Alerting/Templates.md
+++ b/doc/Alerting/Templates.md
@@ -287,7 +287,7 @@ Conditional formatting example, will display a link to the host in
 email or just the hostname in any other transport:
 
 ```text
-@if ($alert->transport == "mail")<a href="https://my.librenms.install/device/device={{ $alert->hostname }}/">{{ $alert->hostname }}</a>
+@if ($alert->transport == 'mail')<a href="https://my.librenms.install/device/device={{ $alert->hostname }}/">{{ $alert->hostname }}</a>
 @else
 {{ $alert->hostname }}
 @endif


### PR DESCRIPTION
The word 'mail' needs quotes around it so php will use it as a string instead of a variable name.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
