### PR TITLE
Migrate scripts to Python 3

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -92,7 +92,7 @@ class DB:
         """
 
         # Does a connection exist for this thread
-        if threading.get_ident() not in self._db.keys():
+        if threading.get_ident() not in list(self._db.keys()):
             self.connect()
 
         return self._db[threading.get_ident()]
@@ -236,10 +236,10 @@ class RedisLock(Lock):
         if redis_kwargs.get('sentinel') and redis_kwargs.get('sentinel_service'):
             sentinels = [tuple(l.split(':')) for l in redis_kwargs.pop('sentinel').split(',')]
             sentinel_service = redis_kwargs.pop('sentinel_service')
-            kwargs = {k: v for k, v in redis_kwargs.items() if k in ["decode_responses", "password", "db", "socket_timeout"]}
+            kwargs = {k: v for k, v in list(redis_kwargs.items()) if k in ["decode_responses", "password", "db", "socket_timeout"]}
             self._redis = Sentinel(sentinels, **kwargs).master_for(sentinel_service)
         else:
-            kwargs = {k: v for k, v in redis_kwargs.items() if "sentinel" not in k}
+            kwargs = {k: v for k, v in list(redis_kwargs.items()) if "sentinel" not in k}
             self._redis = redis.Redis(**kwargs)
         self._redis.ping()
         self._namespace = namespace
@@ -287,7 +287,7 @@ class RedisLock(Lock):
     def print_locks(self):
         keys = self._redis.keys(self.__key('*'))
         for key in keys:
-            print("{} locked by {}, expires in {} seconds".format(key, self._redis.get(key), self._redis.ttl(key)))
+            print(("{} locked by {}, expires in {} seconds".format(key, self._redis.get(key), self._redis.ttl(key))))
 
 
 class RedisUniqueQueue(object):
@@ -298,10 +298,10 @@ class RedisUniqueQueue(object):
         if redis_kwargs.get('sentinel') and redis_kwargs.get('sentinel_service'):
             sentinels = [tuple(l.split(':')) for l in redis_kwargs.pop('sentinel').split(',')]
             sentinel_service = redis_kwargs.pop('sentinel_service')
-            kwargs = {k: v for k, v in redis_kwargs.items() if k in ["decode_responses", "password", "db", "socket_timeout"]}
+            kwargs = {k: v for k, v in list(redis_kwargs.items()) if k in ["decode_responses", "password", "db", "socket_timeout"]}
             self._redis = Sentinel(sentinels, **kwargs).master_for(sentinel_service)
         else:
-            kwargs = {k: v for k, v in redis_kwargs.items() if "sentinel" not in k}
+            kwargs = {k: v for k, v in list(redis_kwargs.items()) if "sentinel" not in k}
             self._redis = redis.Redis(**kwargs)
         self._redis.ping()
         self.key = "{}:{}".format(namespace, name)

--- a/LibreNMS/queuemanager.py
+++ b/LibreNMS/queuemanager.py
@@ -143,9 +143,9 @@ class QueueManager:
     def get_queue(self, group):
         name = self.queue_name(self.type, group)
 
-        if name not in self._queues.keys():
+        if name not in list(self._queues.keys()):
             with self._queue_create_lock:
-                if name not in self._queues.keys():
+                if name not in list(self._queues.keys()):
                     self._queues[name] = self._create_queue(self.type, group)
 
         return self._queues[name]

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -455,7 +455,7 @@ class Service:
         Start all dispatch timers and begin pushing events into queues.
         This should only be started when we are the master dispatcher.
         """
-        for manager in self.queue_managers.values():
+        for manager in list(self.queue_managers.values()):
             try:
                 manager.start_dispatch()
             except AttributeError:
@@ -465,7 +465,7 @@ class Service:
         """
         Stop all dispatch timers, this should be called when we are no longer the master dispatcher.
         """
-        for manager in self.queue_managers.values():
+        for manager in list(self.queue_managers.values()):
             try:
                 manager.stop_dispatch()
             except AttributeError:
