### PR TITLE
Add default values to cast

### DIFF
--- a/app/Http/Controllers/PaginatedAjaxController.php
+++ b/app/Http/Controllers/PaginatedAjaxController.php
@@ -206,6 +206,14 @@ abstract class PaginatedAjaxController extends Controller
      */
     protected function adjustFilterValue($field, $value)
     {
+        switch ($field) {
+            case 'device':
+            case 'device_id':
+            case 'port_id':
+                $value = (int) $value;
+                break;
+        }
+
         return $value;
     }
 }


### PR DESCRIPTION
Makes the SQL query correctly select id columns as int instead of string for most ajax table requests

Not a performance issue I think, but if it was the other way (string to int) we could missed indexed searches.

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
