### PR TITLE
Fix case sensitiv translations

### DIFF
--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -13,6 +13,7 @@ return [
     |
     */
 
+    'title' => 'Auth',
     'failed' => 'These credentials do not match our records.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
 

--- a/resources/lang/en/preferences.php
+++ b/resources/lang/en/preferences.php
@@ -12,6 +12,7 @@ return [
     |
     */
 
+    'title' => 'Preferences',
     'lang' => 'English',
 
 ];

--- a/resources/lang/en/sensors.php
+++ b/resources/lang/en/sensors.php
@@ -11,6 +11,7 @@ return [
     |
     */
 
+    'title' => 'Sensors',
     'airflow' => [
         'short' => 'Airflow',
         'long' => 'Airflow',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'title' => 'Settings',
     'readonly' => 'Set in config.php, remove from config.php to enable.',
     'groups' => [
         'alerting' => 'Alerting',

--- a/resources/lang/en/syslog.php
+++ b/resources/lang/en/syslog.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'title' => 'Syslog',
     'severity' => [
         '0' => 'Emergency',
         '1' => 'Alert',

--- a/resources/lang/en/wireless.php
+++ b/resources/lang/en/wireless.php
@@ -11,6 +11,7 @@ return [
     |
     */
 
+    'title' => 'Wireless',
     'ap-count' => [
         'short' => 'APs',
         'long' => 'AP Count',

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -156,7 +156,7 @@
                 <td class='text-right'>{{ $stat_events }}</td>
             </tr>
             <tr>
-                <td><i class='fa fa-fw fa-dashboard fa-lg icon-theme' aria-hidden='true'></i> <b>@lang('Sensors')</b></td>
+                <td><i class='fa fa-fw fa-dashboard fa-lg icon-theme' aria-hidden='true'></i> <b>@lang('sensors.title')</b></td>
                 <td class='text-right'>{{ $stat_sensors }}</td>
                 <td><i class='fa fa-fw fa-wifi fa-lg icon-theme' aria-hidden='true'></i> <b>@lang('Wireless Sensors')</b></td>
                 <td class='text-right'>{{ $stat_wireless }}</td>

--- a/resources/views/layouts/menu.blade.php
+++ b/resources/views/layouts/menu.blade.php
@@ -118,7 +118,7 @@
                                                                aria-hidden="true"></i> @lang('Eventlog')</a></li>
                         @config('enable_syslog')
                         <li><a href="{{ url('syslog') }}"><i class="fa fa-clone fa-fw fa-lg"
-                                                             aria-hidden="true"></i> @lang('Syslog')</a></li>
+                                                             aria-hidden="true"></i> @lang('syslog.title')</a></li>
                         @endconfig
                         @config('graylog.server')
                         <li><a href="{{ url('graylog') }}"><i class="fa fa-clone fa-fw fa-lg"
@@ -388,7 +388,7 @@
                         <a href="{{ url('wireless') }}" class="dropdown-toggle" data-hover="dropdown"
                            data-toggle="dropdown"><i class="fa fa-wifi fa-fw fa-lg fa-nav-icons hidden-md"
                                                      aria-hidden="true"></i> <span
-                                class="hidden-sm">@lang('Wireless')</span></a>
+                                class="hidden-sm">@lang('wireless.title')</span></a>
                         <ul class="dropdown-menu">
                         @foreach($wireless_menu as $wireless_menu_entry)
                                 <li><a href="{{ url('wireless/metric=' . $wireless_menu_entry->sensor_class) }}"><i class="fa fa-{{ $wireless_menu_entry->icon() }} fa-fw fa-lg" aria-hidden="true"></i> {{ $wireless_menu_entry->classDescr() }}</a></li>
@@ -526,7 +526,7 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"
                        style="margin-left:5px"><i class="fa fa-cog fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i>
-                        <span class="visible-xs-inline-block">@lang('Settings')</span></a>
+                        <span class="visible-xs-inline-block">@lang('settings.title')</span></a>
                     <ul class="dropdown-menu">
                         @admin
                         <li><a href="{{ url('settings') }}"><i class="fa fa-cogs fa-fw fa-lg"

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.librenmsv1')
 
-@section('title', __('Settings'))
+@section('title', __('settings.title'))
 
 @section('content')
     <div class="container">

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -15,7 +15,7 @@
                         <th data-column-id="username">@lang('Username')</th>
                         <th data-column-id="realname">@lang('Real Name')</th>
                         <th data-column-id="level" data-formatter="level" data-type="numeric">@lang('Access')</th>
-                        <th data-column-id="auth_type" data-visible="{{ $multiauth ? 'true' : 'false' }}">@lang('Auth')</th>
+                        <th data-column-id="auth_type" data-visible="{{ $multiauth ? 'true' : 'false' }}">@lang('auth.title')</th>
                         <th data-column-id="email">@lang('Email')</th>
                         @if(\LibreNMS\Authentication\LegacyAuth::getType() == 'mysql')
                         <th data-column-id="enabled" data-formatter="enabled">@lang('Enabled')</th>

--- a/resources/views/user/preferences.blade.php
+++ b/resources/views/user/preferences.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.librenmsv1')
 
-@section('title', __('Preferences'))
+@section('title', __('preferences.title'))
 
 @section('content')
 <div class="container">
@@ -54,7 +54,7 @@
     @endif
 
     <div class="panel panel-default panel-condensed">
-        <div class="panel-heading">@lang('Preferences')</div>
+        <div class="panel-heading">@lang('preferences.title')</div>
         <div class="panel-body">
             <form class="form-horizontal" role="form">
                 @csrf


### PR DESCRIPTION
On case insensitive systems, `@lang('Auth')` would match the auth.php file
and return an array instead of the string "Auth", causing a "Array to string conversion error"

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
