### PR TITLE
Fix device creation using overwrited ip

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -525,7 +525,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
 
     // check if we have the host by IP
     $overwrite_ip = null;
-    if (!empty($overwrite_ip)) {
+    if (!empty($additional['overwrite_ip'])) {
         $overwrite_ip = $additional['overwrite_ip'];
         $ip = $overwrite_ip;
     } elseif (Config::get('addhost_alwayscheckip') === true) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -523,12 +523,10 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
         throw new InvalidPortAssocModeException("Invalid port association_mode '$port_assoc_mode'. Valid modes are: " . join(', ', get_port_assoc_modes()));
     }
 
-    if ($additional['overwrite_ip']) {
-        $overwrite_ip = $additional['overwrite_ip'];
-    }
-
     // check if we have the host by IP
+    $overwrite_ip = null;
     if (!empty($overwrite_ip)) {
+        $overwrite_ip = $additional['overwrite_ip'];
         $ip = $overwrite_ip;
     } elseif (Config::get('addhost_alwayscheckip') === true) {
         $ip = gethostbyname($host);
@@ -569,7 +567,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
         if ($snmpver === "v3") {
             // Try each set of parameters from config
             foreach (Config::get('snmp.v3') as $v3) {
-                $device = deviceArray($host, null, $snmpver, $port, $transport, $v3, $port_assoc_mode);
+                $device = deviceArray($host, null, $snmpver, $port, $transport, $v3, $port_assoc_mode, $overwrite_ip);
                 if ($force_add === true || isSNMPable($device)) {
                     return createHost($host, null, $snmpver, $port, $transport, $v3, $poller_group, $port_assoc_mode, $force_add, $overwrite_ip);
                 } else {
@@ -579,7 +577,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
         } elseif ($snmpver === "v2c" || $snmpver === "v1") {
             // try each community from config
             foreach (Config::get('snmp.community') as $community) {
-                $device = deviceArray($host, $community, $snmpver, $port, $transport, null, $port_assoc_mode);
+                $device = deviceArray($host, $community, $snmpver, $port, $transport, null, $port_assoc_mode, $overwrite_ip);
 
                 if ($force_add === true || isSNMPable($device)) {
                     return createHost($host, $community, $snmpver, $port, $transport, array(), $poller_group, $port_assoc_mode, $force_add, $overwrite_ip);
@@ -599,10 +597,11 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
     throw $host_unreachable_exception;
 }
 
-function deviceArray($host, $community, $snmpver, $port = 161, $transport = 'udp', $v3 = array(), $port_assoc_mode = 'ifIndex')
+function deviceArray($host, $community, $snmpver, $port = 161, $transport = 'udp', $v3 = array(), $port_assoc_mode = 'ifIndex',  $overwrite_ip = null)
 {
     $device = array();
     $device['hostname'] = $host;
+    $device['overwrite_ip'] = $overwrite_ip;
     $device['port'] = $port;
     $device['transport'] = $transport;
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -597,7 +597,7 @@ function addHost($host, $snmp_version = '', $port = '161', $transport = 'udp', $
     throw $host_unreachable_exception;
 }
 
-function deviceArray($host, $community, $snmpver, $port = 161, $transport = 'udp', $v3 = array(), $port_assoc_mode = 'ifIndex',  $overwrite_ip = null)
+function deviceArray($host, $community, $snmpver, $port = 161, $transport = 'udp', $v3 = array(), $port_assoc_mode = 'ifIndex', $overwrite_ip = null)
 {
     $device = array();
     $device['hostname'] = $host;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -625,7 +625,7 @@ function deviceArray($host, $community, $snmpver, $port = 161, $transport = 'udp
     }
 
     return $device;
-}
+}//end deviceArray()
 
 
 function formatUptime($diff, $format = "long")


### PR DESCRIPTION
`deviceArray` was creating a device missing the `overwrite_ip` field, so it was not used by `isSNMPable`

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
