### PR TITLE
Config from dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ __pycache__
 Thumbs.db
 config.php
 config.d/*
-!config.d/.gitkeep
+!config.d/README.md
 html/css/custom/*
 html/images/custom/*
 html/plugins/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ __pycache__
 *.swp
 Thumbs.db
 config.php
+config.d/*
+!config.d/.gitkeep
 html/css/custom/*
 html/images/custom/*
 html/plugins/*

--- a/config.d/README.md
+++ b/config.d/README.md
@@ -1,0 +1,11 @@
+## Configuration directory
+
+You can edit configuration of LibreNMS by placing `*.php` files in the `config.d` folder. Let's say you want to edit the [WebUI settings](https://docs.librenms.org/Support/Configuration/#webui-settings). Create a file called for example `webui.php` with this content:
+
+```php
+<?php
+$config['page_refresh'] = "300";
+$config['webui']['default_dashboard_id'] = 0;
+```
+
+This configuration will be included in LibreNMS and will override the default values.

--- a/config.sample.php
+++ b/config.sample.php
@@ -52,14 +52,14 @@ $config['show_services'] = 1;
 
 # If LIBRENMS_DATA_PATH env var is defined (from our Docker image), load config files from this path
 if (is_dir(getenv('LIBRENMS_DATA_PATH'))) {
-    foreach (glob( getenv('LIBRENMS_DATA_PATH') . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . '*.php') as $configfile) {
+    foreach (glob(getenv('LIBRENMS_DATA_PATH') . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . '*.php') as $configfile) {
         include $configfile;
     }
 }
 
 # Load from config.d folder
 if (is_dir(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.d')) {
-    foreach (glob( dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.d' . DIRECTORY_SEPARATOR . '*.php') as $configfile) {
+    foreach (glob(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.d' . DIRECTORY_SEPARATOR . '*.php') as $configfile) {
         include $configfile;
     }
 }

--- a/config.sample.php
+++ b/config.sample.php
@@ -51,13 +51,15 @@ $config['enable_billing'] = 1;
 $config['show_services'] = 1;
 
 # If LIBRENMS_DATA_PATH env var is defined (from our Docker image), load config files from this path
-if (is_dir(getenv("LIBRENMS_DATA_PATH"))) {
-    foreach (glob( getenv("LIBRENMS_DATA_PATH") . DIRECTORY_SEPARATOR . "config" . DIRECTORY_SEPARATOR . "*.php") as $configfile) {
+if (is_dir(getenv('LIBRENMS_DATA_PATH'))) {
+    foreach (glob( getenv('LIBRENMS_DATA_PATH') . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . '*.php') as $configfile) {
         include $configfile;
     }
 }
 
 # Load from config.d folder
-foreach (glob( dirname(__FILE__) . DIRECTORY_SEPARATOR . "config.d" . DIRECTORY_SEPARATOR . "*.php") as $configfile) {
-    include $configfile;
+if (is_dir(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.d')) {
+    foreach (glob( dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.d' . DIRECTORY_SEPARATOR . '*.php') as $configfile) {
+        include $configfile;
+    }
 }

--- a/config.sample.php
+++ b/config.sample.php
@@ -49,3 +49,15 @@ $config['enable_billing'] = 1;
 
 # Enable the in-built services support (Nagios plugins)
 $config['show_services'] = 1;
+
+# If LIBRENMS_DATA_PATH env var is defined (from our Docker image), load config files from this path
+if (is_dir(getenv("LIBRENMS_DATA_PATH"))) {
+    foreach (glob( getenv("LIBRENMS_DATA_PATH") . DIRECTORY_SEPARATOR . "config" . DIRECTORY_SEPARATOR . "*.php") as $configfile) {
+        include $configfile;
+    }
+}
+
+# Load from config.d folder
+foreach (glob( dirname(__FILE__) . DIRECTORY_SEPARATOR . "config.d" . DIRECTORY_SEPARATOR . "*.php") as $configfile) {
+    include $configfile;
+}

--- a/doc/Installation/Installation-CentOS-6-Apache-Nginx.md
+++ b/doc/Installation/Installation-CentOS-6-Apache-Nginx.md
@@ -338,7 +338,7 @@ $config['fping'] = "/usr/sbin/fping";
 You may skip this section if the web installer succeeded.
 
 ```bash
-cp config.php.default config.php
+cp config.sample.php config.php
 vi config.php
 ```
 

--- a/doc/Installation/Installation-Ubuntu-1404-Apache.md
+++ b/doc/Installation/Installation-Ubuntu-1404-Apache.md
@@ -235,7 +235,7 @@ if you want to continue the setup manually then just keep following
 these instructions.
 
 ```bash
-cp config.php.default config.php
+cp config.sample.php config.php
 vim config.php
 ```
 

--- a/doc/Installation/Installation-Ubuntu-1404-Lighttpd.md
+++ b/doc/Installation/Installation-Ubuntu-1404-Lighttpd.md
@@ -113,7 +113,7 @@ continue the setup manually then just keep following these
 instructions.
 
 ```
-cp config.php.default config.php
+cp config.sample.php config.php
 vim config.php
 ```
 

--- a/doc/Installation/Installation-Ubuntu-1404-Nginx.md
+++ b/doc/Installation/Installation-Ubuntu-1404-Nginx.md
@@ -234,7 +234,7 @@ if you want to continue the setup manually then just keep following
 these instructions.
 
 ```bash
-cp config.php.default config.php
+cp config.sample.php config.php
 vim config.php
 ```
 

--- a/validate.php
+++ b/validate.php
@@ -76,7 +76,7 @@ register_shutdown_function(function () {
 
 // critical config.php checks
 if (!file_exists('config.php')) {
-    print_fail('config.php does not exist, please copy config.php.default to config.php');
+    print_fail('config.php does not exist, please copy config.sample.php to config.php');
     exit;
 }
 


### PR DESCRIPTION
Allow to load config from `config.d` dir. Avoid conflict with default configuration and also will be used by our Docker image if `LIBRENMS_DATA_PATH` is defined.

Also allow to split configurations as one config file can be very long:

* `config.d/rrd.php`
* `config.d/webui.php`
* ...

I have also renamed `config.php.default` to `config.sample.php` to allow code inspection on IDEs.
AFAIK, no breaking changes.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
