### PR TITLE
fixed typo in function htmlspecialchars within snmp edit

### DIFF
--- a/includes/html/pages/device/edit/snmp.inc.php
+++ b/includes/html/pages/device/edit/snmp.inc.php
@@ -230,7 +230,7 @@ echo "
     <div class='form-group'>
     <label for='sysName' class='col-sm-2 control-label'>sysName (optional)</label>
     <div class='col-sm-4'>
-    <input id='sysName' class='form-control' name='sysName' value='".htmspecialchars($device['sysName'])."'/>
+    <input id='sysName' class='form-control' name='sysName' value='".htmlspecialchars($device['sysName'])."'/>
     </div>
     </div>
     <div class='form-group'>


### PR DESCRIPTION
Please give a short description what your pull request is for

There is a typo within the snmp.inc.php which leads to a not working edit of snmp values. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
