### PR TITLE
Increase default RRD data retention of MIN, MAX, and LAST to match AVERAGE

### DIFF
--- a/LibreNMS/Data/Store/Rrd.php
+++ b/LibreNMS/Data/Store/Rrd.php
@@ -57,9 +57,9 @@ class Rrd extends BaseDatastore
         $this->rra = Config::get(
             'rrd_rra',
             'RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1440 RRA:AVERAGE:0.5:24:1440 RRA:AVERAGE:0.5:288:1440 ' .
-            ' RRA:MIN:0.5:1:720 RRA:MIN:0.5:6:1440     RRA:MIN:0.5:24:775     RRA:MIN:0.5:288:797 ' .
-            ' RRA:MAX:0.5:1:720 RRA:MAX:0.5:6:1440     RRA:MAX:0.5:24:775     RRA:MAX:0.5:288:797 ' .
-            ' RRA:LAST:0.5:1:1440 '
+            ' RRA:MIN:0.5:1:2016 RRA:MIN:0.5:6:1440     RRA:MIN:0.5:24:1440     RRA:MIN:0.5:288:1440 ' .
+            ' RRA:MAX:0.5:1:2016 RRA:MAX:0.5:6:1440     RRA:MAX:0.5:24:1440     RRA:MAX:0.5:288:1440 ' .
+            ' RRA:LAST:0.5:1:2016 '
         );
         $this->version = Config::get('rrdtool_version', '1.4');
     }

--- a/misc/config_definitions.json
+++ b/misc/config_definitions.json
@@ -4550,7 +4550,7 @@
             "type": "integer"
         },
         "rrd_rra": {
-            "default": " RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1440 RRA:AVERAGE:0.5:24:1440 RRA:AVERAGE:0.5:288:1440  RRA:MIN:0.5:1:720 RRA:MIN:0.5:6:1440     RRA:MIN:0.5:24:775     RRA:MIN:0.5:288:797  RRA:MAX:0.5:1:720 RRA:MAX:0.5:6:1440     RRA:MAX:0.5:24:775     RRA:MAX:0.5:288:797  RRA:LAST:0.5:1:1440 ",
+            "default": " RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1440 RRA:AVERAGE:0.5:24:1440 RRA:AVERAGE:0.5:288:1440 RRA:MIN:0.5:1:2016 RRA:MIN:0.5:6:1440 RRA:MIN:0.5:24:1440 RRA:MIN:0.5:288:1440 RRA:MAX:0.5:1:2016 RRA:MAX:0.5:6:1440 RRA:MAX:0.5:24:1440 RRA:MAX:0.5:288:1440 RRA:LAST:0.5:1:2016 ",
             "group": "poller",
             "section": "rrdtool",
             "order": 4,


### PR DESCRIPTION
Changed the default RRD RRA definition so that `MIN`, `MAX` and `LAST` CDPs have the same values for row count as `AVERAGE`.
Currently `AVERAGE` has the following definitions:

| PDP/CDP | Rows | Data retention |
|:-----------|:------|:-----------------|
| 1 | 2016 | 7 days |
| 6 | 1440 | 30 days |
| 24 | 1440 | 120 days |
| 288 | 1440 | ~4 years |

While `MIN` and `MAX` have:

| PDP/CDP | Rows | Data retention |
|:-----------|:------|:-----------------|
| 1 | **720** | **60h** |
| 6 | 1440 | 30 days |
| 24 | **775** | **~65 days** |
| 288 | **797** | **2.2 years** |

Which doesn't make much sense. This is most visible when graphing something like temperature that uses `MIN`, `AVERAGE`, and `MAX` on the same graph, resulting in mixed resolution data sets and missing `MIN` and `MAX` for old data like in the image below:
![image](https://user-images.githubusercontent.com/5007811/89211481-2affcb80-d5c2-11ea-8f44-492408693f82.png)

I changed the `MIN`, `MAX` to be the same as `AVERAGE` so the newly created graphs don't have this issue.

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
