### PR TITLE
Use model::class instead of string for binding

### DIFF
--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -58,16 +58,16 @@ class Alert extends Model
 
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id');
     }
 
     public function rule()
     {
-        return $this->belongsTo('App\Models\AlertRule', 'rule_id', 'id');
+        return $this->belongsTo(\App\Models\AlertRule::class, 'rule_id', 'id');
     }
 
     public function users()
     {
-        return $this->belongsToMany('App\Models\User', 'devices_perms', 'device_id', 'user_id');
+        return $this->belongsToMany(\App\Models\User::class, 'devices_perms', 'device_id', 'user_id');
     }
 }

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -80,11 +80,11 @@ class AlertRule extends BaseModel
 
     public function alerts()
     {
-        return $this->hasMany('App\Models\Alert', 'rule_id');
+        return $this->hasMany(\App\Models\Alert::class, 'rule_id');
     }
 
     public function devices()
     {
-        return $this->belongsToMany('App\Models\Device', 'alert_device_map', 'device_id', 'device_id');
+        return $this->belongsToMany(\App\Models\Device::class, 'alert_device_map', 'device_id', 'device_id');
     }
 }

--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -76,11 +76,11 @@ class AlertSchedule extends Model
 
     public function devices()
     {
-        return $this->morphedByMany('App\Models\Device', 'alert_schedulable', 'alert_schedulables', 'schedule_id', 'schedule_id');
+        return $this->morphedByMany(\App\Models\Device::class, 'alert_schedulable', 'alert_schedulables', 'schedule_id', 'schedule_id');
     }
 
     public function deviceGroups()
     {
-        return $this->morphedByMany('App\Models\DeviceGroup', 'alert_schedulable');
+        return $this->morphedByMany(\App\Models\DeviceGroup::class, 'alert_schedulable');
     }
 }

--- a/app/Models/AlertTemplate.php
+++ b/app/Models/AlertTemplate.php
@@ -33,6 +33,6 @@ class AlertTemplate extends BaseModel
 
     public function map()
     {
-        return $this->hasMany('App\Models\AlertTemplateMap', 'alert_templates_id', 'id');
+        return $this->hasMany(\App\Models\AlertTemplateMap::class, 'alert_templates_id', 'id');
     }
 }

--- a/app/Models/AlertTemplateMap.php
+++ b/app/Models/AlertTemplateMap.php
@@ -34,6 +34,6 @@ class AlertTemplateMap extends BaseModel
 
     public function template()
     {
-        return $this->belongsTo('App\Models\AlertTemplate', 'alert_templates_id');
+        return $this->belongsTo(\App\Models\AlertTemplate::class, 'alert_templates_id');
     }
 }

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -96,6 +96,6 @@ class ApiToken extends BaseModel
 
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 }

--- a/app/Models/Bill.php
+++ b/app/Models/Bill.php
@@ -48,6 +48,6 @@ class Bill extends Model
 
     public function ports()
     {
-        return $this->belongsToMany('App\Models\Port', 'bill_ports', 'bill_id', 'bill_id');
+        return $this->belongsToMany(\App\Models\Port::class, 'bill_ports', 'bill_id', 'bill_id');
     }
 }

