### PR TITLE
Added feature to customize rrd port graph colors

### DIFF
--- a/includes/html/graphs/generic_data.inc.php
+++ b/includes/html/graphs/generic_data.inc.php
@@ -136,61 +136,61 @@ if ($format == 'octets' || $format == 'bytes') {
 
 $rrd_options .= " COMMENT:'bps      Now       Ave      Max      " . Config::get('percentile_value') . "th %\\n'";
 
-$rrd_options .= ' AREA:in' . $format . '_max#D7FFC7' . $stacked['transparency'] . ':';
-$rrd_options .= ' AREA:in' . $format . '#90B040' . $stacked['transparency'] . ':';
-$rrd_options .= ' LINE:in' . $format . "#608720:'In '";
+$rrd_options .= ' AREA:in' . $format . '_max#' . Config::get('graph_colours.generic.area_in_max') . $stacked['transparency'] . ':';
+$rrd_options .= ' AREA:in' . $format . '#' . Config::get('graph_colours.generic.area_in') . $stacked['transparency'] . ':';
+$rrd_options .= ' LINE:in' . $format . '#' . Config::get('graph_colours.generic.line_in') . ":'In '";
 $rrd_options .= ' GPRINT:in' . $format . ':LAST:%6.'.$float_precision.'lf%s';
 $rrd_options .= ' GPRINT:in' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
 $rrd_options .= ' GPRINT:in' . $format . '_max:MAX:%6.'.$float_precision.'lf%s';
 $rrd_options .= " GPRINT:percentile_in:%6.".$float_precision."lf%s\\n";
 
-$rrd_options .= ' AREA:dout' . $format . '_max#E0E0FF' . $stacked['transparency'] . ':';
-$rrd_options .= ' AREA:dout' . $format . '#8080C0' . $stacked['transparency'] . ':';
-$rrd_options .= ' LINE:dout' . $format . "#606090:'Out'";
+$rrd_options .= ' AREA:dout' . $format . '_max#' . Config::get('graph_colours.generic.area_out_max') . $stacked['transparency'] . ':';
+$rrd_options .= ' AREA:dout' . $format . '#' . Config::get('graph_colours.generic.area_out') . $stacked['transparency'] . ':';
+$rrd_options .= ' LINE:dout' . $format . '#' . Config::get('graph_colours.generic.line_out') . ":'In '";
 $rrd_options .= ' GPRINT:out' . $format . ':LAST:%6.'.$float_precision.'lf%s';
 $rrd_options .= ' GPRINT:out' . $format . ':AVERAGE:%6.'.$float_precision.'lf%s';
 $rrd_options .= ' GPRINT:out' . $format . '_max:MAX:%6.'.$float_precision.'lf%s';
 $rrd_options .= " GPRINT:percentile_out:%6.".$float_precision."lf%s\\n";
 
 if (Config::get('rrdgraph_real_percentile')) {
-    $rrd_options .= ' HRULE:percentilehigh#FF0000:"Highest"';
+    $rrd_options .= ' HRULE:percentilehigh#' . Config::get('graph_colours.generic.percentile_high') . ':"Highest"';
     $rrd_options .= " GPRINT:percentilehigh:\"%30.".$float_precision."lf%s\\n\"";
 }
 
 $rrd_options .= " GPRINT:tot:'Total %6.".$float_precision."lf%sB'";
 $rrd_options .= " GPRINT:totin:'(In %6.".$float_precision."lf%sB'";
 $rrd_options .= " GPRINT:totout:'Out %6.".$float_precision."lf%sB)\\l'";
-$rrd_options .= ' LINE1:percentile_in#aa0000';
-$rrd_options .= ' LINE1:dpercentile_out#aa0000';
+$rrd_options .= ' LINE1:percentile_in#' . Config::get('graph_colours.generic.percentile_in');
+$rrd_options .= ' LINE1:dpercentile_out#' . Config::get('graph_colours.generic.percentile_out');
 
 // Linear prediction of trend
 if ($to > time()) {
     $rrd_options .= ' VDEF:islope=inbits_max,LSLSLOPE';
     $rrd_options .= ' VDEF:icons=inbits_max,LSLINT';
     $rrd_options .= ' CDEF:ilsl=inbits_max,POP,islope,COUNT,*,icons,+ ';
-    $rrd_options .= " LINE2:ilsl#44aa55:'In Linear Prediction\\n':dashes=8";
+    $rrd_options .= " LINE2:ilsl#". Config::get('graph_colours.generic.lp.in') .":'In Linear Prediction\\n':dashes=8";
 
     $rrd_options .= ' VDEF:oslope=doutbits_max,LSLSLOPE';
     $rrd_options .= ' VDEF:ocons=doutbits_max,LSLINT';
     $rrd_options .= ' CDEF:olsl=doutbits_max,POP,oslope,COUNT,*,ocons,+ ';
-    $rrd_options .= " LINE2:olsl#4400dd:'Out Linear Prediction\\n':dashes=8";
+    $rrd_options .= " LINE2:olsl#". Config::get('graph_colours.generic.lp.out') .":'In Linear Prediction\\n':dashes=8";
 }
 
 if ($_GET['previous'] == 'yes') {
     $rrd_options .= " COMMENT:' \\n'";
-    $rrd_options .= ' LINE1.25:in' . $format . "X#333300:'Prev In '\t";
+    $rrd_options .= ' LINE1.25:in' . $format . "X#" . Config::get('graph_colours.generic.lp.previous.in') . ":'Prev In '\t";
     $rrd_options .= ' GPRINT:in' . $format . 'X:AVERAGE:%6.'.$float_precision.'lf%s';
     $rrd_options .= ' GPRINT:in' . $format . '_maxX:MAX:%6.'.$float_precision.'lf%s';
     $rrd_options .= " GPRINT:percentile_inX:%6.".$float_precision."lf%s\\n";
-    $rrd_options .= ' LINE1.25:dout' . $format . "X#000099:'Prev Out '\t";
+    $rrd_options .= ' LINE1.25:dout' . $format . "X#" . Config::get('graph_colours.generic.lp.previous.out') . ":'Prev Out '\t";
     $rrd_options .= ' GPRINT:out' . $format . 'X:AVERAGE:%6.'.$float_precision.'lf%s';
     $rrd_options .= ' GPRINT:out' . $format . '_maxX:MAX:%6.'.$float_precision.'lf%s';
     $rrd_options .= " GPRINT:percentile_outX:%6.".$float_precision."lf%s\\n";
     $rrd_options .= " GPRINT:totX:'Total %6.".$float_precision."lf%sB'";
     $rrd_options .= " GPRINT:totinX:'(In %6.".$float_precision."lf%sB'";
     $rrd_options .= " GPRINT:totoutX:'Out %6.".$float_precision."lf%sB)\\l'";
-    $rrd_options .= ' LINE1:percentile_inX#00aaaa';
-    $rrd_options .= ' LINE1:dpercentile_outX#00aaaa';
+    $rrd_options .= ' LINE1:percentile_inX#' . Config::get('graph_colours.generic.lp.previous.percentile_in');
+    $rrd_options .= ' LINE1:dpercentile_outX#' . Config::get('graph_colours.generic.lp.previous.percentile_out');
 }
 
 unset($stacked);

--- a/includes/html/graphs/port/errors.inc.php
+++ b/includes/html/graphs/port/errors.inc.php
@@ -1,20 +1,22 @@
 <?php
 
+use LibreNMS\Config;
+
 $rrd_list[1]['filename']        = $rrd_filename;
 $rrd_list[1]['descr']           = $int['ifDescr'];
 $rrd_list[1]['ds_in']           = 'INERRORS';
 $rrd_list[1]['ds_out']          = 'OUTERRORS';
 $rrd_list[1]['descr']           = 'Errors';
-$rrd_list[1]['colour_area_in']  = 'FF3300';
-$rrd_list[1]['colour_area_out'] = 'FF6633';
+$rrd_list[1]['colour_area_in']  = Config::get('graph_colours.ports.err.area_in');
+$rrd_list[1]['colour_area_out'] = Config::get('graph_colours.ports.err.area_out');
 
 $rrd_list[4]['filename']        = $rrd_filename;
 $rrd_list[4]['descr']           = $int['ifDescr'];
 $rrd_list[4]['ds_in']           = 'INDISCARDS';
 $rrd_list[4]['ds_out']          = 'OUTDISCARDS';
 $rrd_list[4]['descr']           = 'Discards';
-$rrd_list[4]['colour_area_in']  = '805080';
-$rrd_list[4]['colour_area_out'] = 'c0a060';
+$rrd_list[4]['colour_area_in']  = Config::get('graph_colours.ports.dis.area_in');
+$rrd_list[4]['colour_area_out'] = Config::get('graph_colours.ports.dis.area_out');
 
 $units       = '';
 $units_descr = 'Packets/sec';

--- a/includes/html/graphs/port/nupkts.inc.php
+++ b/includes/html/graphs/port/nupkts.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use LibreNMS\Config;
+
 $rrd_file = get_port_rrdfile_path($device['hostname'], $port['port_id']);
 
 // FIXME uhh..
@@ -16,16 +18,16 @@ if (1) {
     $rrd_list[2]['ds_in']           = 'INBROADCASTPKTS';
     $rrd_list[2]['ds_out']          = 'OUTBROADCASTPKTS';
     $rrd_list[2]['descr']           = 'Broadcast';
-    $rrd_list[2]['colour_area_in']  = '085F63';
-    $rrd_list[2]['colour_area_out'] = '49BEB7';
+    $rrd_list[2]['colour_area_in']  = Config::get('graph_colours.ports.bpkts.area_in');
+    $rrd_list[2]['colour_area_out'] = Config::get('graph_colours.ports.bpkts.area_out');
 
     $rrd_list[4]['filename']        = $rrd_file;
     $rrd_list[4]['descr']           = $int['ifDescr'];
     $rrd_list[4]['ds_in']           = 'INMULTICASTPKTS';
     $rrd_list[4]['ds_out']          = 'OUTMULTICASTPKTS';
     $rrd_list[4]['descr']           = 'Multicast';
-    $rrd_list[4]['colour_area_in']  = 'FACF5A';
-    $rrd_list[4]['colour_area_out'] = 'FF5959';
+    $rrd_list[4]['colour_area_in']  = Config::get('graph_colours.ports.mpkts.area_in');
+    $rrd_list[4]['colour_area_out'] = Config::get('graph_colours.ports.mpkts.area_out');
 
     $units       = '';
     $units_descr = 'Packets';
@@ -43,13 +45,13 @@ if (1) {
     $ds_in  = 'INNUCASTPKTS';
     $ds_out = 'OUTNUCASTPKTS';
 
-    $colour_area_in  = 'AA66AA';
-    $colour_line_in  = '330033';
-    $colour_area_out = 'FFDD88';
-    $colour_line_out = 'FF6600';
+    $colour_area_in  = Config::get('graph_colours.ports.nupkts.area_in');
+    $colour_line_in  = Config::get('graph_colours.ports.nupkts.line_in');
+    $colour_area_out = Config::get('graph_colours.ports.nupkts.area_out');
+    $colour_line_out = Config::get('graph_colours.ports.nupkts.line_out');
 
-    $colour_area_in_max  = 'cc88cc';
-    $colour_area_out_max = 'FFefaa';
+    $colour_area_in_max  = Config::get('graph_colours.ports.nupkts.area_in_max');
+    $colour_area_out_max = Config::get('graph_colours.ports.nupkts.area_out_max');
 
     $unit_text = 'Packets';
 

--- a/includes/html/graphs/port/upkts.inc.php
+++ b/includes/html/graphs/port/upkts.inc.php
@@ -1,15 +1,17 @@
 <?php
 
+use LibreNMS\Config;
+
 $ds_in  = 'INUCASTPKTS';
 $ds_out = 'OUTUCASTPKTS';
 
-$colour_area_in  = 'AA66AA';
-$colour_line_in  = '330033';
-$colour_area_out = 'FFDD88';
-$colour_line_out = 'FF6600';
+$colour_area_in  = Config::get('graph_colours.ports.upkts.area_in');
+$colour_line_in  = Config::get('graph_colours.ports.upkts.line_in');
+$colour_area_out = Config::get('graph_colours.ports.upkts.area_out');
+$colour_line_out = Config::get('graph_colours.ports.upkts.line_out');
 
-$colour_area_in_max  = 'cc88cc';
-$colour_area_out_max = 'FFefaa';
+$colour_area_in_max  = Config::get('graph_colours.ports.upkts.area_in_max');
+$colour_area_out_max = Config::get('graph_colours.ports.upkts.area_out_max');
 
 $graph_max = 1;
 $unit_text = 'Packets';

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -1755,6 +1755,146 @@
             ],
             "type": "array"
         },
+        "graph_colours.generic.area_in": {
+            "default": "90B040",
+            "type": "text"
+        },
+        "graph_colours.generic.area_in_max": {
+            "default": "D7FFC7",
+            "type": "text"
+        },
+        "graph_colours.generic.line_in": {
+            "default": "608720",
+            "type": "text"
+        },
+        "graph_colours.generic.area_out": {
+            "default": "8080C0",
+            "type": "text"
+        },
+        "graph_colours.generic.area_out_max": {
+            "default": "E0E0FF",
+            "type": "text"
+        },
+        "graph_colours.generic.line_out": {
+            "default": "606090",
+            "type": "text"
+        },
+        "graph_colours.generic.percentile_high": {
+            "default": "FF0000",
+            "type": "text"
+        },
+        "graph_colours.generic.percentile_in": {
+            "default": "AA0000",
+            "type": "text"
+        },
+        "graph_colours.generic.percentile_out": {
+            "default": "AA0000",
+            "type": "text"
+        },
+        "graph_colours.generic.lp.in": {
+            "default": "44AA55",
+            "type": "text"
+        },
+        "graph_colours.generic.lp.out": {
+            "default": "4400DD",
+            "type": "text"
+        },
+        "graph_colours.generic.lp.previous.in": {
+            "default": "333300",
+            "type": "text"
+        },
+        "graph_colours.generic.lp.previous.out": {
+            "default": "000099",
+            "type": "text"
+        },
+        "graph_colours.generic.lp.previous.percentile_in": {
+            "default": "00AAAA",
+            "type": "text"
+        },
+        "graph_colours.generic.lp.previous.percentile_out": {
+            "default": "00AAAA",
+            "type": "text"
+        },
+        "graph_colours.ports.upkts.area_in": {
+            "default": "AA66AA",
+            "type": "text"
+        },
+        "graph_colours.ports.upkts.line_in": {
+            "default": "330033",
+            "type": "text"
+        },
+        "graph_colours.ports.upkts.area_out": {
+            "default": "FFDD88",
+            "type": "text"
+        },
+        "graph_colours.ports.upkts.line_out": {
+            "default": "FF6600",
+            "type": "text"
+        },
+        "graph_colours.ports.upkts.area_in_max": {
+            "default": "CC88CC",
+            "type": "text"
+        },
+        "graph_colours.ports.upkts.area_out_max": {
+            "default": "FFEFAA",
+            "type": "text"
+        },
+        "graph_colours.ports.nupkts.area_in": {
+            "default": "AA66AA",
+            "type": "text"
+        },
+        "graph_colours.ports.nupkts.line_in": {
+            "default": "330033",
+            "type": "text"
+        },
+        "graph_colours.ports.nupkts.area_out": {
+            "default": "FFDD88",
+            "type": "text"
+        },
+        "graph_colours.ports.nupkts.line_out": {
+            "default": "FF6600",
+            "type": "text"
+        },
+        "graph_colours.ports.nupkts.area_in_max": {
+            "default": "CC88CC",
+            "type": "text"
+        },
+        "graph_colours.ports.nupkts.area_out_max": {
+            "default": "FFEFAA",
+            "type": "text"
+        },
+        "graph_colours.ports.bpkts.area_in": {
+            "default": "085F63",
+            "type": "text"
+        },
+        "graph_colours.ports.bpkts.area_out": {
+            "default": "49BEB7",
+            "type": "text"
+        },
+        "graph_colours.ports.mpkts.area_in": {
+            "default": "FACF5A",
+             "type": "text"
+        },
+        "graph_colours.ports.mpkts.area_out": {
+            "default": "FF5959",
+            "type": "text"
+        },
+        "graph_colours.ports.err.area_in": {
+            "default": "FF3300",
+            "type": "text"
+        },
+        "graph_colours.ports.err.area_out": {
+            "default": "FF6633",
+            "type": "text"
+        },
+        "graph_colours.ports.dis.area_in": {
+            "default": "805080",
+            "type": "text"
+        },
+        "graph_colours.ports.dis.area_out": {
+            "default": "C0A060",
+            "type": "text"
+        },
         "graph_descr.device_processor": {
             "default": "This is an aggregate graph of all processors in the system.",
             "type": "text"


### PR DESCRIPTION
Move from hard coded rrd port graph colours for bits/packets/errors to variables within the config file.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
