### PR TITLE
Alert Collection Rule fix for APC on Battery Power 

### DIFF
--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -55,9 +55,7 @@ if (!Auth::user()->hasGlobalAdmin()) {
                             echo "
                                 <tr>
                                     <td>{$rule['name']}</td>
-                                    <td>";
-                            echo $rule['rule'] ?: QueryBuilderParser::fromJson($rule['builder'])->toSql(false);
-                            echo "  </td>
+                                    <td>{$rule['rule']}</td>
                                     <td>{$rule['rule_id']}</td>
                                 </tr>
                             ";

--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -23,8 +23,6 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
-use LibreNMS\Alerting\QueryBuilderParser;
-
 if (!Auth::user()->hasGlobalAdmin()) {
     die('ERROR: You need to be admin');
 }

--- a/includes/html/modal/alert_rule_collection.inc.php
+++ b/includes/html/modal/alert_rule_collection.inc.php
@@ -23,6 +23,8 @@
  * @author     Neil Lathwood <neil@lathwood.co.uk>
  */
 
+use LibreNMS\Alerting\QueryBuilderParser;
+
 if (!Auth::user()->hasGlobalAdmin()) {
     die('ERROR: You need to be admin');
 }
@@ -53,7 +55,9 @@ if (!Auth::user()->hasGlobalAdmin()) {
                             echo "
                                 <tr>
                                     <td>{$rule['name']}</td>
-                                    <td>{$rule['rule']}</td>
+                                    <td>";
+                            echo $rule['rule'] ?: QueryBuilderParser::fromJson($rule['builder'])->toSql(false);
+                            echo "  </td>
                                     <td>{$rule['rule_id']}</td>
                                 </tr>
                             ";

--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -172,7 +172,7 @@
     "name": "APC UPS Battery Needs Replacement"
   },
   {
-    "rule": "sensors.sensor_current = \"3\" && sensors.sensor_type = \"upsBasicOutputStatus\"",
+    "builder": {"condition":"AND","rules":[{"condition":"AND","rules":[{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"3"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"upsBasicOutputStatus"}]},{"condition":"AND","rules":[{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"4"},{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"upsAdvTestDiagnosticsResults"}]}],"valid":true},
     "name": "APC UPS Switched to Battery Power"
   },
   {


### PR DESCRIPTION
Alert should only trigger if on Battery Power and not on self test

OID: upsAdvTestDiagnosticsResults
Reference: [https://networkupstools.org/protocols/snmp/APC-Powernet.pdf](https://networkupstools.org/protocols/snmp/APC-Powernet.pdf)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