@@ -476,10 +476,10 @@ class Service:
         Stop all QueueManagers, and wait for their processing threads to complete.
         We send the stop signal to all QueueManagers first, then wait for them to finish.
         """
-        for manager in self.queue_managers.values():
+        for manager in list(self.queue_managers.values()):
             manager.stop()
 
-        for manager in self.queue_managers.values():
+        for manager in list(self.queue_managers.values()):
             manager.stop_and_wait()
 
     def check_single_instance(self):
@@ -512,7 +512,7 @@ class Service:
             # Find our ID
             self._db.query('SELECT id INTO @parent_poller_id FROM poller_cluster WHERE node_id="{0}"; '.format(self.config.node_id))
 
-            for worker_type, manager in self.queue_managers.items():
+            for worker_type, manager in list(self.queue_managers.items()):
                 worker_seconds, devices = manager.performance.reset()
 
                 # Record the queue state

--- a/discovery-wrapper.py
+++ b/discovery-wrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 """
  discovery-wrapper A small tool which wraps around discovery and tries to
                 guide the discovery process with a more modern approach with a
@@ -35,7 +35,7 @@ try:
 
     import json
     import os
-    import Queue
+    import queue
     import subprocess
     import sys
     import threading
@@ -43,16 +43,16 @@ try:
     from optparse import OptionParser
 
 except:
-    print "ERROR: missing one or more of the following python modules:"
-    print "threading, Queue, sys, subprocess, time, os, json"
+    print("ERROR: missing one or more of the following python modules:")
+    print("threading, Queue, sys, subprocess, time, os, json")
     sys.exit(2)
 
 try:
     import MySQLdb
 except:
-    print "ERROR: missing the mysql python module:"
-    print "On ubuntu: apt-get install python-mysqldb"
-    print "On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean"
+    print("ERROR: missing the mysql python module:")
+    print("On ubuntu: apt-get install python-mysqldb")
+    print("On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean")
     sys.exit(2)
 
 """
@@ -68,7 +68,7 @@ def get_config_data():
     try:
         proc = subprocess.Popen(config_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     except:
-        print "ERROR: Could not execute: %s" % config_cmd
+        print("ERROR: Could not execute: %s" % config_cmd)
         sys.exit(2)
     return proc.communicate()[0]
 
@@ -76,13 +76,13 @@ try:
     with open(config_file) as f:
         pass
 except IOError as e:
-    print "ERROR: Oh dear... %s does not seem readable" % config_file
+    print("ERROR: Oh dear... %s does not seem readable" % config_file)
     sys.exit(2)
 
 try:
     config = json.loads(get_config_data())
 except:
-    print "ERROR: Could not load or parse configuration, are PATHs correct?"
+    print("ERROR: Could not load or parse configuration, are PATHs correct?")
     sys.exit(2)
 
 discovery_path = config['install_dir'] + '/discovery.php'
@@ -109,7 +109,7 @@ def db_open():
             db = MySQLdb.connect(host=db_server, port=db_port, user=db_username, passwd=db_password, db=db_dbname)
         return db
     except:
-        print "ERROR: Could not connect to MySQL database!"
+        print("ERROR: Could not connect to MySQL database!")
         sys.exit(2)
 
 
@@ -152,30 +152,30 @@ if ('distributed_poller' in config and
         memc = memcache.Client([config['distributed_poller_memcached_host'] + ':' +
             str(config['distributed_poller_memcached_port'])])
         if str(memc.get("discovery.master")) == config['distributed_poller_name']:
-            print "This system is already joined as the discovery master."
+            print("This system is already joined as the discovery master.")
             sys.exit(2)
         if memc_alive():
             if memc.get("discovery.master") is None:
-                print "Registered as Master"
+                print("Registered as Master")
                 memc.set("discovery.master", config['distributed_poller_name'], 30)
                 memc.set("discovery.nodes", 0, 3600)
                 IsNode = False
             else:
-                print "Registered as Node joining Master %s" % memc.get("discovery.master")
+                print("Registered as Node joining Master %s" % memc.get("discovery.master"))
                 IsNode = True
                 memc.incr("discovery.nodes")
             distdisco = True
         else:
-            print "Could not connect to memcached, disabling distributed discovery."
+            print("Could not connect to memcached, disabling distributed discovery.")
             distdisco = False
             IsNode = False
     except SystemExit:
         raise
     except ImportError:
-        print "ERROR: missing memcache python module:"
-        print "On deb systems: apt-get install python-memcache"
-        print "On other systems: easy_install python-memcached"
-        print "Disabling distributed discovery."
+        print("ERROR: missing memcache python module:")
+        print("On deb systems: apt-get install python-memcache")
+        print("On other systems: easy_install python-memcached")
+        print("Disabling distributed discovery.")
         distdisco = False
 else:
     distdisco = False
@@ -255,11 +255,11 @@ def printworker():
                 memc_touch('discovery.master', 30)
                 nodes = memc.get('discovery.nodes')
                 if nodes is None and not memc_alive():
-                    print "WARNING: Lost Memcached. Taking over all devices. Nodes will quit shortly."
+                    print("WARNING: Lost Memcached. Taking over all devices. Nodes will quit shortly.")
                     distdisco = False
                     nodes = nodeso
                 if nodes is not nodeso:
-                    print "INFO: %s Node(s) Total" % (nodes)
+                    print("INFO: %s Node(s) Total" % (nodes))
                     nodeso = nodes
             else:
                 memc_touch('discovery.nodes', 30)
@@ -282,9 +282,9 @@ def printworker():
         per_device_duration[device_id] = elapsed_time
         discovered_devices += 1
         if elapsed_time < 300:
-            print "INFO: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time)
+            print("INFO: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time))
         else:
-            print "WARNING: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time)
+            print("WARNING: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time))
         print_queue.task_done()
 
 """
