### PR TITLE
Show Hardware Details on Network Adapters in Device - Inventory

### DIFF
--- a/includes/html/pages/device/hrdevice.inc.php
+++ b/includes/html/pages/device/hrdevice.inc.php
@@ -3,7 +3,7 @@ echo '<h3>Inventory</h3>';
 echo '<hr>';
 echo '<table class="table table-condensed">';
 
-// FIXME missing heading
+echo "<tr class='list'><th>Index</th><th>Description</th><th></th><th>Type</th><th>Status</th><th>Errors</th><th>Load</th></tr>";
 foreach (dbFetchRows('SELECT * FROM `hrDevice` WHERE `device_id` = ? ORDER BY `hrDeviceIndex`', array($device['device_id'])) as $hrdevice) {
     echo "<tr class='list'><td>".$hrdevice['hrDeviceIndex'].'</td>';
 
@@ -30,10 +30,15 @@ foreach (dbFetchRows('SELECT * FROM `hrDevice` WHERE `device_id` = ? ORDER BY `h
         echo '<td>'.$mini_graph.'</td>';
     } elseif ($hrdevice['hrDeviceType'] == 'hrDeviceNetwork') {
         $int       = str_replace('network interface ', '', $hrdevice['hrDeviceDescr']);
-        $interface = dbFetchRow('SELECT * FROM ports WHERE device_id = ? AND ifDescr = ?', array($device['device_id'], $int));
+        $interface = dbFetchRow('SELECT * FROM ports WHERE device_id = ? AND (ifDescr = ? or ifName = ?)', array($device['device_id'], $int, $int));
         $interface = cleanPort($interface);
         if ($interface['ifIndex']) {
-            echo '<td>'.generate_port_link($interface).'</td>';
+            if (!empty($interface['port_descr_type'])) {
+                $interface_text = $interface['port_descr_type'] . ' (' . $int . ')';
+            } else {
+                $interface_text = $int;
+            }
+            echo '<td>'.generate_port_link($interface, $interface_text).'</td>';
 
             $graph_array['height']      = '20';
             $graph_array['width']       = '100';
@@ -45,7 +50,6 @@ foreach (dbFetchRows('SELECT * FROM `hrDevice` WHERE `device_id` = ? ORDER BY `h
             $graph_array_zoom['height'] = '150';
             $graph_array_zoom['width']  = '400';
 
-            // FIXME click on graph should also link to port, but can't use generate_port_link here...
             $mini_graph = overlib_link(generate_port_url($interface), generate_lazy_graph_tag($graph_array), generate_graph_tag($graph_array_zoom), null);
 
             echo "<td>$mini_graph</td>";


### PR DESCRIPTION
In Inventory of a Server Device now:
instead of  "network interface -interface name-"

"-Networkinterfacehardwarename-  -interface name-" is printed.


also Table now has a description header

(Screenshots are shrinked together to relevant parts..)

before:
![image](https://user-images.githubusercontent.com/7978916/80995671-eb003f80-8e3e-11ea-9562-33bb51cb82c2.png)

after:
![image](https://user-images.githubusercontent.com/7978916/80995689-f5bad480-8e3e-11ea-8fe7-83b1303f8e6d.png)



DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
