### PR TITLE
Fix some python3 wrapper connection issues

### DIFF
--- a/LibreNMS/library.py
+++ b/LibreNMS/library.py
@@ -11,18 +11,17 @@ import time
 from logging.handlers import RotatingFileHandler
 
 try:
-    import pymysql
-    pymysql.install_as_MySQLdb()
-except ImportError:
-    pass
-
-try:
     import MySQLdb
-except ImportError as exc:
-    print('ERROR: missing the mysql python module please run:')
-    print('pip install -r requirements.txt')
-    print('ERROR: %s' % exc)
-    sys.exit(2)
+except ImportError:
+    try:
+        import pymysql
+        pymysql.install_as_MySQLdb()
+        import MySQLdb
+    except ImportError as exc:
+        print('ERROR: missing the mysql python module please run:')
+        print('pip install -r requirements.txt')
+        print('ERROR: %s' % exc)
+        sys.exit(2)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When mysqld is configured to listen on a non localhost tcp port, pymysql.install_as_MySQLdb() does not try the unix socket first even if host is localhost.
Try to import MySQLdb first which has the correct behavior.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
