### PR TITLE
Fix bills api percentage calculation with cdr/quota of zero

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1382,13 +1382,21 @@ function list_bills(\Illuminate\Http\Request $request)
         if (strtolower($bill['bill_type']) == "cdr") {
             $allowed = format_si($bill['bill_cdr'])."bps";
             $used    = format_si($rate_data['rate_95th'])."bps";
-            $percent = round(($rate_data['rate_95th'] / $bill['bill_cdr']) * 100, 2);
+            if ($bill['bill_cdr'] > 0) {
+                $percent = round(($rate_data['rate_95th'] / $bill['bill_cdr']) * 100, 2);
+            } else {
+                $percent = "-";
+            }
             $overuse = $rate_data['rate_95th'] - $bill['bill_cdr'];
             $overuse = (($overuse <= 0) ? "-" : format_si($overuse));
         } elseif (strtolower($bill['bill_type']) == "quota") {
             $allowed = format_bytes_billing($bill['bill_quota']);
             $used    = format_bytes_billing($rate_data['total_data']);
-            $percent = round(($rate_data['total_data'] / ($bill['bill_quota'])) * 100, 2);
+            if ($bill['bill_quota'] > 0) {
+                $percent = round(($rate_data['total_data'] / ($bill['bill_quota'])) * 100, 2);
+            } else {
+                $percent = "-";
+            }
             $overuse = $rate_data['total_data'] - $bill['bill_quota'];
             $overuse = (($overuse <= 0) ? "-" : format_bytes_billing($overuse));
         }


### PR DESCRIPTION
PHP allows division by zero but the api will fail when trying to encode
the response to json as reported at
https://github.com/librenms/librenms/pull/11295#issuecomment-604290389

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
