### PR TITLE
Stop using {} for arrays

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1742,7 +1742,7 @@ function hytera_h2f($number, $nd)
     if (strlen(str_replace(" ", "", $number)) == 4) {
         $hex = '';
         for ($i = 0; $i < strlen($number); $i++) {
-            $byte = strtoupper(dechex(ord($number{$i})));
+            $byte = strtoupper(dechex(ord($number[$i])));
             $byte = str_repeat('0', 2 - strlen($byte)).$byte;
             $hex.=$byte." ";
         }
@@ -2210,7 +2210,7 @@ function cache_peeringdb()
                 $get = Requests::get($peeringdb_url . '/net?depth=2&asn=' . $asn, array(), array('proxy' => get_proxy()));
                 $json_data = $get->body;
                 $data = json_decode($json_data);
-                $ixs = $data->{'data'}{0}->{'netixlan_set'};
+                $ixs = $data->{'data'}[0]->{'netixlan_set'};
                 foreach ($ixs as $ix) {
                     $ixid = $ix->{'ix_id'};
                     $tmp_ix = dbFetchRow("SELECT * FROM `pdb_ix` WHERE `ix_id` = ? AND asn = ?", array($ixid, $asn));


### PR DESCRIPTION
This avoids this message in ./validate.php - the line numbers in the output differ
from those in the patch because I'm using LibreNMS 1.61

PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /usr/local/www/librenms/includes/functions.php on line 1833
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /usr/local/www/librenms/includes/functions.php on line 2336

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [y ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ n/a] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
