### PR TITLE
Equalize BootstrapSwitch Style on Device Edit to LibreNMS Standard

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -298,7 +298,7 @@ If `devices.ignore = 0` or `macros.device = 1` condition is is set and ignore al
 </form>
 <br />
 <script>
-    $('[type="checkbox"]').bootstrapSwitch();
+    $('[type="checkbox"]').bootstrapSwitch('offColor', 'danger');
 
     $("#rediscover").click(function() {
         var device_id = $(this).data("device_id");


### PR DESCRIPTION
Please give a short description what your pull request is for

Other tabs when editing a host have "OFF" in Red (offColor danger), updating this tab's UI to match the others,

Before,
![chrome_2020-05-01_04-40-14](https://user-images.githubusercontent.com/363587/80771709-e7846400-8b71-11ea-9c85-3a623fb287dc.png)


After,
![chrome_2020-05-01_04-39-54](https://user-images.githubusercontent.com/363587/80771716-ea7f5480-8b71-11ea-9961-a0c9763b70ff.png)


Other tabs where OFF is in red,
![2020-05-01_06-07-25](https://user-images.githubusercontent.com/363587/80771756-0c78d700-8b72-11ea-88bd-d8e4a6ad3ab3.png)

![image](https://user-images.githubusercontent.com/363587/80771763-139fe500-8b72-11ea-8ccd-074b8ab857b5.png)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
