### PR TITLE
Add type hinting to devicecache

### DIFF
--- a/LibreNMS/Cache/Device.php
+++ b/LibreNMS/Cache/Device.php
@@ -46,7 +46,7 @@ class Device
      *
      * @param int $device_id
      */
-    public function setPrimary($device_id)
+    public function setPrimary(int $device_id)
     {
         $this->primary = $device_id;
     }
@@ -57,13 +57,13 @@ class Device
      * @param int $device_id
      * @return \App\Models\Device
      */
-    public function get($device_id) : \App\Models\Device
+    public function get(?int $device_id) : \App\Models\Device
     {
-        if (!array_key_exists($device_id, $this->devices)) {
+        if (!is_null($device_id) && !array_key_exists($device_id, $this->devices)) {
             return $this->load($device_id);
         }
 
-        return $this->devices[$device_id] ?: new \App\Models\Device;
+        return $this->devices[$device_id] ?? new \App\Models\Device;
     }
 
     /**
@@ -80,7 +80,7 @@ class Device
             return $this->load($hostname, 'hostname');
         }
 
-        return $this->devices[$device_id] ?: new \App\Models\Device;
+        return $this->devices[$device_id] ?? new \App\Models\Device;
     }
 
     /**
@@ -89,7 +89,7 @@ class Device
      * @param int $device_id
      * @return \App\Models\Device
      */
-    public function refresh($device_id) : \App\Models\Device
+    public function refresh(?int $device_id) : \App\Models\Device
     {
         unset($this->devices[$device_id]);
         return $this->get($device_id);


### PR DESCRIPTION
Prevents sql query from executing as string.

Before:
```select * from `devices` where `device_id` = '2' limit 1```
After:
```select * from `devices` where `device_id` = 2 limit 1```

As a bonus it also prevents sql queries with `device_id = null`, small performance win.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
