### PR TITLE
Update RRDCached doc. Removed a Base Options Flag due to breakage.

### DIFF
--- a/doc/Extensions/RRDCached.md
+++ b/doc/Extensions/RRDCached.md
@@ -92,7 +92,7 @@ JOURNAL_PATH=/var/lib/rrdcached/journal/
 PIDFILE=/run/rrdcached.pid
 SOCKFILE=/run/rrdcached.sock
 SOCKGROUP=librenms
-BASE_OPTIONS="-B -F -R"
+BASE_OPTIONS="-F -R"
 ```
 
 2: Fix permissions


### PR DESCRIPTION
The -B flag causes rrdcached to be unable to read/write to the /opt/librenms/rrd directory.
"Only permit writes into the base directory specified in -b (and any sub-directories). This does NOT detect symbolic links.  Paths containing "../" will also be blocked."

Other potential change is to note that this flag can cause rrd files to become inaccessible to librenms/rrdcached.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
