### PR TITLE
Make fping work when fping6 is not present

### DIFF
--- a/LibreNMS/Fping.php
+++ b/LibreNMS/Fping.php
@@ -48,7 +48,7 @@ class Fping
         $cmd = [$fping];
         if ($address_family == 'ipv6') {
             $fping6 = Config::get('fping6');
-            $cmd = (!is_executable($fping6) && is_executable($fping)) ? [$fping, '-6'] : [$fping6];
+            $cmd = is_executable($fping6) ? [$fping6] : [$fping, '-6'];
         }
 
         // build the command

--- a/LibreNMS/Fping.php
+++ b/LibreNMS/Fping.php
@@ -42,13 +42,17 @@ class Fping
      */
     public function ping($host, $count = 3, $interval = 1000, $timeout = 500, $address_family = 'ipv4')
     {
-        // Default to ipv4
-        $fping_name = $address_family == 'ipv6' ? 'fping6' : 'fping';
         $interval = max($interval, 20);
 
+        $fping = Config::get('fping');
+        $cmd = [$fping];
+        if ($address_family == 'ipv6') {
+            $fping6 = Config::get('fping6');
+            $cmd = (!is_executable($fping6) && is_executable($fping)) ? [$fping, '-6'] : [$fping6];
+        }
+
         // build the command
-        $cmd = [
-            Config::get($fping_name, $fping_name),
+        $cmd = array_merge($cmd, [
             '-e',
             '-q',
             '-c',
@@ -58,7 +62,7 @@ class Fping
             '-t',
             max($timeout, $interval),
             $host
-        ];
+        ]);
 
         $process = app()->make(Process::class, ['command' => $cmd]);
         Log::debug('[FPING] ' . $process->getCommandLine() . PHP_EOL);


### PR DESCRIPTION
Modern versions of fping don't have a fping6 binary.  Older versions don't support the -6 switch.
Try fping6 then fallback to fping -6.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
