### PR TITLE
Fixed realtime graph http get spam

### DIFF
--- a/html/graph-realtime.php
+++ b/html/graph-realtime.php
@@ -342,6 +342,7 @@ function handle_error(type) {
     if (real_interval !== 0) {
         SVGDoc.getElementById('cacheinterval').firstChild.data = Math.round(real_interval);
     }
+    return;
   } else {
     SVGDoc.getElementById("error").setAttributeNS(null, 'visibility', 'visible');
   }


### PR DESCRIPTION
When the cache warning appears on the realtime graph, an extra get request is queued on top of the normal one. This causes get requests to increase exponentially over time. The "cachewarning" error does not actually indicate failure, so the setTimeout function does not need to be called again.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