@@ -301,11 +301,11 @@ def poll_worker():
             if distdisco:
                 result = memc.add('discovery.device.' + str(device_id), config['distributed_poller_name'], 300)
                 if not result:
-                    print "This device (%s) appears to be being discovered by another discovery node" % (device_id)
+                    print("This device (%s) appears to be being discovered by another discovery node" % (device_id))
                     poll_queue.task_done()
                     continue
                 if not memc_alive() and IsNode:
-                    print "Lost Memcached, Not discovering Device %s as Node. Master will discover it." % device_id
+                    print("Lost Memcached, Not discovering Device %s as Node. Master will discover it." % device_id)
                     poll_queue.task_done()
                     continue
 # EOC5
@@ -324,11 +324,11 @@ def poll_worker():
                 pass
         poll_queue.task_done()
 
-poll_queue = Queue.Queue()
-print_queue = Queue.Queue()
+poll_queue = queue.Queue()
+print_queue = queue.Queue()
 
-print "INFO: starting the discovery at %s with %s threads, slowest devices first" % (time.strftime("%Y-%m-%d %H:%M:%S"),
-        amount_of_workers)
+print("INFO: starting the discovery at %s with %s threads, slowest devices first" % (time.strftime("%Y-%m-%d %H:%M:%S"),
+        amount_of_workers))
 
 for device_id in devices_list:
     poll_queue.put(device_id)
@@ -350,13 +350,13 @@ except (KeyboardInterrupt, SystemExit):
 
 total_time = int(time.time() - s_time)
 
-print "INFO: discovery-wrapper polled %s devices in %s seconds with %s workers" % (discovered_devices, total_time, amount_of_workers)
+print("INFO: discovery-wrapper polled %s devices in %s seconds with %s workers" % (discovered_devices, total_time, amount_of_workers))
 
 # (c) 2015, GPLv3, Daniel Preussker <f0o@devilcode.org> <<<EOC6
 if distdisco or memc_alive():
     master = memc.get("discovery.master")
     if master == config['distributed_poller_name'] and not IsNode:
-        print "Wait for all discovery-nodes to finish"
+        print("Wait for all discovery-nodes to finish")
         nodes = memc.get("discovery.nodes")
         while nodes > 0 and nodes is not None:
             try:
@@ -364,33 +364,33 @@ if distdisco or memc_alive():
                 nodes = memc.get("discovery.nodes")
             except:
                 pass
-        print "Clearing Locks"
+        print("Clearing Locks")
         x = minlocks
         while x <= maxlocks:
             memc.delete('discovery.device.' + str(x))
             x = x + 1
-        print "%s Locks Cleared" % x
-        print "Clearing Nodes"
+        print("%s Locks Cleared" % x)
+        print("Clearing Nodes")
         memc.delete("discovery.master")
         memc.delete("discovery.nodes")
     else:
         memc.decr("discovery.nodes")
-    print "Finished %s." % time.time()
+    print("Finished %s." % time.time())
 # EOC6
 
 show_stopper = False
 
 if total_time > 21600:
-    print "WARNING: the process took more than 6 hours to finish, you need faster hardware or more threads"
-    print "INFO: in sequential style discovery the elapsed time would have been: %s seconds" % real_duration
+    print("WARNING: the process took more than 6 hours to finish, you need faster hardware or more threads")
+    print("INFO: in sequential style discovery the elapsed time would have been: %s seconds" % real_duration)
     for device in per_device_duration:
         if per_device_duration[device] > 3600:
