### PR TITLE
Builder View Fix for Collection Selector

### DIFF
--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -56,7 +56,7 @@ if (!Auth::user()->hasGlobalAdmin()) {
                                 <tr>
                                     <td>{$rule['name']}</td>
                                     <td>";
-                            echo $rule['rule'] ?: QueryBuilderParser::fromJson($rule['builder'])->toSql(false);
+                            echo $rule['builder'] ? QueryBuilderParser::fromJson($rule['builder'])->toSql(false) : $rule['rule'];
                             echo "  </td>
                                     <td>{$rule['rule_id']}</td>
                                 </tr>

--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -56,7 +56,7 @@ if (!Auth::user()->hasGlobalAdmin()) {
                                 <tr>
                                     <td>{$rule['name']}</td>
                                     <td>";
-                            echo (array_key_exists('builder', $rule) && ! empty($rule['builder'])) ? QueryBuilderParser::fromJson($rule['builder'])->toSql(false) : $rule['rule'];
+                            echo !empty($rule['builder']) ? QueryBuilderParser::fromJson($rule['builder'])->toSql(false) : $rule['rule'];
                             echo "  </td>
                                     <td>{$rule['rule_id']}</td>
                                 </tr>

--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -56,7 +56,7 @@ if (!Auth::user()->hasGlobalAdmin()) {
                                 <tr>
                                     <td>{$rule['name']}</td>
                                     <td>";
-                            echo $rule['builder'] ? QueryBuilderParser::fromJson($rule['builder'])->toSql(false) : $rule['rule'];
+                            echo (array_key_exists('builder', $rule) && ! empty($rule['builder'])) ? QueryBuilderParser::fromJson($rule['builder'])->toSql(false) : $rule['rule'];
                             echo "  </td>
                                     <td>{$rule['rule_id']}</td>
                                 </tr>

--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -23,6 +23,8 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
+use LibreNMS\Alerting\QueryBuilderParser;
+
 if (!Auth::user()->hasGlobalAdmin()) {
     die('ERROR: You need to be admin');
 }
@@ -53,7 +55,9 @@ if (!Auth::user()->hasGlobalAdmin()) {
                             echo "
                                 <tr>
                                     <td>{$rule['name']}</td>
-                                    <td>{$rule['rule']}</td>
+                                    <td>";
+                            echo $rule['rule'] ?: QueryBuilderParser::fromJson($rule['builder'])->toSql(false);
+                            echo "  </td>
                                     <td>{$rule['rule_id']}</td>
                                 </tr>
                             ";


### PR DESCRIPTION
Alert Rule Collection, represented via "builder" key, should also be visible in Selection

before:
![image](https://user-images.githubusercontent.com/7978916/76689324-0d42c180-6635-11ea-8555-c4915c747a20.png)

after:
![image](https://user-images.githubusercontent.com/7978916/76689329-159afc80-6635-11ea-9447-129e8269ef79.png)


#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
