### PR TITLE
Fix display of device modules

### DIFF
--- a/includes/html/pages/device/edit/modules.inc.php
+++ b/includes/html/pages/device/edit/modules.inc.php
@@ -24,6 +24,7 @@ use LibreNMS\Config;
 $language = \config('app.locale');
 $settings = (include Config::get('install_dir').'/resources/lang/'.$language.'/settings.php')['settings'];
 
+$attribs = get_dev_attribs($device['device_id']);
 $poller_module_names = $settings['poller_modules'];
 $discovery_module_names = $settings['discovery_modules'];
 


### PR DESCRIPTION
When navigating Select Device->Edit Device->Modules the Device column for poller and discovery was always displaying unset because data was not retrieved from table devices_attribs.   get_dev_attribs function needed to be added at the top.  I have tested and verified.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
