### PR TITLE
Netgate pfSense firewall hardware appliance incorrectly recognised as standard FreeBSD server #11683

### DIFF
--- a/includes/definitions/freebsd.yaml
+++ b/includes/definitions/freebsd.yaml
@@ -14,3 +14,4 @@ discovery:
       sysDescr_except:
       - FreeNAS
       - TrueNAS
+      - netgate

--- a/includes/definitions/pfsense.yaml
+++ b/includes/definitions/pfsense.yaml
@@ -10,3 +10,4 @@ over:
 discovery:
     - sysDescr:
         - pfSense
+        - netgate


### PR DESCRIPTION
As per Issue: [https://github.com/librenms/librenms/issues/11683](url) these minor edits work for me locally, although environments may vary. The Netgate appliance is now correctly identified as psSense albeit with the FreeBSD reference, but with pfSense logo, these being the primary aims in this case.

`Operating System        pfSense 11.3-STABLE (GENERIC)`

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
