### PR TITLE
Arista sometimes returns NaN value when polling

### DIFF
--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -160,8 +160,8 @@ function record_sensor_data($device, $all_sensors)
         $sensor_value      = $sensor['new_value'];
         $prev_sensor_value = $sensor['sensor_current'];
 
-        if ($sensor_value == -32768) {
-            echo 'Invalid (-32768) ';
+        if ($sensor_value == -32768 || is_nan($sensor_value)) {
+            echo 'Invalid (-32768 or NaN)';
             $sensor_value = 0;
         }
 


### PR DESCRIPTION
Arista devices sometimes returns NaN value when polling optics on ports.
NaN values cannot be written to influx, i got the following log message:
[2020-06-09 13:54:06] production.ERROR: InfluxDB exception: HTTP Code 400 {"error":"unable to parse 'sensor,hostname=hostname,sensor_class=dbm,sensor_type=entity-sensor,sensor_descr=DOM\\ TX\\ Power\\ \\ for\\ Ethernet14,sensor_index=100314212 sensor=NAN': invalid number"}

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
