### PR TITLE
Login form footer center align

### DIFF
--- a/resources/views/auth/login-form.blade.php
+++ b/resources/views/auth/login-form.blade.php
@@ -48,6 +48,6 @@
         </div>
     </div>
     @config('login_message')
-    <div class="panel-footer">{{ \LibreNMS\Config::get('login_message') }}</div>
+    <div class="panel-footer" align="center">{{ \LibreNMS\Config::get('login_message') }}</div>
     @endconfig
 </div>


### PR DESCRIPTION
I believe that it will be looking better aligned. 

**Before:**

<img width="700" alt="Snímka obrazovky 2020-04-30 o 8 24 26" src="https://user-images.githubusercontent.com/36922215/80678988-48e9fb80-8abc-11ea-8bd6-2478f3b7fdff.png">

**After:**

<img width="676" alt="Snímka obrazovky 2020-04-30 o 8 25 25" src="https://user-images.githubusercontent.com/36922215/80679001-52736380-8abc-11ea-8773-5e2de01a02b8.png">


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