--- a/app/Models/Dashboard.php
+++ b/app/Models/Dashboard.php
@@ -48,11 +48,11 @@ class Dashboard extends Model
 
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 
     public function widgets()
     {
-        return $this->hasMany('App\Models\UserWidget', 'dashboard_id');
+        return $this->hasMany(\App\Models\UserWidget::class, 'dashboard_id');
     }
 }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -581,202 +581,202 @@ class Device extends BaseModel
 
     public function alerts()
     {
-        return $this->hasMany('App\Models\Alert', 'device_id');
+        return $this->hasMany(\App\Models\Alert::class, 'device_id');
     }
 
     public function attribs()
     {
-        return $this->hasMany('App\Models\DeviceAttrib', 'device_id');
+        return $this->hasMany(\App\Models\DeviceAttrib::class, 'device_id');
     }
 
     public function alertSchedules()
     {
-        return $this->morphToMany('App\Models\AlertSchedule', 'alert_schedulable', 'alert_schedulables', 'schedule_id', 'schedule_id');
+        return $this->morphToMany(\App\Models\AlertSchedule::class, 'alert_schedulable', 'alert_schedulables', 'schedule_id', 'schedule_id');
     }
 
     public function applications()
     {
-        return $this->hasMany('App\Models\Application', 'device_id');
+        return $this->hasMany(\App\Models\Application::class, 'device_id');
     }
 
     public function bgppeers()
     {
-        return $this->hasMany('App\Models\BgpPeer', 'device_id');
+        return $this->hasMany(\App\Models\BgpPeer::class, 'device_id');
     }
 
     public function cefSwitching()
     {
-        return $this->hasMany('App\Models\CefSwitching', 'device_id');
+        return $this->hasMany(\App\Models\CefSwitching::class, 'device_id');
     }
 
     public function children()
     {
-        return $this->belongsToMany('App\Models\Device', 'device_relationships', 'parent_device_id', 'child_device_id');
+        return $this->belongsToMany(\App\Models\Device::class, 'device_relationships', 'parent_device_id', 'child_device_id');
     }
 
     public function components()
     {
-        return $this->hasMany('App\Models\Component', 'device_id');
+        return $this->hasMany(\App\Models\Component::class, 'device_id');
     }
 
     public function eventlogs()
     {
-        return $this->hasMany('App\Models\Eventlog', 'device_id', 'device_id');
+        return $this->hasMany(\App\Models\Eventlog::class, 'device_id', 'device_id');
     }
 
     public function groups()
     {
-        return $this->belongsToMany('App\Models\DeviceGroup', 'device_group_device', 'device_id', 'device_group_id');
+        return $this->belongsToMany(\App\Models\DeviceGroup::class, 'device_group_device', 'device_id', 'device_group_id');
     }
 
     public function ipv4()
     {
-        return $this->hasManyThrough('App\Models\Ipv4Address', 'App\Models\Port', 'device_id', 'port_id', 'device_id', 'port_id');
+        return $this->hasManyThrough(\App\Models\Ipv4Address::class, \App\Models\Port::class, 'device_id', 'port_id', 'device_id', 'port_id');
     }
 
     public function ipv6()
     {
-        return $this->hasManyThrough('App\Models\Ipv6Address', 'App\Models\Port', 'device_id', 'port_id', 'device_id', 'port_id');
+        return $this->hasManyThrough(\App\Models\Ipv6Address::class, \App\Models\Port::class, 'device_id', 'port_id', 'device_id', 'port_id');
     }
 
     public function location()
     {
-        return $this->belongsTo('App\Models\Location', 'location_id', 'id');
+        return $this->belongsTo(\App\Models\Location::class, 'location_id', 'id');
     }
 
     public function ospfInstances()
     {
-        return $this->hasMany('App\Models\OspfInstance', 'device_id');
+        return $this->hasMany(\App\Models\OspfInstance::class, 'device_id');
     }
 
     public function packages()
     {
-        return $this->hasMany('App\Models\Package', 'device_id', 'device_id');
+        return $this->hasMany(\App\Models\Package::class, 'device_id', 'device_id');
     }
 
     public function parents()
     {
-        return $this->belongsToMany('App\Models\Device', 'device_relationships', 'child_device_id', 'parent_device_id');
+        return $this->belongsToMany(\App\Models\Device::class, 'device_relationships', 'child_device_id', 'parent_device_id');
     }
 
     public function perf()
     {
-        return $this->hasMany('App\Models\DevicePerf', 'device_id');
+        return $this->hasMany(\App\Models\DevicePerf::class, 'device_id');
     }
 
     public function ports()
     {
-        return $this->hasMany('App\Models\Port', 'device_id', 'device_id');
+        return $this->hasMany(\App\Models\Port::class, 'device_id', 'device_id');
     }
 
     public function portsFdb()
     {
-        return $this->hasMany('App\Models\PortsFdb', 'device_id', 'device_id');
+        return $this->hasMany(\App\Models\PortsFdb::class, 'device_id', 'device_id');
     }
 
     public function portsNac()
     {
-        return $this->hasMany('App\Models\PortsNac', 'device_id', 'device_id');
+        return $this->hasMany(\App\Models\PortsNac::class, 'device_id', 'device_id');
     }
 
     public function processors()
     {
-        return $this->hasMany('App\Models\Processor', 'device_id');
+        return $this->hasMany(\App\Models\Processor::class, 'device_id');
     }
 
     public function rules()
     {
-        return $this->belongsToMany('App\Models\AlertRule', 'alert_device_map', 'device_id', 'rule_id');
+        return $this->belongsToMany(\App\Models\AlertRule::class, 'alert_device_map', 'device_id', 'rule_id');
     }
 
     public function sensors()
     {
-        return $this->hasMany('App\Models\Sensor', 'device_id');
+        return $this->hasMany(\App\Models\Sensor::class, 'device_id');
     }
 
     public function services()
     {
-        return $this->hasMany('App\Models\Service', 'device_id');
+        return $this->hasMany(\App\Models\Service::class, 'device_id');
     }
 
     public function storage()
     {
-        return $this->hasMany('App\Models\Storage', 'device_id');
+        return $this->hasMany(\App\Models\Storage::class, 'device_id');
     }
 
     public function mempools()
     {
-        return $this->hasMany('App\Models\Mempool', 'device_id');
+        return $this->hasMany(\App\Models\Mempool::class, 'device_id');
     }
 
     public function mplsLsps()
     {
-        return $this->hasMany('App\Models\MplsLsp', 'device_id');
+        return $this->hasMany(\App\Models\MplsLsp::class, 'device_id');
     }
 
     public function mplsLspPaths()
     {
-        return $this->hasMany('App\Models\MplsLspPath', 'device_id');
+        return $this->hasMany(\App\Models\MplsLspPath::class, 'device_id');
     }
 
     public function mplsSdps()
     {
-        return $this->hasMany('App\Models\MplsSdp', 'device_id');
+        return $this->hasMany(\App\Models\MplsSdp::class, 'device_id');
     }
 
     public function mplsServices()
     {
-        return $this->hasMany('App\Models\MplsService', 'device_id');
+        return $this->hasMany(\App\Models\MplsService::class, 'device_id');
     }
 
     public function mplsSaps()
     {
-        return $this->hasMany('App\Models\MplsSap', 'device_id');
+        return $this->hasMany(\App\Models\MplsSap::class, 'device_id');
     }
 
     public function mplsSdpBinds()
     {
-        return $this->hasMany('App\Models\MplsSdpBind', 'device_id');
+        return $this->hasMany(\App\Models\MplsSdpBind::class, 'device_id');
     }
 
     public function mplsTunnelArHops()
     {
-        return $this->hasMany('App\Models\MplsTunnelArHop', 'device_id');
+        return $this->hasMany(\App\Models\MplsTunnelArHop::class, 'device_id');
     }
 
     public function mplsTunnelCHops()
     {
-        return $this->hasMany('App\Models\MplsTunnelCHop', 'device_id');
+        return $this->hasMany(\App\Models\MplsTunnelCHop::class, 'device_id');
     }
 
     public function syslogs()
     {
-        return $this->hasMany('App\Models\Syslog', 'device_id', 'device_id');
+        return $this->hasMany(\App\Models\Syslog::class, 'device_id', 'device_id');
     }
 
     public function users()
     {
         // FIXME does not include global read
-        return $this->belongsToMany('App\Models\User', 'devices_perms', 'device_id', 'user_id');
+        return $this->belongsToMany(\App\Models\User::class, 'devices_perms', 'device_id', 'user_id');
     }
 
     public function vminfo()
     {
-        return $this->hasMany('App\Models\Vminfo', 'device_id');
+        return $this->hasMany(\App\Models\Vminfo::class, 'device_id');
     }
 
     public function vrfLites()
     {
-        return $this->hasMany('App\Models\VrfLite', 'device_id');
+        return $this->hasMany(\App\Models\VrfLite::class, 'device_id');
     }
 
     public function vrfs()
     {
-        return $this->hasMany('App\Models\Vrf', 'device_id');
+        return $this->hasMany(\App\Models\Vrf::class, 'device_id');
     }
 
     public function wirelessSensors()
     {
-        return $this->hasMany('App\Models\WirelessSensor', 'device_id');
+        return $this->hasMany(\App\Models\WirelessSensor::class, 'device_id');
     }
 }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -611,7 +611,7 @@ class Device extends BaseModel
 
     public function children()
     {
-        return $this->belongsToMany(\App\Models\Device::class, 'device_relationships', 'parent_device_id', 'child_device_id');
+        return $this->belongsToMany(self::class, 'device_relationships', 'parent_device_id', 'child_device_id');
     }
 
     public function components()
