### PR TITLE
fix URL Builder to enforce specific arguments on specified position

### DIFF
--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -293,6 +293,21 @@ class Url
     private static function urlParams($vars, $prefix = '/')
     {
         $url = empty($vars) ? '' : $prefix;
+
+        # enforce elements of $order_list to be on first position in url
+        $order_list = ['device', 'tab', 'app'];
+        foreach ($order_list as $order) {
+            if (in_array($order, array_keys($vars))) {
+                $var = $order;
+                $value = $vars[$order];
+                if ($value == '0' || $value != '' && !Str::contains($var, 'opt') && !is_numeric($var)) {
+                    $url .= $var . '=' . urlencode($value) . '/';
+                }
+                unset($vars[$order]);
+            }
+        }
+
+        # now attach rest of url parameters
         foreach ($vars as $var => $value) {
             if ($value == '0' || $value != '' && !Str::contains($var, 'opt') && !is_numeric($var)) {
                 $url .= $var . '=' . urlencode($value) . '/';


### PR DESCRIPTION
App->Overview

clicking an Image results in 404 because of following URL
**not working:**
https://mydomain.com/device/to=1588276200/from=1588189800/legend=no/type=application_mysql_network_traffic/id=72/**device=1/tab=apps/app=mysql/**
**working:**
https://mydomain.com/device/**device=1/tab=apps/app=mysql/**to=1588276200/from=1588189800/legend=no/type=application_mysql_network_traffic/id=72/

this PR enforces params **device, tab, app** are always on first position in this order, so URLs are working

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
