### PR TITLE
Fix broken ICT current output

### DIFF
--- a/includes/polling/sensors/current/ict-pdu.inc.php
+++ b/includes/polling/sensors/current/ict-pdu.inc.php
@@ -1,9 +1,0 @@
-<?php
-
-$oid_sensor = $sensor['sensor_oid'];
-
-if ($oid_sensor == '.1.3.6.1.4.1.39145.10.8.1.4.0') {
-    $sensor_value = trim(str_replace('"', '', $snmp_data[$oid_sensor]));
-} else {
-    $sensor_value = trim(str_replace('"', '', $snmp_data[$sensor['sensor_oid'].'.0']));
-}


### PR DESCRIPTION
Resulted in broken current output graphs and non-numeric warnings on the ICT180S-12IRC.

See also: https://github.com/librenms/librenms/pull/8558

Before:
```
./poller.php -h HOSTNAME -m sensors -d
...
#### Load poller module sensors ####
SQL[SELECT `sensor_class` FROM `sensors` WHERE `device_id` = ? GROUP BY `sensor_class` [4] 1.6ms]

SQL[SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ? ["current",4] 4.61ms]

SNMP['/usr/bin/snmpget' '-v2c' '-c' 'COMMUNITY' '-OUQnte' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/ict' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.39145.10.8.1.3.0' '.1.3.6.1.4.1.39145.10.8.1.3.1' '.1.3.6.1.4.1.39145.10.8.1.3.2' '.1.3.6.1.4.1.39145.10.8.1.3.3' '.1.3.6.1.4.1.39145.10.8.1.3.4' '.1.3.6.1.4.1.39145.10.8.1.3.5' '.1.3.6.1.4.1.39145.10.8.1.3.6' '.1.3.6.1.4.1.39145.10.8.1.3.7' '.1.3.6.1.4.1.39145.10.8.1.3.8' '.1.3.6.1.4.1.39145.10.8.1.3.9']
.*.4.1.39*.3.0 = "1.2"
.*.4.1.39*.3.1 = "1.1"
.*.4.1.39*.3.2 = "2.4"
.*.4.1.39*.3.3 = "1.1"
.*.4.1.39*.3.4 = "2.5"
.*.4.1.39*.3.5 = "1.1"
.*.4.1.39*.3.6 = "0.0"
.*.4.1.39*.3.7 = "0.0"
.*.4.1.39*.3.8 = "0.0"
.*.4.1.39*.3.9 = "0.0"

SNMP['/usr/bin/snmpget' '-v2c' '-c' 'COMMUNITY' '-OUQnte' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/ict' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.39145.10.8.1.3.10' '.1.3.6.1.4.1.39145.10.8.1.3.11' '.1.3.6.1.4.1.39145.10.7.0']
.*.4.1.39*.3.10 = "19.3"
.*.4.1.39*.3.11 = "0.0"
.*.4.1.39* = "28.9"

Checking (snmp) current Output Current #1...
Checking (snmp) current Output Current #2...
Checking (snmp) current Output Current #3...
Checking (snmp) current Output Current #4...
Checking (snmp) current Output Current #5...
Checking (snmp) current Output Current #6...
Checking (snmp) current Output Current #7...
Checking (snmp) current Output Current #8...
Checking (snmp) current Output Current #9...
Checking (snmp) current Output Current #10...
Checking (snmp) current Output Current #11...
Checking (snmp) current Output Current #12...
Checking (snmp) current System Current...

Warning: A non-numeric value encountered in /opt/librenms/includes/polling/functions.inc.php on line 167
0
RRD[last HOSTNAME/sensor-current-ict-pdu-0.rrd  --daemon rrdcached:42217]
RRD[update HOSTNAME/sensor-current-ict-pdu-0.rrd N:0 --daemon rrdcached:42217]

Warning: A non-numeric value encountered in /opt/librenms/includes/polling/functions.inc.php on line 167
0
RRD[last HOSTNAME/sensor-current-ict-pdu-1.rrd  --daemon rrdcached:42217]
RRD[update HOSTNAME/sensor-current-ict-pdu-1.rrd N:0 --daemon rrdcached:42217]
...
```

