### PR TITLE
Widget hide-show search Field

### DIFF
--- a/app/Http/Controllers/Widgets/AlertlogController.php
+++ b/app/Http/Controllers/Widgets/AlertlogController.php
@@ -34,7 +34,8 @@ class AlertlogController extends WidgetController
         'title' => null,
         'device_id' => '',
         'state' => -1,
-        'min_severity' => null
+        'min_severity' => null,
+        'hidenavigation' => 0,
     ];
 
     public function getView(Request $request)

--- a/app/Http/Controllers/Widgets/AlertlogStatsController.php
+++ b/app/Http/Controllers/Widgets/AlertlogStatsController.php
@@ -34,7 +34,8 @@ class AlertlogStatsController extends WidgetController
         'title' => null,
         'device_id' => '',
         'min_severity' => 2,
-        'time_interval' => 7
+        'time_interval' => 7,
+        'hidenavigation' => 0,
     ];
 
     public function getView(Request $request)

--- a/app/Http/Controllers/Widgets/AlertsController.php
+++ b/app/Http/Controllers/Widgets/AlertsController.php
@@ -41,6 +41,7 @@ class AlertsController extends WidgetController
         'proc' => 0,
         'location' => 1,
         'sort' => 1,
+        'hidenavigation' => 0,
     ];
 
     public function getView(Request $request)

--- a/app/Http/Controllers/Widgets/EventlogController.php
+++ b/app/Http/Controllers/Widgets/EventlogController.php
@@ -36,6 +36,7 @@ class EventlogController extends WidgetController
         'device' => null,
         'device_group' => null,
         'eventtype' => null,
+        'hidenavigation' => 0,
     ];
 
     public function getSettingsView(Request $request)

--- a/app/Http/Controllers/Widgets/GraylogController.php
+++ b/app/Http/Controllers/Widgets/GraylogController.php
@@ -39,6 +39,7 @@ class GraylogController extends WidgetController
         'range' => null,
         'limit' => 15,
         'loglevel' => null,