@@ -656,7 +656,7 @@ class Device extends BaseModel
 
     public function parents()
     {
-        return $this->belongsToMany(\App\Models\Device::class, 'device_relationships', 'child_device_id', 'parent_device_id');
+        return $this->belongsToMany(self::class, 'device_relationships', 'child_device_id', 'parent_device_id');
     }
 
     public function perf()

--- a/app/Models/DeviceGroup.php
+++ b/app/Models/DeviceGroup.php
@@ -142,16 +142,16 @@ class DeviceGroup extends BaseModel
 
     public function devices()
     {
-        return $this->belongsToMany('App\Models\Device', 'device_group_device', 'device_group_id', 'device_id');
+        return $this->belongsToMany(\App\Models\Device::class, 'device_group_device', 'device_group_id', 'device_id');
     }
 
     public function services()
     {
-        return $this->belongsToMany('App\Models\Service', 'device_group_device', 'device_group_id', 'device_id');
+        return $this->belongsToMany(\App\Models\Service::class, 'device_group_device', 'device_group_id', 'device_id');
     }
 
     public function users()
     {
-        return $this->belongsToMany('App\Models\User', 'devices_group_perms', 'device_group_id', 'user_id');
+        return $this->belongsToMany(\App\Models\User::class, 'devices_group_perms', 'device_group_id', 'user_id');
     }
 }

