### PR TITLE
Fix: Widget - TopInterface, TopDevice - device popup missing os name

### DIFF
--- a/app/Http/Controllers/Widgets/TopDevicesController.php
+++ b/app/Http/Controllers/Widgets/TopDevicesController.php
@@ -126,7 +126,7 @@ class TopDevicesController extends WidgetController
 
         /** @var Builder $query */
         return $query->with(['device' => function ($query) {
-            $query->select('device_id', 'hostname', 'sysName', 'status');
+            $query->select('device_id', 'hostname', 'sysName', 'status', 'os');
         }])
             ->select("$left_table.device_id")
             ->leftJoin('devices', "$left_table.device_id", 'devices.device_id')
@@ -145,7 +145,7 @@ class TopDevicesController extends WidgetController
     {
         $settings = $this->getSettings();
 
-        return Device::hasAccess(Auth::user())->select('device_id', 'hostname', 'sysName', 'status')
+        return Device::hasAccess(Auth::user())->select('device_id', 'hostname', 'sysName', 'status', 'os')
             ->where('devices.last_polled', '>', Carbon::now()->subMinutes($settings['time_interval']))
             ->when($settings['device_group'], function ($query) use ($settings) {
                 $query->inDeviceGroup($settings['device_group']);
@@ -181,7 +181,7 @@ class TopDevicesController extends WidgetController
 
         /** @var Builder $query */
         $query = Port::hasAccess(Auth::user())->with(['device' => function ($query) {
-            $query->select('device_id', 'hostname', 'sysName', 'status');
+            $query->select('device_id', 'hostname', 'sysName', 'status', 'os');
         }])
             ->select('device_id')
             ->groupBy('device_id')
@@ -281,7 +281,7 @@ class TopDevicesController extends WidgetController
 
         /** @var Builder $query */
         $query = Storage::hasAccess(Auth::user())->with(['device' => function ($query) {
-            $query->select('device_id', 'hostname', 'sysName', 'status');
+            $query->select('device_id', 'hostname', 'sysName', 'status', 'os');
         }])
             ->leftJoin('devices', 'storage.device_id', 'devices.device_id')
             ->select('storage.device_id', 'storage_id', 'storage_descr', 'storage_perc', 'storage_perc_warn')

--- a/app/Http/Controllers/Widgets/TopInterfacesController.php
+++ b/app/Http/Controllers/Widgets/TopInterfacesController.php
@@ -49,7 +49,7 @@ class TopInterfacesController extends WidgetController
         $data = $this->getSettings();
 
         $query = Port::hasAccess($request->user())->with(['device' => function ($query) {
-            $query->select('device_id', 'hostname', 'sysName', 'status');
+            $query->select('device_id', 'hostname', 'sysName', 'status', 'os');
         }])
             ->select('port_id', 'device_id', 'ifName', 'ifDescr', 'ifAlias')
             ->groupBy('port_id', 'device_id', 'ifName', 'ifDescr', 'ifAlias')


### PR DESCRIPTION
Mouseover on Device Links in following Widgets are now device specific as they should:
- Top Interface
- Top Device

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
