### PR TITLE
Prevent breaking of interface name into 2 words/parts

### DIFF
--- a/includes/html/print-event-short.inc.php
+++ b/includes/html/print-event-short.inc.php
@@ -27,7 +27,7 @@ if ($entry['type'] == 'interface') {
     $entry['link'] = '<b>' . generate_port_link(cleanPort(getifbyid($entry['reference']))) . '</b>';
 }
 
-echo '<td>'.$entry['link'].'</td>';
+echo '<td style="white-space: nowrap;">'.$entry['link'].'</td>';
 echo '<td>' . htmlspecialchars($entry['message']) . '</td>';
 
 echo '</tr>';


### PR DESCRIPTION
DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

Before,

![image](https://user-images.githubusercontent.com/363587/79262913-a0c71680-7eaf-11ea-9880-56d5a74d8568.png)


After,

![image](https://user-images.githubusercontent.com/363587/79262977-bc322180-7eaf-11ea-8489-678bc539ad54.png)

So the "Port 2" (interface name) does not break into 2 lines now


#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
