### PR TITLE
Fix dashboard html escaping and javascript redirect

### DIFF
--- a/includes/html/forms/add-dashboard.inc.php
+++ b/includes/html/forms/add-dashboard.inc.php
@@ -36,7 +36,7 @@ if (!Auth::check()) {
 $status    = 'error';
 $message   = 'unknown error';
 
-$dashboard_name = display($_REQUEST['dashboard_name']);
+$dashboard_name = trim($_REQUEST['dashboard_name']);
 
 if (!empty($dashboard_name) && ($dash_id = dbInsert(['dashboard_name' => $dashboard_name, 'user_id' => Auth::id()], 'dashboards'))) {
     $status  = 'ok';

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -426,7 +426,7 @@
                     if (data.status == "ok") {
                         toastr.success(data.message);
                         setTimeout(function (){
-                            window.location.href = "{{ url('/?dashboard=') }} + dashboard_id";
+                            window.location.href = "{{ url('/?dashboard=') }}" + dashboard_id;
                         }, 500);
                     }
                     else {
@@ -455,7 +455,7 @@
                 if( data.status == "ok" ) {
                     toastr.success(data.message);
                     setTimeout(function (){
-                        window.location.href = "{{ url('/?dashboard=') }} + data.dashboard_id";
+                        window.location.href = "{{ url('/?dashboard=') }}" + data.dashboard_id;
                     }, 500);
                 }
                 else {


### PR DESCRIPTION
Currently if you name a dashboard "foo&bar" it will be displayed as "foo&amp;bar" due to double-escaping.  
Also fixed a redirect issue

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