--- a/app/Models/DeviceRelatedModel.php
+++ b/app/Models/DeviceRelatedModel.php
@@ -47,6 +47,6 @@ class DeviceRelatedModel extends BaseModel
 
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id', 'device_id');
     }
 }

--- a/app/Models/Ipv4Mac.php
+++ b/app/Models/Ipv4Mac.php
@@ -11,6 +11,6 @@ class Ipv4Mac extends PortRelatedModel
 
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id');
     }
 }

--- a/app/Models/Ipv4Network.php
+++ b/app/Models/Ipv4Network.php
@@ -36,6 +36,6 @@ class Ipv4Network extends Model
 
     public function ipv4()
     {
-        return $this->hasMany('App\Models\Ipv4Address', 'ipv4_network_id');
+        return $this->hasMany(\App\Models\Ipv4Address::class, 'ipv4_network_id');
     }
 }

--- a/app/Models/Ipv6Network.php
+++ b/app/Models/Ipv6Network.php
@@ -36,6 +36,6 @@ class Ipv6Network extends Model
 
     public function ipv6()
     {
-        return $this->hasMany('App\Models\Ipv6Address', 'ipv6_network_id');
+        return $this->hasMany(\App\Models\Ipv6Address::class, 'ipv6_network_id');
     }
 }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -153,7 +153,7 @@ class Location extends Model
 
     public function devices()
     {
-        return $this->hasMany('App\Models\Device', 'location_id');
+        return $this->hasMany(\App\Models\Device::class, 'location_id');
     }
 
     public function __toString()

--- a/app/Models/MplsLsp.php
+++ b/app/Models/MplsLsp.php
@@ -48,6 +48,6 @@ class MplsLsp extends Model implements Keyable
 
     public function paths()
     {
-        return $this->hasMany('App\Models\MplsLspPath', 'lsp_id');
+        return $this->hasMany(\App\Models\MplsLspPath::class, 'lsp_id');
     }
 }

--- a/app/Models/MplsLspPath.php
+++ b/app/Models/MplsLspPath.php
@@ -47,6 +47,6 @@ class MplsLspPath extends Model implements Keyable
 
     public function lsp()
     {
-        return $this->belongsTo('App\Models\MplsLsp', 'lsp_id');
+        return $this->belongsTo(\App\Models\MplsLsp::class, 'lsp_id');
     }
 }

--- a/app/Models/MplsSap.php
+++ b/app/Models/MplsSap.php
@@ -40,11 +40,11 @@ class MplsSap extends Model implements Keyable
 
     public function binds()
     {
-        return $this->hasMany('App\Models\MplsSdpBind', 'svc_id');
+        return $this->hasMany(\App\Models\MplsSdpBind::class, 'svc_id');
     }
     
     public function services()
     {
-        return $this->hasMany('App\Models\MplsService', 'svc_id');
+        return $this->hasMany(\App\Models\MplsService::class, 'svc_id');
     }
 }

--- a/app/Models/MplsSdp.php
+++ b/app/Models/MplsSdp.php
@@ -41,6 +41,6 @@ class MplsSdp extends Model implements Keyable
 
     public function binds()
     {
-        return $this->hasMany('App\Models\MplsSdpBind', 'sdp_id');
+        return $this->hasMany(\App\Models\MplsSdpBind::class, 'sdp_id');
     }
 }

