### PR TITLE
Send Device group membership to Pagerduty

### DIFF
--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -24,6 +24,7 @@
 
 namespace LibreNMS\Alert\Transport;
 
+use App\Models\Device;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Http\Request;
@@ -54,12 +55,18 @@ class Pagerduty extends Transport
      */
     public function contactPagerduty($obj, $config)
     {
+        $groups = Device::find($obj['device_id'])->groups;
+        foreach ($groups as $group)
+        {
+            $device_groups[] = $group->name;
+        }
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],
             'dedup_key'    => (string)$obj['alert_id'],
             'payload'    => [
                 'custom_details'  => strip_tags($obj['msg']) ?: 'Test',
+                'device_groups'   => $device_groups,
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
                 'summary'  => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),

--- a/LibreNMS/Alert/Transport/Pagerduty.php
+++ b/LibreNMS/Alert/Transport/Pagerduty.php
@@ -24,7 +24,6 @@
 
 namespace LibreNMS\Alert\Transport;
 
-use App\Models\Device;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Http\Request;
@@ -55,18 +54,13 @@ class Pagerduty extends Transport
      */
     public function contactPagerduty($obj, $config)
     {
-        $groups = Device::find($obj['device_id'])->groups;
-        foreach ($groups as $group)
-        {
-            $device_groups[] = $group->name;
-        }
         $data = [
             'routing_key'  => $config['service_key'],
             'event_action' => $obj['event_type'],
             'dedup_key'    => (string)$obj['alert_id'],
             'payload'    => [
                 'custom_details'  => strip_tags($obj['msg']) ?: 'Test',
-                'device_groups'   => $device_groups,
+                'device_groups'   => \DeviceCache::get($obj['device_id'])->groups->pluck('name'),
                 'source'   => $obj['hostname'],
                 'severity' => $obj['severity'],
                 'summary'  => ($obj['name'] ? $obj['name'] . ' on ' . $obj['hostname'] : $obj['title']),


### PR DESCRIPTION
Send device group membership to pagerduty. This allows routing (event rules) on the Pagerduty side to make decisions based on group membership inside LibreNMS greatly simplifying alert rules and transports in LibreNMS.

I have tested this with a device in 0, 1 and 2 groups and the JSON gets built properly in all cases. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
