### PR TITLE
Since Rancid 3, the separator is ;

### DIFF
--- a/scripts/gen_rancid.php
+++ b/scripts/gen_rancid.php
@@ -56,7 +56,7 @@ foreach (dbFetchRows("SELECT `hostname`,`os`,`disabled`,`status` FROM `devices` 
         if ($devices['disabled']) {
             $status = "down";
         }
-        echo $devices['hostname'] . ':' . $rancid_map[$devices['os']] . ':' . $status . PHP_EOL;
+        echo $devices['hostname'] . ';' . $rancid_map[$devices['os']] . ';' . $status . PHP_EOL;
     }
 }
 echo "# EOF " . PHP_EOL;


### PR DESCRIPTION
Another minor change to the gen_rancid script.

Since rancid 3.0, the separator is ; instead of :.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=778623