### PR TITLE
Devices List: Sort downtime and uptime

### DIFF
--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -67,6 +67,19 @@ class DeviceController extends TableController
         return ['sysName', 'hostname', 'hardware', 'os', 'locations.location'];
     }
 
+    protected function sortFields($request)
+    {
+        return [
+            'status' => 'status',
+            'icon' => 'icon',
+            'hostname' => 'hostname',
+            'hardware' => 'hardware',
+            'os' => 'os',
+            'uptime' => \DB::raw("IF(`status` = 1, `uptime`, `last_polled` - TIME('now'))"),
+            'location' => 'location'
+        ];
+    }
+
     /**
      * Defines the base query for this resource
      *

--- a/app/Http/Controllers/Table/DeviceController.php
+++ b/app/Http/Controllers/Table/DeviceController.php
@@ -75,7 +75,7 @@ class DeviceController extends TableController
             'hostname' => 'hostname',
             'hardware' => 'hardware',
             'os' => 'os',
-            'uptime' => \DB::raw("IF(`status` = 1, `uptime`, `last_polled` - TIME('now'))"),
+            'uptime' => \DB::raw("IF(`status` = 1, `uptime`, `last_polled` - NOW()))"),
             'location' => 'location'
         ];
     }


### PR DESCRIPTION
Affects the sorting of the downtime/uptime field on the devices page.

Now instead of down devices being randomly ordered, they will be sorted by the amount of time they have been down.  Devices that are up will continue to be sorted by uptime.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
