### PR TITLE
Fix automatic service discovery

### DIFF
--- a/includes/services.inc.php
+++ b/includes/services.inc.php
@@ -36,7 +36,7 @@ function get_service_status($device = null)
     return $service_count;
 }
 
-function add_service($device, $type, $desc, $ip = 'localhost', $param = "", $ignore = 0, $disabled = 0)
+function add_service($device, $type, $desc, $ip = '', $param = "", $ignore = 0, $disabled = 0)
 {
 
     if (!is_array($device)) {


### PR DESCRIPTION
Please give a short description what your pull request is for

When discover_services = true, the services are added with 'localhost' and therefore always poll the local librenms instance.
Removing localhost allows the if empty$ip check to work and adds the host with the correct hostname as expected.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
