### PR TITLE
Added option to always update an app metric value and _prev

### DIFF
--- a/html/mix-manifest.json
+++ b/html/mix-manifest.json
@@ -3,12 +3,12 @@
     "/css/app.css": "/css/app.css?id=ffec4165a9c98d892a32",
     "/js/manifest.js": "/js/manifest.js?id=3c768977c2574a34506e",
     "/js/vendor.js": "/js/vendor.js?id=c0e0ebbfd027a8baefb4",
-    "/js/lang/de.js": "/js/lang/de.js?id=73ed23dde31af205f171",
-    "/js/lang/en.js": "/js/lang/en.js?id=e2297f39a1eabc180200",
-    "/js/lang/fr.js": "/js/lang/fr.js?id=91daac2f7383c820457b",
-    "/js/lang/it.js": "/js/lang/it.js?id=c202a58a7f5bca08801b",
-    "/js/lang/ru.js": "/js/lang/ru.js?id=aaab82593592e9368a08",
-    "/js/lang/uk.js": "/js/lang/uk.js?id=9b0b074259847e7aaff3",
-    "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=f6d951b7d6b1f25810fc",
-    "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=21cdd68dc06a428e7260"
+    "/js/lang/de.js": "/js/lang/de.js?id=2c4ad02fa89b684d4f57",
+    "/js/lang/en.js": "/js/lang/en.js?id=a5e0e2426a6af714087d",
+    "/js/lang/fr.js": "/js/lang/fr.js?id=3b61631feb2cb579f713",
+    "/js/lang/it.js": "/js/lang/it.js?id=514765c5399ffaa111b9",
+    "/js/lang/ru.js": "/js/lang/ru.js?id=f6b7c078755312a0907c",
+    "/js/lang/uk.js": "/js/lang/uk.js?id=c19a5dcee4724579cb41",
+    "/js/lang/zh-CN.js": "/js/lang/zh-CN.js?id=68da151165752f2e7983",
+    "/js/lang/zh-TW.js": "/js/lang/zh-TW.js?id=6cec27c0472c6d721d30"
 }

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -351,7 +351,7 @@ function poll_device($device, $force_module = false)
                 echo "Module [ $module ] disabled globally.\n\n";
             }
         }
-        
+
         if (!$force_module && !empty($graphs)) {
             echo "Enabling graphs: ";
             $graphs = collect($graphs)->keys();
@@ -631,7 +631,7 @@ function update_application($app, $response, $metrics = array(), $status = '')
                     'application_metrics'
                 );
                 echo '+';
-            } elseif ($value != $db_metrics[$metric_name]['value']) {
+            } elseif ($value != $db_metrics[$metric_name]['value'] || Str::is(Config::get('applications.metric.always_update'), $metric_name)) {
                 dbUpdate(
                     array(
                         'value' => $value,

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -5283,6 +5283,13 @@
             "section": "smokeping",
             "order": 3,
             "type": "text"
+        },
+        "applications.metric.always_update": {
+            "default": [],
+            "group": "poller",
+            "section": "applications",
+            "order": 0,
+            "type": "array"
         }
     }
 }

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -63,6 +63,7 @@ return [
             'rrdtool' => 'Datastore: RRDTool',
             'snmp' => 'SNMP',
             'poller_modules' => 'Poller Modules',
+            'applications' => 'Applications',
         ],
         'system' => [
             'cleanup' => 'Cleanup',
@@ -1345,6 +1346,10 @@ return [
         'smokeping.url' => [
             'description' => 'URL to smokeping',
             'help' => 'Full URL to the smokeping gui'
+        ],
+        'applications.metric.always_update' => [
+            'description' => 'Always update metric',
+            'help' => 'By default, value and value_prev only updates on change. Adding a metric here will make it always update. NOTE: It must be the internal metric_name'
         ]
 
     ],


### PR DESCRIPTION
Added an option to always update an application metric. This is usefull for mysql slow queries alerting.

The metric name must be the internal one, so for MySQL slow queries, it is `SQs`

NOTE: I made a new one as I had very bad experiences rebasing. At some point I should learn how to correctly do them but, meanwhile...

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
