### PR TITLE
Auth Active Directory add support for userprincipalname

### DIFF
--- a/app/Providers/LegacyUserProvider.php
+++ b/app/Providers/LegacyUserProvider.php
@@ -170,6 +170,10 @@ class LegacyUserProvider implements UserProvider
         }
 
         $username = $credentials['username'] ?? null;
+        // get the sAMAccountName from the UserPrincipalName
+        if (strpos($username, "@") && $type == "active_directory") {
+            $username = $auth->getUsersAMAccountName($username);
+        }
         $auth_id = $auth->getUserid($username);
         $new_user = $auth->getUser($auth_id);
 

--- a/scripts/auth_test.php
+++ b/scripts/auth_test.php
@@ -106,7 +106,12 @@ try {
     `stty echo`;
     echo PHP_EOL;
 
-    echo "Authenticate user $test_username: \n";
+    if (Config::get('auth_mechanism') == "active_directory" && strpos($test_username, "@")) {
+        $test_username = $authorizer->getUsersAMAccountName($test_username);
+        echo "Authenticate user $test_username (" . $options['u'] . "): \n";
+    } else {
+        echo "Authenticate user $test_username: \n";
+    }
     $auth = $authorizer->authenticate(['username' => $test_username, 'password' => $test_password]);
     unset($test_password);
 


### PR DESCRIPTION
As requested on the forum, this PR add the ability to login to LibreNMS with your UserPrincipalName when `auth_mechanism = "active_directory";`.

For LibreNMS your username will always be your sAMAccountName.

If you enter your UserPrincipalName at the login page, it will retrieve your sAMAccountName and use it to login.

I tested Remember Me at login and no problem.

![userprincipal](https://user-images.githubusercontent.com/6872180/77496120-88cd1b80-6e4a-11ea-8725-e17cd7630ec4.gif)
.
![samaccount](https://user-images.githubusercontent.com/6872180/77496153-9c788200-6e4a-11ea-8d8b-f6ec9688150d.gif)


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
