### PR TITLE
oxidized overrides - match on poller group_name

### DIFF
--- a/doc/Extensions/Oxidized.md
+++ b/doc/Extensions/Oxidized.md
@@ -117,7 +117,7 @@ check for the validity of these attributes but will deliver them to
 Oxidized as defined.
 
 Matching of hosts can be done using `hostname`, `sysname`, `os`,
-`location`, `sysDescr` or `hardware` and including either a 'match'
+`location`, `sysDescr`, `poller_group_name` or `hardware` and including either a 'match'
 key and value, or a 'regex' key and value. The order of matching is:
 
 - `hostname`
@@ -127,6 +127,7 @@ key and value, or a 'regex' key and value. The order of matching is:
 - `os`
 - `location`
 - `ip`
+- `poller_group_name`
 
 To match on the device hostnames or sysnames that contain 'lon-sw' or
 if the location contains 'London' then you would place the following

--- a/includes/html/api_functions.inc.php
+++ b/includes/html/api_functions.inc.php
@@ -1318,7 +1318,7 @@ function list_oxidized(\Illuminate\Http\Request $request)
         $params = [$hostname];
     }
 
-    foreach (dbFetchRows("SELECT hostname,sysname,sysDescr,hardware,os,locations.location,ip AS ip FROM `devices` LEFT JOIN locations ON devices.location_id = locations.id LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
+    foreach (dbFetchRows("SELECT hostname,sysname,sysDescr,hardware,os,locations.location,ip AS ip, poller_groups.group_name AS poller_group_name FROM `devices` LEFT JOIN locations ON devices.location_id = locations.id LEFT JOIN poller_groups ON devices.poller_group = poller_groups.id LEFT JOIN devices_attribs AS `DA` ON devices.device_id = DA.device_id AND `DA`.attrib_type='override_Oxidized_disable' WHERE `disabled`='0' AND `ignore` = 0 AND (DA.attrib_value = 'false' OR DA.attrib_value IS NULL) AND (`type` NOT IN ($device_types) AND `os` NOT IN ($device_os)) $sql", $params) as $device) {
         // Convert from packed value to human value
         $device['ip'] = inet6_ntop($device['ip']);
 


### PR DESCRIPTION
Extended oxidized overrides to match on poller group_name.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
