### PR TITLE
RRD Graph Float Precision adjustment

### DIFF
--- a/includes/html/graphs/common.inc.php
+++ b/includes/html/graphs/common.inc.php
@@ -82,6 +82,10 @@ if (isset($scale_rigid)) {
     $rrd_options .= ' -r';
 }
 
+if (!isset($float_precision)) {
+    $float_precision = 2;
+}
+
 $rrd_options .= ' -E --start '.$from.' --end '.$to.' --width '.$width.' --height '.$height.' ';
 
 if (Config::get('applied_site_style') == 'dark') {

--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -139,27 +139,27 @@ $rrd_options .= " COMMENT:'bps      Now       Ave      Max      " . Config::get(
 $rrd_options .= ' AREA:in' . $format . '_max#D7FFC7' . $stacked['transparency'] . ':';
 $rrd_options .= ' AREA:in' . $format . '#90B040' . $stacked['transparency'] . ':';
 $rrd_options .= ' LINE:in' . $format . "#608720:'In '";
-$rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.2lf%s';
-$rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.2lf%s';
-$rrd_options .= ' GPRINT:in' . $format . '_max:MAX:%6.2lf%s';
-$rrd_options .= " GPRINT:percentile_in:%6.2lf%s\\n";
+$rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:in' . $format . '_max:MAX:%6.'.$float_precision.'lf%s';
+$rrd_options .= " GPRINT:percentile_in:%6.'.$float_precision.'lf%s\\n";
 
 $rrd_options .= ' AREA:dout' . $format . '_max#E0E0FF' . $stacked['transparency'] . ':';
 $rrd_options .= ' AREA:dout' . $format . '#8080C0' . $stacked['transparency'] . ':';
 $rrd_options .= ' LINE:dout' . $format . "#606090:'Out'";
-$rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.2lf%s';
-$rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.2lf%s';
-$rrd_options .= ' GPRINT:out' . $format . '_max:MAX:%6.2lf%s';
-$rrd_options .= " GPRINT:percentile_out:%6.2lf%s\\n";
+$rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:out' . $format . '_max:MAX:%6.'.$float_precision.'lf%s';
+$rrd_options .= " GPRINT:percentile_out:%6.'.$float_precision.'lf%s\\n";
 
 if (Config::get('rrdgraph_real_percentile')) {
     $rrd_options .= ' HRULE:percentilehigh#FF0000:"Highest"';
     $rrd_options .= " GPRINT:percentilehigh:\"%30.2lf%s\\n\"";
 }
 
-$rrd_options .= " GPRINT:tot:'Total %6.2lf%sB'";
-$rrd_options .= " GPRINT:totin:'(In %6.2lf%sB'";
-$rrd_options .= " GPRINT:totout:'Out %6.2lf%sB)\\l'";
+$rrd_options .= " GPRINT:tot:'Total %6.'.$float_precision.'lf%sB'";
+$rrd_options .= " GPRINT:totin:'(In %6.'.$float_precision.'lf%sB'";
+$rrd_options .= " GPRINT:totout:'Out %6.'.$float_precision.'lf%sB)\\l'";
 $rrd_options .= ' LINE1:percentile_in#aa0000';
 $rrd_options .= ' LINE1:dpercentile_out#aa0000';
 
@@ -179,16 +179,16 @@ if ($to > time()) {
 if ($_GET['previous'] == 'yes') {
     $rrd_options .= " COMMENT:' \\n'";
     $rrd_options .= ' LINE1.25:in' . $format . "X#333300:'Prev In '\t";
-    $rrd_options .= ' GPRINT:in' . $format . 'X:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:in' . $format . '_maxX:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:percentile_inX:%6.2lf%s\\n";
+    $rrd_options .= ' GPRINT:in' . $format . 'X:AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:in' . $format . '_maxX:MAX:%6.'.$float_precision.'lf%s';
+    $rrd_options .= " GPRINT:percentile_inX:%6.'.$float_precision.'lf%s\\n";
     $rrd_options .= ' LINE1.25:dout' . $format . "X#000099:'Prev Out '\t";
-    $rrd_options .= ' GPRINT:out' . $format . 'X:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:out' . $format . '_maxX:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:percentile_outX:%6.2lf%s\\n";
-    $rrd_options .= " GPRINT:totX:'Total %6.2lf%sB'";
-    $rrd_options .= " GPRINT:totinX:'(In %6.2lf%sB'";
-    $rrd_options .= " GPRINT:totoutX:'Out %6.2lf%sB)\\l'";
+    $rrd_options .= ' GPRINT:out' . $format . 'X:AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:out' . $format . '_maxX:MAX:%6.'.$float_precision.'lf%s';
+    $rrd_options .= " GPRINT:percentile_outX:%6.'.$float_precision.'lf%s\\n";
+    $rrd_options .= " GPRINT:totX:'Total %6.'.$float_precision.'lf%sB'";
+    $rrd_options .= " GPRINT:totinX:'(In %6.'.$float_precision.'lf%sB'";
+    $rrd_options .= " GPRINT:totoutX:'Out %6.'.$float_precision.'lf%sB)\\l'";
     $rrd_options .= ' LINE1:percentile_inX#00aaaa';
     $rrd_options .= ' LINE1:dpercentile_outX#00aaaa';
 }

--- a/includes/html/graphs/generic_duplex.inc.php
+++ b/includes/html/graphs/generic_duplex.inc.php
@@ -99,31 +99,31 @@ if ($percentile) {
 
 $rrd_options .= "\\n'";
 $rrd_options .= ' LINE1.25:in#' . $colour_line_in . ":'" . $in_text . "'";
-$rrd_options .= ' GPRINT:in:LAST:%6.2lf%s';
-$rrd_options .= ' GPRINT:in:AVERAGE:%6.2lf%s';
-$rrd_options .= ' GPRINT:in_max:MAX:%6.2lf%s';
+$rrd_options .= ' GPRINT:in:LAST:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:in:AVERAGE:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:in_max:MAX:%6.'.$float_precision.'lf%s';
 
 if ($percentile) {
-    $rrd_options .= ' GPRINT:percentile_in:%6.2lf%s';
+    $rrd_options .= ' GPRINT:percentile_in:%6.'.$float_precision.'lf%s';
 }
 
 $rrd_options .= " COMMENT:\\n";
 $rrd_options .= ' AREA:dout#' . $colour_area_out . $stacked['transparency'] . ':';
 $rrd_options .= ' LINE1.25:dout#' . $colour_line_out . ":'" . $out_text . "'";
-$rrd_options .= ' GPRINT:out:LAST:%6.2lf%s';
-$rrd_options .= ' GPRINT:out:AVERAGE:%6.2lf%s';
-$rrd_options .= ' GPRINT:out_max:MAX:%6.2lf%s';
+$rrd_options .= ' GPRINT:out:LAST:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:out:AVERAGE:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:out_max:MAX:%6.'.$float_precision.'lf%s';
 
 if ($percentile) {
-    $rrd_options .= ' GPRINT:percentile_out:%6.2lf%s';
+    $rrd_options .= ' GPRINT:percentile_out:%6.'.$float_precision.'lf%s';
 }
 
 $rrd_options .= " COMMENT:\\n";
 
 if ($print_total) {
-    $rrd_options .= " GPRINT:tot:'Total %6.2lf%s'";
-    $rrd_options .= " GPRINT:totin:'(In %6.2lf%s'";
-    $rrd_options .= " GPRINT:totout:'Out %6.2lf%s)\l'";
+    $rrd_options .= " GPRINT:tot:'Total %6.'.$float_precision.'lf%s'";
+    $rrd_options .= " GPRINT:totin:'(In %6.'.$float_precision.'lf%s'";
+    $rrd_options .= " GPRINT:totout:'Out %6.'.$float_precision.'lf%s)\l'";
 }
 
 if ($percentile) {

--- a/includes/html/graphs/generic_multi_bits.inc.php
+++ b/includes/html/graphs/generic_multi_bits.inc.php
@@ -97,16 +97,16 @@ if ($i) {
         $rrd_options .= ' AREA:inbits#' . $colour_area_in . $stacked['transparency'] . ':';
         $rrd_options .= " COMMENT:'bps      Now       Ave      Max      " . \LibreNMS\Config::get('percentile_value') . "th %\\n'";
         $rrd_options .= ' LINE1.25:inbits#' . $colour_line_in . ':In\ ';
-        $rrd_options .= ' GPRINT:inbits:LAST:%6.2lf%s';
-        $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:inbits:MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:percentile_in:%6.2lf%s\\\\n";
+        $rrd_options .= ' GPRINT:inbits:LAST:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:inbits:MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:percentile_in:%6.'.$float_precision.'lf%s\\\\n";
         $rrd_options .= ' AREA:doutbits#' . $colour_area_out . $stacked['transparency'] . ':';
         $rrd_options .= ' LINE1.25:doutbits#' . $colour_line_out . ':Out';
-        $rrd_options .= ' GPRINT:outbits:LAST:%6.2lf%s';
-        $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:outbits:MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:percentile_out:%6.2lf%s\\\\n";
+        $rrd_options .= ' GPRINT:outbits:LAST:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:outbits:MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:percentile_out:%6.'.$float_precision.'lf%s\\\\n";
     }
 
     $rrd_options .= ' LINE1:percentile_in#aa0000';

--- a/includes/html/graphs/generic_multi_bits_separated.inc.php
+++ b/includes/html/graphs/generic_multi_bits_separated.inc.php
@@ -81,11 +81,11 @@ foreach ($rrd_list as $rrd) {
 
     $rrd_options .= ' AREA:inB' . $i . '#' . $colour_in . $stacked['transparency'] . ":'" . $descr . "'$stack";
     if (!$nodetails) {
-        $rrd_options .= ' GPRINT:inB' . $i . ":LAST:%6.2lf%s$units";
-        $rrd_options .= ' GPRINT:inB' . $i . ":AVERAGE:%6.2lf%s$units";
-        $rrd_options .= ' GPRINT:inB' . $i . ":MAX:%6.2lf%s$units";
+        $rrd_options .= ' GPRINT:inB' . $i . ":LAST:%6.'.$float_precision.'lf%s$units";
+        $rrd_options .= ' GPRINT:inB' . $i . ":AVERAGE:%6.'.$float_precision.'lf%s$units";
+        $rrd_options .= ' GPRINT:inB' . $i . ":MAX:%6.'.$float_precision.'lf%s$units";
         if (!$nototal) {
-            $rrd_options .= ' GPRINT:totin' . $i . ":%6.2lf%s$total_units";
+            $rrd_options .= ' GPRINT:totin' . $i . ":%6.'.$float_precision.'lf%s$total_units";
         }
 
         $rrd_options .= '\l';
@@ -95,11 +95,11 @@ foreach ($rrd_list as $rrd) {
     $rrd_optionsb .= " 'AREA:outB" . $i . '_neg#' . $colour_out . $stacked['transparency'] . ":$stack'";
 
     if (!$nodetails) {
-        $rrd_options .= ' GPRINT:outB' . $i . ":LAST:%6.2lf%s$units";
-        $rrd_options .= ' GPRINT:outB' . $i . ":AVERAGE:%6.2lf%s$units";
-        $rrd_options .= ' GPRINT:outB' . $i . ":MAX:%6.2lf%s$units";
+        $rrd_options .= ' GPRINT:outB' . $i . ":LAST:%6.'.$float_precision.'lf%s$units";
+        $rrd_options .= ' GPRINT:outB' . $i . ":AVERAGE:%6.'.$float_precision.'lf%s$units";
+        $rrd_options .= ' GPRINT:outB' . $i . ":MAX:%6.'.$float_precision.'lf%s$units";
         if (!$nototal) {
-            $rrd_options .= ' GPRINT:totout' . $i . ":%6.2lf%s$total_unit";
+            $rrd_options .= ' GPRINT:totout' . $i . ":%6.'.$float_precision.'lf%s$total_unit";
         }
 
         $rrd_options .= '\l';
@@ -133,20 +133,20 @@ if (!$noagg) {
     $rrd_options .= ' VDEF:totalout=aggroutbytes,TOTAL';
     $rrd_options .= " COMMENT:' \\\\n'";
     $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate In', ($descr_len + 5)), 0, ($descr_len + 5)) . "'";
-    $rrd_options .= " GPRINT:aggrinbits:LAST:%6.2lf%s$units";
-    $rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.2lf%s$units";
-    $rrd_options .= " GPRINT:aggrinbits:MAX:%6.2lf%s$units";
+    $rrd_options .= " GPRINT:aggrinbits:LAST:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= " GPRINT:aggrinbits:AVERAGE:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= " GPRINT:aggrinbits:MAX:%6.'.$float_precision.'lf%s$units";
     if (!$nototal) {
-        $rrd_options .= " GPRINT:totalin:%6.2lf%s$total_units";
+        $rrd_options .= " GPRINT:totalin:%6.'.$float_precision.'lf%s$total_units";
     }
 
     $rrd_options .= "\\\\n";
     $rrd_options .= " COMMENT:'" . substr(str_pad('Aggregate Out', ($descr_len + 5)), 0, ($descr_len + 5)) . "'";
-    $rrd_options .= " GPRINT:aggroutbits:LAST:%6.2lf%s$units";
-    $rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.2lf%s$units";
-    $rrd_options .= " GPRINT:aggroutbits:MAX:%6.2lf%s$units";
+    $rrd_options .= " GPRINT:aggroutbits:LAST:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= " GPRINT:aggroutbits:AVERAGE:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= " GPRINT:aggroutbits:MAX:%6.'.$float_precision.'lf%s$units";
     if (!$nototal) {
-        $rrd_options .= " GPRINT:totalout:%6.2lf%s$total_units";
+        $rrd_options .= " GPRINT:totalout:%6.'.$float_precision.'lf%s$total_units";
     }
 
     $rrd_options .= "\\\\n";

--- a/includes/html/graphs/generic_multi_data.inc.php
+++ b/includes/html/graphs/generic_multi_data.inc.php
@@ -106,18 +106,18 @@ if ($i) {
     } else {
         $rrd_options .= " COMMENT:'bps      Now       Ave      Max      " . \LibreNMS\Config::get('percentile_value') . "th %\\n'";
         $rrd_options .= ' AREA:in' . $format . '#' . $colour_area_in . $stacked['transparency'] . ':In ';
-        $rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.2lf%s';
-        $rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:in' . $format . ':MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:percentile_in:%6.2lf%s\\n";
+        $rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:in' . $format . ':MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:percentile_in:%6.'.$float_precision.'lf%s\\n";
         $rrd_options .= ' AREA:dout' . $format . '#' . $colour_area_out . $stacked['transparency'] . ':Out';
-        $rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.2lf%s';
-        $rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:out' . $format . ':MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:percentile_out:%6.2lf%s\\n";
-        $rrd_options .= " GPRINT:tot:'Total %6.2lf%sB'";
-        $rrd_options .= " GPRINT:totin:'(In %6.2lf%sB'";
-        $rrd_options .= " GPRINT:totout:'Out %6.2lf%sB)\\l'";
+        $rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:out' . $format . ':MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:percentile_out:%6.'.$float_precision.'lf%s\\n";
+        $rrd_options .= " GPRINT:tot:'Total %6.'.$float_precision.'lf%sB'";
+        $rrd_options .= " GPRINT:totin:'(In %6.'.$float_precision.'lf%sB'";
+        $rrd_options .= " GPRINT:totout:'Out %6.'.$float_precision.'lf%sB)\\l'";
     }
 
     $rrd_options .= ' LINE1:percentile_in#aa0000';

--- a/includes/html/graphs/generic_multi_data_separated.inc.php
+++ b/includes/html/graphs/generic_multi_data_separated.inc.php
@@ -82,22 +82,22 @@ foreach ($rrd_list as $rrd) {
     }
 
     $rrd_options .= ' AREA:inB' . $i . '#' . $colour_in . $stacked['transparency'] . ":'" . $descr . "'$stack";
-    $rrd_options .= ' GPRINT:inB' . $i . ":LAST:%6.2lf%s$units";
-    $rrd_options .= ' GPRINT:inB' . $i . ":AVERAGE:%6.2lf%s$units";
-    $rrd_options .= ' GPRINT:inB' . $i . ":MAX:%6.2lf%s$units\l";
+    $rrd_options .= ' GPRINT:inB' . $i . ":LAST:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= ' GPRINT:inB' . $i . ":AVERAGE:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= ' GPRINT:inB' . $i . ":MAX:%6.'.$float_precision.'lf%s$units\l";
 
     if (!$nototal) {
-        $rrd_options .= ' GPRINT:totin' . $i . ":%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:totin' . $i . ":%6.'.$float_precision.'lf%s$total_units";
     }
 
     $rrd_options .= " 'HRULE:0#" . $colour_out . ':' . $descr_out . "'";
     $rrd_optionsb .= " 'AREA:outB" . $i . '_neg#' . $colour_out . $stacked['transparency'] . ":$stack'";
-    $rrd_options .= ' GPRINT:outB' . $i . ":LAST:%6.2lf%s$units";
-    $rrd_options .= ' GPRINT:outB' . $i . ":AVERAGE:%6.2lf%s$units";
-    $rrd_options .= ' GPRINT:outB' . $i . ":MAX:%6.2lf%s$units\l";
+    $rrd_options .= ' GPRINT:outB' . $i . ":LAST:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= ' GPRINT:outB' . $i . ":AVERAGE:%6.'.$float_precision.'lf%s$units";
+    $rrd_options .= ' GPRINT:outB' . $i . ":MAX:%6.'.$float_precision.'lf%s$units\l";
 
     if (!$nototal) {
-        $rrd_options .= ' GPRINT:totout' . $i . ":%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:totout' . $i . ":%6.'.$float_precision.'lf%s$total_units";
     }
 
     $rrd_options .= " 'COMMENT:\l'";

--- a/includes/html/graphs/generic_multi_line.inc.php
+++ b/includes/html/graphs/generic_multi_line.inc.php
@@ -78,8 +78,8 @@ foreach ($rrd_list as $rrd) {
         }
     }
 
-    $rrd_optionsb .= ' GPRINT:' . $id . ':LAST:%5.2lf%s' . $units . ' GPRINT:' . $id . 'min:MIN:%5.2lf%s' . $units;
-    $rrd_optionsb .= ' GPRINT:' . $id . 'max:MAX:%5.2lf%s' . $units . ' GPRINT:' . $id . ":AVERAGE:'%5.2lf%s$units\\n'";
+    $rrd_optionsb .= ' GPRINT:' . $id . ':LAST:%5.'.$float_precision.'lf%s' . $units . ' GPRINT:' . $id . 'min:MIN:%5.'.$float_precision.'lf%s' . $units;
+    $rrd_optionsb .= ' GPRINT:' . $id . 'max:MAX:%5.'.$float_precision.'lf%s' . $units . ' GPRINT:' . $id . ":AVERAGE:'%5.'.$float_precision.'lf%s$units\\n'";
 
     $i++;
 }

--- a/includes/html/graphs/generic_multi_line_exact_numbers.inc.php
+++ b/includes/html/graphs/generic_multi_line_exact_numbers.inc.php
@@ -93,7 +93,7 @@ foreach ($rrd_list as $rrd) {
     $rrd_options .= ' GPRINT:'.$t_defname.$i.'max:MAX:%8.0lf%s GPRINT:'.$t_defname.$i.":AVERAGE:'%8.0lf%s\\n'";
 
     if ($printtotal === 1) {
-        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.2lf%s'".rrdtool_escape($total_units)."'";
+        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.'.$float_precision.'lf%s'".rrdtool_escape($total_units)."'";
     }
 
     $rrd_options .= " COMMENT:'\\n'";

--- a/includes/html/graphs/generic_multi_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_seperated.inc.php
@@ -108,40 +108,40 @@ foreach ($rrd_list as $rrd) {
     }
 
     $rrd_options .= ' AREA:inbits' . $i . '#' . $colour_in . $stacked['transparency'] . ":'" . rrdtool_escape($rrd['descr'], $rrddescr_len) . "In '$stack";
-    $rrd_options .= ' GPRINT:inbits' . $i . ':LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:inbits' . $i . ':AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:inbits' . $i . ':MAX:%6.2lf%s';
+    $rrd_options .= ' GPRINT:inbits' . $i . ':LAST:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:inbits' . $i . ':AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:inbits' . $i . ':MAX:%6.'.$float_precision.'lf%s';
 
     if (!$args['nototal']) {
-        $rrd_options .= ' GPRINT:totinB' . $i . ":%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:totinB' . $i . ":%6.'.$float_precision.'lf%s$total_units";
     }
 
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:inbits' . $i . 'X:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:inbits' . $i . 'X:MAX:%6.2lf%s';
+        $rrd_options .= ' GPRINT:inbits' . $i . 'X:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:inbits' . $i . 'X:MAX:%6.'.$float_precision.'lf%s';
         if (!$args['nototal']) {
-            $rrd_options .= ' GPRINT:totinB' . $i . 'X' . ":%6.2lf%s$total_units";
+            $rrd_options .= ' GPRINT:totinB' . $i . 'X' . ":%6.'.$float_precision.'lf%s$total_units";
         }
     }
 
     $rrd_options .= " COMMENT:'\\n'";
     $rrd_optionsb .= ' AREA:outbits' . $i . '_neg#' . $colour_out . $stacked['transparency'] . ":$stack";
     $rrd_options .= ' HRULE:999999999999999#' . $colour_out . ":'" . str_pad('', $rrddescr_len + 1) . "Out'";
-    $rrd_options .= ' GPRINT:outbits' . $i . ':LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:outbits' . $i . ':AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:outbits' . $i . ':MAX:%6.2lf%s';
+    $rrd_options .= ' GPRINT:outbits' . $i . ':LAST:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:outbits' . $i . ':AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:outbits' . $i . ':MAX:%6.'.$float_precision.'lf%s';
 
     if (!$args['nototal']) {
-        $rrd_options .= ' GPRINT:totoutB' . $i . ":%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:totoutB' . $i . ":%6.'.$float_precision.'lf%s$total_units";
     }
     
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= " COMMENT:' \t'";
-        $rrd_options .= ' GPRINT:outbits' . $i . 'X:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:outbits' . $i . 'X:MAX:%6.2lf%s';
+        $rrd_options .= ' GPRINT:outbits' . $i . 'X:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:outbits' . $i . 'X:MAX:%6.'.$float_precision.'lf%s';
         if (!$args['nototal']) {
-            $rrd_options .= ' GPRINT:totoutB' . $i . 'X' . ":%6.2lf%s$total_units";
+            $rrd_options .= ' GPRINT:totoutB' . $i . 'X' . ":%6.'.$float_precision.'lf%s$total_units";
         }
     }
 
@@ -204,44 +204,44 @@ if (!$args['nototal']) {
     $rrd_options .= " COMMENT:' \\n'";
 
     $rrd_options .= " HRULE:999999999999999#FFFFFF:'" . str_pad('Total', $rrddescr_len + 1) . "In '";
-    $rrd_options .= ' GPRINT:inbits:LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:inbits:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:totin:%6.2lf%s$total_units";
+    $rrd_options .= ' GPRINT:inbits:LAST:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:inbits:AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:inbits:MAX:%6.'.$float_precision.'lf%s';
+    $rrd_options .= " GPRINT:totin:%6.'.$float_precision.'lf%s$total_units";
     $rrd_options .= " COMMENT:'\\n'";
 
     $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', $rrddescr_len + 1) . "Out'";
-    $rrd_options .= ' GPRINT:outbits:LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:outbits:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:totout:%6.2lf%s$total_units";
+    $rrd_options .= ' GPRINT:outbits:LAST:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:outbits:AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:outbits:MAX:%6.'.$float_precision.'lf%s';
+    $rrd_options .= " GPRINT:totout:%6.'.$float_precision.'lf%s$total_units";
     $rrd_options .= " COMMENT:'\\n'";
 
     $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', $rrddescr_len + 1) . "Agg'";
-    $rrd_options .= ' GPRINT:bits:LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:bits:AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:bits:MAX:%6.2lf%s';
-    $rrd_options .= " GPRINT:tot:%6.2lf%s$total_units";
+    $rrd_options .= ' GPRINT:bits:LAST:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:bits:AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:bits:MAX:%6.'.$float_precision.'lf%s';
+    $rrd_options .= " GPRINT:tot:%6.'.$float_precision.'lf%s$total_units";
     $rrd_options .= " COMMENT:'\\n'";
     if ($_GET['previous'] == 'yes') {
         $rrd_options .= " COMMENT:' \\n'";
         $rrd_options .= " COMMENT:' \t\t\t\t\t\t'";
         $rrd_options .= " HRULE:999999999999999#FFFFFF:'" . str_pad('Perv Total', $rrddescr_len + 1) . "In '\t\t";
-        $rrd_options .= ' GPRINT:inbitsX:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:inbitsX:MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:totinX:%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:inbitsX:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:inbitsX:MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:totinX:%6.'.$float_precision.'lf%s$total_units";
         $rrd_options .= " COMMENT:'\\n'";
         $rrd_options .= " COMMENT:' \t\t\t\t\t\t'";
         $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', $rrddescr_len + 1) . "Out'\t\t";
-        $rrd_options .= ' GPRINT:outbitsX:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:outbitsX:MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:totoutX:%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:outbitsX:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:outbitsX:MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:totoutX:%6.'.$float_precision.'lf%s$total_units";
         $rrd_options .= " COMMENT:'\\n'";
         $rrd_options .= " COMMENT:' \t\t\t\t\t\t'";
         $rrd_options .= " HRULE:999999999999990#FFFFFF:'" . str_pad('', $rrddescr_len + 1) . "Agg'\t\t";
-        $rrd_options .= ' GPRINT:bitsX:AVERAGE:%6.2lf%s';
-        $rrd_options .= ' GPRINT:bitsX:MAX:%6.2lf%s';
-        $rrd_options .= " GPRINT:totX:%6.2lf%s$total_units";
+        $rrd_options .= ' GPRINT:bitsX:AVERAGE:%6.'.$float_precision.'lf%s';
+        $rrd_options .= ' GPRINT:bitsX:MAX:%6.'.$float_precision.'lf%s';
+        $rrd_options .= " GPRINT:totX:%6.'.$float_precision.'lf%s$total_units";
         $rrd_options .= " COMMENT:'\\n'";
     }
 }

--- a/includes/html/graphs/generic_multi_simplex_seperated.inc.php
+++ b/includes/html/graphs/generic_multi_simplex_seperated.inc.php
@@ -90,11 +90,11 @@ foreach ($rrd_list as $i => $rrd) {
 
     $rrd_options .= ' AREA:'.$g_defname.$i.'#'.$colour.":'".$descr."'$stack";
 
-    $rrd_options .= ' GPRINT:'.$t_defname.$i.':LAST:%5.2lf%s GPRINT:'.$t_defname.$i.'min:MIN:%5.2lf%s';
-    $rrd_options .= ' GPRINT:'.$t_defname.$i.'max:MAX:%5.2lf%s GPRINT:'.$t_defname.$i.":AVERAGE:'%5.2lf%s\\n'";
+    $rrd_options .= ' GPRINT:'.$t_defname.$i.':LAST:%5.'.$float_precision.'lf%s GPRINT:'.$t_defname.$i.'min:MIN:%5.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:'.$t_defname.$i.'max:MAX:%5.'.$float_precision.'lf%s GPRINT:'.$t_defname.$i.":AVERAGE:'%5.'.$float_precision.'lf%s\\n'";
 
     if (!$nototal) {
-        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.2lf%s'".rrdtool_escape($total_units)."'";
+        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.'.$float_precision.'lf%s'".rrdtool_escape($total_units)."'";
     }
 
     $rrd_options .= " COMMENT:'\\n'";

--- a/includes/html/graphs/generic_simplex.inc.php
+++ b/includes/html/graphs/generic_simplex.inc.php
@@ -87,19 +87,19 @@ if (\LibreNMS\Config::get('old_graphs')) {
 
     $rrd_options .= "\\n'";
     $rrd_options .= ' LINE1.25:'.$ds.'#'.$colour_line.":'".$line_text."'";
-    $rrd_options .= ' GPRINT:'.$ds.':LAST:%6.2lf%s';
-    $rrd_options .= ' GPRINT:'.$ds.':AVERAGE:%6.2lf%s';
-    $rrd_options .= ' GPRINT:'.$ds.'_max:MAX:%6.2lf%s';
+    $rrd_options .= ' GPRINT:'.$ds.':LAST:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:'.$ds.':AVERAGE:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:'.$ds.'_max:MAX:%6.'.$float_precision.'lf%s';
 
     if ($percentile) {
-        $rrd_options .= ' GPRINT:'.$ds.'_percentile:%6.2lf%s';
+        $rrd_options .= ' GPRINT:'.$ds.'_percentile:%6.'.$float_precision.'lf%s';
     }
 
     $rrd_options .= "\\\\n";
     $rrd_options .= " COMMENT:\\n";
 
     if ($print_total) {
-        $rrd_options .= ' GPRINT:'.$ds.'_tot:Total\ %6.2lf%s\)\l';
+        $rrd_options .= ' GPRINT:'.$ds.'_tot:Total\ %6.'.$float_precision.'lf%s\)\l';
     }
 
     if ($percentile) {

--- a/includes/html/graphs/generic_v3_multiline_float.inc.php
+++ b/includes/html/graphs/generic_v3_multiline_float.inc.php
@@ -92,11 +92,11 @@ foreach ($rrd_list as $rrd) {
     if ($addarea === 1) {
         $rrd_options .= ' AREA:'.$g_defname.$i.'#'.$colour.$transparency.":''$stack";
     }
-    $rrd_options .= ' GPRINT:'.$t_defname.$i.':LAST:%6.2lf%s GPRINT:'.$t_defname.$i.'min:MIN:%6.2lf%s';
-    $rrd_options .= ' GPRINT:'.$t_defname.$i.'max:MAX:%6.2lf%s GPRINT:'.$t_defname.$i.":AVERAGE:'%6.2lf%s\\n'";
+    $rrd_options .= ' GPRINT:'.$t_defname.$i.':LAST:%6.'.$float_precision.'lf%s GPRINT:'.$t_defname.$i.'min:MIN:%6.'.$float_precision.'lf%s';
+    $rrd_options .= ' GPRINT:'.$t_defname.$i.'max:MAX:%6.'.$float_precision.'lf%s GPRINT:'.$t_defname.$i.":AVERAGE:'%6.'.$float_precision.'lf%s\\n'";
 
     if ($printtotal === 1) {
-        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.2lf%s'".rrdtool_escape($total_units)."'";
+        $rrd_options .= ' GPRINT:tot'.$rrd['ds'].$i.":%6.'.$float_precision.'lf%s'".rrdtool_escape($total_units)."'";
     }
 
     $rrd_options .= " COMMENT:'\\n'";

--- a/includes/html/graphs/old_generic_simplex.inc.php
+++ b/includes/html/graphs/old_generic_simplex.inc.php
@@ -64,19 +64,19 @@ if ($percentile) {
 
 $rrd_options .= "\\n'";
 $rrd_options .= ' LINE1.25:'.$ds.'#'.$colour_line.":'".$line_text."'";
-$rrd_options .= ' GPRINT:'.$ds.':LAST:%6.2lf%s';
-$rrd_options .= ' GPRINT:'.$ds.':AVERAGE:%6.2lf%s';
-$rrd_options .= ' GPRINT:'.$ds.':MAX:%6.2lf%s';
+$rrd_options .= ' GPRINT:'.$ds.':LAST:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:'.$ds.':AVERAGE:%6.'.$float_precision.'lf%s';
+$rrd_options .= ' GPRINT:'.$ds.':MAX:%6.'.$float_precision.'lf%s';
 
 if ($percentile) {
-    $rrd_options .= ' GPRINT:'.$ds.'_percentile:%6.2lf%s';
+    $rrd_options .= ' GPRINT:'.$ds.'_percentile:%6.'.$float_precision.'lf%s';
 }
 
 $rrd_options .= "\\n";
 $rrd_options .= " COMMENT:\\n";
 
 if ($print_total) {
-    $rrd_options .= ' GPRINT:'.$ds.'_total:Total" %6.2lf%s"\\l';
+    $rrd_options .= ' GPRINT:'.$ds.'_total:Total" %6.'.$float_precision.'lf%s"\\l';
 }
 
 if ($percentile) {


### PR DESCRIPTION
if precision of value in RRD Graph is needed to be more/less precise then 2 numbers after comma (default).

e.G.
in RRD configuration add  `$float_precision = '4';`
to have after comma precision set to 4.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
