### PR TITLE
Fix availability map downtime

### DIFF
--- a/app/Http/Controllers/Widgets/AvailabilityMapController.php
+++ b/app/Http/Controllers/Widgets/AvailabilityMapController.php
@@ -102,7 +102,7 @@ class AvailabilityMapController extends WidgetController
             $device_query->isNotDisabled();
         }
         $device_query->orderBy($settings['order_by']);
-        $devices = $device_query->select('devices.device_id', 'hostname', 'sysName', 'status', 'uptime', 'disabled', 'disable_notify', 'location_id')->get();
+        $devices = $device_query->select('devices.device_id', 'hostname', 'sysName', 'status', 'uptime', 'last_polled', 'disabled', 'disable_notify', 'location_id')->get();
 
         // process status
         $uptime_warn = Config::get('uptime_warning', 84600);

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -270,6 +270,11 @@ class Device extends BaseModel
         return Time::formatInterval($this->uptime, $short);
     }
 
+    public function formatDowntime($short = false)
+    {
+        return Time::formatInterval(time() - $this->last_polled, $short);
+    }
+
     /**
      * @return string
      */

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -265,14 +265,10 @@ class Device extends BaseModel
         return Permissions::canAccessDevice($this->device_id, $user->user_id);
     }
 
-    public function formatUptime($short = false)
+    public function formatDownUptime($short = false)
     {
-        return Time::formatInterval($this->uptime, $short);
-    }
-
-    public function formatDowntime($short = false)
-    {
-        return Time::formatInterval(time() - strtotime($this->last_polled), $short);
+        $time = ($device->status == 1) ? $this->uptime : time() - strtotime($this->last_polled);
+        return Time::formatInterval($time, $short);
     }
 
     /**

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -267,7 +267,7 @@ class Device extends BaseModel
 
     public function formatDownUptime($short = false)
     {
-        $time = ($device->status == 1) ? $this->uptime : time() - strtotime($this->last_polled);
+        $time = ($this->status == 1) ? $this->uptime : time() - strtotime($this->last_polled);
         return Time::formatInterval($time, $short);
     }
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -272,10 +272,7 @@ class Device extends BaseModel
 
     public function formatDowntime($short = false)
     {
-        $ret = static::where('hostname', $this->hostname)->first(['hostname', 'last_polled']);
-        if (!empty($ret)) {
-            return Time::formatInterval(time() - strtotime($ret->last_polled), $short);
-        }
+        return Time::formatInterval(time() - strtotime($this->last_polled), $short);
     }
 
     /**

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -272,7 +272,10 @@ class Device extends BaseModel
 
     public function formatDowntime($short = false)
     {
-        return Time::formatInterval(time() - $this->last_polled, $short);
+        $ret = static::where('hostname', $this->hostname)->first(['hostname', 'last_polled']);
+        if (!empty($ret)) {
+            return Time::formatInterval(time() - strtotime($ret->last_polled), $short);
+        }
     }
 
     /**

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -195,9 +195,9 @@ if (defined('SHOW_SETTINGS')) {
         $sql .= " ORDER BY `".$deviceOrderBy."`";
 
         $temp_output = array();
-        $updowntime = "";
 
         foreach (dbFetchRows($sql, $param) as $device) {
+            $updowntime = "";
             if ($device['disabled'] == '1') {
                 $deviceState = "disabled";
                 $deviceLabel = "blackbg";

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -218,13 +218,13 @@ if (defined('SHOW_SETTINGS')) {
                     $deviceLabelOld = 'availability-map-oldview-box-up';
                     $host_up_count++;
                 }
-                $updowntime = "" . ($device['uptime'] ? " - " : "") . formatUptime($device['uptime']);
+                $updowntime = ($device['uptime'] ? " - " : "") . formatUptime($device['uptime']);
             } else {
                 $deviceState = 'down';
                 $deviceLabel = 'label-danger';
                 $deviceLabelOld = 'availability-map-oldview-box-down';
                 $host_down_count++;
-                $updowntime = "" . ($device['last_polled'] ? " - " . formatUptime(time() - strtotime($device['last_polled'])) : "") ;
+                $updowntime = ($device['last_polled'] ? " - " . formatUptime(time() - strtotime($device['last_polled'])) : "") ;
             }
 
             if (AlertUtil::isMaintenance($device['device_id'])) {

--- a/includes/html/common/availability-map.inc.php
+++ b/includes/html/common/availability-map.inc.php
@@ -171,7 +171,7 @@ if (defined('SHOW_SETTINGS')) {
             $in_devices = dbFetchColumn($device_group, [Session::get('group_view')]);
         }
 
-        $sql = 'SELECT `D`.`hostname`, `D`.`sysName`, `D`.`device_id`, `D`.`status`, `D`.`uptime`, `D`.`os`, `D`.`icon`, `D`.`disable_notify`, `D`.`disabled` FROM `devices` AS `D`';
+        $sql = 'SELECT `D`.`hostname`, `D`.`sysName`, `D`.`device_id`, `D`.`status`, `D`.`uptime`, `D`.`last_polled`, `D`.`os`, `D`.`icon`, `D`.`disable_notify`, `D`.`disabled` FROM `devices` AS `D`';
 
         if (!Auth::user()->hasGlobalRead()) {
             $sql .= ' , `devices_perms` AS P WHERE D.`device_id` = P.`device_id` AND P.`user_id` = ? AND ';
@@ -195,6 +195,7 @@ if (defined('SHOW_SETTINGS')) {
         $sql .= " ORDER BY `".$deviceOrderBy."`";
 
         $temp_output = array();
+        $updowntime = "";
 
         foreach (dbFetchRows($sql, $param) as $device) {
             if ($device['disabled'] == '1') {
@@ -217,11 +218,13 @@ if (defined('SHOW_SETTINGS')) {
                     $deviceLabelOld = 'availability-map-oldview-box-up';
                     $host_up_count++;
                 }
+                $updowntime = "" . ($device['uptime'] ? " - " : "") . formatUptime($device['uptime']);
             } else {
                 $deviceState = 'down';
                 $deviceLabel = 'label-danger';
                 $deviceLabelOld = 'availability-map-oldview-box-down';
                 $host_down_count++;
+                $updowntime = "" . ($device['last_polled'] ? " - " . formatUptime(time() - strtotime($device['last_polled'])) : "") ;
             }
 
             if (AlertUtil::isMaintenance($device['device_id'])) {
@@ -235,7 +238,7 @@ if (defined('SHOW_SETTINGS')) {
                 if ($directpage == "yes") {
                     $deviceIcon = getIconTag($device);
                     $temp_output[] = '
-                    <a href="' .generate_device_url($device). '" title="' . $device_system_name . ($device['uptime'] ? " - " : "") . formatUptime($device['uptime']) . '">
+                    <a href="' .generate_device_url($device). '" title="' . $device_system_name . $updowntime . '">
                     <div class="device-availability ' . $deviceState . '" style="width:' . Config::get('webui.availability_map_box_size') . 'px;">
                         <span class="availability-label label ' . $deviceLabel . ' label-font-border">' . $deviceState . '</span>
                         <span class="device-icon">' . $deviceIcon . '</span><br>
@@ -248,12 +251,12 @@ if (defined('SHOW_SETTINGS')) {
                         $deviceLabel .= ' widget-availability-fixed';
                     }
                     $temp_output[] = '
-                    <a href="' .generate_device_url($device). '" title="' . $device_system_name . " - " . formatUptime($device['uptime']) . '">
+                    <a href="' .generate_device_url($device). '" title="' . $device_system_name . $updowntime . '">
                         <span class="label ' . $deviceLabel . ' widget-availability label-font-border">' . $deviceState . '</span>
                     </a>';
                 }
             } else {
-                $temp_output[] = "<a href='" . generate_device_url($device) . "' title='" . $device_system_name . ' - ' . formatUptime($device['uptime']) . "'><div class='" . $deviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
+                $temp_output[] = "<a href='" . generate_device_url($device) . "' title='" . $device_system_name . $updowntime . "'><div class='" . $deviceLabelOld . "' style='width:${compact_tile}px;height:${compact_tile}px;'></div></a>";
             }
         }
     }

--- a/resources/views/auth/public-status.blade.php
+++ b/resources/views/auth/public-status.blade.php
@@ -32,7 +32,7 @@
                             <td><img src="{{ asset($device->icon) }}" width="32px" height="32px"></td>
                             <td class="device-name">{{ $device->displayName() }}</td>
                             <td>{{ $device->hardware }} {{ $device->features }}</td>
-                            <td>{{ $device->formatUptime(true) }}<br>{{ substr($device->location, 0, 32) }}</td>
+                            <td>{{ $device->formatDownUptime(true) }}<br>{{ substr($device->location, 0, 32) }}</td>
                         </tr>
                     @endforeach
                 </table>

--- a/resources/views/overview/simple.blade.php
+++ b/resources/views/overview/simple.blade.php
@@ -65,7 +65,7 @@
             {!! \LibreNMS\Util\Url::deviceLink($device, $device->shortDisplayName()) !!}
             <span class="device-rebooted">@lang('Device Rebooted')</span>
             <br />
-            <span class="body-date-1">{{ $device->formatUptime(true) }}</span>
+            <span class="body-date-1">{{ $device->formatDownUptime(true) }}</span>
         </div>
     @endforeach
 

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,7 +26,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDownUptime(true)) - @endif{{$device->formatDownUptime(true)}}@endif">
+    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDownUptime(true)) - down @endif{{$device->formatDownUptime(true)}}@endif">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,13 +26,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{ $device->displayName() }}
-    @if($device->stateName == 'up' or $device->stateName == 'warn')
-        @if($device->formatUptime(true)) - @endif{{ $device->formatUptime(true) }}
-    @elseif($device->stateName == 'down')
-        @if($device->formatDowntime(true)) - @endif{{ $device->formatDowntime(true) }}
-    @endif
-    ">
+    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatUptime(true))- @endif{{ $device->formatUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDowntime(true)) - @endif{{$device->formatDowntime(true)}}@endif">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,7 +26,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDownUptime(true)) - down @endif{{$device->formatDownUptime(true)}}@endif">
+    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDownUptime(true)) - downtime @endif{{$device->formatDownUptime(true)}}@endif">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,7 +26,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatUptime(true))- @endif{{ $device->formatUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDowntime(true)) - @endif{{$device->formatDowntime(true)}}@endif">
+    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatUptime(true)) - @endif{{ $device->formatUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDowntime(true)) - @endif{{$device->formatDowntime(true)}}@endif">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,7 +26,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDowntime(true)) - @endif{{$device->formatDowntime(true)}}@endif">
+    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDownUptime(true)) - @endif{{$device->formatDownUptime(true)}}@endif">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,7 +26,7 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatUptime(true)) - @endif{{ $device->formatUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDowntime(true)) - @endif{{$device->formatDowntime(true)}}@endif">
+    <a href="@deviceUrl($device)" title="{{$device->displayName() }}@if($device->stateName == 'up' or $device->stateName == 'warn')@if($device->formatDownUptime(true)) - @endif{{ $device->formatDownUptime(true) }}@elseif($device->stateName == 'down')@if($device->formatDowntime(true)) - @endif{{$device->formatDowntime(true)}}@endif">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>

--- a/resources/views/widgets/availability-map.blade.php
+++ b/resources/views/widgets/availability-map.blade.php
@@ -26,7 +26,13 @@
 <br style="clear:both;">
 
 @foreach($devices as $device)
-    <a href="@deviceUrl($device)" title="{{ $device->displayName() }}@if($device->formatUptime(true)) - @endif{{ $device->formatUptime(true) }}">
+    <a href="@deviceUrl($device)" title="{{ $device->displayName() }}
+    @if($device->stateName == 'up' or $device->stateName == 'warn')
+        @if($device->formatUptime(true)) - @endif{{ $device->formatUptime(true) }}
+    @elseif($device->stateName == 'down')
+        @if($device->formatDowntime(true)) - @endif{{ $device->formatDowntime(true) }}
+    @endif
+    ">
         @if($type == 0)
             @if($color_only_select == 1)
                 <span class="label {{ $device->labelClass }} widget-availability-fixed widget-availability label-font-border"> </span>


### PR DESCRIPTION
Down devices on availability map currently displays uptime instead of downtime on mouseover. This is a fix.

![image](https://user-images.githubusercontent.com/47607835/82305877-8b696e80-99be-11ea-85ed-b08a8b490b2c.png)


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
