### PR TITLE
Address Incorrect DATE value in isUnderMaintenance

### DIFF
--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -55,7 +55,6 @@ class AlertSchedule extends Model
                                 $query->where('end_recurring_dt', '>=', DB::raw("date_format(NOW(), '%Y-%m-%d')"))
                                     ->orWhereNull('end_recurring_dt')
                                     ->orWhere('end_recurring_dt', '0000-00-00');
-                                    //->orWhere('end_recurring_dt', '');
                             });
                     })
                     // Check the time is between the start and end hour/minutes/seconds

--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -54,8 +54,8 @@ class AlertSchedule extends Model
                             ->where(function ($query) {
                                 $query->where('end_recurring_dt', '>=', DB::raw("date_format(NOW(), '%Y-%m-%d')"))
                                     ->orWhereNull('end_recurring_dt')
-                                    ->orWhere('end_recurring_dt', '0000-00-00')
-                                    ->orWhere('end_recurring_dt', '');
+                                    ->orWhere('end_recurring_dt', '0000-00-00');
+                                    //->orWhere('end_recurring_dt', '');
                             });
                     })
                     // Check the time is between the start and end hour/minutes/seconds


### PR DESCRIPTION
OK, have been pulling my hair out for a long time with this one 😆. It's related to the issue noted here,
https://community.librenms.org/t/poller-failure-ubuntu-server/9868

In LibreNMS/Alert/AlertUtil.php, I have had to comment out
`function isMaintenance($device_id)
`

And it has been due to the error, 
`General error: 1525 Incorrect DATE value: ''
`

I finally tracked it down to the code modified here. MySQL is not happy with the blank date - it (perhaps) can be avoided with special settings in MySQL (ALLOW_INVALID_DATES, https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html), but really ... not seeing this blank date adding a purpose - so just comment it out.

Thanks!

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
