### PR TITLE
fix default uptime warning to 86400 seconds

### DIFF
--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4876,7 +4876,7 @@
             "group": "alerting",
             "section": "general",
             "order": 0,
-            "default": 84600,
+            "default": 86400,
             "type": "integer",
             "validate": {
                 "value": "integer|min:0"


### PR DESCRIPTION
fix uptime warning from 84600 to 86400 seconds (1 day)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
