### PR TITLE
Prevent unauthorized access to device graphs

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -72,6 +72,12 @@ class DeviceController extends Controller
         if ($current_tab == 'port') {
             $vars = Url::parseLegacyPath($request->path());
             $port = Port::findOrFail($vars->get('port'));
+
+            // This prevents users from traversal device id's by piggybacking on the auth for the specified port
+            if ($port->device_id !== $device_id) {
+                abort(404);
+            }
+
             $this->authorize('view', $port);
         } else {
             $this->authorize('view', $device);

--- a/html/graph.php
+++ b/html/graph.php
@@ -17,9 +17,7 @@ $start = microtime(true);
 $init_modules = array('web', 'graphs', 'auth');
 require realpath(__DIR__ . '/..') . '/includes/init.php';
 
-$auth = Auth::check() || is_client_authorized($_SERVER['REMOTE_ADDR']);
-
-if (!$auth) {
+if (!(Auth::check() || is_client_authorized($_SERVER['REMOTE_ADDR']))) {
     die('Unauthorized');
 }
 


### PR DESCRIPTION
Basically there is no auth in `graph.php` due to `$auth` being reused, It's first defined here:
https://github.com/librenms/librenms/blob/4da411c8398700d1caf61bb6a255f80e8bddba47/html/graph.php#L20-L24

Then all checks are like `if($auth || ...)` so they always evaluate to  true:
https://github.com/librenms/librenms/blob/4da411c8398700d1caf61bb6a255f80e8bddba47/includes/html/graphs/device/auth.inc.php#L3

The other issue is that you can utilize a port authorization to get some device info for another device than the port belong to.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