-            print "WARNING: device %s is taking too long: %s seconds" % (device, per_device_duration[device])
+            print("WARNING: device %s is taking too long: %s seconds" % (device, per_device_duration[device]))
             show_stopper = True
     if show_stopper:
-        print "ERROR: Some devices are taking more than 3600 seconds, the script cannot recommend you what to do."
+        print("ERROR: Some devices are taking more than 3600 seconds, the script cannot recommend you what to do.")
     else:
         recommend = int(total_time / 300.0 * amount_of_workers + 1)
-        print "WARNING: Consider setting a minimum of %d threads. (This does not constitute professional advice!)" % recommend
+        print("WARNING: Consider setting a minimum of %d threads. (This does not constitute professional advice!)" % recommend)
 
     sys.exit(2)

--- a/poller-service.py
+++ b/poller-service.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 """
  poller-service A service to wrap SNMP polling.  It will poll up to $threads devices at a time, and will not re-poll
                 devices that have been polled within the last $poll_frequency seconds. It will prioritize devices based

--- a/poller-wrapper.py
+++ b/poller-wrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 """
  poller-wrapper A small tool which wraps around the poller and tries to
                 guide the polling process with a more modern approach with a
@@ -25,7 +25,7 @@ try:
 
     import json
     import os
-    import Queue
+    import queue
     import subprocess
     import sys
     import threading
@@ -33,16 +33,16 @@ try:
     from optparse import OptionParser
 
 except:
-    print "ERROR: missing one or more of the following python modules:"
-    print "threading, Queue, sys, subprocess, time, os, json"
+    print("ERROR: missing one or more of the following python modules:")
+    print("threading, Queue, sys, subprocess, time, os, json")
     sys.exit(2)
 
 try:
     import MySQLdb
 except:
-    print "ERROR: missing the mysql python module:"
-    print "On ubuntu: apt-get install python-mysqldb"
-    print "On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean"
+    print("ERROR: missing the mysql python module:")
+    print("On ubuntu: apt-get install python-mysqldb")
+    print("On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean")
     sys.exit(2)
 
 """
@@ -58,7 +58,7 @@ def get_config_data():
     try:
         proc = subprocess.Popen(config_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     except:
-        print "ERROR: Could not execute: %s" % config_cmd
+        print("ERROR: Could not execute: %s" % config_cmd)
         sys.exit(2)
     return proc.communicate()[0]
 
@@ -66,13 +66,13 @@ try:
     with open(config_file) as f:
         pass
 except IOError as e:
-    print "ERROR: Oh dear... %s does not seem readable" % config_file
+    print("ERROR: Oh dear... %s does not seem readable" % config_file)
     sys.exit(2)
 
 try:
     config = json.loads(get_config_data())
 except:
-    print "ERROR: Could not load or parse configuration, are PATHs correct?"
+    print("ERROR: Could not load or parse configuration, are PATHs correct?")
     sys.exit(2)
 
 poller_path = config['install_dir'] + '/poller.php'
@@ -99,7 +99,7 @@ def db_open():
             db = MySQLdb.connect(host=db_server, port=db_port, user=db_username, passwd=db_password, db=db_dbname)
         return db
     except:
-        print "ERROR: Could not connect to MySQL database!"
+        print("ERROR: Could not connect to MySQL database!")
         sys.exit(2)
 
 
@@ -161,27 +161,27 @@ if ('distributed_poller' in config and
             distpoll = True
             memc.add(nodes_tag, 0, step)
             if memc.add(master_tag, config['distributed_poller_name'], 10):
-                print "Registered as Master"
+                print("Registered as Master")
                 IsNode = False
             else:
                 if str(memc.get(master_tag)) == config['distributed_poller_name']:
-                    print "This system is already joined as the poller master."
+                    print("This system is already joined as the poller master.")
                     sys.exit(2)
                 else:
-                    print "Registered as Node joining Master %s" % memc.get(master_tag)
+                    print("Registered as Node joining Master %s" % memc.get(master_tag))
                     memc.incr(nodes_tag)
                     IsNode = True
         else:
-            print "Could not connect to memcached, disabling distributed poller."
+            print("Could not connect to memcached, disabling distributed poller.")
             distpoll = False
             IsNode = False
     except SystemExit:
         raise
     except ImportError:
-        print "ERROR: missing memcache python module:"
-        print "On deb systems: apt-get install python-memcache"
-        print "On other systems: easy_install python-memcached"
-        print "Disabling distributed poller."
+        print("ERROR: missing memcache python module:")
+        print("On deb systems: apt-get install python-memcache")
+        print("On other systems: easy_install python-memcached")
+        print("Disabling distributed poller.")
         distpoll = False
 else:
     distpoll = False
@@ -261,11 +261,11 @@ def printworker():
                 memc_touch(master_tag, 10)
                 nodes = memc.get(nodes_tag)
                 if nodes is None and not memc_alive():
-                    print "WARNING: Lost Memcached. Taking over all devices. Nodes will quit shortly."
+                    print("WARNING: Lost Memcached. Taking over all devices. Nodes will quit shortly.")
                     distpoll = False
                     nodes = nodeso
                 if nodes is not nodeso:
-                    print "INFO: %s Node(s) Total" % (nodes)
+                    print("INFO: %s Node(s) Total" % (nodes))
                     nodeso = nodes
             else:
                 memc_touch(nodes_tag, 10)
@@ -288,9 +288,9 @@ def printworker():
         per_device_duration[device_id] = elapsed_time
         polled_devices += 1
         if elapsed_time < step:
-            print "INFO: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time)
+            print("INFO: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time))
         else:
-            print "WARNING: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time)
+            print("WARNING: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time))
         print_queue.task_done()
 
 """
