### PR TITLE
Syslog -> Added colour priority to the label column

### DIFF
--- a/app/Http/Controllers/Table/SyslogController.php
+++ b/app/Http/Controllers/Table/SyslogController.php
@@ -83,6 +83,7 @@ class SyslogController extends TableController
         $device = $syslog->device;
 
         return [
+            'label' => $this->setLabel($syslog),
             'timestamp' => $syslog->timestamp,
             'level' => htmlentities($syslog->level),
             'device_id' => $device ? \LibreNMS\Util\Url::deviceLink($device, $device->shortDisplayName()) : '',
@@ -91,4 +92,40 @@ class SyslogController extends TableController
             'priority' => htmlentities($syslog->priority),
         ];
     }
+
+    private function setLabel($syslog)
+    {
+        $output = "<span class='alert-status ";
+        $output .= $this->priorityLabel($syslog->priority);
+        $output .= "'>";
+        $output .= "</span>";
+
+        return $output;
+    }
+
+    /**
+     * @param int $syslog_priority
+     * @return string $syslog_priority_icon
+     */
+    private function priorityLabel($syslog_priority)
+    {
+        switch ($syslog_priority) {
+            case "debug":
+                return "label-default"; //Debug
+            case "info":
+                return "label-info"; //Informational
+            case "notice":
+                return "label-primary"; //Notice
+            case "warning":
+                return "label-warning"; //Warning
+            case "err":
+                return "label-danger"; //Error
+            case "crit":
+                return "label-danger"; //Critical
+            case "alert":
+                return "label-danger"; //Alert
+            case "emerg":
+                return "label-danger"; //Emergency
+        }
+    } // end syslog_priority
 }


### PR DESCRIPTION
Now the label column have the corresponding colour based on priority.

Feel free to comment if I should change any colour<->priority.

Before:
![image](https://user-images.githubusercontent.com/32565115/81920140-115d7200-95d9-11ea-9c08-c6f059885078.png)

After:
![image](https://user-images.githubusercontent.com/32565115/81919974-cfccc700-95d8-11ea-87b3-d5ba111222fd.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
