### PR TITLE
bugfix: addhost (web) snmp v3 not used first

### DIFF
--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -71,7 +71,7 @@ if (!empty($_POST['hostname'])) {
             Config::set('snmp.v3', $v3_config);
 
             $snmpver = 'v3';
-            print_message("Adding SNMPv3 host $hostname port $port");
+            print_message("Adding SNMPv3 host: $hostname port: $port");
         } else {
             print_error('Unsupported SNMP Version. There was a dropdown menu, how did you reach this error ?');
         }//end if

--- a/includes/html/pages/addhost.inc.php
+++ b/includes/html/pages/addhost.inc.php
@@ -67,7 +67,7 @@ if (!empty($_POST['hostname'])) {
                   );
 
             $v3_config = Config::get('snmp.v3');
-            array_push($v3_config, $v3);
+            array_unshift($v3_config, $v3);
             Config::set('snmp.v3', $v3_config);
 
             $snmpver = 'v3';


### PR DESCRIPTION
Changes the code so that the user settings from the web page is added to the front of the snmp v3 config array and not the back.
If it is not at the front, it will later either not be used or at all, be tested last

For comparison both addhost (cli) and lnms (cli) do use array_unshift
[addhost.php](https://github.com/librenms/librenms/blob/master/addhost.php#L126)
[routes/console.php](https://github.com/librenms/librenms/blob/master/routes/console.php#L95)

To reproduce the bug:
Force add new snmp v3 device.
The v3 settings added to the database will not be the same as entered in the webpage, but it will be the first default snmp v3 entry

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
