### PR TITLE
Fix midnight poller data loss

### DIFF
--- a/LibreNMS/__init__.py
+++ b/LibreNMS/__init__.py
@@ -36,7 +36,7 @@ def call_script(script, args=()):
     cmd = base + ("{}/{}".format(base_dir, script),) + tuple(map(str, args))
     debug("Running {}".format(cmd))
     # preexec_fn=os.setsid here keeps process signals from propagating (close_fds=True is default)
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, preexec_fn=os.setsid).decode()
+    return subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, preexec_fn=os.setsid, close_fds=True)
 
 
 class DB:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -15,7 +15,7 @@ from logging import debug, info, warning, error, critical, exception
 from platform import python_version
 from time import sleep
 from socket import gethostname
-from signal import signal, SIGTERM, SIGQUIT, SIGINT, strsignal
+from signal import signal, SIGTERM, SIGQUIT, SIGINT
 from uuid import uuid1
 
 
@@ -497,7 +497,7 @@ class Service:
         :param _unused:
         :param _:
         """
-        info("Received %s on thead %s, handling", strsignal(signalnum), threading.current_thread().name)
+        info("Received signal on thead %s, handling", threading.current_thread().name)
         self.terminate_flag = True
 
     def shutdown(self, _unused=None, _=None):

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -441,7 +441,7 @@ class Service:
                     `last_polled` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL `last_polled_timetaken` SECOND) OR
                     `last_discovered` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL `last_discovered_timetaken` SECOND)
                 )
-                ORDER BY `last_polled_timetaken` DESC''', (self.service_age(), poller_find_time, self.service_age(), discovery_find_time, poller_find_time, discovery_find_time))
+                ORDER BY `last_polled_timetaken` DESC''', (poller_find_time, self.service_age(), discovery_find_time, poller_find_time, discovery_find_time))
             self.db_failures = 0
             return result
         except pymysql.err.Error:

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -229,7 +229,7 @@ class ServiceConfig:
 
         except ImportError as e:
             exception("Could not import .env - check that the poller user can read the file, and that composer install has been run recently")
-            sys.exit(3)
+            self.exit(3)
 
         config_cmd = ['/usr/bin/env', 'php', '{}/config_to_json.php'.format(self.BASE_DIR), '2>&1']
         try:
@@ -462,12 +462,12 @@ class Service:
             if self.config.distributed:
                 critical("ERROR: Redis connection required for distributed polling")
                 critical("Please install redis-py, either through your os software repository or from PyPI")
-                sys.exit(2)
+                self.exit(2)
         except Exception as e:
             if self.config.distributed:
                 critical("ERROR: Redis connection required for distributed polling")
                 critical("Could not connect to Redis. {}".format(e))
-                sys.exit(2)
+                self.exit(2)
 
         return LibreNMS.ThreadingLock()
 
@@ -517,7 +517,7 @@ class Service:
 
         # try to release master lock
         info('Shutdown of %s/%s complete', os.getpid(), threading.current_thread().name)
-        sys.exit(0)
+        self.exit(0)
 
     def start_dispatch_timers(self):
         """