@@ -307,11 +307,11 @@ def poll_worker():
             if distpoll:
                 result = memc.add('poller.device.%s.%s'% (device_id, time_tag), config['distributed_poller_name'], step)
                 if not result:
-                    print "This device (%s) appears to be being polled by another poller" % (device_id)
+                    print("This device (%s) appears to be being polled by another poller" % (device_id))
                     poll_queue.task_done()
                     continue
                 if not memc_alive() and IsNode:
-                    print "Lost Memcached, Not polling Device %s as Node. Master will poll it." % device_id
+                    print("Lost Memcached, Not polling Device %s as Node. Master will poll it." % device_id)
                     poll_queue.task_done()
                     continue
 # EOC5
@@ -330,11 +330,11 @@ def poll_worker():
                 pass
         poll_queue.task_done()
 
-poll_queue = Queue.Queue()
-print_queue = Queue.Queue()
+poll_queue = queue.Queue()
+print_queue = queue.Queue()
 
-print "INFO: starting the poller at %s with %s threads, slowest devices first" % (time.strftime("%Y-%m-%d %H:%M:%S"),
-        amount_of_workers)
+print("INFO: starting the poller at %s with %s threads, slowest devices first" % (time.strftime("%Y-%m-%d %H:%M:%S"),
+        amount_of_workers))
 
 for device_id in devices_list:
     poll_queue.put(device_id)
@@ -356,13 +356,13 @@ except (KeyboardInterrupt, SystemExit):
 
 total_time = int(time.time() - s_time)
 
-print "INFO: poller-wrapper polled %s devices in %s seconds with %s workers" % (polled_devices, total_time, amount_of_workers)
+print("INFO: poller-wrapper polled %s devices in %s seconds with %s workers" % (polled_devices, total_time, amount_of_workers))
 
 # (c) 2015, GPLv3, Daniel Preussker <f0o@devilcode.org> <<<EOC6
 if distpoll or memc_alive():
     master = memc.get(master_tag)
     if master == config['distributed_poller_name'] and not IsNode:
-        print "Wait for all poller-nodes to finish"
+        print("Wait for all poller-nodes to finish")
         nodes = memc.get(nodes_tag)
         while nodes > 0 and nodes is not None:
             try:
@@ -370,18 +370,18 @@ if distpoll or memc_alive():
                 nodes = memc.get(nodes_tag)
             except:
                 pass
-        print "Clearing Locks for %s" % time_tag
+        print("Clearing Locks for %s" % time_tag)
         x = minlocks
         while x <= maxlocks:
             res = memc.delete('poller.device.%s.%s' % (x, time_tag))
             x += 1
-        print "%s Locks Cleared" % x
-        print "Clearing Nodes"
+        print("%s Locks Cleared" % x)
+        print("Clearing Nodes")
         memc.delete(master_tag)
         memc.delete(nodes_tag)
     else:
         memc.decr(nodes_tag)
-    print "Finished %.3fs after interval start." % (time.time() - int(time_tag))
+    print("Finished %.3fs after interval start." % (time.time() - int(time_tag)))
 # EOC6
 
 show_stopper = False
@@ -402,16 +402,16 @@ db.close()
 
 
 if total_time > step:
