### PR TITLE
Fix wrong str::finish argument order

### DIFF
--- a/LibreNMS/Config.php
+++ b/LibreNMS/Config.php
@@ -408,7 +408,7 @@ class Config
             self::set('base_url', preg_replace('/^http:/', 'https:', self::get('base_url')));
         }
 
-        self::set('base_url', Str::finish('/', self::get('base_url')));
+        self::set('base_url', Str::finish(self::get('base_url'), '/'));
 
         if (!self::get('email_from')) {
             self::set('email_from', '"' . self::get('project_name') . '" <' . self::get('email_user') . '@' . php_uname('n') . '>');


### PR DESCRIPTION
As per https://laravel.com/docs/7.x/helpers#method-str-finish

Fixes UI errors (for example wrong base href).
Every base_url was now prefixed with a /

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
