### PR TITLE
Fixed issue with reporting of Cisco ASA Remote Sessions. rev2

### DIFF
--- a/includes/polling/cisco-remote-access-monitor.inc.php
+++ b/includes/polling/cisco-remote-access-monitor.inc.php
@@ -37,6 +37,12 @@ if ($device['os_group'] == 'cisco') {
     $data     = snmp_get_multi($device, $oid_list, '-OUQs', 'CISCO-REMOTE-ACCESS-MONITOR-MIB');
     $data     = $data[0];
 
+    // Some ASAs return 'No Such Object available on this agent at this OID'
+    // for crasEmailNumSessions.0. Clamp this to 0.
+    if (!is_numeric($data['crasEmailNumSessions'])) {
+        $data['crasEmailNumSessions'] = 0;
+    }
+
     if (is_numeric($data['crasEmailNumSessions']) && is_numeric($data['crasIPSecNumSessions']) && is_numeric($data['crasL2LNumSessions']) && is_numeric($data['crasLBNumSessions']) && is_numeric($data['crasSVCNumSessions']) && is_numeric($data['crasWebvpnNumSessions'])) {
         $rrd_def = RrdDefinition::make()
             ->addDataset('email', 'GAUGE', 0)


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
-----
My ASAv running 9.12(3) reports:
‘crasEmailNumSessions.0 = No Such Object available on this agent at this OID’.

This causes the current code to croak, and the result is that no remote connections are reported.

This fixes that by checking if crasEmailNumSessions.0 is numeric and clamp it to 0 if not.