--- a/app/Models/MplsSdpBind.php
+++ b/app/Models/MplsSdpBind.php
@@ -43,11 +43,11 @@ class MplsSdpBind extends Model implements Keyable
 
     public function sdp()
     {
-        return $this->belongsTo('App\Models\MplsSdp', 'sdp_id');
+        return $this->belongsTo(\App\Models\MplsSdp::class, 'sdp_id');
     }
 
     public function service()
     {
-        return $this->belongsTo('App\Models\MplsService', 'svc_id');
+        return $this->belongsTo(\App\Models\MplsService::class, 'svc_id');
     }
 }

--- a/app/Models/MplsService.php
+++ b/app/Models/MplsService.php
@@ -46,6 +46,6 @@ class MplsService extends Model implements Keyable
 
     public function binds()
     {
-        return $this->hasMany('App\Models\MplsSdpBind', 'svc_id');
+        return $this->hasMany(\App\Models\MplsSdpBind::class, 'svc_id');
     }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -137,6 +137,6 @@ class Notification extends Model
      */
     public function attribs()
     {
-        return $this->hasMany('App\Models\NotificationAttrib', 'notifications_id', 'notifications_id');
+        return $this->hasMany(\App\Models\NotificationAttrib::class, 'notifications_id', 'notifications_id');
     }
 }

--- a/app/Models/NotificationAttrib.php
+++ b/app/Models/NotificationAttrib.php
@@ -18,7 +18,7 @@ class NotificationAttrib extends Model
      */
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 
     /**
@@ -26,6 +26,6 @@ class NotificationAttrib extends Model
      */
     public function notification()
     {
-        return $this->belongsTo('App\Models\Notification', 'notifications_id');
+        return $this->belongsTo(\App\Models\Notification::class, 'notifications_id');
     }
 }

--- a/app/Models/OspfPort.php
+++ b/app/Models/OspfPort.php
@@ -59,6 +59,6 @@ class OspfPort extends PortRelatedModel
 
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id');
     }
 }

--- a/app/Models/PollerCluster.php
+++ b/app/Models/PollerCluster.php
@@ -36,6 +36,6 @@ class PollerCluster extends Model
 
     public function stats()
     {
-        return $this->hasMany('App\Models\PollerClusterStat', 'parent_poller', 'id');
+        return $this->hasMany(\App\Models\PollerClusterStat::class, 'parent_poller', 'id');
     }
 }

--- a/app/Models/PollerGroup.php
+++ b/app/Models/PollerGroup.php
@@ -49,6 +49,6 @@ class PollerGroup extends Model
 
     public function devices()
     {
-        return $this->hasMany('App\Models\Device', 'poller_group', 'id');
+        return $this->hasMany(\App\Models\Device::class, 'poller_group', 'id');
     }
 }

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -262,17 +262,17 @@ class Port extends DeviceRelatedModel
 
     public function fdbEntries()
     {
-        return $this->hasMany('App\Models\PortsFdb', 'port_id', 'port_id');
+        return $this->hasMany(\App\Models\PortsFdb::class, 'port_id', 'port_id');
     }
 
     public function ipv4()
     {
-        return $this->hasMany('App\Models\Ipv4Address', 'port_id');
+        return $this->hasMany(\App\Models\Ipv4Address::class, 'port_id');
     }
 
     public function ipv6()
     {
-        return $this->hasMany('App\Models\Ipv6Address', 'port_id');
+        return $this->hasMany(\App\Models\Ipv6Address::class, 'port_id');
     }
 
     public function macAccounting()
@@ -318,7 +318,7 @@ class Port extends DeviceRelatedModel
     public function users()
     {
         // FIXME does not include global read
-        return $this->belongsToMany('App\Models\User', 'ports_perms', 'port_id', 'user_id');
+        return $this->belongsToMany(\App\Models\User::class, 'ports_perms', 'port_id', 'user_id');
     }
 
     public function vlans()

--- a/app/Models/PortRelatedModel.php
+++ b/app/Models/PortRelatedModel.php
@@ -38,6 +38,6 @@ abstract class PortRelatedModel extends BaseModel
 
     public function port()
     {
-        return $this->belongsTo('App\Models\Port', 'port_id', 'port_id');
+        return $this->belongsTo(\App\Models\Port::class, 'port_id', 'port_id');
     }
 }

