### PR TITLE
Fix Fast-Ping-Check.md to include information about RRDCached

### DIFF
--- a/doc/Extensions/Fast-Ping-Check.md
+++ b/doc/Extensions/Fast-Ping-Check.md
@@ -20,25 +20,32 @@ Collection](../Alerting/Rules.md#alert-rules-collection).
 
 ## Setting the ping check to 1 minute
 
-1: Change the ping_rrd_step setting in config.php
+1: If you are using [RRDCached](http://docs.librenms.org/Extensions/RRDCached/), stop the service.
+
+    - This will flush all pending writes so that the rrdstep.php script can change the steps.
+    
+2: Change the ping_rrd_step setting in config.php
 
 ```
 $config['ping_rrd_step'] = 60;
 ```
 
-2: Update the rrd files to change the step (step is hardcoded at file
+3: Update the rrd files to change the step (step is hardcoded at file
 creation in rrd files)
 
 ```
 ./scripts/rrdstep.php -h all
 ```
 
-3: Add the following line to /etc/cron.d/librenms to allow 1 minute
+4: Add the following line to /etc/cron.d/librenms to allow 1 minute
 ping checks
 
 ```
 *    *    * * *   librenms    /opt/librenms/ping.php >> /dev/null 2>&1
 ```
+
+5: If applicable: Start the [RRDCached](http://docs.librenms.org/Extensions/RRDCached/) service
+
 
 **NOTE**: If you are using distributed pollers you can restrict a
 poller to a group by appending `-g` to the cron entry.  Alternatively,


### PR DESCRIPTION
Added stopping and starting RRDCached during the change of the rrd files step.
This will prevent data loss and corruption of the rrd files.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
