### PR TITLE
Fixed Netscaler vserver rrd ds name

### DIFF
--- a/includes/polling/netscaler-vsvr.inc.php
+++ b/includes/polling/netscaler-vsvr.inc.php
@@ -82,10 +82,11 @@ if ($device['os'] == 'netscaler') {
 
             $fields = array();
             foreach ($oids as $oid) {
+                $oid_ds = str_replace('vsvr', '', $oid);
                 if (is_numeric($vsvr[$oid])) {
-                    $fields[$oid] = $vsvr[$oid];
+                    $fields[$oid_ds] = $vsvr[$oid];
                 } else {
-                    $fields[$oid] = 'U';
+                    $fields[$oid_ds] = 'U';
                 }
             }
 


### PR DESCRIPTION
Changed the key (RRD DS) in `$fields` assoc array to match the one used in `$rrd_def` (`$rrd_def->addDataset` is called with DS name that has `vsvr` prefix stripped).

I guess this is related to #11283 as that's when the Netscaler graphs whent blank.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
