### PR TITLE
Fix wireless sensor polling unit display

### DIFF
--- a/LibreNMS/Device/Sensor.php
+++ b/LibreNMS/Device/Sensor.php
@@ -36,6 +36,7 @@ class Sensor implements DiscoveryModule, PollerModule
     protected static $name = 'Sensor';
     protected static $table = 'sensors';
     protected static $data_name = 'sensor';
+    protected static $translation_prefix = 'sensors';
 
     private $valid = true;
 
@@ -617,7 +618,7 @@ class Sensor implements DiscoveryModule, PollerModule
         foreach ($sensors as $sensor) {
             $sensor_value = $data[$sensor['sensor_id']];
 
-            echo "  {$sensor['sensor_descr']}: $sensor_value " . __('sensors.' . $sensor['sensor_class'] . '.unit') . PHP_EOL;
+            echo "  {$sensor['sensor_descr']}: $sensor_value " . __(static::$translation_prefix . '.' . $sensor['sensor_class'] . '.unit') . PHP_EOL;
 
             // update rrd and database
             $rrd_name = array(

--- a/LibreNMS/Device/WirelessSensor.php
+++ b/LibreNMS/Device/WirelessSensor.php
@@ -33,6 +33,7 @@ class WirelessSensor extends Sensor
     protected static $name = 'Wireless Sensor';
     protected static $table = 'wireless_sensors';
     protected static $data_name = 'wireless-sensor';
+    protected static $translation_prefix = 'wireless';
 
     private $access_point_ip;
 


### PR DESCRIPTION
now
```
rate:
  TX Capacity (Carrier1/1): 730947000 bps
  TX Capacity (Carrier1/2): 730947000 bps
  TX Capacity (Carrier1/1): 730947000 bps
  TX Capacity (Carrier1/2): 730947000 bps
snr:
  SNR (Carrier1/1): 45 dB
  SNR (Carrier1/2): 45 dB
rssi:
  RSL (Carrier1/1): -36.7 dBm
  RSL (Carrier1/2): -37 dBm
power:
  TX Power (Carrier1/1): 22.4 dBm
  TX Power (Carrier1/2): 22.5 dBm
frequency:
  TX Frequency (Carrier1/1): 11565 MHz
  TX Frequency (Carrier1/2): 11565 MHz
```

before
```
rate:
  TX Capacity (Carrier1/1): 730947000 sensors.rate.unit
  TX Capacity (Carrier1/2): 730947000 sensors.rate.unit
  TX Capacity (Carrier1/1): 730947000 sensors.rate.unit
  TX Capacity (Carrier1/2): 730947000 sensors.rate.unit
snr:
  SNR (Carrier1/1): 45 dB
  SNR (Carrier1/2): 45 dB
rssi:
  RSL (Carrier1/1): -36.7 sensors.rssi.unit
  RSL (Carrier1/2): -37 sensors.rssi.unit
power:
  TX Power (Carrier1/1): 22.4 W
  TX Power (Carrier1/2): 22.5 W
frequency:
  TX Frequency (Carrier1/1): 11565 Hz
  TX Frequency (Carrier1/2): 11565 Hz
```

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
