### PR TITLE
Modifies find_device_id

### DIFF
--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1363,10 +1363,7 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
     $where = array();
     $params = array();
 
-    if ($name) {
-        $where[] = '`sysName`=?';
-        $params[] = $name;
-
+    if ($name && is_valid_hostname($name)) {
         $where[] = '`hostname`=?';
         $params[] = $name;
 
@@ -1375,13 +1372,6 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
             $params[] = "$name.$mydomain";
 
             $where[] = 'concat(`hostname`, \'.\', ?) =?';
-            $params[] = "$mydomain";
-            $params[] = "$name";
-
-            $where[] = '`sysName`=?';
-            $params[] = "$name.$mydomain";
-
-            $where[] = 'concat(`sysName`, \'.\', ?) =?';
             $params[] = "$mydomain";
             $params[] = "$name";
         }
@@ -1409,6 +1399,32 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
     if ($mac_address && $mac_address != '000000000000') {
         if ($device_id = dbFetchCell('SELECT `device_id` FROM `ports` WHERE `ifPhysAddress`=?', array($mac_address))) {
             return (int)$device_id;
+        }
+    }
+
+    if($name) {
+        $where = array();
+        $params = array();
+
+        $where[] = '`sysName`=?';
+        $params[] = $name;
+
+        if ($mydomain = Config::get('mydomain')) {
+            $where[] = '`sysName`=?';
+            $params[] = "$name.$mydomain";
+
+            $where[] = 'concat(`sysName`, \'.\', ?) =?';
+            $params[] = "$mydomain";
+            $params[] = "$name";
+        }
+
+        $sql = 'SELECT `device_id` FROM `devices` WHERE ' . implode(' OR ', $where) . ' LIMIT 2';
+        $ids = dbFetchColumn($sql, $params);
+        if (count($ids) == 1) {
+            return (int)$ids[0];
+        } elseif (count($ids) > 1 ) {
+           d_echo("find_device_id: more than one device found with sysName '$name'.\n");
+           // don't do anything, try other methods, if any
         }
     }
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1402,7 +1402,7 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
         }
     }
 
-    if($name) {
+    if ($name) {
         $where = array();
         $params = array();
 
@@ -1422,9 +1422,9 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
         $ids = dbFetchColumn($sql, $params);
         if (count($ids) == 1) {
             return (int)$ids[0];
-        } elseif (count($ids) > 1 ) {
-           d_echo("find_device_id: more than one device found with sysName '$name'.\n");
-           // don't do anything, try other methods, if any
+        } elseif (count($ids) > 1) {
+            d_echo("find_device_id: more than one device found with sysName '$name'.\n");
+            // don't do anything, try other methods, if any
         }
     }
 

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -1363,7 +1363,7 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
     $where = array();
     $params = array();
 
-    if ($name && is_valid_hostname($name)) {
+    if ($name) {
         $where[] = '`sysName`=?';
         $params[] = $name;
 
@@ -1375,6 +1375,13 @@ function find_device_id($name = '', $ip = '', $mac_address = '')
             $params[] = "$name.$mydomain";
 
             $where[] = 'concat(`hostname`, \'.\', ?) =?';
+            $params[] = "$mydomain";
+            $params[] = "$name";
+
+            $where[] = '`sysName`=?';
+            $params[] = "$name.$mydomain";
+
+            $where[] = 'concat(`sysName`, \'.\', ?) =?';
             $params[] = "$mydomain";
             $params[] = "$name";
         }


### PR DESCRIPTION
* Removed host name validation check for RFC. Some devices and OS allow you
  to set a name that contains characters that are prohibited by the RFC.
  Such devices can be added using their IP address, their sysName will be
  written to the database. If the device is already in the database, then it
  should be possible to find it, even if the name is unacceptable according
  to RFC requirements.
* Additional search options for sysName have been added using the default
  domain. This was needed to improve LLDP detection - a short name was used in
  the PDU, and the full name with the domain was stored in the sysName field
  in the database.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
