### PR TITLE
Fix billing graphs: work around jpgraph bug

### DIFF
--- a/includes/html/graphs/bill/historicbits.inc.php
+++ b/includes/html/graphs/bill/historicbits.inc.php
@@ -63,6 +63,14 @@ function YCallback($y)
 $graph = new Graph($vars['width'], $vars['height'], $graph_data['graph_name']);
 $graph->img->SetImgFormat('png');
 
+// work around bug in jpgraph error handling
+$graph->title->Set(' ');
+$graph->subtitle->Set(' ');
+$graph->subsubtitle->Set(' ');
+$graph->footer->left->Set(' ');
+$graph->footer->center->Set(' ');
+$graph->footer->right->Set(' ');
+
 $graph->SetScale('datlin', 0, 0, $graph_data['from'], $graph_data['to']);
 $graph->SetMarginColor('white');
 $graph->SetFrame(false);

--- a/includes/html/graphs/bill/historicmonthly.inc.php
+++ b/includes/html/graphs/bill/historicmonthly.inc.php
@@ -27,6 +27,14 @@ for ($i = 0; $i < count($graph_data['ticklabels']); $i++) {
 $graph = new Graph($vars['width'], $vars['height'], $graph_data['graph_name']);
 $graph->img->SetImgFormat('png');
 
+// work around bug in jpgraph error handling
+$graph->title->Set(' ');
+$graph->subtitle->Set(' ');
+$graph->subsubtitle->Set(' ');
+$graph->footer->left->Set(' ');
+$graph->footer->center->Set(' ');
+$graph->footer->right->Set(' ');
+
 $graph->SetScale('textlin');
 // $graph->title->Set("$graph_name");
 $graph->title->SetFont(FF_FONT2, FS_BOLD, 10);

--- a/includes/html/graphs/bill/historictransfer.inc.php
+++ b/includes/html/graphs/bill/historictransfer.inc.php
@@ -29,6 +29,14 @@ for ($i = 0; $i < count($graph_data['ticklabels']); $i++) {
 $graph = new Graph($vars['width'], $vars['height'], $graph_data['graph_name']);
 $graph->img->SetImgFormat('png');
 
+// work around bug in jpgraph error handling
+$graph->title->Set(' ');
+$graph->subtitle->Set(' ');
+$graph->subsubtitle->Set(' ');
+$graph->footer->left->Set(' ');
+$graph->footer->center->Set(' ');
+$graph->footer->right->Set(' ');
+
 $graph->SetScale('textlin');
 $graph->title->SetFont(FF_FONT2, FS_BOLD, 10);
 $graph->SetMarginColor('white');


### PR DESCRIPTION
apparently GD now returns false when getting the bounding box of empty strings, this causes jpgraph to throw an incorrect error.  Work around that by setting all possible text to a single space character.

https://community.librenms.org/t/graph-issue-after-update/11504
https://github.com/HuasoFoundries/jpgraph/pull/93


DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
