### PR TITLE
Added note about having same APP_KEY value

### DIFF
--- a/doc/Extensions/Distributed-Poller.md
+++ b/doc/Extensions/Distributed-Poller.md
@@ -143,7 +143,7 @@ large installs can be significant and will slow polling down enough to
 cause issues with a large number of devices.
 
 A last note to make sure of, is that all pollers writing to the same DB
-needs to have the same `APP_KEY` value set in the `.env` file.
+need to have the same `APP_KEY` value set in the `.env` file.
 
 ### Discovery
 

--- a/doc/Extensions/Distributed-Poller.md
+++ b/doc/Extensions/Distributed-Poller.md
@@ -12,8 +12,8 @@ away or are behind NAT firewalls.
 Devices can be grouped together into a `poller_group` to pin these
 devices to a single or a group of designated pollers.
 
-All pollers need to share their RRD-folder, for example via NFS or a
-combination of NFS and rrdcached.
+All pollers need to write to the same set of RRD files, preferably via
+RRDcached.
 
 It is a requirement that all pollers can access the central memcached
 to communicate with each other.
@@ -141,6 +141,9 @@ such as pdns-recursor and have all of your pollers use this or install
 a recursive dns server on each poller - the volume of DNS requests on
 large installs can be significant and will slow polling down enough to
 cause issues with a large number of devices.
+
+A last note to make sure of, is that all pollers writing to the same DB
+needs to have the same `APP_KEY` value set in the `.env` file.
 
 ### Discovery
 


### PR DESCRIPTION
As per discussion in discord all pollers belonging to the same LNMS environment, will need to have the same APP_KEY set in future. Updating docs now already to ensure users knows this and fixes their installs where needed.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
