### PR TITLE
cupidazul: svg-dynamic-graphs url fix using asset internal function

### DIFF
--- a/doc/Support/FAQ.md
+++ b/doc/Support/FAQ.md
@@ -125,6 +125,13 @@ using the [included
 snmpd.conf](https://raw.githubusercontent.com/librenms/librenms/master/snmpd.conf.example)
 file.
 
+If you are behind a Proxy or thru a NAT'd ipaddress with an Ngix, you 
+need to add this into your nginx.conf file inside the server statement:
+
+   location ~ ^\/.*\/([a-z_\-]+)\.php$   { try_files $uri $uri/ /$1.php?$query_string;     }
+
+   just before: " location /  { ... }"
+
 ## <a name="faq7"> How do I debug pages not loading correctly?</a>
 
 A debug system is in place which enables you to see the output from

--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -30,9 +30,9 @@ $install_dir = Config::get('install_dir');
 
 if (Config::get('map.engine', 'leaflet') == 'leaflet') {
     $temp_output = '
-<script src="js/leaflet.js"></script>
-<script src="js/leaflet.markercluster.js"></script>
-<script src="js/leaflet.awesome-markers.min.js"></script>
+<script src="' . asset("js/leaflet.js") . '"></script>
+<script src="' . asset("js/leaflet.markercluster.js") . '"></script>
+<script src="' . asset("js/leaflet.awesome-markers.min.js") . '"></script>
 <div id="leaflet-map"></div>
 <script>
         ';

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -20,8 +20,8 @@ if (Config::get('overview_show_sysDescr')) {
 
 echo '</div><div class="panel-body">';
 
-echo '<script src="js/leaflet.js"></script>';
-echo '<script src="js/L.Control.Locate.min.js"></script>';
+echo '<script src="' . asset("js/leaflet.js") . '"></script>';
+echo '<script src="' . asset("js/L.Control.Locate.min.js") . '"></script>';
 
 if ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
     formatCiscoHardware($device);

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -360,7 +360,7 @@ function generate_dynamic_graph_tag($args)
         $urlargs[] = $key . "=" . $value;
     }
 
-    return '<img style="width:'.$width.'px;height:100%" class="graph img-responsive" data-src-template="graph.php?' . implode('&amp;', $urlargs) . '" border="0" />';
+    return '<img style="width:'.$width.'px;height:100%" class="graph img-responsive" data-src-template="' . asset("graph.php") . '?' . implode('&amp;', $urlargs) . '" border="0" />';
 }//end generate_dynamic_graph_tag()
 
 function generate_dynamic_graph_js($args)
@@ -368,9 +368,9 @@ function generate_dynamic_graph_js($args)
     $from = (is_numeric($args['from']) ? $args['from'] : '(new Date()).getTime() / 1000 - 24*3600');
     $range = (is_numeric($args['to']) ? $args['to'] - $args['from'] : '24*3600');
 
-    $output = '<script src="js/RrdGraphJS/q-5.0.2.min.js"></script>
-        <script src="js/RrdGraphJS/moment-timezone-with-data.js"></script>
-        <script src="js/RrdGraphJS/rrdGraphPng.js"></script>
+    $output = '<script src="' . asset("js/RrdGraphJS/q-5.0.2.min.js") . '"></script>
+        <script src="' . asset("moment-timezone-with-data.js") . '"></script>
+        <script src="' . asset("js/RrdGraphJS/rrdGraphPng.js") . '"></script>
           <script type="text/javascript">
               q.ready(function(){
                   var graphs = [];

--- a/includes/html/javascript-interfacepicker.inc.php
+++ b/includes/html/javascript-interfacepicker.inc.php
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="js/tw-sack.js"></script>
+<?php = echo '<script type="text/javascript" src="'. asset("js/tw-sack.js") .'"></script>' ?>
 <script type="text/javascript">
 
 var ajax = new Array();

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -171,8 +171,8 @@ if (Auth::user()->hasGlobalAdmin()) {
         </div>
     </div>
 
-    <script src="js/sql-parser.min.js"></script>
-    <script src="js/query-builder.standalone.min.js"></script>
+    <?php = echo '<script src="'.asset("js/sql-parser.min.js").'"></script>' ?>
+    <?php = echo '<script src="'.asset("js/query-builder.standalone.min.js").'"></script>' ?>
     <script>
         $('#builder').on('afterApplyRuleFlags.queryBuilder afterCreateRuleFilters.queryBuilder', function () {
             $("[name$='_filter']").each(function () {

--- a/includes/html/pages/routing/mpls-path-map.inc.php
+++ b/includes/html/pages/routing/mpls-path-map.inc.php
@@ -166,7 +166,7 @@ $edges = json_encode($links);
 if (count($hops) > 1 && count($links) > 0) {
     $visualization = 'visualization-' . $i;
     echo '<div id="visualization-' . $i . '"></div>
-        <script src="js/vis.min.js"></script>
+        <script src="'. asset("js/vis.min.js") .'"></script>
         <script type="text/javascript">
         var height = $(window).height() / 2;
         ';

--- a/includes/html/print-graph-alerts.inc.php
+++ b/includes/html/print-graph-alerts.inc.php
@@ -44,7 +44,7 @@ $query = "SELECT DATE_FORMAT(time_logged, '" . \LibreNMS\Config::get('alert_grap
     <br>
     <div style="margin:0 auto;width:99%;">
 
-<script src="js/vis.min.js"></script>
+<?php = echo '<script src="'. asset("js/vis.min.js") .'"></script>' ?>
 <div id="visualization" style="margin-bottom: -120px;"></div>
 <script type="text/javascript">
 

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -320,7 +320,7 @@ foreach ($list as $items) {
                 'from'=>$items['local_device_id'],
                 'to'=>$items['remote_device_id'],
                 'label'=>shorten_interface_type($local_port['ifName']) . ' > ' . shorten_interface_type($remote_port['ifName']),
-                'title' => generate_port_link($local_port, "<img src='graph.php?type=port_bits&amp;id=" . $items['local_port_id'] . "&amp;from=" . Config::get('time.day') . "&amp;to=" . Config::get('time.now') . "&amp;width=100&amp;height=20&amp;legend=no&amp;bg=" . str_replace("#", "", $row_colour) . "'>\n", '', 0, 1),
+                'title' => generate_port_link($local_port, "<img src='". asset("graph.php"). "?type=port_bits&amp;id=" . $items['local_port_id'] . "&amp;from=" . Config::get('time.day') . "&amp;to=" . Config::get('time.now') . "&amp;width=100&amp;height=20&amp;legend=no&amp;bg=" . str_replace("#", "", $row_colour) . "'>\n", '', 0, 1),
                 'width'=>$width,
             ),
             $link_style

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -353,7 +353,7 @@ if (count($devices_by_id) > 1 && count($links) > 0) {
     <?php } ?>
 <div id="visualization"></div>
 </form>
-<script src="js/vis.min.js"></script>
+<? = echo '<script src="'. asset("js/vis.min.js") .'"></script>' ?>
 <script type="text/javascript">
 var height = $(window).height() - 100;
 $('#visualization').height(height + 'px');

--- a/resources/views/locations.blade.php
+++ b/resources/views/locations.blade.php
@@ -75,8 +75,8 @@
 @endsection
 
 @section('javascript')
-    <script src="js/leaflet.js"></script>
-    <script src="js/L.Control.Locate.min.js"></script>
+    <?php = echo '<script src="'. asset("js/leaflet.js"). '"></script>' ?>
+    <?php = echo '<script src="'. asset("js/L.Control.Locate.min.js"). '"></script>' ?>
     <script>
         var locationMap = null;
         var locationMarker = null;

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -153,7 +153,7 @@
 @endsection
 
 @section('javascript')
-<script type="text/javascript" src="js/jquery.gridster.min.js"></script>
+<?php = echo '<script type="text/javascript" src="'. asset("js/jquery.gridster.min.js") .'"></script>' ?>
 @endsection
 
 @push('scripts')


### PR DESCRIPTION
cupidazul: svg-dynamic-graphs url fix using asset fn to turn 'js/script.js' to 'hxxp://xxx/js/script.js' .

This fix, is useful for those who need to access LibreNMS from a NAT or Proxy ad use the SVG's with the Dynamic Graphs option.
Without this, the SVG will not show.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
