### PR TITLE
Define Poller Duration precision to 2

### DIFF
--- a/includes/html/table/poll-log.inc.php
+++ b/includes/html/table/poll-log.inc.php
@@ -59,7 +59,7 @@ foreach (dbFetchRows($sql, array()) as $device) {
         'hostname'              => "<a class='list-device' href='".generate_device_url($device, array('tab' => 'graphs', 'group' => 'poller'))."'>".format_hostname($device).'</a>',
         'last_polled'           => $device['last_polled'],
         'poller_group'          => $device['group_name'],
-        'last_polled_timetaken' => $device['last_polled_timetaken'],
+        'last_polled_timetaken' => round($device['last_polled_timetaken'], 2),
     );
 }
 


### PR DESCRIPTION
instead of undefined, which means print poller time taken with maximal precision,
reduce it down to 2 

can be seen in Poller->History
![image](https://user-images.githubusercontent.com/7978916/76360506-69e46a80-631d-11ea-9a9d-d6da02441e26.png)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