After:
```
./poller.php -h HOSTNAME -m sensors -d
...
#### Load poller module sensors ####
SQL[SELECT `sensor_class` FROM `sensors` WHERE `device_id` = ? GROUP BY `sensor_class` [4] 1.77ms]

SQL[SELECT * FROM `sensors` WHERE `sensor_class` = ? AND `device_id` = ? ["current",4] 4.06ms]

SNMP['/usr/bin/snmpget' '-v2c' '-c' 'COMMUNITY' '-OUQnte' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/ict' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.39145.10.8.1.3.0' '.1.3.6.1.4.1.39145.10.8.1.3.1' '.1.3.6.1.4.1.39145.10.8.1.3.2' '.1.3.6.1.4.1.39145.10.8.1.3.3' '.1.3.6.1.4.1.39145.10.8.1.3.4' '.1.3.6.1.4.1.39145.10.8.1.3.5' '.1.3.6.1.4.1.39145.10.8.1.3.6' '.1.3.6.1.4.1.39145.10.8.1.3.7' '.1.3.6.1.4.1.39145.10.8.1.3.8' '.1.3.6.1.4.1.39145.10.8.1.3.9']
.*.4.1.39*.3.0 = "1.1"
.*.4.1.39*.3.1 = "1.1"
.*.4.1.39*.3.2 = "1.1"
.*.4.1.39*.3.3 = "1.1"
.*.4.1.39*.3.4 = "2.5"
.*.4.1.39*.3.5 = "1.1"
.*.4.1.39*.3.6 = "0.0"
.*.4.1.39*.3.7 = "0.0"
.*.4.1.39*.3.8 = "0.0"
.*.4.1.39*.3.9 = "0.0"

SNMP['/usr/bin/snmpget' '-v2c' '-c' 'COMMUNITY' '-OUQnte' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/ict' 'udp:HOSTNAME:161' '.1.3.6.1.4.1.39145.10.8.1.3.10' '.1.3.6.1.4.1.39145.10.8.1.3.11' '.1.3.6.1.4.1.39145.10.7.0']
.*.4.1.39*.3.10 = "19.2"
.*.4.1.39*.3.11 = "0.0"
.*.4.1.39* = "27.4"

Checking (snmp) current Output Current #1...
Checking (snmp) current Output Current #2...
Checking (snmp) current Output Current #3...
Checking (snmp) current Output Current #4...
Checking (snmp) current Output Current #5...
Checking (snmp) current Output Current #6...
Checking (snmp) current Output Current #7...
Checking (snmp) current Output Current #8...
Checking (snmp) current Output Current #9...
Checking (snmp) current Output Current #10...
Checking (snmp) current Output Current #11...
Checking (snmp) current Output Current #12...
Checking (snmp) current System Current...
1.1
RRD[last HOSTNAME/sensor-current-ict-pdu-0.rrd  --daemon rrdcached:42217]
RRD[update HOSTNAME/sensor-current-ict-pdu-0.rrd N:1.1 --daemon rrdcached:42217]
SQL[UPDATE `sensors` set `sensor_current`=?,`sensor_prev`=?,`lastupdate`=NOW() WHERE `sensor_class` = ? AND `sensor_id` = ? [1.1,0,"Current",4] 5.53ms]

1.1
RRD[last HOSTNAME/sensor-current-ict-pdu-1.rrd  --daemon rrdcached:42217]
RRD[update HOSTNAME/sensor-current-ict-pdu-1.rrd N:1.1 --daemon rrdcached:42217]
SQL[UPDATE `sensors` set `sensor_current`=?,`sensor_prev`=?,`lastupdate`=NOW() WHERE `sensor_class` = ? AND `sensor_id` = ? [1.1,0,"Current",5] 5.08ms]
...
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
