### PR TITLE
Add alert rule error on invert map selected but no selection in device, group or location list

### DIFF
--- a/includes/html/forms/alert-rules.inc.php
+++ b/includes/html/forms/alert-rules.inc.php
@@ -101,6 +101,14 @@ $extra = array(
 
 $extra_json = json_encode($extra);
 
+if (!is_array($vars['maps']) && $invert_map) {
+    die(json_encode([
+        'status' => 'error',
+        'message' => 'Invert map is on but no selection in devices, groups and locations match list<br />'
+    ]));
+}
+
+
 if (is_numeric($rule_id) && $rule_id > 0) {
     if (dbUpdate(
         array(
@@ -167,13 +175,6 @@ if (is_numeric($rule_id) && $rule_id > 0) {
         } else {
             $devices[] = (int)$item;
         }
-    }
-
-    if (!is_array($vars['maps']) && $invert_map) {
-        die(json_encode([
-            'status' => 'error',
-            'message' => 'Invert map is on but no selection in devices, groups and locations match list<br />'
-        ]));
     }
 
     dbSyncRelationship('alert_device_map', 'rule_id', $rule_id, 'device_id', $devices);

--- a/includes/html/forms/alert-rules.inc.php
+++ b/includes/html/forms/alert-rules.inc.php
@@ -170,10 +170,9 @@ if (is_numeric($rule_id) && $rule_id > 0) {
     }
 
     if (!is_array($vars['maps']) && $invert_map) {
-        $message .= 'Invert map is on but no selection in devices, groups and locations match list<br />';
         die(json_encode([
             'status' => 'error',
-            'message' => $message
+            'message' => 'Invert map is on but no selection in devices, groups and locations match list<br />'
         ]));
     }
 

--- a/includes/html/forms/alert-rules.inc.php
+++ b/includes/html/forms/alert-rules.inc.php
@@ -169,6 +169,14 @@ if (is_numeric($rule_id) && $rule_id > 0) {
         }
     }
 
+    if (!is_array($vars['maps']) && $invert_map) {
+        $message .= 'Invert map is on but no selection in devices, groups and locations match list<br />';
+        die(json_encode([
+            'status' => 'error',
+            'message' => $message
+        ]));
+    }
+
     dbSyncRelationship('alert_device_map', 'rule_id', $rule_id, 'device_id', $devices);
     dbSyncRelationship('alert_group_map', 'rule_id', $rule_id, 'group_id', $groups);
     dbSyncRelationship('alert_location_map', 'rule_id', $rule_id, 'location_id', $locations);


### PR DESCRIPTION
Currently, ticking “All devices except in list” and not selecting any device, group or location in match list results in selecting all devices. This is misleading.

Added a control so that it will be impossible to save such a rule.

![image](https://user-images.githubusercontent.com/47607835/86451516-4f465f00-bd1b-11ea-86a6-757393f5c643.png)


#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [X] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [X] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
