### PR TITLE
Disable auto-refresh for notifications and alert history

### DIFF
--- a/includes/html/pages/alert-log.inc.php
+++ b/includes/html/pages/alert-log.inc.php
@@ -13,6 +13,7 @@
  * @author     LibreNMS Contributors
 */
 
+$no_refresh = true;
 $device_id= '';
 $vars['fromdevice'] = false;
 require_once 'includes/html/common/alert-log.inc.php';

--- a/includes/html/pages/alerts.inc.php
+++ b/includes/html/pages/alerts.inc.php
@@ -13,6 +13,7 @@
  * @author     LibreNMS Contributors
 */
 
+$no_refresh = true;
 $page_title = 'Alerts';
 ?>
 


### PR DESCRIPTION
Hello,

This PR disables auto-refresh for notifications and alert history

When viewing notifications and alert history, if you select a page number, auto-refresh reloads the page and then you are back to page 1. This is very annoying especially because going to a distant page like for example 30 requires a lot of click.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
