### PR TITLE
Added Proxy support for Api Transport

### DIFF
--- a/LibreNMS/Alert/Transport/Api.php
+++ b/LibreNMS/Alert/Transport/Api.php
@@ -61,6 +61,7 @@ class Api extends Transport
         }
 
         $client = new \GuzzleHttp\Client();
+        $request_opts['proxy'] = get_guzzle_proxy();
         if (isset($auth) && !empty($auth[0])) {
             $request_opts['auth'] = $auth;
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1350,6 +1350,22 @@ function set_curl_proxy($curl)
 }
 
 /**
+ * Return the proxy url in guzzle format
+ *
+ * @return 'tcp://' + $proxy
+ */
+function get_guzzle_proxy()
+{
+    $proxy = get_proxy();
+
+    $tmp = rtrim($proxy, "/");
+    $proxy = str_replace(array("http://", "https://"), "", $tmp);
+    if (!empty($proxy)) {
+        return 'tcp://' . $proxy;
+    }
+}
+
+/**
  * Return the proxy url
  *
  * @return array|bool|false|string


### PR DESCRIPTION
This PR will add proxy support to the Api.php Transport.
Proxy support was not implemented, when switching to the GuzzleHTTP engine a few months ago.

This was also discussed here:
https://community.librenms.org/t/new-guzzlehttp-does-not-honor-proxy-settings/9908

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
