### PR TITLE
Fixes missing items for Eaton M2 management card

### DIFF
--- a/includes/definitions/discovery/eatonups.yaml
+++ b/includes/definitions/discovery/eatonups.yaml
@@ -1,0 +1,19 @@
+mib: EATON-OIDS:EATON-EMP-MIB:XUPS-MIB
+modules:
+    sensors:
+        temperature:
+            data:
+                -
+                    oid: xupsEnvironment
+                    value: xupsEnvRemoteTemp
+                    num_oid: '.1.3.6.1.4.1.534.1.6.5.{{ $index }}'
+                    descr: 'Environment'
+                    index: 'xupsEnvRemoteTemp.{{ $index }}'
+        humidity:
+            data:
+                -
+                    oid: xupsEnvironment
+                    value: xupsEnvRemoteHumidity
+                    num_oid: '.1.3.6.1.4.1.534.1.6.6.{{ $index }}'
+                    descr: 'Environment'
+                    index: 'xupsEnvRemoteHumidity.{{ $index }}'

--- a/includes/definitions/eatonups.yaml
+++ b/includes/definitions/eatonups.yaml
@@ -8,6 +8,7 @@ over:
     - { graph: device_frequency, text: Frequencies }
 mib_dir:
     - ups
+    - mge
 discovery:
     -
         sysObjectID: .1.3.6.1.4.1.534.1

--- a/includes/polling/os/eatonups.inc.php
+++ b/includes/polling/os/eatonups.inc.php
@@ -6,4 +6,3 @@ $version = trim(snmp_get($device, 'upsIdentAgentSoftwareVersion.0', '-OQv', 'UPS
 $version += ' / '.trim(snmp_get($device, 'upsIdentUPSSoftwareVersion.0', '-OQv', 'UPS-MIB'), '" ');
 
 $serial = trim(snmp_get($device, 'upsIdentName.0', '-OQv', 'UPS-MIB'), '" ');
-?>

--- a/includes/polling/os/eatonups.inc.php
+++ b/includes/polling/os/eatonups.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+$hardware = trim(snmp_get($device, 'upsIdentModel.0', '-OQv', 'UPS-MIB'), '" ');
+
+$version = trim(snmp_get($device, 'upsIdentAgentSoftwareVersion.0', '-OQv', 'UPS-MIB'), '" ');
+$version += ' / '.trim(snmp_get($device, 'upsIdentUPSSoftwareVersion.0', '-OQv', 'UPS-MIB'), '" ');
+
+$serial = trim(snmp_get($device, 'upsIdentName.0', '-OQv', 'UPS-MIB'), '" ');
+?>


### PR DESCRIPTION
System overview items like Hardware, Version and Serial and sensors like Temperature and Humidity sensors where missing for UPSes equipped with the Eaton M2 management card.
The M2 is RFC 1628 compatible and doesn't support MG-SNMP-UPS-MIB/upsmg.
Use XUPS-MIBS instead.

Tested on the:
9PX 5000i
9PX 6000i
5P 1150
5PX 1500
(v1.7.5)

Also see:
https://community.librenms.org/t/force-sw-hw-information-from-another-mib/11417

Please review.
I'd lie to add "rfc1628_compat: true"., which should reduce eatonups specific code, and also provide items like "Runtime" (Runtime remaining) and "Load" (device_load). Adding it together with the current eatonups code will make some items appear twice (e.g. Frequency/Bypass).

If we can rely on sysObjectID's .1.3.6.1.4.1.534.1|2 to _only_ match M2s, the rfc1628 code could replace some (most?) eatonups specific code, like e.g. includes/discovery/sensors/charge/eatonups.inc.php
(maybe the rfc1628 code was added after the eatonups code ?)

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