-    print "WARNING: the process took more than %s seconds to finish, you need faster hardware or more threads" % step
-    print "INFO: in sequential style polling the elapsed time would have been: %s seconds" % real_duration
+    print("WARNING: the process took more than %s seconds to finish, you need faster hardware or more threads" % step)
+    print("INFO: in sequential style polling the elapsed time would have been: %s seconds" % real_duration)
     for device in per_device_duration:
         if per_device_duration[device] > step:
-            print "WARNING: device %s is taking too long: %s seconds" % (device, per_device_duration[device])
+            print("WARNING: device %s is taking too long: %s seconds" % (device, per_device_duration[device]))
             show_stopper = True
     if show_stopper:
-        print "ERROR: Some devices are taking more than %s seconds, the script cannot recommend you what to do." % step
+        print("ERROR: Some devices are taking more than %s seconds, the script cannot recommend you what to do." % step)
     else:
         recommend = int(total_time / step * amount_of_workers + 1)
-        print "WARNING: Consider setting a minimum of %d threads. (This does not constitute professional advice!)" % recommend
+        print("WARNING: Consider setting a minimum of %d threads. (This does not constitute professional advice!)" % recommend)
 
     sys.exit(2)

--- a/scripts/github-remove
+++ b/scripts/github-remove
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import argparse, datetime, sys, subprocess
 from subprocess import call, Popen
 from os.path import dirname, abspath
@@ -9,10 +9,10 @@ def confirm(question):
     valid = {"yes":True, "y":True, "ye":True, "no":False, "n":False}
     while 1:
         sys.stdout.write(question + " [y/N] ")
-        choice = raw_input().lower()
+        choice = input().lower()
         if choice == '':
             return False
-        elif choice in valid.keys():
+        elif choice in list(valid.keys()):
             return valid[choice]
         else:
             sys.stdout.write("Please respond with 'yes' or 'no'  (or 'y' or 'n').\n")
@@ -68,4 +68,4 @@ elif args.restore:
     if "github-remove" in last:
         call(["git", "stash", "pop"], cwd=librenms_dir)
     else:
-        print("Last stash was not created by " + __file__ + ". Aborting.")
+        print(("Last stash was not created by " + __file__ + ". Aborting."))

--- a/services-wrapper.py
+++ b/services-wrapper.py
@@ -13,7 +13,7 @@
                 that should run simultaneously. If no argument is given it will assume
                 a default of 1 thread.
 
