### PR TITLE
Fix db_port config in services-wrapper

### DIFF
--- a/services-wrapper.py
+++ b/services-wrapper.py
@@ -99,6 +99,9 @@ elif config['db_socket']:
 elif ':' in config['db_host']:
     db_server = config['db_host'].rsplit(':')[0]
     db_port = int(config['db_host'].rsplit(':')[1])
+elif 'db_port' in config:
+    db_server = config['db_host']
+    db_port = config['db_port']
 else:
     db_server = config['db_host']
     db_port = 0


### PR DESCRIPTION
If db_port is set in the config.php, services-wrapper will not work.
This fixes the issue and adds a check if db_port is set to be used as the DB port when connecting.
I used 'if SETTING in config' method as this is used below in the script.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
