### PR TITLE
fix the max python3 version on daily.sh

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -131,7 +131,7 @@ check_dependencies() {
     local ver_56=$(php -r "echo (int)version_compare(PHP_VERSION, '5.6.4', '<');")
     local ver_71=$(php -r "echo (int)version_compare(PHP_VERSION, '7.1.3', '<');")
     local ver_72=$(php -r "echo (int)version_compare(PHP_VERSION, '7.2.5', '<');")
-    local python3=$(python3 -c "import sys;print(int(sys.version_info < (3, 5)))" 2> /dev/null)
+    local python3=$(python3 -c "import sys;print(int(sys.version_info < (3, 8)))" 2> /dev/null)
     local python_deps=$(scripts/check_requirements.py > /dev/null 2>&1; echo $?)
     local phpver="master"
     local pythonver="master"


### PR DESCRIPTION
Fix the max version of python3 on daily.sh
Change max version python3<3.5 to python3<3.8

**Please note**

> Please read this information carefully. You can run ```./scripts/pre-commit.php``` to check your code before submitting.

- [x] Have you followed our code guidelines?
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

**Testers**

If you would like to test this pull request then please run: ```./scripts/github-apply <pr_id>```, i.e ```./scripts/github-apply 11682```
After you are done testing, you can remove the changes with ```./scripts/github-remove```. If there are schema changes, you can ask on discord how to revert.