--- a/app/Models/PortsFdb.php
+++ b/app/Models/PortsFdb.php
@@ -12,11 +12,11 @@ class PortsFdb extends PortRelatedModel
 
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id', 'device_id');
     }
 
     public function vlan()
     {
-        return $this->belongsTo('App\Models\Vlan', 'vlan_id', 'vlan_id');
+        return $this->belongsTo(\App\Models\Vlan::class, 'vlan_id', 'vlan_id');
     }
 }

--- a/app/Models/PortsNac.php
+++ b/app/Models/PortsNac.php
@@ -53,6 +53,6 @@ class PortsNac extends PortRelatedModel
 
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id', 'device_id');
     }
 }

--- a/app/Models/Route.php
+++ b/app/Models/Route.php
@@ -41,11 +41,11 @@ class Route extends DeviceRelatedModel
     // ---- Define Relationships ----
     public function device()
     {
-        return $this->belongsTo('App\Models\Device', 'device_id', 'device_id');
+        return $this->belongsTo(\App\Models\Device::class, 'device_id', 'device_id');
     }
 
     public function port()
     {
-        return $this->belongsTo('App\Models\Port', 'port_id', 'port_id');
+        return $this->belongsTo(\App\Models\Port::class, 'port_id', 'port_id');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -177,7 +177,7 @@ class User extends Authenticatable
 
     public function apiToken()
     {
-        return $this->hasOne('App\Models\ApiToken', 'user_id', 'user_id');
+        return $this->hasOne(\App\Models\ApiToken::class, 'user_id', 'user_id');
     }
 
     public function devices()
@@ -190,7 +190,7 @@ class User extends Authenticatable
 
     public function deviceGroups()
     {
-        return $this->belongsToMany('App\Models\DeviceGroup', 'devices_group_perms', 'user_id', 'device_group_id');
+        return $this->belongsToMany(\App\Models\DeviceGroup::class, 'devices_group_perms', 'user_id', 'device_group_id');
     }
 
     public function ports()
@@ -199,22 +199,22 @@ class User extends Authenticatable
             return Port::query();
         } else {
             //FIXME we should return all ports for a device if the user has been given access to the whole device.
-            return $this->belongsToMany('App\Models\Port', 'ports_perms', 'user_id', 'port_id');
+            return $this->belongsToMany(\App\Models\Port::class, 'ports_perms', 'user_id', 'port_id');
         }
     }
 
     public function dashboards()
     {
-        return $this->hasMany('App\Models\Dashboard', 'user_id');
+        return $this->hasMany(\App\Models\Dashboard::class, 'user_id');
     }
 
     public function preferences()
     {
-        return $this->hasMany('App\Models\UserPref', 'user_id');
+        return $this->hasMany(\App\Models\UserPref::class, 'user_id');
     }
 
     public function widgets()
     {
-        return $this->hasMany('App\Models\UserWidget', 'user_id');
+        return $this->hasMany(\App\Models\UserWidget::class, 'user_id');
     }
 }

--- a/app/Models/UserPref.php
+++ b/app/Models/UserPref.php
@@ -83,7 +83,7 @@ class UserPref extends BaseModel
 
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 
 

--- a/app/Models/UserWidget.php
+++ b/app/Models/UserWidget.php
@@ -17,16 +17,16 @@ class UserWidget extends Model
 
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'user_id');
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
     }
 
     public function widget()
     {
-        return $this->hasOne('App\Models\Widget', 'widget_id');
+        return $this->hasOne(\App\Models\Widget::class, 'widget_id');
     }
 
     public function dashboard()
     {
-        return $this->belongsTo('App\Models\Dashboard', 'dashboard_id');
+        return $this->belongsTo(\App\Models\Dashboard::class, 'dashboard_id');
     }
 }

--- a/app/Providers/ComposerServiceProvider.php
+++ b/app/Providers/ComposerServiceProvider.php
@@ -37,8 +37,8 @@ class ComposerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        View::composer('layouts.librenmsv1', 'App\Http\ViewComposers\LayoutComposer');
-        View::composer('layouts.menu', 'App\Http\ViewComposers\MenuComposer');
+        View::composer('layouts.librenmsv1', \App\Http\ViewComposers\LayoutComposer::class);
+        View::composer('layouts.menu', \App\Http\ViewComposers\MenuComposer::class);
     }
 
     /**


### PR DESCRIPTION
Part of upgrade to Laravel 6

Originally from laravel shift

Shift bindings

PHP 5.5.9+ adds the new static `class` property which provides the fully qualified class name. This is preferred over using class name strings as these references are checked by the parser.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