- Ubuntu Linux:  apt-get install python-mysqldb
+ Ubuntu Linux:  apt-get install python3-mysqldb
  FreeBSD:       cd /usr/ports/*/py-MySQLdb && make install clean
 
  License:       This program is free software: you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ try:
     import MySQLdb
 except:
     print("ERROR: missing the mysql python module:")
-    print("On ubuntu: apt-get install python-mysqldb")
+    print("On ubuntu: apt-get install python3-mysqldb")
     print("On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean")
     sys.exit(2)
 
@@ -173,8 +173,8 @@ if ('distributed_poller' in config and
         raise
     except ImportError:
         print("ERROR: missing memcache python module:")
-        print("On deb systems: apt-get install python-memcache")
-        print("On other systems: easy_install python-memcached")
+        print("On deb systems: apt-get install python3-memcache")
+        print("On other systems: easy_install python3-memcached")
         print("Disabling distributed discovery.")
         servicedisco = False
 else:

--- a/services-wrapper.py
+++ b/services-wrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 """
  services-wrapper A small tool which wraps around check-services.php and tries to
                 guide the services process with a more modern approach with a
@@ -35,7 +35,7 @@ try:
 
     import json
     import os
-    import Queue
+    import queue
     import subprocess
     import sys
     import threading
@@ -43,16 +43,16 @@ try:
     from optparse import OptionParser
 
 except:
-    print "ERROR: missing one or more of the following python modules:"
-    print "threading, Queue, sys, subprocess, time, os, json"
+    print("ERROR: missing one or more of the following python modules:")
+    print("threading, Queue, sys, subprocess, time, os, json")
     sys.exit(2)
 
 try:
     import MySQLdb
 except:
-    print "ERROR: missing the mysql python module:"
-    print "On ubuntu: apt-get install python-mysqldb"
-    print "On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean"
+    print("ERROR: missing the mysql python module:")
+    print("On ubuntu: apt-get install python-mysqldb")
+    print("On FreeBSD: cd /usr/ports/*/py-MySQLdb && make install clean")
     sys.exit(2)
 
 """
@@ -68,7 +68,7 @@ def get_config_data():
     try:
         proc = subprocess.Popen(config_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     except:
-        print "ERROR: Could not execute: %s" % config_cmd
+        print("ERROR: Could not execute: %s" % config_cmd)
         sys.exit(2)
     return proc.communicate()[0]
 
@@ -76,13 +76,13 @@ try:
     with open(config_file) as f:
         pass
 except IOError as e:
-    print "ERROR: Oh dear... %s does not seem readable" % config_file
+    print("ERROR: Oh dear... %s does not seem readable" % config_file)
     sys.exit(2)
 
 try:
     config = json.loads(get_config_data())
 except:
-    print "ERROR: Could not load or parse configuration, are PATHs correct?"
+    print("ERROR: Could not load or parse configuration, are PATHs correct?")
     sys.exit(2)
 
 service_path = config['install_dir'] + '/check-services.php'
@@ -109,7 +109,7 @@ def db_open():
             db = MySQLdb.connect(host=db_server, port=db_port, user=db_username, passwd=db_password, db=db_dbname)
         return db
     except:
-        print "ERROR: Could not connect to MySQL database!"
+        print("ERROR: Could not connect to MySQL database!")
         sys.exit(2)
 
 
@@ -152,30 +152,30 @@ if ('distributed_poller' in config and
         memc = memcache.Client([config['distributed_poller_memcached_host'] + ':' +
             str(config['distributed_poller_memcached_port'])])
         if str(memc.get("service.master")) == config['distributed_poller_name']:
-            print "This system is already joined as the service master."
+            print("This system is already joined as the service master.")
             sys.exit(2)
         if memc_alive():
             if memc.get("service.master") is None:
-                print "Registered as Master"
+                print("Registered as Master")
                 memc.set("service.master", config['distributed_poller_name'], 10)
                 memc.set("service.nodes", 0, 300)
                 IsNode = False
             else:
-                print "Registered as Node joining Master %s" % memc.get("service.master")
+                print("Registered as Node joining Master %s" % memc.get("service.master"))
                 IsNode = True
                 memc.incr("service.nodes")
             servicedisco = True
         else:
-            print "Could not connect to memcached, disabling distributed service checks."
+            print("Could not connect to memcached, disabling distributed service checks.")
             servicedisco = False
             IsNode = False
     except SystemExit:
         raise
     except ImportError:
-        print "ERROR: missing memcache python module:"
-        print "On deb systems: apt-get install python-memcache"
-        print "On other systems: easy_install python-memcached"
-        print "Disabling distributed discovery."
+        print("ERROR: missing memcache python module:")
+        print("On deb systems: apt-get install python-memcache")
+        print("On other systems: easy_install python-memcached")
+        print("Disabling distributed discovery.")
         servicedisco = False
 else:
     servicedisco = False
@@ -249,11 +249,11 @@ def printworker():
                 memc_touch('service.master', 10)
                 nodes = memc.get('service.nodes')
                 if nodes is None and not memc_alive():
-                    print "WARNING: Lost Memcached. Taking over all devices. Nodes will quit shortly."
+                    print("WARNING: Lost Memcached. Taking over all devices. Nodes will quit shortly.")
                     servicedisco = False
                     nodes = nodeso
                 if nodes is not nodeso:
-                    print "INFO: %s Node(s) Total" % (nodes)
+                    print("INFO: %s Node(s) Total" % (nodes))
                     nodeso = nodes
             else:
                 memc_touch('service.nodes', 10)
@@ -276,9 +276,9 @@ def printworker():
         per_device_duration[device_id] = elapsed_time
         service_devices += 1
         if elapsed_time < 300:
-            print "INFO: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time)
+            print("INFO: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time))
         else:
-            print "WARNING: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time)
+            print("WARNING: worker %s finished device %s in %s seconds" % (worker_id, device_id, elapsed_time))
         print_queue.task_done()
 
 """
@@ -295,11 +295,11 @@ def poll_worker():
             if servicedisco:
                 result = memc.add('service.device.' + str(device_id), config['distributed_poller_name'], 300)
                 if not result:
-                    print "This device (%s) appears to be being service checked by another service node" % (device_id)
+                    print("This device (%s) appears to be being service checked by another service node" % (device_id))
                     poll_queue.task_done()
                     continue
                 if not memc_alive() and IsNode:
-                    print "Lost Memcached, Not service checking Device %s as Node. Master will check it." % device_id
+                    print("Lost Memcached, Not service checking Device %s as Node. Master will check it." % device_id)
                     poll_queue.task_done()
                     continue
 # EOC5
