### PR TITLE
Validate PHP version mismatch

### DIFF
--- a/LibreNMS/Validations/Php.php
+++ b/LibreNMS/Validations/Php.php
@@ -59,8 +59,8 @@ class Php extends BaseValidation
 
         $web_version = PHP_VERSION;
         $cli_version = rtrim(shell_exec('php -r "echo PHP_VERSION;"'));
-        if (version_compare($web_version, $cli_version, '!==')) {
-            $validator->fail("PHP version of your webserver ($web_version) does not match the cli version ($cli_version)", "If you update PHP recently, restart php-fpm or apache to switch to the new version");
+        if (version_compare($web_version, $cli_version, '!=')) {
+            $validator->fail("PHP version of your webserver ($web_version) does not match the cli version ($cli_version)", "If you updated PHP recently, restart php-fpm or apache to switch to the new version");
         }
     }
 

--- a/LibreNMS/Validations/Php.php
+++ b/LibreNMS/Validations/Php.php
@@ -56,6 +56,12 @@ class Php extends BaseValidation
         if (Config::get('update') && version_compare(PHP_VERSION, self::PHP_MIN_VERSION, '<')) {
             $validator->warn("PHP version " . self::PHP_MIN_VERSION . " is the minimum supported version as of " . self::PHP_MIN_VERSION_DATE . ". We recommend you update PHP to a supported version (" . self::PHP_RECOMMENDED_VERSION . " suggested) to continue to receive updates. If you do not update PHP, LibreNMS will continue to function but stop receiving bug fixes and updates.");
         }
+
+        $web_version = PHP_VERSION;
+        $cli_version = rtrim(shell_exec('php -r "echo PHP_VERSION;"'));
+        if (version_compare($web_version, $cli_version, '!==')) {
+            $validator->fail("PHP version of your webserver ($web_version) does not match the cli version ($cli_version)", "If you update PHP recently, restart php-fpm or apache to switch to the new version");
+        }
     }
 
     private function checkSessionDirWritable(Validator $validator)


### PR DESCRIPTION
If the webserver does not match the cli version this means they recently upgraded and have not restarted the service.

This can cause errors with some cached data.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
