### PR TITLE
Added UPS-MIB Trap On Battery (upsTraps.0.1)

### DIFF
--- a/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
@@ -68,6 +68,5 @@ class UpsTrapsOnBattery implements SnmptrapHandler
         }
         $sensor_output->sensor_current = 5;
         $sensor_output->save();
-
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
@@ -49,14 +49,21 @@ class UpsTrapsOnBattery implements SnmptrapHandler
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
             return;
         }
-        $sensor_remaining->sensor_current = $min_remaining;
+        $sensor_remaining->sensor_current = $min_remaining / $sensor_remaining->sensor_divisor;
         $sensor_remaining->save();
         $sensor_time = $device->sensors()->where('sensor_index', '100')->where('sensor_type', 'rfc1628')->first();
         if(!$sensor_time){
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
             return;
         }
-        $sensor_time->sensor_current = $sec_time;
+        $sensor_time->sensor_current = $sec_time / $sensor_time->sensor_divisor;
         $sensor_time->save();
+        $sensor_output = $device->sensors()->where('sensor_type', 'upsOutputSourceState')->first();
+        if(!$sensor_output){
+            Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
+            return;
+        }
+        $sensor_output->sensor_current = 5;
+        $sensor_output->save();
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
@@ -43,27 +43,30 @@ class UpsTrapsOnBattery implements SnmptrapHandler
     {
         $min_remaining = $trap->getOidData($trap->findOid('UPS-MIB::upsEstimatedMinutesRemaining.0'));
         $sec_time  = $trap->getOidData($trap->findOid('UPS-MIB::upsSecondsOnBattery.0'));
-        Log::event("UPS running on battery for $sec_time. Estimated $min_remaining remaining", $trap->getDevice(), 'trap', 5);
+        Log::event("UPS running on battery for $sec_time. Estimated $min_remaining remaining", $device->device_id, 'trap', 5);
         $sensor_remaining = $device->sensors()->where('sensor_index', '200')->where('sensor_type', 'rfc1628')->first();
-        if(!$sensor_remaining){
+        if (!$sensor_remaining) {
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
             return;
         }
         $sensor_remaining->sensor_current = $min_remaining / $sensor_remaining->sensor_divisor;
         $sensor_remaining->save();
+
         $sensor_time = $device->sensors()->where('sensor_index', '100')->where('sensor_type', 'rfc1628')->first();
-        if(!$sensor_time){
+        if (!$sensor_time) {
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
             return;
         }
         $sensor_time->sensor_current = $sec_time / $sensor_time->sensor_divisor;
         $sensor_time->save();
+
         $sensor_output = $device->sensors()->where('sensor_type', 'upsOutputSourceState')->first();
-        if(!$sensor_output){
+        if (!$sensor_output) {
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
             return;
         }
         $sensor_output->sensor_current = 5;
         $sensor_output->save();
+
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * UpsTrapsOnBattery.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @author     TheGreatDoc
+ */
+
+namespace LibreNMS\Snmptrap\Handlers;
+
+use App\Models\Device;
+use LibreNMS\Interfaces\SnmptrapHandler;
+use LibreNMS\Snmptrap\Trap;
+use Log;
+
+class UpsTrapsOnBattery implements SnmptrapHandler
+{
+    /**
+     * Handle snmptrap.
+     * Data is pre-parsed and delivered as a Trap.
+     *
+     * @param Device $device
+     * @param Trap $trap
+     * @return void
+     */
+    public function handle(Device $device, Trap $trap)
+    {
+        $remaining = $trap->getOidData($trap->findOid('UPS-MIB::upsEstimatedMinutesRemaining.0'));
+        $time  = $trap->getOidData($trap->findOid('UPS-MIB::upsSecondsOnBattery.0'));
+        Log::event("UPS running on battery for $time seconds. Estimated $remaining minutes remaining", $device->device_id, 'trap', 5);
+    }
+}

--- a/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
@@ -43,7 +43,7 @@ class UpsTrapsOnBattery implements SnmptrapHandler
     {
         $min_remaining = $trap->getOidData($trap->findOid('UPS-MIB::upsEstimatedMinutesRemaining.0'));
         $sec_time  = $trap->getOidData($trap->findOid('UPS-MIB::upsSecondsOnBattery.0'));
-        Log::event("UPS running on battery for $sec_time seconds. Estimated $min_remaining minutes remaining", $trap->getDevice(), 'trap', 5);
+        Log::event("UPS running on battery for $sec_time. Estimated $min_remaining remaining", $trap->getDevice(), 'trap', 5);
         $sensor_remaining = $device->sensors()->where('sensor_index', '200')->where('sensor_type', 'rfc1628')->first();
         if(!$sensor_remaining){
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);

--- a/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
+++ b/LibreNMS/Snmptrap/Handlers/UpsTrapsOnBattery.php
@@ -28,6 +28,7 @@ use App\Models\Device;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
 use Log;
+use Illuminate\Support\Str;
 
 class UpsTrapsOnBattery implements SnmptrapHandler
 {
@@ -41,9 +42,9 @@ class UpsTrapsOnBattery implements SnmptrapHandler
      */
     public function handle(Device $device, Trap $trap)
     {
-        $min_remaining = $trap->getOidData($trap->findOid('UPS-MIB::upsEstimatedMinutesRemaining.0'));
-        $sec_time  = $trap->getOidData($trap->findOid('UPS-MIB::upsSecondsOnBattery.0'));
-        Log::event("UPS running on battery for $sec_time. Estimated $min_remaining remaining", $device->device_id, 'trap', 5);
+        $min_remaining = Str::before($trap->getOidData($trap->findOid('UPS-MIB::upsEstimatedMinutesRemaining.0')), ' ');
+        $sec_time  = Str::before($trap->getOidData($trap->findOid('UPS-MIB::upsSecondsOnBattery.0')), ' ');
+        Log::event("UPS running on battery for $sec_time seconds. Estimated $min_remaining minutes remaining", $device->device_id, 'trap', 5);
         $sensor_remaining = $device->sensors()->where('sensor_index', '200')->where('sensor_type', 'rfc1628')->first();
         if (!$sensor_remaining) {
             Log::warning("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);

--- a/app/Providers/SnmptrapProvider.php
+++ b/app/Providers/SnmptrapProvider.php
@@ -25,12 +25,9 @@ class SnmptrapProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(SnmptrapHandler::class, function ($app, $oid) {
-            if ($handler = config('snmptraps.trap_handlers.' . reset($oid))) {
-                return $app->make($handler);
-            }
-
-            return $app->make(Fallback::class);
+        $this->app->bind(SnmptrapHandler::class, function ($app, $options) {
+            $oid = reset($options);
+            return $app->make(config('snmptraps.trap_handlers')[$oid] ?? Fallback::class);
         });
     }
 }

--- a/config/snmptraps.php
+++ b/config/snmptraps.php
@@ -101,5 +101,6 @@ return [
         'VMWARE-VMINFO-MIB::vmwVmSuspended' => \LibreNMS\Snmptrap\Handlers\VmwVmSuspended::class,
         'OSPF-TRAP-MIB::ospfIfStateChange' => \LibreNMS\Snmptrap\Handlers\OspfIfStateChange::class,
         'OSPF-TRAP-MIB::ospfNbrStateChange' => \LibreNMS\Snmptrap\Handlers\OspfNbrStateChange::class,
+        'UPS-MIB::upsTraps.0.1' => \LibreNMS\Snmptrap\Handlers\UpsTrapsOnBattery::class,
     ]
 ];

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -168,7 +168,6 @@ $factory->define(\App\Models\Sensor::class, function (Faker\Generator $faker) {
     $sensor_class = ['airflow','ber','charge','chromatic_dispersion','cooling','count','current','dbm','delay','eer','fanspeed','frequency','humidity','load','loss','power','power_consumed','power_factor','pressure','quality_factor','runtime','signal','snr','state','temperature','voltage','waterflow'];
     $sensor_oid = ".1.3.6.1.4.1.4115.1.4.3.3." . $faker->numberBetween(0, 10) . "." . $faker->numberBetween(0, 10) . "." . $faker->numberBetween(0, 10);
     return [
-        'sensor_id' => $faker->randomDigit,
         'sensor_index' => $faker->randomDigit,
         'sensor_class' => $faker->randomElement($sensor_class),
         'sensor_current' => $faker->randomDigit,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -164,3 +164,13 @@ $factory->define(\App\Models\Component::class, function (Faker\Generator $faker)
         'type' => $faker->regexify('[A-Za-z0-9]{4,20}'),
     ];
 });
+$factory->define(\App\Models\Sensor::class, function (Faker\Generator $faker) {
+    $sensor_class = ['airflow','ber','charge','chromatic_dispersion','cooling','count','current','dbm','delay','eer','fanspeed','frequency','humidity','load','loss','power','power_consumed','power_factor','pressure','quality_factor','runtime','signal','snr','state','temperature','voltage','waterflow'];
+
+    return [
+        'sensor_id' => $faker->randomDigit,
+        'sensor_index' => $faker->randomDigit,
+        'sensor_class' => $faker->randomElement($sensor_class),
+        'sensor_value' => $faker->randomDigit,
+    ];
+});

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -171,6 +171,6 @@ $factory->define(\App\Models\Sensor::class, function (Faker\Generator $faker) {
         'sensor_id' => $faker->randomDigit,
         'sensor_index' => $faker->randomDigit,
         'sensor_class' => $faker->randomElement($sensor_class),
-        'sensor_value' => $faker->randomDigit,
+        'sensor_current' => $faker->randomDigit,
     ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -166,11 +166,12 @@ $factory->define(\App\Models\Component::class, function (Faker\Generator $faker)
 });
 $factory->define(\App\Models\Sensor::class, function (Faker\Generator $faker) {
     $sensor_class = ['airflow','ber','charge','chromatic_dispersion','cooling','count','current','dbm','delay','eer','fanspeed','frequency','humidity','load','loss','power','power_consumed','power_factor','pressure','quality_factor','runtime','signal','snr','state','temperature','voltage','waterflow'];
-
+    $sensor_oid = ".1.3.6.1.4.1.4115.1.4.3.3." . $faker->numberBetween(0, 10) . "." . $faker->numberBetween(0, 10) . "." . $faker->numberBetween(0, 10);
     return [
         'sensor_id' => $faker->randomDigit,
         'sensor_index' => $faker->randomDigit,
         'sensor_class' => $faker->randomElement($sensor_class),
         'sensor_current' => $faker->randomDigit,
+        'sensor_oid' => $sensor_oid,
     ];
 });

--- a/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * UpsTrapsOnBatteryTest.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @author     TheGreatDoc
+ */
+
+namespace LibreNMS\Tests\Feature\SnmpTraps;
+
+use App\Models\Device;
+use App\Models\Ipv4Address;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LibreNMS\Snmptrap\Dispatcher;
+use LibreNMS\Snmptrap\Trap;
+use LibreNMS\Tests\DBTestCase;
+
+class UpsTrapsOnBatteryTest extends SnmpTrapTestCase
+{
+    public function testOnBattery()
+    {
+        $device = factory(Device::class)->create();
+
+        $trapText = "$device->hostname
+UDP: [$device->ip]:161->[192.168.5.5]:162
+DISMAN-EVENT-MIB::sysUpTimeInstance 9:22:15:00.01
+SNMPv2-MIB::snmpTrapOID.0 UPS-MIB::upsTraps.0.1
+UPS-MIB::upsEstimatedMinutesRemaining.0 100 minutes
+UPS-MIB::upsSecondsOnBattery.0 120 seconds
+UPS-MIB::upsConfigLowBattTime.0 1 minutes";
+
+        $message = "UPS running on battery for 120 seconds. Estimated 100 minutes remaining";
+        \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 5);
+
+        $trap = new Trap($trapText);
+        $this->assertTrue(Dispatcher::handle($trap), 'Could not handle UPS-MIB::upsTraps.0.1 trap');
+    }
+}

--- a/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
@@ -50,9 +50,9 @@ UPS-MIB::upsEstimatedMinutesRemaining.0 100 minutes
 UPS-MIB::upsSecondsOnBattery.0 120 seconds
 UPS-MIB::upsConfigLowBattTime.0 1 minutes";
 
-        \Log::shouldNotReceive('warning')->once()->with("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
-        \Log::shouldNotReceive('warning')->once()->with("Snmptrap UpsTraps: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
-        \Log::shouldNotReceive('warning')->once()->with("Snmptrap UpsTraps: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
+        \Log::shouldReceive('warning')->never()->with("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
+        \Log::shouldReceive('warning')->never()->with("Snmptrap UpsTraps: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
+        \Log::shouldReceive('warning')->never()->with("Snmptrap UpsTraps: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
 
         $message = "UPS running on battery for 120 seconds. Estimated 100 minutes remaining";
         \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 5);

--- a/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
@@ -36,9 +36,11 @@ class UpsTrapsOnBatteryTest extends SnmpTrapTestCase
     {
         $device = factory(Device::class)->create();
         $state = factory(Sensor::class)->make(['sensor_class' => 'state', 'sensor_type' => 'upsOutputSourceState', 'sensor_current' => '2']);
-        $time = factory(Sensor::class)->make(['sensor_class' => 'runtime', 'sensor_index' => '100', 'sensor_current' => '0']);
-        $remaining = factory(Sensor::class)->make(['sensor_class' => 'runtime', 'sensor_index' => '200', 'sensor_current' => '371']);
-        $device->sensors()->save($state,$time,$remaining);
+        $time = factory(Sensor::class)->make(['sensor_class' => 'runtime', 'sensor_index' => '100', 'sensor_type' => 'rfc1628', 'sensor_current' => '0']);
+        $remaining = factory(Sensor::class)->make(['sensor_class' => 'runtime', 'sensor_index' => '200', 'sensor_type' => 'rfc1628', 'sensor_current' => '371']);
+        $device->sensors()->save($state);
+        $device->sensors()->save($time);
+        $device->sensors()->save($remaining);
 
         $trapText = "$device->hostname
 UDP: [$device->ip]:161->[192.168.5.5]:162

--- a/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
@@ -50,9 +50,9 @@ UPS-MIB::upsEstimatedMinutesRemaining.0 100 minutes
 UPS-MIB::upsSecondsOnBattery.0 120 seconds
 UPS-MIB::upsConfigLowBattTime.0 1 minutes";
 
-        \Log::shouldReceive('warning')->never()->with("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
-        \Log::shouldReceive('warning')->never()->with("Snmptrap UpsTraps: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
-        \Log::shouldReceive('warning')->never()->with("Snmptrap UpsTraps: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
+        \Log::shouldNotReceive('warning')->once()->with("Snmptrap UpsTraps: Could not find matching sensor \'Estimated battery time remaining\' for device: " . $device->hostname);
+        \Log::shouldNotReceive('warning')->once()->with("Snmptrap UpsTraps: Could not find matching sensor \'Time on battery\' for device: " . $device->hostname);
+        \Log::shouldNotReceive('warning')->once()->with("Snmptrap UpsTraps: Could not find matching sensor \'upsOutputSourceState\' for device: " . $device->hostname);
 
         $message = "UPS running on battery for 120 seconds. Estimated 100 minutes remaining";
         \Log::shouldReceive('event')->once()->with($message, $device->device_id, 'trap', 5);

--- a/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
+++ b/tests/Feature/SnmpTraps/UpsTrapsOnBatteryTest.php
@@ -38,6 +38,7 @@ class UpsTrapsOnBatteryTest extends SnmpTrapTestCase
         $state = factory(Sensor::class)->make(['sensor_class' => 'state', 'sensor_type' => 'upsOutputSourceState', 'sensor_current' => '2']);
         $time = factory(Sensor::class)->make(['sensor_class' => 'runtime', 'sensor_index' => '100', 'sensor_current' => '0']);
         $remaining = factory(Sensor::class)->make(['sensor_class' => 'runtime', 'sensor_index' => '200', 'sensor_current' => '371']);
+        $device->sensors()->save($state,$time,$remaining);
 
         $trapText = "$device->hostname
 UDP: [$device->ip]:161->[192.168.5.5]:162


### PR DESCRIPTION
Added UPS-MIB::upsTraps.0.1 support.

This allows for instant notification when an UPS goes on battery state.

It updates database with current `Output source` state (on battery), `Time on battery` and `Estimated battery time remaining`

Example:
`UPS running on battery for 120 seconds. Estimated 100 minutes remaining`

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
