### PR TITLE
Make IPv6 discovery work on JunOS

### DIFF
--- a/includes/discovery/ipv6-addresses.inc.php
+++ b/includes/discovery/ipv6-addresses.inc.php
@@ -41,13 +41,18 @@ foreach ($vrfs_lite_cisco as $vrf) {
             $ipv6_prefixlen = explode('.', $ipv6_prefixlen);
             $ipv6_prefixlen = str_replace('"', '', end($ipv6_prefixlen));
 
+            if (Str::contains($ipv6_prefixlen, 'SNMPv2-SMI::zeroDotZero')) {
+                d_echo('Incomplete IPv6 data in IF-MIB');
+                $oids = trim(Str::replaceFirst($data, '', $oids));
+            }
+            
             $ipv6_origin = snmp_get($device, ".1.3.6.1.2.1.4.34.1.6.2.16.$oid", '-Ovq', 'IP-MIB');
 
             discover_process_ipv6($valid, $ifIndex, $ipv6_address, $ipv6_prefixlen, $ipv6_origin, $device['context_name']);
         } //end if
     } //end foreach
 
-    if (!$oids) {
+    if (empty($oids)) {
         $oids = snmp_walk($device, 'ipv6AddrPfxLength', ['-OsqnU', '-Ln'], 'IPV6-MIB');
         $oids = str_replace('.1.3.6.1.2.1.55.1.8.1.2.', '', $oids);
         $oids = str_replace('"', '', $oids);


### PR DESCRIPTION
Although JunOS populates ipAddressIfIndex.ipv6, it does not add prefix lengths or other metadata. This means that IPv6 discovery fails.

This change removes OIDs from the list when there is incomplete data. If the list is empty after IP-MIB is walked, it then tries IPv6 MIB.

It's not a great fix, but I'm not confident I can fix the underlying issue without a complete re-write of this module.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
