### PR TITLE
Fix DB schema validation for MySQL 8.0.19+

### DIFF
--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -172,8 +172,6 @@ class Database extends BaseValidation
         $current_schema = dump_db_schema();
         $schema_update = array();
 
-        $mysql_version = $validator->getVersions()['mysql_ver'];
-
         foreach ((array)$master_schema as $table => $data) {
             if (empty($current_schema[$table])) {
                 $validator->fail("Database: missing table ($table)");
@@ -188,15 +186,13 @@ class Database extends BaseValidation
                     $column = $cdata['Field'];
 
                     // MySQL 8.0.19+ fix, deprecated integer width
-                    if (!strpos(strtolower($mysql_version), 'mariadb') && version_compare('8.0.18', $mysql_version, '<')) {
-                        if (preg_match('/\w*INT/i', $cdata['Type'])) {
-                            $cdata['Type'] = preg_replace('/\(\d+\)/', '', $cdata['Type']);
-                            $cdata['Type'] = preg_replace('/\s+/', ' ', $cdata['Type']);
-                        }
-                        if (preg_match('/\w*INT/i', $current_columns[$column]['Type'])) {
-                            $current_columns[$column]['Type'] = preg_replace('/\(\d+\)/', '', $current_columns[$column]['Type']);
-                            $current_columns[$column]['Type'] = preg_replace('/\s+/', ' ', $current_columns[$column]['Type']);
-                        }
+                    if (preg_match('/\w*INT/i', $cdata['Type'])) {
+                        $cdata['Type'] = preg_replace('/\(\d+\)/', '', $cdata['Type']);
+                        $cdata['Type'] = preg_replace('/\s+/', ' ', $cdata['Type']);
+                    }
+                    if (preg_match('/\w*INT/i', $current_columns[$column]['Type'])) {
+                        $current_columns[$column]['Type'] = preg_replace('/\(\d+\)/', '', $current_columns[$column]['Type']);
+                        $current_columns[$column]['Type'] = preg_replace('/\s+/', ' ', $current_columns[$column]['Type']);
                     }
 
                     // MySQL 8 fix, remove DEFAULT_GENERATED from timestamp extra columns

--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -214,8 +214,6 @@ class Database extends BaseValidation
                         }
                         $schema_update[] = $this->addColumnSql($table, $cdata, isset($data['Columns'][$index - 1]) ? $data['Columns'][$index - 1]['Field'] : null, $primary);
                     } elseif ($cdata !== $current_columns[$column]) {
-                        print_r($cdata);
-                        print_r($current_columns[$column]); exit;
                         $validator->fail("Database: incorrect column ($table/$column)");
                         $schema_update[] = $this->updateTableSql($table, $column, $cdata);
                     }

--- a/LibreNMS/Validations/Database.php
+++ b/LibreNMS/Validations/Database.php
@@ -190,11 +190,11 @@ class Database extends BaseValidation
                     // MySQL 8.0.19+ fix, deprecated integer width
                     if (!strpos(strtolower($mysql_version), 'mariadb') && version_compare('8.0.18', $mysql_version, '<')) {
                         if (preg_match('/\w*INT/i', $cdata['Type'])) {
-                            $cdata['Type'] = preg_replace('/\(\d+\)/','', $cdata['Type']);
+                            $cdata['Type'] = preg_replace('/\(\d+\)/', '', $cdata['Type']);
                             $cdata['Type'] = preg_replace('/\s+/', ' ', $cdata['Type']);
                         }
                         if (preg_match('/\w*INT/i', $current_columns[$column]['Type'])) {
-                            $current_columns[$column]['Type'] = preg_replace('/\(\d+\)/','', $current_columns[$column]['Type']);
+                            $current_columns[$column]['Type'] = preg_replace('/\(\d+\)/', '', $current_columns[$column]['Type']);
                             $current_columns[$column]['Type'] = preg_replace('/\s+/', ' ', $current_columns[$column]['Type']);
                         }
                     }


### PR DESCRIPTION
Since MySQL 8.0.19, the integer display width is deprecated and not returned anymore.
This make the db schema validation fails.

This is an attempt at fixing the validation so it doesn't fail anymore with MySQL 8.0.19+

Sources:
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html

Related community post:
https://community.librenms.org/t/report-database-schema-issues-here/945

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
