### PR TITLE
Better map link scaling algorithm

### DIFF
--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -164,6 +164,9 @@ marker.bindPopup(title);
               AND ld.ignore = 0
               AND rd.disabled = 0
               AND rd.ignore = 0
+              AND lp.ifOutOctets_rate != 0
+              AND lp.ifInOctets_rate != 0
+              AND lp.ifOperStatus = 'up'
               AND ld.status IN " . dbGenPlaceholders(count($show_status)) . "
               AND rd.status IN " . dbGenPlaceholders(count($show_status)) . "
             GROUP BY
@@ -203,6 +206,9 @@ marker.bindPopup(title);
               AND ld.ignore = 0
               AND rd.disabled = 0
               AND rd.ignore = 0
+              AND lp.ifOutOctets_rate != 0
+              AND lp.ifInOctets_rate != 0
+              AND lp.ifOperStatus = 'up'
               AND ld.status IN " . dbGenPlaceholders(count($show_status)) . "
               AND rd.status IN " . dbGenPlaceholders(count($show_status)) . "
               AND ld.device_id IN " . dbGenPlaceholders(count($device_ids)) . "
@@ -224,7 +230,7 @@ marker.bindPopup(title);
                 $width = round(0.77 * pow($speed, 0.25));
             }
     
-            $link_used = ($link["link_out_usage_pct"] + $link["link_in_usage_pct"]) / 2;
+            $link_used = max($link["link_out_usage_pct"], $link["link_in_usage_pct"]);
             $link_used = round(2 * $link_used, -1) / 2;
             if ($link_used > 100) {
                 $link_used = 100;


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

Improve the algorithm of the link map.
Previous one would not show properly an oveloaded link.
Here I take the high direction instead of the average of both side.
I also ignore the ports with 0 traffic rate (As they are probably isolated or defective)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
