### PR TITLE
Influxdb: fix double escaping

### DIFF
--- a/LibreNMS/Data/Store/InfluxDB.php
+++ b/LibreNMS/Data/Store/InfluxDB.php
@@ -83,7 +83,6 @@ class InfluxDB extends BaseDatastore
         $tmp_fields = [];
         $tmp_tags['hostname'] = $device['hostname'];
         foreach ($tags as $k => $v) {
-            $v = preg_replace(['/ /', '/,/', '/=/'], ['\ ', '\,', '\='], $v);
             if (empty($v)) {
                 $v = '_blank_';
             }


### PR DESCRIPTION
Writing to an Influxdb produces double escaping, e.g `\\ `, `\\,`.

 - [Influxdb-php](https://github.com/librenms/librenms/blob/df16de9d2f5688d57aa13be935281761b685d970/LibreNMS/Data/Store/InfluxDB.php) already handles escaping of special characters such as `" "`,`","` or `"="`. This PR removes the additional escaping done in LibreNMS.

Example output before the patch:

```
sensor,hostname=172.16.7.12,sensor_class=temperature,sensor_type=junos,sensor_descr=Routing\\\\ Engine\\\\ 1,sensor_index=9.2.0.0 sensor=44
storage,hostname=172.16.2.1,mib=hrstorage,descr=/cf\\\\,\\ mounted\\ on:\\ /junos/cf
used=6735872,free=13756416
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
