### PR TITLE
Improvement for matching LLDP neighbors with known hosts.

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1387,6 +1387,9 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
         if ($mydomain = Config::get('mydomain')) {
             $where[] = '`hostname`=?';
             $params[] = "$name.$mydomain";
+
+            $where[] = 'concat(`hostname`, \'.\', \'' . $mydomain . '\') =?';
+            $params[] = "$name";
         }
     }
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1388,7 +1388,8 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
             $where[] = '`hostname`=?';
             $params[] = "$name.$mydomain";
 
-            $where[] = 'concat(`hostname`, \'.\', \'' . $mydomain . '\') =?';
+            $where[] = 'concat(`hostname`, \'.\', ?) =?';
+            $params[] = "$mydomain";
             $params[] = "$name";
         }
     }


### PR DESCRIPTION
LLDP hosts presenting with FQDN do not currently match with devices stored without a FQDN in the devices table.

This fix also compares LLDP hostname with $hostname + $config['mydomain'], when $config['mydomain'] is set.

This yields recognized neighbors and clickable links in the neighbor overview.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
