### PR TITLE
Device Groups alert variable and Pagerduty transport improvements

### DIFF
--- a/LibreNMS/Alert/RunAlerts.php
+++ b/LibreNMS/Alert/RunAlerts.php
@@ -84,6 +84,7 @@ class RunAlerts
         $device      = dbFetchRow('SELECT hostname, sysName, sysDescr, sysContact, os, type, ip, hardware, version, purpose, notes, uptime, status, status_reason, locations.location FROM devices LEFT JOIN locations ON locations.id = devices.location_id WHERE device_id = ?', array($alert['device_id']));
         $attribs     = get_dev_attribs($alert['device_id']);
 
+        $obj['device_groups'] = array_column(dbFetchRows('SELECT name FROM device_groups WHERE id IN (SELECT device_group_id from device_group_device WHERE device_id = ?)', array($alert['device_id'])), 'name');
         $obj['hostname']      = $device['hostname'];
         $obj['sysName']       = $device['sysName'];
         $obj['sysDescr']      = $device['sysDescr'];

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -60,6 +60,7 @@ class Pagerduty extends Transport
             'dedup_key'    => (string)$obj['alert_id'],
             'payload'    => [
                 'custom_details'  => strip_tags($obj['msg']) ?: 'Test',
+				'device_groups'   => $obj['device_groups'],
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
                 'summary'  => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),
@@ -103,6 +104,11 @@ class Pagerduty extends Transport
                     'title' => 'Service',
                     'type'  => 'hidden',
                     'name'  => 'service_name',
+                ],
+                [
+                    'title' => 'Integration Key',
+                    'type'  => 'text',
+                    'name' => 'service_key',
                 ]
             ],
             'validation' => []

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -60,7 +60,7 @@ class Pagerduty extends Transport
             'dedup_key'    => (string)$obj['alert_id'],
             'payload'    => [
                 'custom_details'  => strip_tags($obj['msg']) ?: 'Test',
-				'device_groups'   => $obj['device_groups'],
+                'device_groups'   => $obj['device_groups'],
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
                 'summary'  => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),


### PR DESCRIPTION
Create an array of all the groups a device is a member of and make that available in the alert process.

Modified the Pagerduty transport to allow manual input of a Integration Key (to use global rulesets), and to send the device groups to pagerduty to allow routing decisions on the PD end.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