+        'hidenavigation' => 0,
     ];
 
     /**

--- a/app/Http/Controllers/Widgets/SyslogController.php
+++ b/app/Http/Controllers/Widgets/SyslogController.php
@@ -35,6 +35,7 @@ class SyslogController extends WidgetController
         'title' => null,
         'device' => null,
         'device_group' => null,
+        'hidenavigation' => 0,
     ];
 
     public function getSettingsView(Request $request)

--- a/resources/views/widgets/alertlog.blade.php
+++ b/resources/views/widgets/alertlog.blade.php
@@ -20,6 +20,7 @@
     var grid = $("#alertlog_{{ $id }}").bootgrid({
         ajax: true,
         rowCount: [50, 100, 250, -1],
+        navigation: ! {{ $hidenavigation }},
         post: function () {
             return {
                 id: "alertlog",

--- a/resources/views/widgets/alertlog_stats.blade.php
+++ b/resources/views/widgets/alertlog_stats.blade.php
@@ -18,6 +18,7 @@
     $("#alertlog-stats_{{ $id }}").bootgrid({
         ajax: true,
         rowCount: [50, 100, 250, -1],
+        navigation: ! {{ $hidenavigation }},
         post: function () {
             return {
                 id: "alertlog-stats",

--- a/resources/views/widgets/alerts.blade.php
+++ b/resources/views/widgets/alerts.blade.php
@@ -37,6 +37,7 @@
             }
         },
         url: "ajax_table.php",
+        navigation: ! {{ $hidenavigation }},
         rowCount: [50, 100, 250, -1]
     }).on("loaded.rs.jquery.bootgrid", function() {
         alerts_grid = $(this);

--- a/resources/views/widgets/eventlog.blade.php
+++ b/resources/views/widgets/eventlog.blade.php
@@ -15,6 +15,7 @@
     $("#eventlog").bootgrid({
         ajax: true,
         rowCount: [50, 100, 250, -1],
+        navigation: ! {{ $hidenavigation }},
         post: function ()
         {
             return {

--- a/resources/views/widgets/graylog.blade.php
+++ b/resources/views/widgets/graylog.blade.php
@@ -17,6 +17,7 @@
     $("#graylog-{{ $id }}").bootgrid({
         ajax: true,
         rowCount: ['{{ $limit }}', 25,50,100,250,-1],
+        navigation: ! {{ $hidenavigation }},
         formatters: {
             "browserTime": function(column, row) {
                 @config('graylog.timezone')

--- a/resources/views/widgets/settings/alertlog.blade.php
+++ b/resources/views/widgets/settings/alertlog.blade.php
@@ -22,4 +22,19 @@
             @endforeach
         </select>
     </div>
+    <div class="form-group row">
+        <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
+        <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
+    </div>
+@endsection
+
+@section('javascript')
+    <script type="text/javascript">
+        $('#hidenavigation-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                var hidenav = $(this).is(':checked') ? "1": "0";
+                $('#hidenavigation-{{ $id }}').val(hidenav);
+            });
+    </script>
 @endsection

--- a/resources/views/widgets/settings/alertlog.blade.php
+++ b/resources/views/widgets/settings/alertlog.blade.php
@@ -1,11 +1,11 @@
 @extends('widgets.settings.base')
 
 @section('form')
-    <div class="form-group row">
+    <div class="form-group">
         <label for="title-{{ $id }}" class="control-label">@lang('Widget title')</label>
         <input type="text" class="form-control" name="title" id="title-{{ $id }}" placeholder="@lang('Custom title')" value="{{ $title }}">
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="state-{{ $id }}" class="control-label">@lang('State'):</label>
         <select class="form-control" name="state" id="state-{{ $id }}">
             <option value="-1">@lang('not filtered')</option>
@@ -13,7 +13,7 @@
             <option value="1" @if($state === '0') selected @endif>@lang('Alert')</option>
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="min_severity-{{ $id }}" class="control-label">@lang('Displayed severity'):</label>
         <select class="form-control" name="min_severity" id="min_severity-{{ $id }}">
             <option value="">@lang('any severity')</option>
@@ -22,7 +22,7 @@
             @endforeach
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
         <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
     </div>

--- a/resources/views/widgets/settings/alertlog_stats.blade.php
+++ b/resources/views/widgets/settings/alertlog_stats.blade.php
@@ -1,11 +1,11 @@
 @extends('widgets.settings.base')
 
 @section('form')
-    <div class="form-group row">
+    <div class="form-group">
         <label for="title-{{ $id }}" class="control-label">@lang('Widget title')</label>
         <input type="text" class="form-control" name="title" id="title-{{ $id }}" placeholder="@lang('Custom title')" value="{{ $title }}">
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="min_severity-{{ $id }}" class="control-label">@lang('Displayed severity'):</label>
         <select class="form-control" name="min_severity" id="min_severity-{{ $id }}">
             <option value="">@lang('any severity')</option>

--- a/resources/views/widgets/settings/alertlog_stats.blade.php
+++ b/resources/views/widgets/settings/alertlog_stats.blade.php
@@ -18,4 +18,20 @@
         <label for="time_interval-{{ $id }}" class="control-label">@lang('Last days')</label>
         <input class="form-control" name="time_interval" id="time_interval-{{ $id }}" value="{{ $time_interval }}">
     </div>
+    <div class="form-group">
+        <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
+        <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
+    </div>
 @endsection
+
+@section('javascript')
+    <script type="text/javascript">
+        $('#hidenavigation-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                var hidenav = $(this).is(':checked') ? "1": "0";
+                $('#hidenavigation-{{ $id }}').val(hidenav);
+            });
+    </script>
+@endsection
+

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -67,10 +67,22 @@
             <option value="severity" @if($sort == 0) selected @endif>@lang('severity, descending')</option>
         </select>
     </div>
+    <div class="form-group row">
+        <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation'):</label>
+        <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
+    </div>
+
 @endsection
 
 @section('javascript')
     <script type="text/javascript">
         init_select2('#device_group-{{ $id }}', 'device-group', {});
+
+        $('#hidenavigation-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                var hidenav = $(this).is(':checked') ? "1": "0";
+                $('#hidenavigation-{{ $id }}').val(hidenav);
+            });
     </script>
 @endsection

--- a/resources/views/widgets/settings/alerts.blade.php
+++ b/resources/views/widgets/settings/alerts.blade.php
@@ -1,11 +1,11 @@
 @extends('widgets.settings.base')
 
 @section('form')
-    <div class="form-group row">
+    <div class="form-group">
         <label for="title-{{ $id }}" class="control-label">@lang('Widget title')</label>
         <input type="text" class="form-control" name="title" id="title-{{ $id }}" placeholder="@lang('Custom title')" value="{{ $title }}">
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="acknowledged-{{ $id }}" class="control-label">@lang('Show acknowledged'):</label>
         <select class="form-control" name="acknowledged" id="acknowledged-{{ $id }}">
             <option value="">@lang('not filtered')</option>
@@ -13,14 +13,14 @@
             <option value="0" @if($acknowledged === '0') selected @endif>@lang('hide acknowledged')</option>
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="fired-{{ $id }}" class="control-label">@lang('Show only fired'):</label>
         <select class="form-control" name="fired" id="fired-{{ $id }}">
             <option value="">@lang('not filtered')</option>
             <option value="1" @if($fired === '1') selected @endif>@lang('show only fired alerts')</option>
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="min_severity-{{ $id }}" class="control-label">@lang('Displayed severity'):</label>
         <select class="form-control" name="min_severity" id="min_severity-{{ $id }}">
             <option value="">@lang('any severity')</option>
@@ -29,7 +29,7 @@
             @endforeach
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="state-{{ $id }}" class="control-label">@lang('State'):</label>
         <select class="form-control" name="state" id="state-{{ $id }}">
             <option value="">@lang('any state')</option>
@@ -46,28 +46,28 @@
             @endif
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="proc-{{ $id }}" class="control-label">@lang('Show Procedure field'):</label>
         <select class="form-control" name="proc" id="proc-{{ $id }}">
             <option value="1" @if($proc == 1) selected @endif>@lang('show')</option>
             <option value="0" @if($proc == 0) selected @endif>@lang('hide')</option>
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="location-{{ $id }}" class="control-label">@lang('Show Location field'):</label>
         <select class="form-control" name="location" id="location-{{ $id }}">
             <option value="1" @if($location == 1) selected @endif>@lang('show')</option>
             <option value="0" @if($location == 0) selected @endif>@lang('hide')</option>
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="sort-{{ $id }}" class="control-label">@lang('Sort alerts by'):</label>
         <select class="form-control" name="sort" id="sort-{{ $id }}">
             <option value="" @if($sort == 1) selected @endif>@lang('timestamp, descending')</option>
             <option value="severity" @if($sort == 0) selected @endif>@lang('severity, descending')</option>
         </select>
     </div>
-    <div class="form-group row">
+    <div class="form-group">
         <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation'):</label>
         <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
     </div>

--- a/resources/views/widgets/settings/eventlog.blade.php
+++ b/resources/views/widgets/settings/eventlog.blade.php
@@ -29,6 +29,10 @@
             @endif
         </select>
     </div>
+    <div class="form-group">
+        <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
+        <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
+    </div>
 @endsection
 
 @section('javascript')
@@ -43,5 +47,12 @@
                 page: params.page || 1
             }
         }, '{{ $eventtype ?: "" }}');
+
+        $('#hidenavigation-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                var hidenav = $(this).is(':checked') ? "1": "0";
+                $('#hidenavigation-{{ $id }}').val(hidenav);
+            });
     </script>
 @endsection

--- a/resources/views/widgets/settings/graylog.blade.php
+++ b/resources/views/widgets/settings/graylog.blade.php
@@ -63,11 +63,22 @@
             <option value="2592000" @if($range == 2592000) selected @endif>@lang('Search last 30 days')</option>
         </select>
     </div>
+    <div class="form-group">
+        <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
+        <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
+    </div>
 @endsection
 
 @section('javascript')
     <script type="application/javascript">
         init_select2('#device-{{ $id }}', 'device', {limit: 100}, '{{ $device ? $device->device_id : '' }}');
         init_select2('#stream-{{ $id }}', 'graylog-streams', {}, '{{ $stream }}');
+
+        $('#hidenavigation-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                var hidenav = $(this).is(':checked') ? "1": "0";
+                $('#hidenavigation-{{ $id }}').val(hidenav);
+            });
     </script>
 @endsection

--- a/resources/views/widgets/settings/syslog.blade.php
+++ b/resources/views/widgets/settings/syslog.blade.php
@@ -21,11 +21,22 @@
             @endif
         </select>
     </div>
+    <div class="form-group">
+        <label for="hidenavigation-{{ $id }}" class="control-label">@lang('Hide Navigation')</label>
+        <input type="checkbox" class="form-control" name="hidenavigation" id="hidenavigation-{{ $id }}" value="{{ $hidenavigation }}" data-size="normal" @if($hidenavigation) checked @endif>
+    </div>
 @endsection
 
 @section('javascript')
     <script type="text/javascript">
         init_select2('#device-{{ $id }}', 'device', {}, '{{ $device ? $device->device_id : '' }}');
         init_select2('#device_group-{{ $id }}', 'device-group', {});
+
+        $('#hidenavigation-{{ $id }}')
+            .bootstrapSwitch('offColor','danger')
+            .on('switchChange.bootstrapSwitch', function (e, data) {
+                var hidenav = $(this).is(':checked') ? "1": "0";
+                $('#hidenavigation-{{ $id }}').val(hidenav);
+            });
     </script>
 @endsection

--- a/resources/views/widgets/syslog.blade.php
+++ b/resources/views/widgets/syslog.blade.php
@@ -17,6 +17,7 @@
     $("#syslog").bootgrid({
         ajax: true,
         rowCount: [50, 100, 250, -1],
+        navigation: ! {{ $hidenavigation }},
         post: function ()
         {
             return {


### PR DESCRIPTION
Ability to hide search Field in Widgets if not needed.
Implemented in:
- Alerts
- Alert history
- Alert history stats
- Eventlog
- Graylog
- Syslog

with search field:
![image](https://user-images.githubusercontent.com/7978916/83198129-e62d6380-a13e-11ea-8c6c-02d2f46453c1.png)

without search field:
![image](https://user-images.githubusercontent.com/7978916/83198166-f7767000-a13e-11ea-8eca-6692cf111363.png)

settings:
![image](https://user-images.githubusercontent.com/7978916/83198196-05c48c00-a13f-11ea-9f95-14552f399273.png)




DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
