### PR TITLE
Remove webtatic repo from CentOS install docs

### DIFF
--- a/doc/Installation/Installation-CentOS-7-Apache.md
+++ b/doc/Installation/Installation-CentOS-7-Apache.md
@@ -40,17 +40,6 @@ Install the required packages
 yum install mod_php php-cli php-common php-curl php-gd php-mbstring php-process php-snmp php-xml php-zip php-memcached php-mysqlnd
 ```
 
-#### Running with Webtatic PHP
-
-```
-rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
-```
-
-```
-yum install php72w php72w-cli php72w-common php72w-curl php72w-gd php72w-mbstring php72w-mysqlnd php72w-process php72w-snmp php72w-xml php72w-zip
-```
-
-
 #### Running with CentOS SCL php
 
 ```


### PR DESCRIPTION
I personally have no problem with them, but after a recent discussion in discord about a user asking which Repo, it got me thinking that maybe we should also stick to what the OS providers have to say? I see that (obviously) SCL and remi is on the trusted list, so shouldn't the install docs rather stick with them?

[CentOS Wiki](https://wiki.centos.org/AdditionalResources/Repositories)

I know many people are comfortable using it, and therefor still will use it and that is fine. Looking from an official point of view here, is why I made the PR. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
