### PR TITLE
PagerDuty Transport Improvement

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -59,7 +59,7 @@ class Pagerduty extends Transport
             'event_action' => $obj['event_type'],
             'dedup_key'    => (string)$obj['alert_id'],
             'payload'    => [
-                'custom_details'  => substr(implode(PHP_EOL, array_column($obj['faults'], 'string')), 0, 1020) . '....' ?: 'Test',
+                'custom_details'  => strip_tags($obj['msg']) ?: 'Test',
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
                 'summary'  => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),


### PR DESCRIPTION
Sends the message output of the alert template to PagerDuty as custom data instead of the fault data similar to the default template. This gives the user more flexibility in the data sent to PagerDuty. The images below show information from alerts sent from LibreNMS to PagerDuty. The top image is a Device Down alert sent using the current code, and the After image is using the changed code.

**Before:**

![PD-before-transport](https://user-images.githubusercontent.com/44616159/79913507-55e65b00-83e9-11ea-9140-2515516fd7c8.png)

**After:**

![PD-after-transport](https://user-images.githubusercontent.com/44616159/79913474-45ce7b80-83e9-11ea-868b-f6ef2fac6353.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
