### PR TITLE
Ability to map librenms devicegroup into oxidized group

### DIFF
--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1342,7 +1342,7 @@ function list_oxidized(\Illuminate\Http\Request $request)
         unset($device['sysname']);
         unset($device['sysDescr']);
         unset($device['hardware']);
-	unset($device['devicegroup']);
+        unset($device['devicegroup']);
         $devices[] = $device;
     }
 

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1300,7 +1300,7 @@ function list_oxidized(\Illuminate\Http\Request $request)
         $params = [$hostname];
     }
 
-    foreach (dbFetchRows("SELECT hostname,sysname,sysDescr,hardware,os,locations.location,ip AS ip FROM `devices` LEFT JOIN locations ON devices.location_id = locations.id LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
+    foreach (dbFetchRows("SELECT hostname,sysname,hardware,os,locations.location,ip as ip,DG.name AS devicegroup FROM `devices` LEFT JOIN locations ON devices.location_id = locations.id LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' LEFT JOIN device_group_device AS `DGD` ON devices.device_id = DGD.device_id LEFT JOIN device_groups AS `DG` on DGD.device_group_id = DG.id WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (devices.`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
         // Convert from packed value to human value
         $device['ip'] = inet6_ntop($device['ip']);
 
@@ -1342,6 +1342,7 @@ function list_oxidized(\Illuminate\Http\Request $request)
         unset($device['sysname']);
         unset($device['sysDescr']);
         unset($device['hardware']);
+	unset($device['devicegroup']);
         $devices[] = $device;
     }
 


### PR DESCRIPTION
…ou map LibreNMS groups onto oxidized groups as such:

$config['oxidized']['maps']['group']['devicegroup'][] = array('match' => 'Libre Device Group 1', 'group' => 'group1');
$config['oxidized']['maps']['group']['devicegroup'][] = array('match' => 'Libre Device Group 2', 'group' => 'group2');

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ X]
- [ X] 

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
