### PR TITLE
Fix the PANOS HA state check alert rule from collection

### DIFF
--- a/misc/alert_rules.json
+++ b/misc/alert_rules.json
@@ -312,7 +312,7 @@
     "name": "Cisco NX-OS device has a bad fan"
   },
   {
-    "rule": "devices.os = \"panos\" & sensors.sensor_type = \"panSysHAState\" && sensors.sensor_current = \"1\" && sensors.sensor_prev = \"2\"",
+    "rule": "devices.os = \"panos\" && sensors.sensor_type = \"panSysHAState\" && sensors.sensor_current = \"1\" && sensors.sensor_prev = \"2\"",
     "name": "Palo Alto Networks passive firewall changed to active"
   },
   {


### PR DESCRIPTION
Fix a missing & in the alert collection "Palo Alto Networks passive firewall changed to active" that results in valid but incorrect SQL being generated and the alert not firing.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
