### PR TITLE
Cisco SLA jitter tag

### DIFF
--- a/includes/discovery/cisco-sla.inc.php
+++ b/includes/discovery/cisco-sla.inc.php
@@ -65,7 +65,7 @@ if (Config::get('enable_sla') && $device['os_group'] == 'cisco') {
                     break;
 
                 case 'jitter':
-                    $data['tag'] = $sla_config['rttMonEchoAdminCodecType'] ." (". preg_replace('/milliseconds/', 'ms', $sla_config['rttMonEchoAdminCodecInterval']) .")";
+                    $data['tag'] = IP::fromHexString($sla_config['rttMonEchoAdminTargetAddress'], true) . ":" . $sla_config['rttMonEchoAdminTargetPort'];
                     break;
             }//end switch
         }//end if

--- a/includes/discovery/cisco-sla.inc.php
+++ b/includes/discovery/cisco-sla.inc.php
@@ -65,7 +65,12 @@ if (Config::get('enable_sla') && $device['os_group'] == 'cisco') {
                     break;
 
                 case 'jitter':
-                    $data['tag'] = IP::fromHexString($sla_config['rttMonEchoAdminTargetAddress'], true) . ":" . $sla_config['rttMonEchoAdminTargetPort'];
+                    if ($sla_config['rttMonEchoAdminCodecType'] != 'notApplicable') {
+                        $codec_info = " (" . $sla_config['rttMonEchoAdminCodecType'] . " @ " . preg_replace('/milliseconds/', 'ms', $sla_config['rttMonEchoAdminCodecInterval']) . ")";
+                    } else {
+                        $codec_info = '';
+                    }
+                    $data['tag'] = IP::fromHexString($sla_config['rttMonEchoAdminTargetAddress'], true) . ":" . $sla_config['rttMonEchoAdminTargetPort'] . $codec_info;
                     break;
             }//end switch
         }//end if


### PR DESCRIPTION
Generate tag based on target IP address and port. Codec type that is currently used is not a required parameter and is not usually configured for general purpose jitter probes. Target IP address and port are required parameters and should be always available.

**Before**:
![image](https://user-images.githubusercontent.com/5007811/88963533-4314d980-d2a8-11ea-98da-f06acdd80dde.png)

**After:**
Without codec configured:
![image](https://user-images.githubusercontent.com/5007811/88963553-4ad47e00-d2a8-11ea-95f3-a38ec19db4d5.png)
With codec configured:
![image](https://user-images.githubusercontent.com/5007811/88965319-e109a380-d2aa-11ea-9c05-5b0415e7a602.png)







DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
