### PR TITLE
Allow manual configuration of Pagerduty Integration Key

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -103,6 +103,11 @@ class Pagerduty extends Transport
                     'title' => 'Service',
                     'type'  => 'hidden',
                     'name'  => 'service_name',
+                ],
+                [
+                    'title' => 'Integration Key',
+                    'type'  => 'text',
+                    'name' => 'service_key',
                 ]
             ],
             'validation' => []

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -107,7 +107,7 @@ class Pagerduty extends Transport
                 [
                     'title' => 'Integration Key',
                     'type'  => 'text',
-                    'name' => 'service_key',
+                    'name'  => 'service_key',
                 ]
             ],
             'validation' => []


### PR DESCRIPTION
Pagerduty supports a global event queue per account and provides the integration key for it. This allows you to enter the key directly and bypass the OAuth workflow if desired.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
