### PR TITLE
OPNsense  poller better reporting of Version and Platform

### DIFF
--- a/includes/polling/os/opnsense.inc.php
+++ b/includes/polling/os/opnsense.inc.php
@@ -29,7 +29,7 @@ $hardware = $output[6];
 
 // 20.1 onwards you can enable Display Version OID, which gives use the exact release number
 $OIDVersionString = snmp_get($device, ".1.3.6.1.4.1.8072.1.3.2.3.1.2.7.118.101.114.115.105.111.110", '-Oqv');
-if ($OIDVersionString != "") {
+if (is_string($OIDVersionString) {
     $OIDVersionArray = preg_split("/ /", $OIDVersionString);
     $version = $OIDVersionArray[1];
     $hardware = preg_replace('/\(|\)/','',$OIDVersionArray[2]);

--- a/includes/polling/os/opnsense.inc.php
+++ b/includes/polling/os/opnsense.inc.php
@@ -29,7 +29,7 @@ $hardware = $output[6];
 
 // 20.1 onwards you can enable Display Version OID, which gives use the exact release number
 $OIDVersionString = snmp_get($device, ".1.3.6.1.4.1.8072.1.3.2.3.1.2.7.118.101.114.115.105.111.110", '-Oqv');
-if (is_string($OIDVersionString) {
+if (is_string($OIDVersionString)) {
     $OIDVersionArray = preg_split("/ /", $OIDVersionString);
     $version = $OIDVersionArray[1];
     $hardware = preg_replace('/\(|\)/','',$OIDVersionArray[2]);

--- a/includes/polling/os/opnsense.inc.php
+++ b/includes/polling/os/opnsense.inc.php
@@ -26,3 +26,11 @@
 $output = preg_split("/ /", $device['sysDescr']);
 $version = $output[2];
 $hardware = $output[6];
+
+// 20.1 onwards you can enable Display Version OID, which gives use the exact release number
+$OIDVersionString = snmp_get($device, ".1.3.6.1.4.1.8072.1.3.2.3.1.2.7.118.101.114.115.105.111.110", '-Oqv');
+if ($OIDVersionString != "") {
+    $OIDVersionArray = preg_split("/ /", $OIDVersionString);
+    $version = $OIDVersionArray[1];
+    $hardware = preg_replace('/\(|\)/','',$OIDVersionArray[2]);
+}

--- a/includes/polling/os/opnsense.inc.php
+++ b/includes/polling/os/opnsense.inc.php
@@ -32,5 +32,5 @@ $OIDVersionString = snmp_get($device, ".1.3.6.1.4.1.8072.1.3.2.3.1.2.7.118.101.1
 if (is_string($OIDVersionString)) {
     $OIDVersionArray = preg_split("/ /", $OIDVersionString);
     $version = $OIDVersionArray[1];
-    $hardware = preg_replace('/\(|\)/','',$OIDVersionArray[2]);
+    $hardware = preg_replace('/\(|\)/', '', $OIDVersionArray[2]);
 }

--- a/tests/data/opnsense.json
+++ b/tests/data/opnsense.json
@@ -1,0 +1,40 @@
+{
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": "",
+                    "sysObjectID": ".1.3.6.1.4.1.12325.1.1.2.1.1",
+                    "sysDescr": "OPNsense OPNsense.7p.lan 18.1.1-a5575d7bd OPNsense FreeBSD 11.1-RELEASE-p6 amd64",
+                    "sysContact": null,
+                    "version": null,
+                    "hardware": null,
+                    "features": null,
+                    "os": "opnsense",
+                    "type": "firewall",
+                    "serial": null,
+                    "icon": "opnsense.png",
+                    "location": null
+                }
+            ]
+        },
+        "poller": {
+            "devices": [
+                {
+                    "sysName": "",
+                    "sysObjectID": ".1.3.6.1.4.1.12325.1.1.2.1.1",
+                    "sysDescr": "OPNsense OPNsense.7p.lan 18.1.1-a5575d7bd OPNsense FreeBSD 11.1-RELEASE-p6 amd64",
+                    "sysContact": null,
+                    "version": "18.1.1-a5575d7bd",
+                    "hardware": "amd64",
+                    "features": null,
+                    "os": "opnsense",
+                    "type": "firewall",
+                    "serial": null,
+                    "icon": "opnsense.png",
+                    "location": null
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/opnsense_1.json
+++ b/tests/data/opnsense_1.json
@@ -1,0 +1,40 @@
+{
+    "os": {
+        "discovery": {
+            "devices": [
+                {
+                    "sysName": "",
+                    "sysObjectID": ".1.3.6.1.4.1.8072.3.2.8",
+                    "sysDescr": "FreeBSD fw1-eri1.OPN 11.2-RELEASE-p16-HBSD FreeBSD 11.2-RELEASE-p16-HBSD  fc65add89c3(stable/20.1) amd64",
+                    "sysContact": null,
+                    "version": null,
+                    "hardware": null,
+                    "features": null,
+                    "os": "opnsense",
+                    "type": "firewall",
+                    "serial": null,
+                    "icon": "opnsense.png",
+                    "location": null
+                }
+            ]
+        },
+        "poller": {
+            "devices": [
+                {
+                    "sysName": "",
+                    "sysObjectID": ".1.3.6.1.4.1.8072.3.2.8",
+                    "sysDescr": "FreeBSD fw1-eri1.OPN 11.2-RELEASE-p16-HBSD FreeBSD 11.2-RELEASE-p16-HBSD  fc65add89c3(stable/20.1) amd64",
+                    "sysContact": null,
+                    "version": "20.1.2",
+                    "hardware": "amd64/OpenSSL",
+                    "features": null,
+                    "os": "opnsense",
+                    "type": "firewall",
+                    "serial": null,
+                    "icon": "opnsense.png",
+                    "location": null
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
My following commit allows LibreNMS to report exact version and platform of OPNsense, if the setting in OPNsense is ticked "Display Verion in OID".

Here's a screenshot of what it then looks like if the setting is ticked.
Top entry has it ticked.
Bottom entry is what it shows when its not ticked.
![image](https://user-images.githubusercontent.com/3495647/77581317-6e8c4f80-6ed5-11ea-8077-4235d30aec4c.png)

This file has a copyright and author set, I read the article on https://docs.librenms.org/Developing/Licensing/ but it doesn't say what to do if your amending a file that already has one. Do I just change it to Authors; and add my name?

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
