### PR TITLE
Geo map: check if lat/long exist for each device with link

### DIFF
--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -167,6 +167,10 @@ marker.bindPopup(title);
               AND lp.ifOutOctets_rate != 0
               AND lp.ifInOctets_rate != 0
               AND lp.ifOperStatus = 'up'
+              AND ll.lat IS NOT NULL
+              AND ll.lng IS NOT NULL
+              AND rl.lat IS NOT NULL
+              AND rl.lng IS NOT NULL
               AND ld.status IN " . dbGenPlaceholders(count($show_status)) . "
               AND rd.status IN " . dbGenPlaceholders(count($show_status)) . "
             GROUP BY
@@ -209,6 +213,10 @@ marker.bindPopup(title);
               AND lp.ifOutOctets_rate != 0
               AND lp.ifInOctets_rate != 0
               AND lp.ifOperStatus = 'up'
+              AND ll.lat IS NOT NULL
+              AND ll.lng IS NOT NULL
+              AND rl.lat IS NOT NULL
+              AND rl.lng IS NOT NULL
               AND ld.status IN " . dbGenPlaceholders(count($show_status)) . "
               AND rd.status IN " . dbGenPlaceholders(count($show_status)) . "
               AND ld.device_id IN " . dbGenPlaceholders(count($device_ids)) . "


### PR DESCRIPTION
after 1.62 upgrade and enabling "Display network links on the map" (#11269), the Geo map wasn't loading. JS was failing because polylines were trying to be created between devices that didn't have lat/lng coordinates.

This PR adds check to make sure both devices in link have lat and long.
@kedare if you want to check this out to verify

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
