### PR TITLE
Fix missing Munin controller tab definition

### DIFF
--- a/app/Http/Controllers/DeviceController.php
+++ b/app/Http/Controllers/DeviceController.php
@@ -24,6 +24,7 @@ class DeviceController extends Controller
         'apps' => \App\Http\Controllers\Device\Tabs\AppsController::class,
         'processes' => \App\Http\Controllers\Device\Tabs\ProcessesController::class,
         'collectd' => \App\Http\Controllers\Device\Tabs\CollectdController::class,
+        'munin' => \App\Http\Controllers\Device\Tabs\MuninController::class,
         'ports' => \App\Http\Controllers\Device\Tabs\PortsController::class,
         'port' => \App\Http\Controllers\Device\Tabs\PortController::class,
         'slas' => \App\Http\Controllers\Device\Tabs\SlasController::class,


### PR DESCRIPTION
As simple as that, must've been missed along with rewrite PR and no one noticed until now.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
