### PR TITLE
Fix RRDCached Application Socket Address in Poller

### DIFF
--- a/includes/polling/applications/rrdcached.inc.php
+++ b/includes/polling/applications/rrdcached.inc.php
@@ -46,9 +46,6 @@ if ($agent_data['app'][$name]) {
             $socket_file = substr($socket, 5);
             if (file_exists($socket_file)) {
                 $sock = fsockopen("unix://" . $socket_file);
-                if (!$sock) {
-                    $sock = fsockopen("unix:" . $socket_file);
-                }
             }
         }
     }

--- a/includes/polling/applications/rrdcached.inc.php
+++ b/includes/polling/applications/rrdcached.inc.php
@@ -43,8 +43,12 @@ if ($agent_data['app'][$name]) {
     if (!$sock) {
         $socket = \LibreNMS\Config::get('rrdcached');
         if (substr($socket, 0, 6) == 'unix:/') {
-            if (file_exists(substr($socket, 5))) {
-                $sock = fsockopen($socket);
+            $socket_file = substr($socket, 5);
+            if (file_exists($socket_file)) {
+                $sock = fsockopen("unix://" . $socket_file);
+                if (!$sock) {
+                    $sock = fsockopen("unix:" . $socket_file);
+                }
             }
         }
     }


### PR DESCRIPTION
tries to open unix socket unix:///<full_path> if fails try to open unix:/<full_path> in Poller

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
