### PR TITLE
Enhance Alert History Table View

### DIFF
--- a/includes/html/common/alert-log.inc.php
+++ b/includes/html/common/alert-log.inc.php
@@ -77,11 +77,12 @@ $common_output[] = '
     <table id="alertlog" class="table table-hover table-condensed table-striped">
         <thead>
         <tr>
-            <th data-column-id="status" data-sortable="false"></th>
+            <th data-column-id="status" data-sortable="false">State</th>
             <th data-column-id="time_logged" data-order="desc">Timestamp</th>
             <th data-column-id="details" data-sortable="false">&nbsp;</th>
             <th data-column-id="hostname">Device</th>
             <th data-column-id="alert">Alert</th>
+            <th data-column-id="severity">Severity</th>
         </tr>
         </thead>
     </table>

--- a/includes/html/table/alertlog.inc.php
+++ b/includes/html/table/alertlog.inc.php
@@ -78,7 +78,7 @@ if ($rowCount != -1) {
     $sql .= " LIMIT $limit_low,$limit_high";
 }
 
-$sql = "SELECT D.device_id,name AS alert,rule_id, state,time_logged,DATE_FORMAT(time_logged, '" . \LibreNMS\Config::get('dateformat.mysql.compact') . "') as humandate,details $sql";
+$sql = "SELECT R.severity, D.device_id,name AS alert,rule_id, state,time_logged,DATE_FORMAT(time_logged, '" . \LibreNMS\Config::get('dateformat.mysql.compact') . "') as humandate,details $sql";
 
 $rulei = 0;
 foreach (dbFetchRows($sql, $param) as $alertlog) {
@@ -102,14 +102,14 @@ foreach (dbFetchRows($sql, $param) as $alertlog) {
         $status = 'label-primary';
     }//end if
 
-
     $response[] = array(
         'id' => $rulei++,
         'time_logged' => $alertlog['humandate'],
         'details' => '<a class="fa fa-plus incident-toggle" style="display:none" data-toggle="collapse" data-target="#incident' . ($rulei) . '" data-parent="#alerts"></a>',
         'hostname' => '<div class="incident">' . generate_device_link($dev, shorthost($dev['hostname'])) . '<div id="incident' . ($rulei) . '" class="collapse">' . $fault_detail . '</div></div>',
         'alert' => htmlspecialchars($alertlog['alert']),
-        'status' => "<i class='alert-status " . $status . "'></i>"
+        'status' => "<i class='alert-status " . $status . "' title='". ($alert_state ? 'active':'recovered')."'></i>",
+        'severity' => $alertlog['severity']
     );
 }//end foreach
 


### PR DESCRIPTION
Enhance Alert History Table to be more clear

before:

![image](https://user-images.githubusercontent.com/7978916/87594948-0ebced00-c6ee-11ea-941b-c4680139528f.png)


after:

![image](https://user-images.githubusercontent.com/7978916/87595024-301dd900-c6ee-11ea-8e88-89cc8e473681.png)

also State Color has mouseover Text active/recovered


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
