### PR TITLE
Small test speedup

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -884,19 +884,12 @@ function get_astext($asn)
  */
 function log_event($text, $device = null, $type = null, $severity = 2, $reference = null)
 {
-    if (!is_array($device)) {
-        $device = device_by_id_cache($device);
+    // handle legacy device array
+    if (is_array($device) && isset($device['device_id'])) {
+        $device = $device['device_id'];
     }
 
-    dbInsert([
-        'device_id' => ($device['device_id'] ?: 0),
-        'reference' => $reference,
-        'type' => $type,
-        'datetime' => \Carbon\Carbon::now(),
-        'severity' => $severity,
-        'message' => $text,
-        'username'  => Auth::user()->username ?? '',
-    ], 'eventlog');
+    Log::event($text, $device, $type, $severity, $reference);
 }
 
 // Parse string with emails. Return array with email (as key) and name (as value)

--- a/tests/OSModulesTest.php
+++ b/tests/OSModulesTest.php
@@ -83,6 +83,12 @@ class OSModulesTest extends DBTestCase
     {
         $this->requireSnmpsim();  // require snmpsim for tests
 
+        // stub out Log::event, we don't need to store them for these tests
+        $this->app->bind('log', function ($app) {
+            return \Mockery::mock('\App\Facades\LogManager[event]', [$app])
+                ->shouldReceive('event');
+        });
+
         try {
             set_debug(false); // avoid all undefined index errors in the legacy code
             $helper = new ModuleTestHelper($modules, $os, $variant);


### PR DESCRIPTION
Use Log::event() inside log_event()
Mock Log::event() in module tests to prevent writing to the database.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