@@ -566,7 +566,7 @@ class Service:
             fcntl.lockf(self._fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except IOError:
             warning("Another instance is already running, quitting.")
-            exit(2)
+            self.exit(2)
 
     def log_performance_stats(self):
         info("Counting up time spent polling")
@@ -613,3 +613,6 @@ class Service:
         else:
             info("Log file updated {}s ago".format(int(logfile_mdiff)))
 
+    def exit(self, code=0):
+        sys.stdout.flush()
+        sys.exit(code)

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -326,7 +326,7 @@ class Service:
         while True:
             try:
                 # Request the state of the first waiting child - don't block if there aren't any
-                r = os.waitpid(-1, os.WNOHANG)
+                r = os.waitpid(0, os.WNOHANG)
             except OSError:
                 # No more processes
                 break

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -15,7 +15,7 @@ from logging import debug, info, warning, error, critical, exception
 from platform import python_version
 from time import sleep
 from socket import gethostname
-from signal import signal, SIGTERM
+from signal import signal, SIGTERM, SIGQUIT, SIGINT, strsignal
 from uuid import uuid1
 
 
@@ -286,6 +286,8 @@ class Service:
     def attach_signals(self):
         info("Attaching signal handlers on thread %s", threading.current_thread().name)
         signal(SIGTERM, self.terminate)  # capture sigterm and exit gracefully
+        signal(SIGQUIT, self.terminate)  # capture sigquit and exit gracefully
+        signal(SIGINT, self.terminate)  # capture sigint and exit gracefully
 
     def start(self):
         debug("Performing startup checks...")
@@ -486,13 +488,13 @@ class Service:
         python = sys.executable
         os.execl(python, python, *sys.argv)
 
-    def terminate(self, _unused=None, _=None):
+    def terminate(self, signalnum=None, flag=None):
         """
         Handle a set the terminate flag to begin a clean shutdown
         :param _unused:
         :param _:
         """
-        info("Received SIGTERM on thead %s, handling", threading.current_thread().name)
+        info("Received %s on thead %s, handling", strsignal(signalnum), threading.current_thread().name)
         self.terminate_flag = True
 
     def shutdown(self, _unused=None, _=None):

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -230,7 +230,7 @@ class ServiceConfig:
 
         except ImportError as e:
             exception("Could not import .env - check that the poller user can read the file, and that composer install has been run recently")
-            self.exit(3)
+            sys.exit(3)
 
         config_cmd = ['/usr/bin/env', 'php', '{}/config_to_json.php'.format(self.BASE_DIR), '2>&1']
         try:
@@ -244,18 +244,7 @@ class ServiceConfig:
         if g is None:
             return [0]
         elif type(g) is int:
-            return [g]
-        elif type(g) is str:
-            try:
-                return [int(x) for x in set(g.split(','))]
-            except ValueError:
-                pass
-
-        error("Could not parse group string, defaulting to 0")
-        return [0]
-
-
-class Service:
+            return [g]exit
     config = ServiceConfig()
     _fp = False
     _started = False

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -530,7 +530,7 @@ class Service:
         :param _unused:
         :param _:
         """
-        info("Received signal on thead %s, handling", threading.current_thread().name)
+        info("Received signal on thread %s, handling", threading.current_thread().name)
         self.reload_flag = True
 
     def terminate(self, signalnum=None, flag=None):
@@ -539,7 +539,7 @@ class Service:
         :param _unused:
         :param _:
         """
-        info("Received signal on thead %s, handling", threading.current_thread().name)
+        info("Received signal on thread %s, handling", threading.current_thread().name)
         self.terminate_flag = True
 
     def shutdown(self, signalnum=None, flag=None):

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -453,7 +453,7 @@ class Service:
 
             result = self._db.query('''SELECT `device_id`,
                   `poller_group`,
-                  IF (%s < `last_polled_timetaken` * 1.25, 0, COALESCE(`last_polled` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL `last_polled_timetaken` SECOND), 1)) AS `poll`,
+                  COALESCE(`last_polled` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL `last_polled_timetaken` SECOND), 1) AS `poll`,
                   IF(snmp_disable=1 OR status=0, 0, IF (%s < `last_discovered_timetaken` * 1.25, 0, COALESCE(`last_discovered` <= DATE_ADD(DATE_ADD(NOW(), INTERVAL -%s SECOND), INTERVAL `last_discovered_timetaken` SECOND), 1))) AS `discover`
                 FROM `devices`
                 WHERE `disabled` = 0 AND (

--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -244,7 +244,18 @@ class ServiceConfig:
         if g is None:
             return [0]
         elif type(g) is int:
-            return [g]exit
+            return [g]
+        elif type(g) is str:
+            try:
+                return [int(x) for x in set(g.split(','))]
+            except ValueError:
+                pass
+
+        error("Could not parse group string, defaulting to 0")
+        return [0]
+
+
+class Service:
     config = ServiceConfig()
     _fp = False
     _started = False

--- a/doc/Extensions/Dispatcher-Service.md
+++ b/doc/Extensions/Dispatcher-Service.md
@@ -22,6 +22,7 @@ behaviour only found in Python3.4+.
   install. MySQLclient can also be used, but does require compilation.
 - python-dotenv .env loader
 - redis-py 3.0+ and Redis 5.0+ server (if using distributed polling)
+- psutil
 
 These can be obtained from your OS package manager, or from PyPI with the below commands.
 
@@ -196,7 +197,7 @@ First, enable SCL's on your system:
 Then install and configure the runtime and service:
 
 ```
-# yum install rh-python36 epel-release
+# yum install gcc rh-python36 rh-python36-python-devel epel-release
 # yum --enablerepo=remi install redis
 # vi /opt/librenms/config.php
 # vi /etc/redis.conf

--- a/misc/librenms.service
+++ b/misc/librenms.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/opt/librenms/librenms-service.py -v
+ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/opt/librenms
 User=librenms
 Group=librenms

--- a/misc/librenms.service.scl
+++ b/misc/librenms.service.scl
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/scl enable rh-python36 -- /opt/librenms/librenms-service.py -v
+ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/opt/librenms
 User=librenms
 Group=librenms

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyMySQL
 python-dotenv
 redis>=3.0
 setuptools
+psutil


### PR DESCRIPTION
We have a discovery job that takes around 8 minutes to complete. If it coincides with the nightly reload, the entire poller stops running for those 8 minutes.

This changes things up to eliminate this loss of data, while adding the small chance that a second job may be executed for the same device by executing the new poller process before all processes return.

It also fixes an issue where log messages would be lost. By default, stdout's buffer is not flushed when exit is called.

![graph php](https://user-images.githubusercontent.com/590630/81504788-25585980-92e3-11ea-95ea-e50a749e103a.png)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
