### PR TITLE
Enumerate Alert Level

### DIFF
--- a/LibreNMS/Enum/Alert.php
+++ b/LibreNMS/Enum/Alert.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Alert.php
+ *
+ * Enumerates alarming Level
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2020 Thomas Berberich
+ * @author     Thomas Berberich <sourcehhdoctor@gmail.com>
+ */
+
+namespace LibreNMS\Enum;
+
+abstract class Alert
+{
+    const UNKNOWN = 0;
+    const OK = 1;
+    const INFO = 2;
+    const NOTICE = 3;
+    const WARNING = 4;
+    const ERROR = 5;
+}

--- a/app/Checks.php
+++ b/app/Checks.php
@@ -90,7 +90,7 @@ class Checks
         $user = Auth::user();
 
         if ($user->isAdmin()) {
-            $notifications = Notification::isUnread($user)->where('severity', '>', 1)->get();
+            $notifications = Notification::isUnread($user)->where('severity', '>', \LibreNMS\Enum\Alert::OK)->get();
             foreach ($notifications as $notification) {
                 Toastr::error("<a href='notifications/'>$notification->body</a>", $notification->title);
             }

--- a/app/Facades/LogManager.php
+++ b/app/Facades/LogManager.php
@@ -26,6 +26,7 @@
 namespace App\Facades;
 
 use Auth;
+use LibreNMS\Enum\Alert;
 
 class LogManager extends \Illuminate\Log\LogManager
 {
@@ -38,7 +39,7 @@ class LogManager extends \Illuminate\Log\LogManager
      * @param int $severity 1: ok, 2: info, 3: notice, 4: warning, 5: critical, 0: unknown
      * @param int $reference the id of the referenced entity.  Supported types: interface
      */
-    public function event($text, $device = null, $type = null, $severity = 2, $reference = null)
+    public function event($text, $device = null, $type = null, $severity = Alert::INFO, $reference = null)
     {
         (new \App\Models\Eventlog([
             'device_id' => $device instanceof \App\Models\Device ? $device->device_id : $device,

--- a/app/Http/Controllers/Table/EventlogController.php
+++ b/app/Http/Controllers/Table/EventlogController.php
@@ -29,6 +29,7 @@ use App\Models\Eventlog;
 use Carbon\Carbon;
 use LibreNMS\Config;
 use LibreNMS\Util\Url;
+use LibreNMS\Enum\Alert;
 
 class EventlogController extends TableController
 {
@@ -119,15 +120,15 @@ class EventlogController extends TableController
     private function severityLabel($eventlog_severity)
     {
         switch ($eventlog_severity) {
-            case 1:
+            case Alert::OK:
                 return "label-success"; //OK
-            case 2:
+            case Alert::INFO:
                 return "label-info"; //Informational
-            case 3:
+            case Alert::NOTICE:
                 return "label-primary"; //Notice
-            case 4:
+            case Alert::WARNING:
                 return "label-warning"; //Warning
-            case 5:
+            case Alert::ERROR:
                 return "label-danger"; //Critical
             default:
                 return "label-default"; //Unknown

--- a/app/Models/Eventlog.php
+++ b/app/Models/Eventlog.php
@@ -26,6 +26,7 @@
 namespace App\Models;
 
 use Carbon\Carbon;
+use LibreNMS\Enum\Alert;
 
 class Eventlog extends DeviceRelatedModel
 {
@@ -45,7 +46,7 @@ class Eventlog extends DeviceRelatedModel
      * @param int $severity 1: ok, 2: info, 3: notice, 4: warning, 5: critical, 0: unknown
      * @param int $reference the id of the referenced entity.  Supported types: interface
      */
-    public static function log($text, $device = null, $type = null, $severity = 2, $reference = null)
+    public static function log($text, $device = null, $type = null, $severity = Alert::INFO, $reference = null)
     {
         $log = new static([
             'reference' => $reference,

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Str;
 use LibreNMS\Config;
 use LibreNMS\RRD\RrdDefinition;
+use LibreNMS\Enum\Alert;
 use LibreNMS\Exceptions\JsonAppException;
 use LibreNMS\Exceptions\JsonAppPollingFailedException;
 use LibreNMS\Exceptions\JsonAppParsingFailedException;
@@ -592,26 +593,25 @@ function update_application($app, $response, $metrics = array(), $status = '')
 
         $app_name = \LibreNMS\Util\StringHelpers::nicecase($app['app_type']);
 
-        # $severity 1: ok, 2: info, 3: notice, 4: warning, 5: critical, 0: unknown
         switch ($data['app_state']) {
             case 'OK':
-                $severity = 1;
+                $severity = Alert::OK;
                 $event_msg = "changed to OK";
                 break;
             case 'ERROR':
-                $severity = 5;
+                $severity = Alert::ERROR;
                 $event_msg = "ends with ERROR";
                 break;
             case 'LEGACY':
-                $severity = 4;
+                $severity = Alert::WARNING;
                 $event_msg = "Client Agent is deprecated";
                 break;
             case 'UNSUPPORTED':
-                $severity = 5;
+                $severity = Alert::ERROR;
                 $event_msg = "Client Agent Version is not supported";
                 break;
             default:
-                $severity = 0;
+                $severity = Alert::UNKNOWN;
                 $event_msg = "has UNKNOWN state";
                 break;
         }


### PR DESCRIPTION
instead of "cryptic" numbers Alert Level should be enumated for better maintainability

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
