### PR TITLE
Filter on sensor class as expected and documented

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1306,13 +1306,13 @@ function add_cbgp_peer($device, $peer, $afi, $safi)
 /**
  * check if we should skip this sensor from discovery
  * @param $device
- * @param string $sensor_type
+ * @param string $sensor_class
  * @param string $sensor_descr
  * @return bool
  */
-function can_skip_sensor($device, $sensor_type = '', $sensor_descr = '')
+function can_skip_sensor($device, $sensor_class = '', $sensor_descr = '')
 {
-    if (! empty($sensor_type) && Config::getCombined($device['os'], "disabled_sensors.$sensor_type", false)) {
+    if (! empty($sensor_class) && Config::getCombined($device['os'], "disabled_sensors.$sensor_class", false)) {
         return true;
     }
     foreach (Config::getCombined($device['os'], "disabled_sensors_regex", []) as $skipRegex) {


### PR DESCRIPTION
This code was tested on a device on which sensor_type == sensor_class. But the expected behaviour is to filter on sensor_class (current, temperature, etc) and not on type (which is the same for all cisco sensors, for instance). 

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
