### PR TITLE
Dispatch Service Fix maintenance issues

### DIFF
--- a/LibreNMS/service.py
+++ b/LibreNMS/service.py
@@ -429,8 +429,13 @@ class Service:
             sleep(wait)
 
         info("Running maintenance tasks")
-        output = LibreNMS.call_script('daily.sh')
-        info("Maintenance tasks complete\n{}".format(output))
+        try:
+            output = LibreNMS.call_script('daily.sh')
+            info("Maintenance tasks complete\n{}".format(output))
+        except subprocess.CalledProcessError as e:
+            error("Error in daily.sh:\n" + (e.output.decode() if e.output is not None else 'No output'))
+
+        self._lm.unlock('schema-update', self.config.unique_name)
 
         self.restart()
 


### PR DESCRIPTION
If daily.sh exited with non-zero it would kill the maintenance thread, never to run again until manual restart
The maintenance lock was never released, this wouldn't cause an issue in normal operation as it should expire.

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
