### PR TITLE
Fix another mysql error in isMaintenance()

### DIFF
--- a/app/Models/AlertSchedule.php
+++ b/app/Models/AlertSchedule.php
@@ -53,8 +53,7 @@ class AlertSchedule extends Model
                         $query->where('start_recurring_dt', '<=', DB::raw("date_format(NOW(), '%Y-%m-%d')"))
                             ->where(function ($query) {
                                 $query->where('end_recurring_dt', '>=', DB::raw("date_format(NOW(), '%Y-%m-%d')"))
-                                    ->orWhereNull('end_recurring_dt')
-                                    ->orWhere('end_recurring_dt', '0000-00-00');
+                                    ->orWhereNull('end_recurring_dt');
                             });
                     })
                     // Check the time is between the start and end hour/minutes/seconds


### PR DESCRIPTION
OK, in #11736 I removed the blank mysql date value (i.e. '') - that corrected the poller failure I was having due to isMaintenance(). But at the time I wondered about the date value '0000-00-00' 😆. Well, it seems that's the issue behind what I posted earlier today, https://community.librenms.org/t/all-devices-page-empty/12286

I checked librenms.log, saw a similar thing to the earlier PR,
```
[previous exception] [object] (PDOException(code: HY000): SQLSTATE[HY000]: General error: 1525 Incorrect DATE value: '0000-00-00' at /opt/librenms/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:127)
[stacktrace]
#0 /opt/librenms/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php(127): PDOStatement->execute()
#1 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(335): Doctrine\\DBAL\\Driver\\PDOStatement->execute()
#2 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(662): Illuminate\\Database\\Connection->Illuminate\\Database\\{closure}()
#3 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(629): Illuminate\\Database\\Connection->runQueryCallback()
#4 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Connection.php(338): Illuminate\\Database\\Connection->run()
#5 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2409): Illuminate\\Database\\Connection->select()
#6 /opt/librenms/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1366): Illuminate\\Database\\Query\\Builder->exists()
#7 /opt/librenms/app/Models/Device.php(159): Illuminate\\Database\\Eloquent\\Builder->__call()
#8 /opt/librenms/LibreNMS/Alert/AlertUtil.php(200): App\\Models\\Device->isUnderMaintenance()
#9 /opt/librenms/app/Http/Controllers/Table/DeviceController.php(131): LibreNMS\\Alert\\AlertUtil::isMaintenance()
```

So, now removing that invalid date value, '0000-00-00'. After this, my devices page is happy again, and no error in librenms.log! Life is good 😄.

Thanks!

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
