### PR TITLE
js files that needed asset function prepend

### DIFF
--- a/doc/Support/FAQ.md
+++ b/doc/Support/FAQ.md
@@ -125,6 +125,13 @@ using the [included
 snmpd.conf](https://raw.githubusercontent.com/librenms/librenms/master/snmpd.conf.example)
 file.
 
+If you are behind a Proxy or thru a NAT'd ipaddress with an Ngix, you 
+need to add this into your nginx.conf file inside the server statement:
+
+   location ~ ^\/.*\/([a-z_\-]+)\.php$   { try_files $uri $uri/ /$1.php?$query_string;     }
+
+   just before: " location /  { ... }"
+
 ## <a name="faq7"> How do I debug pages not loading correctly?</a>
 
 A debug system is in place which enables you to see the output from

--- a/doc/Support/FAQ.md
+++ b/doc/Support/FAQ.md
@@ -125,7 +125,7 @@ using the [included
 snmpd.conf](https://raw.githubusercontent.com/librenms/librenms/master/snmpd.conf.example)
 file.
 
-If you are behind a Proxy or thru a NAT'd ipaddress with an Ngix, you 
+If you are behind a Proxy or thru a NAT'd ipaddress with an Nginx, you 
 need to add this into your nginx.conf file inside the server statement:
 
    location ~ ^\/.*\/([a-z_\-]+)\.php$   { try_files $uri $uri/ /$1.php?$query_string;     }

--- a/html/install.php
+++ b/html/install.php
@@ -112,10 +112,10 @@ $complete = 1;
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" />
     <link href="<?php echo(Config::get('stylesheet')); ?>" rel="stylesheet" type="text/css"/>
-  <script src="js/jquery.min.js"></script>
-  <script src="js/bootstrap.min.js"></script>
-  <script src="js/bootstrap-hover-dropdown.min.js"></script>
-  <script src="js/hogan-2.0.0.js"></script>
+<?php     echo '   <script src="' . asset("js/jquery.min.js")                   . '"></script>';    ?>
+<?php     echo '   <script src="' . asset("js/bootstrap.min.js")                . '"></script>';    ?>
+<?php     echo '   <script src="' . asset("js/bootstrap-hover-dropdown.min.js") . '"></script>';    ?>
+<?php     echo '   <script src="' . asset("js/hogan-2.0.0.js")                  . '"></script>';    ?>
 </head>
 <body>
   <div class="container">

--- a/includes/html/common/worldmap.inc.php
+++ b/includes/html/common/worldmap.inc.php
@@ -30,9 +30,9 @@ $install_dir = Config::get('install_dir');
 
 if (Config::get('map.engine', 'leaflet') == 'leaflet') {
     $temp_output = '
-<script src="js/leaflet.js"></script>
-<script src="js/leaflet.markercluster.js"></script>
-<script src="js/leaflet.awesome-markers.min.js"></script>
+<script src="' . asset("js/leaflet.js") . '"></script>
+<script src="' . asset("js/leaflet.markercluster.js") . '"></script>
+<script src="' . asset("js/leaflet.awesome-markers.min.js") . '"></script>
 <div id="leaflet-map"></div>
 <script>
         ';

--- a/includes/html/dev-overview-data.inc.php
+++ b/includes/html/dev-overview-data.inc.php
@@ -20,8 +20,8 @@ if (Config::get('overview_show_sysDescr')) {
 
 echo '</div><div class="panel-body">';
 
-echo '<script src="js/leaflet.js"></script>';
-echo '<script src="js/L.Control.Locate.min.js"></script>';
+echo '<script src="' . asset("js/leaflet.js") . '"></script>';
+echo '<script src="' . asset("js/L.Control.Locate.min.js") . '"></script>';
 
 if ($device['os'] == 'ios' || $device['os'] == 'iosxe') {
     formatCiscoHardware($device);

--- a/includes/html/functions.inc.php
+++ b/includes/html/functions.inc.php
@@ -154,7 +154,7 @@ function get_percentage_colours($percentage, $component_perc_warn = null)
 
 function generate_minigraph_image($device, $start, $end, $type, $legend = 'no', $width = 275, $height = 100, $sep = '&amp;', $class = 'minigraph-image', $absolute_size = 0)
 {
-    return '<img class="' . $class . '" width="' . $width . '" height="' . $height . '" src="graph.php?' . implode($sep, array('device=' . $device['device_id'], "from=$start", "to=$end", "width=$width", "height=$height", "type=$type", "legend=$legend", "absolute=$absolute_size")) . '">';
+    return '<img class="' . $class . '" width="' . $width . '" height="' . $height . '" src="' . asset("graph.php") . '?' . implode($sep, array('device=' . $device['device_id'], "from=$start", "to=$end", "width=$width", "height=$height", "type=$type", "legend=$legend", "absolute=$absolute_size")) . '">';
 }//end generate_minigraph_image()
 
 
@@ -360,7 +360,7 @@ function generate_dynamic_graph_tag($args)
         $urlargs[] = $key . "=" . $value;
     }
 
-    return '<img style="width:'.$width.'px;height:100%" class="graph img-responsive" data-src-template="graph.php?' . implode('&amp;', $urlargs) . '" border="0" />';
+    return '<img style="width:'.$width.'px;height:100%" class="graph img-responsive" data-src-template="' . asset("graph.php") . '?' . implode('&amp;', $urlargs) . '" border="0" />';
 }//end generate_dynamic_graph_tag()
 
 function generate_dynamic_graph_js($args)
@@ -368,9 +368,9 @@ function generate_dynamic_graph_js($args)
     $from = (is_numeric($args['from']) ? $args['from'] : '(new Date()).getTime() / 1000 - 24*3600');
     $range = (is_numeric($args['to']) ? $args['to'] - $args['from'] : '24*3600');
 
-    $output = '<script src="js/RrdGraphJS/q-5.0.2.min.js"></script>
-        <script src="js/RrdGraphJS/moment-timezone-with-data.js"></script>
-        <script src="js/RrdGraphJS/rrdGraphPng.js"></script>
+    $output = '<script src="' . asset("js/RrdGraphJS/q-5.0.2.min.js") . '"></script>
+        <script src="' . asset("moment-timezone-with-data.js") . '"></script>
+        <script src="' . asset("js/RrdGraphJS/rrdGraphPng.js") . '"></script>
           <script type="text/javascript">
               q.ready(function(){
                   var graphs = [];

--- a/includes/html/javascript-interfacepicker.inc.php
+++ b/includes/html/javascript-interfacepicker.inc.php
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="js/tw-sack.js"></script>
+<?php = echo '<script type="text/javascript" src="'. asset("js/tw-sack.js") .'"></script>' ?>
 <script type="text/javascript">
 
 var ajax = new Array();

--- a/includes/html/modal/new_alert_rule.inc.php
+++ b/includes/html/modal/new_alert_rule.inc.php
@@ -171,8 +171,8 @@ if (Auth::user()->hasGlobalAdmin()) {
         </div>
     </div>
 
-    <script src="js/sql-parser.min.js"></script>
-    <script src="js/query-builder.standalone.min.js"></script>
+    <?php = echo '<script src="'.asset("js/sql-parser.min.js").'"></script>' ?>
+    <?php = echo '<script src="'.asset("js/query-builder.standalone.min.js").'"></script>' ?>
     <script>
         $('#builder').on('afterApplyRuleFlags.queryBuilder afterCreateRuleFilters.queryBuilder', function () {
             $("[name$='_filter']").each(function () {

--- a/includes/html/pages/bill/history.inc.php
+++ b/includes/html/pages/bill/history.inc.php
@@ -5,7 +5,7 @@ $pagetitle[] = 'Historical Usage';
 // $url         = $PHP_SELF."/bill/".$bill_id."/history/";
 $i = 0;
 
-$img['his']  = '<img src="graph.php?id='.$bill_id;
+$img['his']  = '<img src="' . asset("graph.php") . '?id='.$bill_id;
 $img['his'] .= '&amp;type=bill_historicmonthly';
 $img['his'] .= '&amp;width=1190&amp;height=250';
 $img['his'] .= '" style="margin: 15px 5px 25px 5px;" />';
@@ -24,7 +24,7 @@ $img['his'] .= '" style="margin: 15px 5px 25px 5px;" />';
 
 function showDetails($bill_id, $imgtype, $bill_hist_id)
 {
-    $res = '<img src="graph.php?id='.$bill_id;
+    $res = '<img src="' . asset("graph.php") . '?id='.$bill_id;
 
     if ($imgtype == 'bitrate') {
         $res .= '&amp;type=bill_historicbits';

--- a/includes/html/pages/routing/mpls-path-map.inc.php
+++ b/includes/html/pages/routing/mpls-path-map.inc.php
@@ -166,7 +166,7 @@ $edges = json_encode($links);
 if (count($hops) > 1 && count($links) > 0) {
     $visualization = 'visualization-' . $i;
     echo '<div id="visualization-' . $i . '"></div>
-        <script src="js/vis.min.js"></script>
+        <script src="'. asset("js/vis.min.js") .'"></script>
         <script type="text/javascript">
         var height = $(window).height() / 2;
         ';

--- a/includes/html/print-graph-alerts.inc.php
+++ b/includes/html/print-graph-alerts.inc.php
@@ -44,7 +44,7 @@ $query = "SELECT DATE_FORMAT(time_logged, '" . \LibreNMS\Config::get('alert_grap
     <br>
     <div style="margin:0 auto;width:99%;">
 
-<script src="js/vis.min.js"></script>
+<?php = echo '<script src="'. asset("js/vis.min.js") .'"></script>' ?>
 <div id="visualization" style="margin-bottom: -120px;"></div>
 <script type="text/javascript">
 

--- a/includes/html/print-map.inc.php
+++ b/includes/html/print-map.inc.php
@@ -320,7 +320,7 @@ foreach ($list as $items) {
                 'from'=>$items['local_device_id'],
                 'to'=>$items['remote_device_id'],
                 'label'=>shorten_interface_type($local_port['ifName']) . ' > ' . shorten_interface_type($remote_port['ifName']),
-                'title' => generate_port_link($local_port, "<img src='graph.php?type=port_bits&amp;id=" . $items['local_port_id'] . "&amp;from=" . Config::get('time.day') . "&amp;to=" . Config::get('time.now') . "&amp;width=100&amp;height=20&amp;legend=no&amp;bg=" . str_replace("#", "", $row_colour) . "'>\n", '', 0, 1),
+                'title' => generate_port_link($local_port, "<img src='". asset("graph.php"). "?type=port_bits&amp;id=" . $items['local_port_id'] . "&amp;from=" . Config::get('time.day') . "&amp;to=" . Config::get('time.now') . "&amp;width=100&amp;height=20&amp;legend=no&amp;bg=" . str_replace("#", "", $row_colour) . "'>\n", '', 0, 1),
                 'width'=>$width,
             ),
             $link_style
@@ -353,7 +353,7 @@ if (count($devices_by_id) > 1 && count($links) > 0) {
     <?php } ?>
 <div id="visualization"></div>
 </form>
-<script src="js/vis.min.js"></script>
+<? = echo '<script src="'. asset("js/vis.min.js") .'"></script>' ?>
 <script type="text/javascript">
 var height = $(window).height() - 100;
 $('#visualization').height(height + 'px');

--- a/resources/views/locations.blade.php
+++ b/resources/views/locations.blade.php
@@ -75,8 +75,8 @@
 @endsection
 
 @section('javascript')
-    <script src="js/leaflet.js"></script>
-    <script src="js/L.Control.Locate.min.js"></script>
+    <?php = echo '<script src="'. asset("js/leaflet.js"). '"></script>' ?>
+    <?php = echo '<script src="'. asset("js/L.Control.Locate.min.js"). '"></script>' ?>
     <script>
         var locationMap = null;
         var locationMarker = null;

--- a/resources/views/overview/default.blade.php
+++ b/resources/views/overview/default.blade.php
@@ -153,7 +153,7 @@
 @endsection
 
 @section('javascript')
-<script type="text/javascript" src="js/jquery.gridster.min.js"></script>
+<?php = echo '<script type="text/javascript" src="'. asset("js/jquery.gridster.min.js") .'"></script>' ?>
 @endsection
 
 @push('scripts')

--- a/resources/views/widgets/graph.blade.php
+++ b/resources/views/widgets/graph.blade.php
@@ -3,7 +3,7 @@
         <img class="minigraph-image"
              width="{{ $dimensions['x'] }}"
              height="{{ $dimensions['y'] }}"
-             src="graph.php?{{ implode('&', $params) }}&from={{ $from }}&to={{ $to }}&width={{ $dimensions['x'] }}&height={{ $dimensions['y'] }}&type={{ $graph_type }}&legend={{ $graph_legend }}&absolute=1"
+             <?php    echo 'src="'.asset("graph.php").'?{{ implode('."'&'".', $params) }}&from={{ $from }}&to={{ $to }}&width={{ $dimensions['."'x'".'] }}&height={{ $dimensions['."'y'".'] }}&type={{ $graph_type }}&legend={{ $graph_legend }}&absolute=1"';     ?>
         />
     </a>
 </div>


### PR DESCRIPTION
cupidazul: svg-dynamic-graphs url fix using asset fn to turn 'js/script.js' to 'hxxp://xxx/js/script.js' .

This fix, is useful for those who need to access LibreNMS from a NAT or Proxy ad use the SVG's with the Dynamic Graphs option.
Without this, the SVG will not show.


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
