### PR TITLE
Fix external auth auto-login

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -89,6 +89,7 @@ class Kernel extends HttpKernel
     protected $middlewarePriority = [
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \App\Http\Middleware\LegacyExternalAuth::class,
         \App\Http\Middleware\Authenticate::class,
         \Illuminate\Routing\Middleware\ThrottleRequests::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -39,9 +39,9 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
 
-        'auth.web' => [
+        'auth' => [
             \App\Http\Middleware\LegacyExternalAuth::class,
-            'auth',
+            'authenticate',
             \App\Http\Middleware\VerifyTwoFactor::class,
             \App\Http\Middleware\LoadUserPreferences::class,
         ],
@@ -53,7 +53,7 @@ class Kernel extends HttpKernel
 
         'api' => [
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            'auth:token',
+            'authenticate:token',
             \Spatie\Cors\Cors::class,
         ],
     ];
@@ -66,7 +66,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => \App\Http\Middleware\Authenticate::class,
+        'authenticate' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@
 Auth::routes(['register' => false, 'reset' => false, 'verify' => false]);
 
 // WebUI
-Route::group(['middleware' => ['auth.web'], 'guard' => 'auth'], function () {
+Route::group(['middleware' => ['auth'], 'guard' => 'auth'], function () {
 
     // pages
     Route::resource('device-groups', 'DeviceGroupController');
@@ -144,8 +144,8 @@ Route::group(['middleware' => ['auth.web'], 'guard' => 'auth'], function () {
 });
 
 // Legacy routes
-Route::any('/dummy_legacy_auth/{path?}', 'LegacyController@dummy')->middleware('auth.web');
+Route::any('/dummy_legacy_auth/{path?}', 'LegacyController@dummy')->middleware('auth');
 Route::any('/dummy_legacy_unauth/{path?}', 'LegacyController@dummy');
 Route::any('/{path?}', 'LegacyController@index')
     ->where('path', '^((?!_debugbar).)*')
-    ->middleware('auth.web');
+    ->middleware('auth');


### PR DESCRIPTION
rename auth middlewares so LegacyExternalAuth is registered on the Auth::routes() login routes.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
