### PR TITLE
Widget Fix - Server Stats - show DisplayName instead Device ID

### DIFF
--- a/resources/views/widgets/settings/server-stats.blade.php
+++ b/resources/views/widgets/settings/server-stats.blade.php
@@ -30,6 +30,6 @@
 
 @section('javascript')
     <script type="text/javascript">
-        init_select2('#device-{{ $id }}', 'device', {}, '{{ $device ? $device->device_id : '' }}');
+        init_select2('#device-{{ $id }}', 'device', {}, '{{ $device ? $device->displayName() : '' }}');
     </script>
 @endsection

--- a/resources/views/widgets/settings/server-stats.blade.php
+++ b/resources/views/widgets/settings/server-stats.blade.php
@@ -30,6 +30,6 @@
 
 @section('javascript')
     <script type="text/javascript">
-        init_select2('#device-{{ $id }}', 'device', {}, '{{ $device ? $device->displayName() : '' }}');
+        init_select2('#device-{{ $id }}', 'device', {}, @json($device ? ['id' => $device->device_id, 'text' => $device->displayName()] : ''));
     </script>
 @endsection


### PR DESCRIPTION
show Devicename instead of Device_id when Host selected

before:
![image](https://user-images.githubusercontent.com/7978916/76909819-90ba1800-68ac-11ea-8f1e-48dac09c59f1.png)


after:
![image](https://user-images.githubusercontent.com/7978916/76909679-3325cb80-68ac-11ea-98e2-df2060e6627c.png)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
