### PR TITLE
QNAP NAS - Added RAID states for each volume.

### DIFF
--- a/includes/definitions/discovery/qnap.yaml
+++ b/includes/definitions/discovery/qnap.yaml
@@ -6,6 +6,7 @@ modules:
                 -
                     oid:
                         - diskEnclosureID
+                        - volumeName
         temperature:
             options:
                 skip_values: -1
@@ -107,3 +108,18 @@ modules:
                     states:
                         - { value: 0, generic: 0, graph: 0, descr: 'Ok' }
                         - { value: -1, generic: 2, graph: -1, descr: 'Fail' }
+                -
+                    oid: raidGroupTable
+                    value: raidStatus
+                    num_oid: '.1.3.6.1.4.1.24681.1.4.1.1.1.2.1.2.1.5.{{ $index }}'
+                    descr: '{{ $volumeName }} Raid {{ $raidLevel }}'
+                    index: 'raidStatus.{{ $index }}'
+                    group: 'Volumes'
+                    state_name: raidStatus
+                    states:
+                        - { value: 0, generic: 0, graph: 0, descr: 'Ready' }
+                        - { value: 3, generic: 2, graph: 3, descr: 'Synchronizing' }
+                        - { value: 2, generic: 2, graph: 2, descr: 'Rebulding' }
+                        - { value: 1, generic: 1, graph: 1, descr: 'Degraded' }
+                        - { value: 5, generic: 3, graph: 5, descr: 'Offline' }
+                        - { value: 4, generic: 1, graph: 4, descr: 'Failure' }


### PR DESCRIPTION
Added QNAP NAS raid status for each created volume.

The states comes in STRING and are not documented, so I opened a support ticket in QNAP and they told me the returning states for raidStatus.

I dont have a testing qnap device to test if the returning states they told me are correct, so lets hope they all are.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
