### PR TITLE
Dell included a typo in their sysDescr

### DIFF
--- a/includes/definitions/dell-compellent.yaml
+++ b/includes/definitions/dell-compellent.yaml
@@ -23,5 +23,5 @@ discovery_modules:
     wireless: false
 discovery:
     -
-        sysDescr: COMPELLENT
+        sysDescr: COMPELLEN
         sysObjectID: .1.3.6.1.4.1.8072.3.2.8


### PR DESCRIPTION
The latest firmware revision drops the 'T' from COMPELLENT. Maybe it'll come back at some point, but for now it's gone.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
