### PR TITLE
Add new sysobjectid for Arbor ArbOS TMS appliances

### DIFF
--- a/includes/definitions/arbos.yaml
+++ b/includes/definitions/arbos.yaml
@@ -10,5 +10,6 @@ over:
 discovery:
     - sysObjectID:
         - .1.3.6.1.4.1.9694.1.4
+        - .1.3.6.1.4.1.9694.1.5
 mib_dir:
     - arbornet


### PR DESCRIPTION
Arbor TMS appliances use a sysobjectID of SNMPv2-SMI::enterprises.9694.1.5

netnms01:/opt/librenms# snmpwalk -v2c -cdeleted arbortms01.dal
SNMPv2-MIB::sysDescr.0 = STRING: Peakflow TMS 8.4  Model: TMS-HD1000  Serial: XXXXXXXXXX
SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.9694.1.5

Please give a short description what your pull request is for

Add new SysobjectID for Arbor ArbOS TMS appliances.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
