### PR TITLE
Alert Collection Rule - APC UPS Diagnostics Test Result

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -172,6 +172,10 @@
     "name": "APC UPS Battery Needs Replacement"
   },
   {
+    "builder": {"condition":"AND","rules":[{"id":"sensors.sensor_type","field":"sensors.sensor_type","type":"string","input":"text","operator":"equal","value":"upsAdvTestDiagnosticsResults"},{"condition":"OR","rules":[{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"2"},{"id":"sensors.sensor_current","field":"sensors.sensor_current","type":"string","input":"text","operator":"equal","value":"3"}]}],"valid":true},
+    "name": "APC UPS Diagonstics Test Result"
+  },
+  {
     "rule": "sensors.sensor_current = \"3\" && sensors.sensor_type = \"upsBasicOutputStatus\"",
     "name": "APC UPS Switched to Battery Power"
   },


### PR DESCRIPTION
Add Alert Rule to Collection for getting APC UPS Self Diagnostics Test Result

OID: upsAdvTestDiagnosticsResults
Reference: https://networkupstools.org/protocols/snmp/APC-Powernet.pdf

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