@@ -318,11 +318,11 @@ def poll_worker():
                 pass
         poll_queue.task_done()
 
-poll_queue = Queue.Queue()
-print_queue = Queue.Queue()
+poll_queue = queue.Queue()
+print_queue = queue.Queue()
 
-print "INFO: starting the service check at %s with %s threads" % (time.strftime("%Y-%m-%d %H:%M:%S"),
-        amount_of_workers)
+print("INFO: starting the service check at %s with %s threads" % (time.strftime("%Y-%m-%d %H:%M:%S"),
+        amount_of_workers))
 
 for device_id in devices_list:
     poll_queue.put(device_id)
@@ -344,13 +344,13 @@ except (KeyboardInterrupt, SystemExit):
 
 total_time = int(time.time() - s_time)
 
-print "INFO: services-wrapper checked %s devices in %s seconds with %s workers" % (service_devices, total_time, amount_of_workers)
+print("INFO: services-wrapper checked %s devices in %s seconds with %s workers" % (service_devices, total_time, amount_of_workers))
 
 # (c) 2015, GPLv3, Daniel Preussker <f0o@devilcode.org> <<<EOC6
 if servicedisco or memc_alive():
     master = memc.get("service.master")
     if master == config['distributed_poller_name'] and not IsNode:
-        print "Wait for all service-nodes to finish"
+        print("Wait for all service-nodes to finish")
         nodes = memc.get("service.nodes")
         while nodes > 0 and nodes is not None:
             try:
@@ -358,33 +358,33 @@ if servicedisco or memc_alive():
                 nodes = memc.get("service.nodes")
             except:
                 pass
-        print "Clearing Locks"
+        print("Clearing Locks")
         x = minlocks
         while x <= maxlocks:
             memc.delete('service.device.' + str(x))
             x = x + 1
-        print "%s Locks Cleared" % x
-        print "Clearing Nodes"
+        print("%s Locks Cleared" % x)
+        print("Clearing Nodes")
         memc.delete("service.master")
         memc.delete("service.nodes")
     else:
         memc.decr("service.nodes")
-    print "Finished %s." % time.time()
+    print("Finished %s." % time.time())
 # EOC6
 
 show_stopper = False
 
 if total_time > 300:
-    print "WARNING: the process took more than 5 minutes to finish, you need faster hardware or more threads"
-    print "INFO: in sequential style service checks the elapsed time would have been: %s seconds" % real_duration
+    print("WARNING: the process took more than 5 minutes to finish, you need faster hardware or more threads")
+    print("INFO: in sequential style service checks the elapsed time would have been: %s seconds" % real_duration)
     for device in per_device_duration:
         if per_device_duration[device] > 300:
-            print "WARNING: device %s is taking too long: %s seconds" % (device, per_device_duration[device])
+            print("WARNING: device %s is taking too long: %s seconds" % (device, per_device_duration[device]))
             show_stopper = True
     if show_stopper:
-        print "ERROR: Some devices are taking more than 300 seconds, the script cannot recommend you what to do."
+        print("ERROR: Some devices are taking more than 300 seconds, the script cannot recommend you what to do.")
     else:
         recommend = int(total_time / 300.0 * amount_of_workers + 1)
-        print "WARNING: Consider setting a minimum of %d threads. (This does not constitute professional advice!)" % recommend
+        print("WARNING: Consider setting a minimum of %d threads. (This does not constitute professional advice!)" % recommend)
 
     sys.exit(2)

--- a/snmp-scan.py
+++ b/snmp-scan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Scan networks for snmp hosts and add them to LibreNMS
 
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 @author     Tony Murray <murraytony@gmail.com>
 """
 
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
 
 import argparse
 from argparse import RawTextHelpFormatter
@@ -201,7 +201,7 @@ Example: """ + __file__ + """ -P 192.168.0.0/24""")
     networks = []
     for net in (netargs if netargs else CONFIG.get('nets', [])):
         try:
-            networks.append(ip_network(u'%s' % net, True))
+            networks.append(ip_network('%s' % net, True))
             debug('Network parsed: {}'.format(net), 2)
         except ValueError as e:
             parser.error('Invalid network format {}'.format(e))


### PR DESCRIPTION
Migrate all Python scripts to Python 3 using the 2to3 tool, so that users can run librenms on Ubuntu 20.04 LTS. However, this change means the user need to install `python3-mysqldb` and `python3-memcache` instead of the older ones.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
