### PR TITLE
Ping Perf fix while running Squid

### DIFF
--- a/includes/polling/applications/squid.inc.php
+++ b/includes/polling/applications/squid.inc.php
@@ -175,5 +175,5 @@ $fields = array(
 $tags = array('name' => $name, 'app_id' => $app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name);
 data_update($device, 'app', $tags, $fields);
 
-$response = ($returnedoids == false) ? false : 'Data ok';
-update_application($app, $response, $fields);
+$squid_status = ($returnedoids == false) ? false : 'Data ok';
+update_application($app, $squid_status, $fields);

--- a/includes/polling/applications/squid.inc.php
+++ b/includes/polling/applications/squid.inc.php
@@ -175,5 +175,5 @@ $fields = array(
 $tags = array('name' => $name, 'app_id' => $app_id, 'rrd_def' => $rrd_def, 'rrd_name' => $rrd_name);
 data_update($device, 'app', $tags, $fields);
 
-$squid_status = ($returnedoids == false) ? false : 'Data ok';
-update_application($app, $squid_status, $fields);
+$squid_app_status = ($returnedoids == false) ? false : 'Data ok';
+update_application($app, $squid_app_status, $fields);


### PR DESCRIPTION
on each poll includes/polling/functions.inc.php is running and loads device status from DB into $response array
after this all application poller are running
finally ping perf graph is drawn with data from $response array, if device is pingable

if squid application poller runs $response array was overwritten with its application status string
resolving in no ping perf graph could be drawn for this device

this Bugfix solves the issue

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
