### PR TITLE
Black legend text in dark theme

### DIFF
--- a/html/css/dark.css
+++ b/html/css/dark.css
@@ -7207,3 +7207,6 @@
   .bootgrid-table th:active, .bootgrid-table th:hover {
     background: #525961;
   }
+  .vis-legend-text {
+    color: black;
+  }


### PR DESCRIPTION
using the dark theme the legend text is the same color as background on the latency page. Change to black. 

https://imgur.com/PRmYSXx

https://imgur.com/BV5rllq

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
