### PR TITLE
Fix dynamic group membership rule for devices.status equal 0

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -224,6 +224,22 @@ function record_sensor_data($device, $all_sensors)
     }
 }
 
+
+/**
+ * @param array $device The device for which to update the groups for
+ */
+function poll_update_device_groups($device)
+{
+    // Update device_groups
+    echo "### Start Device Groups ###\n";
+    $dg_start = microtime(true);
+    $group_changes = \App\Models\DeviceGroup::updateGroupsFor($device['device_id']);
+    d_echo("Groups Added: " . implode(',', $group_changes['attached']) . PHP_EOL);
+    d_echo("Groups Removed: " . implode(',', $group_changes['detached']) . PHP_EOL);
+    echo "### End Device Groups, runtime: " . round(microtime(true) - $dg_start, 4) . "s ### \n\n";
+}
+
+
 /**
  * @param array $device The device to poll
  * @param bool $force_module Ignore device module overrides
@@ -354,16 +370,8 @@ function poll_device($device, $force_module = false)
                 echo "Module [ $module ] disabled globally.\n\n";
             }
         }
-
-        // Update device_groups
-        echo "### Start Device Groups ###\n";
-        $dg_start = microtime(true);
-
-        $group_changes = \App\Models\DeviceGroup::updateGroupsFor($device['device_id']);
-        d_echo("Groups Added: " . implode(',', $group_changes['attached']) . PHP_EOL);
-        d_echo("Groups Removed: " . implode(',', $group_changes['detached']) . PHP_EOL);
-
-        echo "### End Device Groups, runtime: " . round(microtime(true) - $dg_start, 4) . "s ### \n\n";
+        
+        poll_update_device_groups($device);
 
         if (!$force_module && !empty($graphs)) {
             echo "Enabling graphs: ";
@@ -445,6 +453,8 @@ function poll_device($device, $force_module = false)
         // Clear cache (unify all things here?)
 
         return true; // device was polled
+    } else {
+        poll_update_device_groups($device);
     }
 
     return false; // device not polled

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -224,22 +224,6 @@ function record_sensor_data($device, $all_sensors)
     }
 }
 
-
-/**
- * @param array $device The device for which to update the groups for
- */
-function poll_update_device_groups($device)
-{
-    // Update device_groups
-    echo "### Start Device Groups ###\n";
-    $dg_start = microtime(true);
-    $group_changes = \App\Models\DeviceGroup::updateGroupsFor($device['device_id']);
-    d_echo("Groups Added: " . implode(',', $group_changes['attached']) . PHP_EOL);
-    d_echo("Groups Removed: " . implode(',', $group_changes['detached']) . PHP_EOL);
-    echo "### End Device Groups, runtime: " . round(microtime(true) - $dg_start, 4) . "s ### \n\n";
-}
-
-
 /**
  * @param array $device The device to poll
  * @param bool $force_module Ignore device module overrides
@@ -371,8 +355,6 @@ function poll_device($device, $force_module = false)
             }
         }
         
-        poll_update_device_groups($device);
-
         if (!$force_module && !empty($graphs)) {
             echo "Enabling graphs: ";
             // FIXME EVENTLOGGING -- MAKE IT SO WE DO THIS PER-MODULE?
@@ -453,8 +435,6 @@ function poll_device($device, $force_module = false)
         // Clear cache (unify all things here?)
 
         return true; // device was polled
-    } else {
-        poll_update_device_groups($device);
     }
 
     return false; // device not polled

--- a/poller.php
+++ b/poller.php
@@ -143,6 +143,14 @@ foreach (dbFetch($query) as $device) {
         $unreachable_devices++;
     }
 
+    // Update device_groups
+    echo "### Start Device Groups ###\n";
+    $dg_start = microtime(true);
+    $group_changes = \App\Models\DeviceGroup::updateGroupsFor($device['device_id']);
+    d_echo("Groups Added: " . implode(',', $group_changes['attached']) . PHP_EOL);
+    d_echo("Groups Removed: " . implode(',', $group_changes['detached']) . PHP_EOL);
+    echo "### End Device Groups, runtime: " . round(microtime(true) - $dg_start, 4) . "s ### \n\n";
+
     echo "#### Start Alerts ####\n";
     $rules = new AlertRules();
     $rules->runRules($device['device_id']);


### PR DESCRIPTION
A dynamic group membership rule can be added with “devices.status equal 0”.
This would be very useful for e.g. Maps -> Device Group Dependencies
However, the device group membership is updated by the poller, and the poller code won’t update the device group membership for devices that are down.

This PR runs group membership updates for down and up devices, fixing e.g. network maps with device group dependencies.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
